### PR TITLE
Style engine: support nested CSS rules (or CSS containers)

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -195,9 +195,9 @@ require __DIR__ . '/experiments-page.php';
 
 // Copied package PHP files.
 if ( is_dir( __DIR__ . '/../build/style-engine' ) ) {
-	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-container-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rule-gutenberg.php';
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-container-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-store-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-processor-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -195,6 +195,7 @@ require __DIR__ . '/experiments-page.php';
 
 // Copied package PHP files.
 if ( is_dir( __DIR__ . '/../build/style-engine' ) ) {
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-container-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rule-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-store-gutenberg.php';

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -15,7 +15,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 	 * @access private
 	 */
 	class WP_Style_Engine_CSS_Rule {
-
 		/**
 		 * The selector.
 		 *
@@ -24,7 +23,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		protected $selector;
 
 		/**
-		 * The container.
+		 * A CSS selector or CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @var string
 		 */
@@ -40,26 +39,15 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		protected $declarations;
 
 		/**
-		 * The CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
-		 *
-		 * @var string
-		 */
-		protected $at_rule;
-
-
-		/**
 		 * Constructor
 		 *
 		 * @param string                                    $selector     The CSS selector.
 		 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
 		 *                                                                or a WP_Style_Engine_CSS_Declarations object.
-		 * @param string                                    $at_rule      A CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
-		 *
 		 */
-		public function __construct( $selector = '', $declarations = array(), $at_rule = '' ) {
+		public function __construct( $selector = '', $declarations = array() ) {
 			$this->set_selector( $selector );
 			$this->add_declarations( $declarations );
-			$this->set_at_rule( $at_rule );
 		}
 
 		/**
@@ -77,7 +65,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		/**
 		 * Sets the container.
 		 *
-		 * @param string $container The CSS selector.
+		 * @param string $container The CSS container selector or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
@@ -123,18 +111,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		}
 
 		/**
-		 * Sets the at_rule.
-		 *
-		 * @param string $at_rule A CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
-		 *
-		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
-		 */
-		public function set_at_rule( $at_rule ) {
-			$this->at_rule = $at_rule;
-			return $this;
-		}
-
-		/**
 		 * Gets the declarations object.
 		 *
 		 * @return WP_Style_Engine_CSS_Declarations The declarations object.
@@ -153,15 +129,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		}
 
 		/**
-		 * Gets the at_rule.
-		 *
-		 * @return string
-		 */
-		public function get_at_rule() {
-			return $this->at_rule;
-		}
-
-		/**
 		 * Gets the CSS.
 		 *
 		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
@@ -170,26 +137,17 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		 * @return string
 		 */
 		public function get_css( $should_prettify = false, $indent_count = 0 ) {
-			$rule_indent                = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
-			$nested_rule_indent         = $should_prettify ? str_repeat( "\t", $indent_count + 1 ) : '';
-			$declarations_indent        = $should_prettify ? $indent_count + 1 : 0;
-			$nested_declarations_indent = $should_prettify ? $indent_count + 2 : 0;
-			$suffix                     = $should_prettify ? "\n" : '';
-			$spacer                     = $should_prettify ? ' ' : '';
+			$rule_indent         = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
+			$declarations_indent = $should_prettify ? $indent_count + 1 : 0;
+			$suffix              = $should_prettify ? "\n" : '';
+			$spacer              = $should_prettify ? ' ' : '';
 			// Trims any multiple selectors strings.
 			$selector         = $should_prettify ? implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) ) : $this->get_selector();
 			$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector ) : $selector;
-			$at_rule          = $this->get_at_rule();
-			$has_at_rule      = ! empty( $at_rule );
-			$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $has_at_rule ? $nested_declarations_indent : $declarations_indent );
+			$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
 
 			if ( empty( $css_declarations ) ) {
 				return '';
-			}
-
-			if ( $has_at_rule ) {
-				$selector = "{$rule_indent}{$at_rule}{$spacer}{{$suffix}{$nested_rule_indent}{$selector}{$spacer}{{$suffix}{$css_declarations}{$suffix}{$nested_rule_indent}}{$suffix}{$rule_indent}}";
-				return $selector;
 			}
 
 			return "{$rule_indent}{$selector}{$spacer}{{$suffix}{$css_declarations}{$suffix}{$rule_indent}}";

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -15,19 +15,13 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 	 * @access private
 	 */
 	class WP_Style_Engine_CSS_Rule {
+
 		/**
 		 * The selector.
 		 *
 		 * @var string
 		 */
 		protected $selector;
-
-		/**
-		 * A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
-		 *
-		 * @var string
-		 */
-		protected $container;
 
 		/**
 		 * The selector declarations.
@@ -61,30 +55,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 			$this->selector = $selector;
 			return $this;
 		}
-
-		/**
-		 * Sets the container.
-		 *
-		 * @param string $container A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
-		 *                          such as `@media (min-width: 80rem)` or `@layer module`.
-		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
-		 */
-		public function set_container( $container ) {
-			if ( ! empty( $container ) ) {
-				$this->container = $container;
-			}
-			return $this;
-		}
-
-		/**
-		 * Gets the container.
-		 *
-		 * @return string Container.
-		 */
-		public function get_container() {
-			return $this->container;
-		}
-
 
 		/**
 		 * Sets the declarations.

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -52,7 +52,9 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
 		public function set_selector( $selector ) {
-			$this->selector = $selector;
+			if ( ! empty( $selector ) ) {
+				$this->selector = $selector;
+			}
 			return $this;
 		}
 
@@ -65,6 +67,9 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
 		public function add_declarations( $declarations ) {
+			if ( empty( $declarations ) ) {
+				return $this;
+			}
 			$is_declarations_object = ! is_array( $declarations );
 			$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
 
@@ -114,7 +119,8 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 			// Trims any multiple selectors strings.
 			$selector         = $should_prettify ? implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) ) : $this->get_selector();
 			$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector ) : $selector;
-			$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
+			$css_declarations = ! empty( $this->declarations ) ? $this->declarations->get_declarations_string( $should_prettify, $declarations_indent ) : '';
+
 
 			if ( empty( $css_declarations ) ) {
 				return '';

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -24,6 +24,13 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		protected $selector;
 
 		/**
+		 * The container.
+		 *
+		 * @var string
+		 */
+		protected $container;
+
+		/**
 		 * The selector declarations.
 		 *
 		 * Contains a WP_Style_Engine_CSS_Declarations object.
@@ -66,6 +73,30 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 			$this->selector = $selector;
 			return $this;
 		}
+
+		/**
+		 * Sets the container.
+		 *
+		 * @param string $container The CSS selector.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
+		 */
+		public function set_container( $container ) {
+			if ( ! empty( $container ) ) {
+				$this->container = $container;
+			}
+			return $this;
+		}
+
+		/**
+		 * Gets the container.
+		 *
+		 * @return string Container.
+		 */
+		public function get_container() {
+			return $this->container;
+		}
+
 
 		/**
 		 * Sets the declarations.
@@ -165,3 +196,4 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		}
 	}
 }
+

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -10,7 +10,7 @@
 if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 
 	/**
-	 * Holds, sanitizes, processes and prints CSS declarations for the Style Engine.
+	 * Holds, sanitizes, processes and prints CSS rules for the Style Engine.
 	 *
 	 * @access private
 	 */
@@ -23,7 +23,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		protected $selector;
 
 		/**
-		 * A CSS selector or CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @var string
 		 */
@@ -65,8 +65,8 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		/**
 		 * Sets the container.
 		 *
-		 * @param string $container The CSS container selector or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
-		 *
+		 * @param string $container A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
+		 *                          such as `@media (min-width: 80rem)` or `@layer module`.
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
 		public function set_container( $container ) {
@@ -154,4 +154,3 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		}
 	}
 }
-

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -121,7 +121,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 			$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector ) : $selector;
 			$css_declarations = ! empty( $this->declarations ) ? $this->declarations->get_declarations_string( $should_prettify, $declarations_indent ) : '';
 
-
 			if ( empty( $css_declarations ) ) {
 				return '';
 			}

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -106,6 +106,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 			$new_line     = $should_prettify ? "\n" : '';
 			$spacer       = $should_prettify ? ' ' : '';
 			$css         .= ! empty( $this->declarations ) ? $this->declarations->get_declarations_string( $should_prettify, $indent_count ) : '';
+			$css         .= $should_prettify && $css ? "\n" : '';
 
 			foreach ( $this->rules as $rule ) {
 				$css .= $rule->get_css( $should_prettify, $indent_count );

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 				if ( ! $rule instanceof WP_Style_Engine_CSS_Rule ) {
 					_doing_it_wrong(
 						__METHOD__,
-						__( 'Rules passed to WP_Style_Engine_CSS_Rules_Containermust be an instance of WP_Style_Engine_CSS_Rule', 'default' ),
+						__( 'Rules passed to WP_Style_Engine_CSS_Rules_Container must be an instance of WP_Style_Engine_CSS_Rule', 'default' ),
 						'6.6.0'
 					);
 					continue;

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -36,9 +36,9 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 		 *
 		 * @param string                                              $selector  A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
 		 *                                                                       such as `@media (min-width: 80rem)` or `@layer module`.
-		 * @param WP_Style_Engine_CSS_Rule[]|WP_Style_Engine_CSS_Rule $rule      A WP_Style_Engine_CSS_Rule object.
+		 * @param WP_Style_Engine_CSS_Rule[]|WP_Style_Engine_CSS_Rule $rule      Optional. A WP_Style_Engine_CSS_Rule object.
 		 */
-		public function __construct( $selector = '', $rule ) {
+		public function __construct( $selector = '', $rule = array() ) {
 			$this->set_selector( $selector );
 			$this->add_rules( $rule );
 		}
@@ -94,6 +94,10 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 		 * @return WP_Style_Engine_CSS_Rules_Container Returns the object to allow chaining of methods.
 		 */
 		public function add_rules( $rules ) {
+			if ( empty( $rules ) ) {
+				return $this;
+			}
+
 			if ( ! is_array( $rules ) ) {
 				$rules = array( $rules );
 			}

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -6,9 +6,8 @@
  *
  * @package Gutenberg
  */
-// @TODO new file and tests
-// Should have same/similar interface to WP_Style_Engine_CSS_Rule or maybe even part of it?
-
+// @TODO add unit tests
+// @TODO Should have same/similar interface to WP_Style_Engine_CSS_Rule or maybe inherits from WP_Style_Engine_CSS_Rule?
 if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 	/**
 	 * Holds, sanitizes, processes and prints nested CSS rules for the Style Engine.
@@ -21,7 +20,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 		 *
 		 * @var string
 		 */
-		protected $container;
+		protected $selector;
 
 		/**
 		 * The container declarations.
@@ -35,37 +34,37 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 		/**
 		 * Constructor
 		 *
-		 * @param string                                              $container A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
+		 * @param string                                              $selector  A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
 		 *                                                                       such as `@media (min-width: 80rem)` or `@layer module`.
 		 * @param WP_Style_Engine_CSS_Rule[]|WP_Style_Engine_CSS_Rule $rule      A WP_Style_Engine_CSS_Rule object.
 		 */
-		public function __construct( $container = '', $rule ) {
-			$this->set_container( $container );
+		public function __construct( $selector = '', $rule ) {
+			$this->set_selector( $selector );
 			$this->add_rules( $rule );
 		}
 
 		/**
-		 * Sets the container.
+		 * Sets the selector/container name.
 		 *
-		 * @param string $container A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
+		 * @param string $selector A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
 		 *                          such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return WP_Style_Engine_CSS_Rules_Container Returns the object to allow chaining of methods.
 		 */
-		public function set_container( $container ) {
-			if ( ! empty( $container ) ) {
-				$this->container = $container;
+		public function set_selector( $selector ) {
+			if ( ! empty( $selector ) ) {
+				$this->selector = $selector;
 			}
 			return $this;
 		}
 
 		/**
-		 * Gets the container.
+		 * Gets the selector/container name.
 		 *
 		 * @return string Container.
 		 */
-		public function get_container() {
-			return $this->container;
+		public function get_selector() {
+			return $this->selector;
 		}
 
 		/**
@@ -94,27 +93,16 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 		 *
 		 * @return WP_Style_Engine_CSS_Rules_Container Returns the object to allow chaining of methods.
 		 */
-		public function add_rules( $container_rules ) {
-			if ( ! is_array( $container_rules ) ) {
-				$container_rules = array( $container_rules );
+		public function add_rules( $rules ) {
+			if ( ! is_array( $rules ) ) {
+				$rules = array( $rules );
 			}
 
-			foreach ( $container_rules as $rule ) {
+			foreach ( $rules as $rule ) {
 				if ( ! $rule instanceof WP_Style_Engine_CSS_Rule ) {
 					_doing_it_wrong(
 						__METHOD__,
 						__( 'Rules passed to WP_Style_Engine_CSS_Rules_Containermust be an instance of WP_Style_Engine_CSS_Rule', 'default' ),
-						'6.6.0'
-					);
-					continue;
-				}
-
-				$container = $rule->get_container();
-
-				if ( $container !== $this->container ) {
-					_doing_it_wrong(
-						__METHOD__,
-						__( 'Rules passed to WP_Style_Engine_CSS_Rules_Container must have the same container as the container object', 'default' ),
 						'6.6.0'
 					);
 					continue;
@@ -141,20 +129,21 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 		 * @return string
 		 */
 		public function get_css( $should_prettify = false, $indent_count = 0 ) {
-			$css                 = '';
-			$indent_count         = $should_prettify ? $indent_count + 1 : $indent_count;
-			$new_line            = $should_prettify ? "\n" : '';
-			$spacer              = $should_prettify ? ' ' : '';
+			$css          = '';
+			$indent_count = $should_prettify ? $indent_count + 1 : $indent_count;
+			$new_line     = $should_prettify ? "\n" : '';
+			$spacer       = $should_prettify ? ' ' : '';
+
 			foreach ( $this->rules as $rule ) {
 				$css .= $rule->get_css( $should_prettify, $indent_count );
 				$css .= $should_prettify ? "\n" : '';
 			}
 
 			if ( empty( $css ) ) {
-				return '';
+				return $css;
 			}
 
-			return "{$this->container}{$spacer}{{$new_line}{$css}}";
+			return "{$this->selector}{$spacer}{{$new_line}{$css}}";
 		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -6,21 +6,29 @@
  *
  * @package Gutenberg
  */
-// @TODO add unit tests
-// @TODO Should have same/similar interface to WP_Style_Engine_CSS_Rule or maybe inherits from WP_Style_Engine_CSS_Rule?
+
 if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 	/**
 	 * Holds, sanitizes, processes and prints nested CSS rules for the Style Engine.
 	 *
 	 * @access private
 	 */
-	class WP_Style_Engine_CSS_Rules_Container {
+	class WP_Style_Engine_CSS_Rules_Container extends WP_Style_Engine_CSS_Rule {
 		/**
 		 * A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`
 		 *
 		 * @var string
 		 */
 		protected $selector;
+
+		/**
+		 * The selector declarations.
+		 *
+		 * Contains a WP_Style_Engine_CSS_Declarations object.
+		 *
+		 * @var WP_Style_Engine_CSS_Declarations
+		 */
+		protected $declarations;
 
 		/**
 		 * The container declarations.
@@ -41,30 +49,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 		public function __construct( $selector = '', $rule = array() ) {
 			$this->set_selector( $selector );
 			$this->add_rules( $rule );
-		}
-
-		/**
-		 * Sets the selector/container name.
-		 *
-		 * @param string $selector A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
-		 *                          such as `@media (min-width: 80rem)` or `@layer module`.
-		 *
-		 * @return WP_Style_Engine_CSS_Rules_Container Returns the object to allow chaining of methods.
-		 */
-		public function set_selector( $selector ) {
-			if ( ! empty( $selector ) ) {
-				$this->selector = $selector;
-			}
-			return $this;
-		}
-
-		/**
-		 * Gets the selector/container name.
-		 *
-		 * @return string Container.
-		 */
-		public function get_selector() {
-			return $this->selector;
 		}
 
 		/**
@@ -137,6 +121,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 			$indent_count = $should_prettify ? $indent_count + 1 : $indent_count;
 			$new_line     = $should_prettify ? "\n" : '';
 			$spacer       = $should_prettify ? ' ' : '';
+			$css         .=  ! empty( $this->declarations ) ? $this->declarations->get_declarations_string( $should_prettify, $indent_count ) : '';
 
 			foreach ( $this->rules as $rule ) {
 				$css .= $rule->get_css( $should_prettify, $indent_count );

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -15,22 +15,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 	 */
 	class WP_Style_Engine_CSS_Rules_Container extends WP_Style_Engine_CSS_Rule {
 		/**
-		 * A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`
-		 *
-		 * @var string
-		 */
-		protected $selector;
-
-		/**
-		 * The selector declarations.
-		 *
-		 * Contains a WP_Style_Engine_CSS_Declarations object.
-		 *
-		 * @var WP_Style_Engine_CSS_Declarations
-		 */
-		protected $declarations;
-
-		/**
 		 * The container declarations.
 		 *
 		 * Contains a WP_Style_Engine_CSS_Rule object.

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -105,7 +105,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 			$indent_count = $should_prettify ? $indent_count + 1 : $indent_count;
 			$new_line     = $should_prettify ? "\n" : '';
 			$spacer       = $should_prettify ? ' ' : '';
-			$css         .=  ! empty( $this->declarations ) ? $this->declarations->get_declarations_string( $should_prettify, $indent_count ) : '';
+			$css         .= ! empty( $this->declarations ) ? $this->declarations->get_declarations_string( $should_prettify, $indent_count ) : '';
 
 			foreach ( $this->rules as $rule ) {
 				$css .= $rule->get_css( $should_prettify, $indent_count );

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -112,7 +112,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
 					continue;
 				}
 
-				$selector  = $rule->get_selector();
+				$selector = $rule->get_selector();
 
 				if ( isset( $this->rules[ $selector ] ) ) {
 					$this->rules[ $selector ]->add_declarations( $rule->get_declarations() );

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * WP_Style_Engine_CSS_Rules_Container
+ *
+ * A container for WP_Style_Engine_CSS_Rule objects.
+ *
+ * @package Gutenberg
+ */
+// @TODO new file and tests
+// Should have same/similar interface to WP_Style_Engine_CSS_Rule or maybe even part of it?
+class WP_Style_Engine_CSS_Rules_Container {
+	protected $container;
+	protected $rules = array();
+
+	public function __construct( $container = '', $rule ) {
+		$this->set_container( $container );
+		// @TODO should be able to add multiple rules.
+		// @TODO check for instance of WP_Style_Engine_CSS_Rule
+		$this->add_rule( $rule );
+	}
+
+	public function set_container( $container ) {
+		$this->container = $container;
+		return $this;
+	}
+
+	public function get_container() {
+		return $this->container;
+	}
+
+	public function get_rules() {
+		return $this->rules;
+	}
+
+	public function get_rule( $selector ) {
+		return $this->rules[ $selector ] ?? null;
+	}
+
+	public function add_rule( $rule ) {
+		// @TODO should be able to add multiple rules.
+		// @TODO should be able to return a rule and update its selectors
+		// @TODO check for instance of WP_Style_Engine_CSS_Rule
+		$selector = $rule->get_selector();
+
+		if ( isset( $this->rules[ $selector ] ) ) {
+			$this->rules[ $selector ]->add_declarations( $rule->get_declarations() );
+		} else {
+			$this->rules[ $selector ] = $rule;
+		}
+		return $this;
+	}
+
+	public function get_css( $should_prettify = false, $indent_count = 0 ) {
+		$css                 = '';
+		$indent_count         = $should_prettify ? $indent_count + 1 : $indent_count;
+		$new_line            = $should_prettify ? "\n" : '';
+		$spacer              = $should_prettify ? ' ' : '';
+		foreach ( $this->rules as $rule ) {
+			$css .= $rule->get_css( $should_prettify, $indent_count );
+			$css .= $should_prettify ? "\n" : '';
+		}
+
+		if ( empty( $css ) ) {
+			return '';
+		}
+
+		return "{$this->container}{$spacer}{{$new_line}{$css}}";
+	}
+}

--- a/packages/style-engine/class-wp-style-engine-css-rules-container.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-container.php
@@ -8,62 +8,153 @@
  */
 // @TODO new file and tests
 // Should have same/similar interface to WP_Style_Engine_CSS_Rule or maybe even part of it?
-class WP_Style_Engine_CSS_Rules_Container {
-	protected $container;
-	protected $rules = array();
 
-	public function __construct( $container = '', $rule ) {
-		$this->set_container( $container );
-		// @TODO should be able to add multiple rules.
-		// @TODO check for instance of WP_Style_Engine_CSS_Rule
-		$this->add_rule( $rule );
-	}
+if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Container' ) ) {
+	/**
+	 * Holds, sanitizes, processes and prints nested CSS rules for the Style Engine.
+	 *
+	 * @access private
+	 */
+	class WP_Style_Engine_CSS_Rules_Container {
+		/**
+		 * A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`
+		 *
+		 * @var string
+		 */
+		protected $container;
 
-	public function set_container( $container ) {
-		$this->container = $container;
-		return $this;
-	}
+		/**
+		 * The container declarations.
+		 *
+		 * Contains a WP_Style_Engine_CSS_Rule object.
+		 *
+		 * @var WP_Style_Engine_CSS_Rule[]
+		 */
+		protected $rules = array();
 
-	public function get_container() {
-		return $this->container;
-	}
-
-	public function get_rules() {
-		return $this->rules;
-	}
-
-	public function get_rule( $selector ) {
-		return $this->rules[ $selector ] ?? null;
-	}
-
-	public function add_rule( $rule ) {
-		// @TODO should be able to add multiple rules.
-		// @TODO should be able to return a rule and update its selectors
-		// @TODO check for instance of WP_Style_Engine_CSS_Rule
-		$selector = $rule->get_selector();
-
-		if ( isset( $this->rules[ $selector ] ) ) {
-			$this->rules[ $selector ]->add_declarations( $rule->get_declarations() );
-		} else {
-			$this->rules[ $selector ] = $rule;
-		}
-		return $this;
-	}
-
-	public function get_css( $should_prettify = false, $indent_count = 0 ) {
-		$css                 = '';
-		$indent_count         = $should_prettify ? $indent_count + 1 : $indent_count;
-		$new_line            = $should_prettify ? "\n" : '';
-		$spacer              = $should_prettify ? ' ' : '';
-		foreach ( $this->rules as $rule ) {
-			$css .= $rule->get_css( $should_prettify, $indent_count );
-			$css .= $should_prettify ? "\n" : '';
+		/**
+		 * Constructor
+		 *
+		 * @param string                                              $container A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
+		 *                                                                       such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param WP_Style_Engine_CSS_Rule[]|WP_Style_Engine_CSS_Rule $rule      A WP_Style_Engine_CSS_Rule object.
+		 */
+		public function __construct( $container = '', $rule ) {
+			$this->set_container( $container );
+			$this->add_rules( $rule );
 		}
 
-		if ( empty( $css ) ) {
-			return '';
+		/**
+		 * Sets the container.
+		 *
+		 * @param string $container A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
+		 *                          such as `@media (min-width: 80rem)` or `@layer module`.
+		 *
+		 * @return WP_Style_Engine_CSS_Rules_Container Returns the object to allow chaining of methods.
+		 */
+		public function set_container( $container ) {
+			if ( ! empty( $container ) ) {
+				$this->container = $container;
+			}
+			return $this;
 		}
 
-		return "{$this->container}{$spacer}{{$new_line}{$css}}";
+		/**
+		 * Gets the container.
+		 *
+		 * @return string Container.
+		 */
+		public function get_container() {
+			return $this->container;
+		}
+
+		/**
+		 * Gets all nested rules.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule[]
+		 */
+		public function get_rules() {
+			return $this->rules;
+		}
+
+		/**
+		 * Gets a stored nested rules.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule
+		 */
+		public function get_rule( $selector ) {
+			return $this->rules[ $selector ] ?? null;
+		}
+
+		/**
+		 * Adds the rules.
+		 *
+		 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[] $container_rules An array of declarations (property => value pairs),
+		 *                                                             or a WP_Style_Engine_CSS_Declarations object.
+		 *
+		 * @return WP_Style_Engine_CSS_Rules_Container Returns the object to allow chaining of methods.
+		 */
+		public function add_rules( $container_rules ) {
+			if ( ! is_array( $container_rules ) ) {
+				$container_rules = array( $container_rules );
+			}
+
+			foreach ( $container_rules as $rule ) {
+				if ( ! $rule instanceof WP_Style_Engine_CSS_Rule ) {
+					_doing_it_wrong(
+						__METHOD__,
+						__( 'Rules passed to WP_Style_Engine_CSS_Rules_Containermust be an instance of WP_Style_Engine_CSS_Rule', 'default' ),
+						'6.6.0'
+					);
+					continue;
+				}
+
+				$container = $rule->get_container();
+
+				if ( $container !== $this->container ) {
+					_doing_it_wrong(
+						__METHOD__,
+						__( 'Rules passed to WP_Style_Engine_CSS_Rules_Container must have the same container as the container object', 'default' ),
+						'6.6.0'
+					);
+					continue;
+				}
+
+				$selector  = $rule->get_selector();
+
+				if ( isset( $this->rules[ $selector ] ) ) {
+					$this->rules[ $selector ]->add_declarations( $rule->get_declarations() );
+				} else {
+					$this->rules[ $selector ] = $rule;
+				}
+			}
+
+			return $this;
+		}
+
+		/**
+		 * Gets the nested CSS.
+		 *
+		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
+		 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+		 *
+		 * @return string
+		 */
+		public function get_css( $should_prettify = false, $indent_count = 0 ) {
+			$css                 = '';
+			$indent_count         = $should_prettify ? $indent_count + 1 : $indent_count;
+			$new_line            = $should_prettify ? "\n" : '';
+			$spacer              = $should_prettify ? ' ' : '';
+			foreach ( $this->rules as $rule ) {
+				$css .= $rule->get_css( $should_prettify, $indent_count );
+				$css .= $should_prettify ? "\n" : '';
+			}
+
+			if ( empty( $css ) ) {
+				return '';
+			}
+
+			return "{$this->container}{$spacer}{{$new_line}{$css}}";
+		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -109,21 +109,30 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		 * Gets a WP_Style_Engine_CSS_Rule object by its selector.
 		 * If the rule does not exist, it will be created.
 		 *
-		 * @param string $selector The CSS selector.
+		 * @param string|WP_Style_Engine_CSS_Rule $rule The CSS selector or a WP_Style_Engine_CSS_Rule object.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 		 */
-		public function add_rule( $selector ) {
-			$selector = trim( $selector );
+		public function add_rule( $rule ) {
+			if ( empty( $rule ) ) {
+				return;
+			}
 
-			// Bail early if there is no selector.
+			if ( $rule instanceof WP_Style_Engine_CSS_Rule ) {
+				$selector = $rule->get_selector();
+			} else {
+				$selector = trim( $rule );
+			}
+
 			if ( empty( $selector ) ) {
 				return;
 			}
 
 			// Create the rule if it doesn't exist.
 			if ( empty( $this->rules[ $selector ] ) ) {
-				$this->rules[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
+				if ( ! empty( $selector ) ) {
+					$this->rules[ $selector ] = $rule instanceof WP_Style_Engine_CSS_Rule ? $rule : new WP_Style_Engine_CSS_Rule( $selector );
+				}
 			}
 
 			return $this->rules[ $selector ];

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -110,24 +110,15 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		 * If the rule does not exist, it will be created.
 		 *
 		 * @param string $selector The CSS selector.
-		 * @param string $at_rule  The CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 		 */
-		public function add_rule( $selector, $at_rule = '' ) {
+		public function add_rule( $selector ) {
 			$selector = trim( $selector );
-			$at_rule  = trim( $at_rule );
 
 			// Bail early if there is no selector.
 			if ( empty( $selector ) ) {
 				return;
-			}
-
-			if ( ! empty( $at_rule ) ) {
-				if ( empty( $this->rules[ "$at_rule $selector" ] ) ) {
-					$this->rules[ "$at_rule $selector" ] = new WP_Style_Engine_CSS_Rule( $selector, array(), $at_rule );
-				}
-				return $this->rules[ "$at_rule $selector" ];
 			}
 
 			// Create the rule if it doesn't exist.

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -135,7 +135,14 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 			/*
 				Create a new WP_Style_Engine_CSS_Rule rule by default if it doesn't exist.
 			*/
-			if ( empty( $this->rules[ $selector ] ) ) {
+			if ( isset( $this->rules[ $selector ] ) ) {
+				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Container ) {
+					$this->rules[ $selector ]->add_rules( $rule->get_rules() );
+				}
+				if ( $is_rules_object ) {
+					$this->rules[ $selector ]->add_declarations( $rule->get_declarations() );
+				}
+			} else {
 				$this->rules[ $selector ] = $is_rules_object ? $rule : new WP_Style_Engine_CSS_Rule( $selector );
 			}
 

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -118,36 +118,26 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 				return;
 			}
 
-			$is_rules_object = $rule instanceof WP_Style_Engine_CSS_Rules_Container || $rule instanceof WP_Style_Engine_CSS_Rule;
-
-			if ( $is_rules_object ) {
-				$selector = $rule->get_selector();
-			}
-
 			if ( is_string( $rule ) ) {
 				$selector = trim( $rule );
+				/*
+					Create a new WP_Style_Engine_CSS_Rule rule by default if it doesn't exist.
+				*/
+				if ( ! isset( $this->rules[ $selector ] ) ) {
+					$rule = new WP_Style_Engine_CSS_Rule( $selector );
+				} else {
+					return $this->rules[ $selector ];
+				}
 			}
 
-			if ( empty( $selector ) ) {
-				return;
-			}
-
-			/*
-				Create a new WP_Style_Engine_CSS_Rule rule by default if it doesn't exist.
-			*/
+			$selector = $rule->get_selector();
 			if ( isset( $this->rules[ $selector ] ) ) {
-				// @TODO Create a unit test to check if an incoming rule is a container too. Don't overwrite existing containers?
-				// @TODO Maybe have a helper function on the class to check if the rule is a container?
-				// Or store them in the store in different containers?
-				// Or an ->merge() method?
-				if ( $this->rules[ $selector ] instanceof WP_Style_Engine_CSS_Rules_Container && $rule instanceof WP_Style_Engine_CSS_Rules_Container ) {
+				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Container && $this->rules[ $selector ] instanceof WP_Style_Engine_CSS_Rules_Container ) {
 					$this->rules[ $selector ]->add_rules( $rule->get_rules() );
 				}
-				if ( $is_rules_object ) {
-					$this->rules[ $selector ]->add_declarations( $rule->get_declarations() );
-				}
+				$this->rules[ $selector ]->add_declarations( $rule->get_declarations() );
 			} else {
-				$this->rules[ $selector ] = $is_rules_object ? $rule : new WP_Style_Engine_CSS_Rule( $selector );
+				$this->rules[ $selector ] = $rule;
 			}
 
 			return $this->rules[ $selector ];

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -109,7 +109,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		 * Gets a WP_Style_Engine_CSS_Rule object by its selector.
 		 * If the rule does not exist, it will be created.
 		 *
-		 * @param string|WP_Style_Engine_CSS_Rule $rule The CSS selector or a WP_Style_Engine_CSS_Rule object.
+		 * @param string|WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rules_Container $rule The CSS selector or a WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rules_Container object.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 		 */
@@ -118,9 +118,13 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 				return;
 			}
 
-			if ( $rule instanceof WP_Style_Engine_CSS_Rule ) {
+			$is_rules_object = $rule instanceof WP_Style_Engine_CSS_Rules_Container || $rule instanceof WP_Style_Engine_CSS_Rule;
+
+			if ( $is_rules_object ) {
 				$selector = $rule->get_selector();
-			} else {
+			}
+
+			if ( is_string( $rule ) ) {
 				$selector = trim( $rule );
 			}
 
@@ -128,11 +132,11 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 				return;
 			}
 
-			// Create the rule if it doesn't exist.
+			/*
+				Create a new WP_Style_Engine_CSS_Rule rule by default if it doesn't exist.
+			*/
 			if ( empty( $this->rules[ $selector ] ) ) {
-				if ( ! empty( $selector ) ) {
-					$this->rules[ $selector ] = $rule instanceof WP_Style_Engine_CSS_Rule ? $rule : new WP_Style_Engine_CSS_Rule( $selector );
-				}
+				$this->rules[ $selector ] = $is_rules_object ? $rule : new WP_Style_Engine_CSS_Rule( $selector );
 			}
 
 			return $this->rules[ $selector ];

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -136,7 +136,11 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 				Create a new WP_Style_Engine_CSS_Rule rule by default if it doesn't exist.
 			*/
 			if ( isset( $this->rules[ $selector ] ) ) {
-				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Container ) {
+				// @TODO Create a unit test to check if an incoming rule is a container too. Don't overwrite existing containers?
+				// @TODO Maybe have a helper function on the class to check if the rule is a container?
+				// Or store them in the store in different containers?
+				// Or an ->merge() method?
+				if ( $this->rules[ $selector ] instanceof WP_Style_Engine_CSS_Rules_Container && $rule instanceof WP_Style_Engine_CSS_Rules_Container ) {
 					$this->rules[ $selector ]->add_rules( $rule->get_rules() );
 				}
 				if ( $is_rules_object ) {

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 
 				if ( ! empty( $container ) ) {
 					if ( isset( $this->css_containers[ $container ] ) ) {
-						$this->css_containers[ $container ]->add_rule( $rule );
+						$this->css_containers[ $container ]->add_rules( $rule );
 					} else {
 						$this->css_containers[ $container ] = new WP_Style_Engine_CSS_Rules_Container( $container, $rule );
 					}

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 
 			foreach ( $css_rules as $rule ) {
 				// Check for rules that need to be nested in containers.
-				$selector  = $rule->get_selector();
+				$selector = $rule->get_selector();
 
 				if ( empty( $selector ) ) {
 					continue;

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -63,7 +63,7 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 		/**
 		 * Adds rules to be processed.
 		 *
-		 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[] $css_rules A single, or an array of, WP_Style_Engine_CSS_Rule objects from a store or otherwise.
+		 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[]|WP_Style_Engine_CSS_Rules_Container|WP_Style_Engine_CSS_Rules_Container[] $css_rules A single, or an array of, WP_Style_Engine_CSS_Rule objects from a store or otherwise.
 		 *
 		 * @return WP_Style_Engine_Processor Returns the object to allow chaining methods.
 		 */
@@ -74,23 +74,26 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 
 			foreach ( $css_rules as $rule ) {
 				// Check for rules that need to be nested in containers.
-				$container = $rule->get_container();
 				$selector  = $rule->get_selector();
 
-				if ( ! empty( $container ) ) {
-					if ( isset( $this->css_containers[ $container ] ) ) {
-						$this->css_containers[ $container ]->add_rules( $rule );
+				if ( empty( $selector ) ) {
+					continue;
+				}
+
+				if ( $rule instanceof WP_Style_Engine_CSS_Rule ) {
+					if ( isset( $this->css_rules[ $selector ] ) ) {
+						$this->css_rules[ $selector ]->add_declarations( $rule->get_declarations() );
 					} else {
-						$this->css_containers[ $container ] = new WP_Style_Engine_CSS_Rules_Container( $container, $rule );
+						$this->css_rules[ $selector ] = $rule;
 					}
 					continue;
 				}
 
-				if ( ! empty( $selector ) ) {
-					if ( isset( $this->css_rules[ $selector ] ) ) {
-						$this->css_rules[ $selector ]->add_declarations( $rule->get_declarations() );
+				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Container ) {
+					if ( isset( $this->css_containers[ $selector ] ) ) {
+						$this->css_containers[ $selector ]->add_rules( $rule->get_rules() );
 					} else {
-						$this->css_rules[ $rule->get_selector() ] = $rule;
+						$this->css_containers[ $selector ] = $rule;
 					}
 				}
 			}

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -80,6 +80,11 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 					continue;
 				}
 
+				/*
+				 * Merge existing rule and container objects or create new ones.
+				 * Containers and rules are stored in separate arrays to allow for
+				 * separate processing.
+				 */
 				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Container ) {
 					if ( isset( $this->css_containers[ $selector ] ) ) {
 						$this->css_containers[ $selector ]->add_rules( $rule->get_rules() );

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -80,20 +80,21 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 					continue;
 				}
 
+				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Container ) {
+					if ( isset( $this->css_containers[ $selector ] ) ) {
+						$this->css_containers[ $selector ]->add_rules( $rule->get_rules() );
+						$this->css_containers[ $selector ]->add_declarations( $rule->get_declarations() );
+					} else {
+						$this->css_containers[ $selector ] = $rule;
+					}
+					continue;
+				}
+
 				if ( $rule instanceof WP_Style_Engine_CSS_Rule ) {
 					if ( isset( $this->css_rules[ $selector ] ) ) {
 						$this->css_rules[ $selector ]->add_declarations( $rule->get_declarations() );
 					} else {
 						$this->css_rules[ $selector ] = $rule;
-					}
-					continue;
-				}
-
-				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Container ) {
-					if ( isset( $this->css_containers[ $selector ] ) ) {
-						$this->css_containers[ $selector ]->add_rules( $rule->get_rules() );
-					} else {
-						$this->css_containers[ $selector ] = $rule;
 					}
 				}
 			}

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -626,7 +626,7 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 *
 		 * @return string A compiled CSS string.
 		 */
-		public static function compile_css( $css_declarations, $css_selector, $container = '' ) {
+		public static function compile_css( $css_declarations, $css_selector ) {
 			if ( empty( $css_declarations ) || ! is_array( $css_declarations ) ) {
 				return '';
 			}
@@ -634,12 +634,6 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 			// Return an entire rule if there is a selector.
 			if ( $css_selector ) {
 				$css_rule = new WP_Style_Engine_CSS_Rule( $css_selector, $css_declarations );
-				if ( $container ) {
-					$css_rule->set_container( $container );
-					$css_container = new WP_Style_Engine_CSS_Rules_Container( $container, $css_rule );
-					return $css_container->get_css();
-				}
-
 				return $css_rule->get_css();
 			}
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -626,7 +626,7 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 *
 		 * @return string A compiled CSS string.
 		 */
-		public static function compile_css( $css_declarations, $css_selector ) {
+		public static function compile_css( $css_declarations, $css_selector, $container = '' ) {
 			if ( empty( $css_declarations ) || ! is_array( $css_declarations ) ) {
 				return '';
 			}
@@ -634,6 +634,12 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 			// Return an entire rule if there is a selector.
 			if ( $css_selector ) {
 				$css_rule = new WP_Style_Engine_CSS_Rule( $css_selector, $css_declarations );
+				if ( $container ) {
+					$css_rule->set_container( $container );
+					$css_container = new WP_Style_Engine_CSS_Rules_Container( $container, $css_rule );
+					return $css_container->get_css();
+				}
+
 				return $css_rule->get_css();
 			}
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -358,11 +358,11 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 *
 		 * @return void.
 		 */
-		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $css_at_rule = '' ) {
+		public static function store_css_rule( $store_name, $css_selector, $css_declarations ) {
 			if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
 				return;
 			}
-			static::get_store( $store_name )->add_rule( $css_selector, $css_at_rule )->add_declarations( $css_declarations );
+			static::get_store( $store_name )->add_rule( $css_selector )->add_declarations( $css_declarations );
 		}
 
 		/**

--- a/packages/style-engine/style-engine.php
+++ b/packages/style-engine/style-engine.php
@@ -148,7 +148,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		$new_rule  = null;
 
 		if ( $selector ) {
-			$new_rule  = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
+			$new_rule = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
 		}
 
 		if ( $container ) {

--- a/packages/style-engine/style-engine.php
+++ b/packages/style-engine/style-engine.php
@@ -57,15 +57,15 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 	$styles_output = array();
 
 	if ( ! empty( $parsed_styles['declarations'] ) ) {
-		$container                     = $options['container'] ?? null;
-		$selector                      = $options['selector'] ?? null;
-		$css_declarations              = new WP_Style_Engine_CSS_Declarations( $parsed_styles['declarations'] );
-		$new_rule                      = null;
+		$container        = $options['container'] ?? null;
+		$selector         = $options['selector'] ?? null;
+		$css_declarations = new WP_Style_Engine_CSS_Declarations( $parsed_styles['declarations'] );
+		$new_rule         = null;
 
 		if ( $selector ) {
 			$new_rule = new WP_Style_Engine_CSS_Rule( $options['selector'], $css_declarations );
 			if ( $container ) {
-				$css_container = new WP_Style_Engine_CSS_Rules_Container( $container, $new_rule );
+				$css_container        = new WP_Style_Engine_CSS_Rules_Container( $container, $new_rule );
 				$styles_output['css'] = $css_container->get_css();
 			} else {
 				$styles_output['css'] = $new_rule->get_css();
@@ -138,7 +138,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		}
 
 		$container = $css_rule['container'] ?? null;
-		$new_rule = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
+		$new_rule  = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
 
 		if ( $container ) {
 			$new_rule = new WP_Style_Engine_CSS_Rules_Container( $container, $new_rule );

--- a/packages/style-engine/style-engine.php
+++ b/packages/style-engine/style-engine.php
@@ -121,7 +121,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 			continue;
 		}
 		// @TODO should this be in $options['container']?
-		$container = $css_rules['container'] ?? null;
+		$container = $css_rule['container'] ?? null;
 
 		if ( ! empty( $options['context'] ) ) {
 			// @TODO how to combine rules with the same container? in a container_rule class?
@@ -131,6 +131,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		}
 		$new_rule = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
 		$new_rule->set_container( $container );
+
 		$css_rule_objects[] = $new_rule;
 	}
 

--- a/packages/style-engine/style-engine.php
+++ b/packages/style-engine/style-engine.php
@@ -65,7 +65,6 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 		if ( $selector ) {
 			$new_rule = new WP_Style_Engine_CSS_Rule( $options['selector'], $css_declarations );
 			if ( $container ) {
-				$new_rule->set_container( $container );
 				$css_container = new WP_Style_Engine_CSS_Rules_Container( $container, $new_rule );
 				$styles_output['css'] = $css_container->get_css();
 			} else {
@@ -139,8 +138,11 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		}
 
 		$container = $css_rule['container'] ?? null;
-		$new_rule  = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
-		$new_rule->set_container( $container );
+		$new_rule = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
+
+		if ( $container ) {
+			$new_rule = new WP_Style_Engine_CSS_Rules_Container( $container, $new_rule );
+		}
 
 		if ( ! empty( $options['context'] ) ) {
 			WP_Style_Engine::get_store( $options['context'] )->add_rule( $new_rule );

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-container-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-container-test.php
@@ -44,15 +44,15 @@ class WP_Style_Engine_CSS_Rules_Container_Test extends WP_UnitTestCase {
 	 */
 	public function test_should_only_add_rule_objects() {
 		$css_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@media not all and (hover: hover)' );
-		$selector      = '.goanna';
-		$css_rule_1    = new WP_Style_Engine_CSS_Rule_Gutenberg(
-			$selector,
-			array(
-				'font-size' => '2rem',
-			)
-		);
+
 		$css_container->add_rules( '' );
-		$this->assertSame( array(), $css_container->get_rules(), 'Return value of get_rules() does not match expected rules.' );
+		$this->assertSame( array(), $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when empty string added.' );
+
+		$css_container->add_rules( array() );
+		$this->assertSame( array(), $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when array() added.' );
+
+		$css_container->add_rules( new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@media not all and (hover: hover)' ) );
+		$this->assertSame( array(), $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when unknown class added.' );
 	}
 
 	/**

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-container-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-container-test.php
@@ -37,22 +37,19 @@ class WP_Style_Engine_CSS_Rules_Container_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that only WP_Style_Engine_CSS_Rule can be added to a container.
+	 * Tests that empty values cannot be added.
 	 *
 	 * @covers ::add_rules
 	 * @covers ::get_rules
 	 */
-	public function test_should_only_add_rule_objects() {
+	public function test_cannot_add_empty_values() {
 		$css_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@media not all and (hover: hover)' );
 
 		$css_container->add_rules( '' );
-		$this->assertSame( array(), $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when empty string added.' );
+		$this->assertEmpty( $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when empty string added.' );
 
 		$css_container->add_rules( array() );
-		$this->assertSame( array(), $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when array() added.' );
-
-		$css_container->add_rules( new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@media not all and (hover: hover)' ) );
-		$this->assertSame( array(), $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when unknown class added.' );
+		$this->assertEmpty( $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when array() added.' );
 	}
 
 	/**

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-container-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-container-test.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Tests the Style Engine CSS Rules Container class.
+ *
+ * @package    Gutenberg
+ * @subpackage style-engine
+ */
+
+/**
+ * Tests for registering, storing and generating CSS rules containers.
+ *
+ * @group style-engine
+ * @coversDefaultClass WP_Style_Engine_CSS_Rules_Container
+ */
+class WP_Style_Engine_CSS_Rules_Container_Test extends WP_UnitTestCase {
+	/**
+	 * Tests that declarations are set on instantiation.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_should_instantiate_with_selector_and_rules() {
+		$container_selector = '#gecko';
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			'&:hover',
+			array(
+				'background-position' => '50% 50%',
+				'color'               => 'green',
+			)
+		);
+		$css_container      = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( $container_selector, $css_rule );
+
+		$this->assertSame( $container_selector, $css_container->get_selector(), 'Return value of get_selector() does not match value passed to constructor.' );
+
+		$expected = "$container_selector{{$css_rule->get_css()}}";
+
+		$this->assertSame( $expected, $css_container->get_css(), 'Value returned by get_css() does not match expected CSS string.' );
+	}
+
+	/**
+	 * Tests that only WP_Style_Engine_CSS_Rule can be added to a container.
+	 *
+	 * @covers ::add_rules
+	 * @covers ::get_rules
+	 */
+	public function test_should_only_add_rule_objects() {
+		$css_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@media not all and (hover: hover)' );
+		$selector      = '.goanna';
+		$css_rule_1    = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			$selector,
+			array(
+				'font-size' => '2rem',
+			)
+		);
+		$css_container->add_rules( '' );
+		$this->assertSame( array(), $css_container->get_rules(), 'Return value of get_rules() does not match expected rules.' );
+	}
+
+	/**
+	 * Tests that nested rule declaration properties are deduplicated.
+	 *
+	 * @covers ::add_rules
+	 * @covers ::get_css
+	 */
+	public function test_should_dedupe_properties_in_rules() {
+		$css_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@media not all and (hover: hover)' );
+		$selector      = '.goanna';
+		$css_rule_1    = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			$selector,
+			array(
+				'font-size' => '2rem',
+			)
+		);
+		$css_container->add_rules( $css_rule_1 );
+
+		$this->assertSame( '@media not all and (hover: hover){.goanna{font-size:2rem;}}', $css_container->get_css(), 'Return value of get_css() does not match expected CSS container CSS.' );
+
+		$css_rule_2 = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			$selector,
+			array(
+				'font-size' => '4px',
+			)
+		);
+		$css_container->add_rules( $css_rule_2 );
+
+		$this->assertSame( '@media not all and (hover: hover){.goanna{font-size:4px;}}', $css_container->get_css(), 'Return value of get_css() does not match expected value with overwritten rule declaration.' );
+	}
+
+	/**
+	 * Tests that rules can be added to existing containers.
+	 *
+	 * @covers ::add_rules
+	 * @covers ::get_rule
+	 * @covers ::get_css
+	 */
+	public function test_should_add_rules_to_existing_containers() {
+		$css_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@media screen, print' );
+
+		$css_rule_1 = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			'body',
+			array(
+				'line-height' => '0.1',
+			)
+		);
+		$css_container->add_rules( $css_rule_1 );
+
+		$css_rule_2 = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			'p',
+			array(
+				'line-height' => '0.9',
+			)
+		);
+		$css_container->add_rules( $css_rule_2 );
+
+		$this->assertEquals( $css_rule_2, $css_container->get_rule( 'p' ), 'Return value of get_rule() does not match expected value.' );
+
+		$expected = '@media screen, print{body{line-height:0.1;}p{line-height:0.9;}}';
+
+		$this->assertSame( $expected, $css_container->get_css(), 'Return value of get_css() does not match expected value.' );
+	}
+
+	/**
+	 * Tests setting a selector to a container.
+	 *
+	 * @covers ::set_selector
+	 */
+	public function test_should_set_selector() {
+		$css_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@layer state' );
+
+		$this->assertSame( '@layer state', $css_container->get_selector(), 'Return value of get_selector() does not match value passed to constructor.' );
+
+		$css_container->set_selector( '@layer pony' );
+
+		$this->assertSame( '@layer pony', $css_container->get_selector(), 'Return value of get_selector() does not match value passed to set_selector().' );
+	}
+
+	/**
+	 * Tests generating a CSS rule string.
+	 *
+	 * @covers ::get_css
+	 */
+	public function test_should_generate_css_rule_string() {
+		$selector           = '.chips';
+		$input_declarations = array(
+			'margin-top' => '10px',
+			'font-size'  => '2rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
+		$css_container      = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@layer sauce', $css_rule );
+		$expected           = "@layer sauce{{$selector}{{$css_declarations->get_declarations_string()}}}";
+
+		$this->assertSame( $expected, $css_container->get_css() );
+	}
+
+	/**
+	 * Tests that an empty string will be returned where there are no rules in a CSS container.
+	 *
+	 * @covers ::get_css
+	 */
+	public function test_should_return_empty_string_with_no_rules() {
+		$selector           = '.holmes';
+		$input_declarations = array();
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
+		$css_container      = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@layer sauce', $css_rule );
+
+		$this->assertSame( '', $css_container->get_css() );
+	}
+
+	/**
+	 * Tests that CSS containers are prettified.
+	 *
+	 * @covers ::get_css
+	 */
+	public function test_should_prettify_css_rule_output() {
+		$selector           = '.baptiste';
+		$input_declarations = array(
+			'margin-left' => '0',
+			'font-family' => 'Detective Sans',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
+		$expected           = '@container (width < 650px) {
+	.baptiste {
+		margin-left: 0;
+		font-family: Detective Sans;
+	}
+}';
+		$css_container      = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@container (width < 650px)', $css_rule );
+
+		$this->assertSame( $expected, $css_container->get_css( true ) );
+	}
+}

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -148,14 +148,15 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	public function test_should_add_rule_object_to_existing_store() {
 		$new_hotdog_store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'hotdog' );
 
-		$selector         = '.wp-block-pickle a:hover';
+		$selector         = '&.pickle';
 		$pickle_rule      = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, array(
 			'color'         => 'brown',
 			'border-color'  => 'yellow',
 			'border-radius' => '10rem',
 		) );
-		$added_rule       = $new_hotdog_store->add_rule( $pickle_rule );
-		$expected         = $pickle_rule->get_css();
+		$pickle_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.hotdog', $pickle_rule );
+		$added_rule       = $new_hotdog_store->add_rule( $pickle_container );
+		$expected         = ".hotdog{&.pickle{color:brown;border-color:yellow;border-radius:10rem;}}";
 
 		$this->assertSame( $expected, $added_rule->get_css(), 'Return value of store rule get_css() matches passed rule object get_css().' );
 	}

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -145,6 +145,53 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::add_rule
 	 */
+	public function test_should_combine_existing_rule_objects_to_store() {
+		$new_hotdog_store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'hotdog' );
+
+		$selector         = '.pickle';
+		$pickle_rule      = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			$selector,
+			array(
+				'color'         => 'brown',
+				'border-color'  => 'yellow',
+				'border-radius' => '10rem',
+			)
+		);
+		$pickle_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.hotdog', $pickle_rule );
+		$added_rule       = $new_hotdog_store->add_rule( $pickle_container );
+		$expected         = '.hotdog{.pickle{color:brown;border-color:yellow;border-radius:10rem;}}';
+
+		$this->assertSame( $expected, $added_rule->get_css(), 'Return value of store rule get_css() matches passed rule object get_css().' );
+
+		$pickle_container_2 = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.hotdog', array(
+				new WP_Style_Engine_CSS_Rule_Gutenberg(
+					'.pickle-2',
+					array(
+						'color'         => 'pink',
+						'border-color'  => 'blue',
+						'border-radius' => '11rem',
+					)
+				),
+				new WP_Style_Engine_CSS_Rule_Gutenberg(
+					$selector,
+					array(
+						'border-radius' => '1px',
+					)
+				)
+			)
+		);
+		$pickle_container->add_declarations( array( 'padding' => '100px' ) );
+		$added_rule       = $new_hotdog_store->add_rule( $pickle_container_2 );
+		$expected         = '.hotdog{padding:100px;.pickle{color:brown;border-color:yellow;border-radius:1px;}.pickle-2{color:pink;border-color:blue;border-radius:11rem;}}';
+		$this->assertSame( $expected, $added_rule->get_css(), 'Return value of store rule get_css() matches passed rule object get_css().' );
+	}
+
+
+	/**
+	 * Tests adding rules to an existing store.
+	 *
+	 * @covers ::add_rule
+	 */
 	public function test_should_add_rule_object_to_existing_store() {
 		$new_hotdog_store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'hotdog' );
 

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -163,7 +163,9 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $added_rule->get_css(), 'Return value of store rule get_css() matches passed rule object get_css().' );
 
-		$pickle_container_2 = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.hotdog', array(
+		$pickle_container_2 = new WP_Style_Engine_CSS_Rules_Container_Gutenberg(
+			'.hotdog',
+			array(
 				new WP_Style_Engine_CSS_Rule_Gutenberg(
 					'.pickle-2',
 					array(
@@ -177,12 +179,12 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 					array(
 						'border-radius' => '1px',
 					)
-				)
+				),
 			)
 		);
 		$pickle_container->add_declarations( array( 'padding' => '100px' ) );
-		$added_rule       = $new_hotdog_store->add_rule( $pickle_container_2 );
-		$expected         = '.hotdog{padding:100px;.pickle{color:brown;border-color:yellow;border-radius:1px;}.pickle-2{color:pink;border-color:blue;border-radius:11rem;}}';
+		$added_rule = $new_hotdog_store->add_rule( $pickle_container_2 );
+		$expected   = '.hotdog{padding:100px;.pickle{color:brown;border-color:yellow;border-radius:1px;}.pickle-2{color:pink;border-color:blue;border-radius:11rem;}}';
 		$this->assertSame( $expected, $added_rule->get_css(), 'Return value of store rule get_css() matches passed rule object get_css().' );
 	}
 

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -141,6 +141,26 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests adding rules to an existing store.
+	 *
+	 * @covers ::add_rule
+	 */
+	public function test_should_add_rule_object_to_existing_store() {
+		$new_hotdog_store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'hotdog' );
+
+		$selector         = '.wp-block-pickle a:hover';
+		$pickle_rule      = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, array(
+			'color'         => 'brown',
+			'border-color'  => 'yellow',
+			'border-radius' => '10rem',
+		) );
+		$added_rule       = $new_hotdog_store->add_rule( $pickle_rule );
+		$expected         = $pickle_rule->get_css();
+
+		$this->assertSame( $expected, $added_rule->get_css(), 'Return value of store rule get_css() matches passed rule object get_css().' );
+	}
+
+	/**
 	 * Tests that all stored rule objects are returned.
 	 *
 	 * @covers ::get_all_rules

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -148,7 +148,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	public function test_should_add_rule_object_to_existing_store() {
 		$new_hotdog_store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'hotdog' );
 
-		$selector         = '&.pickle';
+		$selector         = '.pickle';
 		$pickle_rule      = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, array(
 			'color'         => 'brown',
 			'border-color'  => 'yellow',
@@ -156,7 +156,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 		) );
 		$pickle_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.hotdog', $pickle_rule );
 		$added_rule       = $new_hotdog_store->add_rule( $pickle_container );
-		$expected         = ".hotdog{&.pickle{color:brown;border-color:yellow;border-radius:10rem;}}";
+		$expected         = ".hotdog{.pickle{color:brown;border-color:yellow;border-radius:10rem;}}";
 
 		$this->assertSame( $expected, $added_rule->get_css(), 'Return value of store rule get_css() matches passed rule object get_css().' );
 	}

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -141,6 +141,65 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests separation of stores.
+	 *
+	 * @covers ::add_rule
+	 * @covers ::get_store
+	 */
+	public function test_should_add_rules_to_separate_stores() {
+		$store_one           = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'one' );
+		$store_one_rule      = $store_one->add_rule( '.one' );
+		$store_one_container = $store_one->add_rule( new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.one_container' ) );
+
+		$store_two      = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'two' );
+		$store_rule_two = $store_two->add_rule( '.two' );
+
+		$this->assertSame(
+			array(
+				'.one'           => $store_one_rule,
+				'.one_container' => $store_one_container,
+			),
+			WP_Style_Engine_Gutenberg::get_store( 'one' )->get_all_rules(),
+			'get_all_rules() does not return expected array of rules for store one.'
+		);
+
+		$this->assertSame(
+			array(
+				'.two' => $store_rule_two,
+			),
+			WP_Style_Engine_Gutenberg::get_store( 'two' )->get_all_rules(),
+			'get_all_rules() does not return expected array of rules for store two.'
+		);
+	}
+
+	/**
+	 * Tests adding identical selectors.
+	 *
+	 * @covers ::add_rule
+	 */
+	public function test_should_not_overwrite_existing_rules() {
+		$store_one           = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'one' );
+		$store_one_container = $store_one->add_rule( new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.one' ) );
+		$store_one_rule      = $store_one->add_rule( '.one' );
+
+		$store_two           = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'two' );
+		$store_rule_two      = $store_two->add_rule( '.two' );
+		$store_two_container = $store_two->add_rule( new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.two' ) );
+
+		$this->assertSame(
+			$store_one_rule,
+			$store_one_container,
+			'add_rule() does not return already existing return .one rule.'
+		);
+
+		$this->assertSame(
+			$store_two_container,
+			$store_rule_two,
+			'add_rule() does not return already existing return .two rule.'
+		);
+	}
+
+	/**
 	 * Tests adding rules to an existing store.
 	 *
 	 * @covers ::add_rule

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -149,14 +149,17 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 		$new_hotdog_store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'hotdog' );
 
 		$selector         = '.pickle';
-		$pickle_rule      = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, array(
-			'color'         => 'brown',
-			'border-color'  => 'yellow',
-			'border-radius' => '10rem',
-		) );
+		$pickle_rule      = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			$selector,
+			array(
+				'color'         => 'brown',
+				'border-color'  => 'yellow',
+				'border-radius' => '10rem',
+			)
+		);
 		$pickle_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '.hotdog', $pickle_rule );
 		$added_rule       = $new_hotdog_store->add_rule( $pickle_container );
-		$expected         = ".hotdog{.pickle{color:brown;border-color:yellow;border-radius:10rem;}}";
+		$expected         = '.hotdog{.pickle{color:brown;border-color:yellow;border-radius:10rem;}}';
 
 		$this->assertSame( $expected, $added_rule->get_css(), 'Return value of store rule get_css() matches passed rule object get_css().' );
 	}

--- a/phpunit/style-engine/class-wp-style-engine-processor-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-processor-test.php
@@ -337,7 +337,6 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nicer_css_rule->set_container( '@layer nicety' );
 		$a_nicer_css_container = new WP_Style_Engine_CSS_Rules_Container_Gutenberg( '@layer nicety', $a_nicer_css_rule );
 
 		$a_nice_processor = new WP_Style_Engine_Processor_Gutenberg();

--- a/phpunit/style-engine/class-wp-style-engine-processor-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-processor-test.php
@@ -58,7 +58,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nice_css_rule->set_at_rule( '@media (min-width: 80rem)' );
+		$a_nice_css_rule->set_container( '@media (min-width: 80rem)' );
 
 		$a_nicer_css_rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.a-nicer-rule' );
 		$a_nicer_css_rule->add_declarations(
@@ -68,7 +68,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nicer_css_rule->set_at_rule( '@layer nicety' );
+		$a_nicer_css_rule->set_container( '@layer nicety' );
 
 		$a_nice_processor = new WP_Style_Engine_Processor_Gutenberg();
 		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
@@ -143,7 +143,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'orange',
 			)
 		);
-		$a_wonderful_css_rule->set_at_rule( '@media (min-width: 80rem)' );
+		$a_wonderful_css_rule->set_container( '@media (min-width: 80rem)' );
 
 		$a_very_wonderful_css_rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.a-very_wonderful-rule' );
 		$a_very_wonderful_css_rule->add_declarations(
@@ -152,7 +152,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'orange',
 			)
 		);
-		$a_very_wonderful_css_rule->set_at_rule( '@layer wonderfulness' );
+		$a_very_wonderful_css_rule->set_container( '@layer wonderfulness' );
 
 		$a_wonderful_processor = new WP_Style_Engine_Processor_Gutenberg();
 		$a_wonderful_processor->add_rules( array( $a_wonderful_css_rule, $a_very_wonderful_css_rule ) );
@@ -412,7 +412,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_panda_renderer = new WP_Style_Engine_Processor_Gutenberg();
 		$a_panda_renderer->add_store( $panda_store );
 		$this->assertSame(
-			'@container (width > 400px){.blueberry{background-color:blue;}}.wp-block-mushroom a:hover{padding:100px;}',
+			'.wp-block-mushroom a:hover{padding:100px;}@container (width > 400px){.blueberry{background-color:blue;}}',
 			$a_panda_renderer->get_css( array( 'prettify' => false ) ),
 			'Returns processed CSS rules with containers'
 		);
@@ -429,21 +429,21 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_panda_renderer->add_rules( $a_raspberry_rule );
 
 		$this->assertSame(
-			'@container (width > 400px){.blueberry{background-color:blue;}.raspberry{background-color:red;}}.wp-block-mushroom a:hover{padding:100px;}',
+			'.wp-block-mushroom a:hover{padding:100px;}@container (width > 400px){.blueberry{background-color:blue;}.raspberry{background-color:red;}}',
 			$a_panda_renderer->get_css( array( 'prettify' => false ) ),
 			'Returns processed CSS rules with rules added to containers'
 		);
 
-		$expected_prettified = '@container (width > 400px) {
+		$expected_prettified = '.wp-block-mushroom a:hover {
+	padding: 100px;
+}
+@container (width > 400px) {
 	.blueberry {
 		background-color: blue;
 	}
 	.raspberry {
 		background-color: red;
 	}
-}
-.wp-block-mushroom a:hover {
-	padding: 100px;
 }
 ';
 		$this->assertSame(

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -887,20 +887,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 		$this->assertSame( '.foo{background-color:red;@media (orientation: landscape){background-color:blue;}@media (min-width > 1024px){background-color:cotton-blue;}}', $compiled_stylesheet );
 	}
 
-	/*
-	.foo {
-  display: grid;
-
-  @media (orientation: landscape) {
-    grid-auto-flow: column;
-
-    @media (min-width > 1024px) {
-      max-inline-size: 1024px;
-    }
-  }
-}
-	 */
-
 	/**
 	 * Tests that incoming styles are deduped and merged.
 	 *

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -236,7 +236,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'style_block_with_nested_selector'                    => array(
+			'style_block_with_nested_selector'             => array(
 				'block_styles'    => array(
 					'spacing' => array(
 						'padding' => array(
@@ -247,7 +247,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'options'         => array( 'selector' => '.wp-selector > p', 'container' => '@layer sandwich' ),
+				'options'         => array(
+					'selector'  => '.wp-selector > p',
+					'container' => '@layer sandwich',
+				),
 				'expected_output' => array(
 					'css'          => '@layer sandwich{.wp-selector > p{padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;}}',
 					'declarations' => array(
@@ -709,8 +712,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'selector'     => '.saruman',
 				'container'    => '@container (min-width: 700px)',
 				'declarations' => array(
-					'color'        => 'black',
-					'font-family'  => 'The-Great-Eye',
+					'color'       => 'black',
+					'font-family' => 'The-Great-Eye',
 				),
 			),
 			array(

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -617,6 +617,26 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	public function test_should_get_stored_stylesheet_from_context() {
 		$css_rules           = array(
 			array(
+				'selector'     => '.pippin',
+				'container'    => '@container (min-width: 700px)',
+				'declarations' => array(
+					'color'        => 'brown',
+					'height'       => '12px',
+					'width'        => '15px',
+					'border-style' => 'dashed',
+				),
+			),
+			array(
+				'selector'     => '.merry',
+				'container'    => '@container (min-width: 700px)',
+				'declarations' => array(
+					'color'        => 'khaki',
+					'height'       => '23px',
+					'width'        => '23px',
+					'border-style' => 'solid',
+				),
+			),
+			array(
 				'selector'     => '.frodo',
 				'declarations' => array(
 					'color'        => 'brown',
@@ -634,7 +654,16 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'border-style' => 'solid',
 				),
 			),
+			array(
+				'selector'     => '.pippin',
+				'container'    => '@container (min-width: 700px)',
+				'declarations' => array(
+					'color'        => 'tan',
+				),
+			),
 		);
+
+		// Unit tests for the `wp_style_engine_get_stylesheet_from_css_rules` function below.
 		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$css_rules,
 			array(

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -687,11 +687,17 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests returning a generated stylesheet from a set of nested rules.
 	 */
-	public function test_should_return_stylesheet_from_nested_css_rules() {
+	public function test_should_return_stylesheet_with_combined_nested_css_rules_printed_after_non_nested() {
 		$css_rules = array(
 			array(
 				'selector'     => '.saruman',
-				'container'    => '@supports (align-self: stretch)',
+				'declarations' => array(
+					'letter-spacing' => '1px',
+				),
+			),
+			array(
+				'selector'     => '.saruman',
+				'container'    => '@container (min-width: 700px)',
 				'declarations' => array(
 					'color'        => 'white',
 					'height'       => '100px',
@@ -701,10 +707,24 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 			array(
 				'selector'     => '.saruman',
-				'container'    => '@supports (align-self: stretch)',
+				'container'    => '@container (min-width: 700px)',
 				'declarations' => array(
 					'color'        => 'black',
 					'font-family'  => 'The-Great-Eye',
+				),
+			),
+			array(
+				'selector'     => '.voldemort',
+				'container'    => '@supports (align-self: stretch)',
+				'declarations' => array(
+					'height'     => '100px',
+					'align-self' => 'stretch',
+				),
+			),
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'letter-spacing' => '2px',
 				),
 			),
 			array(
@@ -731,7 +751,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
 
-		$this->assertSame( '@supports (align-self: stretch){.saruman{color:black;height:100px;border-style:solid;align-self:stretch;font-family:The-Great-Eye;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}}@supports (border-style: dotted){.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}}', $compiled_stylesheet );
+		$this->assertSame( '.saruman{letter-spacing:1px;}.gandalf{letter-spacing:2px;}@container (min-width: 700px){.saruman{color:black;height:100px;border-style:solid;align-self:stretch;font-family:The-Great-Eye;}}@supports (align-self: stretch){.voldemort{height:100px;align-self:stretch;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}}@supports (border-style: dotted){.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}}', $compiled_stylesheet );
 	}
 
 	/**

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -601,7 +601,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 			array(
 				'context'   => 'block-supports',
-				'container' => 'main'
+				'container' => 'main',
 			)
 		);
 
@@ -619,7 +619,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			array(
 				'context'   => 'block-supports',
 				'selector'  => '& .container',
-				'container' => 'main'
+				'container' => 'main',
 			)
 		);
 

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -856,6 +856,52 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests returning a generated stylesheet from a set of nested rules.
+	 */
+	public function test_should_return_stylesheet_with_nested_at_rules() {
+		$css_rules = array(
+			array(
+				'container'    => '.foo',
+				'declarations' => array(
+					'background-color' => 'red',
+				),
+			),
+			array(
+				'container'    => '.foo',
+				'selector'     => '@media (orientation: landscape)',
+				'declarations' => array(
+					'background-color' => 'blue',
+				),
+			),
+			array(
+				'container'    => '.foo',
+				'selector'     => '@media (min-width > 1024px)',
+				'declarations' => array(
+					'background-color' => 'cotton-blue',
+				),
+			),
+		);
+
+		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+
+		$this->assertSame( '.foo{background-color:red;@media (orientation: landscape){background-color:blue;}@media (min-width > 1024px){background-color:cotton-blue;}}', $compiled_stylesheet );
+	}
+
+	/*
+	.foo {
+  display: grid;
+
+  @media (orientation: landscape) {
+    grid-auto-flow: column;
+
+    @media (min-width > 1024px) {
+      max-inline-size: 1024px;
+    }
+  }
+}
+	 */
+
+	/**
 	 * Tests that incoming styles are deduped and merged.
 	 *
 	 * @ticket 58811

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -700,6 +700,14 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 			array(
+				'selector'     => '.saruman',
+				'container'    => '@supports (align-self: stretch)',
+				'declarations' => array(
+					'color'        => 'black',
+					'font-family'  => 'The-Great-Eye',
+				),
+			),
+			array(
 				'selector'     => '.gandalf',
 				'container'    => '@supports (border-style: dotted)',
 				'declarations' => array(
@@ -723,7 +731,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
 
-		$this->assertSame( '.saruman{color:white;height:100px;border-style:solid;align-self:unset;}.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}', $compiled_stylesheet );
+		$this->assertSame( '@supports (align-self: stretch){.saruman{color:black;height:100px;border-style:solid;align-self:stretch;font-family:The-Great-Eye;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}}@supports (border-style: dotted){.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}}', $compiled_stylesheet );
 	}
 
 	/**

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -236,6 +236,29 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
+			'style_block_with_nested_selector'                    => array(
+				'block_styles'    => array(
+					'spacing' => array(
+						'padding' => array(
+							'top'    => '42px',
+							'left'   => '2%',
+							'bottom' => '44px',
+							'right'  => '5rem',
+						),
+					),
+				),
+				'options'         => array( 'selector' => '.wp-selector > p', 'container' => '@layer sandwich' ),
+				'expected_output' => array(
+					'css'          => '@layer sandwich{.wp-selector > p{padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;}}',
+					'declarations' => array(
+						'padding-top'    => '42px',
+						'padding-left'   => '2%',
+						'padding-bottom' => '44px',
+						'padding-right'  => '5rem',
+					),
+				),
+			),
+
 			'elements_with_css_var_value'                  => array(
 				'block_styles'    => array(
 					'color'      => array(
@@ -647,6 +670,48 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 			array(
 				'selector'     => '.radagast',
+				'declarations' => array(
+					'color'        => 'brown',
+					'height'       => '60px',
+					'border-style' => 'dashed',
+					'align-self'   => 'stretch',
+				),
+			),
+		);
+
+		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+
+		$this->assertSame( '.saruman{color:white;height:100px;border-style:solid;align-self:unset;}.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}', $compiled_stylesheet );
+	}
+
+	/**
+	 * Tests returning a generated stylesheet from a set of nested rules.
+	 */
+	public function test_should_return_stylesheet_from_nested_css_rules() {
+		$css_rules = array(
+			array(
+				'selector'     => '.saruman',
+				'container'    => '@supports (align-self: stretch)',
+				'declarations' => array(
+					'color'        => 'white',
+					'height'       => '100px',
+					'border-style' => 'solid',
+					'align-self'   => 'stretch',
+				),
+			),
+			array(
+				'selector'     => '.gandalf',
+				'container'    => '@supports (border-style: dotted)',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+					'align-self'   => 'safe center',
+				),
+			),
+			array(
+				'selector'     => '.radagast',
+				'container'    => '@supports (align-self: stretch)',
 				'declarations' => array(
 					'color'        => 'brown',
 					'height'       => '60px',

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -44,6 +44,7 @@ const bundledPackagesPhpConfig = [
 		replaceClasses: [
 			'WP_Style_Engine_CSS_Declarations',
 			'WP_Style_Engine_CSS_Rules_Store',
+			'WP_Style_Engine_CSS_Rules_Container',
 			'WP_Style_Engine_CSS_Rule',
 			'WP_Style_Engine_Processor',
 			'WP_Style_Engine',


### PR DESCRIPTION
_In progress... this PR will be pared back to satisfy the minimum requirements of #58867. I'm coding "ahead" to validate the approach 😁_

## What?

Proposed refactor as a follow up to https://github.com/WordPress/gutenberg/pull/58867, from which all the ideas flow. Props to @tellthemachines 

Provide an API to generate nested CSS rules, e.g., 

```css
@container (width > 650px) {
    .hero {
        display: flex;
    }
}

@layer batman {
    .batarang {
        color: black;
    }
}

.foo {
       background-color: red;
       @media (orientation: landscape) {
               background-color: blue;
       }
       @media (min-width > 1024px) {
               background-color: cotton-blue;
       }
}
```

Expressed in PHP:

```php

$container = new WP_Style_Engine_CSS_Rules_Container( '.batcave', array(
    new WP_Style_Engine_CSS_Rule( '.alfred', array(
         'font-style' => 'italic',
    ) ),
    new WP_Style_Engine_CSS_Rule( '.robin', array(
         ' font-weight' => 700,
    ) ),
    new WP_Style_Engine_CSS_Rule( '.rubber-suit', array(
         ' font-family' => 'awesome',
    ) ),
) );

echo $container->get_css( true ); // `true` for pretty
/*
Output:

.batcave {
    .alfred {
        font-style: italic;
    }
    .robin {
        font-weight: 700;
    }
    .rubber-suit {
        font-family: 'awesome';
    }
}
*/

```

Features:

- CSS rules can be added to existing stored containers, with incoming declarations merged for same-name rules
- Processed CSS output groups CSS rules in existing containers
- CSS containers are output at the end of the CSS output, after non-nested CSS rules.


### TODO
- [x] Allow containers to have top-level declarations. https://github.com/WordPress/gutenberg/pull/58797/files#r1485232568
- [x] More unit tests to check overwriting/merging stored rules with same selectors/container names in the store and processor
- [ ] Update documentation and PHP comments 
- [x] Check against https://github.com/WordPress/gutenberg/pull/58539 (The PR that introduces `@container` queries) See: https://github.com/WordPress/gutenberg/pull/58919
- [ ] Test other scenarios
- [ ] Think about JS version for later

## Why?
To provide a base-line way to add nested rules.

## How?
Creating a `WP_Style_Engine_CSS_Rules_Container` that stores `WP_Style_Engine_CSS_Rule` objects and outputs nested CSS. 

Accepting a `container` value in the public API functions of:

- `wp_style_engine_get_stylesheet_from_css_rules()`
- `wp_style_engine_get_styles()`


## Testing Instructions

`npm run test:unit:php:base -- --group style-engine`


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
