### PR TITLE
Editor: Fix block context defined for template parts

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -28,6 +28,12 @@ const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
 
 const noop = () => {};
+const NON_CONTEXTUALU_POST_TYPES = [
+	'wp_block',
+	'wp_template',
+	'wp_navigation',
+	'wp_template_part',
+];
 
 /**
  * Depending on the post, template and template mode,
@@ -113,7 +119,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {
 			const postContext =
-				rootLevelPost.type !== 'wp_template' || shouldRenderTemplate
+				! NON_CONTEXTUALU_POST_TYPES.includes( rootLevelPost.type ) ||
+				shouldRenderTemplate
 					? { postId: post.id, postType: post.type }
 					: {};
 
@@ -124,7 +131,13 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 						? rootLevelPost.slug
 						: undefined,
 			};
-		}, [ post.id, post.type, rootLevelPost.type, rootLevelPost.slug ] );
+		}, [
+			shouldRenderTemplate,
+			post.id,
+			post.type,
+			rootLevelPost.type,
+			rootLevelPost.slug,
+		] );
 		const { editorSettings, selection, isReady } = useSelect(
 			( select ) => {
 				const {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -28,7 +28,7 @@ const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
 
 const noop = () => {};
-const NON_CONTEXTUALU_POST_TYPES = [
+const NON_CONTEXTUAL_POST_TYPES = [
 	'wp_block',
 	'wp_template',
 	'wp_navigation',
@@ -119,7 +119,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {
 			const postContext =
-				! NON_CONTEXTUALU_POST_TYPES.includes( rootLevelPost.type ) ||
+				! NON_CONTEXTUAL_POST_TYPES.includes( rootLevelPost.type ) ||
 				shouldRenderTemplate
 					? { postId: post.id, postType: post.type }
 					: {};


### PR DESCRIPTION
closes #58215 
Regression introduced in #56000 

## What?

Using Post Content blocks was causing an error within the template part editor because we were considering that the "postId" defined in the context corresponded to the same template part being rendered and obviously we can't render a template part within itself.

The problem is that we shouldn't be defining the template part's postId as the "post" context being rendered. In fact there are multiple post types who's editor shouldn't define any context: navigation, template part, reusable block and templates These are global entities that are only there to split blocks into logical units but they don't provide a "context" for the current post/page being rendered. 

## How?

So this PR solve the issue by not providing any "post" context when editing these entities.

## Testing instructions

 - Open the site editor
 - Create a template part or a pattern
 - Insert "Post Content" block
 - No error is triggered.