### PR TITLE
Add test:e2e:playwright:debug command to debug Playwright tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,6 +320,7 @@
 		"test:e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test:e2e:debug": "wp-scripts --inspect-brk test-e2e  --runInBand --no-cache --verbose --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test:e2e:playwright": "wp-scripts test-playwright --config test/e2e/playwright.config.ts",
+		"test:e2e:playwright:debug": "wp-scripts test-playwright --config test/e2e/playwright.config.ts --debug",
 		"test:e2e:storybook": "playwright test --config test/storybook-playwright/playwright.config.ts",
 		"test:e2e:watch": "npm run test:e2e -- --watch",
 		"test:native": "cross-env NODE_ENV=test jest --config test/native/jest.config.js",

--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
 		"test:e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test:e2e:debug": "wp-scripts --inspect-brk test-e2e  --runInBand --no-cache --verbose --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test:e2e:playwright": "wp-scripts test-playwright --config test/e2e/playwright.config.ts",
-		"test:e2e:playwright:debug": "wp-scripts test-playwright --config test/e2e/playwright.config.ts --debug",
+		"test:e2e:playwright:debug": "wp-scripts test-playwright --config test/e2e/playwright.config.ts --ui",
 		"test:e2e:storybook": "playwright test --config test/storybook-playwright/playwright.config.ts",
 		"test:e2e:watch": "npm run test:e2e -- --watch",
 		"test:native": "cross-env NODE_ENV=test jest --config test/native/jest.config.js",


### PR DESCRIPTION
Adds a new `npm run test:e2e:playwright:debug` command to run Playwright tests in debug mode. This runs the tests visually (non-headless) and displays a specialized Playwright Inspector debugger where you can step through the test.

It proved very useful in #55585.