### PR TITLE
DataViews: set color for primary field/`a` element when focused

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -370,7 +370,6 @@
 @mixin link-reset {
 	&:focus {
 		color: var(--wp-admin-theme-color--rgb);
-		/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color, #007cba);
 		border-radius: $radius-block-ui;
 	}

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -367,6 +367,15 @@
 	}
 }
 
+@mixin link-reset {
+	&:focus {
+		color: var(--wp-admin-theme-color--rgb);
+		/* stylelint-disable-next-line declaration-property-value-disallowed-list */
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color, #007cba);
+		border-radius: $radius-block-ui;
+	}
+}
+
 // The editor input reset with increased specificity to avoid theme styles bleeding in.
 @mixin editor-input-reset() {
 	font-family: $editor-html-font !important;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -237,7 +237,8 @@
 		}
 		&:focus {
 			color: var(--wp-admin-theme-color--rgb);
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+			border-radius: $grid-unit-05;
 		}
 	}
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -231,7 +231,6 @@
 		overflow: hidden;
 		display: block;
 		width: 100%;
-		margin: 0 var(--wp-admin-border-width-focus);
 
 		&:hover {
 			color: $gray-900;
@@ -239,7 +238,7 @@
 		&:focus {
 			color: var(--wp-admin-theme-color--rgb);
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-			border-radius: $grid-unit-05;
+			border-radius: $radius-block-ui;
 		}
 	}
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -219,7 +219,6 @@
 	color: $gray-900;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	overflow: hidden;
 	display: block;
 	width: 100%;
 
@@ -235,11 +234,7 @@
 		&:hover {
 			color: $gray-900;
 		}
-		&:focus {
-			color: var(--wp-admin-theme-color--rgb);
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-			border-radius: $radius-block-ui;
-		}
+		@include link-reset();
 	}
 
 	button.components-button.is-link {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -231,13 +231,14 @@
 		overflow: hidden;
 		display: block;
 		width: 100%;
+		margin: 0 var(--wp-admin-border-width-focus);
 
 		&:hover {
 			color: $gray-900;
 		}
 		&:focus {
 			color: var(--wp-admin-theme-color--rgb);
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
 			border-radius: $grid-unit-05;
 		}
 	}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -235,6 +235,10 @@
 		&:hover {
 			color: $gray-900;
 		}
+		&:focus {
+			color: var(--wp-admin-theme-color--rgb);
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
 	}
 
 	button.components-button.is-link {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Fixes https://github.com/WordPress/gutenberg/issues/58811


| Layout | Before | After |
| --- | --- | --- |
| Grid | <img width="968" alt="Captura de ecrã 2024-02-08, às 10 28 22" src="https://github.com/WordPress/gutenberg/assets/583546/db9844f6-f009-40b7-8056-3c1afdc8aaaa"> | <img width="910" alt="Captura de ecrã 2024-02-28, às 10 12 33" src="https://github.com/WordPress/gutenberg/assets/583546/d6e1ac26-ab20-4243-8123-8601eb318842"> |
| Table | <img width="968" alt="Captura de ecrã 2024-02-08, às 10 28 13" src="https://github.com/WordPress/gutenberg/assets/583546/41ae6157-c88b-4b9c-9ad1-cd62aeb9ff91"> | <img width="910" alt="Captura de ecrã 2024-02-28, às 10 12 24" src="https://github.com/WordPress/gutenberg/assets/583546/f479d14b-2d69-4f3c-8051-77c02ed0caa1"> |

