### PR TITLE
Docs: Fix mistake in viewScriptModule documentation

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -527,13 +527,13 @@ It's possible to pass a script handle registered with the [`wp_register_script`]
 
 _Note: An option to pass also an array of view scripts exists since WordPress `6.1.0`._
 
-### View script
+### View script module
 
 -   Type: `WPDefinedAsset`|`WPDefinedAsset[]` ([learn more](#wpdefinedasset))
 -   Optional
 -   Localized: No
--   Property: `viewScript`
--   Since: `WordPress 5.9.0`
+-   Property: `viewScriptModule`
+-   Since: `WordPress 6.5.0`
 
 ```json
 { "viewScriptModule": [ "file:./view.js", "example-shared-script-module-id" ] }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix a documentation mistake introduced in #58731.

## Why?

Some copy/pasted documentation was not correctly updated.

You can see a duplicated "View script" [section in the docs at the moment.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script)

Thanks @gziolo for spotting it here https://github.com/WordPress/wordpress-develop/pull/5860#issuecomment-1933680873.