### PR TITLE
DataViews: Use chips for filter summary

### DIFF
--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -242,6 +242,9 @@ export default function FilterSummary( {
 									// back to the available filters from `Add filter` component.
 									if ( ! isPrimary ) {
 										addFilterRef.current?.focus();
+									} else {
+										// If is primary, focus the toggle button.
+										toggleRef.current?.focus();
 									}
 								} }
 							>

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -17,7 +17,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useRef } from '@wordpress/element';
+import { useRef, createInterpolateElement } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
@@ -32,15 +32,23 @@ const FilterText = ( { activeElement, filterInView, filter } ) => {
 		return filter.name;
 	}
 
+	const filterTextWrappers = {
+		Span1: <span className="dataviews-filter-summary__filter-text-name" />,
+		Span2: <span className="dataviews-filter-summary__filter-text-value" />,
+	};
+
 	if (
 		activeElement !== undefined &&
 		filterInView?.operator === OPERATOR_IN
 	) {
-		return sprintf(
-			/* translators: 1: Filter name. 2: Filter value. e.g.: "Author is Admin". */
-			__( '%1$s is %2$s' ),
-			filter.name,
-			activeElement.label
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Author is Admin". */
+				__( '<Span1>%1$s </Span1><Span2>is %2$s</Span2>' ),
+				filter.name,
+				activeElement.label
+			),
+			filterTextWrappers
 		);
 	}
 
@@ -48,11 +56,14 @@ const FilterText = ( { activeElement, filterInView, filter } ) => {
 		activeElement !== undefined &&
 		filterInView?.operator === OPERATOR_NOT_IN
 	) {
-		return sprintf(
-			/* translators: 1: Filter name. 2: Filter value. e.g.: "Author is not Admin". */
-			__( '%1$s is not %2$s' ),
-			filter.name,
-			activeElement.label
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Author is not Admin". */
+				__( '<Span1>%1$s </Span1><Span2>is not %2$s</Span2>' ),
+				filter.name,
+				activeElement.label
+			),
+			filterTextWrappers
 		);
 	}
 
@@ -206,6 +217,7 @@ export default function FilterSummary( {
 									[ ENTER, SPACE ].includes( event.keyCode )
 								) {
 									onToggle();
+									event.preventDefault();
 								}
 							} }
 							aria-pressed={ isOpen }

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -210,7 +210,6 @@ export default function FilterSummary( {
 							) }
 							role="button"
 							tabIndex={ 0 }
-							// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 							onClick={ onToggle }
 							onKeyDown={ ( event ) => {
 								if (

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -8,9 +13,13 @@ import {
 	__experimentalHStack as HStack,
 	FlexItem,
 	SelectControl,
+	Tooltip,
+	Icon,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
+import { closeSmall } from '@wordpress/icons';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -153,11 +162,14 @@ export default function FilterSummary( {
 	...commonProps
 } ) {
 	const toggleRef = useRef();
-	const { filter, view } = commonProps;
+	const { filter, view, onChangeView } = commonProps;
 	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
 	const activeElement = filter.elements.find(
 		( element ) => element.value === filterInView?.value
 	);
+	const isPrimary = filter.isPrimary;
+	const hasValues = filterInView?.value !== undefined;
+	const canResetOrRemove = ! isPrimary || hasValues;
 	return (
 		<Dropdown
 			defaultOpen={ openedFilter === filter.field }
@@ -167,19 +179,77 @@ export default function FilterSummary( {
 				toggleRef.current?.focus();
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					__experimentalIsFocusable
-					size="compact"
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-					ref={ toggleRef }
-				>
-					<FilterText
-						activeElement={ activeElement }
-						filterInView={ filterInView }
-						filter={ filter }
-					/>
-				</Button>
+				<div className="dataviews-filter-summary__chip-container">
+					<Tooltip
+						text={ sprintf(
+							/* translators: 1: Filter name. */
+							__( 'Filter by: %1$s' ),
+							filter.name.toLowerCase()
+						) }
+						placement="top"
+					>
+						<div
+							className={ classnames(
+								'dataviews-filter-summary__chip',
+								{
+									'has-reset': canResetOrRemove,
+									'has-values': hasValues,
+									'is-primary': isPrimary,
+								}
+							) }
+							role="button"
+							tabIndex={ 0 }
+							// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+							onClick={ onToggle }
+							onKeyDown={ ( event ) => {
+								if (
+									[ ENTER, SPACE ].includes( event.keyCode )
+								) {
+									onToggle();
+								}
+							} }
+							aria-pressed={ isOpen }
+							aria-expanded={ isOpen }
+							ref={ toggleRef }
+						>
+							<FilterText
+								activeElement={ activeElement }
+								filterInView={ filterInView }
+								filter={ filter }
+							/>
+						</div>
+					</Tooltip>
+					{ canResetOrRemove && (
+						<Tooltip
+							text={ isPrimary ? __( 'Reset' ) : __( 'Remove' ) }
+							placement="top"
+						>
+							<button
+								className={ classnames(
+									'dataviews-filter-summary__chip-remove',
+									{ 'is-primary': isPrimary }
+								) }
+								onClick={ () => {
+									onChangeView( {
+										...view,
+										page: 1,
+										filters: view.filters.filter(
+											( _filter ) =>
+												_filter.field !== filter.field
+										),
+									} );
+									// If the filter is not primary and can be removed, it will be added
+									// back to the available filters from `Add filter` component.
+									if ( ! isPrimary ) {
+										addFilterRef.current?.focus();
+									}
+								} }
+							>
+								<Icon icon={ closeSmall } />
+							</button>
+						</Tooltip>
+					) }
+				</div>
 			) }
 			renderContent={ () => {
 				return (

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -227,7 +227,8 @@ export default function FilterSummary( {
 							<button
 								className={ classnames(
 									'dataviews-filter-summary__chip-remove',
-									{ 'is-primary': isPrimary }
+									{ 'is-primary': isPrimary },
+									{ 'has-values': hasValues }
 								) }
 								onClick={ () => {
 									onChangeView( {

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -205,7 +205,6 @@ export default function FilterSummary( {
 								{
 									'has-reset': canResetOrRemove,
 									'has-values': hasValues,
-									'is-primary': isPrimary,
 								}
 							) }
 							role="button"
@@ -238,7 +237,6 @@ export default function FilterSummary( {
 							<button
 								className={ classnames(
 									'dataviews-filter-summary__chip-remove',
-									{ 'is-primary': isPrimary },
 									{ 'has-values': hasValues }
 								) }
 								onClick={ () => {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -634,6 +634,7 @@
 
 .dataviews-filter-summary__chip-container {
 	position: relative;
+	white-space: pre-wrap;
 
 	.dataviews-filter-summary__chip {
 		border-radius: $grid-unit-20;
@@ -713,5 +714,9 @@
 			outline: none;
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
+	}
+
+	.dataviews-filter-summary__filter-text-value {
+		color: $white;
 	}
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -649,7 +649,7 @@
 		align-items: center;
 
 		&.has-reset {
-			padding-inline-end: 28px;
+			padding-inline-end: $button-size-small + $grid-unit-05;
 		}
 
 		&:hover,

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -715,8 +715,4 @@
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
-
-	.dataviews-filter-summary__filter-text-value {
-		color: $white;
-	}
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -631,3 +631,84 @@
 	padding: $grid-unit-05;
 	border-top: 1px solid $gray-200;
 }
+
+.dataviews-filter-summary__chip-container {
+	position: relative;
+
+	.dataviews-filter-summary__chip {
+		border-radius: $grid-unit-20;
+		border: 1px solid transparent;
+		cursor: pointer;
+		transition: all 0.1s linear;
+		@include reduce-motion("transition");
+		padding: 6px $grid-unit-15;
+		background: $gray-100;
+		color: $gray-700;
+		position: relative;
+
+		&.has-reset {
+			padding-inline-end: 28px;
+		}
+
+		&:hover,
+		&:focus {
+			background: $gray-200;
+			color: $gray-900;
+		}
+
+		&.is-primary.has-values {
+			color: var(--wp-admin-theme-color);
+			&:hover {
+				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			}
+		}
+
+		&:focus {
+			outline: none;
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
+	}
+
+	.dataviews-filter-summary__chip-remove {
+		width: $icon-size;
+		height: $icon-size;
+		border-radius: 50%;
+		border: 0;
+		padding: 0;
+		position: absolute;
+		right: 2px;
+		top: 50%;
+		transform: translateY(-50%);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
+		cursor: pointer;
+
+		svg {
+			fill: $gray-700;
+		}
+
+		&:hover,
+		&:focus {
+			background: $gray-200;
+			svg {
+				fill: $gray-900;
+			}
+		}
+
+		&.is-primary {
+			svg {
+				fill: var(--wp-admin-theme-color);
+			}
+			&:hover {
+				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			}
+		}
+
+		&:focus {
+			outline: none;
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
+	}
+}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -639,31 +639,34 @@
 		border-radius: $grid-unit-20;
 		border: 1px solid transparent;
 		cursor: pointer;
-		transition: all 0.1s linear;
-		@include reduce-motion("transition");
-		padding: 6px $grid-unit-15;
+		padding: 0 $grid-unit-15;
+		height: $grid-unit-40;
 		background: $gray-100;
 		color: $gray-700;
 		position: relative;
+		display: flex;
+		align-items: center;
 
 		&.has-reset {
 			padding-inline-end: 28px;
 		}
 
 		&:hover,
-		&:focus {
+		&:focus-visible {
 			background: $gray-200;
 			color: $gray-900;
 		}
 
-		&.is-primary.has-values {
+		&.has-values {
 			color: var(--wp-admin-theme-color);
+			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+
 			&:hover {
-				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+				background: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 			}
 		}
 
-		&:focus {
+		&:focus-visible {
 			outline: none;
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
@@ -676,7 +679,7 @@
 		border: 0;
 		padding: 0;
 		position: absolute;
-		right: 2px;
+		right: $grid-unit-05;
 		top: 50%;
 		transform: translateY(-50%);
 		display: flex;
@@ -697,16 +700,16 @@
 			}
 		}
 
-		&.is-primary {
+		&.has-values {
 			svg {
 				fill: var(--wp-admin-theme-color);
 			}
 			&:hover {
-				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+				background: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 			}
 		}
 
-		&:focus {
+		&:focus-visible {
 			outline: none;
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -671,6 +671,10 @@
 			outline: none;
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
+
+		.dataviews-filter-summary__filter-text-name {
+			font-weight: 500;
+		}
 	}
 
 	.dataviews-filter-summary__chip-remove {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR redesigns the filter's summary based on the [suggested designs](https://github.com/WordPress/gutenberg/issues/55100#issuecomment-1929913880).

<img width="634" alt="Chips" src="https://github.com/WordPress/gutenberg/assets/846565/aa818779-9509-4fa4-964f-a7c51b2684c1">


### Notes

1. This needs polishing as the differences between colors are very subtle.


## Testing instructions
1. Filters should work as before
2. a11y testing


