### PR TITLE
Interactivity API: Fix - Prevent undefined key warning

### DIFF
--- a/lib/experimental/interactivity-api.php
+++ b/lib/experimental/interactivity-api.php
@@ -13,7 +13,7 @@
  */
 function gutenberg_interactivity_override_script_module_urls( $url ) {
 	$pattern = '/wp-includes\/js\/dist\/interactivity(-router)?(\.min)?\.js/';
-	if ( preg_match( $pattern, $url, $matches ) ) {
+	if ( preg_match( $pattern, $url, $matches ) && isset( $matches[1] ) ) {
 		return gutenberg_url( '/build/interactivity/' . ( $matches[1] ? 'router' : 'index' ) . wp_scripts_get_suffix() . '.js' );
 	}
 	return $url;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
I'm getting a warning on loading default WP Site. Adding an additional check should fix it.
![Screenshot 2024-02-08 at 12 34 49](https://github.com/WordPress/gutenberg/assets/37012961/5a8f21fb-842a-4f59-94c2-df79be88b2bb)