### PR TITLE
Link Control: Simplify the sprintf

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -137,10 +137,9 @@ export default function LinkPreview( {
 				<Button
 					icon={ copySmall }
 					label={ sprintf(
-						// Translators: %1$s is a placeholder for an optional colon, %2$s is a placeholder for the link URL (if present).
-						__( 'Copy link%1$s%2$s' ), // Ends up looking like "Copy link: https://example.com".
-						isEmptyURL ? '' : ': ',
-						value.url
+						// Translators: %s is a placeholder for the link URL and an optional colon, (if a Link URL is present).
+						__( 'Copy link%s' ), // Ends up looking like "Copy link: https://example.com".
+						isEmptyURL ? '' : ': ' + value.url
 					) }
 					ref={ ref }
 					disabled={ isEmptyURL }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Simplify this sprintf. We introduced this in https://github.com/WordPress/gutenberg/pull/58183 but I don't think we need two parameters.

## Why?
Cleaner, simpler code.

## How?
Combine the URL and the colon into one variable.

## Testing Instructions
1. Create a post
2. Add some text
3. Add a link
4. Hover over the link preview
5. Confirm that the tooltip says "Copy link: [URL]"

## Screenshots or screencast <!-- if applicable -->
<img width="429" alt="Screenshot 2024-02-08 at 11 57 54" src="https://github.com/WordPress/gutenberg/assets/275961/e2c4c525-c6ff-4f1b-bc90-fa32e1e5d4a5">
