### PR TITLE
ViewScriptModule: 6.5 compatibility changes

### DIFF
--- a/lib/compat/wordpress-6.5/scripts-modules.php
+++ b/lib/compat/wordpress-6.5/scripts-modules.php
@@ -70,7 +70,7 @@ if ( ! function_exists( 'wp_script_modules' ) ) {
 		return $settings;
 	}
 
-	add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_modules', 11, 2 );
+	add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_modules', 10, 2 );
 
 	/**
 	 * Enqueue modules associated with the block.

--- a/lib/compat/wordpress-6.5/scripts-modules.php
+++ b/lib/compat/wordpress-6.5/scripts-modules.php
@@ -92,6 +92,31 @@ if ( ! function_exists( 'wp_script_modules' ) ) {
 	}
 
 	add_filter( 'render_block', 'gutenberg_filter_render_block_enqueue_view_script_modules', 10, 3 );
+
+	/**
+	 * Registers a REST field for block types to provide view script module IDs.
+	 *
+	 * Adds the `view_script_module_ids` and `view_module_ids` (deprecated) field to block type objects in the REST API, which
+	 * lists the script module IDs for any script modules associated with the
+	 * block's viewScriptModule key.
+	 */
+	function gutenberg_register_view_script_module_ids_rest_field() {
+		register_rest_field(
+			'block-type',
+			'view_script_module_ids',
+			array(
+				'get_callback' => function ( $item ) {
+					$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $item['name'] );
+					if ( isset( $block_type->view_script_module_ids ) ) {
+						return $block_type->view_script_module_ids;
+					}
+					return array();
+				},
+			)
+		);
+	}
+
+	add_action( 'rest_api_init', 'gutenberg_register_view_script_module_ids_rest_field' );
 }
 
 if ( ! function_exists( 'wp_register_script_module' ) ) {

--- a/lib/compat/wordpress-6.5/scripts-modules.php
+++ b/lib/compat/wordpress-6.5/scripts-modules.php
@@ -118,3 +118,69 @@ if ( ! function_exists( 'wp_dequeue_script_module' ) ) {
 		wp_script_modules()->dequeue( $id );
 	}
 }
+
+if ( ! function_exists( 'wp_script_modules' ) ) {
+	/**
+	 * Add module fields from block metadata to WP_Block_Type settings.
+	 *
+	 * This filter allows us to register modules from block metadata and attach additional fields to
+	 * WP_Block_Type instances.
+	 *
+	 * @param array $settings Array of determined settings for registering a block type.
+	 * @param array $metadata Metadata provided for registering a block type.
+	 */
+	function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
+		$module_fields = array(
+			'viewScriptModule' => 'view_script_module_ids',
+		);
+		foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
+			if ( ! empty( $settings[ $metadata_field_name ] ) ) {
+				$metadata[ $metadata_field_name ] = $settings[ $metadata_field_name ];
+			}
+			if ( ! empty( $metadata[ $metadata_field_name ] ) ) {
+				$modules           = $metadata[ $metadata_field_name ];
+				$processed_modules = array();
+				if ( is_array( $modules ) ) {
+					for ( $index = 0; $index < count( $modules ); $index++ ) {
+						$processed_modules[] = gutenberg_register_block_module_id(
+							$metadata,
+							$metadata_field_name,
+							$index
+						);
+					}
+				} else {
+					$processed_modules[] = gutenberg_register_block_module_id(
+						$metadata,
+						$metadata_field_name
+					);
+				}
+				$settings[ $settings_field_name ] = $processed_modules;
+			}
+		}
+
+		return $settings;
+	}
+
+	add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_modules', 11, 2 );
+
+	/**
+	 * Enqueue modules associated with the block.
+	 *
+	 * @param string   $block_content  The block content.
+	 * @param array    $parsed_block   The full block, including name and attributes.
+	 * @param WP_Block $block_instance The block instance.
+	 */
+	function gutenberg_filter_render_block_enqueue_view_script_modules( $block_content, $parsed_block, $block_instance ) {
+		$block_type = $block_instance->block_type;
+
+		if ( ! empty( $block_type->view_script_module_ids ) ) {
+			foreach ( $block_type->view_script_module_ids as $module_id ) {
+				wp_enqueue_script_module( $module_id );
+			}
+		}
+
+		return $block_content;
+	}
+
+	add_filter( 'render_block', 'gutenberg_filter_render_block_enqueue_view_script_modules', 10, 3 );
+}

--- a/lib/compat/wordpress-6.5/scripts-modules.php
+++ b/lib/compat/wordpress-6.5/scripts-modules.php
@@ -28,6 +28,70 @@ if ( ! function_exists( 'wp_script_modules' ) ) {
 		return $wp_script_modules;
 	}
 	wp_script_modules()->add_hooks();
+
+	/**
+	 * Add module fields from block metadata to WP_Block_Type settings.
+	 *
+	 * This filter allows us to register modules from block metadata and attach additional fields to
+	 * WP_Block_Type instances.
+	 *
+	 * @param array $settings Array of determined settings for registering a block type.
+	 * @param array $metadata Metadata provided for registering a block type.
+	 */
+	function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
+		$module_fields = array(
+			'viewScriptModule' => 'view_script_module_ids',
+		);
+		foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
+			if ( ! empty( $settings[ $metadata_field_name ] ) ) {
+				$metadata[ $metadata_field_name ] = $settings[ $metadata_field_name ];
+			}
+			if ( ! empty( $metadata[ $metadata_field_name ] ) ) {
+				$modules           = $metadata[ $metadata_field_name ];
+				$processed_modules = array();
+				if ( is_array( $modules ) ) {
+					for ( $index = 0; $index < count( $modules ); $index++ ) {
+						$processed_modules[] = gutenberg_register_block_module_id(
+							$metadata,
+							$metadata_field_name,
+							$index
+						);
+					}
+				} else {
+					$processed_modules[] = gutenberg_register_block_module_id(
+						$metadata,
+						$metadata_field_name
+					);
+				}
+				$settings[ $settings_field_name ] = $processed_modules;
+			}
+		}
+
+		return $settings;
+	}
+
+	add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_modules', 11, 2 );
+
+	/**
+	 * Enqueue modules associated with the block.
+	 *
+	 * @param string   $block_content  The block content.
+	 * @param array    $parsed_block   The full block, including name and attributes.
+	 * @param WP_Block $block_instance The block instance.
+	 */
+	function gutenberg_filter_render_block_enqueue_view_script_modules( $block_content, $parsed_block, $block_instance ) {
+		$block_type = $block_instance->block_type;
+
+		if ( ! empty( $block_type->view_script_module_ids ) ) {
+			foreach ( $block_type->view_script_module_ids as $module_id ) {
+				wp_enqueue_script_module( $module_id );
+			}
+		}
+
+		return $block_content;
+	}
+
+	add_filter( 'render_block', 'gutenberg_filter_render_block_enqueue_view_script_modules', 10, 3 );
 }
 
 if ( ! function_exists( 'wp_register_script_module' ) ) {
@@ -117,70 +181,4 @@ if ( ! function_exists( 'wp_dequeue_script_module' ) ) {
 	function wp_dequeue_script_module( string $id ) {
 		wp_script_modules()->dequeue( $id );
 	}
-}
-
-if ( ! function_exists( 'wp_script_modules' ) ) {
-	/**
-	 * Add module fields from block metadata to WP_Block_Type settings.
-	 *
-	 * This filter allows us to register modules from block metadata and attach additional fields to
-	 * WP_Block_Type instances.
-	 *
-	 * @param array $settings Array of determined settings for registering a block type.
-	 * @param array $metadata Metadata provided for registering a block type.
-	 */
-	function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
-		$module_fields = array(
-			'viewScriptModule' => 'view_script_module_ids',
-		);
-		foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
-			if ( ! empty( $settings[ $metadata_field_name ] ) ) {
-				$metadata[ $metadata_field_name ] = $settings[ $metadata_field_name ];
-			}
-			if ( ! empty( $metadata[ $metadata_field_name ] ) ) {
-				$modules           = $metadata[ $metadata_field_name ];
-				$processed_modules = array();
-				if ( is_array( $modules ) ) {
-					for ( $index = 0; $index < count( $modules ); $index++ ) {
-						$processed_modules[] = gutenberg_register_block_module_id(
-							$metadata,
-							$metadata_field_name,
-							$index
-						);
-					}
-				} else {
-					$processed_modules[] = gutenberg_register_block_module_id(
-						$metadata,
-						$metadata_field_name
-					);
-				}
-				$settings[ $settings_field_name ] = $processed_modules;
-			}
-		}
-
-		return $settings;
-	}
-
-	add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_modules', 11, 2 );
-
-	/**
-	 * Enqueue modules associated with the block.
-	 *
-	 * @param string   $block_content  The block content.
-	 * @param array    $parsed_block   The full block, including name and attributes.
-	 * @param WP_Block $block_instance The block instance.
-	 */
-	function gutenberg_filter_render_block_enqueue_view_script_modules( $block_content, $parsed_block, $block_instance ) {
-		$block_type = $block_instance->block_type;
-
-		if ( ! empty( $block_type->view_script_module_ids ) ) {
-			foreach ( $block_type->view_script_module_ids as $module_id ) {
-				wp_enqueue_script_module( $module_id );
-			}
-		}
-
-		return $block_content;
-	}
-
-	add_filter( 'render_block', 'gutenberg_filter_render_block_enqueue_view_script_modules', 10, 3 );
 }

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -42,7 +42,7 @@ function gutenberg_filter_block_type_metadata_settings_register_view_module( $se
 	return $settings;
 }
 
-add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_view_module', 10, 2 );
+add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_view_module', 20, 2 );
 
 /**
  * Finds a module ID for the selected block metadata field. It detects

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -5,14 +5,14 @@
  * This filter allows us to register modules from block metadata and attach additional fields to
  * WP_Block_Type instances.
  *
+ * @todo remove viewModule support in Gutenberg >= 17.8 (replaced by viewScriptModule).
+ *
  * @param array $settings Array of determined settings for registering a block type.
  * @param array $metadata Metadata provided for registering a block type.
  */
-function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
+function gutenberg_filter_block_type_metadata_settings_register_view_module( $settings, $metadata = null ) {
 	$module_fields = array(
-		// @todo remove viewModule support in Gutenberg >= 17.8 (replaced by viewScriptModule).
 		'viewModule'       => 'view_script_module_ids',
-		'viewScriptModule' => 'view_script_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {
@@ -42,28 +42,7 @@ function gutenberg_filter_block_type_metadata_settings_register_modules( $settin
 	return $settings;
 }
 
-add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_modules', 10, 2 );
-
-/**
- * Enqueue modules associated with the block.
- *
- * @param string   $block_content  The block content.
- * @param array    $parsed_block   The full block, including name and attributes.
- * @param WP_Block $block_instance The block instance.
- */
-function gutenberg_filter_render_block_enqueue_view_script_modules( $block_content, $parsed_block, $block_instance ) {
-	$block_type = $block_instance->block_type;
-
-	if ( ! empty( $block_type->view_script_module_ids ) ) {
-		foreach ( $block_type->view_script_module_ids as $module_id ) {
-			wp_enqueue_script_module( $module_id );
-		}
-	}
-
-	return $block_content;
-}
-
-add_filter( 'render_block', 'gutenberg_filter_render_block_enqueue_view_script_modules', 10, 3 );
+add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_view_module', 10, 2 );
 
 /**
  * Finds a module ID for the selected block metadata field. It detects

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -5,13 +5,12 @@
  * This filter allows us to register modules from block metadata and attach additional fields to
  * WP_Block_Type instances.
  *
- * @todo remove viewModule support in Gutenberg >= 17.8 (replaced by viewScriptModule).
- *
  * @param array $settings Array of determined settings for registering a block type.
  * @param array $metadata Metadata provided for registering a block type.
  */
 function gutenberg_filter_block_type_metadata_settings_register_view_module( $settings, $metadata = null ) {
 	$module_fields = array(
+		// @todo remove viewModule support in Gutenberg >= 17.8 (replaced by viewScriptModule).
 		'viewModule' => 'view_script_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -142,7 +142,7 @@ function gutenberg_generate_block_asset_module_id( $block_name, $field_name, $in
  * lists the script module IDs for any script modules associated with the
  * block's viewScriptModule key.
  */
-function gutenberg_register_view_script_module_ids_rest_field() {
+function gutenberg_register_view_module_ids_rest_field() {
 	// @todo remove view_module_ids support in Gutenberg >= 17.8 (replaced by view_script_module_ids).
 	register_rest_field(
 		'block-type',
@@ -157,23 +157,9 @@ function gutenberg_register_view_script_module_ids_rest_field() {
 			},
 		)
 	);
-
-	register_rest_field(
-		'block-type',
-		'view_script_module_ids',
-		array(
-			'get_callback' => function ( $item ) {
-				$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $item['name'] );
-				if ( isset( $block_type->view_script_module_ids ) ) {
-					return $block_type->view_script_module_ids;
-				}
-				return array();
-			},
-		)
-	);
 }
 
-add_action( 'rest_api_init', 'gutenberg_register_view_script_module_ids_rest_field' );
+add_action( 'rest_api_init', 'gutenberg_register_view_module_ids_rest_field' );
 
 /**
  * Registers the module if no module with that module identifier has already

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -12,7 +12,7 @@
  */
 function gutenberg_filter_block_type_metadata_settings_register_view_module( $settings, $metadata = null ) {
 	$module_fields = array(
-		'viewModule'       => 'view_script_module_ids',
+		'viewModule' => 'view_script_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -81,25 +81,9 @@ function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 
 	$module_id             = gutenberg_generate_block_asset_module_id( $metadata['name'], $field_name, $index );
 	$module_asset_path     = wp_normalize_path( realpath( $module_asset_raw_path ) );
 
-	if ( empty( $module_asset_path ) ) {
-		_doing_it_wrong(
-			__FUNCTION__,
-			sprintf(
-				// This string is from WordPress Core. See `register_block_script_handle`.
-				// Translators: This is a translation from WordPress Core (default). No need to translate.
-				__( 'The asset file (%1$s) for the "%2$s" defined in "%3$s" block definition is missing.', 'default' ),
-				$module_asset_raw_path,
-				$field_name,
-				$metadata['name']
-			),
-			'6.5.0'
-		);
-		return false;
-	}
-
 	$module_path_norm    = wp_normalize_path( realpath( $path . '/' . $module_path ) );
 	$module_uri          = get_block_asset_url( $module_path_norm );
-	$module_asset        = require $module_asset_path;
+	$module_asset        = ! empty( $module_asset_path ) ? require $module_asset_path : array();
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
 
 	wp_register_script_module(


### PR DESCRIPTION
## What?

`viewScriptModule` block.json field support has landed in Core 6.5 (https://github.com/WordPress/wordpress-develop/pull/5860 / https://core.trac.wordpress.org/changeset/57565).

Move `viewScriptModule` support in Gutenberg to 6.5 compatibility.

`viewModule` support and the `view_module_ids` REST API field are maintained in Gutenberg regardless of the WordPress version.

## Testing Instructions

Test with latest WordPress 6.4.3 and WordPress trunk. Try these steps with `viewModule`, `viewScriptModule` and both.

Add a block using `block.json` with a (`viewModule`, `viewScriptModule`, both) field pointing to its view module. I've compiled a block (with #57461) that's available [at this gist](https://gist.github.com/sirreal/940bb5917c3c5449c98626a8878bf071). It can be unzipped as a plugin and used for testing.

We should be able to add our block in the editor. If we use the REST API to query block types and search for `view_module_ids` and `view_script_module_ids` we should find our block:

```js
(await wp.apiFetch( { path: '/wp/v2/block-types' }))
  .filter( ({ view_module_ids }) => view_module_ids.length )
  .map(blockType => ({
    name: blockType.name,
    view_module_ids: blockType.view_module_ids,
    view_script_module_ids: blockType.view_script_module_ids,
  }))[0]
// { "name": "jon/the-block", "view_module_ids": [ "jon-the-block-view-module" ], "view_script_module_ids": [ "jon-the-block-view-module" ] }
```

If the block is added to a post and we visit it on the frontend, we should see it working as expected (a counter in our example).

We should also see the expected modules added to the importmap and module preloads on our post with the block. I used an older theme to ensure nothing else was enqueuing the interactivity module:

```js
document.querySelector('[type=importmap]');
// <script type=​"importmap">​{"imports":{"@wordpress\/interactivity":"…"}}</script>​
document.querySelector('#\\@wordpress\\/interactivity[rel=modulepreload]');
// <link rel="modulepreload" href="…" id="@wordpress/interactivity">
```
