### PR TITLE
Font Library: Convert heading text to heading elements and group fonts as a list

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -332,18 +332,37 @@ function FontCollection( { slug } ) {
 								) }
 
 							<div className="font-library-modal__fonts-grid__main">
-								{ items.map( ( font ) => (
-									<FontCard
-										key={ font.font_family_settings.slug }
-										font={ font.font_family_settings }
-										navigatorPath={ '/fontFamily' }
-										onClick={ () => {
-											setSelectedFont(
-												font.font_family_settings
-											);
-										} }
-									/>
-								) ) }
+								{ /*
+								 * Disable reason: The `list` ARIA role is redundant but
+								 * Safari+VoiceOver won't announce the list otherwise.
+								 */
+								/* eslint-disable jsx-a11y/no-redundant-roles */ }
+								<ul
+									role="list"
+									className="font-library-modal__fonts-list"
+								>
+									{ items.map( ( font ) => (
+										<li
+											key={
+												font.font_family_settings.slug
+											}
+											className="font-library-modal__fonts-list-item"
+										>
+											<FontCard
+												font={
+													font.font_family_settings
+												}
+												navigatorPath={ '/fontFamily' }
+												onClick={ () => {
+													setSelectedFont(
+														font.font_family_settings
+													);
+												} }
+											/>
+										</li>
+									) ) }
+								</ul>
+								{ /* eslint-enable jsx-a11y/no-redundant-roles */ }{ ' ' }
 							</div>
 						</NavigatorScreen>
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -126,97 +126,94 @@ function InstalledFonts() {
 						}
 					>
 						<NavigatorScreen path="/">
-							{ notice && (
-								<>
-									<Spacer margin={ 1 } />
+							<VStack spacing="8">
+								{ notice && (
 									<Notice
 										status={ notice.type }
 										onRemove={ () => setNotice( null ) }
 									>
 										{ notice.message }
 									</Notice>
-									<Spacer margin={ 1 } />
-								</>
-							) }
-							{ baseCustomFonts.length > 0 && (
-								<VStack>
-									<h2 className="font-library-modal__fonts-title">
-										{ __( 'Installed Fonts' ) }
-									</h2>
-									{ /*
-									 * Disable reason: The `list` ARIA role is redundant but
-									 * Safari+VoiceOver won't announce the list otherwise.
-									 */
-									/* eslint-disable jsx-a11y/no-redundant-roles */ }
-									<ul
-										role="list"
-										className="font-library-modal__fonts-list"
-									>
-										{ baseCustomFonts.map( ( font ) => (
-											<li
-												key={ font.slug }
-												className="font-library-modal__fonts-list-item"
-											>
-												<FontCard
-													font={ font }
-													navigatorPath={
-														'/fontFamily'
-													}
-													variantsText={ getFontCardVariantsText(
-														font
-													) }
-													onClick={ () => {
-														handleSetLibraryFontSelected(
+								) }
+								{ baseCustomFonts.length > 0 && (
+									<VStack>
+										<h2 className="font-library-modal__fonts-title">
+											{ __( 'Installed Fonts' ) }
+										</h2>
+										{ /*
+										 * Disable reason: The `list` ARIA role is redundant but
+										 * Safari+VoiceOver won't announce the list otherwise.
+										 */
+										/* eslint-disable jsx-a11y/no-redundant-roles */ }
+										<ul
+											role="list"
+											className="font-library-modal__fonts-list"
+										>
+											{ baseCustomFonts.map( ( font ) => (
+												<li
+													key={ font.slug }
+													className="font-library-modal__fonts-list-item"
+												>
+													<FontCard
+														font={ font }
+														navigatorPath={
+															'/fontFamily'
+														}
+														variantsText={ getFontCardVariantsText(
 															font
-														);
-													} }
-												/>
-											</li>
-										) ) }
-									</ul>
-									{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
-								</VStack>
-							) }
-
-							{ baseThemeFonts.length > 0 && (
-								<VStack>
-									<h2 className="font-library-modal__fonts-title">
-										{ __( 'Theme Fonts' ) }
-									</h2>
-									{ /*
-									 * Disable reason: The `list` ARIA role is redundant but
-									 * Safari+VoiceOver won't announce the list otherwise.
-									 */
-									/* eslint-disable jsx-a11y/no-redundant-roles */ }
-									<ul
-										role="list"
-										className="font-library-modal__fonts-list"
-									>
-										{ baseThemeFonts.map( ( font ) => (
-											<li
-												key={ font.slug }
-												className="font-library-modal__fonts-list-item"
-											>
-												<FontCard
-													font={ font }
-													navigatorPath={
-														'/fontFamily'
-													}
-													variantsText={ getFontCardVariantsText(
-														font
-													) }
-													onClick={ () => {
-														handleSetLibraryFontSelected(
+														) }
+														onClick={ () => {
+															handleSetLibraryFontSelected(
+																font
+															);
+														} }
+													/>
+												</li>
+											) ) }
+										</ul>
+										{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+									</VStack>
+								) }
+								{ baseThemeFonts.length > 0 && (
+									<VStack>
+										<h2 className="font-library-modal__fonts-title">
+											{ __( 'Theme Fonts' ) }
+										</h2>
+										{ /*
+										 * Disable reason: The `list` ARIA role is redundant but
+										 * Safari+VoiceOver won't announce the list otherwise.
+										 */
+										/* eslint-disable jsx-a11y/no-redundant-roles */ }
+										<ul
+											role="list"
+											className="font-library-modal__fonts-list"
+										>
+											{ baseThemeFonts.map( ( font ) => (
+												<li
+													key={ font.slug }
+													className="font-library-modal__fonts-list-item"
+												>
+													<FontCard
+														font={ font }
+														navigatorPath={
+															'/fontFamily'
+														}
+														variantsText={ getFontCardVariantsText(
 															font
-														);
-													} }
-												/>
-											</li>
-										) ) }
-									</ul>
-									{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
-								</VStack>
-							) }
+														) }
+														onClick={ () => {
+															handleSetLibraryFontSelected(
+																font
+															);
+														} }
+													/>
+												</li>
+											) ) }
+										</ul>
+										{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+									</VStack>
+								) }
+							</VStack>
 						</NavigatorScreen>
 
 						<NavigatorScreen path="/fontFamily">

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -139,52 +139,83 @@ function InstalledFonts() {
 								</>
 							) }
 							{ baseCustomFonts.length > 0 && (
-								<>
-									<Text className="font-library-modal__subtitle">
+								<VStack>
+									<h2 className="font-library-modal__fonts-title">
 										{ __( 'Installed Fonts' ) }
-									</Text>
-									<Spacer margin={ 2 } />
-									{ baseCustomFonts.map( ( font ) => (
-										<FontCard
-											font={ font }
-											key={ font.slug }
-											navigatorPath={ '/fontFamily' }
-											variantsText={ getFontCardVariantsText(
-												font
-											) }
-											onClick={ () => {
-												handleSetLibraryFontSelected(
-													font
-												);
-											} }
-										/>
-									) ) }
-									<Spacer margin={ 8 } />
-								</>
+									</h2>
+									{ /*
+									 * Disable reason: The `list` ARIA role is redundant but
+									 * Safari+VoiceOver won't announce the list otherwise.
+									 */
+									/* eslint-disable jsx-a11y/no-redundant-roles */ }
+									<ul
+										role="list"
+										className="font-library-modal__fonts-list"
+									>
+										{ baseCustomFonts.map( ( font ) => (
+											<li
+												key={ font.slug }
+												className="font-library-modal__fonts-list-item"
+											>
+												<FontCard
+													font={ font }
+													navigatorPath={
+														'/fontFamily'
+													}
+													variantsText={ getFontCardVariantsText(
+														font
+													) }
+													onClick={ () => {
+														handleSetLibraryFontSelected(
+															font
+														);
+													} }
+												/>
+											</li>
+										) ) }
+									</ul>
+									{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+								</VStack>
 							) }
 
 							{ baseThemeFonts.length > 0 && (
-								<>
-									<Text className="font-library-modal__subtitle">
+								<VStack>
+									<h2 className="font-library-modal__fonts-title">
 										{ __( 'Theme Fonts' ) }
-									</Text>
-									<Spacer margin={ 2 } />
-									{ baseThemeFonts.map( ( font ) => (
-										<FontCard
-											font={ font }
-											key={ font.slug }
-											navigatorPath={ '/fontFamily' }
-											variantsText={ getFontCardVariantsText(
-												font
-											) }
-											onClick={ () => {
-												handleSetLibraryFontSelected(
-													font
-												);
-											} }
-										/>
-									) ) }
-								</>
+									</h2>
+									{ /*
+									 * Disable reason: The `list` ARIA role is redundant but
+									 * Safari+VoiceOver won't announce the list otherwise.
+									 */
+									/* eslint-disable jsx-a11y/no-redundant-roles */ }
+									<ul
+										role="list"
+										className="font-library-modal__fonts-list"
+									>
+										{ baseThemeFonts.map( ( font ) => (
+											<li
+												key={ font.slug }
+												className="font-library-modal__fonts-list-item"
+											>
+												<FontCard
+													font={ font }
+													navigatorPath={
+														'/fontFamily'
+													}
+													variantsText={ getFontCardVariantsText(
+														font
+													) }
+													onClick={ () => {
+														handleSetLibraryFontSelected(
+															font
+														);
+													} }
+												/>
+											</li>
+										) ) }
+									</ul>
+									{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+								</VStack>
 							) }
 						</NavigatorScreen>
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -80,7 +80,6 @@ $footer-height: 70px;
 }
 
 .font-library-modal__fonts-list-item {
-	margin-top: -1px; /* To collapse the margin with the previous element */
 	margin-bottom: 0;
 }
 
@@ -89,6 +88,7 @@ $footer-height: 70px;
 	width: 100%;
 	height: auto;
 	padding: $grid-unit-20;
+	margin-top: -1px; /* To collapse the margin with the previous element */
 
 	&:hover {
 		background-color: $gray-100;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -66,12 +66,29 @@ $footer-height: 70px;
 	margin-bottom: 0;
 }
 
+.font-library-modal__fonts-title {
+	text-transform: uppercase;
+	font-size: 11px;
+	font-weight: 600;
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.font-library-modal__fonts-list {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.font-library-modal__fonts-list-item {
+	margin-top: -1px; /* To collapse the margin with the previous element */
+	margin-bottom: 0;
+}
+
 .font-library-modal__font-card {
 	border: 1px solid $gray-200;
 	width: 100%;
 	height: auto;
 	padding: $grid-unit-20;
-	margin-top: -1px; /* To collapse the margin with the previous element */
 
 	&:hover {
 		background-color: $gray-100;

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -61,7 +61,7 @@ test.describe( 'Font Library', () => {
 				.click();
 			await expect( page.getByRole( 'dialog' ) ).toBeVisible();
 			await expect(
-				page.getByRole( 'heading', { name: 'Fonts' } )
+				page.getByRole( 'heading', { name: 'Fonts', exact: true } )
 			).toBeVisible();
 		} );
 


### PR DESCRIPTION
Related to #55220
Part of #58403
See this comment: https://github.com/WordPress/gutenberg/issues/58403#issuecomment-1932358501

## What?

This PR achieves the following two things in the font library modal.

- Convert heading text to heading elements
- Group fonts as a list

![font-list](https://github.com/WordPress/gutenberg/assets/54422211/05cfe62e-13c9-43ac-bef8-8c938223d898)

## Why?

~~User-installed fonts don't have the title, so Users don't know what that font list means.~~ Also, since the font list is actually just a list of button elements, users using screen readers cannot understand how many fonts there are.

## How?

Group the font list as follows.

```html
<h2>XXX Fonts</h2>
<ul>
	<li>
		<button>...</button>
	</li>
	<li>
		<button>...</button>
	</li>
</ul>
```

> [!NOTE]
> ~~By using `fieldset` and `legend`, we should be able to properly associate the heading with the content. But maybe these elements should be inside the `form` element. I would appreciate it if you could give me advice on whether this implementation violates a11y.~~

### Testing Instructions for Keyboard

- Launch a screen reader such as NVDA or VoiceOver.
- Open the font library modal just by using the keyboard.
- When you focus on the beginning of the font list: You should hear something like this: `Library  property page  list  with X items  {fontName}  graphic    X/X variants active  button  

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/919415e2-4dc4-43b8-b11b-9da9efe76b1e

