### PR TITLE
resolve Hover-Effects-for-Font-Names-and-Checkboxes

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -62,12 +62,21 @@
 	.font-library-modal__font-card__count {
 		color: #6e6e6e;
 	}
+	&:hover{
+		outline: 1px solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		border-color:transparent;
+	}
 }
 
 .font-library-modal__library-font-variant {
 	border: 1px solid #e5e5e5;
 	padding: 1rem;
 	margin-top: -1px; /* To collapse the margin with the previous element */
+	&:hover{
+		.components-checkbox-control__input[type=checkbox]{
+			border-color: var(--wp-admin-theme-color);
+		}
+	}
 }
 
 .font-library-modal__font-variant {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Resolve the mentioned issue :- #58800

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The font-variant selection interface currently lacks hover effects for font names and checkboxes. The cursor pointer change is the only indication of interactivity.
Also, the font selection UI lacks hover effects on the font names, while it already has an effect for the arrow >.


