### PR TITLE
Core data: useEntityBlockEditor: fix parsed blocks cache

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -155,7 +155,7 @@ const parsedBlocksCache = new WeakMap();
 export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
-	const { getEntityRecord } = useSelect( STORE_NAME );
+	const { getEntityRecord, getEntityRecordEdits } = useSelect( STORE_NAME );
 	const { content, editedBlocks, meta } = useSelect(
 		( select ) => {
 			if ( ! id ) {
@@ -187,16 +187,28 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return EMPTY_ARRAY;
 		}
 
-		const entityRecord = getEntityRecord( kind, name, id );
-		let _blocks = parsedBlocksCache.get( entityRecord );
+		// If there's an edit, cache the parsed blocks by the edit.
+		// If not, cache by the original enity record.
+		const edits = getEntityRecordEdits( kind, name, id );
+		const isUnedited = ! edits || ! Object.keys( edits ).length;
+		const cackeKey = isUnedited ? getEntityRecord( kind, name, id ) : edits;
+		let _blocks = parsedBlocksCache.get( cackeKey );
 
 		if ( ! _blocks ) {
 			_blocks = parse( content );
-			parsedBlocksCache.set( entityRecord, _blocks );
+			parsedBlocksCache.set( cackeKey, _blocks );
 		}
 
 		return _blocks;
-	}, [ kind, name, id, editedBlocks, content, getEntityRecord ] );
+	}, [
+		kind,
+		name,
+		id,
+		editedBlocks,
+		content,
+		getEntityRecord,
+		getEntityRecordEdits,
+	] );
 
 	const updateFootnotes = useCallback(
 		( _blocks ) => updateFootnotesFromMeta( _blocks, meta ),

--- a/test/e2e/specs/editor/various/editor-modes.spec.js
+++ b/test/e2e/specs/editor/various/editor-modes.spec.js
@@ -155,4 +155,35 @@ test.describe( 'Editing modes (visual/HTML)', () => {
 			},
 		] );
 	} );
+
+	test( 'should reparse changes from code editor', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Open the code editor.
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		const textbox = page.getByRole( 'textbox', {
+			name: 'Type text or HTML',
+		} );
+
+		// Change content by typing.
+		await textbox.fill( '' );
+		await textbox.focus();
+
+		await page.keyboard.type( `<!-- wp:paragraph -->
+<p>abc</p>
+<!-- /wp:paragraph -->` );
+
+		// Go back to the visual editor.
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'abc' },
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In #58146, I didn't account for editing being made without the blocks key. This can happen when you change the content in the code editor, in which case the content needs to be parsed. Currently the cache will return the unedited blocks.

The solution is to change the cache key when edits are made. We can use the unedited record as a cache key when `getEntityRecordEdits` returns undefined or an empty object. I'm not sure why it sometimes returns an empty object. That sounds like a bug that needs to be fixed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
