### PR TITLE
DataViews: fix storybook

### DIFF
--- a/packages/dataviews/src/stories/index.story.js
+++ b/packages/dataviews/src/stories/index.story.js
@@ -8,9 +8,7 @@ import { useState, useMemo, useCallback } from '@wordpress/element';
  */
 import { DataViews } from '../index';
 import { DEFAULT_VIEW, actions, data } from './fixtures';
-
-const LAYOUT_GRID = 'grid';
-const LAYOUT_TABLE = 'table';
+import { LAYOUT_GRID, LAYOUT_TABLE } from '../constants';
 
 const meta = {
 	title: 'DataViews (Experimental)/DataViews',

--- a/packages/dataviews/src/stories/index.story.js
+++ b/packages/dataviews/src/stories/index.story.js
@@ -6,9 +6,11 @@ import { useState, useMemo, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { DataViews, LAYOUT_GRID, LAYOUT_TABLE } from '../index';
-
+import { DataViews } from '../index';
 import { DEFAULT_VIEW, actions, data } from './fixtures';
+
+const LAYOUT_GRID = 'grid';
+const LAYOUT_TABLE = 'table';
 
 const meta = {
 	title: 'DataViews (Experimental)/DataViews',
@@ -17,7 +19,9 @@ const meta = {
 export default meta;
 
 const defaultConfigPerViewType = {
-	[ LAYOUT_TABLE ]: {},
+	[ LAYOUT_TABLE ]: {
+		primaryField: 'title',
+	},
 	[ LAYOUT_GRID ]: {
 		mediaField: 'image',
 		primaryField: 'title',
@@ -100,23 +104,19 @@ export const Default = ( props ) => {
 		};
 	}, [ view ] );
 	const onChangeView = useCallback(
-		( viewUpdater ) => {
-			let updatedView =
-				typeof viewUpdater === 'function'
-					? viewUpdater( view )
-					: viewUpdater;
-			if ( updatedView.type !== view.type ) {
-				updatedView = {
-					...updatedView,
+		( newView ) => {
+			if ( newView.type !== view.type ) {
+				newView = {
+					...newView,
 					layout: {
-						...defaultConfigPerViewType[ updatedView.type ],
+						...defaultConfigPerViewType[ newView.type ],
 					},
 				};
 			}
 
-			setView( updatedView );
+			setView( newView );
 		},
-		[ view, setView ]
+		[ view.type, setView ]
 	);
 	return (
 		<DataViews
@@ -131,7 +131,5 @@ export const Default = ( props ) => {
 };
 Default.args = {
 	actions,
-	getItemId: ( item ) => item.id,
-	isLoading: false,
 	supportedLayouts: [ LAYOUT_TABLE, LAYOUT_GRID ],
 };


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Fixes the storybook for dataviews: upon clicking the view actions menu it broke.

## How?

Import constants from the proper place.

## Testing Instructions

Run storybook locally, and verify that you can interact with the view actions menu. The easiest way to reach it is via keyboard (you can also scroll horizontally).

https://github.com/WordPress/gutenberg/assets/583546/c7ecf53b-7f80-458f-8297-6c1ce9f732e7

In `trunk`, upon clicking the menu there is an error:

<img width="1509" alt="Captura de ecrã 2024-02-14, às 12 59 26" src="https://github.com/WordPress/gutenberg/assets/583546/23aabe4c-e4fd-4c86-9598-a08f2a8bff6d">

