### PR TITLE
Block Bindings: Update bindings registry with latest changes

### DIFF
--- a/lib/compat/wordpress-6.5/block-bindings/block-bindings.php
+++ b/lib/compat/wordpress-6.5/block-bindings/block-bindings.php
@@ -38,7 +38,7 @@
  *                                        The callback has a mixed return type; it may return a string to override
  *                                        the block's original value, null, false to remove an attribute, etc.
  * }
- * @return array|false Source when the registration was successful, or `false` on failure.
+ * @return WP_Block_Bindings_Source|false Source when the registration was successful, or `false` on failure.
  */
 if ( ! function_exists( 'register_block_bindings_source' ) ) {
 	function register_block_bindings_source( string $source_name, array $source_properties ) {
@@ -52,7 +52,7 @@ if ( ! function_exists( 'register_block_bindings_source' ) ) {
  * @since 6.5.0
  *
  * @param string $source_name Block bindings source name including namespace.
- * @return array|false The unregistred block bindings source on success and `false` otherwise.
+ * @return WP_Block_Bindings_Source|false The unregistred block bindings source on success and `false` otherwise.
  */
 if ( ! function_exists( 'unregister_block_bindings_source' ) ) {
 	function unregister_block_bindings_source( string $source_name ) {
@@ -65,7 +65,7 @@ if ( ! function_exists( 'unregister_block_bindings_source' ) ) {
  *
  * @since 6.5.0
  *
- * @return array The array of registered block bindings sources.
+ * @return WP_Block_Bindings_Source The array of registered block bindings sources.
  */
 if ( ! function_exists( 'get_all_registered_block_bindings_sources' ) ) {
 	function get_all_registered_block_bindings_sources() {
@@ -79,7 +79,7 @@ if ( ! function_exists( 'get_all_registered_block_bindings_sources' ) ) {
  * @since 6.5.0
  *
  * @param string $source_name The name of the source.
- * @return array|null The registered block bindings source, or `null` if it is not registered.
+ * @return WP_Block_Bindings_Source|null The registered block bindings source, or `null` if it is not registered.
  */
 if ( ! function_exists( 'get_block_bindings_source' ) ) {
 	function get_block_bindings_source( string $source_name ) {

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -2,27 +2,25 @@
 /**
  * Block Bindings API: WP_Block_Bindings_Registry class.
  *
- * Support for overriding content in blocks by connecting them to different sources.
+ * Supports overriding content in blocks by connecting them to different sources.
  *
  * @package WordPress
  * @subpackage Block Bindings
  * @since 6.5.0
  */
 
+/**
+ * Class used for interacting with block bindings sources.
+ *
+ *  @since 6.5.0
+ */
 if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
-
-	/**
-	 * Class used for interacting with block bindings sources.
-	 *
-	 *  @since 6.5.0
-	 */
 	final class WP_Block_Bindings_Registry {
 		/**
 		 * Holds the registered block bindings sources, keyed by source identifier.
 		 *
 		 * @since 6.5.0
-		 *
-		 * @var array
+		 * @var WP_Block_Bindings_Source[]
 		 */
 		private $sources = array();
 
@@ -59,11 +57,11 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 		 *                                                                              used to look up the override value,
 		 *                                                                              i.e. {"key": "foo"}.
 		 *                                            - @param WP_Block $block_instance The block instance.
-		 *                                            - @param string   $attribute_name The name of the target attribute .
+		 *                                            - @param string   $attribute_name The name of the target attribute.
 		 *                                        The callback has a mixed return type; it may return a string to override
 		 *                                        the block's original value, null, false to remove an attribute, etc.
 		 * }
-		 * @return array|false Source when the registration was successful, or `false` on failure.
+		 * @return WP_Block_Bindings_Source|false Source when the registration was successful, or `false` on failure.
 		 */
 		public function register( string $source_name, array $source_properties ) {
 			if ( ! is_string( $source_name ) ) {
@@ -98,14 +96,44 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 				_doing_it_wrong(
 					__METHOD__,
 					/* translators: %s: Block bindings source name. */
-					sprintf( __( 'Block bindings sources "%s" already registered.' ), $source_name ),
+					sprintf( __( 'Block bindings source "%s" already registered.' ), $source_name ),
 					'6.5.0'
 				);
 				return false;
 			}
 
-			$source = array_merge(
-				array( 'name' => $source_name ),
+			/* Validate that the source properties contain the label */
+			if ( ! isset( $source_properties['label'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'The $source_properties must contain a "label".' ),
+					'6.5.0'
+				);
+				return false;
+			}
+
+			/* Validate that the source properties contain the get_value_callback */
+			if ( ! isset( $source_properties['get_value_callback'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'The $source_properties must contain a "get_value_callback".' ),
+					'6.5.0'
+				);
+				return false;
+			}
+
+			/* Validate that the get_value_callback is a valid callback */
+			if ( ! is_callable( $source_properties['get_value_callback'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'The "get_value_callback" parameter must be a valid callback.' ),
+					'6.5.0'
+				);
+				return false;
+			}
+
+			$source = new WP_Block_Bindings_Source(
+				$source_name,
 				$source_properties
 			);
 
@@ -120,14 +148,14 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 		 * @since 6.5.0
 		 *
 		 * @param string $source_name Block bindings source name including namespace.
-		 * @return array|false The unregistred block bindings source on success and `false` otherwise.
+		 * @return WP_Block_Bindings_Source|false The unregistered block bindings source on success and `false` otherwise.
 		 */
 		public function unregister( string $source_name ) {
 			if ( ! $this->is_registered( $source_name ) ) {
 				_doing_it_wrong(
 					__METHOD__,
 					/* translators: %s: Block bindings source name. */
-					sprintf( __( 'Block bindings "%s" not found.' ), $source_name ),
+					sprintf( __( 'Block binding "%s" not found.' ), $source_name ),
 					'6.5.0'
 				);
 				return false;
@@ -144,7 +172,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 		 *
 		 * @since 6.5.0
 		 *
-		 * @return array The array of registered sources.
+		 * @return WP_Block_Bindings_Source[] The array of registered sources.
 		 */
 		public function get_all_registered() {
 			return $this->sources;
@@ -156,7 +184,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 		 * @since 6.5.0
 		 *
 		 * @param string $source_name The name of the source.
-		 * @return array|null The registered block bindings source, or `null` if it is not registered.
+		 * @return WP_Block_Bindings_Source|null The registered block bindings source, or `null` if it is not registered.
 		 */
 		public function get_registered( string $source_name ) {
 			if ( ! $this->is_registered( $source_name ) ) {

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-source.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-source.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Block Bindings API: WP_Block_Bindings_Source class.
+ *
+ *
+ * @package WordPress
+ * @subpackage Block Bindings
+ * @since 6.5.0
+ */
+
+/**
+ * Class representing block bindings source.
+ *
+ * This class is designed for internal use by the Block Bindings registry.
+ *
+ * @since 6.5.0
+ * @access private
+ *
+ * @see WP_Block_Bindings_Registry
+ */
+if ( ! class_exists( 'WP_Block_Bindings_Source' ) ) {
+	final class WP_Block_Bindings_Source {
+
+		/**
+		 * The name of the source.
+		 *
+		 * @since 6.5.0
+		 * @var string
+		 */
+		public $name;
+
+		/**
+		 * The label of the source.
+		 *
+		 * @since 6.5.0
+		 * @var string
+		 */
+		public $label;
+
+
+		/**
+		 * The function used to get the value from the source.
+		 *
+		 * @since 6.5.0
+		 * @var callable
+		 */
+		private $get_value_callback;
+
+		/**
+		 * Constructor.
+		 *
+		 * Do not use this constructor directly. Instead, use the
+		 * `WP_Block_Bindings_Registry::register` method or the `register_block_bindings_source` function.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string $name               The name of the source.
+		 * @param array  $source_properties  The properties of the source.
+		 */
+		public function __construct( string $name, array $source_properties ) {
+			$this->name               = $name;
+			$this->label              = $source_properties['label'];
+			$this->get_value_callback = $source_properties['get_value_callback'];
+		}
+
+		/**
+		 * Retrieves the value from the source.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array    $source_args     Array containing source arguments used to look up the override value, i.e. {"key": "foo"}.
+		 * @param WP_Block $block_instance  The block instance.
+		 * @param string   $attribute_name  The name of the target attribute.
+		 *
+		 * @return mixed The value of the source.
+		 */
+		public function get_value( array $source_args, $block_instance, string $attribute_name ) {
+			return call_user_func_array( $this->get_value_callback, array( $source_args, $block_instance, $attribute_name ) );
+		}
+
+		/**
+		 * Wakeup magic method.
+		 *
+		 * @since 6.5.0
+		 */
+		public function __wakeup() {
+			throw new \LogicException( __CLASS__ . ' should never be unserialized' );
+		}
+	}
+}

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -206,9 +206,8 @@ function gutenberg_process_block_bindings( $block_content, $parsed_block, $block
 			continue;
 		}
 
-		$source_callback = $block_binding_source['get_value_callback'];
-		$source_args     = ! empty( $block_binding['args'] ) && is_array( $block_binding['args'] ) ? $block_binding['args'] : array();
-		$source_value    = call_user_func_array( $source_callback, array( $source_args, $block_instance, $attribute_name ) );
+		$source_args  = ! empty( $block_binding['args'] ) && is_array( $block_binding['args'] ) ? $block_binding['args'] : array();
+		$source_value = $block_binding_source->get_value( $source_args, $block_instance, $attribute_name );
 
 		// If the value is not null, process the HTML based on the block and the attribute.
 		if ( ! is_null( $source_value ) ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -113,6 +113,9 @@ require __DIR__ . '/compat/wordpress-6.5/interactivity-api/class-wp-interactivit
 require __DIR__ . '/compat/wordpress-6.5/interactivity-api/interactivity-api.php';
 require __DIR__ . '/compat/wordpress-6.5/class-wp-script-modules.php';
 require __DIR__ . '/compat/wordpress-6.5/scripts-modules.php';
+if ( ! class_exists( 'WP_Block_Bindings_Source' ) ) {
+	require __DIR__ . '/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-source.php';
+}
 if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 	require __DIR__ . '/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php';
 }


### PR DESCRIPTION
## What?
Migrate [the changes made in core](https://core.trac.wordpress.org/changeset/57562) to Gutenberg plugin.

## Why?
To keep the code synced and solve and issue with the e2e tests.

## How?
Just copy and pasting 🙂 
