### PR TITLE
Block Bindings: Ensure to pass bound attributes

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -82,8 +82,8 @@ const createEditFunctionWithBindingsAttribute = () =>
 			return (
 				<BlockEdit
 					key="edit"
-					attributes={ updatedAttributes }
 					{ ...props }
+					attributes={ updatedAttributes }
 				/>
 			);
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR ensures passing the update (bound) attributes to the block edit component function.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the `attributes` property previously defined with the bound attribute is overwritten by the original attributes object though the `{ ...props }` assignment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Use testing instructions - https://github.com/WordPress/gutenberg/pull/58085.

## Screenshots or screencast <!-- if applicable -->
