### PR TITLE
Font Utils: Replace `join()` alias with `implode()`.

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -134,7 +134,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 				$slug_elements
 			);
 
-			return sanitize_text_field( join( ';', $slug_elements ) );
+			return sanitize_text_field( implode( ';', $slug_elements ) );
 		}
 
 		/**


### PR DESCRIPTION
## What?
Replaces `join()` with `implode()`.

## Why?
>Using the canonical function name for PHP functions is strongly recommended, as aliases may be deprecated or removed without (much) warning.

See Core's https://core.trac.wordpress.org/changeset/49193.

This change is being tracked in https://core.trac.wordpress.org/ticket/60473 and is (or will be shortly) committed into WP Core. This PR keeps the code in sync.

Props to @david-binda.