### PR TITLE
Interactivity API: use compat versions of HTML APIs

### DIFF
--- a/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api-directives-processor.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api-directives-processor.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WP_Interactivity_API_Directives_Processor' ) ) {
 	 *
 	 * @access private
 	 */
-	final class WP_Interactivity_API_Directives_Processor extends WP_HTML_Tag_Processor {
+	final class WP_Interactivity_API_Directives_Processor extends Gutenberg_HTML_Tag_Processor_6_5 {
 		/**
 		 * List of tags whose closer tag is not visited by the WP_HTML_Tag_Processor.
 		 *
@@ -78,7 +78,7 @@ if ( ! class_exists( 'WP_Interactivity_API_Directives_Processor' ) ) {
 			}
 			list( $after_opener_tag, $before_closer_tag ) = $positions;
 
-			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates[] = new Gutenberg_HTML_Text_Replacement_6_5(
 				$after_opener_tag,
 				$before_closer_tag - $after_opener_tag,
 				esc_html( $new_content )
@@ -112,7 +112,7 @@ if ( ! class_exists( 'WP_Interactivity_API_Directives_Processor' ) ) {
 			$this->release_bookmark( $bookmark );
 
 			// Appends the new content.
-			$this->lexical_updates[] = new WP_HTML_Text_Replacement( $after_closing_tag, 0, $new_content );
+			$this->lexical_updates[] = new Gutenberg_HTML_Text_Replacement_6_5( $after_closing_tag, 0, $new_content );
 
 			return true;
 		}
@@ -238,7 +238,7 @@ if ( ! class_exists( 'WP_Interactivity_API_Directives_Processor' ) ) {
 			$tag_name = $this->get_tag();
 
 			return null !== $tag_name && (
-			! WP_HTML_Processor::is_void( $tag_name ) &&
+			! Gutenberg_HTML_Processor_6_5::is_void( $tag_name ) &&
 			! in_array( $tag_name, self::TAGS_THAT_DONT_VISIT_CLOSER_TAG, true )
 			);
 		}

--- a/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
@@ -90,6 +90,8 @@ if ( ! function_exists( 'wp_interactivity' ) ) {
 		}
 		return $wp_interactivity;
 	}
+
+	wp_interactivity()->add_hooks();
 }
 
 if ( ! function_exists( 'wp_interactivity_process_directives' ) ) {

--- a/lib/experimental/interactivity-api.php
+++ b/lib/experimental/interactivity-api.php
@@ -14,7 +14,7 @@
 function gutenberg_interactivity_override_script_module_urls( $url ) {
 	$pattern = '/wp-includes\/js\/dist\/interactivity(-router)?(\.min)?\.js/';
 	if ( preg_match( $pattern, $url, $matches ) ) {
-		return gutenberg_url( '/build/interactivity/' . ( ( isset( $matches[1] ) && $matches[1] ) ? 'router' : 'index' ) . wp_scripts_get_suffix() . '.js' );
+		return gutenberg_url( '/build/interactivity/' . ( ( isset( $matches[1] ) && $matches[1] ) ? 'router' : 'index' ) . '.min.js' );
 	}
 	return $url;
 }

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -38,8 +38,9 @@ function render_block_core_file( $attributes, $content ) {
 
 	// If it's interactive, enqueue the script module and add the directives.
 	if ( ! empty( $attributes['displayPreview'] ) ) {
+		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( "/build/interactivity/file.min.js" );
+			$module_url = gutenberg_url( '/build/interactivity/file.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -38,9 +38,8 @@ function render_block_core_file( $attributes, $content ) {
 
 	// If it's interactive, enqueue the script module and add the directives.
 	if ( ! empty( $attributes['displayPreview'] ) ) {
-		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( "/build/interactivity/file{$suffix}.js" );
+			$module_url = gutenberg_url( "/build/interactivity/file.min.js" );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -47,8 +47,9 @@ function render_block_core_image( $attributes, $content, $block ) {
 		isset( $lightbox_settings['enabled'] ) &&
 		true === $lightbox_settings['enabled']
 	) {
+		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( "/build/interactivity/image.min.js" );
+			$module_url = gutenberg_url( '/build/interactivity/image.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -47,9 +47,8 @@ function render_block_core_image( $attributes, $content, $block ) {
 		isset( $lightbox_settings['enabled'] ) &&
 		true === $lightbox_settings['enabled']
 	) {
-		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( "/build/interactivity/image{$suffix}.js" );
+			$module_url = gutenberg_url( "/build/interactivity/image.min.js" );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -588,9 +588,8 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function handle_view_script_module_loading( $attributes, $block, $inner_blocks ) {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
-			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( "/build/interactivity/navigation{$suffix}.js" );
+				$module_url = gutenberg_url( "/build/interactivity/navigation.min.js" );
 			}
 
 			wp_register_script_module(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -588,8 +588,9 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function handle_view_script_module_loading( $attributes, $block, $inner_blocks ) {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
+			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( "/build/interactivity/navigation.min.js" );
+				$module_url = gutenberg_url( '/build/interactivity/navigation.min.js' );
 			}
 
 			wp_register_script_module(

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -24,8 +24,9 @@ function render_block_core_query( $attributes, $content, $block ) {
 	// Enqueue the script module and add the necessary directives if the block is
 	// interactive.
 	if ( $is_interactive ) {
+		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( "/build/interactivity/query.min.js" );
+			$module_url = gutenberg_url( '/build/interactivity/query.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -24,9 +24,8 @@ function render_block_core_query( $attributes, $content, $block ) {
 	// Enqueue the script module and add the necessary directives if the block is
 	// interactive.
 	if ( $is_interactive ) {
-		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( "/build/interactivity/query{$suffix}.js" );
+			$module_url = gutenberg_url( "/build/interactivity/query.min.js" );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,8 +80,9 @@ function render_block_core_search( $attributes ) {
 		// If it's interactive, enqueue the script module and add the directives.
 		$is_expandable_searchfield = 'button-only' === $button_position;
 		if ( $is_expandable_searchfield ) {
+			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( "/build/interactivity/search.min.js" );
+				$module_url = gutenberg_url( '/build/interactivity/search.min.js' );
 			}
 
 			wp_register_script_module(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,9 +80,8 @@ function render_block_core_search( $attributes ) {
 		// If it's interactive, enqueue the script module and add the directives.
 		$is_expandable_searchfield = 'button-only' === $button_position;
 		if ( $is_expandable_searchfield ) {
-			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( "/build/interactivity/search{$suffix}.js" );
+				$module_url = gutenberg_url( "/build/interactivity/search.min.js" );
 			}
 
 			wp_register_script_module(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Use the compat versions of HTML APIs in the compat verison of the Interactivity API.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the Interactivity API relies on the latest version of the HTML APIs, which are not available before WP 6.5.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By replacing the HTML APIs with the compat version.