### PR TITLE
Try fixing flaky 'inserting blocks' e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -573,14 +573,20 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			} )
 			.click();
 
-		const searchBox = page.getByRole( 'searchbox', {
-			name: 'Search for blocks and patterns',
-		} );
-
-		await searchBox.fill( 'Verse' );
+		await page
+			.getByRole( 'searchbox', {
+				name: 'Search for blocks and patterns',
+			} )
+			.fill( 'Verse' );
 		await page.getByRole( 'button', { name: 'Browse All' } ).click();
 
-		await expect( searchBox ).toHaveValue( 'Verse' );
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Block Library' } )
+				.getByRole( 'searchbox', {
+					name: 'Search for blocks and patterns',
+				} )
+		).toHaveValue( 'Verse' );
 		await expect(
 			page.getByRole( 'listbox', { name: 'Blocks' } )
 		).toHaveCount( 1 );

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -393,7 +393,9 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await admin.createNewPost();
-		await page.keyboard.press( 'Enter' );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
 		await page.keyboard.type( '/tag cloud' );
 
 		await expect(
@@ -413,7 +415,9 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await admin.createNewPost();
-		await page.keyboard.press( 'Enter' );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '## Heading' );
@@ -465,7 +469,9 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		insertingBlocksUtils,
 	} ) => {
 		await admin.createNewPost();
-		await page.keyboard.press( 'Enter' );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await editor.insertBlock( { name: 'core/image' } );
 


### PR DESCRIPTION
## What?
Fixes #41477.
Fixes #40301.
Fixes #35280.
Fixes #45332.

PR tries to fix a few flaky tests in the `inserting blocks` suite.

## How?
* Moving from the focused post title field to the editor canvas using the `Enter` key failed, so I replaced it with the default block appender click action.
* #45332 - for a brief moment, two inserters can be on the page, and the locator strick check will fail. I've added context to the locators. Similar to #47066.

## Testing Instructions
```
npm run test:e2e:playwright -- inserting-blocks.spec.js
```

## Screenshots

![test-failed-1](https://github.com/WordPress/gutenberg/assets/240569/88e1dba1-003f-4a38-a576-62752fd41629)

![test-failed-1](https://github.com/WordPress/gutenberg/assets/240569/8778f5fa-0c31-4030-bc9e-1cd937f0f9f2)
