### PR TITLE
Font Library: fix size of demo text

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-demo.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-demo.js
@@ -31,6 +31,8 @@ function FontFaceDemo( { customPreviewUrl, fontFace, text, style = {} } ) {
 
 	const faceStyles = getFacePreviewStyle( fontFace );
 	const textDemoStyle = {
+		fontSize: '18px',
+		lineHeight: 1,
 		opacity: isAssetLoaded ? '1' : '0',
 		...faceStyles,
 		...style,

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -74,7 +74,6 @@
 .font-library-modal__font-variant_demo-text {
 	white-space: nowrap;
 	flex-shrink: 0;
-	font-size: 18px;
 	transition: opacity 0.3s ease-in-out;
 	@include reduce-motion("transition");
 }


### PR DESCRIPTION
## What?
 Fix size of fonts without preview image.

## Why?
Some of the changes added here https://github.com/WordPress/gutenberg/pull/58451 related to move the demo styles to a css class instead of passing them to the `<Text>` component broke how the demo of fonts without preview image looks.

## How?
By avoiding `<Text>` component overrides the font size for the system fonts demo.

## Testing Instructions
Navigate a collection of system fonts or fonts without a preview image.

## Screenshots or screencast <!-- if applicable -->

| Before | After  |
| --- | --- |
| ![Screenshot from 2024-02-08 13-25-34](https://github.com/WordPress/gutenberg/assets/1310626/aebed2d4-4fb5-4387-9e5c-7df07fb13a44) | ![Screenshot from 2024-02-08 13-26-09](https://github.com/WordPress/gutenberg/assets/1310626/b30bab6d-19c4-451c-87db-c9aae12b6f49) |

