### PR TITLE
Fix top toolbar buttons not clickable on "mobile"

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -185,8 +185,8 @@ $z-layers: (
 
 	// Site editor layout
 	".edit-site-layout__header-container": 4,
-	".edit-site-layout__hub": 3,
-	".edit-site-layout__header": 2,
+	".edit-site-layout__hub": 2,
+	".edit-site-layout__header": 3,
 	".edit-site-page-header": 2,
 	".edit-site-page-content": 1,
 	".edit-site-patterns__header": 2,

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -3,7 +3,7 @@ $header-toolbar-min-width: 335px;
 .edit-site-header-edit-mode {
 	height: $header-height;
 	align-items: center;
-	background-color: $white;
+	// background-color: $white;
 	color: $gray-900;
 	display: flex;
 	box-sizing: border-box;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -32,6 +32,7 @@
 }
 
 .edit-site-layout__header-container {
+	background-color: $white;
 	z-index: z-index(".edit-site-layout__header-container");
 }
 
@@ -258,6 +259,7 @@
 		right: 0;
 		z-index: z-index(".edit-site-layout__header-container");
 		width: 100%;
+		background-color: #fff;
 
 		// We need ! important because we override inline styles
 		// set by the motion component.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes bug where top toolbar buttons are unresponsive on mobile.

Closes https://github.com/WordPress/gutenberg/issues/58781

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Mobile should function as per desktop and all elements of top toolbar shoulld be interactive.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This is a z-indexing issue. The whole top toolbar is split across multiple DOM elements and these are stacked in unusual ways.

The elements housing the site icon were stacked above the elements housing the majority of the buttons.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. On a mobile app or mobile browser on a site with an block theme active, open the Site Editor by clicking the option to update your site's design. 
2. Go to templates and choose a template
3. Click on any of the buttons at the top of the page, like save or the block inserter 
4. Check all buttons are interactive.
5. Check site icon is still interactive.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/75b73d24-f6af-435b-8804-025a78eaee8c

