### PR TITLE
Mobile site editor header toolbar button bugfix

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -19,15 +19,10 @@
 	}
 
 	.edit-site-layout.is-full-canvas & {
-		padding-right: $grid-unit-20;
+		padding-right: 0;
 		border-radius: 0;
-		width: 100vw;
+		width: $header-height;
 		box-shadow: none;
-
-		@include break-medium {
-			width: $header-height;
-			padding-right: 0;
-		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes bug where top toolbar buttons are unresponsive on mobile. I believe this was caused by https://github.com/WordPress/gutenberg/pull/57938/files#diff-b948436daf4637baf6bada5f65931d841feed7039369fba4176b1afb23d497f4L17-L33, so I undid some of it.

Closes https://github.com/WordPress/gutenberg/issues/58781

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Mobile should function as per desktop and all elements of top toolbar shoulld be interactive.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The site hub icon was full width at smaller screens, obstructing the icons in the toolbar from being clicked.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. On a mobile app or mobile browser on a site with an block theme active, open the Site Editor by clicking the option to update your site's design. 
2. Go to templates and choose a template
3. Click on any of the buttons at the top of the page, like save or the block inserter 
4. Check all buttons are interactive.
5. Check site icon is still interactive.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/75b73d24-f6af-435b-8804-025a78eaee8c

Co-authored-by: getdave <get_dave@git.wordpress.org>
