### PR TITLE
Font Library: Fix font loading for uploaded fonts with names of more than one word.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -397,11 +397,11 @@ function FontLibraryProvider( { children } ) {
 		fontsToAdd.forEach( ( font ) => {
 			if ( font.fontFace ) {
 				font.fontFace.forEach( ( face ) => {
-					// Load font faces just in the iframe because they already are in the document.
+					// Load font face in the browser.
 					loadFontFaceInBrowser(
 						face,
 						getDisplaySrcFromFontFace( face.src ),
-						'iframe'
+						'all'
 					);
 				} );
 			}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -263,28 +263,29 @@ function FontLibraryProvider( { children } ) {
 			}
 
 			// Install the fonts (upload the font files to the server and create the post in the database).
-			let sucessfullyInstalledFontFaces = [];
-			let unsucessfullyInstalledFontFaces = [];
+			let successfullyInstalledFontFaces = [];
+			let unsuccessfullyInstalledFontFaces = [];
 			if ( fontFamilyToInstall?.fontFace?.length > 0 ) {
 				const response = await batchInstallFontFaces(
 					installedFontFamily.id,
 					makeFontFacesFormData( fontFamilyToInstall )
 				);
-				sucessfullyInstalledFontFaces = response?.successes;
-				unsucessfullyInstalledFontFaces = response?.errors;
+				successfullyInstalledFontFaces = response?.successes;
+				unsuccessfullyInstalledFontFaces = response?.errors;
 			}
 
-			const detailedErrorMessage = unsucessfullyInstalledFontFaces.reduce(
-				( errorMessageCollection, error ) => {
-					return `${ errorMessageCollection } ${ error.message }`;
-				},
-				''
-			);
+			const detailedErrorMessage =
+				unsuccessfullyInstalledFontFaces.reduce(
+					( errorMessageCollection, error ) => {
+						return `${ errorMessageCollection } ${ error.message }`;
+					},
+					''
+				);
 
 			// If there were no successes and nothing already installed then we don't need to activate anything and can bounce now.
 			if (
 				fontFamilyToInstall?.fontFace?.length > 0 &&
-				sucessfullyInstalledFontFaces.length === 0 &&
+				successfullyInstalledFontFaces.length === 0 &&
 				alreadyInstalledFontFaces.length === 0
 			) {
 				throw new Error(
@@ -296,14 +297,14 @@ function FontLibraryProvider( { children } ) {
 				);
 			}
 
-			// Use the sucessfully installed font faces
+			// Use the successfully installed font faces
 			// As well as any font faces that were already installed (those will be activated)
 			if (
-				sucessfullyInstalledFontFaces?.length > 0 ||
+				successfullyInstalledFontFaces?.length > 0 ||
 				alreadyInstalledFontFaces?.length > 0
 			) {
 				fontFamilyToInstall.fontFace = [
-					...sucessfullyInstalledFontFaces,
+					...successfullyInstalledFontFaces,
 					...alreadyInstalledFontFaces,
 				];
 			}
@@ -318,7 +319,7 @@ function FontLibraryProvider( { children } ) {
 
 			refreshLibrary();
 
-			if ( unsucessfullyInstalledFontFaces.length > 0 ) {
+			if ( unsuccessfullyInstalledFontFaces.length > 0 ) {
 				throw new Error(
 					sprintf(
 						/* translators: %s: Specific error message returned from server. */

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -9,7 +9,6 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { FONT_WEIGHTS, FONT_STYLES } from './constants';
 import { unlock } from '../../../../lock-unlock';
 import { fetchInstallFontFace } from '../resolvers';
-import { formatFontFamily } from './preview-styles';
 
 /**
  * Browser dependencies
@@ -98,14 +97,10 @@ export async function loadFontFaceInBrowser( fontFace, source, addTo = 'all' ) {
 		return;
 	}
 
-	const newFont = new window.FontFace(
-		formatFontFamily( fontFace.fontFamily ),
-		dataSource,
-		{
-			style: fontFace.fontStyle,
-			weight: fontFace.fontWeight,
-		}
-	);
+	const newFont = new window.FontFace( fontFace.fontFamily, dataSource, {
+		style: fontFace.fontStyle,
+		weight: fontFace.fontWeight,
+	} );
 
 	const loadedFace = await newFont.load();
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -9,6 +9,7 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { FONT_WEIGHTS, FONT_STYLES } from './constants';
 import { unlock } from '../../../../lock-unlock';
 import { fetchInstallFontFace } from '../resolvers';
+import { formatFontFamily } from './preview-styles';
 
 /**
  * Browser dependencies
@@ -97,10 +98,14 @@ export async function loadFontFaceInBrowser( fontFace, source, addTo = 'all' ) {
 		return;
 	}
 
-	const newFont = new window.FontFace( fontFace.fontFamily, dataSource, {
-		style: fontFace.fontStyle,
-		weight: fontFace.fontWeight,
-	} );
+	const newFont = new window.FontFace(
+		formatFontFamily( fontFace.fontFamily ),
+		dataSource,
+		{
+			style: fontFace.fontStyle,
+			weight: fontFace.fontWeight,
+		}
+	);
 
 	const loadedFace = await newFont.load();
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -31,21 +31,25 @@ function extractFontWeights( fontFaces ) {
 }
 
 export function formatFontFamily( input ) {
-	return input
-		.split( ',' )
-		.map( ( font ) => {
-			font = font.trim(); // Remove any leading or trailing white spaces
-			// If the font doesn't start with quotes and contains a space, then wrap in quotes.
-			// Check that string starts with a single or double quote and not a space
-			if (
-				! ( font.startsWith( '"' ) || font.startsWith( "'" ) ) &&
-				font.indexOf( ' ' ) !== -1
-			) {
-				return `"${ font }"`;
-			}
-			return font; // Return font as is if no transformation is needed
-		} )
-		.join( ', ' );
+	return input.includes( ',' )
+		? input
+				.split( ',' )
+				.map( ( font ) => {
+					font = font.trim(); // Remove any leading or trailing white spaces
+					// If the font doesn't start with quotes and contains a space, then wrap in quotes.
+					// Check that string starts with a single or double quote and not a space
+					if (
+						! (
+							font.startsWith( '"' ) || font.startsWith( "'" )
+						) &&
+						font.indexOf( ' ' ) !== -1
+					) {
+						return `"${ font }"`;
+					}
+					return font; // Return font as is if no transformation is needed
+				} )
+				.join( ', ' )
+		: input.replace( /"/g, '' );
 }
 
 export function getFamilyPreviewStyle( family ) {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
@@ -143,8 +143,8 @@ describe( 'formatFontFamily', () => {
 		);
 	} );
 
-	it( 'should wrap single font name with spaces in quotes', () => {
-		expect( formatFontFamily( 'Baloo 2' ) ).toBe( '"Baloo 2"' );
+	it( 'should not add quotes to single font name with spaces', () => {
+		expect( formatFontFamily( 'Baloo 2' ) ).toBe( 'Baloo 2' );
 	} );
 
 	it( 'should wrap multiple font names with spaces in quotes', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update the use of quotes in font family names, so that they're properly loaded in the browser.

Fixes https://github.com/WordPress/gutenberg/issues/58765

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When uploading a font with a name of more than one word, `formatFontFamily` was formatting things to in a way that was preventing the font from being loaded correctly in the browser (for a later use). As a result, the font would only be available after refresh.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updating the way the font family is being formatted so that it can be loaded correctly in the browser. And adding the font to the whole document so that it's also accessible in the sidebar.

## Testing Instructions

**Uploading new fonts**

1. Download the "Super Enjoy" font from https://www.dafont.com/super-enjoy.font.
2. Upload and activate the font in the Font Library modal.
3. Apply the newly activated font to a heading block in the Gutenberg editor.
4. Observe that the canvas updates to show the new font.

**Installing Google fonts**

1. Install the "Abril Fatface" font from Google fonts.
2. Confirm that the font family has effect on the sidebar.
3. Apply the newly activated font to a heading block in the Gutenberg editor.
4. Observe that the canvas updates to show the new font.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/252415/48e2eb69-bfe1-4522-aee8-2d83663bddf7



