### PR TITLE
Tweak metrics and labels for background size controls

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -365,12 +365,12 @@ function BackgroundImagePanelItem( {
 
 function backgroundSizeHelpText( value ) {
 	if ( value === 'cover' || value === undefined ) {
-		return __( 'Stretch image to cover the block.' );
+		return __( 'Image covers the space evenly.' );
 	}
 	if ( value === 'contain' ) {
-		return __( 'Resize image to fit without cropping.' );
+		return __( 'Image is contained without distortion.' );
 	}
-	return __( 'Set a fixed width.' );
+	return __( 'Specify a fixed width.' );
 }
 
 export const coordsToBackgroundPosition = ( value ) => {
@@ -510,7 +510,6 @@ function BackgroundSizePanelItem( {
 			panelId={ clientId }
 		>
 			<FocalPointPicker
-				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label={ __( 'Position' ) }
 				url={ style?.background?.backgroundImage?.url }
@@ -520,7 +519,6 @@ function BackgroundSizePanelItem( {
 				onChange={ updateBackgroundPosition }
 			/>
 			<ToggleGroupControl
-				__nextHasNoMarginBottom
 				size={ '__unstable-large' }
 				label={ __( 'Size' ) }
 				value={ currentValueForToggle }
@@ -555,8 +553,7 @@ function BackgroundSizePanelItem( {
 			) : null }
 			{ currentValueForToggle !== 'cover' && (
 				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Repeat image' ) }
+					label={ __( 'Repeat' ) }
 					checked={ repeatCheckedValue }
 					onChange={ toggleIsRepeated }
 				/>


### PR DESCRIPTION
A quick follow-up to https://github.com/WordPress/gutenberg/pull/58592, to use similar labels to what we're using elsewhere for similar controls. Part of https://github.com/WordPress/gutenberg/issues/54336. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a group block.
3. Add a background image via the inspector.
4. Add the size control in the same UI. 
5. See changes. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-02-08 at 13 08 59](https://github.com/WordPress/gutenberg/assets/1813435/7b36f58e-8796-4b3e-b437-35fabc1fea72)|![CleanShot 2024-02-08 at 13 05 46](https://github.com/WordPress/gutenberg/assets/1813435/40cc197a-9769-4309-bf47-9a715cbd8436)|