### PR TITLE
Fix: Removing footnotes from the allowed blocks does not remove footnotes

### DIFF
--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -62,6 +62,16 @@ export const format = {
 					return false;
 				}
 
+				const allowedBlocks =
+					select( blockEditorStore ).getSettings().allowedBlockTypes;
+				if (
+					allowedBlocks === false ||
+					( Array.isArray( allowedBlocks ) &&
+						! allowedBlocks.includes( 'core/footnotes' ) )
+				) {
+					return false;
+				}
+
 				const entityRecord = select( coreDataStore ).getEntityRecord(
 					'postType',
 					postType,


### PR DESCRIPTION
This PR fixes an issue where the footnotes format is still available even if the footnotes block is disabled.
This creates an user noticed problem where the user can create footnotes and use the footnote format but can not edit its content.

## Testing Instructions
I added the following code in blocks.php:
```

add_filter( 'allowed_block_types_all', 'footnotes_allowed_block_types', 10, 2 );
 
function footnotes_allowed_block_types( $allowed_blocks, $editor_context ) {
    if( 'post' === $editor_context->post->post_type ) {
		$allowed_blocks_array = array();
		if ( is_array( $allowed_blocks )) {
			$allowed_blocks_array = $allowed_blocks;
		} else if( $allowed_blocks === false ) {
			return false;
		} else if ($allowed_blocks === true ) {
			$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
			foreach( $block_types as $block_type) {
    			$allowed_blocks_array[] = $block_type->name;
			}
		}
	
        $allowed_blocks = array_values( array_diff( $allowed_blocks_array, array(
        'core/footnotes',
        ) ) );
    }
    return $allowed_blocks;
}
```
I created a new post added some text and verified I could not add a footnote. I can add a footnote on the trunk but not edit its content.