### PR TITLE
Archives: Make the label above the dropdown editable

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 -	**Name:** core/archives
 -	**Category:** widgets
 -	**Supports:** align, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
+-	**Attributes:** displayAsDropdown, isEdit, label, showLabel, showPostCounts, type, uniqueId
 
 ## Audio
 

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -22,6 +22,18 @@
 		"type": {
 			"type": "string",
 			"default": "monthly"
+		},
+		"label": {
+			"type": "string",
+			"default": "Archives"
+		},
+		"isEdit": {
+			"type": "boolean",
+			"default": false
+		},
+		"uniqueId": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -8,11 +8,30 @@ import {
 	Disabled,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockProps,
+	RichText,
+} from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
+import { useInstanceId } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 
 export default function ArchivesEdit( { attributes, setAttributes } ) {
-	const { showLabel, showPostCounts, displayAsDropdown, type } = attributes;
+	const {
+		showLabel,
+		showPostCounts,
+		displayAsDropdown,
+		type,
+		label,
+		uniqueId,
+	} = attributes;
+	const editAttributes = structuredClone( attributes );
+	editAttributes.isEdit = true;
+	const instanceId = useInstanceId( ArchivesEdit, 'wp-block-archives' );
+	useEffect( () => {
+		setAttributes( { uniqueId: instanceId } );
+	} );
 
 	return (
 		<>
@@ -67,11 +86,23 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...useBlockProps() }>
+				{ displayAsDropdown && showLabel && (
+					<RichText
+						tagName="label"
+						value={ label }
+						htmlFor={ uniqueId }
+						className={ 'wp-block-archives__label' }
+						onChange={ ( value ) =>
+							setAttributes( { label: value } )
+						}
+						placeholder={ __( 'Archives' ) }
+					/>
+				) }
 				<Disabled>
 					<ServerSideRender
 						block="core/archives"
 						skipBlockSupportAttributes
-						attributes={ attributes }
+						attributes={ editAttributes }
 					/>
 				</Disabled>
 			</div>

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -17,6 +17,7 @@
 function render_block_core_archives( $attributes ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
 	$type            = isset( $attributes['type'] ) ? $attributes['type'] : 'monthly';
+	$title           = isset( $attributes['label'] ) ? $attributes['label'] : __( 'Archives' );
 
 	$class = 'wp-block-archives-list';
 
@@ -24,8 +25,7 @@ function render_block_core_archives( $attributes ) {
 
 		$class = 'wp-block-archives-dropdown';
 
-		$dropdown_id = wp_unique_id( 'wp-block-archives-' );
-		$title       = __( 'Archives' );
+		$dropdown_id = isset( $attributes['uniqueId'] ) ? $attributes['uniqueId'] : wp_unique_id( 'wp-block-archives-' );
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 		$dropdown_args = apply_filters(
@@ -63,8 +63,12 @@ function render_block_core_archives( $attributes ) {
 
 		$show_label = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 
-		$block_content = '<label for="' . $dropdown_id . '" class="wp-block-archives__label' . $show_label . '">' . esc_html( $title ) . '</label>
-		<select id="' . $dropdown_id . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
+		$block_content = '';
+
+		if ( empty( $attributes['isEdit'] ) ) {
+			$block_content .= '<label for="' . $dropdown_id . '" class="wp-block-archives__label' . $show_label . '">' . wp_kses_post( $title ) . '</label>';
+		}
+		$block_content .= '<select id="' . $dropdown_id . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
 		<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
 
 		return sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds an editable label attribute to the Archives block that is displayed when "display as a dropdown" is selected.

## Why?
https://github.com/WordPress/gutenberg/issues/57528
Currently the dropdown's label is not editable.

## How?
I initially opened https://github.com/WordPress/gutenberg/pull/57613 in which I added the label attribute and put it in the sidebar. I didn't like that experience and felt it should be a RichText component instead. I bungled a rebase on that pull request. Rather than untangle my git mess I closed that PR and opened this one.

In the current PR the label is a RichText component. However, there are a few questions to resolve here
1. If @WordPress/gutenberg-design would prefer, I can put the label back in the sidebar.
2. Because this is a dynamic block and makes use of the ServerSideRender component I needed a way to signal to the render callback whether or not the current context was the editor. (AFAIK there is no php function to test this) This led me down an inelegant path of adding an isEdit attribute and a clone of attributes. I would welcome any suggestions about improving this.
3. I used wp_keses_post() to escape the label so you can use HTML tags in the label. Is that the best choice?
4. It's worth noting that the render callback had used wp_unique_id() which led all block instances to have the same label for and select id value in the editor. I added a uniqueId attribute and set it with useInstanceId which results in unique values for each instance in both the editor and the front end.

## Testing Instructions
1. Open a post or page.
5. Insert an archives block.
6. Set to display as a dropdown and show label
7. Set a custom label. 
8. Note that toggling the display as dropdown or show labels shows/hides the label correctly.
9. save post and confirm label is shown on the front end and the editor.

### Testing Instructions for Keyboard
Similar to cursor, but confirm that tab controls correctly include the new RichText component to set the label. The tab control works correctly when the textControl is removed when the display as dropdown is unchecked.


https://github.com/WordPress/gutenberg/assets/2152870/82aaf317-4bdc-4d8a-a308-bd54d92ccc4a



