### PR TITLE
Tabs: Fix infinite loop in useEffect

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,6 +26,7 @@
 -   `Placeholder`: Fix Global Styles typography settings bleeding into placeholder component ([#58303](https://github.com/WordPress/gutenberg/pull/58303)).
 -   `PaletteEdit`: Fix palette item accessibility in details view ([#58214](https://github.com/WordPress/gutenberg/pull/58214)).
 -   `Snackbar`: Fix the auto-dismissal timers ([#58604](https://github.com/WordPress/gutenberg/pull/58604)).
+-   `Tabs`: Fix infinite loop in `useEffect` ([#58861](https://github.com/WordPress/gutenberg/pull/58861)).
 
 ### Experimental
 

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -151,13 +151,7 @@ function Tabs( {
 		if ( tabsHavePopulated.current && !! selectedTabId && ! selectedTab ) {
 			setSelectedId( null );
 		}
-	}, [
-		isControlled,
-		selectedId,
-		selectedTab,
-		selectedTabId,
-		setSelectedId,
-	] );
+	}, [ isControlled, selectedTab, selectedTabId, setSelectedId ] );
 
 	useEffect( () => {
 		if ( ! isControlled ) {


### PR DESCRIPTION
## What?

Removes an extraneous dependency in a Tabs `useLayoutEffect` that can cause an infinite loop crash.


## Why?

Fixes a bug that manifests in WP Core ([first breaking commit](https://github.com/WordPress/wordpress-develop/commit/cf8b74de)), but not within the Gutenberg repo. (I have not yet looked into why.)

## Testing Instructions

### Set up

1. Check out and build this PR branch.
1. Clone the `wordpress-develop` repo and follow the instructions to set up a local dev environment. (Don't forget to read the [extra steps for Apple Silicon](https://github.com/WordPress/wordpress-develop#apple-silicone-machines-and-old-mysql-versions) if that applies to you.)
1. Copy the `packages/components/build-module` from the `gutenberg` directory to the `node_modules/@wordpress/components/build-module` of the `wordpress-develop` directory. (Something like `rsync --recursive ../gutenberg/packages/components/build-module/ node_modules/@wordpress/components/build-module`.) I don't know why, but simply aliasing the `@wordpress/components` in `package.json` to the locally-built package file didn't work for me.
1. `npm run build:dev` in `wordpress-develop`

### Steps

Go to the post editor and toggle the Settings sidebar on and off and on again. The editor should not crash. (Also, doing this same thing in the `gutenberg` dev env should also not crash, as before.)

<img width="160" alt="Settings sidebar toggle" src="https://github.com/WordPress/gutenberg/assets/555336/4eb48a97-ec0b-4d1c-b033-1ae4a38124c3">
