### PR TITLE
Fix empty link preview after creating link from empty selection

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -113,70 +113,63 @@ function InlineLinkUI( {
 
 		const newText = nextValue.title || newUrl;
 
+		// Scenario: we have any active text selection or an active format.
+		let newValue;
 		if ( isCollapsed( value ) && ! isActive ) {
 			// Scenario: we don't have any actively selected text or formats.
-			const toInsert = applyFormat(
-				create( { text: newText } ),
+			const inserted = insert( value, newText );
+
+			newValue = applyFormat(
+				inserted,
 				linkFormat,
-				0,
-				newText.length
+				value.start,
+				value.end + newText.length
 			);
-			onChange( insert( value, toInsert ) );
+		} else if ( newText === richTextText ) {
+			newValue = applyFormat( value, linkFormat );
 		} else {
-			// Scenario: we have any active text selection or an active format.
-			let newValue;
+			// Scenario: Editing an existing link.
 
-			if ( newText === richTextText ) {
-				// If we're not updating the text then ignore.
-				newValue = applyFormat( value, linkFormat );
-			} else {
-				// Create new RichText value for the new text in order that we
-				// can apply formats to it.
-				newValue = create( { text: newText } );
+			// Create new RichText value for the new text in order that we
+			// can apply formats to it.
+			newValue = create( { text: newText } );
+			// Apply the new Link format to this new text value.
+			newValue = applyFormat( newValue, linkFormat, 0, newText.length );
 
-				// Apply the new Link format to this new text value.
-				newValue = applyFormat(
-					newValue,
-					linkFormat,
-					0,
-					newText.length
-				);
+			// Get the boundaries of the active link format.
+			const boundary = getFormatBoundary( value, {
+				type: 'core/link',
+			} );
 
-				// Get the boundaries of the active link format.
-				const boundary = getFormatBoundary( value, {
-					type: 'core/link',
-				} );
+			// Split the value at the start of the active link format.
+			// Passing "start" as the 3rd parameter is required to ensure
+			// the second half of the split value is split at the format's
+			// start boundary and avoids relying on the value's "end" property
+			// which may not correspond correctly.
+			const [ valBefore, valAfter ] = split(
+				value,
+				boundary.start,
+				boundary.start
+			);
 
-				// Split the value at the start of the active link format.
-				// Passing "start" as the 3rd parameter is required to ensure
-				// the second half of the split value is split at the format's
-				// start boundary and avoids relying on the value's "end" property
-				// which may not correspond correctly.
-				const [ valBefore, valAfter ] = split(
-					value,
-					boundary.start,
-					boundary.start
-				);
+			// Update the original (full) RichTextValue replacing the
+			// target text with the *new* RichTextValue containing:
+			// 1. The new text content.
+			// 2. The new link format.
+			// As "replace" will operate on the first match only, it is
+			// run only against the second half of the value which was
+			// split at the active format's boundary. This avoids a bug
+			// with incorrectly targetted replacements.
+			// See: https://github.com/WordPress/gutenberg/issues/41771.
+			// Note original formats will be lost when applying this change.
+			// That is expected behaviour.
+			// See: https://github.com/WordPress/gutenberg/pull/33849#issuecomment-936134179.
+			const newValAfter = replace( valAfter, richTextText, newValue );
 
-				// Update the original (full) RichTextValue replacing the
-				// target text with the *new* RichTextValue containing:
-				// 1. The new text content.
-				// 2. The new link format.
-				// As "replace" will operate on the first match only, it is
-				// run only against the second half of the value which was
-				// split at the active format's boundary. This avoids a bug
-				// with incorrectly targetted replacements.
-				// See: https://github.com/WordPress/gutenberg/issues/41771.
-				// Note original formats will be lost when applying this change.
-				// That is expected behaviour.
-				// See: https://github.com/WordPress/gutenberg/pull/33849#issuecomment-936134179.
-				const newValAfter = replace( valAfter, richTextText, newValue );
-
-				newValue = concat( valBefore, newValAfter );
-			}
-
-			onChange( newValue );
+			newValue = concat( valBefore, newValAfter );
 		}
+
+		onChange( newValue );
 
 		// Focus should only be returned to the rich text on submit if this link is not
 		// being created for the first time. If it is then focus should remain within the


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When creating a link from an empty selection, the link control popover would say there's no link. This sets the correct active link.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We need to apply the active format in order to have an active link, which applyFormat handles. Previously, the formats were applied, and then inserted, so it would remove all the active formats. By inserting, and _then_ applying formats, we can set the correct active format.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- In a paragraph with text and no selected (highlighted) text
- Command + k
- Create a link
- Link popover should be open with the correct link
- Press escape
- The caret should return to the newly inserted link

## Screenshots or screencast <!-- if applicable -->
