### PR TITLE
Interactivity API: Limit the exported APIs

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-init/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-init/view.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { store, directive, getContext } from '@wordpress/interactivity';
+import { store, getContext, privateApis } from '@wordpress/interactivity';
+
+const { directive } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
 
 // Mock `data-wp-show` directive to test when things are removed from the
 // DOM.  Replace with `data-wp-show` when it's ready.

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/view.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { store, directive } from '@wordpress/interactivity';
+import { store, privateApis } from '@wordpress/interactivity';
+
+const { directive } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
 
 // Mock `data-wp-show` directive to test when things are removed from the
 // DOM.  Replace with `data-wp-show` when it's ready.

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/view.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { store, directive } from '@wordpress/interactivity';
+import { store, privateApis } from '@wordpress/interactivity';
+
+const { directive } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
 
 // Mock `data-wp-show` directive to test when things are removed from the
 // DOM.  Replace with `data-wp-show` when it's ready.

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/view.js
@@ -4,11 +4,13 @@
 import {
 	store,
 	getContext,
-	directive,
-	deepSignal,
 	useEffect,
-	createElement as h,
+	privateApis
 } from '@wordpress/interactivity';
+
+const { directive, deepSignal, h } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
 
 /**
  * Namespace used in custom directives and store.

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.js
@@ -3,12 +3,15 @@
  */
 import {
 	store,
-	directive,
 	useInit,
 	useWatch,
-	cloneElement,
 	getElement,
+	privateApis
 } from '@wordpress/interactivity';
+
+const { directive, cloneElement } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
 
 // Custom directive to show hide the content elements in which it is placed.
 directive(

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/view.js
@@ -1,12 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext, createElement } from '@wordpress/interactivity';
+import { store, getContext, privateApis } from '@wordpress/interactivity';
+
+const { h } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
+
 
 const { state } = store( 'directive-context', {
 	state: {
 		text: 'Text 1',
-		component: () => (createElement( 'div', {}, state.text )),
+		component: () => ( h( 'div', {}, state.text ) ),
 		number: 1,
 		boolean: true
 	},

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-watch/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-watch/view.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { store, directive } from '@wordpress/interactivity';
+import { store, privateApis } from '@wordpress/interactivity';
+
+const { directive } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
 
 // Fake `data-wp-show-mock` directive to test when things are removed from the
 // DOM.  Replace with `data-wp-show` when it's ready.

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/view.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { store, directive, createElement as h } from '@wordpress/interactivity';
+import { store, privateApis } from '@wordpress/interactivity';
+
+const { directive, h } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
 
 // Fake `data-wp-show-mock` directive to test when things are removed from the
 // DOM.  Replace with `data-wp-show` when it's ready.

--- a/packages/interactivity-router/src/index.js
+++ b/packages/interactivity-router/src/index.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { render, store, privateApis } from '@wordpress/interactivity';
+import { store, privateApis } from '@wordpress/interactivity';
 
-const { directivePrefix, getRegionRootFragment, initialVdom, toVdom } =
+const { directivePrefix, getRegionRootFragment, initialVdom, toVdom, render } =
 	privateApis(
 		'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
 	);

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -1,13 +1,20 @@
 /**
+ * External dependencies
+ */
+import { h, cloneElement, render } from 'preact';
+import { deepSignal } from 'deepsignal';
+
+/**
  * Internal dependencies
  */
 import registerDirectives from './directives';
 import { init, getRegionRootFragment, initialVdom } from './init';
 import { directivePrefix } from './constants';
 import { toVdom } from './vdom';
+import { directive, getNamespace } from './hooks';
 
 export { store } from './store';
-export { directive, getContext, getElement, getNamespace } from './hooks';
+export { getContext, getElement } from './hooks';
 export {
 	withScope,
 	useWatch,
@@ -18,20 +25,24 @@ export {
 	useMemo,
 } from './utils';
 
-export { h as createElement, cloneElement, render } from 'preact';
-export { useContext, useState, useRef } from 'preact/hooks';
-export { deepSignal } from 'deepsignal';
+export { useState, useRef } from 'preact/hooks';
 
 const requiredConsent =
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';
 
-export const privateApis = ( lock ) => {
+export const privateApis = ( lock ): any => {
 	if ( lock === requiredConsent ) {
 		return {
 			directivePrefix,
 			getRegionRootFragment,
 			initialVdom,
 			toVdom,
+			directive,
+			getNamespace,
+			h,
+			cloneElement,
+			render,
+			deepSignal,
 		};
 	}
 


### PR DESCRIPTION
## What?

Epic: https://github.com/WordPress/gutenberg/issues/56803

Makes the `@wordpress/interactivity` module to export only the APIs that will be public on WordPress 6.5.

Only the following functions should be exposed publicly: `getConfig`, `getContext`, `getElement`, `store`, `useCallback`, `useEffect`, `useInit`, `useLayoutEffect`, `useMemo`, `useRef`, `useState`, `useWatch`, and `withScope`.

The rest of the APIs are accessible only through the function `privateAPIs`, meant to be used exclusively internally.

PS: You can notice that `getConfig` doesn't appear in the PR changes:  it's part of https://github.com/WordPress/gutenberg/pull/58749.

