### PR TITLE
Template Part: Fix site editor error when loading with list view set to always display

### DIFF
--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -43,7 +43,9 @@ export const settings = {
 			return;
 		}
 
-		return decodeEntities( entity.title ) || capitalCase( entity.slug );
+		return (
+			decodeEntities( entity.title ) || capitalCase( entity.slug || '' )
+		);
 	},
 	edit,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follows #58644 

Fix a site editor error when opening the site editor with the list view set to always display ("Always open list view" in preferences)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When initially loading, until an entity object is properly resolved, the entity object appears to be an empty object, so `capitalCase` was being called with `undefined` which throws an error.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

If `entity.slug` is not present, fallback to an empty string to avoid `capitalCase` throwing an error

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In the site editor, open the preferences and set `Always open list view` and then do a full page reload the site editor in canvas mode, i.e: `/wp-admin/site-editor.php?canvas=edit`

On `trunk` if your template has Header or Footer template parts, there'll be an error.

With this PR applied there should be no error

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

The error:

<img width="1277" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/0125a404-59d8-4c1e-a56a-48fd07904017">
