### PR TITLE
Color Palette: Respect defaultPalette setting (fixes Cover block placeholder state)

### DIFF
--- a/packages/block-editor/src/components/color-palette/with-color-context.js
+++ b/packages/block-editor/src/components/color-palette/with-color-context.js
@@ -2,18 +2,42 @@
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useSettings } from '../use-settings';
 
+const EMPTY_COLORS = [];
+
 export default createHigherOrderComponent( ( WrappedComponent ) => {
 	return ( props ) => {
-		const [ colorsFeature, enableCustomColors ] = useSettings(
-			'color.palette',
+		const [
+			customColors,
+			themeColors,
+			defaultColors,
+			defaultPaletteEnabled,
+			enableCustomColors,
+		] = useSettings(
+			'color.palette.custom',
+			'color.palette.theme',
+			'color.palette.default',
+			'color.defaultPalette',
 			'color.custom'
 		);
+
+		const colorsFeature = useMemo(
+			() => [
+				...( customColors || EMPTY_COLORS ),
+				...( themeColors || EMPTY_COLORS ),
+				...( defaultColors && defaultPaletteEnabled
+					? defaultColors
+					: EMPTY_COLORS ),
+			],
+			[ customColors, themeColors, defaultColors, defaultPaletteEnabled ]
+		);
+
 		const {
 			colors = colorsFeature,
 			disableCustomColors = ! enableCustomColors,

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -317,7 +317,7 @@ function CoverEdit( {
 	const ref = useRef();
 	const blockProps = useBlockProps( { ref } );
 
-	// Check for fontSize support before we pass a fontSize attribute to the innerBlocks.
+	// Gather settings for font sizes and color palette values.
 	const [
 		fontSizes,
 		customColors,
@@ -331,6 +331,7 @@ function CoverEdit( {
 		'color.palette.default',
 		'color.defaultPalette'
 	);
+	// Check for fontSize support before we pass a fontSize attribute to the innerBlocks.
 	const hasFontSizes = fontSizes?.length > 0;
 	const innerBlocksTemplate = getInnerBlocksTemplate( {
 		fontSize: hasFontSizes ? 'large' : undefined,
@@ -351,6 +352,7 @@ function CoverEdit( {
 		}
 	);
 
+	// Set the colors to be used by the placeholder state's color picker.
 	// Only show the default colors if the default palette is enabled and no theme colors are set.
 	const colors = useMemo(
 		() => [

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -318,7 +318,19 @@ function CoverEdit( {
 	const blockProps = useBlockProps( { ref } );
 
 	// Check for fontSize support before we pass a fontSize attribute to the innerBlocks.
-	const [ fontSizes ] = useSettings( 'typography.fontSizes' );
+	const [
+		fontSizes,
+		customColors,
+		themeColors,
+		defaultColors,
+		defaultPaletteEnabled,
+	] = useSettings(
+		'typography.fontSizes',
+		'color.palette.custom',
+		'color.palette.theme',
+		'color.palette.default',
+		'color.defaultPalette'
+	);
 	const hasFontSizes = fontSizes?.length > 0;
 	const innerBlocksTemplate = getInnerBlocksTemplate( {
 		fontSize: hasFontSizes ? 'large' : undefined,
@@ -337,6 +349,18 @@ function CoverEdit( {
 			templateLock,
 			dropZoneElement: ref.current,
 		}
+	);
+
+	// Only show the default colors if the default palette is enabled and no theme colors are set.
+	const colors = useMemo(
+		() => [
+			...( customColors || [] ),
+			...( themeColors || [] ),
+			...( defaultColors && defaultPaletteEnabled && ! themeColors?.length
+				? defaultColors
+				: [] ),
+		],
+		[ customColors, themeColors, defaultColors, defaultPaletteEnabled ]
 	);
 
 	const mediaElement = useRef();
@@ -464,6 +488,7 @@ function CoverEdit( {
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette
+								colors={ colors }
 								disableCustomColors={ true }
 								value={ overlayColor.color }
 								onChange={ onSetOverlayColor }

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -335,7 +335,11 @@ describe( 'Cover block', () => {
 			describe( 'when colors are disabled', () => {
 				test( 'does not render overlay control', async () => {
 					await setup( undefined, true, disabledColorSettings );
-					await createAndSelectBlock();
+					await userEvent.click(
+						screen.getByRole( 'document', {
+							name: 'Block: Cover',
+						} )
+					);
 					await userEvent.click(
 						screen.getByRole( 'tab', { name: 'Styles' } )
 					);
@@ -348,7 +352,11 @@ describe( 'Cover block', () => {
 				} );
 				test( 'does not render opacity control', async () => {
 					await setup( undefined, true, disabledColorSettings );
-					await createAndSelectBlock();
+					await userEvent.click(
+						screen.getByRole( 'document', {
+							name: 'Block: Cover',
+						} )
+					);
 					await userEvent.click(
 						screen.getByRole( 'tab', { name: 'Styles' } )
 					);

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -92,6 +92,78 @@ describe( 'Cover block', () => {
 			);
 		} );
 
+		test( 'placeholder color picker shows only those colors coming from the theme', async () => {
+			const themeColorSettings = {
+				...defaultSettings,
+				__experimentalFeatures: {
+					...defaultSettings.__experimentalFeatures,
+					color: {
+						...defaultSettings.__experimentalFeatures.color,
+						palette: {
+							...defaultSettings.__experimentalFeatures.color
+								.palette,
+							theme: [
+								{
+									name: 'Green',
+									slug: 'green',
+									color: '#00FF00',
+								},
+							],
+						},
+					},
+				},
+			};
+			await setup( undefined, true, themeColorSettings );
+			expect(
+				screen.queryByRole( 'option', {
+					name: 'Color: Black',
+				} )
+			).not.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'option', {
+					name: 'Color: Green',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		test( 'placeholder color picker shows default colors', async () => {
+			await setup( undefined, true, defaultSettings );
+			expect(
+				screen.getByRole( 'option', {
+					name: 'Color: Black',
+				} )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'option', {
+					name: 'Color: White',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		test( 'placeholder shows no default colors', async () => {
+			const defaultPaletteFalseSettings = {
+				...defaultSettings,
+				__experimentalFeatures: {
+					...defaultSettings.__experimentalFeatures,
+					color: {
+						...defaultSettings.__experimentalFeatures.color,
+						defaultPalette: false,
+					},
+				},
+			};
+			await setup( undefined, true, defaultPaletteFalseSettings );
+			expect(
+				screen.queryByRole( 'option', {
+					name: 'Color: Black',
+				} )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'option', {
+					name: 'Color: White',
+				} )
+			).not.toBeInTheDocument();
+		} );
+
 		test( 'can have the title edited', async () => {
 			await setup();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: #58753

Update the `ColorPalette` component used by the Cover block's placeholder state so that it is aware of the `color.defaultPalette` setting, and therefore can skip outputting the default palette when required.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This was raised in: https://github.com/WordPress/gutenberg/issues/58753 and from a git bisect, it seems that the PR that originally caused this to regress was: https://github.com/WordPress/gutenberg/pull/55219

If my understanding is correct, #55219 resulted in combining the values for all origins into `color.palette` since it's included in the `__EXPERIMENTAL_PATHS_WITH_MERGE` object [here](https://github.com/WordPress/gutenberg/blob/2e01f2208e1e43492236684315f1654cb54e2973/packages/blocks/src/api/constants.js#L277). So, after that PR, and prior to this one, `'color.palette'` will automatically include all the default palettes in it.

So that means one solution is to:

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Select the `custom`, `theme`, and `default` colors separately, and combine them, skipping the `default` colors if `color.defaultPalette` is falsy.
* This approach is borrowed the logic from [the Palette in the site editor](https://github.com/WordPress/gutenberg/blob/48473a78dfa825d3d674801c3a4a5d87b4db44f1/packages/edit-site/src/components/global-styles/palette.js#L31), which grabs the custom/theme/default values separately and strips out the default colors if `color.defaultPalette` is not enabled.
* For the Cover block, provide a `colors` value, that will only show the default palette colors if there are no theme colors, and if the `color.defaultPalette` value is truthy.

I'm not sure if this is the best way to fix it, but it seems to do the job so far!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With TT4 theme applied, test that on `trunk` if you add a Cover block to a post, page, or template, you'll see the default colors in addition to theme or custom colors in the placeholder
2. With this PR applied (and TT4 active, since it disables `defaultPalette`), you should only see theme + custom colors in the placeholder
3. Try toggling `settings.color.defaultPalette` in `theme.json` — switching it to `true` should re-enable the display of the default colors again — they will be visible when highlighting text, and in the using color pickers. In the Cover block placeholder, however, we only show the default palette if there are no theme colors available.
4. Ensure this PR matches (or is closer to) behaviour in the last major WordPress release. The regression has been around for a while, so a decent way to test is to toggle the Gutenberg plugin on and off in a test site. Try a few different themes, too, to check for consistency.

## Screenshots or screencast <!-- if applicable -->

| Before (or if `color.defaulPalette` is set to `true`) | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/7948abb1-0d3c-422f-aecb-9c7dcb1d6908) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/030b0bbe-be04-47a6-8887-2e322e7b5e7d) |

This should also fix an issue with the colors displayed when highlighting text, too:

| Before | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/28afa576-2284-4f74-9a89-d286f1c8fe96) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/68bdbda7-2122-440c-bbef-bf9f1bfcc855) |