### PR TITLE
e2e: Add a test to confirm that the focus moves from the post title to the paragraph using the enter key

### DIFF
--- a/test/e2e/specs/editor/various/post-title.spec.js
+++ b/test/e2e/specs/editor/various/post-title.spec.js
@@ -7,6 +7,7 @@ test.describe( 'Post title', () => {
 	test.describe( 'Focus handling', () => {
 		test( 'should focus on the post title field when creating a new post in visual mode', async ( {
 			editor,
+			page,
 			admin,
 		} ) => {
 			await admin.createNewPost();
@@ -16,6 +17,13 @@ test.describe( 'Post title', () => {
 			} );
 
 			await expect( pageTitleField ).toBeFocused();
+			await page.keyboard.press( 'Enter' );
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Empty block',
+				} ),
+				'sould move focus to an empty paragraph block when the Enter key is pressed'
+			).toBeFocused();
 		} );
 
 		test( 'should focus on the post title field when creating a new post in code editor mode', async ( {


### PR DESCRIPTION
See this comment: https://github.com/WordPress/gutenberg/pull/58848#pullrequestreview-1871609146

## What?

This PR adds an e2e test to ensure that the paragraph block gets focus when the enter key is pressed on the post title.

## Why?

This test was implicitly present in the `inserting blocks` e2e test. However, since #58848 resolved the test instability and no longer presses the Enter key on the post title, I think we need to add a new explicit test.
## Testing Instructions

```
npm run test:e2e:playwright test/e2e/specs/editor/various/post-title.spec.js
```
