### PR TITLE
Update pattern copy to Synced instead of Fully Synced

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -94,7 +94,10 @@ export default function usePatternDetails( postType, postId ) {
 			label: __( 'Syncing' ),
 			value:
 				record.wp_pattern_sync_status === PATTERN_SYNC_TYPES.unsynced
-					? __( 'Not synced' )
+					? _x(
+							'Not synced',
+							'Text that indicates that the pattern is not synchronized'
+					  )
 					: _x(
 							'Synced',
 							'Text that indicates that the pattern is synchronized'

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -95,7 +95,7 @@ export default function usePatternDetails( postType, postId ) {
 			value:
 				record.wp_pattern_sync_status === PATTERN_SYNC_TYPES.unsynced
 					? __( 'Not synced' )
-					: __( 'Fully synced' ),
+					: __( 'Synced' ),
 		} );
 
 		if ( record.wp_pattern_category?.length === 0 ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -6,7 +6,7 @@ import { sentenceCase } from 'change-case';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
@@ -95,7 +95,10 @@ export default function usePatternDetails( postType, postId ) {
 			value:
 				record.wp_pattern_sync_status === PATTERN_SYNC_TYPES.unsynced
 					? __( 'Not synced' )
-					: __( 'Synced' ),
+					: _x(
+							'Synced',
+							'Text that indicates that the pattern is synchronized'
+					  ),
 		} );
 
 		if ( record.wp_pattern_category?.length === 0 ) {

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -48,7 +48,7 @@ export default function PostSyncStatus() {
 			<div className="editor-post-sync-status__value">
 				{ syncStatus === 'unsynced'
 					? __( 'Not synced' )
-					: __( 'Fully synced' ) }
+					: __( 'Synced' ) }
 			</div>
 		</PostPanelRow>
 	);

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -48,7 +48,10 @@ export default function PostSyncStatus() {
 			<div className="editor-post-sync-status__value">
 				{ syncStatus === 'unsynced'
 					? __( 'Not synced' )
-					: __( 'Synced' ) }
+					: _x(
+							'Synced',
+							'Text that indicates that the pattern is synchronized'
+					  ) }
 			</div>
 		</PostPanelRow>
 	);

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -47,7 +47,10 @@ export default function PostSyncStatus() {
 		<PostPanelRow label={ __( 'Sync status' ) }>
 			<div className="editor-post-sync-status__value">
 				{ syncStatus === 'unsynced'
-					? __( 'Not synced' )
+					? _x(
+							'Not synced',
+							'Text that indicates that the pattern is not synchronized'
+					  )
 					: _x(
 							'Synced',
 							'Text that indicates that the pattern is synchronized'


### PR DESCRIPTION
## What?
Addresses some of #58725

## Why?
In light of pattern overrides, the wording 'Fully synced' might be outdated.

In this PR I'm simpifying it to just 'Synced', which matches the terminology used when creating a pattern

## Testing Instructions
1. Create a 'synced' pattern
2. In the site editor patterns screen, select the pattern
3. On the sidebar, you should see 'Syncing: Synced'.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-02-09 at 4 02 29 pm](https://github.com/WordPress/gutenberg/assets/677833/a7e5f4e4-dbe2-4c67-8d3e-846acfa1cc4f)
