### PR TITLE
Update: Increase footnotes meta priority and separate footnotes meta registration.

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -105,7 +105,8 @@ function register_block_core_footnotes_post_meta() {
 		}
 	}
 }
-// Use a priority of 20 to be higher than the default of 10 the priority with which most post types are registered.
+// Most post types are registered at priority 10, so use priority 20 here in
+// order to catch them.
 add_action( 'init', 'register_block_core_footnotes_post_meta', 20 );
 
 /**

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -105,8 +105,10 @@ function register_block_core_footnotes_post_meta() {
 		}
 	}
 }
-// Most post types are registered at priority 10, so use priority 20 here in
-// order to catch them.
+/**
+ * Most post types are registered at priority 10, so use priority 20 here in
+ * order to catch them.
+*/
 add_action( 'init', 'register_block_core_footnotes_post_meta', 20 );
 
 /**

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -68,6 +68,22 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
  * @since 6.3.0
  */
 function register_block_core_footnotes() {
+	register_block_type_from_metadata(
+		__DIR__ . '/footnotes',
+		array(
+			'render_callback' => 'render_block_core_footnotes',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_footnotes' );
+
+
+/**
+ * Registers the footnotes meta field required for footnotes to work.
+ *
+ * @since 6.5.0
+ */
+function wp_register_footnotes_post_meta() {
 	$post_types = get_post_types(
 		array(
 			'show_in_rest' => true,
@@ -76,7 +92,11 @@ function register_block_core_footnotes() {
 	);
 	foreach ( $post_types as $post_type ) {
 		// Only register the meta field if the post type supports the editor, custom fields, and revisions.
-		if ( post_type_supports( $post_type, 'editor' ) && post_type_supports( $post_type, 'custom-fields' ) && post_type_supports( $post_type, 'revisions' ) ) {
+		if (
+			post_type_supports( $post_type, 'editor' ) &&
+			post_type_supports( $post_type, 'custom-fields' ) &&
+			post_type_supports( $post_type, 'revisions' )
+		) {
 			register_post_meta(
 				$post_type,
 				'footnotes',
@@ -89,14 +109,9 @@ function register_block_core_footnotes() {
 			);
 		}
 	}
-	register_block_type_from_metadata(
-		__DIR__ . '/footnotes',
-		array(
-			'render_callback' => 'render_block_core_footnotes',
-		)
-	);
 }
-add_action( 'init', 'register_block_core_footnotes' );
+// Use a priority of 20 to be higher than the default of 10 the priority with which most post types are registered.
+add_action( 'init', 'wp_register_footnotes_post_meta', 20 );
 
 /**
  * Adds the footnotes field to the revisions display.

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -83,13 +83,8 @@ add_action( 'init', 'register_block_core_footnotes' );
  *
  * @since 6.5.0
  */
-function wp_register_footnotes_post_meta() {
-	$post_types = get_post_types(
-		array(
-			'show_in_rest' => true,
-			'public'       => true,
-		)
-	);
+function register_block_core_footnotes_post_meta() {
+	$post_types = get_post_types( array( 'show_in_rest' => true ) );
 	foreach ( $post_types as $post_type ) {
 		// Only register the meta field if the post type supports the editor, custom fields, and revisions.
 		if (
@@ -111,7 +106,7 @@ function wp_register_footnotes_post_meta() {
 	}
 }
 // Use a priority of 20 to be higher than the default of 10 the priority with which most post types are registered.
-add_action( 'init', 'wp_register_footnotes_post_meta', 20 );
+add_action( 'init', 'register_block_core_footnotes_post_meta', 20 );
 
 /**
  * Adds the footnotes field to the revisions display.


### PR DESCRIPTION
This PR does two actions:
- Separates the footnotes meta registration from the block registration.
- Increases the priority of the registration to 20.

Most post types are registered on init with a priority of 10 having a priority of 20 makes sure the footnotes meta is registered for all of the post types with a priority of 20. While also allowing plugins to change the footnotes meta if they have an advanced need ( as long as they use a priority higher than 20).

## Testing Instructions
- In the core install you are using to test Gutenberg comment the line add_action( 'init', 'register_block_core_footnotes' ); in src/wp-includes/blocks/footnotes.php (otherwise, the meta is registered there anyway).
- Verify it is still possible to add footnotes to a post.
