### PR TITLE
Close link preview if collapsed selection when creating link

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -48,17 +48,6 @@ function Edit( {
 			return;
 		}
 
-		// Close the Link popover if there is no active selection
-		// after the link was added - this can happen if the user
-		// adds a link without any text selected.
-		// We assume that if there is no active selection after
-		// link insertion there are no active formats.
-		if ( ! value.activeFormats ) {
-			editableContentElement.focus();
-			setAddingLink( false );
-			return;
-		}
-
 		function handleClick( event ) {
 			// There is a situation whereby there is an existing link in the rich text
 			// and the user clicks on the leftmost edge of that link and fails to activate
@@ -78,7 +67,7 @@ function Edit( {
 		return () => {
 			editableContentElement.removeEventListener( 'click', handleClick );
 		};
-	}, [ contentRef, isActive, addingLink, value ] );
+	}, [ contentRef, isActive ] );
 
 	function addLink( target ) {
 		const text = getTextContent( slice( value ) );

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -123,8 +123,13 @@ function InlineLinkUI( {
 				inserted,
 				linkFormat,
 				value.start,
-				value.end + newText.length
+				value.start + newText.length
 			);
+
+			onChange( newValue );
+			// If there was no selection, move straight back to editing content flow
+			stopAddingLink();
+			return;
 		} else if ( newText === richTextText ) {
 			newValue = applyFormat( value, linkFormat );
 		} else {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Closes the link preview after adding a link.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is the behavior that was added in https://github.com/WordPress/gutenberg/pull/58771, but the approach it used doesn't work alongside https://github.com/WordPress/gutenberg/pull/58863 because https://github.com/WordPress/gutenberg/pull/58771 relies on a previous bug where no active format were present when inserting a link via a collapsed (no selected text) selection.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Call the passed the `stopAddingLink` method when adding a link with a collapsed (no selected text) selection. This follows the pattern further down the `onChangeLink`.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- In the post editor
- Command + k (without any selection)
- Select a link
- A link should be added to the editor
- The preview should _not_ be open
- focus (the caret) should be at the end of the newly added link
