### PR TITLE
Add: Bulk export patterns action.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22223,6 +22223,11 @@
 			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
 			"dev": true
 		},
+		"node_modules/client-zip": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.4.4.tgz",
+			"integrity": "sha512-Ixk40BUI7VvNDxW7SCze20GbCuC+gjP4tGkXUpo6/W96bOf96HSed6cOQVeUOIe74SJAG/dIrBr7AtR4xBVnsA=="
+		},
 		"node_modules/cliui": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -55252,6 +55257,7 @@
 				"@wordpress/wordcount": "file:../wordcount",
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
+				"client-zip": "^2.4.4",
 				"colord": "^2.9.2",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
@@ -70379,6 +70385,7 @@
 				"@wordpress/wordcount": "file:../wordcount",
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
+				"client-zip": "^2.4.4",
 				"colord": "^2.9.2",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
@@ -74230,6 +74237,11 @@
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
 			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
 			"dev": true
+		},
+		"client-zip": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.4.4.tgz",
+			"integrity": "sha512-Ixk40BUI7VvNDxW7SCze20GbCuC+gjP4tGkXUpo6/W96bOf96HSed6cOQVeUOIe74SJAG/dIrBr7AtR4xBVnsA=="
 		},
 		"cliui": {
 			"version": "6.0.0",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -69,6 +69,7 @@
 		"@wordpress/wordcount": "file:../wordcount",
 		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
+		"client-zip": "^2.4.4",
 		"colord": "^2.9.2",
 		"deepmerge": "^4.3.0",
 		"fast-deep-equal": "^3.1.3",

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -75,7 +75,7 @@ export const exportJSONaction = {
 			return {
 				name: `${
 					name +
-					( nameCount[ name ] > 1 ? '-' + nameCount[ name ] : '' )
+					( nameCount[ name ] > 1 ? '-' + nameCount[ name ] - 1 : '' )
 				}.json`,
 				lastModified: new Date(),
 				input: getJsonFromItem( item ),

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { paramCase as kebabCase } from 'change-case';
+import { downloadZip } from 'client-zip';
 
 /**
  * WordPress dependencies
@@ -41,21 +42,43 @@ const { useHistory } = unlock( routerPrivateApis );
 const { CreatePatternModalContents, useDuplicatePatternProps } =
 	unlock( patternsPrivateApis );
 
-export const exportJSONaction = {
-	id: 'export-pattern',
-	label: __( 'Export as JSON' ),
-	isEligible: ( item ) => item.type === PATTERN_TYPES.user,
-	callback: ( [ item ] ) => {
-		const json = {
+function getJsonFromItem( item ) {
+	return JSON.stringify(
+		{
 			__file: item.type,
 			title: item.title || item.name,
 			content: item.patternPost.content.raw,
 			syncStatus: item.patternPost.wp_pattern_sync_status,
-		};
+		},
+		null,
+		2
+	);
+}
+
+export const exportJSONaction = {
+	id: 'export-pattern',
+	label: __( 'Export as JSON' ),
+	supportsBulk: true,
+	isEligible: ( item ) => item.type === PATTERN_TYPES.user,
+	callback: async ( items ) => {
+		if ( items.length === 1 ) {
+			return downloadBlob(
+				`${ kebabCase( items[ 0 ].title || items[ 0 ].name ) }.json`,
+				getJsonFromItem( items[ 0 ] ),
+				'application/json'
+			);
+		}
+		const filesToZip = items.map( ( item ) => {
+			return {
+				name: `${ kebabCase( item.title || item.name ) }.json`,
+				lastModified: new Date(),
+				input: getJsonFromItem( item ),
+			};
+		} );
 		return downloadBlob(
-			`${ kebabCase( item.title || item.name ) }.json`,
-			JSON.stringify( json, null, 2 ),
-			'application/json'
+			__( 'patterns-export' ) + '.zip',
+			await downloadZip( filesToZip ).blob(),
+			'application/zip'
 		);
 	},
 };

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -68,9 +68,15 @@ export const exportJSONaction = {
 				'application/json'
 			);
 		}
+		const nameCount = {};
 		const filesToZip = items.map( ( item ) => {
+			const name = kebabCase( item.title || item.name );
+			nameCount[ name ] = ( nameCount[ name ] || 0 ) + 1;
 			return {
-				name: `${ kebabCase( item.title || item.name ) }.json`,
+				name: `${
+					name +
+					( nameCount[ name ] > 1 ? '-' + nameCount[ name ] : '' )
+				}.json`,
 				lastModified: new Date(),
 				input: getJsonFromItem( item ),
 			};

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -75,7 +75,9 @@ export const exportJSONaction = {
 			return {
 				name: `${
 					name +
-					( nameCount[ name ] > 1 ? '-' + nameCount[ name ] - 1 : '' )
+					( nameCount[ name ] > 1
+						? '-' + ( nameCount[ name ] - 1 )
+						: '' )
 				}.json`,
 				lastModified: new Date(),
 				input: getJsonFromItem( item ),


### PR DESCRIPTION
This PR adds the ability to bulk export a set of patterns.
If more than one pattern is selected to be exported a zip file with all the patterns is generated.


## How?
I selected multiple patterns.
Went to bulk edit and pressed export.
I downloaded the generated zip file, extracted it, and verified it contained the selected patterns as json files.
