### PR TITLE
Fix incorrect useAnchor positioning when switching from virtual to rich text elements

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -21,7 +21,6 @@ import {
 import {
 	__experimentalLinkControl as LinkControl,
 	store as blockEditorStore,
-	useCachedTruthy,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
@@ -195,27 +194,8 @@ function InlineLinkUI( {
 
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
-		settings,
+		settings: { ...settings, isActive },
 	} );
-
-	//  As you change the link by interacting with the Link UI
-	//  the return value of document.getSelection jumps to the field you're editing,
-	//  not the highlighted text. Given that useAnchor uses document.getSelection,
-	//  it will return null, since it can't find the <mark> element within the Link UI.
-	//  This caches the last truthy value of the selection anchor reference.
-	// This ensures the Popover is positioned correctly on initial submission of the link.
-	const cachedRect = useCachedTruthy( popoverAnchor.getBoundingClientRect() );
-
-	// If the link is not active (i.e. it is a new link) then we need to
-	// override the getBoundingClientRect method on the anchor element
-	// to return the cached value of the selection represented by the text
-	// that the user selected to be linked.
-	// If the link is active (i.e. it is an existing link) then we allow
-	// the default behaviour of the popover anchor to be used. This will get
-	// the anchor based on the `<a>` element in the rich text.
-	if ( ! isActive ) {
-		popoverAnchor.getBoundingClientRect = () => cachedRect;
-	}
 
 	async function handleCreate( pageTitle ) {
 		const page = await createPageEntity( {

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -120,6 +120,7 @@ function TextColorEdit( {
 					value={ value }
 					onChange={ onChange }
 					contentRef={ contentRef }
+					isActive={ isActive }
 				/>
 			) }
 		</>

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -15,7 +15,6 @@ import {
 	getColorObjectByColorValue,
 	getColorObjectByAttributeValues,
 	store as blockEditorStore,
-	useCachedTruthy,
 } from '@wordpress/block-editor';
 import {
 	Popover,
@@ -147,21 +146,12 @@ export default function InlineColorUI( {
 	onChange,
 	onClose,
 	contentRef,
+	isActive,
 } ) {
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
-		settings,
+		settings: { ...settings, isActive },
 	} );
-
-	/*
-	 As you change the text color by typing a HEX value into a field,
-	 the return value of document.getSelection jumps to the field you're editing,
-	 not the highlighted text. Given that useAnchor uses document.getSelection,
-	 it will return null, since it can't find the <mark> element within the HEX input.
-	 This caches the last truthy value of the selection anchor reference.
-	 */
-	const cachedRect = useCachedTruthy( popoverAnchor.getBoundingClientRect() );
-	popoverAnchor.getBoundingClientRect = () => cachedRect;
 
 	return (
 		<Popover

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { usePrevious } from '@wordpress/compose';
 import { useState, useLayoutEffect } from '@wordpress/element';
 
 /** @typedef {import('../register-format-type').WPFormat} WPFormat */
@@ -137,44 +138,31 @@ function getAnchor( editableContentElement, tagName, className ) {
  * @return {Element|VirtualAnchorElement|undefined|null} The active element or selection range.
  */
 export function useAnchor( { editableContentElement, settings = {} } ) {
-	const { tagName, className } = settings;
+	const { tagName, className, isActive } = settings;
 	const [ anchor, setAnchor ] = useState( () =>
 		getAnchor( editableContentElement, tagName, className )
 	);
+	const wasActive = usePrevious( isActive );
 
 	useLayoutEffect( () => {
 		if ( ! editableContentElement ) return;
 
 		const { ownerDocument } = editableContentElement;
 
-		function callback() {
+		if (
+			editableContentElement === ownerDocument.activeElement ||
+			// When a link is created, we need to attach the popover to the newly created anchor.
+			( ! wasActive && isActive ) ||
+			// Sometimes we're _removing_ an active anchor, such as the inline color popover.
+			// When we add the color, it switches from a virtual anchor to a `<mark>` element.
+			// When we _remove_ the color, it switches from a `<mark>` element to a virtual anchor.
+			( wasActive && ! isActive )
+		) {
 			setAnchor(
 				getAnchor( editableContentElement, tagName, className )
 			);
 		}
-
-		function attach() {
-			ownerDocument.addEventListener( 'selectionchange', callback );
-		}
-
-		function detach() {
-			ownerDocument.removeEventListener( 'selectionchange', callback );
-		}
-
-		if ( editableContentElement === ownerDocument.activeElement ) {
-			attach();
-		}
-
-		editableContentElement.addEventListener( 'focusin', attach );
-		editableContentElement.addEventListener( 'focusout', detach );
-
-		return () => {
-			detach();
-
-			editableContentElement.removeEventListener( 'focusin', attach );
-			editableContentElement.removeEventListener( 'focusout', detach );
-		};
-	}, [ editableContentElement, tagName, className ] );
+	}, [ editableContentElement, tagName, className, isActive, wasActive ] );
 
 	return anchor;
 }


### PR DESCRIPTION
When creating a link or inline text color, we start with a virtual element and then after creating the link/adding a color, it switches from a virtual to rich text element (<a> or <mark>). We want to recompute that we've changed elements and reanchor appropriately when this happens.

Also, useAnchor was adding focus and selectionChange events that were only used by a previous version of the link control UX where the link popover would show based on the caret position. If the caret was within the link, we would show the link popover. This is no longer the case, so we can remove these event listeners.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes scrolling bug related to caching the popover position when switching from a virtual to rich text element (and back from rich text to virtual). When the popover position is cached, it will scroll down the page in a fixed position rather than be anchored near the element.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Simplicity: Removes unused selections
- Bug fix popover scroll issue

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Recompute anchor position when going from selection to a active rich text element and vice versa. 
Remove unnecessary event listeners.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- **Click a text link**
- Popover should be in the correct position
- **Click a new link in the same paragraph**
- Popover should be in the correct position
- **Create a new link from an empty text selection**
- Popover should be in the correct position
- **Create a new link from a text selection**
- Popover should be in the correct position
- **Highlight text**
- Select the "more" dropdown in the block toolbar to use the highlight color
- Select a highlight color
- Popover should be in the correct position
- Clear the color
- Popover should be in the correct position

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

#### Before
https://github.com/WordPress/gutenberg/assets/967608/7e4c3693-bb3e-4ded-89ec-3029f81427c8 

#### After
https://github.com/WordPress/gutenberg/assets/967608/b9c13ed8-f92f-4052-b0f1-891a6b9c9d54






