### PR TITLE
Details block: Try double enter to escape inner blocks

### DIFF
--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -19,6 +19,7 @@
 		}
 	},
 	"supports": {
+		"__experimentalOnEnter": true,
 		"align": [ "wide", "full" ],
 		"color": {
 			"gradients": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds the double enter functionality to exit inner blocks of the details block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Improves accessibility for keyboard users.

Fixes: https://github.com/WordPress/gutenberg/issues/56263

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds an `__experimentalOnEnter` support.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post or page.
2. Insert a details block.
3. Type a summary.
4. Insert a paragraph block and enter some content.
5. Press enter twice quickly to insert another block (outside of details block) as you can also do with list and quote.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
