### PR TITLE
Update source-map-loader package to v4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -234,7 +234,7 @@
 				"semver": "7.5.4",
 				"simple-git": "3.5.0",
 				"snapshot-diff": "0.10.0",
-				"source-map-loader": "3.0.0",
+				"source-map-loader": "4.0.2",
 				"sprintf-js": "1.1.1",
 				"storybook": "7.2.2",
 				"storybook-source-link": "2.0.9",
@@ -11417,15 +11417,6 @@
 			},
 			"peerDependencies": {
 				"ajv": "^8.8.2"
-			}
-		},
-		"node_modules/@storybook/builder-webpack5/node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@storybook/builder-webpack5/node_modules/style-loader": {
@@ -23905,15 +23896,6 @@
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
 			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
 			"dev": true
-		},
-		"node_modules/csso/node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/cssstyle": {
 			"version": "3.0.0",
@@ -43519,15 +43501,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
-		"node_modules/postcss/node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -47867,33 +47840,31 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-			"integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-			"dev": true,
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-loader": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.0.tgz",
-			"integrity": "sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.2.tgz",
+			"integrity": "sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==",
 			"dev": true,
 			"dependencies": {
-				"abab": "^2.0.5",
-				"iconv-lite": "^0.6.2",
-				"source-map-js": "^0.6.2"
+				"iconv-lite": "^0.6.3",
+				"source-map-js": "^1.0.2"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 14.15.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^5.0.0"
+				"webpack": "^5.72.1"
 			}
 		},
 		"node_modules/source-map-resolve": {
@@ -49078,15 +49049,6 @@
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
 			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
 			"dev": true
-		},
-		"node_modules/svgo/node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/swc-loader": {
 			"version": "0.2.3",
@@ -53798,14 +53760,6 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
-		"packages/block-editor/node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
 			"version": "8.28.0",
@@ -55953,6 +55907,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"packages/scripts/node_modules/source-map-loader": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.2.tgz",
+			"integrity": "sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==",
+			"dev": true,
+			"dependencies": {
+				"abab": "^2.0.5",
+				"iconv-lite": "^0.6.3",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.0.0"
 			}
 		},
 		"packages/scripts/node_modules/spawnd": {
@@ -64168,12 +64143,6 @@
 						}
 					}
 				},
-				"source-map-js": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-					"dev": true
-				},
 				"style-loader": {
 					"version": "3.3.3",
 					"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.3.tgz",
@@ -68987,11 +68956,6 @@
 						"picocolors": "^1.0.0",
 						"source-map-js": "^1.0.2"
 					}
-				},
-				"source-map-js": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
 				}
 			}
 		},
@@ -70448,6 +70412,17 @@
 					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 					"dev": true
+				},
+				"source-map-loader": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.2.tgz",
+					"integrity": "sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==",
+					"dev": true,
+					"requires": {
+						"abab": "^2.0.5",
+						"iconv-lite": "^0.6.3",
+						"source-map-js": "^1.0.1"
+					}
 				},
 				"spawnd": {
 					"version": "9.0.1",
@@ -75101,12 +75076,6 @@
 					"version": "2.0.28",
 					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
 					"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-					"dev": true
-				},
-				"source-map-js": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 					"dev": true
 				}
 			}
@@ -89591,14 +89560,6 @@
 				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
-			},
-			"dependencies": {
-				"source-map-js": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-					"dev": true
-				}
 			}
 		},
 		"postcss-calc": {
@@ -93434,20 +93395,18 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
 		"source-map-js": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-			"integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
-			"dev": true
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
 		},
 		"source-map-loader": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.0.tgz",
-			"integrity": "sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.2.tgz",
+			"integrity": "sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.5",
-				"iconv-lite": "^0.6.2",
-				"source-map-js": "^0.6.2"
+				"iconv-lite": "^0.6.3",
+				"source-map-js": "^1.0.2"
 			}
 		},
 		"source-map-resolve": {
@@ -94373,12 +94332,6 @@
 					"version": "2.0.30",
 					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
 					"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-					"dev": true
-				},
-				"source-map-js": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-					"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
 		"semver": "7.5.4",
 		"simple-git": "3.5.0",
 		"snapshot-diff": "0.10.0",
-		"source-map-loader": "3.0.0",
+		"source-map-loader": "4.0.2",
 		"sprintf-js": "1.1.1",
 		"storybook": "7.2.2",
 		"storybook-source-link": "2.0.9",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update source-map-loader package to v4.0.2.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When installing `@wordpress/scripts` package, there are some deprecated packages warnings raised.

See more in [this issue](https://github.com/WordPress/gutenberg/issues/56543).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Two packages are the culprit. `jest-environment-jsdom` and `source-map-loader`.

The first one uses deprecated packages in the latest version (nothing we can do for now, I opened a ticket in `jest-environment-jsdom` repository).

The second one `source-map-loader` removed dependency of the deprecated `abab` package in the `4.0.2` version.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I'm not exactly sure how would one test this change. Since it's related to loading source maps, seems like running debugging session and looking into source code being properly mapped and no errors are raised would be sufficient.
