### PR TITLE
Modal: add `box-sizing` reset style

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `Modal`: Add `box-sizing` reset style ([#58905](https://github.com/WordPress/gutenberg/pull/58905)).
+
 ### Experimental
 
 -   `CustomSelectControlV2`: Adapt component for legacy usage ([#57902](https://github.com/WordPress/gutenberg/pull/57902)).

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -15,6 +15,7 @@
 
 // The modal window element.
 .components-modal__frame {
+	@include reset;
 	// Use the entire viewport on smaller screens.
 	margin: $grid-unit-50 0 0 0;
 	width: 100%;

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -46,8 +46,7 @@ body.js.block-editor-page {
 .edit-post-header,
 .edit-post-text-editor,
 .edit-post-sidebar,
-.editor-post-publish-panel,
-.components-modal__frame {
+.editor-post-publish-panel {
 	@include reset;
 }
 

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -67,13 +67,8 @@ body.js.site-editor-php {
 	background: $gray-900;
 }
 
-.edit-site,
-// The modals are shown outside the .edit-site wrapper, they need these styles.
-.components-modal__frame {
-	@include reset;
-}
-
 .edit-site {
+	@include reset;
 	height: 100vh;
 
 	// On mobile the main content area has to scroll, otherwise you can invoke

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -16,14 +16,8 @@ body.js.widgets-php {
 	@include wp-admin-reset( ".blocks-widgets-container" );
 }
 
-.blocks-widgets-container,
-// The modals are shown outside the .blocks-widgets-container wrapper, they need these styles
-.components-modal__frame {
-	@include reset;
-
-}
-
 .blocks-widgets-container {
+	@include reset;
 	// On mobile the main content area has to scroll, otherwise you can invoke
 	// the overscroll bounce on the non-scrolling container, for a bad experience.
 	@include break-small {


### PR DESCRIPTION
Similar to #58871
Part of #42415

## What?

This PR applies `box-sizing` reset style to the `Modal` component itself to prevent unintended horizontal scrollbars from appearing in any context. 

In all editor instances, we have already applied `box-sizing` reset style to this component, so nothing should change, but it will fix the appearance of the `Guide` component on the Storybook.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/e3791ee3-04e7-405f-ab5d-d8fa819285d3) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/e28dc724-d35d-4ec8-94ee-57d83e191b48)| 

## Why?

There are no problems when this component is used in the post editor or site editor, but if you use this component elsewhere and there is content inside an element with padding, an unintended overflow may occur.

## How?

Applied a `box-sizing` reset style to the component itself and removed the reset mixin when it was no longer needed.

## Testing Instructions

- Launch Storybook on this PR.
- Access http://172.26.171.177:50240/?path=/story/components-guide--default.
- Make sure the scroll bar is not displayed.
