### PR TITLE
URLPopover: Fix a problem with the layout of link settings

### DIFF
--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -92,12 +92,12 @@ const URLPopover = forwardRef(
 							/>
 						) }
 					</div>
-					{ showSettings && (
-						<div className="block-editor-url-popover__row block-editor-url-popover__settings">
-							{ renderSettings() }
-						</div>
-					) }
 				</div>
+				{ showSettings && (
+					<div className="block-editor-url-popover__settings">
+						{ renderSettings() }
+					</div>
+				) }
 				{ additionalControls && ! showSettings && (
 					<div className="block-editor-url-popover__additional-controls">
 						{ additionalControls }


### PR DESCRIPTION
Follow up #57608, #58505

## What?

This PR fixes the layout collapse when opening "Link Settings" in the URLPopover component.

| Header | Header |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/7ed22006-9b7f-491b-9872-d28f50c69d0e) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/e7867a0a-d50d-40f1-904e-241aebf0a5b1) | 

## Why?

As far as I investigated, I think that the location rendered by `renderSettings` may not be correct in the first place. There may have been no problems up until now, but the redesign with #57608 may have caused the layout to break down.

I think it's easier to apply a consistent style if this setting is placed in parallel with `additionalControls`.

## How?

I changed where the content is rendered when opening the link settings. The `block-editor-url-popover__row` class should also be unnecessary.

This PR only includes minimal fixes, but we should fix those issues in a follow-up. Based on the discussion made in #58505, at least the following issues should be addressed:

- Change input field height to 40px
- Align the input field and button vertically
- Reserve space for the spinner icon (#58679)
- Minor UI improvements (#58840)
- Is a top border necessary? (See: https://github.com/WordPress/gutenberg/pull/58505#issuecomment-1932008974)
- Change input field container padding from 8px to 16px (See: https://github.com/WordPress/gutenberg/pull/58505#discussion_r1477059682)


## Testing Instructions

- Insert an image block.
- Click the Link button on the block toolbar.
- Click the link settings button and check the layout.