### PR TITLE
Spacer block: Fix `null` label in tooltip when horizontal layout

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -42,5 +42,7 @@
 
 	&.resize-horizontal {
 		margin-bottom: 0;
+		// Important is used to have higher specificity than the inline style set by re-resizable library.
+		height: 100% !important;
 	}
 }


### PR DESCRIPTION
Fixes #47418
Also mentioned in this comment: https://github.com/WordPress/gutenberg/pull/49322#pullrequestreview-1358142616

## What?

This PR fixes the following unintended behavior when a Spacer block is used in horizontal layout and the drag handle is manipulated:

- Tooltip label contains null
- Drag handle moves to top right
- Spacer block color changes to transparent

### Before

https://github.com/WordPress/gutenberg/assets/54422211/4b84c5fd-1d2d-4428-a746-3cf8ca7d4bd8

### After

https://github.com/WordPress/gutenberg/assets/54422211/4fe3b4bb-b3fc-4f05-9227-148f779f6738

## Why?

This tooltip internally displays the width and height obtained via `useResizeListener` hook as a tooltip label.

https://github.com/WordPress/gutenberg/blob/5939c41670df4f2caee40c24806d3be20a09dab1/packages/components/src/resizable-box/resize-tooltip/index.tsx#L63-L65

When the Spacer block is NOT resized, the container has the following style applied so the `useResizeLister` hook can get the height correctly.

https://github.com/WordPress/gutenberg/blob/5939c41670df4f2caee40c24806d3be20a09dab1/packages/block-library/src/spacer/editor.scss#L32-L36

On the other hand, during resizing, this style is not applied, so the height of the container is zero. This can also be explained by the fact that during resizing, the gray background color applied to the container becomes invisible and the handle moves to the top right. The `useResizeLister` hook can no longer successfully retrieve the height of the parent container, so the tooltip label will contain null.


## How?

Applies `height:100%` only when the Spacer block is used in horizontal layout. This will inherit the `height:24px` applied to the block wrapper div, so the `useResizeListener` hook will get the height correctly, and as a result, the label will display correctly.

## Testing Instructions

- Insert a Spacer block inside the Row block.
- Move the drag handle to see the tooltip label.
- Confirm that it works as before when inserting a sSpacer block in vertical layout.