### PR TITLE
Block JSON schema: Update `shadow` definition

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -558,7 +558,16 @@
 				"shadow": {
 					"type": "boolean",
 					"description": "Allow blocks to define a box shadow.",
-					"default": false
+					"oneOf": [
+						{
+							"type": "boolean",
+							"description": "Defines whether a box shadow is enabled or not.",
+							"default": false
+						},
+						{
+							"type": "object"
+						}
+					]
 				},
 				"typography": {
 					"type": "object",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -556,15 +556,9 @@
 					}
 				},
 				"shadow": {
+					"type": "boolean",
 					"description": "Allow blocks to define a box shadow.",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object"
-						}
-					]
+					"default": false
 				},
 				"typography": {
 					"type": "object",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -556,13 +556,12 @@
 					}
 				},
 				"shadow": {
-					"type": "boolean",
+					"default": false,
 					"description": "Allow blocks to define a box shadow.",
 					"oneOf": [
 						{
 							"type": "boolean",
-							"description": "Defines whether a box shadow is enabled or not.",
-							"default": false
+							"description": "Defines whether a box shadow is enabled or not."
 						},
 						{
 							"type": "object"


### PR DESCRIPTION
Follow up #58306

## What?

This PR updates the definition of the shadow property in the block.json schema.

## Why?

Current schema allows boolean or object. I think the reason object is allowed is because it assumes the `__experimentalSkipSerialization` property. However, this property is not exposed on block.json schema. Furthermore, it is not possible to read from the schema whether the default value of `shadow` is true or false.

## How?

~~I changed the type back to boolean only and defined the default value as false.~~

I initially simply changed the type to a `boolean` value as below, but this seems to cause [unit tests to fail](https://github.com/WordPress/gutenberg/actions/runs/7855869194/job/21438024331).

```
"shadow": {
	"type": "boolean",
	"description": "Allow blocks to define a box shadow.",
	"default": false
},
```

This is because the actual block.json also defines an object with the `__experimentalSkipSerialization` property, even though the schema expects only `boolean` type.

Therefore, in this PR, I limited ourselves to adding the default value (`false`) and description. Ideally, we might need to update [the unit test](https://github.com/WordPress/gutenberg/blob/7b49a812112ad5b35b2529fe1497ed43a7bf423c/test/integration/blocks-schema.test.js#L38-L51) logic to exclude properties with the `__experimental` prefix before validating the schema.

## Testing Instructions

Verify that the code editor displays the correct definition using the file below.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/block-schema/shadow-boolean/schemas/json/block.json",
	"apiVersion": 2,
	"name": "test/test",
	"title": "Test",
	"supports": {
	}
}
```

### Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/54422211/c2d7d81b-d81d-49b2-b7df-2841cdd2affb

