### PR TITLE
Blocks: Add formula typesetting block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -317,6 +317,15 @@ A submission button for forms. ([Source](https://github.com/WordPress/gutenberg/
 -	**Supports:** 
 -	**Attributes:** 
 
+## Formula
+
+Render mathematical formulæ. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/formula))
+
+-	**Name:** core/formula
+-	**Category:** text
+-	**Supports:** align, anchor, spacing (blockGap, margin, padding), ~~html~~
+-	**Attributes:** alt, formulaSource
+
 ## Classic
 
 Use the classic WordPress editor. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/freeform))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -22,6 +22,7 @@ function gutenberg_reregister_core_block_types() {
 				'column',
 				'columns',
 				'details',
+				'formula',
 				'form-input',
 				'form-submit-button',
 				'group',

--- a/packages/block-library/src/formula/block.json
+++ b/packages/block-library/src/formula/block.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/formula",
+	"title": "Formula",
+	"category": "text",
+	"description": "Render mathematical formulæ.",
+	"textdomain": "default",
+	"attributes": {
+		"formulaSource": {
+			"type": "string",
+			"selector": "img",
+			"source": "attribute",
+			"attribute": "data-formula"
+		},
+		"alt": {
+			"type": "string",
+			"selector": "img",
+			"source": "attribute",
+			"attribute": "alt"
+		}
+	},
+	"supports": {
+		"anchor": true,
+		"align": true,
+		"html": false,
+		"spacing": {
+			"padding": true,
+			"margin": [ "top", "bottom" ],
+			"blockGap": true,
+			"__experimentalDefaultControls": {
+				"padding": true,
+				"blockGap": true
+			}
+		}
+	},
+	"editorStyle": "wp-block-formula",
+	"style": "wp-block-formula"
+}

--- a/packages/block-library/src/formula/edit.js
+++ b/packages/block-library/src/formula/edit.js
@@ -1,0 +1,97 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps, PlainText } from '@wordpress/block-editor';
+
+let loading = false;
+
+const requireMathJaxScript = () => {
+	if ( loading ) {
+		return;
+	}
+
+	loading = true;
+	const script = document.createElement( 'script' );
+	script.id = 'MathJax-script';
+	script.setAttribute( 'async', '' );
+	script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js';
+	document.head.appendChild( script );
+};
+
+document.addEventListener( 'readystatechange', () => {
+	if ( document.readyState === 'complete' ) {
+		requireMathJaxScript();
+	}
+} );
+
+/**
+ * Generate an SVG data URI for embedding in an IMG element src.
+ *
+ * @param {Element} svg The input SVG
+ * @return {string} Data URI for safely embedding SVG as a string.
+ */
+const svgElementToDataURI = ( svg ) => {
+	return `data:image/svg+xml,${ encodeURIComponent(
+		svg.childNodes[ 0 ].outerHTML
+	) }`;
+};
+
+export const Edit = ( { attributes, isSelected, setAttributes } ) => {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<figure>
+				{ isSelected && (
+					<>
+						<PlainText
+							value={ attributes.formulaSource }
+							onChange={ ( value ) =>
+								window.MathJax.tex2svgPromise( value ).then(
+									( svg ) => {
+										const errors =
+											svg.childNodes[ 1 ].querySelectorAll(
+												'merror'
+											);
+
+										if ( ! errors.length ) {
+											setAttributes( {
+												src: svgElementToDataURI( svg ),
+												formulaSource: value,
+												errors: null,
+											} );
+										} else {
+											setAttributes( {
+												formulaSource: value,
+												errors: [ ...errors ].map(
+													( error ) =>
+														error.textContent
+												),
+											} );
+										}
+									}
+								)
+							}
+							placeholder="a^2 = b^2 + c^2"
+						/>
+						<PlainText
+							value={ attributes.alt }
+							onChange={ ( alt ) => setAttributes( { alt } ) }
+							placeholder="How would you describe your formula if your reader cannot read the symbols?"
+						/>
+					</>
+				) }
+				<img src={ attributes.src } alt={ attributes.alt } />
+				{ attributes.errors?.length && (
+					<ul>
+						{ attributes.errors.map( ( error ) => (
+							<li key={ error }>{ error }</li>
+						) ) }
+					</ul>
+				) }
+			</figure>
+		</div>
+	);
+};
+
+export default Edit;

--- a/packages/block-library/src/formula/index.js
+++ b/packages/block-library/src/formula/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import Save from './save';
+import initBlock from '../utils/init-block';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	apiVersion: 3,
+	icon: 'edit-page',
+	example: {
+		attributes: {
+			formulaSource:
+				'\\Delta T_{\\text{heatsink}} = 100W\n\\cdot 0.15 \\frac{K}{W} = 15^\\circ C',
+			alt: "At 100W, the heatsink's temperature will rise by 15 degrees Celsius.",
+		},
+	},
+	save: Save,
+	edit: Edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/formula/index.php
+++ b/packages/block-library/src/formula/index.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Server-side rendering of the `core/formula` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/formula` block on server.
+ *
+ * @param array  $attributes The block attributes.
+ * @param string $content    The block rendered content.
+ *
+ * @return string Returns the formula block markup.
+ */
+function render_block_core_formula( $attributes, $content ) {
+	return '<p>Formula!</p>';
+}
+
+/**
+ * Registers the `core/cover` block renderer on server.
+ */
+function register_block_core_formula() {
+	register_block_type_from_metadata(
+		__DIR__ . '/formula',
+		array(
+			'render_callback' => 'formula',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_formula' );

--- a/packages/block-library/src/formula/save.js
+++ b/packages/block-library/src/formula/save.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+export const Save = ( { attributes } ) => {
+	const blockProps = useBlockProps.save();
+
+	return (
+		<figure className="wp-block-formula" { ...blockProps }>
+			<img
+				src={ attributes.src }
+				data-formula-source={ attributes.formulaSource }
+				alt={ attributes.alt }
+			/>
+		</figure>
+	);
+};
+
+export default Save;

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -49,6 +49,7 @@ import * as details from './details';
 import * as embed from './embed';
 import * as file from './file';
 import * as form from './form';
+import * as formula from './formula';
 import * as formInput from './form-input';
 import * as formSubmitButton from './form-submit-button';
 import * as formSubmissionNotification from './form-submission-notification';
@@ -154,6 +155,7 @@ const getAllBlocks = () => {
 		details,
 		embed,
 		file,
+		formula,
 		group,
 		html,
 		latestComments,


### PR DESCRIPTION
## Status

This is a working demo that's barely constructed.

### Todo

 - [ ] Manage the MathJax dependency. This could be vendored, pulled in via `npm`, or custom-built with only the parts needed for Gutenberg.
 - [ ] Should this generate an image in the media library or should it stick with the data URI?
    - [x] Ensure that the contributor role may store the generated SVG inside the image as a data URI.
 - [ ] Stop auto-crashing the block after saving and reloading.
    - The "Resolve" window shows that it's loading `wp-core-block-image` instead of `wp-core-block-figure` and I can't figure out where this comes from.
 - [ ] Add block controls.
    - [ ] Adjust the size of the formula.
    - [ ] Align the formula: left, center, right.
    - [ ] Add toggle to show or not show the figure number.
 - [ ] Add a unique anchor name to the formula to make it easier to reference.
 - [ ] Can we add the extension to align multi-line formulas? e.g. `a + 2 &= x\nx &= x - 2`
 - [ ] There's a temporal gap between loading the block and loading MathJax. Queue updates in case the block updates first.

### Related work
 - #35005 
 - #47198 
 - #10884
 - Adam Silverstein's [MathML block in the Playground](https://playground.wordpress.net/?plugin=mathml-block)
 - My own precursor to this PR [Typesetting Math in Gutenberg](https://fluffyandflakey.blog/2019/09/09/typesetting-math-in-gutenberg/)

## What?

This patch introduces a new block type meant for typesetting mathematical formulae. This block renders TeX formula input and produces an SVG output via the MathJax external library.

https://github.com/WordPress/gutenberg/assets/5431237/c45a9c53-6d7c-4367-83d6-3b8b2fda6766

<img width="452" alt="Screenshot 2024-02-10 at 1 52 23 PM" src="https://github.com/WordPress/gutenberg/assets/5431237/0021b892-e06a-437a-8b9d-2a170f72e4e7">

## Why?

For posts interacting with mathematical concepts it's important to be able to conveniently and cleanly represent mathematical formulae. The editor doesn't directly support this, yet a well-known and near-universal format exists for describing those formulae. This format is the TeX mathematical syntax.

## How?

This patch draws in the MathJax project as a dependency to render formula in the editor as they are typed. It creates an SVG output, which is stored as a data URI in the block's HTML, and requests a textual description of the formula for those who won't be able to see or read it.

## Testing Instructions
This is not yet ready to test, however you can try adding a formula block [in the Playground](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/wordpress/pr%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/wordpress/pr/pr.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%2520Gutenberg%2520Plugin%2520Zip&artifact=gutenberg-plugin&pr=58912%22,%22caption%22:%22Downloading%20Gutenberg%20PR%2058912%22%7D,%22progress%22:%7B%22weight%22:2,%22caption%22:%22Applying%20Gutenberg%20PR%2058912%22%7D%7D,%7B%22step%22:%22unzip%22,%22zipPath%22:%22/wordpress/pr/pr.zip%22,%22extractToPath%22:%22/wordpress/pr%22%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/wordpress/pr/gutenberg.zip%22%7D%7D%5D%7D)