### PR TITLE
Font Library: Show error message when no fonts found to install

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -61,15 +61,6 @@ function FontLibraryProvider( { children } ) {
 		setRefreshKey( Date.now() );
 	};
 
-	// Reset notice on dismiss.
-	useEffect( () => {
-		if ( notice ) {
-			notice.onRemove = () => {
-				setNotice( null );
-			};
-		}
-	}, [ notice, setNotice ] );
-
 	const {
 		records: libraryPosts = [],
 		isResolving: isResolvingLibrary,

--- a/packages/edit-site/src/components/global-styles/font-library-modal/tab-panel-layout.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/tab-panel-layout.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useContext } from '@wordpress/element';
 import {
 	__experimentalText as Text,
 	__experimentalHeading as Heading,
@@ -14,6 +15,11 @@ import {
 import { chevronLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { FontLibraryContext } from './context';
+
 function TabPanelLayout( {
 	title,
 	description,
@@ -22,6 +28,8 @@ function TabPanelLayout( {
 	children,
 	footer,
 } ) {
+	const { setNotice } = useContext( FontLibraryContext );
+
 	return (
 		<div className="font-library-modal__tabpanel-layout">
 			<Spacer margin={ 4 } />
@@ -53,7 +61,7 @@ function TabPanelLayout( {
 							<Spacer margin={ 1 } />
 							<Notice
 								status={ notice.type }
-								onRemove={ notice.onRemove }
+								onRemove={ () => setNotice( null ) }
 							>
 								{ notice.message }
 							</Notice>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -63,6 +63,12 @@ function UploadFonts() {
 		} );
 		if ( allowedFiles.length > 0 ) {
 			loadFiles( allowedFiles );
+		} else {
+			setNotice( {
+				type: 'error',
+				message: __( 'No fonts found to install.' ),
+			} );
+			setIsUploading( false );
 		}
 	};
 


### PR DESCRIPTION
Fixes #58874

## What?

This PR displays an error message when a file with an extension that is not allowed as a font is uploaded.

![image](https://github.com/WordPress/gutenberg/assets/54422211/c06f11d1-c20a-425e-8b57-1043f3ee41b5)

## Why?

In the current implementation, if there are no fonts available for installation, the `isUploading` state will remain `true`, and the user will not know what is happening.

## How?

If there are no valid fonts, an error message will be displayed.

At the same time, I removed unnecessary `useEffects` from the context. This is part of #58428. This will also fix the issue where the error message cannot be removed.

https://github.com/WordPress/gutenberg/assets/54422211/4b4f7db3-8978-4117-8587-b1af0dadba4c

## Testing Instructions

- Access the Site Editor.
- Open the Font Library.
- Click "Upload" tab.
- Drag and drop files.
- Please test the following scenario.
  - If all uploaded files are font files: All fonts should be installed as before.
  - If the uploaded file contains non-font files: No error message is displayed. Only valid font files should be installed.
  - If all uploaded files are not valid files: An error message should be displayed.

## Screenshots or screencast <!-- if applicable -->


