### PR TITLE
Patterns: disable image caption if part of synced pattern

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -146,27 +146,13 @@ export function RichTextWrapper(
 			isSelected = selectionStart.clientId === clientId;
 		}
 
-		// Disable Rich Text editing if block bindings specify that, or if there are block bindings
-		// but rich text attribute is not included in the bindings.
+		// Disable Rich Text editing if block bindings specify that.
 		let shouldDisableEditing = false;
 		if ( blockBindings && blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) {
 			const blockTypeAttributes = getBlockType( blockName ).attributes;
-
-			for ( const [ attributeName, attributeValue ] of Object.entries(
-				blockTypeAttributes
-			) ) {
-				if (
-					attributeValue.source === 'rich-text' &&
-					! Object.keys( blockBindings ).includes( attributeName )
-				) {
-					shouldDisableEditing = true;
-				}
-			}
-
 			const { getBlockBindingsSource } = unlock(
 				select( blockEditorStore )
 			);
-
 			for ( const [ attribute, args ] of Object.entries(
 				blockBindings
 			) ) {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -109,6 +109,7 @@ export function RichTextWrapper(
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
 		__unstableAllowPrefixTransformations,
+		disableEditing,
 		...props
 	},
 	forwardedRef
@@ -147,7 +148,7 @@ export function RichTextWrapper(
 		}
 
 		// Disable Rich Text editing if block bindings specify that.
-		let shouldDisableEditing = false;
+		let disableBoundBlocks = false;
 		if ( blockBindings && blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) {
 			const blockTypeAttributes = getBlockType( blockName ).attributes;
 			const { getBlockBindingsSource } = unlock(
@@ -170,7 +171,7 @@ export function RichTextWrapper(
 					! blockBindingsSource ||
 					blockBindingsSource.lockAttributesEditing
 				) {
-					shouldDisableEditing = true;
+					disableBoundBlocks = true;
 					break;
 				}
 			}
@@ -180,16 +181,19 @@ export function RichTextWrapper(
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,
 			isSelected,
-			shouldDisableEditing,
+			disableBoundBlocks,
 		};
 	};
-	const { selectionStart, selectionEnd, isSelected, shouldDisableEditing } =
+	const { selectionStart, selectionEnd, isSelected, disableBoundBlocks } =
 		useSelect( selector, [
 			clientId,
 			identifier,
 			originalIsSelected,
 			isBlockSelected,
 		] );
+
+	const shouldDisableEditing = disableEditing || disableBoundBlocks;
+
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
 	const { selectionChange } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -146,13 +146,27 @@ export function RichTextWrapper(
 			isSelected = selectionStart.clientId === clientId;
 		}
 
-		// Disable Rich Text editing if block bindings specify that.
+		// Disable Rich Text editing if block bindings specify that, or if there are block bindings
+		// but rich text attribute is not included in the bindings.
 		let shouldDisableEditing = false;
 		if ( blockBindings && blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) {
 			const blockTypeAttributes = getBlockType( blockName ).attributes;
+
+			for ( const [ attributeName, attributeValue ] of Object.entries(
+				blockTypeAttributes
+			) ) {
+				if (
+					attributeValue.source === 'rich-text' &&
+					! Object.keys( blockBindings ).includes( attributeName )
+				) {
+					shouldDisableEditing = true;
+				}
+			}
+
 			const { getBlockBindingsSource } = unlock(
 				select( blockEditorStore )
 			);
+
 			for ( const [ attribute, args ] of Object.entries(
 				blockBindings
 			) ) {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -109,7 +109,7 @@ export function RichTextWrapper(
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
 		__unstableAllowPrefixTransformations,
-		privateDisableEditing,
+		disableEditing,
 		...props
 	},
 	forwardedRef
@@ -192,7 +192,7 @@ export function RichTextWrapper(
 			isBlockSelected,
 		] );
 
-	const shouldDisableEditing = privateDisableEditing || disableBoundBlocks;
+	const shouldDisableEditing = disableEditing || disableBoundBlocks;
 
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -463,11 +463,7 @@ PrivateRichText.isEmpty = ( value ) => {
  */
 const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 	return (
-		<PrivateRichText
-			ref={ ref }
-			{ ...props }
-			privateDisableEditing={ false }
-		/>
+		<PrivateRichText ref={ ref } { ...props } disableEditing={ false } />
 	);
 } );
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -109,7 +109,6 @@ export function RichTextWrapper(
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
 		__unstableAllowPrefixTransformations,
-		disableEditing,
 		...props
 	},
 	forwardedRef
@@ -148,7 +147,7 @@ export function RichTextWrapper(
 		}
 
 		// Disable Rich Text editing if block bindings specify that.
-		let disableBoundBlocks = false;
+		let shouldDisableEditing = false;
 		if ( blockBindings && blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) {
 			const blockTypeAttributes = getBlockType( blockName ).attributes;
 			const { getBlockBindingsSource } = unlock(
@@ -171,7 +170,7 @@ export function RichTextWrapper(
 					! blockBindingsSource ||
 					blockBindingsSource.lockAttributesEditing
 				) {
-					disableBoundBlocks = true;
+					shouldDisableEditing = true;
 					break;
 				}
 			}
@@ -181,18 +180,16 @@ export function RichTextWrapper(
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,
 			isSelected,
-			disableBoundBlocks,
+			shouldDisableEditing,
 		};
 	};
-	const { selectionStart, selectionEnd, isSelected, disableBoundBlocks } =
+	const { selectionStart, selectionEnd, isSelected, shouldDisableEditing } =
 		useSelect( selector, [
 			clientId,
 			identifier,
 			originalIsSelected,
 			isBlockSelected,
 		] );
-
-	const shouldDisableEditing = disableEditing || disableBoundBlocks;
 
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -367,6 +364,7 @@ export function RichTextWrapper(
 				aria-multiline={ ! disableLineBreaks }
 				aria-label={ placeholder }
 				aria-readonly={ shouldDisableEditing }
+				contentEditable={ ! shouldDisableEditing }
 				{ ...props }
 				{ ...autocompleteProps }
 				ref={ useMergeRefs( [
@@ -421,7 +419,6 @@ export function RichTextWrapper(
 					useFirefoxCompat(),
 					anchorRef,
 				] ) }
-				contentEditable={ ! shouldDisableEditing }
 				suppressContentEditableWarning={ true }
 				className={ classnames(
 					'block-editor-rich-text__editable',

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -109,6 +109,7 @@ export function RichTextWrapper(
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
 		__unstableAllowPrefixTransformations,
+		disableEditing,
 		...props
 	},
 	forwardedRef
@@ -147,7 +148,7 @@ export function RichTextWrapper(
 		}
 
 		// Disable Rich Text editing if block bindings specify that.
-		let shouldDisableEditing = false;
+		let disableBoundBlocks = false;
 		if ( blockBindings && blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) {
 			const blockTypeAttributes = getBlockType( blockName ).attributes;
 			const { getBlockBindingsSource } = unlock(
@@ -170,7 +171,7 @@ export function RichTextWrapper(
 					! blockBindingsSource ||
 					blockBindingsSource.lockAttributesEditing
 				) {
-					shouldDisableEditing = true;
+					disableBoundBlocks = true;
 					break;
 				}
 			}
@@ -180,16 +181,18 @@ export function RichTextWrapper(
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,
 			isSelected,
-			shouldDisableEditing,
+			disableBoundBlocks,
 		};
 	};
-	const { selectionStart, selectionEnd, isSelected, shouldDisableEditing } =
+	const { selectionStart, selectionEnd, isSelected, disableBoundBlocks } =
 		useSelect( selector, [
 			clientId,
 			identifier,
 			originalIsSelected,
 			isBlockSelected,
 		] );
+
+	const shouldDisableEditing = disableEditing || disableBoundBlocks;
 
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -364,7 +367,6 @@ export function RichTextWrapper(
 				aria-multiline={ ! disableLineBreaks }
 				aria-label={ placeholder }
 				aria-readonly={ shouldDisableEditing }
-				contentEditable={ ! shouldDisableEditing }
 				{ ...props }
 				{ ...autocompleteProps }
 				ref={ useMergeRefs( [
@@ -419,6 +421,7 @@ export function RichTextWrapper(
 					useFirefoxCompat(),
 					anchorRef,
 				] ) }
+				contentEditable={ ! shouldDisableEditing }
 				suppressContentEditableWarning={ true }
 				className={ classnames(
 					'block-editor-rich-text__editable',

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -445,7 +445,7 @@ export function RichTextWrapper(
 	);
 }
 
-// This is the private API for the ListView component.
+// This is the private API for the RichText component.
 // It allows access to all props, not just the public ones.
 export const PrivateRichText = withDeprecations(
 	forwardRef( RichTextWrapper )

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -27,6 +27,7 @@ import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
 import { useFlashEditableBlocks } from './components/use-flash-editable-blocks';
 import { selectBlockPatternsKey } from './store/private-keys';
+import { PrivateRichText } from './components/rich-text/';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -58,4 +59,5 @@ lock( privateApis, {
 	usesContextKey,
 	useFlashEditableBlocks,
 	selectBlockPatternsKey,
+	PrivateRichText,
 } );

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -810,7 +810,8 @@ export default function Image( {
 				insertBlocksAfter={ insertBlocksAfter }
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={ isSingleSelected && hasNonContentControls }
-				disableEditing={ lockCaption }
+				contentEditable={ ! lockCaption }
+				aria-readonly={ lockCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -408,6 +408,7 @@ export default function Image( {
 		lockHrefControls = false,
 		lockAltControls = false,
 		lockTitleControls = false,
+		lockCaption = false,
 	} = useSelect(
 		( select ) => {
 			if ( ! isSingleSelected ) {
@@ -440,6 +441,10 @@ export default function Image( {
 				lockHrefControls:
 					// Disable editing the link of the URL if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the link on the frontend.
+					hasParentPattern,
+				lockCaption:
+					// Disable editing the caption if the image is inside a pattern instance.
+					// This is a temporary solution until we support overriding the caption on the frontend.
 					hasParentPattern,
 				lockAltControls:
 					!! altBinding &&
@@ -797,14 +802,23 @@ export default function Image( {
 				which causes duplicated image upload. */ }
 			{ ! temporaryURL && controls }
 			{ img }
-			<Caption
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				isSelected={ isSingleSelected }
-				insertBlocksAfter={ insertBlocksAfter }
-				label={ __( 'Image caption text' ) }
-				showToolbarButton={ isSingleSelected && hasNonContentControls }
-			/>
+
+			{ lockCaption && (
+				<figcaption>{ attributes.caption?.toHTMLString() }</figcaption>
+			) }
+
+			{ ! lockCaption && (
+				<Caption
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					isSelected={ isSingleSelected }
+					insertBlocksAfter={ insertBlocksAfter }
+					label={ __( 'Image caption text' ) }
+					showToolbarButton={
+						isSingleSelected && hasNonContentControls
+					}
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -810,7 +810,7 @@ export default function Image( {
 				insertBlocksAfter={ insertBlocksAfter }
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={ isSingleSelected && hasNonContentControls }
-				disableEditing={ lockCaption }
+				privateDisableEditing={ lockCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -803,22 +803,15 @@ export default function Image( {
 			{ ! temporaryURL && controls }
 			{ img }
 
-			{ lockCaption && (
-				<figcaption>{ attributes.caption?.toHTMLString() }</figcaption>
-			) }
-
-			{ ! lockCaption && (
-				<Caption
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					isSelected={ isSingleSelected }
-					insertBlocksAfter={ insertBlocksAfter }
-					label={ __( 'Image caption text' ) }
-					showToolbarButton={
-						isSingleSelected && hasNonContentControls
-					}
-				/>
-			) }
+			<Caption
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				isSelected={ isSingleSelected }
+				insertBlocksAfter={ insertBlocksAfter }
+				label={ __( 'Image caption text' ) }
+				showToolbarButton={ isSingleSelected && hasNonContentControls }
+				disableEditing={ lockCaption }
+			/>
 		</>
 	);
 }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -810,8 +810,7 @@ export default function Image( {
 				insertBlocksAfter={ insertBlocksAfter }
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={ isSingleSelected && hasNonContentControls }
-				contentEditable={ ! lockCaption }
-				aria-readonly={ lockCaption }
+				disableEditing={ lockCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -810,7 +810,7 @@ export default function Image( {
 				insertBlocksAfter={ insertBlocksAfter }
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={ isSingleSelected && hasNonContentControls }
-				privateDisableEditing={ lockCaption }
+				disableEditing={ lockCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -28,6 +28,7 @@ export function Caption( {
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
 	className,
+	disableEditing,
 } ) {
 	const caption = attributes[ key ];
 	const prevCaption = usePrevious( caption );
@@ -101,6 +102,7 @@ export function Caption( {
 								createBlock( getDefaultBlockName() )
 							)
 						}
+						disableEditing={ disableEditing }
 					/>
 				) }
 		</>

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -35,7 +35,7 @@ export function Caption( {
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
 	className,
-	privateDisableEditing,
+	disableEditing,
 } ) {
 	const caption = attributes[ key ];
 	const prevCaption = usePrevious( caption );
@@ -109,7 +109,7 @@ export function Caption( {
 								createBlock( getDefaultBlockName() )
 							)
 						}
-						privateDisableEditing={ privateDisableEditing }
+						disableEditing={ disableEditing }
 					/>
 				) }
 		</>

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -28,7 +28,7 @@ export function Caption( {
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
 	className,
-	disableEditing,
+	...props
 } ) {
 	const caption = attributes[ key ];
 	const prevCaption = usePrevious( caption );
@@ -102,7 +102,7 @@ export function Caption( {
 								createBlock( getDefaultBlockName() )
 							)
 						}
-						disableEditing={ disableEditing }
+						{ ...props }
 					/>
 				) }
 		</>

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -28,7 +28,7 @@ export function Caption( {
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
 	className,
-	...props
+	disableEditing,
 } ) {
 	const caption = attributes[ key ];
 	const prevCaption = usePrevious( caption );
@@ -102,7 +102,7 @@ export function Caption( {
 								createBlock( getDefaultBlockName() )
 							)
 						}
-						{ ...props }
+						disableEditing={ disableEditing }
 					/>
 				) }
 		</>

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -10,13 +10,20 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { usePrevious } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import {
-	RichText,
 	BlockControls,
 	__experimentalGetElementClassName,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { ToolbarButton } from '@wordpress/components';
 import { caption as captionIcon } from '@wordpress/icons';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { PrivateRichText: RichText } = unlock( blockEditorPrivateApis );
 
 export function Caption( {
 	key = 'caption',
@@ -28,7 +35,7 @@ export function Caption( {
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
 	className,
-	disableEditing,
+	privateDisableEditing,
 } ) {
 	const caption = attributes[ key ];
 	const prevCaption = usePrevious( caption );
@@ -102,7 +109,7 @@ export function Caption( {
 								createBlock( getDefaultBlockName() )
 							)
 						}
-						disableEditing={ disableEditing }
+						privateDisableEditing={ privateDisableEditing }
 					/>
 				) }
 		</>


### PR DESCRIPTION
## What?

Disables the image caption if the image is part of a sync pattern.


## Why?
Currently it is not possible to add a binding for the caption as the HTML processor is not capable of replacing the innerHTML on the frontend. But currently in the editor an bound image in a pattern still allows the caption to edited, but these changes are not saved or displayed on the frontend.

## How?
Shows a standard `figcaption` for caption instead of a rich text input if the image is the child of a synced pattern.

## Testing Instructions

- Add a synced pattern with an image and set `Allow instance overrides` on the image, and add a caption to the image
- Add the pattern to a post and check that the caption can't be edited
- Add a standalone image block to a post and check that the caption can be edited as expected
- Check the caption in a number of other components like Gallery, Audio, etc. and make sure it still works as expected
- Check a number of components that use `RichText`, eg. `Paragraph`, and check that it works as expected still

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/cbb0d3a2-7837-4237-a037-a719de6f2061



