### PR TITLE
Site Editor: Tweak save hub button

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -206,7 +206,7 @@ export default function HeaderEditMode() {
 						</div>
 					) }
 					<PostViewLink />
-					<SaveButton />
+					<SaveButton size="compact" />
 					{ ! isDistractionFree && (
 						<PinnedItems.Slot scope="core/edit-site" />
 					) }

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -22,6 +22,7 @@ export default function SaveButton( {
 	showTooltip = true,
 	defaultLabel,
 	icon,
+	size,
 	__next40pxDefaultSize = false,
 } ) {
 	const { isDirty, isSaving, isSaveViewOpen, previewingThemeName } =
@@ -119,7 +120,7 @@ export default function SaveButton( {
 			showTooltip={ showTooltip }
 			icon={ icon }
 			__next40pxDefaultSize={ __next40pxDefaultSize }
-			size="compact"
+			size={ size }
 		>
 			{ label }
 		</Button>

--- a/packages/edit-site/src/components/save-hub/style.scss
+++ b/packages/edit-site/src/components/save-hub/style.scss
@@ -3,13 +3,16 @@
 	border-top: 1px solid $gray-800;
 	flex-shrink: 0;
 	margin: 0;
-	padding: $grid-unit-20 + $grid-unit-05 $canvas-padding;
+	padding: $grid-unit-20 $canvas-padding;
 }
 
 .edit-site-save-hub__button {
 	color: inherit;
 	width: 100%;
-	justify-content: center;
+
+	&.components-button.components-button {
+		justify-content: center;
+	}
 
 	&[aria-disabled="true"] {
 		opacity: 1;


### PR DESCRIPTION
Part of #46734

## What?

This PR makes the following changes to the save button at the bottom left of the site editor:

- Adjust height to 40px
- Always center text horizontally

|  | Before | After |
|--------|--------|--------|
| Disabled | ![disabled_before](https://github.com/WordPress/gutenberg/assets/54422211/6a2ea266-8ed9-400d-889a-b99743b95313) ![disabled_hover_before](https://github.com/WordPress/gutenberg/assets/54422211/fee8abee-624f-4a7f-9ea3-607ea0765ace) | ![disabled_after](https://github.com/WordPress/gutenberg/assets/54422211/242850c9-f76a-4473-854b-7b2971605e14) ![disabled_hover_after](https://github.com/WordPress/gutenberg/assets/54422211/d65a930f-e11e-4bb2-bd95-23533f126471) |
| Dirty |  ![dirty_1_before](https://github.com/WordPress/gutenberg/assets/54422211/b34889bd-2b6a-45c8-a82f-605ee34b199b) ![dirty_2_before](https://github.com/WordPress/gutenberg/assets/54422211/d326047d-e3c6-445a-a242-857eb8a063ed) | ![dirty_1_after](https://github.com/WordPress/gutenberg/assets/54422211/c0d1299e-9147-46dd-b12c-c1ee973c8c93) ![dirty_2_after](https://github.com/WordPress/gutenberg/assets/54422211/ee11cf47-117e-47a5-91a9-ce08aad27236) |

## Why?

This button is a common component ( `SaveButton` ) that is also used in the header, and the component itself has `size="compact"`. So even if you give it the `__next40pxDefaultSize` prop and use this component, it might end up being 32px tall instead of 40px.

Also, this component should expect the text to be horizontally centered. However, if this component is disabled, i.e. has a check icon, the Button component's selector for left-aligning text is more specific, as shown below, overriding the left-right center style.

```scss
.components-button.has-icon.has-text {
    justify-content: start;
}
```

## How?

- The `size` prop that was hard-coded in the `SaveButton` component is received as a component prop.
- Increase the CSS  specificity for aligning text horizontally.

## Testing Instructions

- No matter what state the Save button in the bottom left is in the site editor, it should always be 40px tall and the text should be centered horizontally.
- The save button in the header should still be 32px high.
