### PR TITLE
Style engine: add support for nested CSS rules to `wp_style_engine_get_stylesheet_from_css_rule()`

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -197,6 +197,7 @@ require __DIR__ . '/experiments-page.php';
 if ( is_dir( __DIR__ . '/../build/style-engine' ) ) {
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rule-gutenberg.php';
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-group-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-store-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-processor-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php';

--- a/packages/style-engine/CHANGELOG.md
+++ b/packages/style-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Enhancement
+-   Style engine: add support for nested CSS rules to wp_style_engine_get_stylesheet_from_css_rule() ([#58918](https://github.com/WordPress/gutenberg/pull/58918)).
+
 ## 1.34.0 (2024-02-09)
 
 ## 1.33.0 (2024-01-24)

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -148,7 +148,7 @@ $styles = array(
     ),
     array(
         'rules_group'  => '@media (min-width: 80rem)',
-        'selector'     => '@container (width > 400px) and (height > 400px)',
+        'selector'     => '.wp-tomato',
         'declarations' => array( 'color' => 'red' )
     ),
 );

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -126,9 +126,30 @@ $styles = array(
         'selector'     => '.wp-tomato',
         'declarations' => array( 'padding' => '100px' )
     ),
+);
+
+$stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
+    $styles,
     array(
-        'selector'     => '.wp-kumquat',
+        'context' => 'block-supports', // Indicates that these styles should be stored with block supports CSS.
+    )
+);
+print_r( $stylesheet ); // .wp-pumpkin{color:orange}.wp-tomato{color:red;padding:100px}
+```
+
+It's also possible to build simple, nested CSS rules using the `rules_group` key.
+
+```php
+$styles = array(
+    array(
+        'rules_group'  => '@media (min-width: 80rem)',
+        'selector'     => '.wp-carrot',
         'declarations' => array( 'color' => 'orange' )
+    ),
+    array(
+        'rules_group'  => '@media (min-width: 80rem)',
+        'selector'     => '@container (width > 400px) and (height > 400px)',
+        'declarations' => array( 'color' => 'red' )
     ),
 );
 
@@ -138,7 +159,7 @@ $stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
         'context' => 'block-supports', // Indicates that these styles should be stored with block supports CSS.
     )
 );
-print_r( $stylesheet ); // .wp-pumpkin,.wp-kumquat{color:orange}.wp-tomato{color:red;padding:100px}
+print_r( $stylesheet ); // @media (min-width: 80rem){.wp-carrot{color:orange}.wp-tomato{color:red;}}
 ```
 
 ### wp_style_engine_get_stylesheet_from_context()

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		 *
 		 * @var string
 		 */
-		protected $rule_group;
+		protected $rules_group;
 
 		/**
 		 * Constructor
@@ -45,13 +45,13 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		 * @param string                                    $selector     The CSS selector.
 		 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
 		 *                                                                or a WP_Style_Engine_CSS_Declarations object.
-		 * @param string                                    $rule_group   A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param string                                    $rules_group  A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 */
-		public function __construct( $selector = '', $declarations = array(), $rule_group = '' ) {
+		public function __construct( $selector = '', $declarations = array(), $rules_group = '' ) {
 			$this->set_selector( $selector );
 			$this->add_declarations( $declarations );
-			$this->set_rule_group( $rule_group );
+			$this->set_rules_group( $rules_group );
 		}
 
 		/**
@@ -91,24 +91,24 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		}
 
 		/**
-		 * Sets the rule group.
+		 * Sets the rules group.
 		 *
-		 * @param string $rule_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param string $rules_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
-		public function set_rule_group( $rule_group ) {
-			$this->rule_group = $rule_group;
+		public function set_rules_group( $rules_group ) {
+			$this->rules_group = $rules_group;
 			return $this;
 		}
 
 		/**
-		 * Gets the rule group.
+		 * Gets the rules group.
 		 *
 		 * @return string
 		 */
-		public function get_rule_group() {
-			return $this->rule_group ?? null;
+		public function get_rules_group() {
+			return $this->rules_group ?? null;
 		}
 
 		/**

--- a/packages/style-engine/class-wp-style-engine-css-rules-group.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-group.php
@@ -137,8 +137,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Group' ) ) {
 			$indent_count = $should_prettify ? $indent_count + 1 : $indent_count;
 			$new_line     = $should_prettify ? "\n" : '';
 			$spacer       = $should_prettify ? ' ' : '';
-			$css         .= ! empty( $this->declarations ) ? $this->declarations->get_declarations_string( $should_prettify, $indent_count ) : '';
-			$css         .= $should_prettify && $css ? "\n" : '';
 
 			foreach ( $this->rules as $rule ) {
 				$css .= $rule->get_css( $should_prettify, $indent_count );

--- a/packages/style-engine/class-wp-style-engine-css-rules-group.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-group.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * WP_Style_Engine_CSS_Rules_Group
+ *
+ * A container for WP_Style_Engine_CSS_Rule objects.
+ *
+ * @package Gutenberg
+ */
+
+if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Group' ) ) {
+	/**
+	 * Holds, sanitizes, processes and prints nested CSS rules for the Style Engine.
+	 *
+	 * @access private
+	 */
+	class WP_Style_Engine_CSS_Rules_Group {
+		/**
+		 * The group's CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 *
+		 * @var string
+		 */
+		protected $rule_group;
+
+		/**
+		 * The container declarations.
+		 *
+		 * Contains a WP_Style_Engine_CSS_Rule object.
+		 *
+		 * @var WP_Style_Engine_CSS_Rule[]
+		 */
+		protected $rules = array();
+
+		/**
+		 * Constructor
+		 *
+		 * @param string                                              $rule_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
+		 *                                                                        such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param WP_Style_Engine_CSS_Rule[]|WP_Style_Engine_CSS_Rule $rules      Optional. A WP_Style_Engine_CSS_Rule object.
+		 */
+		public function __construct( $rule_group, $rules = array() ) {
+			$this->set_rule_group( $rule_group );
+			$this->add_rules( $rules );
+		}
+
+		/**
+		 * Sets the rule group.
+		 *
+		 * @param string $rule_group The group's CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
+		 */
+		public function set_rule_group( $rule_group ) {
+			$this->rule_group = $rule_group;
+			return $this;
+		}
+
+		/**
+		 * Gets the rule group.
+		 *
+		 * @return string
+		 */
+		public function get_rule_group() {
+			return $this->rule_group;
+		}
+
+		/**
+		 * Gets all nested rules.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule[]
+		 */
+		public function get_rules() {
+			return $this->rules;
+		}
+
+		/**
+		 * Gets a stored nested rules.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule
+		 */
+		public function get_rule( $selector ) {
+			return $this->rules[ $selector ] ?? null;
+		}
+
+		/**
+		 * Adds the rules.
+		 *
+		 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[] $container_rules An array of declarations (property => value pairs),
+		 *                                                             or a WP_Style_Engine_CSS_Declarations object.
+		 *
+		 * @return WP_Style_Engine_CSS_Rules_Group Returns the object to allow chaining of methods.
+		 */
+		public function add_rules( $rules ) {
+			if ( empty( $rules ) ) {
+				return $this;
+			}
+
+			if ( ! is_array( $rules ) ) {
+				$rules = array( $rules );
+			}
+
+			foreach ( $rules as $rule ) {
+				if ( ! $rule instanceof WP_Style_Engine_CSS_Rule ) {
+					_doing_it_wrong(
+						__METHOD__,
+						__( 'Rules passed to WP_Style_Engine_CSS_Rules_Container must be an instance of WP_Style_Engine_CSS_Rule', 'default' ),
+						'6.6.0'
+					);
+					continue;
+				}
+
+				if ( $this->rule_group !== $rule->get_rule_group() ) {
+					continue;
+				}
+
+				$selector = $rule->get_selector();
+
+				if ( isset( $this->rules[ $selector ] ) ) {
+					$this->rules[ $selector ]->add_declarations( $rule->get_declarations() );
+				} else {
+					$this->rules[ $selector ] = $rule;
+				}
+			}
+
+			return $this;
+		}
+
+		/**
+		 * Gets the nested CSS.
+		 *
+		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
+		 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+		 *
+		 * @return string
+		 */
+		public function get_css( $should_prettify = false, $indent_count = 0 ) {
+			$css          = '';
+			$indent_count = $should_prettify ? $indent_count + 1 : $indent_count;
+			$new_line     = $should_prettify ? "\n" : '';
+			$spacer       = $should_prettify ? ' ' : '';
+			$css         .= ! empty( $this->declarations ) ? $this->declarations->get_declarations_string( $should_prettify, $indent_count ) : '';
+			$css         .= $should_prettify && $css ? "\n" : '';
+
+			foreach ( $this->rules as $rule ) {
+				$css .= $rule->get_css( $should_prettify, $indent_count );
+				$css .= $should_prettify ? "\n" : '';
+			}
+
+			if ( empty( $css ) ) {
+				return $css;
+			}
+
+			return "{$this->rule_group}{$spacer}{{$new_line}{$css}}";
+		}
+	}
+}

--- a/packages/style-engine/class-wp-style-engine-css-rules-group.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-group.php
@@ -19,7 +19,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Group' ) ) {
 		 *
 		 * @var string
 		 */
-		protected $rule_group;
+		protected $rules_group;
 
 		/**
 		 * The container declarations.
@@ -33,34 +33,34 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Group' ) ) {
 		/**
 		 * Constructor
 		 *
-		 * @param string                                              $rule_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
-		 *                                                                        such as `@media (min-width: 80rem)` or `@layer module`.
-		 * @param WP_Style_Engine_CSS_Rule[]|WP_Style_Engine_CSS_Rule $rules      Optional. A WP_Style_Engine_CSS_Rule object.
+		 * @param string                                              $rules_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
+		 *                                                                         such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param WP_Style_Engine_CSS_Rule[]|WP_Style_Engine_CSS_Rule $rules       Optional. A WP_Style_Engine_CSS_Rule object.
 		 */
-		public function __construct( $rule_group, $rules = array() ) {
-			$this->set_rule_group( $rule_group );
+		public function __construct( $rules_group, $rules = array() ) {
+			$this->set_rules_group( $rules_group );
 			$this->add_rules( $rules );
 		}
 
 		/**
-		 * Sets the rule group.
+		 * Sets the rules group.
 		 *
-		 * @param string $rule_group The group's CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param string $rules_group The group's CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
-		public function set_rule_group( $rule_group ) {
-			$this->rule_group = $rule_group;
+		public function set_rules_group( $rules_group ) {
+			$this->rules_group = $rules_group;
 			return $this;
 		}
 
 		/**
-		 * Gets the rule group.
+		 * Gets the rules group.
 		 *
 		 * @return string
 		 */
-		public function get_rule_group() {
-			return $this->rule_group;
+		public function get_rules_group() {
+			return $this->rules_group;
 		}
 
 		/**
@@ -108,7 +108,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Group' ) ) {
 					continue;
 				}
 
-				if ( $this->rule_group !== $rule->get_rule_group() ) {
+				if ( $this->rules_group !== $rule->get_rules_group() ) {
 					continue;
 				}
 
@@ -149,7 +149,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Group' ) ) {
 				return $css;
 			}
 
-			return "{$this->rule_group}{$spacer}{{$new_line}{$css}}";
+			return "{$this->rules_group}{$spacer}{{$new_line}{$css}}";
 		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -115,7 +115,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 		 */
 		public function add_rule( $selector, $rules_group = '' ) {
-			$selector    = $selector? trim( $selector ) : '';
+			$selector    = $selector ? trim( $selector ) : '';
 			$rules_group = $rules_group ? trim( $rules_group ) : '';
 
 			// Bail early if there is no selector.

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		/**
 		 * An array of CSS Rules objects assigned to the store.
 		 *
-		 * @var Array<WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rules_Group>
+		 * @var WP_Style_Engine_CSS_Rule[]
 		 */
 		protected $rules = array();
 
@@ -109,35 +109,25 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		 * Gets a WP_Style_Engine_CSS_Rule object by its selector.
 		 * If the rule does not exist, it will be created.
 		 *
-		 * @param string $selector   The CSS selector.
-		 * @param string $rule_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`..
+		 * @param string $selector    The CSS selector.
+		 * @param string $rules_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`..
 		 *
 		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 		 */
-		public function add_rule( $selector, $rule_group = '' ) {
-			$selector   = $selector ? trim( $selector ) : '';
-			$rule_group = $rule_group ? trim( $rule_group ) : '';
+		public function add_rule( $selector, $rules_group = '' ) {
+			$selector    = trim( $selector );
+			$rules_group = trim( $rules_group );
 
 			// Bail early if there is no selector.
 			if ( empty( $selector ) ) {
 				return;
 			}
 
-			if ( ! empty( $rule_group ) ) {
-				if ( empty( $this->rules[ $rule_group ] ) ) {
-					$this->rules[ $rule_group ] = new WP_Style_Engine_CSS_Rules_Group( $rule_group );
+			if ( ! empty( $rules_group ) ) {
+				if ( empty( $this->rules[ "$rules_group $selector" ] ) ) {
+					$this->rules[ "$rules_group $selector" ] = new WP_Style_Engine_CSS_Rule( $selector, array(), $rules_group );
 				}
-
-				if ( $this->rules[ $rule_group ] instanceof WP_Style_Engine_CSS_Rules_Group ) {
-					if ( $this->rules[ $rule_group ]->get_rule( $selector ) ) {
-						return $this->rules[ $rule_group ]->get_rule( $selector );
-					}
-
-					$nested_rule = new WP_Style_Engine_CSS_Rule( $selector );
-					$nested_rule->set_rule_group( $rule_group );
-					$this->rules[ $rule_group ]->add_rules( $nested_rule );
-					return $this->rules[ $rule_group ]->get_rule( $selector );
-				}
+				return $this->rules[ "$rules_group $selector" ];
 			}
 
 			// Create the rule if it doesn't exist.

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -115,8 +115,8 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 		 */
 		public function add_rule( $selector, $rules_group = '' ) {
-			$selector    = trim( $selector );
-			$rules_group = trim( $rules_group );
+			$selector    = $selector? trim( $selector ) : '';
+			$rules_group = $rules_group ? trim( $rules_group ) : '';
 
 			// Bail early if there is no selector.
 			if ( empty( $selector ) ) {

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		/**
 		 * An array of CSS Rules objects assigned to the store.
 		 *
-		 * @var WP_Style_Engine_CSS_Rule[]
+		 * @var Array<WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rules_Group>
 		 */
 		protected $rules = array();
 
@@ -109,25 +109,35 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		 * Gets a WP_Style_Engine_CSS_Rule object by its selector.
 		 * If the rule does not exist, it will be created.
 		 *
-		 * @param string $selector The CSS selector.
-		 * @param string $at_rule  The CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param string $selector   The CSS selector.
+		 * @param string $rule_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`..
 		 *
 		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 		 */
-		public function add_rule( $selector, $at_rule = '' ) {
-			$selector = trim( $selector );
-			$at_rule  = trim( $at_rule );
+		public function add_rule( $selector, $rule_group = '' ) {
+			$selector   = $selector ? trim( $selector ) : '';
+			$rule_group = $rule_group ? trim( $rule_group ) : '';
 
 			// Bail early if there is no selector.
 			if ( empty( $selector ) ) {
 				return;
 			}
 
-			if ( ! empty( $at_rule ) ) {
-				if ( empty( $this->rules[ "$at_rule $selector" ] ) ) {
-					$this->rules[ "$at_rule $selector" ] = new WP_Style_Engine_CSS_Rule( $selector, array(), $at_rule );
+			if ( ! empty( $rule_group ) ) {
+				if ( empty( $this->rules[ $rule_group ] ) ) {
+					$this->rules[ $rule_group ] = new WP_Style_Engine_CSS_Rules_Group( $rule_group );
 				}
-				return $this->rules[ "$at_rule $selector" ];
+
+				if ( $this->rules[ $rule_group ] instanceof WP_Style_Engine_CSS_Rules_Group ) {
+					if ( $this->rules[ $rule_group ]->get_rule( $selector ) ) {
+						return $this->rules[ $rule_group ]->get_rule( $selector );
+					}
+
+					$nested_rule = new WP_Style_Engine_CSS_Rule( $selector );
+					$nested_rule->set_rule_group( $rule_group );
+					$this->rules[ $rule_group ]->add_rules( $nested_rule );
+					return $this->rules[ $rule_group ]->get_rule( $selector );
+				}
 			}
 
 			// Create the rule if it doesn't exist.

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 			}
 
 			foreach ( $css_rules as $rule ) {
-				$rule_group = $rule->get_rule_group();
+				$rules_group = $rule->get_rules_group();
 
 				/*
 				 * Merge existing rule and container objects or create new ones.
@@ -81,10 +81,10 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 				 * separate processing.
 				 */
 				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Group ) {
-					if ( isset( $this->css_containers[ $rule_group ] ) ) {
-						$this->css_containers[ $rule_group ]->add_rules( $rule->get_rules() );
+					if ( isset( $this->css_containers[ $rules_group ] ) ) {
+						$this->css_containers[ $rules_group ]->add_rules( $rule->get_rules() );
 					} else {
-						$this->css_containers[ $rule_group ] = $rule;
+						$this->css_containers[ $rules_group ] = $rule;
 					}
 					continue;
 				}
@@ -92,12 +92,12 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 				if ( $rule instanceof WP_Style_Engine_CSS_Rule ) {
 					$selector = $rule->get_selector();
 					// incoming new rule has a parent rule group
-					if ( $rule_group ) {
+					if ( $rules_group ) {
 						// if not it's already stored
-						if ( ! isset( $this->css_containers[ $rule_group ] ) ) {
-							$this->css_containers[ $rule_group ] = new WP_Style_Engine_CSS_Rules_Group( $rule_group );
+						if ( ! isset( $this->css_containers[ $rules_group ] ) ) {
+							$this->css_containers[ $rules_group ] = new WP_Style_Engine_CSS_Rules_Group( $rules_group );
 						}
-						$this->css_containers[ $rule_group ]->add_rules( $rule );
+						$this->css_containers[ $rules_group ]->add_rules( $rule );
 						continue;
 					}
 

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -33,9 +33,9 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 		/**
 		 * The set of rules group with nested CSS rules that this processor will work on.
 		 *
-		 * @var WP_Style_Engine_CSS_Rules_Container[]
+		 * @var WP_Style_Engine_CSS_Rules_Group[]
 		 */
-		protected $css_containers = array();
+		protected $css_rules_groups = array();
 
 
 		/**
@@ -76,15 +76,15 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 				$rules_group = $rule->get_rules_group();
 
 				/*
-				 * Merge existing rule and container objects or create new ones.
-				 * Containers and rules are stored in separate arrays to allow for
-				 * separate processing.
+				 * Merge existing rule and rules groups objects or create new ones.
+				 * Rules groups and rules are stored in separate arrays to allow for
+				 * unique processing.
 				 */
 				if ( $rule instanceof WP_Style_Engine_CSS_Rules_Group ) {
-					if ( isset( $this->css_containers[ $rules_group ] ) ) {
-						$this->css_containers[ $rules_group ]->add_rules( $rule->get_rules() );
+					if ( isset( $this->css_rules_groups[ $rules_group ] ) ) {
+						$this->css_rules_groups[ $rules_group ]->add_rules( $rule->get_rules() );
 					} else {
-						$this->css_containers[ $rules_group ] = $rule;
+						$this->css_rules_groups[ $rules_group ] = $rule;
 					}
 					continue;
 				}
@@ -94,10 +94,10 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 					// incoming new rule has a parent rule group
 					if ( $rules_group ) {
 						// if not it's already stored
-						if ( ! isset( $this->css_containers[ $rules_group ] ) ) {
-							$this->css_containers[ $rules_group ] = new WP_Style_Engine_CSS_Rules_Group( $rules_group );
+						if ( ! isset( $this->css_rules_groups[ $rules_group ] ) ) {
+							$this->css_rules_groups[ $rules_group ] = new WP_Style_Engine_CSS_Rules_Group( $rules_group );
 						}
-						$this->css_containers[ $rules_group ]->add_rules( $rule );
+						$this->css_rules_groups[ $rules_group ]->add_rules( $rule );
 						continue;
 					}
 
@@ -145,7 +145,7 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 			// Build the CSS.
 			$css = '';
 			// Merge the rules and containers. Containers come last.
-			$merged_rules = array_merge( $this->css_rules, $this->css_containers );
+			$merged_rules = array_merge( $this->css_rules, $this->css_rules_groups );
 
 			foreach ( $merged_rules as $rule ) {
 				$css .= $rule->get_css( $options['prettify'] );

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -355,14 +355,15 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 * @param string   $store_name       A valid store key.
 		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 		 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 * @param string $rules_group        Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return void.
 		 */
-		public static function store_css_rule( $store_name, $css_selector, $css_declarations ) {
+		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $rules_group = '' ) {
 			if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
 				return;
 			}
-			static::get_store( $store_name )->add_rule( $css_selector )->add_declarations( $css_declarations );
+			static::get_store( $store_name )->add_rule( $css_selector, $rules_group )->add_declarations( $css_declarations );
 		}
 
 		/**

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -358,11 +358,11 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 *
 		 * @return void.
 		 */
-		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $css_at_rule = '' ) {
+		public static function store_css_rule( $store_name, $css_selector, $css_declarations ) {
 			if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
 				return;
 			}
-			static::get_store( $store_name )->add_rule( $css_selector, $css_at_rule )->add_declarations( $css_declarations );
+			static::get_store( $store_name )->add_rule( $css_selector )->add_declarations( $css_declarations );
 		}
 
 		/**

--- a/packages/style-engine/style-engine.php
+++ b/packages/style-engine/style-engine.php
@@ -83,7 +83,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *     Required. A collection of CSS rules.
  *
  *     @type array ...$0 {
- *         @type string   $rule_group   A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+ *         @type string   $rules_group  A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
  *         @type string   $selector     A CSS selector.
  *         @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
  *     }
@@ -117,17 +117,12 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 			continue;
 		}
 
-		$rule_group = $css_rule['rule_group'] ?? null;
+		$rules_group = $css_rule['rules_group'] ?? null;
 		if ( ! empty( $options['context'] ) ) {
-			WP_Style_Engine::get_store( $options['context'] )->add_rule( $css_rule['selector'], $rule_group )->add_declarations( $css_rule['declarations'] );
+			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'], $rules_group );
 		}
 
-		$new_rule = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
-		if ( $rule_group ) {
-			$new_rule->set_rule_group( $rule_group );
-		}
-
-		$css_rule_objects[] = $new_rule;
+		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'], $rules_group );
 	}
 
 	if ( empty( $css_rule_objects ) ) {

--- a/packages/style-engine/style-engine.php
+++ b/packages/style-engine/style-engine.php
@@ -83,7 +83,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *     Required. A collection of CSS rules.
  *
  *     @type array ...$0 {
- *         @type string   $at_rule      A CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+ *         @type string   $rule_group   A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
  *         @type string   $selector     A CSS selector.
  *         @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
  *     }
@@ -117,13 +117,17 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 			continue;
 		}
 
-		$at_rule = ! empty( $css_rule['at_rule'] ) ? $css_rule['at_rule'] : '';
-
+		$rule_group = $css_rule['rule_group'] ?? null;
 		if ( ! empty( $options['context'] ) ) {
-			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'], $at_rule );
+			WP_Style_Engine::get_store( $options['context'] )->add_rule( $css_rule['selector'], $rule_group )->add_declarations( $css_rule['declarations'] );
 		}
 
-		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'], $at_rule );
+		$new_rule = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
+		if ( $rule_group ) {
+			$new_rule->set_rule_group( $rule_group );
+		}
+
+		$css_rule_objects[] = $new_rule;
 	}
 
 	if ( empty( $css_rule_objects ) ) {

--- a/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
@@ -35,6 +35,22 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests setting and getting a rules group.
+	 *
+	 * @covers ::set_rules_group
+	 * @covers ::get_rules_group
+	 */
+	public function test_should_set_rules_group() {
+		$rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.heres-johnny', array(), '@layer state' );
+
+		$this->assertSame( '@layer state', $rule->get_rules_group(), 'Return value of get_rules_group() does not match value passed to constructor.' );
+
+		$rule->set_rules_group( '@layer pony' );
+
+		$this->assertSame( '@layer pony', $rule->get_rules_group(), 'Return value of get_rules_group() does not match value passed to set_rules_group().' );
+	}
+
+	/**
 	 * Tests that declaration properties are deduplicated.
 	 *
 	 * @covers ::add_declarations

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-group-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-group-test.php
@@ -28,9 +28,7 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 			),
 			$rules_group
 		);
-		$group = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group, $css_rule );
-
-		$this->assertSame( $rules_group, $group->get_rule_group(), 'Return value of get_selector() does not match value passed to constructor.' );
+		$group       = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group, $css_rule );
 
 		$expected = "$rules_group{{$css_rule->get_css()}}";
 
@@ -44,13 +42,13 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 	 * @covers ::get_rules
 	 */
 	public function test_cannot_add_empty_values() {
-		$css_container = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@media not all and (hover: hover)' );
+		$rules_group = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@media not all and (hover: hover)' );
 
-		$css_container->add_rules( '' );
-		$this->assertEmpty( $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when empty string added.' );
+		$rules_group->add_rules( '' );
+		$this->assertEmpty( $rules_group->get_rules(), 'Return value of get_rules() does not match expected rules when empty string added.' );
 
-		$css_container->add_rules( array() );
-		$this->assertEmpty( $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when array() added.' );
+		$rules_group->add_rules( array() );
+		$this->assertEmpty( $rules_group->get_rules(), 'Return value of get_rules() does not match expected rules when array() added.' );
 	}
 
 	/**
@@ -60,30 +58,30 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 	 * @covers ::get_css
 	 */
 	public function test_should_merge_existing_rule_declarations() {
-		$rule_group    = '@media not all and (hover: hover)';
-		$css_container = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rule_group );
-		$selector      = '.goanna';
-		$css_rule_1    = new WP_Style_Engine_CSS_Rule_Gutenberg(
+		$rules_group        = '@media not all and (hover: hover)';
+		$rules_group_object = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group );
+		$selector           = '.goanna';
+		$css_rule_1         = new WP_Style_Engine_CSS_Rule_Gutenberg(
 			$selector,
 			array(
 				'font-size' => '2rem',
 			),
-			$rule_group
+			$rules_group
 		);
-		$css_container->add_rules( $css_rule_1 );
+		$rules_group_object->add_rules( $css_rule_1 );
 
-		$this->assertSame( '@media not all and (hover: hover){.goanna{font-size:2rem;}}', $css_container->get_css(), 'Return value of get_css() does not match expected CSS container CSS.' );
+		$this->assertSame( '@media not all and (hover: hover){.goanna{font-size:2rem;}}', $rules_group_object->get_css(), 'Return value of get_css() does not match expected CSS container CSS.' );
 
 		$css_rule_2 = new WP_Style_Engine_CSS_Rule_Gutenberg(
 			$selector,
 			array(
 				'font-size' => '4px',
 			),
-			$rule_group
+			$rules_group
 		);
-		$css_container->add_rules( $css_rule_2 );
+		$rules_group_object->add_rules( $css_rule_2 );
 
-		$this->assertSame( '@media not all and (hover: hover){.goanna{font-size:4px;}}', $css_container->get_css(), 'Return value of get_css() does not match expected value with overwritten rule declaration.' );
+		$this->assertSame( '@media not all and (hover: hover){.goanna{font-size:4px;}}', $rules_group_object->get_css(), 'Return value of get_css() does not match expected value with overwritten rule declaration.' );
 	}
 
 	/**
@@ -94,8 +92,8 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 	 * @covers ::get_css
 	 */
 	public function test_should_add_rules_to_existing_containers() {
-		$rules_group = '@media screen, print';
-		$css_container = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group );
+		$rules_group        = '@media screen, print';
+		$rules_group_object = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group );
 
 		$css_rule_1 = new WP_Style_Engine_CSS_Rule_Gutenberg(
 			'body',
@@ -104,7 +102,7 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 			),
 			$rules_group
 		);
-		$css_container->add_rules( $css_rule_1 );
+		$rules_group_object->add_rules( $css_rule_1 );
 
 		$css_rule_2 = new WP_Style_Engine_CSS_Rule_Gutenberg(
 			'p',
@@ -113,28 +111,29 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 			),
 			$rules_group
 		);
-		$css_container->add_rules( $css_rule_2 );
+		$rules_group_object->add_rules( $css_rule_2 );
 
-		$this->assertEquals( $css_rule_2, $css_container->get_rule( 'p' ), 'Return value of get_rule() does not match expected value.' );
+		$this->assertEquals( $css_rule_2, $rules_group_object->get_rule( 'p' ), 'Return value of get_rule() does not match expected value.' );
 
 		$expected = '@media screen, print{body{line-height:0.1;}p{line-height:0.9;}}';
 
-		$this->assertSame( $expected, $css_container->get_css(), 'Return value of get_css() does not match expected value.' );
+		$this->assertSame( $expected, $rules_group_object->get_css(), 'Return value of get_css() does not match expected value.' );
 	}
 
 	/**
-	 * Tests setting a selector to a container.
+	 * Tests setting and getting a rules group.
 	 *
-	 * @covers ::set_selector
+	 * @covers ::set_rules_group
+	 * @covers ::get_rules_group
 	 */
-	public function test_should_set_rule_group() {
-		$css_container = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@layer state' );
+	public function test_should_set_rules_group() {
+		$rules_group_object = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@layer state' );
 
-		$this->assertSame( '@layer state', $css_container->get_rule_group(), 'Return value of get_selector() does not match value passed to constructor.' );
+		$this->assertSame( '@layer state', $rules_group_object->get_rules_group(), 'Return value of get_rules_group() does not match value passed to constructor.' );
 
-		$css_container->set_rule_group( '@layer pony' );
+		$rules_group_object->set_rules_group( '@layer pony' );
 
-		$this->assertSame( '@layer pony', $css_container->get_rule_group(), 'Return value of get_selector() does not match value passed to set_selector().' );
+		$this->assertSame( '@layer pony', $rules_group_object->get_rules_group(), 'Return value of get_rules_group() does not match value passed to set_rules_group().' );
 	}
 
 	/**
@@ -151,10 +150,10 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
 		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations, $rules_group );
-		$css_container      = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group, $css_rule );
+		$rules_group_object = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group, $css_rule );
 		$expected           = "{$rules_group}{{$selector}{{$css_declarations->get_declarations_string()}}}";
 
-		$this->assertSame( $expected, $css_container->get_css() );
+		$this->assertSame( $expected, $rules_group_object->get_css() );
 	}
 
 	/**
@@ -167,9 +166,9 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 		$input_declarations = array();
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
 		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
-		$css_container      = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@layer coolio', $css_rule );
+		$rules_group_object = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@layer coolio', $css_rule );
 
-		$this->assertSame( '', $css_container->get_css() );
+		$this->assertSame( '', $rules_group_object->get_css() );
 	}
 
 	/**
@@ -192,8 +191,8 @@ class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
 		font-family: Detective Sans;
 	}
 }';
-		$css_container      = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group, $css_rule );
+		$rules_group_object = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $rules_group, $css_rule );
 
-		$this->assertSame( $expected, $css_container->get_css( true ) );
+		$this->assertSame( $expected, $rules_group_object->get_css( true ) );
 	}
 }

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-group-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-group-test.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Tests the Style Engine CSS Rules group class.
+ *
+ * @package    Gutenberg
+ * @subpackage style-engine
+ */
+
+/**
+ * Tests for registering, storing and generating CSS rules groups.
+ *
+ * @group style-engine
+ * @coversDefaultClass WP_Style_Engine_CSS_Rules_Group
+ */
+class WP_Style_Engine_CSS_Rules_Group_Test extends WP_UnitTestCase {
+	/**
+	 * Tests that declarations are set on instantiation.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_should_instantiate_with_selector_and_rules() {
+		$container_selector = '#gecko';
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			'&:hover',
+			array(
+				'background-position' => '50% 50%',
+				'color'               => 'green',
+			)
+		);
+		$css_container      = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( $container_selector, $css_rule );
+
+		$this->assertSame( $container_selector, $css_container->get_selector(), 'Return value of get_selector() does not match value passed to constructor.' );
+
+		$expected = "$container_selector{{$css_rule->get_css()}}";
+
+		$this->assertSame( $expected, $css_container->get_css(), 'Value returned by get_css() does not match expected CSS string.' );
+	}
+
+	/**
+	 * Tests that empty values cannot be added.
+	 *
+	 * @covers ::add_rules
+	 * @covers ::get_rules
+	 */
+	public function test_cannot_add_empty_values() {
+		$css_container = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@media not all and (hover: hover)' );
+
+		$css_container->add_rules( '' );
+		$this->assertEmpty( $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when empty string added.' );
+
+		$css_container->add_rules( array() );
+		$this->assertEmpty( $css_container->get_rules(), 'Return value of get_rules() does not match expected rules when array() added.' );
+	}
+
+	/**
+	 * Tests that nested rule declaration properties are deduplicated.
+	 *
+	 * @covers ::add_rules
+	 * @covers ::get_css
+	 */
+	public function test_should_dedupe_properties_in_rules() {
+		$css_container = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@media not all and (hover: hover)' );
+		$selector      = '.goanna';
+		$css_rule_1    = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			$selector,
+			array(
+				'font-size' => '2rem',
+			)
+		);
+		$css_container->add_rules( $css_rule_1 );
+
+		$this->assertSame( '@media not all and (hover: hover){.goanna{font-size:2rem;}}', $css_container->get_css(), 'Return value of get_css() does not match expected CSS container CSS.' );
+
+		$css_rule_2 = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			$selector,
+			array(
+				'font-size' => '4px',
+			)
+		);
+		$css_container->add_rules( $css_rule_2 );
+
+		$this->assertSame( '@media not all and (hover: hover){.goanna{font-size:4px;}}', $css_container->get_css(), 'Return value of get_css() does not match expected value with overwritten rule declaration.' );
+	}
+
+	/**
+	 * Tests that rules can be added to existing containers.
+	 *
+	 * @covers ::add_rules
+	 * @covers ::get_rule
+	 * @covers ::get_css
+	 */
+	public function test_should_add_rules_to_existing_containers() {
+		$css_container = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@media screen, print' );
+
+		$css_rule_1 = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			'body',
+			array(
+				'line-height' => '0.1',
+			)
+		);
+		$css_container->add_rules( $css_rule_1 );
+
+		$css_rule_2 = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			'p',
+			array(
+				'line-height' => '0.9',
+			)
+		);
+		$css_container->add_rules( $css_rule_2 );
+
+		$this->assertEquals( $css_rule_2, $css_container->get_rule( 'p' ), 'Return value of get_rule() does not match expected value.' );
+
+		$expected = '@media screen, print{body{line-height:0.1;}p{line-height:0.9;}}';
+
+		$this->assertSame( $expected, $css_container->get_css(), 'Return value of get_css() does not match expected value.' );
+	}
+
+	/**
+	 * Tests setting a selector to a container.
+	 *
+	 * @covers ::set_selector
+	 */
+	public function test_should_set_selector() {
+		$css_container = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@layer state' );
+
+		$this->assertSame( '@layer state', $css_container->get_selector(), 'Return value of get_selector() does not match value passed to constructor.' );
+
+		$css_container->set_selector( '@layer pony' );
+
+		$this->assertSame( '@layer pony', $css_container->get_selector(), 'Return value of get_selector() does not match value passed to set_selector().' );
+	}
+
+	/**
+	 * Tests generating a CSS rule string.
+	 *
+	 * @covers ::get_css
+	 */
+	public function test_should_generate_css_rule_string() {
+		$selector           = '.chips';
+		$input_declarations = array(
+			'margin-top' => '10px',
+			'font-size'  => '2rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
+		$css_container      = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@layer sauce', $css_rule );
+		$expected           = "@layer sauce{{$selector}{{$css_declarations->get_declarations_string()}}}";
+
+		$this->assertSame( $expected, $css_container->get_css() );
+	}
+
+	/**
+	 * Tests that an empty string will be returned where there are no rules in a CSS container.
+	 *
+	 * @covers ::get_css
+	 */
+	public function test_should_return_empty_string_with_no_rules() {
+		$selector           = '.holmes';
+		$input_declarations = array();
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
+		$css_container      = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@layer sauce', $css_rule );
+
+		$this->assertSame( '', $css_container->get_css() );
+	}
+
+	/**
+	 * Tests that CSS containers are prettified.
+	 *
+	 * @covers ::get_css
+	 */
+	public function test_should_prettify_css_rule_output() {
+		$selector           = '.baptiste';
+		$input_declarations = array(
+			'margin-left' => '0',
+			'font-family' => 'Detective Sans',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule_Gutenberg( $selector, $css_declarations );
+		$expected           = '@container (width < 650px) {
+	.baptiste {
+		margin-left: 0;
+		font-family: Detective Sans;
+	}
+}';
+		$css_container      = new WP_Style_Engine_CSS_Rules_Group_Gutenberg( '@container (width < 650px)', $css_rule );
+
+		$this->assertSame( $expected, $css_container->get_css( true ) );
+	}
+}

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -172,56 +172,17 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that rules with rule groups defined are stored as WP_Style_Engine_CSS_Rules_Group.
-	 *
-	 * @covers ::add_rule
-	 * @covers ::get_store
-	 */
-	public function test_should_add_rules_according_to_rule_groups() {
-		$store_one             = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'one' );
-		$store_one_rule        = $store_one->add_rule( '.one' );
-		$store_one_rules_group = $store_one->add_rule( '.one', '.one_container' );
-
-		$this->assertInstanceOf(
-			'WP_Style_Engine_CSS_Rules_Group_Gutenberg',
-			$store_one->get_all_rules()[ $store_one_rules_group->get_rule_group() ],
-			'$store_one_container is not an instance of WP_Style_Engine_CSS_Rules_Group_Gutenberg.'
-		);
-
-		$this->assertSame(
-			array(
-				'.one'           => $store_one_rule,
-				'.one_container' => $store_one->get_all_rules()[ $store_one_rules_group->get_rule_group() ],
-			),
-			WP_Style_Engine_Gutenberg::get_store( 'one' )->get_all_rules(),
-			'get_all_rules() does not return expected array of rules for store one.'
-		);
-
-		$store_two_rules_group = $store_one->add_rule( '.two', '.one_container' );
-
-		$this->assertSame(
-			array(
-				'.one' => $store_one_rules_group,
-				'.two' => $store_two_rules_group,
-			),
-			$store_one->get_all_rules()[ $store_two_rules_group->get_rule_group() ]->get_rules(),
-			'get_all_rules() does not return expected array of rules for store one.'
-		);
-	}
-
-	/**
 	 * Tests adding identical selectors.
 	 *
 	 * @covers ::add_rule
 	 */
-	public function test_should_not_overwrite_existing_rules() {
-		$store_one           = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'one' );
-		$store_one_container = $store_one->add_rule( '.tony', '.one' );
-		$store_one_rule      = $store_one->add_rule( '.one' );
+	public function test_should_store_as_concatenated_rules_groups_and_selector() {
+		$store_one      = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'one' );
+		$store_one_rule = $store_one->add_rule( '.tony', '.one' );
 
 		$this->assertSame(
-			$store_one_rule,
-			$store_one_container,
+			'.one .tony',
+			"{$store_one_rule->get_rule_group()} {$store_one_rule->get_selector()}",
 			'add_rule() does not return already existing return .one rule.'
 		);
 	}

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -182,7 +182,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'.one .tony',
-			"{$store_one_rule->get_rule_group()} {$store_one_rule->get_selector()}",
+			"{$store_one_rule->get_rules_group()} {$store_one_rule->get_selector()}",
 			'add_rule() does not return already existing return .one rule.'
 		);
 	}

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -170,4 +170,59 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $new_pizza_store->get_all_rules(), 'Return value for get_all_rules() does not match expectations after adding new rules to store.' );
 	}
+
+	/**
+	 * Tests that rules with rule groups defined are stored as WP_Style_Engine_CSS_Rules_Group.
+	 *
+	 * @covers ::add_rule
+	 * @covers ::get_store
+	 */
+	public function test_should_add_rules_according_to_rule_groups() {
+		$store_one             = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'one' );
+		$store_one_rule        = $store_one->add_rule( '.one' );
+		$store_one_rules_group = $store_one->add_rule( '.one', '.one_container' );
+
+		$this->assertInstanceOf(
+			'WP_Style_Engine_CSS_Rules_Group_Gutenberg',
+			$store_one->get_all_rules()[ $store_one_rules_group->get_rule_group() ],
+			'$store_one_container is not an instance of WP_Style_Engine_CSS_Rules_Group_Gutenberg.'
+		);
+
+		$this->assertSame(
+			array(
+				'.one'           => $store_one_rule,
+				'.one_container' => $store_one->get_all_rules()[ $store_one_rules_group->get_rule_group() ],
+			),
+			WP_Style_Engine_Gutenberg::get_store( 'one' )->get_all_rules(),
+			'get_all_rules() does not return expected array of rules for store one.'
+		);
+
+		$store_two_rules_group = $store_one->add_rule( '.two', '.one_container' );
+
+		$this->assertSame(
+			array(
+				'.one' => $store_one_rules_group,
+				'.two' => $store_two_rules_group,
+			),
+			$store_one->get_all_rules()[ $store_two_rules_group->get_rule_group() ]->get_rules(),
+			'get_all_rules() does not return expected array of rules for store one.'
+		);
+	}
+
+	/**
+	 * Tests adding identical selectors.
+	 *
+	 * @covers ::add_rule
+	 */
+	public function test_should_not_overwrite_existing_rules() {
+		$store_one           = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'one' );
+		$store_one_container = $store_one->add_rule( '.tony', '.one' );
+		$store_one_rule      = $store_one->add_rule( '.one' );
+
+		$this->assertSame(
+			$store_one_rule,
+			$store_one_container,
+			'add_rule() does not return already existing return .one rule.'
+		);
+	}
 }

--- a/phpunit/style-engine/class-wp-style-engine-processor-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-processor-test.php
@@ -58,7 +58,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nice_css_rule->set_rule_group( '@media (min-width: 80rem)' );
+		$a_nice_css_rule->set_rules_group( '@media (min-width: 80rem)' );
 
 		$a_nicer_css_rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.a-nicer-rule' );
 		$a_nicer_css_rule->add_declarations(
@@ -68,7 +68,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nicer_css_rule->set_rule_group( '@layer nicety' );
+		$a_nicer_css_rule->set_rules_group( '@layer nicety' );
 
 		$a_nice_processor = new WP_Style_Engine_Processor_Gutenberg();
 		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
@@ -143,7 +143,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'orange',
 			)
 		);
-		$a_wonderful_css_rule->set_rule_group( '@media (min-width: 80rem)' );
+		$a_wonderful_css_rule->set_rules_group( '@media (min-width: 80rem)' );
 
 		$a_very_wonderful_css_rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.a-very_wonderful-rule' );
 		$a_very_wonderful_css_rule->add_declarations(
@@ -152,7 +152,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'orange',
 			)
 		);
-		$a_very_wonderful_css_rule->set_rule_group( '@layer wonderfulness' );
+		$a_very_wonderful_css_rule->set_rules_group( '@layer wonderfulness' );
 
 		$a_wonderful_processor = new WP_Style_Engine_Processor_Gutenberg();
 		$a_wonderful_processor->add_rules( array( $a_wonderful_css_rule, $a_very_wonderful_css_rule ) );
@@ -406,7 +406,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		// Add a nested rule.
 		$panda_store->add_rule( '.blueberry', $rules_group )->add_declarations(
 			array(
-				'background-color' => 'blue'
+				'background-color' => 'blue',
 			)
 		);
 

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -23,7 +23,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests generating block styles and classnames based on various manifestations of the $block_styles argument.
 	 *
-	 * @covers ::gutenberg_style_engine_get_styles
+	 * @covers ::wp_style_engine_get_styles
 	 * @covers WP_Style_Engine_Gutenberg::parse_block_styles
 	 * @covers WP_Style_Engine_Gutenberg::compile_css
 	 *
@@ -531,7 +531,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 *
-	 * @covers ::gutenberg_style_engine_get_styles
+	 * @covers ::wp_style_engine_get_styles
 	 * @covers WP_Style_Engine_Gutenberg::store_css_rule
 	 */
 	public function test_should_store_block_styles_using_context() {
@@ -666,7 +666,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @ticket 58811
 	 *
-	 * @covers ::gutenberg_style_engine_get_stylesheet_from_css_rules
+	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
 	 * @covers WP_Style_Engine_Gutenberg::compile_stylesheet_from_css_rules
 	 */
 	public function test_should_dedupe_and_merge_css_rules() {
@@ -716,7 +716,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * This is testing this fix: https://github.com/WordPress/gutenberg/pull/49004
 	 *
-	 * @covers ::gutenberg_style_engine_get_stylesheet_from_css_rules
+	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
 	 * @covers WP_Style_Engine_Gutenberg::compile_stylesheet_from_css_rules
 	 */
 	public function test_should_return_stylesheet_from_duotone_css_rules() {
@@ -735,5 +735,114 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
 		$this->assertSame( ".wp-duotone-ffffff-000000-1{filter:url('#wp-duotone-ffffff-000000-1') !important;}", $compiled_stylesheet );
+	}
+
+	/**
+	 * Tests returning a generated stylesheet from a set of nested rules.
+	 */
+	public function test_should_return_stylesheet_with_combined_nested_css_rules_printed_after_non_nested() {
+		$css_rules = array(
+			array(
+				'rules_group'  => '.sauron',
+				'selector'     => '.witch-king',
+				'declarations' => array(
+					'text-transform' => 'lowercase',
+				),
+			),
+			array(
+				'selector'     => '.saruman',
+				'declarations' => array(
+					'letter-spacing' => '1px',
+				),
+			),
+			array(
+				'selector'     => '.saruman',
+				'rules_group'  => '@container (min-width: 700px)',
+				'declarations' => array(
+					'color'        => 'white',
+					'height'       => '100px',
+					'border-style' => 'solid',
+					'align-self'   => 'stretch',
+				),
+			),
+			array(
+				'selector'     => '.saruman',
+				'rules_group'  => '@container (min-width: 700px)',
+				'declarations' => array(
+					'color'       => 'black',
+					'font-family' => 'The-Great-Eye',
+				),
+			),
+			array(
+				'selector'     => '.voldemort',
+				'rules_group'  => '@supports (align-self: stretch)',
+				'declarations' => array(
+					'height'     => '100px',
+					'align-self' => 'stretch',
+				),
+			),
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'letter-spacing' => '2px',
+				),
+			),
+			array(
+				'selector'     => '.gandalf',
+				'rules_group'  => '@supports (border-style: dotted)',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+					'align-self'   => 'safe center',
+				),
+			),
+			array(
+				'selector'     => '.radagast',
+				'rules_group'  => '@supports (align-self: stretch)',
+				'declarations' => array(
+					'color'        => 'brown',
+					'height'       => '60px',
+					'border-style' => 'dashed',
+					'align-self'   => 'stretch',
+				),
+			),
+			array(
+				'selector'     => '.tom-bombadil',
+				'declarations' => array(
+					'font-size' => '1000px',
+				),
+			),
+		);
+
+		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+
+		$this->assertSame( '.saruman{letter-spacing:1px;}.gandalf{letter-spacing:2px;}.tom-bombadil{font-size:1000px;}.sauron{.witch-king{text-transform:lowercase;}}@container (min-width: 700px){.saruman{color:black;height:100px;border-style:solid;align-self:stretch;font-family:The-Great-Eye;}}@supports (align-self: stretch){.voldemort{height:100px;align-self:stretch;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}}@supports (border-style: dotted){.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}}', $compiled_stylesheet );
+	}
+
+	/**
+	 * Tests returning a generated stylesheet from a set of nested rules.
+	 */
+	public function test_should_return_stylesheet_with_nested_at_rules() {
+		$css_rules = array(
+			array(
+				'rules_group'  => '.foo',
+				'selector'     => '@media (orientation: landscape)',
+				'declarations' => array(
+					'background-color' => 'blue',
+				),
+			),
+			array(
+				'rules_group'  => '.foo',
+				'selector'     => '@media (min-width > 1024px)',
+				'declarations' => array(
+					'background-color' => 'cotton-blue',
+				),
+			),
+		);
+
+		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+
+		$this->assertSame( '.foo{@media (orientation: landscape){background-color:blue;}@media (min-width > 1024px){background-color:cotton-blue;}}', $compiled_stylesheet );
 	}
 }

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -44,6 +44,7 @@ const bundledPackagesPhpConfig = [
 		replaceClasses: [
 			'WP_Style_Engine_CSS_Declarations',
 			'WP_Style_Engine_CSS_Rules_Store',
+			'WP_Style_Engine_CSS_Rules_Group',
 			'WP_Style_Engine_CSS_Rule',
 			'WP_Style_Engine_Processor',
 			'WP_Style_Engine',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Builds on:

- https://github.com/WordPress/gutenberg/pull/58867

by:

1. renaming `$at_rule` to `$rules_group`. 
2. Creates a new class to store rules groups.
3. Allows nested rules to be combined and grouped under similar rules groups when compiled to CSS. 
4. Ensuring that nesting rules groups appear at the end of any compiled CSS. **Note**: this PR does not yet discern between rules groups, e.g., nesting CSS style groups and at-rules
5. Adds missing tests

A related exploratory PR for supporting nested rules is here:

- https://github.com/WordPress/gutenberg/pull/58797

## Why?

1. To make it clear that it supports other styles nesting patterns. For example, "rules group" could be a [nesting style rule](https://www.w3.org/TR/css-nesting-1/#nested-style-rule), a [conditional group rule](https://www.w3.org/TR/css-conditional-3/#conditional-group-rule) or [at-rule groups](https://www.w3.org/TR/css-syntax-3/#at-rule).
2. To separate rules and rules group functionality, e.g., generating each's CSS.
3. Combining declarations is already supported for existing rules. The PR extends that pattern to existing rules groups.
4. There are cases where `@at-rules` don't affect specificity.

## How?
Main changes are the the `WP_Style_Engine_Processor`, which merges incoming/stored rules and outputs compiled CSS with rules groups appearing after any regular CSS rules.

## Potential follow ups in the future

- [ ] Add the same functionality to `wp_style_engine_get_styles()`
- [ ] At the moment `"$rules_group . $selector"` keys are stored in the store, which means they can be overwritten. Later we can allow to add and merge nested rules to the store.
- [ ] Discern between rules groups, e.g., nesting CSS style groups and at-rules when considering order
- [ ] Allow rules groups to have top-level CSS declarations, e.g., `.ham { color: red; &:hover { color: blue; } }`
- [ ] JS version

## Testing Instructions

Run the tests

`npm run test:unit:php:base -- --group style-engine`

Fire up this branch using a block theme, e.g., 2024. Check that the `core-block-supports-inline-css` on the frontend is exactly the same as trunk.

You can manually check how rules are generated and printed. 

<details>

<summary>Here are some rules declared by gutenberg_style_engine_get_stylesheet_from_css_rules()</summary>

```php
	gutenberg_style_engine_get_stylesheet_from_css_rules(
		array(
			array(
				'rules_group'  => '@media (orientation: landscape)',
				'selector'     => '.ham',
				'declarations' => array( 'gap' => '10px' ),
			)
		),
		array(
			'context'  => 'block-supports',
			'prettify' => true,
		)
	);

	gutenberg_style_engine_get_stylesheet_from_css_rules(
		array(
			array(
				'rules_group'  => '@media (orientation: landscape)',
				'selector'     => '.ham',
				'declarations' => array( 'gap' => '1px', 'background-color' => 'blue' ),
			)
		),
		array(
			'context'  => 'block-supports',
			'prettify' => true,
		)
	);

	gutenberg_style_engine_get_stylesheet_from_css_rules(
		array(
			array(
				'rules_group'  => '@media (orientation: landscape)',
				'selector'     => '.jam',
				'declarations' => array( 'background-color' => 'pink' ),
			)
		),
		array(
			'context'  => 'block-supports',
			'prettify' => true,
		)
	);

	gutenberg_style_engine_get_stylesheet_from_css_rules(
		array(
			array(
				'rules_group'  => '@layer',
				'selector'     => '.toast',
				'declarations' => array( 'color' => 'red' ),
			)
		),
		array(
			'context'  => 'block-supports',
			'prettify' => true,
		)
	);

	gutenberg_style_engine_get_stylesheet_from_css_rules(
		array(
			array(
				'rules_group'  => '@layer',
				'selector'     => '.toast:hover',
				'declarations' => array( 'color' => 'purple' ),
			)
		),
		array(
			'context'  => 'block-supports',
			'prettify' => true,
		)
	);


```

</details>


The CSS should be printed at the end of `core-block-supports-inline-css` rules stylesheet:

``` css
@media (orientation: landscape) {
	.ham {
		gap: 1px;
		background-color: blue;
	}
	.jam {
		background-color: pink;
	}
}
@layer {
	toast {
		color: red;
	}
	toast:hover {
		color: purple;
	}
}
```

