### PR TITLE
Template revisions API: move from experimental to compat/6.4

### DIFF
--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-templates-controller-6-4.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-templates-controller-6-4.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * REST API: Gutenberg_REST_Template_Revision_Count class
+ * REST API: Gutenberg_REST_Templates_Controller_6_4 class
  *
  * @package    gutenberg
  */
 
 /**
- * Gutenberg_REST_Template_Revision_Count class
+ * Gutenberg_REST_Templates_Controller_6_4 class
  *
  * Template revision changes are waiting on a core change to be merged.
  * See: https://github.com/WordPress/gutenberg/pull/45215#issuecomment-1592704026
  * When merging into core, prepare_revision_links() should be merged with
  * WP_REST_Templates_Controller::prepare_links().
  */
-class Gutenberg_REST_Template_Revision_Count extends WP_REST_Templates_Controller {
+class Gutenberg_REST_Templates_Controller_6_4 extends WP_REST_Templates_Controller {
 	/**
 	 * Add revisions to the response.
 	 *

--- a/lib/compat/wordpress-6.4/rest-api.php
+++ b/lib/compat/wordpress-6.4/rest-api.php
@@ -38,4 +38,3 @@ if ( ! function_exists( 'wp_api_template_revision_args' ) ) {
 	}
 }
 add_filter( 'register_post_type_args', 'wp_api_template_revision_args', 10, 2 );
-

--- a/lib/compat/wordpress-6.4/rest-api.php
+++ b/lib/compat/wordpress-6.4/rest-api.php
@@ -18,3 +18,24 @@ function gutenberg_register_rest_block_patterns_routes() {
 	$block_patterns->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns_routes' );
+
+
+if ( ! function_exists( 'wp_api_template_revision_args' ) ) {
+	/**
+	 * Hook in to the template and template part post types and decorate
+	 * the rest endpoint with the revision count.
+	 *
+	 * @param array  $args Current registered post type args.
+	 * @param string $post_type Name of post type.
+	 *
+	 * @return array
+	 */
+	function wp_api_template_revision_args( $args, $post_type ) {
+		if ( 'wp_template' === $post_type || 'wp_template_part' === $post_type ) {
+			$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_6_4';
+		}
+		return $args;
+	}
+}
+add_filter( 'register_post_type_args', 'wp_api_template_revision_args', 10, 2 );
+

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -101,25 +101,3 @@ function gutenberg_auto_draft_get_sample_permalink( $permalink, $id, $title, $na
 	return $permalink;
 }
 add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink', 10, 5 );
-
-if ( ! function_exists( 'wp_api_template_revision_args' ) ) {
-	/**
-	 * Hook in to the template and template part post types and decorate
-	 * the rest endpoint with the revision count.
-	 *
-	 * When merging to core, this can be removed once Gutenberg_REST_Template_Revision_Count is
-	 * merged with WP_REST_Template_Controller.
-	 *
-	 * @param array  $args Current registered post type args.
-	 * @param string $post_type Name of post type.
-	 *
-	 * @return array
-	 */
-	function wp_api_template_revision_args( $args, $post_type ) {
-		if ( 'wp_template' === $post_type || 'wp_template_part' === $post_type ) {
-			$args['rest_controller_class'] = 'Gutenberg_REST_Template_Revision_Count';
-		}
-		return $args;
-	}
-}
-add_filter( 'register_post_type_args', 'wp_api_template_revision_args', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -36,6 +36,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	}
 
 	// WordPress 6.4 compat.
+	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-templates-controller-6-4.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/rest-api.php';
@@ -53,7 +54,6 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
 		require_once __DIR__ . '/experimental/class-wp-rest-customizer-nonces.php';
 	}
-	require_once __DIR__ . '/experimental/class-gutenberg-rest-template-revision-count.php';
 	require_once __DIR__ . '/experimental/rest-api.php';
 
 	require_once __DIR__ . '/experimental/kses-allowed-html.php';


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reverting https://github.com/WordPress/gutenberg/pull/51774 by moving the templates revisions experimental code into `compat/6.4`

Original PR:

- https://github.com/WordPress/gutenberg/pull/45215


> [!NOTE]
> Doesn't require a backport

## Why?
The [original PR](https://github.com/WordPress/gutenberg/pull/45215) was slated for Wordpress 6.3, but didn't make it because of an upstream issue. See https://github.com/WordPress/gutenberg/pull/45215#issuecomment-1600056081

The upstream fix was made in WordPress 6.4. See: https://github.com/WordPress/wordpress-develop/commit/1f51e1f4f6c81238fffed706ff165795ea34d522


Also cc @georgeh


## Testing Instructions

Check for no regressions from trunk.

Check that you see a templates revision item when editing a template in the site editor (after 3 changes)

<img width="286" alt="Screenshot 2024-02-12 at 2 54 43 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/a6744bce-597b-4fc3-bfbc-d725d877b61a">

Using WordPress 6.4 + this branch, ensure that you can do the same.


