### PR TITLE
Style engine: rename at_rule to rules_groups and update test/docs

### DIFF
--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -126,9 +126,30 @@ $styles = array(
         'selector'     => '.wp-tomato',
         'declarations' => array( 'padding' => '100px' )
     ),
+);
+
+$stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
+    $styles,
     array(
-        'selector'     => '.wp-kumquat',
+        'context' => 'block-supports', // Indicates that these styles should be stored with block supports CSS.
+    )
+);
+print_r( $stylesheet ); // .wp-pumpkin{color:orange}.wp-tomato{color:red;padding:100px}
+```
+
+It's also possible to build simple, nested CSS rules using the `rules_group` key.
+
+```php
+$styles = array(
+    array(
+        'rules_group'  => '@media (min-width: 80rem)',
+        'selector'     => '.wp-carrot',
         'declarations' => array( 'color' => 'orange' )
+    ),
+    array(
+        'rules_group'  => '@media (min-width: 80rem)',
+        'selector'     => '.wp-tomato',
+        'declarations' => array( 'color' => 'red' )
     ),
 );
 
@@ -138,7 +159,7 @@ $stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
         'context' => 'block-supports', // Indicates that these styles should be stored with block supports CSS.
     )
 );
-print_r( $stylesheet ); // .wp-pumpkin,.wp-kumquat{color:orange}.wp-tomato{color:red;padding:100px}
+print_r( $stylesheet ); // @media (min-width: 80rem){.wp-carrot{color:orange}}@media (min-width: 80rem){.wp-tomato{color:red;}}
 ```
 
 ### wp_style_engine_get_stylesheet_from_context()

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -33,12 +33,11 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		protected $declarations;
 
 		/**
-		 * The CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`..
 		 *
 		 * @var string
 		 */
-		protected $at_rule;
-
+		protected $rules_group;
 
 		/**
 		 * Constructor
@@ -46,13 +45,13 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		 * @param string                                    $selector     The CSS selector.
 		 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
 		 *                                                                or a WP_Style_Engine_CSS_Declarations object.
-		 * @param string                                    $at_rule      A CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param string                                    $rules_group  A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 */
-		public function __construct( $selector = '', $declarations = array(), $at_rule = '' ) {
+		public function __construct( $selector = '', $declarations = array(), $rules_group = '' ) {
 			$this->set_selector( $selector );
 			$this->add_declarations( $declarations );
-			$this->set_at_rule( $at_rule );
+			$this->set_rules_group( $rules_group );
 		}
 
 		/**
@@ -92,15 +91,24 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		}
 
 		/**
-		 * Sets the at_rule.
+		 * Sets the rules group.
 		 *
-		 * @param string $at_rule A CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param string $rules_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
-		public function set_at_rule( $at_rule ) {
-			$this->at_rule = $at_rule;
+		public function set_rules_group( $rules_group ) {
+			$this->rules_group = $rules_group;
 			return $this;
+		}
+
+		/**
+		 * Gets the rules group.
+		 *
+		 * @return string
+		 */
+		public function get_rules_group() {
+			return $this->rules_group ?? null;
 		}
 
 		/**
@@ -122,15 +130,6 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		}
 
 		/**
-		 * Gets the at_rule.
-		 *
-		 * @return string
-		 */
-		public function get_at_rule() {
-			return $this->at_rule;
-		}
-
-		/**
 		 * Gets the CSS.
 		 *
 		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
@@ -148,16 +147,16 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 			// Trims any multiple selectors strings.
 			$selector         = $should_prettify ? implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) ) : $this->get_selector();
 			$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector ) : $selector;
-			$at_rule          = $this->get_at_rule();
-			$has_at_rule      = ! empty( $at_rule );
-			$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $has_at_rule ? $nested_declarations_indent : $declarations_indent );
+			$rules_group      = $this->get_rules_group();
+			$has_rules_group      = ! empty( $rules_group );
+			$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $has_rules_group ? $nested_declarations_indent : $declarations_indent );
 
 			if ( empty( $css_declarations ) ) {
 				return '';
 			}
 
-			if ( $has_at_rule ) {
-				$selector = "{$rule_indent}{$at_rule}{$spacer}{{$suffix}{$nested_rule_indent}{$selector}{$spacer}{{$suffix}{$css_declarations}{$suffix}{$nested_rule_indent}}{$suffix}{$rule_indent}}";
+			if ( $has_rules_group ) {
+				$selector = "{$rule_indent}{$rules_group}{$spacer}{{$suffix}{$nested_rule_indent}{$selector}{$spacer}{{$suffix}{$css_declarations}{$suffix}{$nested_rule_indent}}{$suffix}{$rule_indent}}";
 				return $selector;
 			}
 

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -105,10 +105,10 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		/**
 		 * Gets the rules group.
 		 *
-		 * @return string|null
+		 * @return string
 		 */
 		public function get_rules_group() {
-			return $this->rules_group ?? null;
+			return $this->rules_group;
 		}
 
 		/**

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -105,7 +105,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		/**
 		 * Gets the rules group.
 		 *
-		 * @return string
+		 * @return string|null
 		 */
 		public function get_rules_group() {
 			return $this->rules_group ?? null;

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -148,7 +148,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 			$selector         = $should_prettify ? implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) ) : $this->get_selector();
 			$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector ) : $selector;
 			$rules_group      = $this->get_rules_group();
-			$has_rules_group      = ! empty( $rules_group );
+			$has_rules_group  = ! empty( $rules_group );
 			$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $has_rules_group ? $nested_declarations_indent : $declarations_indent );
 
 			if ( empty( $css_declarations ) ) {

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -109,25 +109,25 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 		 * Gets a WP_Style_Engine_CSS_Rule object by its selector.
 		 * If the rule does not exist, it will be created.
 		 *
-		 * @param string $selector The CSS selector.
-		 * @param string $at_rule  The CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param string $selector    The CSS selector.
+		 * @param string $rules_group A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`..
 		 *
 		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 		 */
-		public function add_rule( $selector, $at_rule = '' ) {
-			$selector = trim( $selector );
-			$at_rule  = trim( $at_rule );
+		public function add_rule( $selector, $rules_group = '' ) {
+			$selector    = $selector ? trim( $selector ) : '';
+			$rules_group = $rules_group ? trim( $rules_group ) : '';
 
 			// Bail early if there is no selector.
 			if ( empty( $selector ) ) {
 				return;
 			}
 
-			if ( ! empty( $at_rule ) ) {
-				if ( empty( $this->rules[ "$at_rule $selector" ] ) ) {
-					$this->rules[ "$at_rule $selector" ] = new WP_Style_Engine_CSS_Rule( $selector, array(), $at_rule );
+			if ( ! empty( $rules_group ) ) {
+				if ( empty( $this->rules[ "$rules_group $selector" ] ) ) {
+					$this->rules[ "$rules_group $selector" ] = new WP_Style_Engine_CSS_Rule( $selector, array(), $rules_group );
 				}
-				return $this->rules[ "$at_rule $selector" ];
+				return $this->rules[ "$rules_group $selector" ];
 			}
 
 			// Create the rule if it doesn't exist.

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -66,19 +66,19 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 
 			foreach ( $css_rules as $rule ) {
 				$selector = $rule->get_selector();
-				$at_rule  = $rule->get_at_rule();
+				$rules_group  = $rule->get_rules_group();
 
 				/**
 				 * If there is an at_rule and it already exists in the css_rules array,
 				 * add the rule to it.
 				 * Otherwise, create a new entry for the at_rule
 				 */
-				if ( ! empty( $at_rule ) ) {
-					if ( isset( $this->css_rules[ "$at_rule $selector" ] ) ) {
-						$this->css_rules[ "$at_rule $selector" ]->add_declarations( $rule->get_declarations() );
+				if ( ! empty( $rules_group ) ) {
+					if ( isset( $this->css_rules[ "$rules_group $selector" ] ) ) {
+						$this->css_rules[ "$rules_group $selector" ]->add_declarations( $rule->get_declarations() );
 						continue;
 					}
-					$this->css_rules[ "$at_rule $selector" ] = $rule;
+					$this->css_rules[ "$rules_group $selector" ] = $rule;
 					continue;
 				}
 

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -65,8 +65,8 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 			}
 
 			foreach ( $css_rules as $rule ) {
-				$selector = $rule->get_selector();
-				$rules_group  = $rule->get_rules_group();
+				$selector    = $rule->get_selector();
+				$rules_group = $rule->get_rules_group();
 
 				/**
 				 * If there is an at_rule and it already exists in the css_rules array,

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -355,14 +355,15 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 * @param string   $store_name       A valid store key.
 		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 		 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 * @param string $rules_group        Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return void.
 		 */
-		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $css_at_rule = '' ) {
+		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $rules_group = '' ) {
 			if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
 				return;
 			}
-			static::get_store( $store_name )->add_rule( $css_selector, $css_at_rule )->add_declarations( $css_declarations );
+			static::get_store( $store_name )->add_rule( $css_selector, $rules_group )->add_declarations( $css_declarations );
 		}
 
 		/**

--- a/packages/style-engine/style-engine.php
+++ b/packages/style-engine/style-engine.php
@@ -83,7 +83,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *     Required. A collection of CSS rules.
  *
  *     @type array ...$0 {
- *         @type string   $at_rule      A CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+ *         @type string   $rules_group  A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
  *         @type string   $selector     A CSS selector.
  *         @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
  *     }
@@ -117,13 +117,12 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 			continue;
 		}
 
-		$at_rule = ! empty( $css_rule['at_rule'] ) ? $css_rule['at_rule'] : '';
-
+		$rules_group = $css_rule['rules_group'] ?? null;
 		if ( ! empty( $options['context'] ) ) {
-			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'], $at_rule );
+			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'], $rules_group );
 		}
 
-		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'], $at_rule );
+		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'], $rules_group );
 	}
 
 	if ( empty( $css_rule_objects ) ) {

--- a/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
@@ -35,6 +35,22 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests setting and getting a rules group.
+	 *
+	 * @covers ::set_rules_group
+	 * @covers ::get_rules_group
+	 */
+	public function test_should_set_rules_group() {
+		$rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.heres-johnny', array(), '@layer state' );
+
+		$this->assertSame( '@layer state', $rule->get_rules_group(), 'Return value of get_rules_group() does not match value passed to constructor.' );
+
+		$rule->set_rules_group( '@layer pony' );
+
+		$this->assertSame( '@layer pony', $rule->get_rules_group(), 'Return value of get_rules_group() does not match value passed to set_rules_group().' );
+	}
+
+	/**
 	 * Tests that declaration properties are deduplicated.
 	 *
 	 * @covers ::add_declarations

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -172,7 +172,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests adding identical selectors.
+	 * Tests adding rules group keys to store.
 	 *
 	 * @covers ::add_rule
 	 */

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -170,4 +170,20 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $new_pizza_store->get_all_rules(), 'Return value for get_all_rules() does not match expectations after adding new rules to store.' );
 	}
+
+	/**
+	 * Tests adding identical selectors.
+	 *
+	 * @covers ::add_rule
+	 */
+	public function test_should_store_as_concatenated_rules_groups_and_selector() {
+		$store_one      = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'one' );
+		$store_one_rule = $store_one->add_rule( '.tony', '.one' );
+
+		$this->assertSame(
+			'.one .tony',
+			"{$store_one_rule->get_rules_group()} {$store_one_rule->get_selector()}",
+			'add_rule() does not return already existing return .one rule.'
+		);
+	}
 }

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -183,7 +183,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			'.one .tony',
 			"{$store_one_rule->get_rules_group()} {$store_one_rule->get_selector()}",
-			'add_rule() does not return already existing return .one rule.'
+			'add_rule() does not concatenate rules group and selector.'
 		);
 	}
 }

--- a/phpunit/style-engine/class-wp-style-engine-processor-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-processor-test.php
@@ -58,7 +58,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nice_css_rule->set_at_rule( '@media (min-width: 80rem)' );
+		$a_nice_css_rule->set_rules_group( '@media (min-width: 80rem)' );
 
 		$a_nicer_css_rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.a-nicer-rule' );
 		$a_nicer_css_rule->add_declarations(
@@ -68,7 +68,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nicer_css_rule->set_at_rule( '@layer nicety' );
+		$a_nicer_css_rule->set_rules_group( '@layer nicety' );
 
 		$a_nice_processor = new WP_Style_Engine_Processor_Gutenberg();
 		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
@@ -143,7 +143,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'orange',
 			)
 		);
-		$a_wonderful_css_rule->set_at_rule( '@media (min-width: 80rem)' );
+		$a_wonderful_css_rule->set_rules_group( '@media (min-width: 80rem)' );
 
 		$a_very_wonderful_css_rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.a-very_wonderful-rule' );
 		$a_very_wonderful_css_rule->add_declarations(
@@ -152,7 +152,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'orange',
 			)
 		);
-		$a_very_wonderful_css_rule->set_at_rule( '@layer wonderfulness' );
+		$a_very_wonderful_css_rule->set_rules_group( '@layer wonderfulness' );
 
 		$a_wonderful_processor = new WP_Style_Engine_Processor_Gutenberg();
 		$a_wonderful_processor->add_rules( array( $a_wonderful_css_rule, $a_very_wonderful_css_rule ) );

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -738,23 +738,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests returning a generated stylesheet from a set of nested rules.
+	 * Tests returning a generated stylesheet from a set of nested rules and merging their declarations.
 	 */
-	public function test_should_return_stylesheet_with_combined_nested_css_rules_printed_after_non_nested() {
+	public function test_should_merge_declarations_for_rules_groups() {
 		$css_rules = array(
-			array(
-				'rules_group'  => '.sauron',
-				'selector'     => '.witch-king',
-				'declarations' => array(
-					'text-transform' => 'lowercase',
-				),
-			),
-			array(
-				'selector'     => '.saruman',
-				'declarations' => array(
-					'letter-spacing' => '1px',
-				),
-			),
 			array(
 				'selector'     => '.saruman',
 				'rules_group'  => '@container (min-width: 700px)',
@@ -773,51 +760,11 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'font-family' => 'The-Great-Eye',
 				),
 			),
-			array(
-				'selector'     => '.voldemort',
-				'rules_group'  => '@supports (align-self: stretch)',
-				'declarations' => array(
-					'height'     => '100px',
-					'align-self' => 'stretch',
-				),
-			),
-			array(
-				'selector'     => '.gandalf',
-				'declarations' => array(
-					'letter-spacing' => '2px',
-				),
-			),
-			array(
-				'selector'     => '.gandalf',
-				'rules_group'  => '@supports (border-style: dotted)',
-				'declarations' => array(
-					'color'        => 'grey',
-					'height'       => '90px',
-					'border-style' => 'dotted',
-					'align-self'   => 'safe center',
-				),
-			),
-			array(
-				'selector'     => '.radagast',
-				'rules_group'  => '@supports (align-self: stretch)',
-				'declarations' => array(
-					'color'        => 'brown',
-					'height'       => '60px',
-					'border-style' => 'dashed',
-					'align-self'   => 'stretch',
-				),
-			),
-			array(
-				'selector'     => '.tom-bombadil',
-				'declarations' => array(
-					'font-size' => '1000px',
-				),
-			),
 		);
 
 		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
 
-		$this->assertSame( '.sauron{.witch-king{text-transform:lowercase;}}.saruman{letter-spacing:1px;}@container (min-width: 700px){.saruman{color:black;height:100px;border-style:solid;align-self:stretch;font-family:The-Great-Eye;}}@supports (align-self: stretch){.voldemort{height:100px;align-self:stretch;}}.gandalf{letter-spacing:2px;}@supports (border-style: dotted){.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}}@supports (align-self: stretch){.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}}.tom-bombadil{font-size:1000px;}', $compiled_stylesheet );
+		$this->assertSame( '@container (min-width: 700px){.saruman{color:black;height:100px;border-style:solid;align-self:stretch;font-family:The-Great-Eye;}}', $compiled_stylesheet );
 	}
 
 	/**


### PR DESCRIPTION

## What?
A minimal change that builds on:

- https://github.com/WordPress/gutenberg/pull/58867

by:

1. renaming `$at_rule` to `$rules_group`. 
2. Adds missing tests
3. Updates docs

Props to @tellthemachines and @andrewserong 

## Why?

To make it clear that it supports other styles nesting patterns. For example, "rules group" could be a [nesting style rule](https://www.w3.org/TR/css-nesting-1/#nested-style-rule), a [conditional group rule](https://www.w3.org/TR/css-conditional-3/#conditional-group-rule) or [at-rule groups](https://www.w3.org/TR/css-syntax-3/#at-rule).

Increase test coverage.

Future possibilities, including supporting merging rules groups and `@keyframes` outlined in https://github.com/WordPress/gutenberg/pull/58918

## Testing Instructions

`npm run test:unit:php:base -- --group style-engine`

