### PR TITLE
Patterns: Fix pattern categories on import

### DIFF
--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -15,6 +15,7 @@ import PatternsMenuItems from './components';
 import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
 import PartialSyncingControls from './components/partial-syncing-controls';
 import ResetOverridesControl from './components/reset-overrides-control';
+import { usePatternCategoriesMap } from './private-hooks';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
@@ -35,6 +36,7 @@ lock( privateApis, {
 	RenamePatternCategoryModal,
 	PartialSyncingControls,
 	ResetOverridesControl,
+	usePatternCategoriesMap,
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -15,7 +15,7 @@ import PatternsMenuItems from './components';
 import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
 import PartialSyncingControls from './components/partial-syncing-controls';
 import ResetOverridesControl from './components/reset-overrides-control';
-import { usePatternCategoriesMap } from './private-hooks';
+import { useAddPatternCategory } from './private-hooks';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
@@ -36,7 +36,7 @@ lock( privateApis, {
 	RenamePatternCategoryModal,
 	PartialSyncingControls,
 	ResetOverridesControl,
-	usePatternCategoriesMap,
+	useAddPatternCategory,
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,

--- a/packages/patterns/src/private-hooks.js
+++ b/packages/patterns/src/private-hooks.js
@@ -1,18 +1,25 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { CATEGORY_SLUG } from './components/category-selector';
 
 /**
  * Helper hook that creates a Map with the core and user patterns categories
  * and removes any duplicates. It's used when we need to create new user
  * categories when creating or importing patterns.
+ * This hook also provides a function to find or create a pattern category.
  *
- * @return {Map} The merged categories.
+ * @return {Object} The merged categories map and the callback function to find or create a category.
  */
-export function usePatternCategoriesMap() {
+export function useAddPatternCategory() {
+	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
 	const { corePatternCategories, userPatternCategories } = useSelect(
 		( select ) => {
 			const { getUserPatternCategories, getBlockPatternCategories } =
@@ -25,7 +32,7 @@ export function usePatternCategoriesMap() {
 		},
 		[]
 	);
-	return useMemo( () => {
+	const categoryMap = useMemo( () => {
 		// Merge the user and core pattern categories and remove any duplicates.
 		const uniqueCategories = new Map();
 		userPatternCategories.forEach( ( category ) => {
@@ -51,4 +58,34 @@ export function usePatternCategoriesMap() {
 		} );
 		return uniqueCategories;
 	}, [ userPatternCategories, corePatternCategories ] );
+
+	async function findOrCreateTerm( term ) {
+		try {
+			const existingTerm = categoryMap.get( term.toLowerCase() );
+			if ( existingTerm?.id ) {
+				return existingTerm.id;
+			}
+			// If we have an existing core category we need to match the new user category to the
+			// correct slug rather than autogenerating it to prevent duplicates, eg. the core `Headers`
+			// category uses the singular `header` as the slug.
+			const termData = existingTerm
+				? { name: existingTerm.label, slug: existingTerm.name }
+				: { name: term };
+			const newTerm = await saveEntityRecord(
+				'taxonomy',
+				CATEGORY_SLUG,
+				termData,
+				{ throwOnError: true }
+			);
+			invalidateResolution( 'getUserPatternCategories' );
+			return newTerm.id;
+		} catch ( error ) {
+			if ( error.code !== 'term_exists' ) {
+				throw error;
+			}
+			return error.data.term_id;
+		}
+	}
+
+	return { categoryMap, findOrCreateTerm };
 }

--- a/packages/patterns/src/private-hooks.js
+++ b/packages/patterns/src/private-hooks.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Helper hook that creates a Map with the core and user patterns categories
+ * and removes any duplicates. It's used when we need to create new user
+ * categories when creating or importing patterns.
+ *
+ * @return {Map} The merged categories.
+ */
+export function usePatternCategoriesMap() {
+	const { corePatternCategories, userPatternCategories } = useSelect(
+		( select ) => {
+			const { getUserPatternCategories, getBlockPatternCategories } =
+				select( coreStore );
+
+			return {
+				corePatternCategories: getBlockPatternCategories(),
+				userPatternCategories: getUserPatternCategories(),
+			};
+		},
+		[]
+	);
+	return useMemo( () => {
+		// Merge the user and core pattern categories and remove any duplicates.
+		const uniqueCategories = new Map();
+		userPatternCategories.forEach( ( category ) => {
+			uniqueCategories.set( category.label.toLowerCase(), {
+				label: category.label,
+				name: category.name,
+				id: category.id,
+			} );
+		} );
+
+		corePatternCategories.forEach( ( category ) => {
+			if (
+				! uniqueCategories.has( category.label.toLowerCase() ) &&
+				// There are two core categories with `Post` label so explicitly remove the one with
+				// the `query` slug to avoid any confusion.
+				category.name !== 'query'
+			) {
+				uniqueCategories.set( category.label.toLowerCase(), {
+					label: category.label,
+					name: category.name,
+				} );
+			}
+		} );
+		return uniqueCategories;
+	}, [ userPatternCategories, corePatternCategories ] );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/58901

Currently in patterns page when we import a pattern, there is an issue where we only add the pattern category if it's an already created user pattern category. This PR adds similar logic to the creation pattern flow, where we also check the core categories and create a user category with same name and slug.

This results in adding the current category in the imported pattern properly and remaining in the same view we were.


<!-- In a few words, what is the PR actually doing? -->

## How?
I created a private hook to get the same patterns category map with the creation flow.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Importing a pattern will add the current pattern category we're viewing and create the respective user pattern category if not exists.
2. If we import a pattern while viewing `my patterns`, we stay at the same page
3. Ensure the creation of patterns flow with adding categories works as before

