### PR TITLE
Editor: Hide template part and post content blocks in some site editor contexts

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -9,7 +9,6 @@ import {
 import deprecated from '@wordpress/deprecated';
 import { createRoot } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
-import { addFilter } from '@wordpress/hooks';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	registerLegacyWidgetBlock,
@@ -92,48 +91,6 @@ export function initializeEditor(
 			enableFSEBlocks: settings.__unstableEnableFullSiteEditingBlocks,
 		} );
 	}
-
-	/*
-	 * Prevent adding template part in the post editor.
-	 * Only add the filter when the post editor is initialized, not imported.
-	 * Also only add the filter(s) after registerCoreBlocks()
-	 * so that common filters in the block library are not overwritten.
-	 */
-	addFilter(
-		'blockEditor.__unstableCanInsertBlockType',
-		'removeTemplatePartsFromInserter',
-		( canInsert, blockType ) => {
-			if ( blockType.name === 'core/template-part' ) {
-				return false;
-			}
-			return canInsert;
-		}
-	);
-
-	/*
-	 * Prevent adding post content block (except in query block) in the post editor.
-	 * Only add the filter when the post editor is initialized, not imported.
-	 * Also only add the filter(s) after registerCoreBlocks()
-	 * so that common filters in the block library are not overwritten.
-	 */
-	addFilter(
-		'blockEditor.__unstableCanInsertBlockType',
-		'removePostContentFromInserter',
-		(
-			canInsert,
-			blockType,
-			rootClientId,
-			{ getBlockParentsByBlockName }
-		) => {
-			if ( blockType.name === 'core/post-content' ) {
-				return (
-					getBlockParentsByBlockName( rootClientId, 'core/query' )
-						.length > 0
-				);
-			}
-			return canInsert;
-		}
-	);
 
 	// Show a console log warning if the browser is not in Standards rendering mode.
 	const documentMode =

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -23,6 +23,7 @@ import useBlockEditorSettings from './use-block-editor-settings';
 import { unlock } from '../../lock-unlock';
 import DisableNonPageContentBlocks from './disable-non-page-content-blocks';
 import NavigationBlockEditingMode from './navigation-block-editing-mode';
+import { useHideBlocksFromInserter } from './use-hide-bocks-from-inserter';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -228,6 +229,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		useEffect( () => {
 			setRenderingMode( settings.defaultRenderingMode ?? 'post-only' );
 		}, [ settings.defaultRenderingMode, setRenderingMode ] );
+
+		useHideBlocksFromInserter( post.type );
 
 		if ( ! isReady ) {
 			return null;

--- a/packages/editor/src/components/provider/use-hide-bocks-from-inserter.js
+++ b/packages/editor/src/components/provider/use-hide-bocks-from-inserter.js
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { addFilter, removeFilter } from '@wordpress/hooks';
+
+// These post types are "structural" block lists.
+// We should be allowed to use
+// the post content and template parts blocks within them.
+const POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART = [
+	'wp_block',
+	'wp_template',
+	'wp_template_part',
+];
+
+/**
+ * In some specific contexts,
+ * the template part and post content blocks need to be hidden.
+ *
+ * @param {string} postType Post Type
+ */
+export function useHideBlocksFromInserter( postType ) {
+	useEffect( () => {
+		/*
+		 * Prevent adding template part in the post editor.
+		 */
+		addFilter(
+			'blockEditor.__unstableCanInsertBlockType',
+			'removeTemplatePartsFromInserter',
+			( canInsert, blockType ) => {
+				if (
+					! POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART.includes(
+						postType
+					) &&
+					blockType.name === 'core/template-part'
+				) {
+					return false;
+				}
+				return canInsert;
+			}
+		);
+
+		/*
+		 * Prevent adding post content block (except in query block) in the post editor.
+		 */
+		addFilter(
+			'blockEditor.__unstableCanInsertBlockType',
+			'removePostContentFromInserter',
+			(
+				canInsert,
+				blockType,
+				rootClientId,
+				{ getBlockParentsByBlockName }
+			) => {
+				if (
+					! POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART.includes(
+						postType
+					) &&
+					blockType.name === 'core/post-content'
+				) {
+					return (
+						getBlockParentsByBlockName( rootClientId, 'core/query' )
+							.length > 0
+					);
+				}
+				return canInsert;
+			}
+		);
+
+		return () => {
+			removeFilter(
+				'blockEditor.__unstableCanInsertBlockType',
+				'removeTemplatePartsFromInserter'
+			);
+			removeFilter(
+				'blockEditor.__unstableCanInsertBlockType',
+				'removePostContentFromInserter'
+			);
+		};
+	}, [ postType ] );
+}

--- a/packages/editor/src/components/provider/use-hide-bocks-from-inserter.js
+++ b/packages/editor/src/components/provider/use-hide-bocks-from-inserter.js
@@ -22,7 +22,7 @@ const POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART = [
 export function useHideBlocksFromInserter( postType ) {
 	useEffect( () => {
 		/*
-		 * Prevent adding template part in the post editor.
+		 * Prevent adding template part in the editor.
 		 */
 		addFilter(
 			'blockEditor.__unstableCanInsertBlockType',
@@ -41,7 +41,7 @@ export function useHideBlocksFromInserter( postType ) {
 		);
 
 		/*
-		 * Prevent adding post content block (except in query block) in the post editor.
+		 * Prevent adding post content block (except in query block) in the editor.
 		 */
 		addFilter(
 			'blockEditor.__unstableCanInsertBlockType',


### PR DESCRIPTION
Related #52632 

## What?

In the post editor, we hide the "post content" block and the "template part" blocks in the default mode. But in the site editor, we also have the same modes but we don't do anything for these blocks, we just keep them around. This PR unifies that by moving this logic to the EditorProvider.

I think the existence of these filters is an indication that we're lacking some block API to define in which contexts (postTypes?) these blocks are allowed or not. That said, it's not entirely clear what such API should look like.

I also think the "template locked" mode should have the same treatment because you can't insert blocks outside post content there as well.

## Testing Instructions

Try inserting "content" or "header" within posts or pages (either in post or site editors), you shouldn't be able to find these blocks in the inserter.