### PR TITLE
Upgrade Floating UI packages, fix nested iframe positioning bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5131,26 +5131,38 @@
 			"dev": true
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
-			"integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
 			"dependencies": {
-				"@floating-ui/utils": "^0.1.1"
+				"@floating-ui/utils": "^0.2.1"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
-			"integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+			"integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
 			"dependencies": {
-				"@floating-ui/core": "^1.4.1",
-				"@floating-ui/utils": "^0.1.1"
+				"@floating-ui/core": "^1.0.0",
+				"@floating-ui/utils": "^0.2.0"
+			}
+		},
+		"node_modules/@floating-ui/react-dom": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.6.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
-			"integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+			"integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
 		},
 		"node_modules/@geometricpanda/storybook-addon-badges": {
 			"version": "2.0.1",
@@ -7722,19 +7734,6 @@
 				"@types/react-dom": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@radix-ui/react-select/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-			"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
-			"dev": true,
-			"dependencies": {
-				"@floating-ui/dom": "^1.3.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/primitive": {
@@ -53994,7 +53993,7 @@
 				"@emotion/serialize": "^1.0.2",
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^2.0.1",
+				"@floating-ui/react-dom": "^2.0.8",
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.2.24",
@@ -54042,18 +54041,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/components/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-			"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
-			"dependencies": {
-				"@floating-ui/dom": "^1.3.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"packages/components/node_modules/@types/gradient-parser": {
@@ -59590,26 +59577,34 @@
 			"dev": true
 		},
 		"@floating-ui/core": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
-			"integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
 			"requires": {
-				"@floating-ui/utils": "^0.1.1"
+				"@floating-ui/utils": "^0.2.1"
 			}
 		},
 		"@floating-ui/dom": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
-			"integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+			"integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
 			"requires": {
-				"@floating-ui/core": "^1.4.1",
-				"@floating-ui/utils": "^0.1.1"
+				"@floating-ui/core": "^1.0.0",
+				"@floating-ui/utils": "^0.2.0"
+			}
+		},
+		"@floating-ui/react-dom": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+			"requires": {
+				"@floating-ui/dom": "^1.6.1"
 			}
 		},
 		"@floating-ui/utils": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
-			"integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+			"integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
 		},
 		"@geometricpanda/storybook-addon-badges": {
 			"version": "2.0.1",
@@ -61538,15 +61533,6 @@
 				"react-remove-scroll": "2.5.5"
 			},
 			"dependencies": {
-				"@floating-ui/react-dom": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-					"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
-					"dev": true,
-					"requires": {
-						"@floating-ui/dom": "^1.3.0"
-					}
-				},
 				"@radix-ui/primitive": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
@@ -69135,7 +69121,7 @@
 				"@emotion/serialize": "^1.0.2",
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^2.0.1",
+				"@floating-ui/react-dom": "^2.0.8",
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.2.24",
@@ -69178,14 +69164,6 @@
 				"valtio": "1.7.0"
 			},
 			"dependencies": {
-				"@floating-ui/react-dom": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-					"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
-					"requires": {
-						"@floating-ui/dom": "^1.3.0"
-					}
-				},
 				"@types/gradient-parser": {
 					"version": "0.1.3",
 					"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   `Modal`: Add `box-sizing` reset style ([#58905](https://github.com/WordPress/gutenberg/pull/58905)).
+-   `Popover`: Fix positioning in nested iframes by upgrading Floating UI packages to their latest versions ([#58932](https://github.com/WordPress/gutenberg/pull/58932)).
 
 ### Experimental
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -38,7 +38,7 @@
 		"@emotion/serialize": "^1.0.2",
 		"@emotion/styled": "^11.6.0",
 		"@emotion/utils": "^1.0.0",
-		"@floating-ui/react-dom": "^2.0.1",
+		"@floating-ui/react-dom": "^2.0.8",
 		"@types/gradient-parser": "0.1.3",
 		"@types/highlight-words-core": "1.2.1",
 		"@use-gesture/react": "^10.2.24",


### PR DESCRIPTION
Upgrades Floating UI packages to their latest version. The latest version of `@floating-ui/dom` includes https://github.com/floating-ui/floating-ui/pull/2785 which in turn fixes #58756.

This also fixes the positioning bug we've been seeing in Storybook for some time. Now the positioning in Storybook is 100% right!

<img width="938" alt="Screenshot 2024-02-12 at 13 03 43" src="https://github.com/WordPress/gutenberg/assets/664258/a7821642-914d-471f-baa8-2091a314d2c1">
