### PR TITLE
Clean up link control CSS.

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -340,13 +340,6 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 }
 
-.block-editor-link-control__drawer {
-	display: flex; // allow for ordering.
-	order: 30;
-	flex-direction: column;
-	flex-basis: 100%; // occupy full width.
-}
-
 // Inner div required to avoid padding/margin
 // causing janky animation.
 .block-editor-link-control__drawer-inner {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58931

## What?
<!-- In a few words, what is the PR actually doing? -->
Some CSS applied on the LinkControl settings is unnecessary.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For a cleaner CSS and to save some bytes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the unnecessary CSS ruleset.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a link.
- Open the link settings UI.
- Observe the layout of the link 'Advanced' settings panel (also known as 'drawer') is unchanged.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
