### PR TITLE
Editor: Remove the 'all' rendering mode

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1409,7 +1409,7 @@ Returns an action used to set the rendering mode of the post editor. We support 
 
 _Parameters_
 
--   _mode_ `string`: Mode (one of 'post-only', 'template-locked' or 'all').
+-   _mode_ `string`: Mode (one of 'post-only' or 'template-locked').
 
 ### setTemplateValidity
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -89,15 +89,13 @@ function Editor( {
 		);
 
 	const { updatePreferredStyleVariations } = useDispatch( editPostStore );
-	const defaultRenderingMode =
-		currentPost.postType === 'wp_template' ? 'all' : 'post-only';
 
 	const editorSettings = useMemo(
 		() => ( {
 			...settings,
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
-			defaultRenderingMode,
+			defaultRenderingMode: 'post-only',
 			__experimentalPreferredStyleVariations: {
 				value: preferredStyleVariations,
 				onChange: updatePreferredStyleVariations,
@@ -111,7 +109,6 @@ function Editor( {
 			updatePreferredStyleVariations,
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
-			defaultRenderingMode,
 		]
 	);
 

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -103,10 +103,7 @@ export function initializeEditor(
 		'blockEditor.__unstableCanInsertBlockType',
 		'removeTemplatePartsFromInserter',
 		( canInsert, blockType ) => {
-			if (
-				select( editorStore ).getRenderingMode() === 'post-only' &&
-				blockType.name === 'core/template-part'
-			) {
+			if ( blockType.name === 'core/template-part' ) {
 				return false;
 			}
 			return canInsert;
@@ -128,10 +125,7 @@ export function initializeEditor(
 			rootClientId,
 			{ getBlockParentsByBlockName }
 		) => {
-			if (
-				select( editorStore ).getRenderingMode() === 'post-only' &&
-				blockType.name === 'core/post-content'
-			) {
+			if ( blockType.name === 'core/post-content' ) {
 				return (
 					getBlockParentsByBlockName( rootClientId, 'core/query' )
 						.length > 0

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -556,7 +556,7 @@ export const isEditingTemplate = createRegistrySelector( ( select ) => () => {
 		since: '6.5',
 		alternative: `select( 'core/editor' ).getRenderingMode`,
 	} );
-	return select( editorStore ).getRenderingMode() !== 'post-only';
+	return select( editorStore ).getCurrentPostType() !== 'post-only';
 } );
 
 /**

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -144,7 +144,9 @@ export function useSpecificEditorSettings() {
 		[]
 	);
 	const archiveLabels = useArchiveLabel( templateSlug );
-	const defaultRenderingMode = postWithTemplate ? 'template-locked' : 'all';
+	const defaultRenderingMode = postWithTemplate
+		? 'template-locked'
+		: 'post-only';
 	const onNavigateToPreviousEntityRecord =
 		useNavigateToPreviousEntityRecord();
 	const defaultEditorSettings = useMemo( () => {

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -110,7 +110,7 @@ function EditorCanvas( {
 
 		if ( postTypeSlug === 'wp_block' ) {
 			_wrapperBlockName = 'core/block';
-		} else if ( ! _renderingMode === 'post-only' ) {
+		} else if ( _renderingMode === 'post-only' ) {
 			_wrapperBlockName = 'core/post-content';
 		}
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -585,7 +585,7 @@ export function updateEditorSettings( settings ) {
  * -   `post-only`: This mode extracts the post blocks from the template and renders only those. The idea is to allow the user to edit the post/page in isolation without the wrapping template.
  * -   `template-locked`: This mode renders both the template and the post blocks but the template blocks are locked and can't be edited. The post blocks are editable.
  *
- * @param {string} mode Mode (one of 'post-only', 'template-locked' or 'all').
+ * @param {string} mode Mode (one of 'post-only' or 'template-locked').
  */
 export const setRenderingMode =
 	( mode ) =>

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -266,7 +266,7 @@ export function editorSettings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
 	return state;
 }
 
-export function renderingMode( state = 'all', action ) {
+export function renderingMode( state = 'post-only', action ) {
 	switch ( action.type ) {
 		case 'SET_RENDERING_MODE':
 			return action.mode;


### PR DESCRIPTION
## What?

At some point in the post and site editor, we were rendering both templates and posts while being able to edit both at the same time. This rendering mode's name was "all".  That said, this rendering mode is not anymore and it was introduced recently to the EditorProvider so this PR just removes it entirely.

## Testing Instructions

 - You can check enabling/hiding templates, switching to templates in the post or site editors.
 - You should be able to edit things just like in trunk.