### PR TITLE
Fix visual and DOM order of the list view header tabs and close button.

### DIFF
--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -130,12 +130,6 @@ export default function ListViewSidebar() {
 				initialTabId="list-view"
 			>
 				<div className="edit-post-editor__document-overview-panel__header">
-					<Button
-						className="editor-list-view-sidebar__close-button"
-						icon={ closeSmall }
-						label={ __( 'Close' ) }
-						onClick={ closeListView }
-					/>
 					<Tabs.TabList
 						className="editor-list-view-sidebar__tabs-tablist"
 						ref={ tabsRef }
@@ -153,6 +147,12 @@ export default function ListViewSidebar() {
 							{ _x( 'Outline', 'Post overview' ) }
 						</Tabs.Tab>
 					</Tabs.TabList>
+					<Button
+						className="editor-list-view-sidebar__close-button"
+						icon={ closeSmall }
+						label={ __( 'Close' ) }
+						onClick={ closeListView }
+					/>
 				</div>
 
 				<Tabs.TabPanel

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -14,7 +14,6 @@
 	}
 	.editor-list-view-sidebar__close-button {
 		background: $white;
-		order: 1;
 		align-self: center;
 		margin-right: $grid-unit-10;
 	}

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -360,7 +360,6 @@ test.describe( 'List View', () => {
 		// out of range of the sidebar region. Must shift+tab 2 times to reach
 		// close button before tab panel.
 		await pageUtils.pressKeys( 'shift+Tab' );
-		await pageUtils.pressKeys( 'shift+Tab' );
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Document Overview' } )

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -378,6 +378,7 @@ test.describe( 'List View', () => {
 		// Focus the outline tab and select it. This test ensures the outline
 		// tab receives similar focus events based on the shortcut.
 		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'shift+Tab' );
 		await page.keyboard.press( 'ArrowRight' );
 		const outlineButton = page.getByRole( 'tab', {
 			name: 'Outline',
@@ -387,7 +388,7 @@ test.describe( 'List View', () => {
 
 		// From here, tab in to the editor so focus can be checked on return to
 		// the outline tab in the sidebar.
-		await pageUtils.pressKeys( 'Tab', { times: 2 } );
+		await pageUtils.pressKeys( 'Tab', { times: 3 } );
 		// Focus should be placed on the outline tab button since there is
 		// nothing to focus inside the tab itself.
 		await pageUtils.pressKeys( 'access+o' );

--- a/test/e2e/specs/site-editor/list-view.spec.js
+++ b/test/e2e/specs/site-editor/list-view.spec.js
@@ -118,7 +118,6 @@ test.describe( 'Site Editor List View', () => {
 		// out of range of the sidebar region. Must shift+tab 1 time to reach
 		// close button before list view area.
 		await pageUtils.pressKeys( 'shift+Tab' );
-		await pageUtils.pressKeys( 'shift+Tab' );
 		await expect(
 			page
 				.getByRole( 'region', { name: 'List View' } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58940

## What?
<!-- In a few words, what is the PR actually doing? -->
In the List View header, the tabs and the close button visual order and DOM order mismatch. A new `order` CSS property was introduced to swap the order in place of the previous absolute positioning so, in a way, the problem is not new. However, it would be great to not introduce new `order' properties in the codebase.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For accessibility, visual / reading order and DOM order must match when they affect 'meaning and operation'.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Render the elements in the desired order in the DOM rather than swapping their visual order via CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue https://github.com/WordPress/gutenberg/issues/58940
- Observe the DOM order and the visual / tabbing order match.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
