### PR TITLE
Editor: Remove inline toolbar preference

### DIFF
--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -115,11 +115,10 @@ export function useMouseMoveTypingReset() {
  *   field, presses ESC or TAB, or moves the mouse in the document.
  */
 export function useTypingObserver() {
-	const { isTyping, hasInlineToolbar } = useSelect( ( select ) => {
-		const { isTyping: _isTyping, getSettings } = select( blockEditorStore );
+	const { isTyping } = useSelect( ( select ) => {
+		const { isTyping: _isTyping } = select( blockEditorStore );
 		return {
 			isTyping: _isTyping(),
-			hasInlineToolbar: getSettings().hasInlineToolbar,
 		};
 	}, [] );
 	const { startTyping, stopTyping } = useDispatch( blockEditorStore );
@@ -183,12 +182,10 @@ export function useTypingObserver() {
 				node.addEventListener( 'focus', stopTypingOnNonTextField );
 				node.addEventListener( 'keydown', stopTypingOnEscapeKey );
 
-				if ( ! hasInlineToolbar ) {
-					ownerDocument.addEventListener(
-						'selectionchange',
-						stopTypingOnSelectionUncollapse
-					);
-				}
+				ownerDocument.addEventListener(
+					'selectionchange',
+					stopTypingOnSelectionUncollapse
+				);
 
 				return () => {
 					defaultView.clearTimeout( timerId );
@@ -245,7 +242,7 @@ export function useTypingObserver() {
 				node.removeEventListener( 'keydown', startTypingInTextField );
 			};
 		},
-		[ isTyping, hasInlineToolbar, startTyping, stopTyping ]
+		[ isTyping, startTyping, stopTyping ]
 	);
 
 	return useMergeRefs( [ ref1, ref2 ] );

--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -3,13 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Popover, ToolbarGroup } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import {
-	isCollapsed,
-	getActiveFormats,
-	useAnchor,
-	store as richTextStore,
-} from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -17,22 +10,6 @@ import {
 import BlockControls from '../block-controls';
 import FormatToolbar from './format-toolbar';
 import NavigableToolbar from '../navigable-toolbar';
-import { store as blockEditorStore } from '../../store';
-
-function InlineSelectionToolbar( { editableContentElement, activeFormats } ) {
-	const lastFormat = activeFormats[ activeFormats.length - 1 ];
-	const lastFormatType = lastFormat?.type;
-	const settings = useSelect(
-		( select ) => select( richTextStore ).getFormatType( lastFormatType ),
-		[ lastFormatType ]
-	);
-	const popoverAnchor = useAnchor( {
-		editableContentElement,
-		settings,
-	} );
-
-	return <InlineToolbar popoverAnchor={ popoverAnchor } />;
-}
 
 function InlineToolbar( { popoverAnchor } ) {
 	return (
@@ -56,33 +33,9 @@ function InlineToolbar( { popoverAnchor } ) {
 	);
 }
 
-const FormatToolbarContainer = ( {
-	inline,
-	editableContentElement,
-	value,
-} ) => {
-	const hasInlineToolbar = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().hasInlineToolbar,
-		[]
-	);
-
+const FormatToolbarContainer = ( { inline, editableContentElement } ) => {
 	if ( inline ) {
 		return <InlineToolbar popoverAnchor={ editableContentElement } />;
-	}
-
-	if ( hasInlineToolbar ) {
-		const activeFormats = getActiveFormats( value );
-
-		if ( isCollapsed( value ) && ! activeFormats.length ) {
-			return null;
-		}
-
-		return (
-			<InlineSelectionToolbar
-				editableContentElement={ editableContentElement }
-				activeFormats={ activeFormats }
-			/>
-		);
 	}
 
 	// Render regular toolbar.

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -348,7 +348,6 @@ export function RichTextWrapper(
 				<FormatToolbarContainer
 					inline={ inlineToolbar }
 					editableContentElement={ anchorRef.current }
-					value={ value }
 				/>
 			) }
 			<TagName

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -49,44 +49,41 @@ function Editor( {
 		onNavigateToPreviousEntityRecord,
 	} = useNavigateToEntityRecord( initialPostId, initialPostType );
 
-	const { hasInlineToolbar, post, preferredStyleVariations, template } =
-		useSelect(
-			( select ) => {
-				const { isFeatureActive, getEditedPostTemplate } =
-					select( editPostStore );
-				const { getEntityRecord, getPostType, canUser } =
-					select( coreStore );
-				const { getEditorSettings } = select( editorStore );
+	const { post, preferredStyleVariations, template } = useSelect(
+		( select ) => {
+			const { getEditedPostTemplate } = select( editPostStore );
+			const { getEntityRecord, getPostType, canUser } =
+				select( coreStore );
+			const { getEditorSettings } = select( editorStore );
 
-				const postObject = getEntityRecord(
-					'postType',
-					currentPost.postType,
-					currentPost.postId
-				);
+			const postObject = getEntityRecord(
+				'postType',
+				currentPost.postType,
+				currentPost.postId
+			);
 
-				const supportsTemplateMode =
-					getEditorSettings().supportsTemplateMode;
-				const isViewable =
-					getPostType( currentPost.postType )?.viewable ?? false;
-				const canEditTemplate = canUser( 'create', 'templates' );
-				return {
-					hasInlineToolbar: isFeatureActive( 'inlineToolbar' ),
-					preferredStyleVariations: select( preferencesStore ).get(
-						'core/edit-post',
-						'preferredStyleVariations'
-					),
-					template:
-						supportsTemplateMode &&
-						isViewable &&
-						canEditTemplate &&
-						currentPost.postType !== 'wp_template'
-							? getEditedPostTemplate()
-							: null,
-					post: postObject,
-				};
-			},
-			[ currentPost.postType, currentPost.postId ]
-		);
+			const supportsTemplateMode =
+				getEditorSettings().supportsTemplateMode;
+			const isViewable =
+				getPostType( currentPost.postType )?.viewable ?? false;
+			const canEditTemplate = canUser( 'create', 'templates' );
+			return {
+				preferredStyleVariations: select( preferencesStore ).get(
+					'core/edit-post',
+					'preferredStyleVariations'
+				),
+				template:
+					supportsTemplateMode &&
+					isViewable &&
+					canEditTemplate &&
+					currentPost.postType !== 'wp_template'
+						? getEditedPostTemplate()
+						: null,
+				post: postObject,
+			};
+		},
+		[ currentPost.postType, currentPost.postId ]
+	);
 
 	const { updatePreferredStyleVariations } = useDispatch( editPostStore );
 
@@ -100,11 +97,9 @@ function Editor( {
 				value: preferredStyleVariations,
 				onChange: updatePreferredStyleVariations,
 			},
-			hasInlineToolbar,
 		} ),
 		[
 			settings,
-			hasInlineToolbar,
 			preferredStyleVariations,
 			updatePreferredStyleVariations,
 			onNavigateToEntityRecord,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -52,7 +52,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'gradients',
 	'generateAnchors',
 	'onNavigateToEntityRecord',
-	'hasInlineToolbar',
 	'imageDefaultSize',
 	'imageDimensions',
 	'imageEditing',


### PR DESCRIPTION
Related #52632 

## What?

It seems we had a preference that was introduced in #42399 in order to be used by distraction free mod but as far as I know, this doesn't seem to be used at all and distraction free is using top toolbar instead.

## Testing Instructions

There should be no impact on how RichText toolbars are rendered.