### PR TITLE
Templates: Allow browsing by source, grouping all Custom templates

### DIFF
--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -91,7 +91,7 @@ const DEFAULT_VIEW = {
 	},
 	// All fields are visible by default, so it's
 	// better to keep track of the hidden ones.
-	hiddenFields: [ 'preview', 'source' ],
+	hiddenFields: [ 'preview' ],
 	layout: defaultConfigPerViewType[ LAYOUT_TABLE ],
 	filters: [],
 };
@@ -271,12 +271,6 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 		} ) );
 	}, [ records ] );
 
-	const sources = useMemo( () => ( {
-		theme: __( 'Theme' ),
-		plugin: __( 'Plugin' ),
-		user: __( 'User' ),
-	} ) );
-
 	const fields = useMemo( () => {
 		const _fields = [
 			{
@@ -344,27 +338,8 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 			elements: authors,
 			width: '1%',
 		} );
-		_fields.push( {
-			header: __( 'Source' ),
-			id: 'source',
-			getValue: ( { item } ) => item.original_source,
-			render: ( { item } ) => {
-				return (
-					<span className="page-templates-source">
-						{ sources[ item.original_source ] }
-					</span>
-				);
-			},
-			type: ENUMERATION_TYPE,
-			elements: Object.entries( sources ).map( ( [ value, label ] ) => ( {
-				value,
-				label,
-			} ) ),
-			enableHiding: false,
-			enableSorting: false,
-		} );
 		return _fields;
-	}, [ postType, authors, sources, view.type ] );
+	}, [ postType, authors, view.type ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		if ( ! records ) {

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -189,29 +189,12 @@ function Preview( { item, viewType } ) {
 }
 
 function computeFilters( activeView ) {
-	// activeView takes values such as:
-	// - 'all'
-	// - 'user'
-	// - 'theme'
-	// - 'plugin:My Plugin'
 	switch ( activeView ) {
 		case 'all':
 			return [];
 
-		case 'user':
-		case 'theme':
-			return [ { field: 'source', operator: 'in', value: activeView } ];
-
-		default: {
-			const idx = activeView.indexOf( ':' );
-			const source = activeView.substring( 0, idx );
-			const author = activeView.substring( idx + 1 );
-			const filters = [
-				{ field: 'source', operator: 'in', value: source },
-				{ field: 'author', operator: 'in', value: author },
-			];
-			return filters;
-		}
+		default:
+			return [ { field: 'author', operator: 'in', value: activeView } ];
 	}
 }
 
@@ -383,22 +366,6 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 				) {
 					filteredData = filteredData.filter( ( item ) => {
 						return item.author_text !== filter.value;
-					} );
-				} else if (
-					filter.field === 'source' &&
-					filter.operator === OPERATOR_IN &&
-					filter.value
-				) {
-					filteredData = filteredData.filter( ( item ) => {
-						return item.original_source === filter.value;
-					} );
-				} else if (
-					filter.field === 'source' &&
-					filter.operator === OPERATOR_NOT_IN &&
-					filter.value
-				) {
-					filteredData = filteredData.filter( ( item ) => {
-						return item.original_source !== filter.value;
 					} );
 				}
 			} );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -40,7 +40,7 @@ export default function DataviewsTemplatesSidebarContent( {
 				if ( ! obj[ src ] ) {
 					obj[ src ] = {
 						count: 0,
-						text: template.author_text,
+						value: template.author_text,
 					};
 				}
 				obj[ src ].count++;
@@ -62,10 +62,10 @@ export default function DataviewsTemplatesSidebarContent( {
 			/>
 			{ sources?.theme && (
 				<DataViewItem
-					slug={ `theme:${ sources.theme.text }` }
+					slug="theme"
 					title={ __( 'Theme' ) }
 					icon={ themeIcon }
-					isActive={ activeView.startsWith( 'theme:' ) }
+					isActive={ activeView === 'theme' }
 					isCustom="false"
 					suffix={ <span>{ sources.theme.count }</span> }
 				/>
@@ -82,13 +82,13 @@ export default function DataviewsTemplatesSidebarContent( {
 			) }
 			{ sources?.plugin &&
 				Object.entries( sources.plugin ).map(
-					( [ key, { count, text } ] ) => (
+					( [ key, { count, value } ] ) => (
 						<DataViewItem
 							key={ key }
-							slug={ `plugin:${ text }` }
-							title={ text }
+							slug={ `plugin:${ value }` }
+							title={ value }
 							icon={ pluginIcon }
-							isActive={ activeView === `plugin:${ text }` }
+							isActive={ activeView === `plugin:${ value }` }
 							isCustom="false"
 							suffix={ <span>{ count }</span> }
 						/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -10,7 +10,7 @@ import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
  */
 import DataViewItem from '../sidebar-dataviews/dataview-item';
 import { useAddedBy } from '../list/added-by';
-import { layout } from '@wordpress/icons';
+import { file } from '@wordpress/icons';
 
 const EMPTY_ARRAY = [];
 
@@ -53,9 +53,9 @@ export default function DataviewsTemplatesSidebarContent( {
 	return (
 		<ItemGroup>
 			<DataViewItem
-				slug={ 'all' }
+				slug="all"
 				title={ config[ postType ].title }
-				icon={ layout }
+				icon={ file }
 				isActive={ activeView === 'all' }
 				isCustom="false"
 			/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -73,7 +73,7 @@ export default function DataviewsTemplatesSidebarContent( {
 			{ sources?.user && (
 				<DataViewItem
 					slug="user"
-					title={ __( 'Custom' ) }
+					title={ __( 'User' ) }
 					icon={ customIcon }
 					isActive={ activeView === 'user' }
 					isCustom="false"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -40,7 +40,7 @@ export default function DataviewsTemplatesSidebarContent( {
 				if ( ! obj[ src ] ) {
 					obj[ src ] = {
 						count: 0,
-						slug: template.author_text,
+						text: template.author_text,
 					};
 				}
 				obj[ src ].count++;
@@ -62,33 +62,33 @@ export default function DataviewsTemplatesSidebarContent( {
 			/>
 			{ sources?.theme && (
 				<DataViewItem
-					slug={ sources.theme.slug }
+					slug={ `theme:${ sources.theme.text }` }
 					title={ __( 'Theme' ) }
 					icon={ themeIcon }
-					isActive={ activeView === sources.theme.slug }
+					isActive={ activeView.startsWith( 'theme:' ) }
 					isCustom="false"
 					suffix={ <span>{ sources.theme.count }</span> }
 				/>
 			) }
 			{ sources?.user && (
 				<DataViewItem
-					slug={ sources.user.slug }
+					slug="user"
 					title={ __( 'Custom' ) }
 					icon={ customIcon }
-					isActive={ activeView === sources.user.slug }
+					isActive={ activeView === 'user' }
 					isCustom="false"
 					suffix={ <span>{ sources.user.count }</span> }
 				/>
 			) }
 			{ sources?.plugin &&
 				Object.entries( sources.plugin ).map(
-					( [ key, { count, slug } ] ) => (
+					( [ key, { count, text } ] ) => (
 						<DataViewItem
 							key={ key }
-							slug={ slug }
-							title={ slug }
+							slug={ `plugin:${ text }` }
+							title={ text }
 							icon={ pluginIcon }
-							isActive={ activeView === slug }
+							isActive={ activeView === `plugin:${ text }` }
 							isCustom="false"
 							suffix={ <span>{ count }</span> }
 						/>


### PR DESCRIPTION
## What?

Fixes #58111
Follows up on #58124 

Implements the following remaining improvements [suggested](https://github.com/WordPress/gutenberg/issues/58111#issuecomment-1914688356) in the parent issue:

> - For the 'All templates' view could we use the file icon to differentiate it from the theme views?
> - It would be nice to include the counts.
> - Perhaps most important: ideally all user-generated templates would be grouped together in a view called "Custom", rather than individual views per user. This view would be the equivalent to filtering by author and selecting all users.

## How?

* Introduce a new field type for templates and template parts named `source`,  corresponding to records' `original_source` property.
* Expected sources are: `theme`, `plugin`, `user`. The latter corresponds to custom templates.
* Keep it hidden from the UI using `hiddenFields`, `enableHiding` and `enableSorting`.
* Adapt the `activeView` location param to encode source data as follows:
  * `all`: same meaning as before
  * `user`: filter by source to reveal custom templates
  * `theme`: filter by source to reveal current theme's templates (previously, we simply filtered by author and hoped that no other source's items could overlap with the theme's name).
  * `plugin:My Plugin Name` filter by source (plugin) **and** author (My Plugin Name)


## Testing instructions

* See parent issue
* When testing, you should have custom templates created by more than one author, so that you can confirm that the source filter is working as intended.


## Screen capture

https://github.com/WordPress/gutenberg/assets/150562/5488d2ef-4f2d-48fd-bf0b-f1d9f4f18e89

