### PR TITLE
Fix central command area missing when no block tools available

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -26,7 +26,6 @@ import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
 import { useFlashEditableBlocks } from './components/use-flash-editable-blocks';
-import { useHasAnyBlockControls } from './components/block-controls/use-has-block-controls';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -57,5 +56,4 @@ lock( privateApis, {
 	useReusableBlocksRenameHint,
 	usesContextKey,
 	useFlashEditableBlocks,
-	useHasAnyBlockControls,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -26,6 +26,7 @@ import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
 import { useFlashEditableBlocks } from './components/use-flash-editable-blocks';
+import { useHasAnyBlockControls } from './components/block-controls/use-has-block-controls';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -56,4 +57,5 @@ lock( privateApis, {
 	useReusableBlocksRenameHint,
 	usesContextKey,
 	useFlashEditableBlocks,
+	useHasAnyBlockControls,
 } );

--- a/packages/block-editor/src/utils/use-can-block-toolbar-be-focused.js
+++ b/packages/block-editor/src/utils/use-can-block-toolbar-be-focused.js
@@ -9,6 +9,7 @@ import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
  */
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
+import { useHasAnyBlockControls } from '../components/block-controls/use-has-block-controls';
 
 /**
  * Returns true if the block toolbar should be able to receive focus.
@@ -16,33 +17,39 @@ import { unlock } from '../lock-unlock';
  * @return {boolean} Whether the block toolbar should be able to receive focus
  */
 export function useCanBlockToolbarBeFocused() {
-	return useSelect( ( select ) => {
-		const {
-			__unstableGetEditorMode,
-			getBlock,
-			getSettings,
-			getSelectedBlockClientId,
-			getFirstMultiSelectedBlockClientId,
-		} = unlock( select( blockEditorStore ) );
+	const hasBlockControls = useHasAnyBlockControls();
+	return useSelect(
+		( select ) => {
+			const {
+				__unstableGetEditorMode,
+				getBlock,
+				getSettings,
+				getSelectedBlockClientId,
+				getFirstMultiSelectedBlockClientId,
+			} = unlock( select( blockEditorStore ) );
 
-		const selectedBlockId =
-			getFirstMultiSelectedBlockClientId() || getSelectedBlockClientId();
-		const isEmptyDefaultBlock = isUnmodifiedDefaultBlock(
-			getBlock( selectedBlockId ) || {}
-		);
+			const selectedBlockId =
+				getFirstMultiSelectedBlockClientId() ||
+				getSelectedBlockClientId();
+			const isEmptyDefaultBlock = isUnmodifiedDefaultBlock(
+				getBlock( selectedBlockId ) || {}
+			);
 
-		// Fixed Toolbar can be focused when:
-		// - a block is selected
-		// - fixed toolbar is on
-		// Block Toolbar Popover can be focused when:
-		// - a block is selected
-		// - we are in edit mode
-		// - it is not an empty default block
-		return (
-			!! selectedBlockId &&
-			( getSettings().hasFixedToolbar ||
-				( __unstableGetEditorMode() === 'edit' &&
-					! isEmptyDefaultBlock ) )
-		);
-	}, [] );
+			// Fixed Toolbar can be focused when:
+			// - a block is selected
+			// - fixed toolbar is on
+			// Block Toolbar Popover can be focused when:
+			// - a block is selected
+			// - we are in edit mode
+			// - it is not an empty default block
+			return (
+				hasBlockControls &&
+				!! selectedBlockId &&
+				( getSettings().hasFixedToolbar ||
+					( __unstableGetEditorMode() === 'edit' &&
+						! isEmptyDefaultBlock ) )
+			);
+		},
+		[ hasBlockControls ]
+	);
 }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -92,23 +92,13 @@ export default function HeaderEditMode() {
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
 
-	const hasBlockControls = useCanBlockToolbarBeFocused();
-	const hasBlockToolbar = !! blockSelectionStart && hasBlockControls;
+	const hasBlockToolbar = useCanBlockToolbarBeFocused();
 
 	useEffect( () => {
-		// If we don't have block controls, collapse the block tools.
-		// There are times where there is a block selected, but the block
-		// doesn't have any toolbars. In these instances, we want to make
-		// sure to show the central command area.
-		// https://github.com/WordPress/gutenberg/issues/57288
-		if ( ! hasBlockControls ) {
-			setIsBlockToolsCollapsed( true );
-		}
-		// If we have a new block selection, show the block tools
-		else if ( blockSelectionStart ) {
+		if ( blockSelectionStart ) {
 			setIsBlockToolsCollapsed( false );
 		}
-	}, [ blockSelectionStart, hasBlockControls ] );
+	}, [ blockSelectionStart ] );
 
 	const toolbarVariants = {
 		isDistractionFree: { y: '-50px' },
@@ -139,7 +129,7 @@ export default function HeaderEditMode() {
 						blockEditorMode={ blockEditorMode }
 						isDistractionFree={ isDistractionFree }
 					/>
-					{ isTopToolbar && (
+					{ isTopToolbar && hasBlockToolbar && (
 						<>
 							<div
 								className={ classnames(
@@ -155,24 +145,20 @@ export default function HeaderEditMode() {
 								ref={ blockToolbarRef }
 								name="block-toolbar"
 							/>
-							{ hasBlockToolbar && (
-								<Button
-									className="edit-site-header-edit-mode__block-tools-toggle"
-									icon={
-										isBlockToolsCollapsed ? next : previous
-									}
-									onClick={ () => {
-										setIsBlockToolsCollapsed(
-											( collapsed ) => ! collapsed
-										);
-									} }
-									label={
-										isBlockToolsCollapsed
-											? __( 'Show block tools' )
-											: __( 'Hide block tools' )
-									}
-								/>
-							) }
+							<Button
+								className="edit-site-header-edit-mode__block-tools-toggle"
+								icon={ isBlockToolsCollapsed ? next : previous }
+								onClick={ () => {
+									setIsBlockToolsCollapsed(
+										( collapsed ) => ! collapsed
+									);
+								} }
+								label={
+									isBlockToolsCollapsed
+										? __( 'Show block tools' )
+										: __( 'Hide block tools' )
+								}
+							/>
 						</>
 					) }
 				</motion.div>
@@ -184,7 +170,14 @@ export default function HeaderEditMode() {
 						'edit-site-header-edit-mode__center',
 						{
 							'is-collapsed':
-								! isBlockToolsCollapsed && isLargeViewport,
+								! isBlockToolsCollapsed &&
+								isLargeViewport &&
+								isTopToolbar &&
+								// There are times where there is a block selected, but the block
+								// doesn't have any toolbars. In these instances, we want to make
+								// sure to show the central command area.
+								// https://github.com/WordPress/gutenberg/issues/57288
+								hasBlockToolbar,
 						}
 					) }
 				>

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -44,7 +44,7 @@ import { unlock } from '../../lock-unlock';
 import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
 const { PostViewLink, PreviewDropdown } = unlock( editorPrivateApis );
-const { useHasAnyBlockControls } = unlock( blockEditorPrivateApis );
+const { useCanBlockToolbarBeFocused } = unlock( blockEditorPrivateApis );
 
 export default function HeaderEditMode() {
 	const {
@@ -92,7 +92,7 @@ export default function HeaderEditMode() {
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
 
-	const hasBlockControls = useHasAnyBlockControls();
+	const hasBlockControls = useCanBlockToolbarBeFocused();
 	const hasBlockToolbar = !! blockSelectionStart && hasBlockControls;
 
 	useEffect( () => {


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/57288 alternative to https://github.com/WordPress/gutenberg/pull/57291. I'm thinking neither of these approaches is best, and it is better to combine things into one consistent hook to see if we should show a block toolbar or not.

There are times where a block is selected but no tools are available. If we don't have any tools, we don't want to show a toolbar. This privately exports the same check used by the block toolbar so we can have a more reliable check if we should show the block toolbar or not.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds `useHasAnyBlockTools` to `useCanBlockToolbarBeFocused`. At this point, it means "is there a block toolbar"
- Checks if any block tools are available before adding the `is-collapsed` class to the central toolbar area
- Removes selected block tools wrapper from DOM if no block tools available. I'm not sure if this was intentional to leave it in the DOM before, or if it was because there wasn't a reliable way of checking for it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
