### PR TITLE
InputControl: Use less Emotion styled API

### DIFF
--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -144,7 +144,6 @@ function BoxControl( {
 		...inputProps,
 		onChange: handleOnChange,
 		onFocus: handleOnFocus,
-		isLinked,
 		units,
 		selectedUnits,
 		setSelectedUnits,

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -5,9 +5,10 @@ import { HStack } from '../h-stack';
 import { Text } from '../text';
 import { Spacer } from '../spacer';
 import { space } from '../utils/space';
-import { RangeControl, NumberControlWrapper } from './styles';
+import { RangeControl } from './styles';
 import { COLORS } from '../utils/colors-values';
 import type { InputWithSliderProps } from './types';
+import NumberControl from '../number-control';
 
 export const InputWithSlider = ( {
 	min,
@@ -31,7 +32,8 @@ export const InputWithSlider = ( {
 
 	return (
 		<HStack spacing={ 4 }>
-			<NumberControlWrapper
+			<NumberControl
+				__unstableInputWidth={ space( 24 ) }
 				min={ min }
 				max={ max }
 				label={ label }

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -6,7 +6,6 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import NumberControl from '../number-control';
 import InnerSelectControl from '../select-control';
 import InnerRangeControl from '../range-control';
 import { space } from '../utils/space';
@@ -14,17 +13,8 @@ import { boxSizingReset } from '../utils';
 import Button from '../button';
 import { Flex } from '../flex';
 import { HStack } from '../h-stack';
-import {
-	BackdropUI,
-	Container as InputControlContainer,
-} from '../input-control/styles/input-control-styles';
+import { BackdropUI } from '../input-control/styles/input-control-styles';
 import CONFIG from '../utils/config-values';
-
-export const NumberControlWrapper = styled( NumberControl )`
-	${ InputControlContainer } {
-		width: ${ space( 24 ) };
-	}
-`;
 
 export const SelectControl = styled( InnerSelectControl )`
 	margin-left: ${ space( -2 ) };

--- a/packages/components/src/custom-select-control/styles.ts
+++ b/packages/components/src/custom-select-control/styles.ts
@@ -8,7 +8,6 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import InputBase from '../input-control/input-base';
-import { Container as InputControlContainer } from '../input-control/styles/input-control-styles';
 
 type BackCompatMinWidthProps = {
 	__nextUnconstrainedWidth: boolean;
@@ -17,7 +16,7 @@ type BackCompatMinWidthProps = {
 const backCompatMinWidth = ( props: BackCompatMinWidthProps ) =>
 	! props.__nextUnconstrainedWidth
 		? css`
-				${ InputControlContainer } {
+				.components-input-control__container {
 					min-width: 130px;
 				}
 		  `

--- a/packages/components/src/date-time/time/styles.ts
+++ b/packages/components/src/date-time/time/styles.ts
@@ -9,10 +9,7 @@ import { css } from '@emotion/react';
  */
 import { COLORS, CONFIG } from '../../utils';
 import { space } from '../../utils/space';
-import {
-	Input,
-	BackdropUI,
-} from '../../input-control/styles/input-control-styles';
+import { BackdropUI } from '../../input-control/styles/input-control-styles';
 import NumberControl from '../../number-control';
 
 export const Wrapper = styled.div`
@@ -36,7 +33,7 @@ export const TimeWrapper = styled.div`
 `;
 
 const baseInput = css`
-	&&& ${ Input } {
+	&&& input {
 		padding-left: ${ space( 2 ) };
 		padding-right: ${ space( 2 ) };
 		text-align: center;
@@ -48,7 +45,7 @@ export const HoursInput = styled( NumberControl )`
 
 	width: ${ space( 9 ) };
 
-	&&& ${ Input } {
+	&&& input {
 		padding-right: 0;
 	}
 
@@ -73,7 +70,7 @@ export const MinutesInput = styled( NumberControl )`
 
 	width: ${ space( 9 ) };
 
-	&&& ${ Input } {
+	&&& input {
 		padding-left: 0;
 	}
 

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -8,7 +8,7 @@ import type { ForwardedRef } from 'react';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useState, forwardRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -56,8 +56,6 @@ export function UnforwardedInputControl(
 		...restProps
 	} = useDeprecated36pxDefaultSizeProp< InputControlProps >( props );
 
-	const [ isFocused, setIsFocused ] = useState( false );
-
 	const id = useUniqueId( idProp );
 	const classes = classNames( 'components-input-control', className );
 
@@ -86,7 +84,6 @@ export function UnforwardedInputControl(
 				gap={ 3 }
 				hideLabelFromVision={ hideLabelFromVision }
 				id={ id }
-				isFocused={ isFocused }
 				justify="left"
 				label={ label }
 				labelPosition={ labelPosition }
@@ -101,14 +98,12 @@ export function UnforwardedInputControl(
 					__next40pxDefaultSize={ __next40pxDefaultSize }
 					disabled={ disabled }
 					id={ id }
-					isFocused={ isFocused }
 					isPressEnterToChange={ isPressEnterToChange }
 					onKeyDown={ onKeyDown }
 					onValidate={ onValidate }
 					hasPrefix={ !! prefix }
 					hasSuffix={ !! suffix }
 					ref={ ref }
-					setIsFocused={ setIsFocused }
 					size={ size }
 					stateReducer={ stateReducer }
 					{ ...draftHookProps }

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -16,7 +16,6 @@ import { useState, forwardRef } from '@wordpress/element';
 import InputBase from './input-base';
 import InputField from './input-field';
 import type { InputControlProps } from './types';
-import { space } from '../utils/space';
 import { useDraft } from './utils';
 import BaseControl from '../base-control';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
@@ -100,15 +99,14 @@ export function UnforwardedInputControl(
 					{ ...restProps }
 					{ ...helpProp }
 					__next40pxDefaultSize={ __next40pxDefaultSize }
-					className="components-input-control__input"
 					disabled={ disabled }
 					id={ id }
 					isFocused={ isFocused }
 					isPressEnterToChange={ isPressEnterToChange }
 					onKeyDown={ onKeyDown }
 					onValidate={ onValidate }
-					paddingInlineStart={ prefix ? space( 2 ) : undefined }
-					paddingInlineEnd={ suffix ? space( 2 ) : undefined }
+					hasPrefix={ !! prefix }
+					hasSuffix={ !! suffix }
 					ref={ ref }
 					setIsFocused={ setIsFocused }
 					size={ size }

--- a/packages/components/src/input-control/input-base.tsx
+++ b/packages/components/src/input-control/input-base.tsx
@@ -6,14 +6,11 @@ import type { ForwardedRef } from 'react';
 /**
  * WordPress dependencies
  */
-import { useInstanceId } from '@wordpress/compose';
 import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import Backdrop from './backdrop';
-import Label from './label';
 import { getSizeConfig } from './styles/input-control-styles';
 import * as styles from './styles/input-control-styles';
 import type { InputBaseProps, LabelPosition } from './types';
@@ -24,15 +21,14 @@ import {
 	useContextSystem,
 } from '../context';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
-import { Flex } from '../flex';
 import { useCx } from '../utils';
 
-function useUniqueId( idProp?: string ) {
-	const instanceId = useInstanceId( InputBase );
-	const id = `input-base-control-${ instanceId }`;
+// function useUniqueId( idProp?: string ) {
+// 	const instanceId = useInstanceId( InputBase );
+// 	const id = `input-base-control-${ instanceId }`;
 
-	return idProp || id;
-}
+// 	return idProp || id;
+// }
 
 // Adapter to map props for the new ui/flex component.
 function getUIFlexProps( labelPosition?: LabelPosition ) {
@@ -75,7 +71,6 @@ export function InputBase(
 		labelPosition,
 		id: idProp,
 		isBorderless = false,
-		isFocused = false,
 		label,
 		prefix,
 		size = 'default',
@@ -85,7 +80,7 @@ export function InputBase(
 		useContextSystem( props, 'InputBase' )
 	);
 
-	const id = useUniqueId( idProp );
+	// const id = useUniqueId( idProp );
 
 	const { paddingLeft, paddingRight } = getSizeConfig( {
 		inputSize: size,
@@ -101,36 +96,35 @@ export function InputBase(
 	const cx = useCx();
 	const rootClasses = cx(
 		styles.inputBase,
-		styles.inputBaseFocusedStyles( isFocused ),
+		// styles.inputBaseFocusedStyles( isFocused ),
 		className
 	);
 	const containerClasses = cx(
 		styles.inputBaseContainer,
-		styles.inputBaseContainerDisabledStyles( disabled ),
-		styles.inputBaseContainerWidthStyles( {
-			__unstableInputWidth,
-			labelPosition,
-		} ),
+		// styles.inputBaseContainerDisabledStyles( disabled ),
+		// styles.inputBaseContainerWidthStyles( {
+		// 	__unstableInputWidth,
+		// 	labelPosition,
+		// } ),
 		'components-input-control__container'
 	);
 
 	return (
-		// @ts-expect-error The `direction` prop from Flex (FlexDirection) conflicts with legacy SVGAttributes `direction` (string) that come from React intrinsic prop definitions.
-		<Flex
+		<div
 			{ ...restProps }
 			{ ...getUIFlexProps( labelPosition ) }
 			className={ rootClasses }
-			gap={ 2 }
+			// gap={ 2 }
 			ref={ ref }
 		>
-			<Label
+			{ /* <Label
 				className="components-input-control__label"
 				hideLabelFromVision={ hideLabelFromVision }
 				labelPosition={ labelPosition }
 				htmlFor={ id }
 			>
 				{ label }
-			</Label>
+			</Label> */ }
 			<div className={ containerClasses }>
 				<ContextSystemProvider value={ prefixSuffixContextValue }>
 					{ prefix && (
@@ -155,13 +149,13 @@ export function InputBase(
 						</span>
 					) }
 				</ContextSystemProvider>
-				<Backdrop
+				{ /* <Backdrop
 					disabled={ disabled }
 					isBorderless={ isBorderless }
 					isFocused={ isFocused }
-				/>
+				/> */ }
 			</div>
-		</Flex>
+		</div>
 	);
 }
 

--- a/packages/components/src/input-control/input-base.tsx
+++ b/packages/components/src/input-control/input-base.tsx
@@ -14,13 +14,8 @@ import { useMemo } from '@wordpress/element';
  */
 import Backdrop from './backdrop';
 import Label from './label';
-import {
-	Container,
-	Root,
-	Prefix,
-	Suffix,
-	getSizeConfig,
-} from './styles/input-control-styles';
+import { getSizeConfig } from './styles/input-control-styles';
+import * as styles from './styles/input-control-styles';
 import type { InputBaseProps, LabelPosition } from './types';
 import type { WordPressComponentProps } from '../context';
 import {
@@ -29,6 +24,8 @@ import {
 	useContextSystem,
 } from '../context';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
+import { Flex } from '../flex';
+import { useCx } from '../utils';
 
 function useUniqueId( idProp?: string ) {
 	const instanceId = useInstanceId( InputBase );
@@ -89,7 +86,6 @@ export function InputBase(
 	);
 
 	const id = useUniqueId( idProp );
-	const hideLabel = hideLabelFromVision || ! label;
 
 	const { paddingLeft, paddingRight } = getSizeConfig( {
 		inputSize: size,
@@ -102,15 +98,29 @@ export function InputBase(
 		};
 	}, [ paddingLeft, paddingRight ] );
 
+	const cx = useCx();
+	const rootClasses = cx(
+		styles.inputBase,
+		styles.inputBaseFocusedStyles( isFocused ),
+		className
+	);
+	const containerClasses = cx(
+		styles.inputBaseContainer,
+		styles.inputBaseContainerDisabledStyles( disabled ),
+		styles.inputBaseContainerWidthStyles( {
+			__unstableInputWidth,
+			labelPosition,
+		} ),
+		'components-input-control__container'
+	);
+
 	return (
 		// @ts-expect-error The `direction` prop from Flex (FlexDirection) conflicts with legacy SVGAttributes `direction` (string) that come from React intrinsic prop definitions.
-		<Root
+		<Flex
 			{ ...restProps }
 			{ ...getUIFlexProps( labelPosition ) }
-			className={ className }
+			className={ rootClasses }
 			gap={ 2 }
-			isFocused={ isFocused }
-			labelPosition={ labelPosition }
 			ref={ ref }
 		>
 			<Label
@@ -121,24 +131,28 @@ export function InputBase(
 			>
 				{ label }
 			</Label>
-			<Container
-				__unstableInputWidth={ __unstableInputWidth }
-				className="components-input-control__container"
-				disabled={ disabled }
-				hideLabel={ hideLabel }
-				labelPosition={ labelPosition }
-			>
+			<div className={ containerClasses }>
 				<ContextSystemProvider value={ prefixSuffixContextValue }>
 					{ prefix && (
-						<Prefix className="components-input-control__prefix">
+						<span
+							className={ cx(
+								styles.prefix,
+								'components-input-control__prefix'
+							) }
+						>
 							{ prefix }
-						</Prefix>
+						</span>
 					) }
 					{ children }
 					{ suffix && (
-						<Suffix className="components-input-control__suffix">
+						<span
+							className={ cx(
+								styles.suffix,
+								'components-input-control__suffix'
+							) }
+						>
 							{ suffix }
-						</Suffix>
+						</span>
 					) }
 				</ContextSystemProvider>
 				<Backdrop
@@ -146,8 +160,8 @@ export function InputBase(
 					isBorderless={ isBorderless }
 					isFocused={ isFocused }
 				/>
-			</Container>
-		</Root>
+			</div>
+		</Flex>
 	);
 }
 

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -40,18 +40,15 @@ function InputField(
 		hasSuffix,
 		id,
 		isDragEnabled = false,
-		isFocused,
 		isPressEnterToChange = false,
 		onBlur = noop,
 		onChange = noop,
 		onDrag = noop,
 		onDragEnd = noop,
 		onDragStart = noop,
-		onFocus = noop,
 		onKeyDown = noop,
 		onValidate = noop,
 		size = 'default',
-		setIsFocused,
 		stateReducer = ( state: any ) => state,
 		value: valueProp,
 		type,
@@ -90,7 +87,6 @@ function InputField(
 
 	const handleOnBlur = ( event: FocusEvent< HTMLInputElement > ) => {
 		onBlur( event );
-		setIsFocused?.( false );
 
 		/**
 		 * If isPressEnterToChange is set, this commits the value to
@@ -100,11 +96,6 @@ function InputField(
 			wasDirtyOnBlur.current = true;
 			handleOnCommit( event );
 		}
-	};
-
-	const handleOnFocus = ( event: FocusEvent< HTMLInputElement > ) => {
-		onFocus( event );
-		setIsFocused?.( true );
 	};
 
 	const handleOnChange = ( event: ChangeEvent< HTMLInputElement > ) => {
@@ -241,7 +232,6 @@ function InputField(
 			id={ id }
 			onBlur={ handleOnBlur }
 			onChange={ handleOnChange }
-			onFocus={ handleOnFocus }
 			onKeyDown={ handleOnKeyDown }
 			onMouseDown={ handleOnMouseDown }
 			ref={ ref }

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useDrag } from '@use-gesture/react';
+import classnames from 'classnames';
 import type {
 	SyntheticEvent,
 	ChangeEvent,
@@ -21,10 +22,10 @@ import { forwardRef, useRef } from '@wordpress/element';
  */
 import type { WordPressComponentProps } from '../context';
 import { useDragCursor } from './utils';
-import * as styles from './styles/input-control-styles';
+// import * as styles from './styles/input-control-styles';
 import { useInputControlStateReducer } from './reducer/reducer';
 import type { InputFieldProps } from './types';
-import { useCx } from '../utils';
+// import { useCx } from '../utils';
 
 const noop = () => {};
 
@@ -215,17 +216,21 @@ function InputField(
 		};
 	}
 
-	const cx = useCx();
-	const classes = cx(
-		styles.input,
-		styles.inputDragStyles( { isDragging, dragCursor } ),
-		styles.inputDisabledStyles( disabled ),
-		styles.fontSizeStyles( { inputSize: size } ),
-		styles.inputSizeStyles( { inputSize: size, __next40pxDefaultSize } ),
-		styles.inputCustomPaddings( { hasPrefix, hasSuffix } ),
-		className,
-		'components-input-control__input'
-	);
+	// const cx = useCx();
+	// const classes = cx(
+	// 	styles.input,
+	// 	styles.inputDragStyles( { isDragging, dragCursor } ),
+	// 	styles.inputDisabledStyles( disabled ),
+	// 	styles.fontSizeStyles( { inputSize: size } ),
+	// 	styles.inputSizeStyles( { inputSize: size, __next40pxDefaultSize } ),
+	// 	styles.inputCustomPaddings( { hasPrefix, hasSuffix } ),
+	// 	className,
+	// 	'components-input-control__input'
+	// );
+
+	const classes = classnames( 'components-input-control__input', className, {
+		'is-dragging': isDragging,
+	} );
 
 	return (
 		<input
@@ -243,6 +248,7 @@ function InputField(
 			// Fallback to `''` to avoid "uncontrolled to controlled" warning.
 			// See https://github.com/WordPress/gutenberg/pull/47250 for details.
 			value={ value ?? '' }
+			style={ { '--drag-cursor': dragCursor } as React.CSSProperties }
 			type={ type }
 		/>
 	);

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -21,17 +21,22 @@ import { forwardRef, useRef } from '@wordpress/element';
  */
 import type { WordPressComponentProps } from '../context';
 import { useDragCursor } from './utils';
-import { Input } from './styles/input-control-styles';
+import * as styles from './styles/input-control-styles';
 import { useInputControlStateReducer } from './reducer/reducer';
 import type { InputFieldProps } from './types';
+import { useCx } from '../utils';
 
 const noop = () => {};
 
 function InputField(
 	{
+		__next40pxDefaultSize,
+		className,
 		disabled = false,
 		dragDirection = 'n',
 		dragThreshold = 10,
+		hasPrefix,
+		hasSuffix,
 		id,
 		isDragEnabled = false,
 		isFocused,
@@ -210,14 +215,24 @@ function InputField(
 		};
 	}
 
+	const cx = useCx();
+	const classes = cx(
+		styles.input,
+		styles.inputDragStyles( { isDragging, dragCursor } ),
+		styles.inputDisabledStyles( disabled ),
+		styles.fontSizeStyles( { inputSize: size } ),
+		styles.inputSizeStyles( { inputSize: size, __next40pxDefaultSize } ),
+		styles.inputCustomPaddings( { hasPrefix, hasSuffix } ),
+		className,
+		'components-input-control__input'
+	);
+
 	return (
-		<Input
+		<input
 			{ ...props }
 			{ ...dragProps }
-			className="components-input-control__input"
+			className={ classes }
 			disabled={ disabled }
-			dragCursor={ dragCursor }
-			isDragging={ isDragging }
 			id={ id }
 			onBlur={ handleOnBlur }
 			onChange={ handleOnChange }
@@ -225,7 +240,6 @@ function InputField(
 			onKeyDown={ handleOnKeyDown }
 			onMouseDown={ handleOnMouseDown }
 			ref={ ref }
-			inputSize={ size }
 			// Fallback to `''` to avoid "uncontrolled to controlled" warning.
 			// See https://github.com/WordPress/gutenberg/pull/47250 for details.
 			value={ value ?? '' }

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -10,39 +10,26 @@ import type { CSSProperties, ReactNode } from 'react';
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../../context';
-import { Flex, FlexItem } from '../../flex';
+import { FlexItem } from '../../flex';
 import { Text } from '../../text';
-import { baseLabelTypography, COLORS, CONFIG, rtl } from '../../utils';
+import { baseLabelTypography, COLORS, CONFIG } from '../../utils';
 import type { LabelPosition, Size } from '../types';
 import { space } from '../../utils/space';
 
-type ContainerProps = {
-	disabled?: boolean;
-	hideLabel?: boolean;
-	__unstableInputWidth?: CSSProperties[ 'width' ];
-	labelPosition?: LabelPosition;
-};
-
-type RootProps = {
-	isFocused?: boolean;
-	labelPosition?: LabelPosition;
-};
-
-const rootFocusedStyles = ( { isFocused }: RootProps ) => {
+export const inputBaseFocusedStyles = ( isFocused?: boolean ) => {
 	if ( ! isFocused ) return '';
 
 	return css( { zIndex: 1 } );
 };
 
-export const Root = styled( Flex )< RootProps >`
+export const inputBase = css`
 	box-sizing: border-box;
 	position: relative;
 	border-radius: 2px;
 	padding-top: 0;
-	${ rootFocusedStyles }
 `;
 
-const containerDisabledStyles = ( { disabled }: ContainerProps ) => {
+export const inputBaseContainerDisabledStyles = ( disabled?: boolean ) => {
 	const backgroundColor = disabled
 		? COLORS.ui.backgroundDisabled
 		: COLORS.ui.background;
@@ -50,10 +37,13 @@ const containerDisabledStyles = ( { disabled }: ContainerProps ) => {
 	return css( { backgroundColor } );
 };
 
-const containerWidthStyles = ( {
+export const inputBaseContainerWidthStyles = ( {
 	__unstableInputWidth,
 	labelPosition,
-}: ContainerProps ) => {
+}: {
+	__unstableInputWidth?: CSSProperties[ 'width' ];
+	labelPosition?: LabelPosition;
+} ) => {
 	if ( ! __unstableInputWidth ) return css( { width: '100%' } );
 
 	if ( labelPosition === 'side' ) return '';
@@ -67,29 +57,21 @@ const containerWidthStyles = ( {
 	return css( { width: __unstableInputWidth } );
 };
 
-export const Container = styled.div< ContainerProps >`
+export const inputBaseContainer = css`
 	align-items: center;
 	box-sizing: border-box;
 	border-radius: inherit;
 	display: flex;
 	flex: 1;
 	position: relative;
-
-	${ containerDisabledStyles }
-	${ containerWidthStyles }
 `;
 
-type InputProps = {
+type InputSizeProps = {
 	__next40pxDefaultSize?: boolean;
-	disabled?: boolean;
 	inputSize?: Size;
-	isDragging?: boolean;
-	dragCursor?: CSSProperties[ 'cursor' ];
-	paddingInlineStart?: CSSProperties[ 'paddingInlineStart' ];
-	paddingInlineEnd?: CSSProperties[ 'paddingInlineEnd' ];
 };
 
-const disabledStyles = ( { disabled }: InputProps ) => {
+export const inputDisabledStyles = ( disabled?: boolean ) => {
 	if ( ! disabled ) return '';
 
 	return css( {
@@ -97,7 +79,7 @@ const disabledStyles = ( { disabled }: InputProps ) => {
 	} );
 };
 
-export const fontSizeStyles = ( { inputSize: size }: InputProps ) => {
+export const fontSizeStyles = ( { inputSize: size }: InputSizeProps ) => {
 	const sizes = {
 		default: '13px',
 		small: '11px',
@@ -122,7 +104,7 @@ export const fontSizeStyles = ( { inputSize: size }: InputProps ) => {
 export const getSizeConfig = ( {
 	inputSize: size,
 	__next40pxDefaultSize,
-}: InputProps ) => {
+}: InputSizeProps ) => {
 	// Paddings may be overridden by the custom paddings props.
 	const sizes = {
 		default: {
@@ -162,18 +144,32 @@ export const getSizeConfig = ( {
 	return sizes[ size as Size ] || sizes.default;
 };
 
-const sizeStyles = ( props: InputProps ) => {
+export const inputSizeStyles = (
+	props: Parameters< typeof getSizeConfig >[ 0 ]
+) => {
 	return css( getSizeConfig( props ) );
 };
 
-const customPaddings = ( {
-	paddingInlineStart,
-	paddingInlineEnd,
-}: InputProps ) => {
-	return css( { paddingInlineStart, paddingInlineEnd } );
+export const inputCustomPaddings = ( {
+	hasPrefix,
+	hasSuffix,
+}: {
+	hasPrefix: boolean;
+	hasSuffix: boolean;
+} ) => {
+	return css( {
+		paddingInlineStart: hasPrefix ? space( 2 ) : undefined,
+		paddingInlineEnd: hasSuffix ? space( 2 ) : undefined,
+	} );
 };
 
-const dragStyles = ( { isDragging, dragCursor }: InputProps ) => {
+export const inputDragStyles = ( {
+	isDragging,
+	dragCursor,
+}: {
+	isDragging?: boolean;
+	dragCursor?: CSSProperties[ 'cursor' ];
+} ) => {
 	let defaultArrowStyles: SerializedStyles | undefined;
 	let activeDragCursorStyles: SerializedStyles | undefined;
 
@@ -206,8 +202,7 @@ const dragStyles = ( { isDragging, dragCursor }: InputProps ) => {
 
 // TODO: Resolve need to use &&& to increase specificity
 // https://github.com/WordPress/gutenberg/issues/18483
-
-export const Input = styled.input< InputProps >`
+export const input = css`
 	&&& {
 		background-color: transparent;
 		box-sizing: border-box;
@@ -219,12 +214,6 @@ export const Input = styled.input< InputProps >`
 		margin: 0;
 		outline: none;
 		width: 100%;
-
-		${ dragStyles }
-		${ disabledStyles }
-		${ fontSizeStyles }
-		${ sizeStyles }
-		${ customPaddings }
 
 		&::-webkit-input-placeholder {
 			line-height: normal;
@@ -308,22 +297,22 @@ export const BackdropUI = styled.div< BackdropProps >`
 		left: 0;
 		margin: 0;
 		padding: 0;
+		padding-inline-start: 2px;
 		pointer-events: none;
 		position: absolute;
 		right: 0;
 		top: 0;
 
 		${ backdropFocusedStyles }
-		${ rtl( { paddingLeft: 2 } ) }
 	}
 `;
 
-export const Prefix = styled.span`
+export const prefix = css`
 	box-sizing: border-box;
 	display: block;
 `;
 
-export const Suffix = styled.span`
+export const suffix = css`
 	align-items: center;
 	align-self: stretch;
 	box-sizing: border-box;

--- a/packages/components/src/input-control/styles/style.scss
+++ b/packages/components/src/input-control/styles/style.scss
@@ -1,0 +1,31 @@
+.components-input-control__input {
+	background-color: transparent;
+	box-sizing: border-box;
+	border: none;
+	box-shadow: none !important;
+	color: $components-color-foreground;
+	display: block;
+	font-family: inherit;
+	margin: 0;
+	outline: none;
+	width: 100%;
+
+	&::-webkit-input-placeholder {
+		line-height: normal;
+	}
+
+	&.is-dragging {
+		cursor: var(--drag-cursor);
+		user-select: none;
+
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			-webkit-appearance: none !important;
+			margin: 0 !important;
+		}
+
+		&:active {
+			cursor: var(--drag-cursor);
+		}
+	}
+}

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -88,6 +88,8 @@ export interface InputFieldProps
 	 * @default 10
 	 */
 	dragThreshold?: number;
+	hasPrefix: boolean;
+	hasSuffix: boolean;
 	/**
 	 * If true, enables mouse drag gestures.
 	 *
@@ -109,8 +111,6 @@ export interface InputFieldProps
 		nextValue: string,
 		event?: SyntheticEvent< HTMLInputElement >
 	) => void;
-	paddingInlineStart?: CSSProperties[ 'paddingInlineStart' ];
-	paddingInlineEnd?: CSSProperties[ 'paddingInlineEnd' ];
 	setIsFocused: ( isFocused: boolean ) => void;
 	stateReducer?: StateReducer;
 	/**
@@ -197,17 +197,17 @@ export interface InputControlProps
 		 * be the only prefix prop. Otherwise it tries to do a union of the two prefix properties and you end up
 		 * with an unresolvable type.
 		 *
-		 * `isFocused`, `setIsFocused`, `paddingInlineStart`, and `paddingInlineEnd` are managed internally by
+		 * `isFocused`, `setIsFocused`, `hasPrefix`, and `hasSuffix` are managed internally by
 		 * the InputControl, but the rest of the props for InputField are passed through.
 		 */
 		Omit<
 			WordPressComponentProps< InputFieldProps, 'input', false >,
 			| 'stateReducer'
 			| 'prefix'
+			| 'hasPrefix'
+			| 'hasSuffix'
 			| 'isFocused'
 			| 'setIsFocused'
-			| 'paddingInlineStart'
-			| 'paddingInlineEnd'
 		> {
 	__unstableStateReducer?: InputFieldProps[ 'stateReducer' ];
 }

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -47,14 +47,6 @@ interface BaseProps {
 	 */
 	hideLabelFromVision?: boolean;
 	/**
-	 * Whether the component should be in a focused state.
-	 * Used to coordinate focus states when the actual focused element and the component handling
-	 * visual focus are separate.
-	 *
-	 * @default false
-	 */
-	isFocused: boolean;
-	/**
 	 * The position of the label.
 	 *
 	 * @default 'top'
@@ -111,7 +103,6 @@ export interface InputFieldProps
 		nextValue: string,
 		event?: SyntheticEvent< HTMLInputElement >
 	) => void;
-	setIsFocused: ( isFocused: boolean ) => void;
 	stateReducer?: StateReducer;
 	/**
 	 * The current value of the input.
@@ -197,17 +188,12 @@ export interface InputControlProps
 		 * be the only prefix prop. Otherwise it tries to do a union of the two prefix properties and you end up
 		 * with an unresolvable type.
 		 *
-		 * `isFocused`, `setIsFocused`, `hasPrefix`, and `hasSuffix` are managed internally by
+		 * `hasPrefix`, and `hasSuffix` are managed internally by
 		 * the InputControl, but the rest of the props for InputField are passed through.
 		 */
 		Omit<
 			WordPressComponentProps< InputFieldProps, 'input', false >,
-			| 'stateReducer'
-			| 'prefix'
-			| 'hasPrefix'
-			| 'hasSuffix'
-			| 'isFocused'
-			| 'setIsFocused'
+			'stateReducer' | 'prefix' | 'hasPrefix' | 'hasSuffix'
 		> {
 	__unstableStateReducer?: InputFieldProps[ 'stateReducer' ];
 }

--- a/packages/components/src/number-control/styles/number-control-styles.ts
+++ b/packages/components/src/number-control/styles/number-control-styles.ts
@@ -30,7 +30,9 @@ const htmlArrowStyles = ( { hideHTMLArrows }: { hideHTMLArrows: boolean } ) => {
 	`;
 };
 
-export const Input = styled( InputControl )`
+export const Input = styled( InputControl, {
+	shouldForwardProp: ( prop ) => prop !== 'hideHTMLArrows',
+} )`
 	${ htmlArrowStyles };
 `;
 

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -65,6 +65,7 @@ const DEFAULT_COLOR = '#000';
 function NameInput( { value, onChange, label }: NameInputProps ) {
 	return (
 		<NameInputControl
+			size="compact"
 			label={ label }
 			hideLabelFromVision
 			value={ value }

--- a/packages/components/src/palette-edit/styles.ts
+++ b/packages/components/src/palette-edit/styles.ts
@@ -14,11 +14,7 @@ import { space } from '../utils/space';
 import { COLORS, CONFIG, font } from '../utils';
 import { View } from '../view';
 import InputControl from '../input-control';
-import {
-	Container as InputControlContainer,
-	Input,
-	BackdropUI as InputBackdropUI,
-} from '../input-control/styles/input-control-styles';
+import { BackdropUI as InputBackdropUI } from '../input-control/styles/input-control-styles';
 import ColorIndicator from '../color-indicator';
 
 export const IndicatorStyled = styled( ColorIndicator )`
@@ -30,16 +26,11 @@ export const IndicatorStyled = styled( ColorIndicator )`
 `;
 
 export const NameInputControl = styled( InputControl )`
-	${ InputControlContainer } {
-		background: ${ COLORS.gray[ 100 ] };
-		border-radius: ${ CONFIG.controlBorderRadius };
-		${ Input }${ Input }${ Input }${ Input } {
-			height: ${ space( 8 ) };
-		}
-		${ InputBackdropUI }${ InputBackdropUI }${ InputBackdropUI } {
-			border-color: transparent;
-			box-shadow: none;
-		}
+	--wp-components-color-background: ${ COLORS.theme.gray[ 100 ] };
+
+	&& ${ InputBackdropUI } {
+		border-color: transparent;
+		box-shadow: none;
 	}
 `;
 

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -8,43 +8,16 @@ import classnames from 'classnames';
  */
 import { useInstanceId, useMergeRefs } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Icon, search, closeSmall } from '@wordpress/icons';
 import { forwardRef, useMemo, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import Button from '../button';
 import type { WordPressComponentProps } from '../context/wordpress-component';
-import type { SearchControlProps, SuffixItemProps } from './types';
+import type { SearchControlProps } from './types';
 import type { ForwardedRef } from 'react';
 import { ContextSystemProvider } from '../context';
-import { StyledInputControl, SuffixItemWrapper } from './styles';
-
-function SuffixItem( {
-	searchRef,
-	value,
-	onChange,
-	onClose,
-}: SuffixItemProps ) {
-	if ( ! onClose && ! value ) {
-		return <Icon icon={ search } />;
-	}
-
-	const onReset = () => {
-		onChange( '' );
-		searchRef.current?.focus();
-	};
-
-	return (
-		<Button
-			size="small"
-			icon={ closeSmall }
-			label={ onClose ? __( 'Close search' ) : __( 'Reset search' ) }
-			onClick={ onClose ?? onReset }
-		/>
-	);
-}
+import InputControl from '../input-control';
 
 function UnforwardedSearchControl(
 	{
@@ -89,7 +62,7 @@ function UnforwardedSearchControl(
 
 	return (
 		<ContextSystemProvider value={ contextValue }>
-			<StyledInputControl
+			<InputControl
 				__next40pxDefaultSize
 				id={ instanceId }
 				hideLabelFromVision={ hideLabelFromVision }
@@ -101,22 +74,22 @@ function UnforwardedSearchControl(
 					'components-search-control',
 					className
 				) }
-				onChange={ ( nextValue?: string ) =>
-					onChange( nextValue ?? '' )
-				}
+				// onChange={ ( nextValue?: string ) =>
+				// 	onChange( nextValue ?? '' )
+				// }
 				autoComplete="off"
 				placeholder={ placeholder }
 				value={ value ?? '' }
-				suffix={
-					<SuffixItemWrapper size={ size }>
-						<SuffixItem
-							searchRef={ searchRef }
-							value={ value }
-							onChange={ onChange }
-							onClose={ onClose }
-						/>
-					</SuffixItemWrapper>
-				}
+				// suffix={
+				// 	<SuffixItemWrapper size={ size }>
+				// 		<SuffixItem
+				// 			searchRef={ searchRef }
+				// 			value={ value }
+				// 			onChange={ onChange }
+				// 			onClose={ onClose }
+				// 		/>
+				// 	</SuffixItemWrapper>
+				// }
 				{ ...restProps }
 			/>
 		</ContextSystemProvider>

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -8,16 +8,44 @@ import classnames from 'classnames';
  */
 import { useInstanceId, useMergeRefs } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { Icon, search, closeSmall } from '@wordpress/icons';
 import { forwardRef, useMemo, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import Button from '../button';
 import type { WordPressComponentProps } from '../context/wordpress-component';
-import type { SearchControlProps } from './types';
+import type { SearchControlProps, SuffixItemProps } from './types';
 import type { ForwardedRef } from 'react';
 import { ContextSystemProvider } from '../context';
+import { SuffixItemWrapper } from './styles';
 import InputControl from '../input-control';
+
+function SuffixItem( {
+	searchRef,
+	value,
+	onChange,
+	onClose,
+}: SuffixItemProps ) {
+	if ( ! onClose && ! value ) {
+		return <Icon icon={ search } />;
+	}
+
+	const onReset = () => {
+		onChange( '' );
+		searchRef.current?.focus();
+	};
+
+	return (
+		<Button
+			size="small"
+			icon={ closeSmall }
+			label={ onClose ? __( 'Close search' ) : __( 'Reset search' ) }
+			onClick={ onClose ?? onReset }
+		/>
+	);
+}
 
 function UnforwardedSearchControl(
 	{
@@ -80,16 +108,16 @@ function UnforwardedSearchControl(
 				autoComplete="off"
 				placeholder={ placeholder }
 				value={ value ?? '' }
-				// suffix={
-				// 	<SuffixItemWrapper size={ size }>
-				// 		<SuffixItem
-				// 			searchRef={ searchRef }
-				// 			value={ value }
-				// 			onChange={ onChange }
-				// 			onClose={ onClose }
-				// 		/>
-				// 	</SuffixItemWrapper>
-				// }
+				suffix={
+					<SuffixItemWrapper size={ size }>
+						<SuffixItem
+							searchRef={ searchRef }
+							value={ value }
+							onChange={ onChange }
+							onClose={ onClose }
+						/>
+					</SuffixItemWrapper>
+				}
 				{ ...restProps }
 			/>
 		</ContextSystemProvider>

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useState, forwardRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -55,7 +55,7 @@ function UnforwardedSelectControl(
 		__nextHasNoMarginBottom = false,
 		...restProps
 	} = useDeprecated36pxDefaultSizeProp( props );
-	const [ isFocused, setIsFocused ] = useState( false );
+	// const [ isFocused, setIsFocused ] = useState( false );
 	const id = useUniqueId( idProp );
 	const helpId = help ? `${ id }__help` : undefined;
 
@@ -64,12 +64,12 @@ function UnforwardedSelectControl(
 
 	const handleOnBlur = ( event: React.FocusEvent< HTMLSelectElement > ) => {
 		onBlur( event );
-		setIsFocused( false );
+		// setIsFocused( false );
 	};
 
 	const handleOnFocus = ( event: React.FocusEvent< HTMLSelectElement > ) => {
 		onFocus( event );
-		setIsFocused( true );
+		// setIsFocused( true );
 	};
 
 	const handleOnChange = (
@@ -100,7 +100,7 @@ function UnforwardedSelectControl(
 				disabled={ disabled }
 				hideLabelFromVision={ hideLabelFromVision }
 				id={ id }
-				isFocused={ isFocused }
+				// isFocused={ isFocused }
 				label={ label }
 				size={ size }
 				suffix={

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -31,6 +31,7 @@
 @import "./form-token-field/style.scss";
 @import "./guide/style.scss";
 @import "./higher-order/navigate-regions/style.scss";
+@import "./input-control/styles/style.scss";
 @import "./menu-group/style.scss";
 @import "./menu-item/style.scss";
 @import "./menu-items-choice/style.scss";


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/56524#issuecomment-1936434139