### PR TITLE
Disable selection checkbox if no bulk actions are eligible

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -297,6 +297,16 @@
 			}
 		}
 	}
+
+	&[aria-disabled="true"],
+	&:disabled {
+		background: $gray-100;
+		border-color: $gray-300;
+		cursor: default;
+
+		// Override style inherited from wp-admin. Required to avoid degraded appearance on different backgrounds.
+		opacity: 1;
+	}
 }
 
 @mixin radio-control {

--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -21,6 +21,14 @@ const {
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
+export function useHasAPossibleBulkAction( actions, item ) {
+	return useMemo( () => {
+		return actions.some( ( action ) => {
+			return action.supportsBulk && action.isEligible( item );
+		} );
+	}, [ actions, item ] );
+}
+
 function ActionWithModal( {
 	action,
 	selectedItems,

--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -29,6 +29,16 @@ export function useHasAPossibleBulkAction( actions, item ) {
 	}, [ actions, item ] );
 }
 
+export function useSomeItemHasAPossibleBulkAction( actions, data ) {
+	return useMemo( () => {
+		return data.some( ( item ) => {
+			return actions.some( ( action ) => {
+				return action.supportsBulk && action.isEligible( item );
+			} );
+		} );
+	}, [ actions, data ] );
+}
+
 function ActionWithModal( {
 	action,
 	selectedItems,
@@ -118,6 +128,12 @@ export default function BulkActions( {
 	const areAllSelected = selection && selection.length === data.length;
 	const [ isMenuOpen, onMenuOpenChange ] = useState( false );
 	const [ actionWithModal, setActionWithModal ] = useState();
+	const numberSelectableItems = useMemo( () => {
+		return data.filter( ( item ) => {
+			return bulkActions.some( ( action ) => action.isEligible( item ) );
+		} ).length;
+	}, [ data, bulkActions ] );
+
 	const selectedItems = useMemo( () => {
 		return data.filter( ( item ) =>
 			selection.includes( getItemId( item ) )
@@ -167,7 +183,7 @@ export default function BulkActions( {
 						onClick={ () => {
 							onSelectionChange( data );
 						} }
-						suffix={ data.length }
+						suffix={ numberSelectableItems }
 					>
 						{ __( 'Select all' ) }
 					</DropdownMenuItem>

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -20,6 +20,16 @@ import BulkActions from './bulk-actions';
 const defaultGetItemId = ( item ) => item.id;
 const defaultOnSelectionChange = () => {};
 
+function useSomeItemHasAPossibleBulkAction( actions, data ) {
+	return useMemo( () => {
+		return data.some( ( item ) => {
+			return actions.some( ( action ) => {
+				return action.supportsBulk && action.isEligible( item );
+			} );
+		} );
+	}, [ actions, data ] );
+}
+
 export default function DataViews( {
 	view,
 	onChangeView,
@@ -75,6 +85,11 @@ export default function DataViews( {
 			render: field.render || field.getValue,
 		} ) );
 	}, [ fields ] );
+
+	const hasPossibleBulkAction = useSomeItemHasAPossibleBulkAction(
+		actions,
+		data
+	);
 	return (
 		<div className="dataviews-wrapper">
 			<VStack spacing={ 3 } justify="flex-start">
@@ -103,15 +118,16 @@ export default function DataViews( {
 							setOpenedFilter={ setOpenedFilter }
 						/>
 					</HStack>
-					{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) && (
-						<BulkActions
-							actions={ actions }
-							data={ data }
-							onSelectionChange={ onSetSelection }
-							selection={ selection }
-							getItemId={ getItemId }
-						/>
-					) }
+					{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
+						hasPossibleBulkAction(
+							<BulkActions
+								actions={ actions }
+								data={ data }
+								onSelectionChange={ onSetSelection }
+								selection={ selection }
+								getItemId={ getItemId }
+							/>
+						) }
 					<ViewActions
 						fields={ _fields }
 						view={ view }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -119,7 +119,7 @@ export default function DataViews( {
 						/>
 					</HStack>
 					{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
-						hasPossibleBulkAction(
+						hasPossibleBulkAction && (
 							<BulkActions
 								actions={ actions }
 								data={ data }

--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -11,6 +11,7 @@ export default function SingleSelectionCheckbox( {
 	data,
 	getItemId,
 	primaryField,
+	disabled,
 } ) {
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
@@ -33,6 +34,7 @@ export default function SingleSelectionCheckbox( {
 			__nextHasNoMarginBottom
 			checked={ isSelected }
 			label={ selectionLabel }
+			disabled={ disabled }
 			onChange={ () => {
 				if ( ! isSelected ) {
 					onSelectionChange(

--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -35,8 +35,6 @@ export default function SingleSelectionCheckbox( {
 			checked={ isSelected }
 			label={ selectionLabel }
 			disabled={ disabled }
-			aria-disabled={ disabled }
-			tabindex={ 0 }
 			onChange={ () => {
 				if ( ! isSelected ) {
 					onSelectionChange(

--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -35,6 +35,8 @@ export default function SingleSelectionCheckbox( {
 			checked={ isSelected }
 			label={ selectionLabel }
 			disabled={ disabled }
+			aria-disabled={ disabled }
+			tabindex={ 0 }
 			onChange={ () => {
 				if ( ! isSelected ) {
 					onSelectionChange(

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -119,7 +119,7 @@
 			background-color: #f8f8f8;
 		}
 
-		.components-checkbox-control__input {
+		.components-checkbox-control__input.components-checkbox-control__input {
 			opacity: 0;
 
 			&:checked,

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -14,13 +14,21 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import ItemActions from './item-actions';
 import SingleSelectionCheckbox from './single-selection-checkbox';
+
+function useHasAPossibleBulkAction( actions, item ) {
+	return useMemo( () => {
+		return actions.some( ( action ) => {
+			return action.supportsBulk && action.isEligible( item );
+		} );
+	}, [ actions, item ] );
+}
 
 function GridItem( {
 	selection,
@@ -34,6 +42,7 @@ function GridItem( {
 	visibleFields,
 } ) {
 	const [ hasNoPointerEvents, setHasNoPointerEvents ] = useState( false );
+	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
 	return (
@@ -45,7 +54,7 @@ function GridItem( {
 				'has-no-pointer-events': hasNoPointerEvents,
 			} ) }
 			onMouseDown={ ( event ) => {
-				if ( event.ctrlKey || event.metaKey ) {
+				if ( hasBulkAction && ( event.ctrlKey || event.metaKey ) ) {
 					setHasNoPointerEvents( true );
 					if ( ! isSelected ) {
 						onSelectionChange(
@@ -83,6 +92,7 @@ function GridItem( {
 				justify="space-between"
 				className="dataviews-view-grid__title-actions"
 			>
+				{ hasBulkAction && (
 				<SingleSelectionCheckbox
 					id={ id }
 					item={ item }
@@ -92,6 +102,7 @@ function GridItem( {
 					data={ data }
 					primaryField={ primaryField }
 				/>
+				) }
 				<HStack className="dataviews-view-grid__primary-field">
 					{ primaryField?.render( { item } ) }
 				</HStack>

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -14,7 +14,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
-import { useState, useMemo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,13 +22,7 @@ import { useState, useMemo } from '@wordpress/element';
 import ItemActions from './item-actions';
 import SingleSelectionCheckbox from './single-selection-checkbox';
 
-function useHasAPossibleBulkAction( actions, item ) {
-	return useMemo( () => {
-		return actions.some( ( action ) => {
-			return action.supportsBulk && action.isEligible( item );
-		} );
-	}, [ actions, item ] );
-}
+import { useHasAPossibleBulkAction } from './bulk-actions';
 
 function GridItem( {
 	selection,
@@ -50,7 +44,7 @@ function GridItem( {
 			spacing={ 0 }
 			key={ id }
 			className={ classnames( 'dataviews-view-grid__card', {
-				'is-selected': isSelected,
+				'is-selected': hasBulkAction && isSelected,
 				'has-no-pointer-events': hasNoPointerEvents,
 			} ) }
 			onMouseDown={ ( event ) => {

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -86,7 +86,6 @@ function GridItem( {
 				justify="space-between"
 				className="dataviews-view-grid__title-actions"
 			>
-				{ hasBulkAction && (
 				<SingleSelectionCheckbox
 					id={ id }
 					item={ item }
@@ -95,8 +94,8 @@ function GridItem( {
 					getItemId={ getItemId }
 					data={ data }
 					primaryField={ primaryField }
+					disabled={ ! hasBulkAction }
 				/>
-				) }
 				<HStack className="dataviews-view-grid__primary-field">
 					{ primaryField?.render( { item } ) }
 				</HStack>

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -33,6 +33,7 @@ import { unlock } from './lock-unlock';
 import ItemActions from './item-actions';
 import { sanitizeOperators } from './utils';
 import { ENUMERATION_TYPE, SORTING_DIRECTIONS } from './constants';
+import { useHasAPossibleBulkAction } from './bulk-actions';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -219,10 +220,10 @@ function ViewTable( {
 	onSelectionChange,
 	setOpenedFilter,
 } ) {
-	const hasBulkActions = actions?.some( ( action ) => action.supportsBulk );
 	const headerMenuRefs = useRef( new Map() );
 	const headerMenuToFocusRef = useRef();
 	const [ nextHeaderMenuToFocus, setNextHeaderMenuToFocus ] = useState();
+	const hasBulkActions = useHasAPossibleBulkAction( actions, data );
 
 	useEffect( () => {
 		if ( headerMenuToFocusRef.current ) {

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -23,6 +23,7 @@ import {
 	useState,
 	Children,
 	Fragment,
+	useMemo,
 } from '@wordpress/element';
 
 /**
@@ -190,8 +191,20 @@ const HeaderMenu = forwardRef( function HeaderMenu(
 	);
 } );
 
-function BulkSelectionCheckbox( { selection, onSelectionChange, data } ) {
-	const areAllSelected = selection.length === data.length;
+function BulkSelectionCheckbox( {
+	selection,
+	onSelectionChange,
+	data,
+	actions,
+} ) {
+	const selectableItems = useMemo( () => {
+		return data.filter( ( item ) => {
+			return actions.some(
+				( action ) => action.supportsBulk && action.isEligible( item )
+			);
+		} );
+	}, [ data, actions ] );
+	const areAllSelected = selection.length === selectableItems.length;
 	return (
 		<CheckboxControl
 			className="dataviews-view-table-selection-checkbox"
@@ -202,7 +215,7 @@ function BulkSelectionCheckbox( { selection, onSelectionChange, data } ) {
 				if ( areAllSelected ) {
 					onSelectionChange( [] );
 				} else {
-					onSelectionChange( data );
+					onSelectionChange( selectableItems );
 				}
 			} }
 			label={ areAllSelected ? __( 'Deselect all' ) : __( 'Select all' ) }
@@ -239,17 +252,16 @@ function TableRow( {
 					} }
 				>
 					<div className="dataviews-view-table__cell-content-wrapper">
-						{ hasPossibleBulkAction && (
-							<SingleSelectionCheckbox
-								id={ id }
-								item={ item }
-								selection={ selection }
-								onSelectionChange={ onSelectionChange }
-								getItemId={ getItemId }
-								data={ data }
-								primaryField={ primaryField }
-							/>
-						) }
+						<SingleSelectionCheckbox
+							id={ id }
+							item={ item }
+							selection={ selection }
+							onSelectionChange={ onSelectionChange }
+							getItemId={ getItemId }
+							data={ data }
+							primaryField={ primaryField }
+							disabled={ ! hasPossibleBulkAction }
+						/>
 					</div>
 				</td>
 			) }
@@ -365,6 +377,7 @@ function ViewTable( {
 									selection={ selection }
 									onSelectionChange={ onSelectionChange }
 									data={ data }
+									actions={ actions }
 								/>
 							</th>
 						) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/58737

This pull request solves an issue where the selection checkbox was appearing on the grid layout even when there were no bulk actions eligible for the item. This issue was more prominent on patterns, where items without possible bulk actions were displaying a lock icon, causing visual pollution with the checkbox.

cc: @jameskoster

## Testing Instructions
1. Go to the patterns page at site-wp-dev/wp-admin/site-editor.php?path=%2Fpatterns.
2. Check that the selection checkbox is not available for patterns with the lock icon.