### PR TITLE
Blocks: refactor deletion warnings dialog

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -17,7 +17,7 @@ import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 export function BlockRemovalWarningModal( { rules } ) {
-	const { clientIds, selectPrevious, messages } = useSelect( ( select ) =>
+	const { clientIds, selectPrevious, message } = useSelect( ( select ) =>
 		unlock( select( blockEditorStore ) ).getRemovalPromptData()
 	);
 
@@ -36,7 +36,7 @@ export function BlockRemovalWarningModal( { rules } ) {
 		};
 	}, [ rules, setBlockRemovalRules ] );
 
-	if ( ! messages ) {
+	if ( ! message ) {
 		return;
 	}
 
@@ -51,11 +51,7 @@ export function BlockRemovalWarningModal( { rules } ) {
 			onRequestClose={ clearBlockRemovalPrompt }
 			size="medium"
 		>
-			<ul>
-				{ messages.map( ( message ) => {
-					return <li key={ message }>{ message }</li>;
-				} ) }
-			</ul>
+			<p>{ message }</p>
 			<HStack justify="right">
 				<Button variant="tertiary" onClick={ clearBlockRemovalPrompt }>
 					{ __( 'Cancel' ) }

--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -17,9 +17,8 @@ import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 export function BlockRemovalWarningModal( { rules } ) {
-	const { clientIds, selectPrevious, ruleKeysForPrompt } = useSelect(
-		( select ) =>
-			unlock( select( blockEditorStore ) ).getRemovalPromptData()
+	const { clientIds, selectPrevious, messages } = useSelect( ( select ) =>
+		unlock( select( blockEditorStore ) ).getRemovalPromptData()
 	);
 
 	const {
@@ -37,7 +36,7 @@ export function BlockRemovalWarningModal( { rules } ) {
 		};
 	}, [ rules, setBlockRemovalRules ] );
 
-	if ( ! ruleKeysForPrompt ) {
+	if ( ! messages ) {
 		return;
 	}
 
@@ -53,15 +52,8 @@ export function BlockRemovalWarningModal( { rules } ) {
 			size="medium"
 		>
 			<ul>
-				{ ruleKeysForPrompt.map( ( ruleKey ) => {
-					if ( rules[ ruleKey ]?.message ) {
-						return (
-							<li key={ ruleKey }>
-								{ rules[ ruleKey ].message }
-							</li>
-						);
-					}
-					return null;
+				{ messages.map( ( message ) => {
+					return <li key={ message }>{ message }</li>;
 				} ) }
 			</ul>
 			<HStack justify="right">

--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -8,7 +8,7 @@ import {
 	Button,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { __, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -17,10 +17,10 @@ import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 export function BlockRemovalWarningModal( { rules } ) {
-	const { clientIds, selectPrevious, blockNamesForPrompt, messageType } =
-		useSelect( ( select ) =>
+	const { clientIds, selectPrevious, ruleKeysForPrompt } = useSelect(
+		( select ) =>
 			unlock( select( blockEditorStore ) ).getRemovalPromptData()
-		);
+	);
 
 	const {
 		clearBlockRemovalPrompt,
@@ -37,22 +37,9 @@ export function BlockRemovalWarningModal( { rules } ) {
 		};
 	}, [ rules, setBlockRemovalRules ] );
 
-	if ( ! blockNamesForPrompt ) {
+	if ( ! ruleKeysForPrompt ) {
 		return;
 	}
-
-	const message =
-		messageType === 'templates'
-			? _n(
-					'Deleting this block will stop your post or page content from displaying on this template. It is not recommended.',
-					'Deleting these blocks will stop your post or page content from displaying on this template. It is not recommended.',
-					blockNamesForPrompt.length
-			  )
-			: _n(
-					'Deleting this block could break patterns on your site that have content linked to it. Are you sure you want to delete it?',
-					'Deleting these blocks could break patterns on your site that have content linked to them. Are you sure you want to delete them?',
-					blockNamesForPrompt.length
-			  );
 
 	const onConfirmRemoval = () => {
 		privateRemoveBlocks( clientIds, selectPrevious, /* force */ true );
@@ -65,7 +52,18 @@ export function BlockRemovalWarningModal( { rules } ) {
 			onRequestClose={ clearBlockRemovalPrompt }
 			size="medium"
 		>
-			<p>{ message }</p>
+			<ul>
+				{ ruleKeysForPrompt.map( ( ruleKey ) => {
+					if ( rules[ ruleKey ]?.message ) {
+						return (
+							<li key={ ruleKey }>
+								{ rules[ ruleKey ].message }
+							</li>
+						);
+					}
+					return null;
+				} ) }
+			</ul>
 			<HStack justify="right">
 				<Button variant="tertiary" onClick={ clearBlockRemovalPrompt }>
 					{ __( 'Cancel' ) }

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -141,8 +141,8 @@ export const privateRemoveBlocks =
 
 			// Find the first message and use it.
 			let message;
-			for ( const rule in rules ) {
-				message = rule( flattenedBlocks );
+			for ( const rule of rules ) {
+				message = rule.callback( flattenedBlocks );
 				if ( message ) {
 					dispatch(
 						displayBlockRemovalPrompt(

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -124,43 +124,34 @@ export const privateRemoveBlocks =
 		// @see https://github.com/WordPress/gutenberg/pull/51145
 		const rules = ! forceRemove && select.getBlockRemovalRules();
 		if ( rules ) {
-			const blockNamesForPrompt = new Set();
+			const ruleKeysForPrompt = new Set();
 
 			// Given a list of client IDs of blocks that the user intended to
 			// remove, perform a tree search (BFS) to find all block names
 			// corresponding to "important" blocks, i.e. blocks that require a
 			// removal prompt.
 			const queue = [ ...clientIds ];
-			let messageType = 'templates';
 			while ( queue.length ) {
 				const clientId = queue.shift();
 				const blockName = select.getBlockName( clientId );
-				if ( rules[ blockName ] ) {
-					blockNamesForPrompt.add( blockName );
-				}
 
-				if ( rules[ 'bindings/core/pattern-overrides' ] ) {
-					const parentPatternBlocks =
-						select.getBlockParentsByBlockName(
-							clientId,
-							'core/block'
-						);
-					// We only need to run this check when editing the original pattern, not pattern instances.
-					if ( parentPatternBlocks?.length > 0 ) {
-						continue;
-					}
-					const blockAttributes =
-						select.getBlockAttributes( clientId );
+				Object.values( rules ).forEach( ( rule ) => {
 					if (
-						blockAttributes?.metadata?.bindings &&
-						JSON.stringify(
-							blockAttributes.metadata.bindings
-						).includes( 'core/pattern-overrides' )
+						( rule.postTypes &&
+							! rule.postTypes.includes(
+								rules.currentPostType
+							) ) ||
+						! rule.callback
 					) {
-						blockNamesForPrompt.add( blockName );
-						messageType = 'patternOverrides';
+						return;
 					}
-				}
+
+					rule.callback(
+						blockName,
+						ruleKeysForPrompt,
+						select.getBlockAttributes( clientId )
+					);
+				} );
 
 				const innerBlocks = select.getBlockOrder( clientId );
 				queue.push( ...innerBlocks );
@@ -168,13 +159,12 @@ export const privateRemoveBlocks =
 
 			// If any such blocks were found, trigger the removal prompt and
 			// skip any other steps (thus postponing actual removal).
-			if ( blockNamesForPrompt.size ) {
+			if ( ruleKeysForPrompt.size ) {
 				dispatch(
 					displayBlockRemovalPrompt(
 						clientIds,
 						selectPrevious,
-						Array.from( blockNamesForPrompt ),
-						messageType
+						Array.from( ruleKeysForPrompt )
 					)
 				);
 				return;
@@ -228,30 +218,30 @@ export const ensureDefaultBlock =
  *
  * Contrast with `setBlockRemovalRules`.
  *
- * @param {string|string[]} clientIds           Client IDs of blocks to remove.
- * @param {boolean}         selectPrevious      True if the previous block
- *                                              or the immediate parent
- *                                              (if no previous block exists)
- *                                              should be selected
- *                                              when a block is removed.
- * @param {string[]}        blockNamesForPrompt Names of the blocks that
- *                                              triggered the need for
- *                                              confirmation before removal.
- * @param {string}          messageType         The type of message to display.
+ * @param {string|string[]} clientIds         Client IDs of blocks to remove.
+ * @param {boolean}         selectPrevious    True if the previous block
+ *                                            or the immediate parent
+ *                                            (if no previous block exists)
+ *                                            should be selected
+ *                                            when a block is removed.
+ * @param {string[]}        ruleKeysForPrompt Names of the rules that
+ *                                            triggered the need for
+ *                                            confirmation before removal.
+ * @param {string}          messageType       The type of message to display.
  *
  * @return {Object} Action object.
  */
 function displayBlockRemovalPrompt(
 	clientIds,
 	selectPrevious,
-	blockNamesForPrompt,
+	ruleKeysForPrompt,
 	messageType
 ) {
 	return {
 		type: 'DISPLAY_BLOCK_REMOVAL_PROMPT',
 		clientIds,
 		selectPrevious,
-		blockNamesForPrompt,
+		ruleKeysForPrompt,
 		messageType,
 	};
 }

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -139,19 +139,20 @@ export const privateRemoveBlocks =
 			const blockList = clientIds.map( select.getBlock );
 			const flattenedBlocks = flattenBlocks( blockList );
 
-			const messages = rules
-				.map( ( { callback } ) => callback( flattenedBlocks ) )
-				.filter( ( candidateMessage ) => candidateMessage );
-
-			if ( messages.length ) {
-				dispatch(
-					displayBlockRemovalPrompt(
-						clientIds,
-						selectPrevious,
-						messages
-					)
-				);
-				return;
+			// Find the first message and use it.
+			let message;
+			for ( const rule in rules ) {
+				message = rule( flattenedBlocks );
+				if ( message ) {
+					dispatch(
+						displayBlockRemovalPrompt(
+							clientIds,
+							selectPrevious,
+							message
+						)
+					);
+					return;
+				}
 			}
 		}
 
@@ -207,16 +208,16 @@ export const ensureDefaultBlock =
  *                                         immediate parent (if no previous
  *                                         block exists) should be selected
  *                                         when a block is removed.
- * @param {string[]}        messages       Messages to display in the prompt.
+ * @param {string}          message        Message to display in the prompt.
  *
  * @return {Object} Action object.
  */
-function displayBlockRemovalPrompt( clientIds, selectPrevious, messages ) {
+function displayBlockRemovalPrompt( clientIds, selectPrevious, message ) {
 	return {
 		type: 'DISPLAY_BLOCK_REMOVAL_PROMPT',
 		clientIds,
 		selectPrevious,
-		messages,
+		message,
 	};
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1521,11 +1521,11 @@ export function isSelectionEnabled( state = true, action ) {
 function removalPromptData( state = false, action ) {
 	switch ( action.type ) {
 		case 'DISPLAY_BLOCK_REMOVAL_PROMPT':
-			const { clientIds, selectPrevious, messages } = action;
+			const { clientIds, selectPrevious, message } = action;
 			return {
 				clientIds,
 				selectPrevious,
-				messages,
+				message,
 			};
 		case 'CLEAR_BLOCK_REMOVAL_PROMPT':
 			return false;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1521,11 +1521,11 @@ export function isSelectionEnabled( state = true, action ) {
 function removalPromptData( state = false, action ) {
 	switch ( action.type ) {
 		case 'DISPLAY_BLOCK_REMOVAL_PROMPT':
-			const { clientIds, selectPrevious, ruleKeysForPrompt } = action;
+			const { clientIds, selectPrevious, messages } = action;
 			return {
 				clientIds,
 				selectPrevious,
-				ruleKeysForPrompt,
+				messages,
 			};
 		case 'CLEAR_BLOCK_REMOVAL_PROMPT':
 			return false;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1521,17 +1521,11 @@ export function isSelectionEnabled( state = true, action ) {
 function removalPromptData( state = false, action ) {
 	switch ( action.type ) {
 		case 'DISPLAY_BLOCK_REMOVAL_PROMPT':
-			const {
-				clientIds,
-				selectPrevious,
-				blockNamesForPrompt,
-				messageType,
-			} = action;
+			const { clientIds, selectPrevious, ruleKeysForPrompt } = action;
 			return {
 				clientIds,
 				selectPrevious,
-				blockNamesForPrompt,
-				messageType,
+				ruleKeysForPrompt,
 			};
 		case 'CLEAR_BLOCK_REMOVAL_PROMPT':
 			return false;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -12,8 +12,6 @@ import { useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { CommandMenu } from '@wordpress/commands';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -25,14 +23,6 @@ import { unlock } from './lock-unlock';
 import useNavigateToEntityRecord from './hooks/use-navigate-to-entity-record';
 
 const { ExperimentalEditorProvider } = unlock( editorPrivateApis );
-const { BlockRemovalWarningModal } = unlock( blockEditorPrivateApis );
-// Prevent accidental removal of certain blocks, asking the user for
-// confirmation.
-const blockRemovalRules = {
-	'bindings/core/pattern-overrides': __(
-		'Blocks from synced patterns that can have overriden content.'
-	),
-};
 
 function Editor( {
 	postId: initialPostId,
@@ -108,7 +98,6 @@ function Editor( {
 					<CommandMenu />
 					<EditorInitialization postId={ currentPost.postId } />
 					<Layout initialPost={ initialPost } />
-					<BlockRemovalWarningModal rules={ blockRemovalRules } />
 				</ErrorBoundary>
 				<PostLockedModal />
 			</ExperimentalEditorProvider>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -14,7 +14,6 @@ import {
 	BlockBreadcrumb,
 	BlockToolbar,
 	store as blockEditorStore,
-	privateApis as blockEditorPrivateApis,
 	BlockInspector,
 } from '@wordpress/block-editor';
 import {
@@ -56,7 +55,6 @@ import SiteEditorCanvas from '../block-editor/site-editor-canvas';
 import TemplatePartConverter from '../template-part-converter';
 import { useSpecificEditorSettings } from '../block-editor/use-site-editor-settings';
 
-const { BlockRemovalWarningModal } = unlock( blockEditorPrivateApis );
 const {
 	ExperimentalEditorProvider: EditorProvider,
 	InserterSidebar,
@@ -72,21 +70,6 @@ const interfaceLabels = {
 	actions: __( 'Editor publish' ),
 	/* translators: accessibility text for the editor footer landmark region. */
 	footer: __( 'Editor footer' ),
-};
-
-// Prevent accidental removal of certain blocks, asking the user for
-// confirmation.
-const blockRemovalRules = {
-	'core/query': __( 'Query Loop displays a list of posts or pages.' ),
-	'core/post-content': __(
-		'Post Content displays the content of a post or page.'
-	),
-	'core/post-template': __(
-		'Post Template displays each post or page in a Query Loop.'
-	),
-	'bindings/core/pattern-overrides': __(
-		'Blocks from synced patterns that can have overriden content.'
-	),
 };
 
 export default function Editor( { isLoading } ) {
@@ -243,9 +226,6 @@ export default function Editor( { isLoading } ) {
 											<BlockToolbar hideDragHandle />
 										) }
 										<SiteEditorCanvas />
-										<BlockRemovalWarningModal
-											rules={ blockRemovalRules }
-										/>
 										<PatternModal />
 									</>
 								) }

--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+
+import { __ } from '@wordpress/i18n';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
+
+const { BlockRemovalWarningModal } = unlock( blockEditorPrivateApis );
+
+// Prevent accidental removal of certain blocks, asking the user for confirmation first.
+const blockRemovalRules = {
+	'core-query': {
+		message: __(
+			'The Query Loop block displays a list of posts or pages, so removing it will prevent that content from displaying.'
+		),
+		postTypes: [ 'wp_template' ],
+		callback: ( blockName, ruleKeysForPrompt ) => {
+			if ( blockName === 'core/query' ) {
+				ruleKeysForPrompt.add( 'core-query' );
+			}
+		},
+	},
+	'core-post-content': {
+		message: __(
+			'Removing the Post Content block will stop your post or page content from displaying on this template.'
+		),
+		postTypes: [ 'wp_template' ],
+		callback: ( blockName, ruleKeysForPrompt ) => {
+			if ( blockName === 'core/post-content' ) {
+				ruleKeysForPrompt.add( 'core-post-content' );
+			}
+		},
+	},
+	'core-post-template': {
+		message: __(
+			'The Post Template block displays each post or page in a Query Loop, so removing it will stop post content displaying in your query loop.'
+		),
+		postTypes: [ 'wp_template', 'post', 'page' ],
+		callback: ( blockName, ruleKeysForPrompt ) => {
+			if ( blockName === 'core/post-template' ) {
+				ruleKeysForPrompt.add( 'core-post-template' );
+			}
+		},
+	},
+	'core-pattern-overrides': {
+		message: __(
+			'Deleting a block with pattern instance overrides can break other blocks on your site that have content linked to it.'
+		),
+		postTypes: [ 'wp_block' ],
+		callback: ( blockName, ruleKeysForPrompt, blockAttributes ) => {
+			if (
+				blockAttributes?.metadata?.bindings &&
+				JSON.stringify( blockAttributes.metadata.bindings ).includes(
+					'core/pattern-overrides'
+				)
+			) {
+				ruleKeysForPrompt.add( 'core-pattern-overrides' );
+			}
+		},
+	},
+};
+
+export default function BlockRemovalWarnings() {
+	const { currentPostType } = useSelect( ( select ) => {
+		const { getCurrentPostType } = select( editorStore );
+
+		return {
+			currentPostType: getCurrentPostType(),
+		};
+	}, [] );
+	blockRemovalRules.currentPostType = currentPostType;
+	return <BlockRemovalWarningModal rules={ blockRemovalRules } />;
+}

--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -41,7 +41,7 @@ const BLOCK_REMOVAL_RULES = [
 	},
 	{
 		// Pattern overrides.
-		// The warning is only shown when the user manipulates
+		// The warning is only shown when the user edits a pattern.
 		postTypes: [ 'wp_block' ],
 		callback( removedBlocks ) {
 			const removedBlocksWithOverrides = removedBlocks.filter(

--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -64,16 +64,18 @@ const BLOCK_REMOVAL_RULES = [
 ];
 
 export default function BlockRemovalWarnings() {
-	const { currentPostType } = useSelect(
+	const currentPostType = useSelect(
 		( select ) => select( editorStore ).getCurrentPostType(),
 		[]
 	);
 
-	const removalRulesForPostType = useMemo( () => {
-		BLOCK_REMOVAL_RULES.filter( ( rule ) =>
-			rule.postTypes.some( ( postType ) => postType === currentPostType )
-		);
-	}, [ currentPostType ] );
+	const removalRulesForPostType = useMemo(
+		() =>
+			BLOCK_REMOVAL_RULES.filter( ( rule ) =>
+				rule.postTypes.includes( currentPostType )
+			),
+		[ currentPostType ]
+	);
 
 	if ( ! removalRulesForPostType ) {
 		return null;

--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -91,5 +91,9 @@ export default function BlockRemovalWarnings() {
 		);
 	}, [ currentPostType ] );
 
+	if ( ! removalRulesForPostType ) {
+		return null;
+	}
+
 	return <BlockRemovalWarningModal rules={ removalRulesForPostType } />;
 }

--- a/packages/editor/src/components/block-removal-warnings/index.js
+++ b/packages/editor/src/components/block-removal-warnings/index.js
@@ -77,6 +77,13 @@ export default function BlockRemovalWarnings() {
 		[ currentPostType ]
 	);
 
+	// `BlockRemovalWarnings` is rendered in the editor provider, a shared component
+	// across react native and web. However, `BlockRemovalWarningModal` is web only.
+	// Check it exists before trying to render it.
+	if ( ! BlockRemovalWarningModal ) {
+		return null;
+	}
+
 	if ( ! removalRulesForPostType ) {
 		return null;
 	}

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -25,6 +25,7 @@ import DisableNonPageContentBlocks from './disable-non-page-content-blocks';
 import NavigationBlockEditingMode from './navigation-block-editing-mode';
 import { useHideBlocksFromInserter } from './use-hide-blocks-from-inserter';
 import useCommands from '../commands';
+import BlockRemovalWarnings from '../block-removal-warnings';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -264,6 +265,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 							{ type === 'wp_navigation' && (
 								<NavigationBlockEditingMode />
 							) }
+							<BlockRemovalWarnings />
 						</BlockEditorProviderComponent>
 					</BlockContextProvider>
 				</EntityProvider>

--- a/test/e2e/specs/site-editor/block-removal.spec.js
+++ b/test/e2e/specs/site-editor/block-removal.spec.js
@@ -59,7 +59,7 @@ test.describe( 'Site editor block removal prompt', () => {
 		// Expect the block removal prompt to have appeared
 		await expect(
 			page.getByText(
-				'Deleting this block will stop your post or page content from displaying on this template. It is not recommended.'
+				'Some of the deleted blocks will stop your post or page content from displaying on this template. It is not recommended.'
 			)
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/site-editor/block-removal.spec.js
+++ b/test/e2e/specs/site-editor/block-removal.spec.js
@@ -35,7 +35,7 @@ test.describe( 'Site editor block removal prompt', () => {
 		// Expect the block removal prompt to have appeared
 		await expect(
 			page.getByText(
-				'Deleting these blocks will stop your post or page content from displaying on this template. It is not recommended.'
+				'Post or page content may not be displayed correctly if you delete these blocks:'
 			)
 		).toBeVisible();
 	} );
@@ -59,7 +59,7 @@ test.describe( 'Site editor block removal prompt', () => {
 		// Expect the block removal prompt to have appeared
 		await expect(
 			page.getByText(
-				'Deleting this block will stop your post or page content from displaying on this template. It is not recommended.'
+				'Post or page content may not be displayed correctly if you delete this block:'
 			)
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/site-editor/block-removal.spec.js
+++ b/test/e2e/specs/site-editor/block-removal.spec.js
@@ -35,7 +35,7 @@ test.describe( 'Site editor block removal prompt', () => {
 		// Expect the block removal prompt to have appeared
 		await expect(
 			page.getByText(
-				'Post or page content may not be displayed correctly if you delete these blocks:'
+				'Some of the deleted blocks will stop your post or page content from displaying on this template. It is not recommended.'
 			)
 		).toBeVisible();
 	} );
@@ -59,7 +59,7 @@ test.describe( 'Site editor block removal prompt', () => {
 		// Expect the block removal prompt to have appeared
 		await expect(
 			page.getByText(
-				'Post or page content may not be displayed correctly if you delete this block:'
+				'Deleting this block will stop your post or page content from displaying on this template. It is not recommended.'
 			)
 		).toBeVisible();
 	} );


### PR DESCRIPTION
## What?
Refactors the block deletion warnings

## Why?
#58796 Added some code to show a warning if a user tries to delete a block that has pattern overrides, but could do with some code improvements.

This follow up makes the block removal warnings more flexible to cover the use case for patterns

## How?

- Some of the code (the block removal rules) is moved into the `wordpress/editor` package along with the copy, so that it works across the post and site editor automatically.
- The rules can specify a `postType` that the associated message should appear for. This is mostly use to ensure the message for pattern overrides only shows when editing a pattern (see [Patterns: Avoid showing block removal warning when deleting a pattern instance that has overrides](https://github.com/WordPress/gutenberg/pull/59044#top))
- Rather than hard coding a message, the rules now have a callback that receives the list of blocks being removed and returns a message to show. If no message is returned by any of the rules, no removal warning is displayed.
- I've made some small changes to the copy, but largely it's as it is in `trunk`.

## Testing Instructions

- Try deleting a post content block and query block in both the post and site editor and make sure a confirmation warning shows
- Add a synced pattern block and set overrides on one of the child blocks. Try deleting the child block and make sure the deletion warning message shows.

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-02-21 at 4 16 53 pm](https://github.com/WordPress/gutenberg/assets/677833/1d91f231-20a5-4c72-983a-e37553b28ac6)



