### PR TITLE
Block Bindings: Fix focus behavior when pressing Enter on connected block

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -57,6 +57,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				event.preventDefault();
 
 				if ( keyCode === ENTER ) {
+					target.blur();
 					insertDefaultBlock(
 						{},
 						getBlockRootClientId( clientId ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -10,7 +10,6 @@ import { useRefEffect } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../../store';
-import { useShouldDisableEditing } from '../../rich-text/use-should-disable-editing';
 
 /**
  * Adds block behaviour:
@@ -24,7 +23,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 	const { getBlockRootClientId, getBlockIndex } =
 		useSelect( blockEditorStore );
 	const { insertDefaultBlock, removeBlock } = useDispatch( blockEditorStore );
-	const shouldDisableEditing = useShouldDisableEditing();
 
 	return useRefEffect(
 		( node ) => {
@@ -59,11 +57,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				event.preventDefault();
 
 				if ( keyCode === ENTER ) {
-					// If the block is a bound rich text block, we should
-					// blur the target so focus can be set to the new block.
-					if ( shouldDisableEditing ) {
-						target.blur();
-					}
 					insertDefaultBlock(
 						{},
 						getBlockRootClientId( clientId ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -10,6 +10,7 @@ import { useRefEffect } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../../store';
+import { useShouldDisableEditing } from '../../rich-text/use-should-disable-editing';
 
 /**
  * Adds block behaviour:
@@ -23,6 +24,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 	const { getBlockRootClientId, getBlockIndex } =
 		useSelect( blockEditorStore );
 	const { insertDefaultBlock, removeBlock } = useDispatch( blockEditorStore );
+	const shouldDisableEditing = useShouldDisableEditing();
 
 	return useRefEffect(
 		( node ) => {
@@ -57,7 +59,11 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				event.preventDefault();
 
 				if ( keyCode === ENTER ) {
-					target.blur();
+					// If the block is a bound rich text block, we should
+					// blur the target so focus can be set to the new block.
+					if ( shouldDisableEditing ) {
+						target.blur();
+					}
 					insertDefaultBlock(
 						{},
 						getBlockRootClientId( clientId ),

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -409,24 +409,13 @@ export function RichTextWrapper(
 					useEnter( {
 						removeEditorOnlyFormats,
 						value,
-						onReplace: (
-							blocks,
-							indexToSelect,
-							initialPosition
-						) => {
-							if ( ! shouldDisableEditing ) {
-								onReplace(
-									blocks,
-									indexToSelect,
-									initialPosition
-								);
-							}
-						},
+						onReplace,
 						onSplit,
 						onChange,
 						disableLineBreaks,
 						onSplitAtEnd,
 						onSplitAtDoubleLineEnd,
+						shouldDisableEditing,
 					} ),
 					useFirefoxCompat(),
 					anchorRef,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -294,12 +294,7 @@ export function RichTextWrapper(
 	}
 
 	const TagName = tagName;
-	let tabIndex;
-	if ( shouldDisableEditing ) {
-		tabIndex = 0;
-	} else {
-		tabIndex = props.tabIndex === 0 ? null : props.tabIndex;
-	}
+	const tabIndex = props.tabIndex === 0 ? null : props.tabIndex;
 	return (
 		<>
 			{ isSelected && (
@@ -394,13 +389,13 @@ export function RichTextWrapper(
 					props.className,
 					'rich-text'
 				) }
-				// Setting tabIndex to 0 is unnecessary, the element is already
+				// Setting tabIndex to 0 is unnecessary, if the element is already
 				// focusable because it's contentEditable. This also fixes a
 				// Safari bug where it's not possible to Shift+Click multi
 				// select blocks when Shift Clicking into an element with
 				// tabIndex because Safari will focus the element. However,
 				// Safari will correctly ignore nested contentEditable elements.
-				tabIndex={ tabIndex }
+				tabIndex={ shouldDisableEditing ? 0 : tabIndex }
 				data-wp-block-attribute-key={ identifier }
 			/>
 		</>

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -294,6 +294,12 @@ export function RichTextWrapper(
 	}
 
 	const TagName = tagName;
+	let tabIndex;
+	if ( shouldDisableEditing ) {
+		tabIndex = 0;
+	} else {
+		tabIndex = props.tabIndex === 0 ? null : props.tabIndex;
+	}
 	return (
 		<>
 			{ isSelected && (
@@ -394,11 +400,7 @@ export function RichTextWrapper(
 				// select blocks when Shift Clicking into an element with
 				// tabIndex because Safari will focus the element. However,
 				// Safari will correctly ignore nested contentEditable elements.
-				tabIndex={
-					props.tabIndex === 0 && ! shouldDisableEditing
-						? null
-						: props.tabIndex
-				}
+				tabIndex={ tabIndex }
 				data-wp-block-attribute-key={ identifier }
 			/>
 		</>

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -154,7 +154,7 @@ export function RichTextWrapper(
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
 	// Disable Rich Text editing if block bindings specify that.
-	const shouldDisableEditing = useShouldDisableEditing();
+	const shouldDisableEditing = useShouldDisableEditing( identifier );
 	const { selectionChange } = useDispatch( blockEditorStore );
 	const adjustedAllowedFormats = getAllowedFormats( {
 		allowedFormats,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -12,7 +12,7 @@ import {
 	forwardRef,
 	createContext,
 } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { select, dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { useMergeRefs } from '@wordpress/compose';
 import {
 	__unstableUseRichText as useRichText,
@@ -194,7 +194,7 @@ export function RichTextWrapper(
 
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
-	const { selectionChange } = useDispatch( blockEditorStore );
+	const { selectionChange, selectBlock } = useDispatch( blockEditorStore );
 	const adjustedAllowedFormats = getAllowedFormats( {
 		allowedFormats,
 		disableFormats,
@@ -332,6 +332,17 @@ export function RichTextWrapper(
 		anchorRef.current?.focus();
 	}
 
+	const onReplaceCallback = shouldDisableEditing
+		? ( blocks ) => {
+				// Find block that does not have the clientId
+				const blockToFocus = blocks.find(
+					( block ) => block.clientId !== clientId
+				);
+
+				// selectBlock( blockToFocus.clientId );
+		  }
+		: onReplace;
+
 	const TagName = tagName;
 	return (
 		<>
@@ -396,7 +407,7 @@ export function RichTextWrapper(
 						value,
 						formatTypes,
 						tagName,
-						onReplace,
+						onReplaceCallback,
 						onSplit,
 						__unstableEmbedURLOnPaste,
 						pastePlainText,
@@ -409,7 +420,7 @@ export function RichTextWrapper(
 					useEnter( {
 						removeEditorOnlyFormats,
 						value,
-						onReplace,
+						onReplaceCallback,
 						onSplit,
 						onChange,
 						disableLineBreaks,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -12,7 +12,7 @@ import {
 	forwardRef,
 	createContext,
 } from '@wordpress/element';
-import { select, dispatch, useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useMergeRefs } from '@wordpress/compose';
 import {
 	__unstableUseRichText as useRichText,
@@ -194,7 +194,7 @@ export function RichTextWrapper(
 
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
-	const { selectionChange, selectBlock } = useDispatch( blockEditorStore );
+	const { selectionChange } = useDispatch( blockEditorStore );
 	const adjustedAllowedFormats = getAllowedFormats( {
 		allowedFormats,
 		disableFormats,
@@ -332,17 +332,6 @@ export function RichTextWrapper(
 		anchorRef.current?.focus();
 	}
 
-	const onReplaceCallback = shouldDisableEditing
-		? ( blocks ) => {
-				// Find block that does not have the clientId
-				const blockToFocus = blocks.find(
-					( block ) => block.clientId !== clientId
-				);
-
-				// selectBlock( blockToFocus.clientId );
-		  }
-		: onReplace;
-
 	const TagName = tagName;
 	return (
 		<>
@@ -407,7 +396,7 @@ export function RichTextWrapper(
 						value,
 						formatTypes,
 						tagName,
-						onReplaceCallback,
+						onReplace,
 						onSplit,
 						__unstableEmbedURLOnPaste,
 						pastePlainText,
@@ -420,7 +409,19 @@ export function RichTextWrapper(
 					useEnter( {
 						removeEditorOnlyFormats,
 						value,
-						onReplaceCallback,
+						onReplace: (
+							blocks,
+							indexToSelect,
+							initialPosition
+						) => {
+							if ( ! shouldDisableEditing ) {
+								onReplace(
+									blocks,
+									indexToSelect,
+									initialPosition
+								);
+							}
+						},
 						onSplit,
 						onChange,
 						disableLineBreaks,

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -32,7 +32,7 @@ export function useEnter( props ) {
 			const {
 				removeEditorOnlyFormats,
 				value,
-				onReplace,
+				onReplaceCallback: onReplace,
 				onSplit,
 				onChange,
 				disableLineBreaks,

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -69,7 +69,9 @@ export function useEnter( props ) {
 			const { text, start, end } = _value;
 
 			if ( shouldDisableEditing ) {
-				_value.text = '';
+				// Simulate the cursor is at the end of the rich text.
+				_value.start = _value.text?.length;
+				_value.end = _value.text?.length;
 				splitValue( {
 					value: _value,
 					onReplace,

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -38,7 +38,12 @@ export function useEnter( props ) {
 				disableLineBreaks,
 				onSplitAtEnd,
 				onSplitAtDoubleLineEnd,
+				shouldDisableEditing,
 			} = propsRef.current;
+
+			if ( shouldDisableEditing ) {
+				return;
+			}
 
 			event.preventDefault();
 

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -41,10 +41,6 @@ export function useEnter( props ) {
 				shouldDisableEditing,
 			} = propsRef.current;
 
-			if ( shouldDisableEditing ) {
-				return;
-			}
-
 			event.preventDefault();
 
 			const _value = { ...value };
@@ -72,7 +68,14 @@ export function useEnter( props ) {
 
 			const { text, start, end } = _value;
 
-			if ( event.shiftKey ) {
+			if ( shouldDisableEditing ) {
+				_value.text = '';
+				splitValue( {
+					value: _value,
+					onReplace,
+					onSplit,
+				} );
+			} else if ( event.shiftKey ) {
 				if ( ! disableLineBreaks ) {
 					onChange( insert( _value, '\n' ) );
 				}

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -72,12 +72,9 @@ export function useEnter( props ) {
 				// Simulate the cursor is at the end of the rich text.
 				_value.start = _value.text?.length;
 				_value.end = _value.text?.length;
-				splitValue( {
-					value: _value,
-					onReplace,
-					onSplit,
-				} );
-			} else if ( event.shiftKey ) {
+			}
+
+			if ( event.shiftKey && ! shouldDisableEditing ) {
 				if ( ! disableLineBreaks ) {
 					onChange( insert( _value, '\n' ) );
 				}

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -32,7 +32,7 @@ export function useEnter( props ) {
 			const {
 				removeEditorOnlyFormats,
 				value,
-				onReplaceCallback: onReplace,
+				onReplace,
 				onSplit,
 				onChange,
 				disableLineBreaks,

--- a/packages/block-editor/src/components/rich-text/use-should-disable-editing.js
+++ b/packages/block-editor/src/components/rich-text/use-should-disable-editing.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { getBlockType, store as blocksStore } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { BLOCK_BINDINGS_ALLOWED_BLOCKS } from '../../hooks/use-bindings-attributes';
+import { useBlockEditContext } from '../block-edit';
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+export function useShouldDisableEditing() {
+	const { clientId, name: blockName } = useBlockEditContext();
+
+	const { getBlockAttributes } = useSelect( blockEditorStore );
+	const { getBlockBindingsSource } = unlock( useSelect( blocksStore ) );
+	const blockBindings = getBlockAttributes( clientId )?.metadata?.bindings;
+
+	if ( blockBindings && blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) {
+		const blockTypeAttributes = getBlockType( blockName ).attributes;
+
+		for ( const [ attribute, args ] of Object.entries( blockBindings ) ) {
+			if ( blockTypeAttributes?.[ attribute ]?.source !== 'rich-text' ) {
+				break;
+			}
+
+			// If the source is not defined, or if its value of `lockAttributesEditing` is `true`, disable it.
+			const blockBindingsSource = getBlockBindingsSource( args.source );
+			if (
+				! blockBindingsSource ||
+				blockBindingsSource.lockAttributesEditing
+			) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -293,12 +293,23 @@ function ButtonEdit( props ) {
 						...spacingProps.style,
 						...shadowProps.style,
 					} }
-					onSplit={ ( value ) =>
-						createBlock( 'core/button', {
-							...attributes,
-							text: value,
-						} )
-					}
+					onSplit={ ( value, isOriginal ) => {
+						let newAttributes;
+						if ( isOriginal || value ) {
+							newAttributes = {
+								...attributes,
+								text: value,
+							};
+						}
+						const block = createBlock(
+							'core/button',
+							newAttributes
+						);
+						if ( isOriginal ) {
+							block.clientId = clientId;
+						}
+						return block;
+					} }
 					onReplace={ onReplace }
 					onMerge={ mergeBlocks }
 					identifier="text"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR is meant to set focus correctly after pressing Enter on a connected block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses [fix/bindings-focus-on-enter](https://github.com/WordPress/gutenberg/issues/58674).
Currently, pressing Enter on a bound block causes two paragraphs to be created — one erroneously gets created before the bound block and another one after, and focus is not set properly to the latter. 

## How?

This PR blurs focus from a bound block after the Enter button is pressed so that, when a new default block is inserted, focus can be set to the new block accordingly. It also prevents RichText logic from running if the block is bound.

## Testing Instructions

1. Follow instructions from https://github.com/WordPress/wordpress-develop/pull/5888 to create a Paragraph with content connected to a post meta.
2. Click to select the connected Paragraph.
3. Press Enter.
4. Observe that a new Paragraph is created and focus is set to it as expected.
5. Repeat the same for the Heading block.

## Screenshare

https://github.com/WordPress/gutenberg/assets/5360536/c5c2628c-ca3a-4bfe-ad66-c907f69cd392