### PR TITLE
DataViews: Remove second `reset filter` button in filter dialog

### DIFF
--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import {
 	Dropdown,
-	Button,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	FlexItem,
@@ -133,40 +132,6 @@ function OperatorSelector( { filter, view, onChangeView } ) {
 	);
 }
 
-function ResetFilter( { filter, view, onChangeView, addFilterRef } ) {
-	const isDisabled =
-		filter.isPrimary &&
-		view.filters.find( ( _filter ) => _filter.field === filter.field )
-			?.value === undefined;
-	return (
-		<div className="dataviews-filter-summary__reset">
-			<Button
-				disabled={ isDisabled }
-				__experimentalIsFocusable
-				size="compact"
-				variant="tertiary"
-				style={ { justifyContent: 'center', width: '100%' } }
-				onClick={ () => {
-					onChangeView( {
-						...view,
-						page: 1,
-						filters: view.filters.filter(
-							( _filter ) => _filter.field !== filter.field
-						),
-					} );
-					// If the filter is not primary and can be removed, it will be added
-					// back to the available filters from `Add filter` component.
-					if ( ! filter.isPrimary ) {
-						addFilterRef.current?.focus();
-					}
-				} }
-			>
-				{ filter.isPrimary ? __( 'Reset' ) : __( 'Remove' ) }
-			</Button>
-		</div>
-	);
-}
-
 export default function FilterSummary( {
 	addFilterRef,
 	openedFilter,
@@ -269,10 +234,6 @@ export default function FilterSummary( {
 					<VStack spacing={ 0 } justify="flex-start">
 						<OperatorSelector { ...commonProps } />
 						<SearchWidget { ...commonProps } />
-						<ResetFilter
-							{ ...commonProps }
-							addFilterRef={ addFilterRef }
-						/>
 					</VStack>
 				);
 			} }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -627,11 +627,6 @@
 	}
 }
 
-.dataviews-filter-summary__reset {
-	padding: $grid-unit-05;
-	border-top: 1px solid $gray-200;
-}
-
 .dataviews-filter-summary__chip-container {
 	position: relative;
 	white-space: pre-wrap;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR removes the extra `remove/reset` button inside a filter's dialog. The `remove/reset` inside the filter chip should be enough.

<img width="498" alt="Screenshot 2024-02-13 at 10 00 49 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/5c51f2e0-5265-4002-a058-649cf68ca81c">
