### PR TITLE
All backports for WordPress Beta1

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1409,7 +1409,7 @@ Returns an action used to set the rendering mode of the post editor. We support 
 
 _Parameters_
 
--   _mode_ `string`: Mode (one of 'post-only', 'template-locked' or 'all').
+-   _mode_ `string`: Mode (one of 'post-only' or 'template-locked').
 
 ### setTemplateValidity
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5131,26 +5131,38 @@
 			"dev": true
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
-			"integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
 			"dependencies": {
-				"@floating-ui/utils": "^0.1.1"
+				"@floating-ui/utils": "^0.2.1"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
-			"integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+			"integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
 			"dependencies": {
-				"@floating-ui/core": "^1.4.1",
-				"@floating-ui/utils": "^0.1.1"
+				"@floating-ui/core": "^1.0.0",
+				"@floating-ui/utils": "^0.2.0"
+			}
+		},
+		"node_modules/@floating-ui/react-dom": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.6.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
-			"integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+			"integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
 		},
 		"node_modules/@geometricpanda/storybook-addon-badges": {
 			"version": "2.0.1",
@@ -7722,19 +7734,6 @@
 				"@types/react-dom": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@radix-ui/react-select/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-			"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
-			"dev": true,
-			"dependencies": {
-				"@floating-ui/dom": "^1.3.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/primitive": {
@@ -53994,7 +53993,7 @@
 				"@emotion/serialize": "^1.0.2",
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^2.0.1",
+				"@floating-ui/react-dom": "^2.0.8",
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.2.24",
@@ -54042,18 +54041,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/components/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-			"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
-			"dependencies": {
-				"@floating-ui/dom": "^1.3.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"packages/components/node_modules/@types/gradient-parser": {
@@ -59590,26 +59577,34 @@
 			"dev": true
 		},
 		"@floating-ui/core": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
-			"integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
 			"requires": {
-				"@floating-ui/utils": "^0.1.1"
+				"@floating-ui/utils": "^0.2.1"
 			}
 		},
 		"@floating-ui/dom": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
-			"integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+			"integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
 			"requires": {
-				"@floating-ui/core": "^1.4.1",
-				"@floating-ui/utils": "^0.1.1"
+				"@floating-ui/core": "^1.0.0",
+				"@floating-ui/utils": "^0.2.0"
+			}
+		},
+		"@floating-ui/react-dom": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+			"requires": {
+				"@floating-ui/dom": "^1.6.1"
 			}
 		},
 		"@floating-ui/utils": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
-			"integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+			"integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
 		},
 		"@geometricpanda/storybook-addon-badges": {
 			"version": "2.0.1",
@@ -61538,15 +61533,6 @@
 				"react-remove-scroll": "2.5.5"
 			},
 			"dependencies": {
-				"@floating-ui/react-dom": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-					"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
-					"dev": true,
-					"requires": {
-						"@floating-ui/dom": "^1.3.0"
-					}
-				},
 				"@radix-ui/primitive": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
@@ -69135,7 +69121,7 @@
 				"@emotion/serialize": "^1.0.2",
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^2.0.1",
+				"@floating-ui/react-dom": "^2.0.8",
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.2.24",
@@ -69178,14 +69164,6 @@
 				"valtio": "1.7.0"
 			},
 			"dependencies": {
-				"@floating-ui/react-dom": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-					"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
-					"requires": {
-						"@floating-ui/dom": "^1.3.0"
-					}
-				},
 				"@types/gradient-parser": {
 					"version": "0.1.3",
 					"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -340,13 +340,6 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 }
 
-.block-editor-link-control__drawer {
-	display: flex; // allow for ordering.
-	order: 30;
-	flex-direction: column;
-	flex-basis: 100%; // occupy full width.
-}
-
 // Inner div required to avoid padding/margin
 // causing janky animation.
 .block-editor-link-control__drawer-inner {

--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -3,7 +3,7 @@
  */
 import { useRef } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
-import { insert, isCollapsed, toHTMLString } from '@wordpress/rich-text';
+import { insert, toHTMLString } from '@wordpress/rich-text';
 import { getBlockTransforms, findTransform } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 
@@ -45,34 +45,6 @@ function findSelection( blocks ) {
 	}
 
 	return [];
-}
-
-/**
- * An input rule that replaces two spaces with an en space, and an en space
- * followed by a space with an em space.
- *
- * @param {Object} value Value to replace spaces in.
- *
- * @return {Object} Value with spaces replaced.
- */
-function replacePrecedingSpaces( value ) {
-	if ( ! isCollapsed( value ) ) {
-		return value;
-	}
-
-	const { text, start } = value;
-	const lastTwoCharacters = text.slice( start - 2, start );
-
-	// Replace two spaces with an em space.
-	if ( lastTwoCharacters === '  ' ) {
-		return insert( value, '\u2002', start - 2, start );
-	}
-	// Replace an en space followed by a space with an em space.
-	else if ( lastTwoCharacters === '\u2002 ' ) {
-		return insert( value, '\u2003', start - 2, start );
-	}
-
-	return value;
 }
 
 export function useInputRules( props ) {
@@ -155,7 +127,7 @@ export function useInputRules( props ) {
 
 					return accumlator;
 				},
-				preventEventDiscovery( replacePrecedingSpaces( value ) )
+				preventEventDiscovery( value )
 			);
 
 			if ( transformed !== value ) {

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -18,10 +18,6 @@ $input-size: 300px;
 		margin-left: 0;
 		margin-right: 0;
 
-		&:not(:focus) {
-			border-color: transparent;
-		}
-
 		/* Fonts smaller than 16px causes mobile safari to zoom. */
 		font-size: $mobile-text-min-font-size;
 		@include break-small {

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -46,7 +46,7 @@ const createEditFunctionWithBindingsAttribute = () =>
 							settings.source
 						);
 
-						if ( source ) {
+						if ( source && source.useSource ) {
 							// Second argument (`updateMetaValue`) will be used to update the value in the future.
 							const {
 								placeholder,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2057,7 +2057,7 @@ function blockBindingsSources( state = {}, action ) {
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
 				useSource: action.useSource,
-				lockAttributesEditing: action.lockAttributesEditing,
+				lockAttributesEditing: action.lockAttributesEditing ?? true,
 			},
 		};
 	}

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -246,7 +246,7 @@ function ButtonEdit( props ) {
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
 					getBlockBindingsSource( metadata?.bindings?.url?.source )
-						?.lockAttributesEditing === true,
+						?.lockAttributesEditing,
 			};
 		},
 		[ isSelected ]

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -53,7 +53,7 @@ function render_block_core_file( $attributes, $content ) {
 
 		$processor = new WP_HTML_Tag_Processor( $content );
 		$processor->next_tag();
-		$processor->set_attribute( 'data-wp-interactive', '{"namespace":"core/file"}' );
+		$processor->set_attribute( 'data-wp-interactive', 'core/file' );
 		$processor->next_tag( 'object' );
 		$processor->set_attribute( 'data-wp-bind--hidden', '!state.hasPdfPreview' );
 		$processor->set_attribute( 'hidden', true );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -349,7 +349,7 @@ export function ImageEdit( {
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
 					getBlockBindingsSource( metadata?.bindings?.url?.source )
-						?.lockAttributesEditing === true,
+						?.lockAttributesEditing,
 			};
 		},
 		[ isSingleSelected ]

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -427,7 +427,7 @@ export default function Image( {
 				lockUrlControls:
 					!! urlBinding &&
 					getBlockBindingsSource( urlBinding?.source )
-						?.lockAttributesEditing === true,
+						?.lockAttributesEditing,
 				lockHrefControls:
 					// Disable editing the link of the URL if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the link on the frontend.
@@ -435,11 +435,11 @@ export default function Image( {
 				lockAltControls:
 					!! altBinding &&
 					getBlockBindingsSource( altBinding?.source )
-						?.lockAttributesEditing === true,
+						?.lockAttributesEditing,
 				lockTitleControls:
 					!! titleBinding &&
 					getBlockBindingsSource( titleBinding?.source )
-						?.lockAttributesEditing === true,
+						?.lockAttributesEditing,
 			};
 		},
 		[ clientId, isSingleSelected, metadata?.bindings ]

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -159,7 +159,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$figure_class_names = $p->get_attribute( 'class' );
 	$figure_styles      = $p->get_attribute( 'style' );
 	$p->add_class( 'wp-lightbox-container' );
-	$p->set_attribute( 'data-wp-interactive', '{"namespace":"core/image"}' );
+	$p->set_attribute( 'data-wp-interactive', 'core/image' );
 	$p->set_attribute(
 		'data-wp-context',
 		wp_json_encode(
@@ -240,7 +240,7 @@ function block_core_image_print_lightbox_overlay() {
 	echo <<<HTML
 		<div 
 			class="wp-lightbox-overlay zoom"
-			data-wp-interactive='{"namespace":"core/image"}'
+			data-wp-interactive="core/image"
 			data-wp-context='{}'
 			data-wp-bind--role="state.roleAttribute"
 			data-wp-bind--aria-label="state.currentImage.ariaLabel"

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -557,19 +557,17 @@ class WP_Navigation_Block_Renderer {
 			return '';
 		}
 		// When adding to this array be mindful of security concerns.
-		$nav_element_context    = wp_json_encode(
+		$nav_element_context    = data_wp_context(
 			array(
 				'overlayOpenedBy' => array(),
 				'type'            => 'overlay',
 				'roleAttribute'   => '',
 				'ariaLabel'       => __( 'Menu' ),
-			),
-			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP
+			)
 		);
 		$nav_element_directives = '
-			data-wp-interactive=\'{"namespace":"core/navigation"}\'
-			data-wp-context=\'' . $nav_element_context . '\'
-		';
+		 data-wp-interactive="core/navigation"'
+		. $nav_element_context;
 
 		/*
 		* When the navigation's 'overlayMenu' attribute is set to 'always', JavaScript
@@ -780,7 +778,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 		)
 	) ) {
 		// Add directives to the parent `<li>`.
-		$tags->set_attribute( 'data-wp-interactive', '{ "namespace": "core/navigation" }' );
+		$tags->set_attribute( 'data-wp-interactive', 'core/navigation' );
 		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": {}, "type": "submenu" }' );
 		$tags->set_attribute( 'data-wp-watch', 'callbacks.initMenu' );
 		$tags->set_attribute( 'data-wp-on--focusout', 'actions.handleMenuFocusout' );

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -91,14 +91,17 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 	}
 
 	if ( $enhanced_pagination ) {
-		$p = new WP_HTML_Tag_Processor( $content );
+		$p         = new WP_HTML_Tag_Processor( $content );
+		$tag_index = 0;
 		while ( $p->next_tag(
-			array(
-				'tag_name'   => 'a',
-				'class_name' => 'page-numbers',
-			)
+			array( 'class_name' => 'page-numbers' )
 		) ) {
-			$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
+			if ( null === $p->get_attribute( 'data-wp-key' ) ) {
+				$p->set_attribute( 'data-wp-key', 'index-' . $tag_index++ );
+			}
+			if ( 'A' === $p->get_tag() ) {
+				$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
+			}
 		}
 		$content = $p->get_updated_html();
 	}

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -49,7 +49,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 		$p = new WP_HTML_Tag_Processor( $content );
 		if ( $p->next_tag() ) {
 			// Add the necessary directives.
-			$p->set_attribute( 'data-wp-interactive', '{"namespace":"core/query"}' );
+			$p->set_attribute( 'data-wp-interactive', 'core/query' );
 			$p->set_attribute( 'data-wp-router-region', 'query-' . $attributes['queryId'] );
 			$p->set_attribute( 'data-wp-init', 'callbacks.setQueryRef' );
 			$p->set_attribute( 'data-wp-context', '{}' );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -47,7 +47,7 @@ function render_block_core_search( $attributes ) {
 	$border_color_classes = get_border_color_classes_for_block_core_search( $attributes );
 	// This variable is a constant and its value is always false at this moment.
 	// It is defined this way because some values depend on it, in case it changes in the future.
-	$open_by_default = 'false';
+	$open_by_default = false;
 
 	$label_inner_html = empty( $attributes['label'] ) ? __( 'Search' ) : wp_kses_post( $attributes['label'] );
 	$label            = new WP_HTML_Tag_Processor( sprintf( '<label %1$s>%2$s</label>', $inline_styles['label'], $label_inner_html ) );
@@ -179,12 +179,20 @@ function render_block_core_search( $attributes ) {
 	if ( $is_expandable_searchfield ) {
 		$aria_label_expanded  = __( 'Submit Search' );
 		$aria_label_collapsed = __( 'Expand search field' );
+		$form_context         = data_wp_context(
+			array(
+				'isSearchInputVisible' => $open_by_default,
+				'inputId'              => $input_id,
+				'ariaLabelExpanded'    => $aria_label_expanded,
+				'ariaLabelCollapsed'   => $aria_label_collapsed,
+			)
+		);
 		$form_directives      = '
-			data-wp-interactive=\'{ "namespace": "core/search" }\'
-			data-wp-context=\'{ "isSearchInputVisible": ' . $open_by_default . ', "inputId": "' . $input_id . '", "ariaLabelExpanded": "' . $aria_label_expanded . '", "ariaLabelCollapsed": "' . $aria_label_collapsed . '" }\'
-			data-wp-class--wp-block-search__searchfield-hidden="!context.isSearchInputVisible"
-			data-wp-on--keydown="actions.handleSearchKeydown"
-			data-wp-on--focusout="actions.handleSearchFocusout"
+		 data-wp-interactive=\'"core/search"\''
+		. $form_context .
+		'data-wp-class--wp-block-search__searchfield-hidden="!context.isSearchInputVisible"
+		 data-wp-on--keydown="actions.handleSearchKeydown"
+		 data-wp-on--focusout="actions.handleSearchFocusout"
 		';
 	}
 

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -93,9 +93,14 @@ const SpacerEdit = ( {
 		return editorSettings?.disableCustomSpacingSizes;
 	} );
 	const { orientation } = context;
-	const { orientation: parentOrientation, type } = parentLayout || {};
+	const {
+		orientation: parentOrientation,
+		type,
+		default: { type: defaultType } = {},
+	} = parentLayout || {};
 	// Check if the spacer is inside a flex container.
-	const isFlexLayout = type === 'flex';
+	const isFlexLayout =
+		type === 'flex' || ( ! type && defaultType === 'flex' );
 	// If the spacer is inside a flex container, it should either inherit the orientation
 	// of the parent or use the flex default orientation.
 	const inheritedOrientation =

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -42,5 +42,7 @@
 
 	&.resize-horizontal {
 		margin-bottom: 0;
+		// Important is used to have higher specificity than the inline style set by re-resizable library.
+		height: 100% !important;
 	}
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `Popover`: Fix positioning in nested iframes by upgrading Floating UI packages to their latest versions ([#58932](https://github.com/WordPress/gutenberg/pull/58932)).
+
 ## 26.0.0 (2024-02-09)
 
 ### Breaking Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -38,7 +38,7 @@
 		"@emotion/serialize": "^1.0.2",
 		"@emotion/styled": "^11.6.0",
 		"@emotion/utils": "^1.0.0",
-		"@floating-ui/react-dom": "^2.0.1",
+		"@floating-ui/react-dom": "^2.0.8",
 		"@types/gradient-parser": "0.1.3",
 		"@types/highlight-words-core": "1.2.1",
 		"@use-gesture/react": "^10.2.24",

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import {
 	Dropdown,
-	Button,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	FlexItem,
@@ -133,40 +132,6 @@ function OperatorSelector( { filter, view, onChangeView } ) {
 	);
 }
 
-function ResetFilter( { filter, view, onChangeView, addFilterRef } ) {
-	const isDisabled =
-		filter.isPrimary &&
-		view.filters.find( ( _filter ) => _filter.field === filter.field )
-			?.value === undefined;
-	return (
-		<div className="dataviews-filter-summary__reset">
-			<Button
-				disabled={ isDisabled }
-				__experimentalIsFocusable
-				size="compact"
-				variant="tertiary"
-				style={ { justifyContent: 'center', width: '100%' } }
-				onClick={ () => {
-					onChangeView( {
-						...view,
-						page: 1,
-						filters: view.filters.filter(
-							( _filter ) => _filter.field !== filter.field
-						),
-					} );
-					// If the filter is not primary and can be removed, it will be added
-					// back to the available filters from `Add filter` component.
-					if ( ! filter.isPrimary ) {
-						addFilterRef.current?.focus();
-					}
-				} }
-			>
-				{ filter.isPrimary ? __( 'Reset' ) : __( 'Remove' ) }
-			</Button>
-		</div>
-	);
-}
-
 export default function FilterSummary( {
 	addFilterRef,
 	openedFilter,
@@ -269,10 +234,6 @@ export default function FilterSummary( {
 					<VStack spacing={ 0 } justify="flex-start">
 						<OperatorSelector { ...commonProps } />
 						<SearchWidget { ...commonProps } />
-						<ResetFilter
-							{ ...commonProps }
-							addFilterRef={ addFilterRef }
-						/>
 					</VStack>
 				);
 			} }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -627,11 +627,6 @@
 	}
 }
 
-.dataviews-filter-summary__reset {
-	padding: $grid-unit-05;
-	border-top: 1px solid $gray-200;
-}
-
 .dataviews-filter-summary__chip-container {
 	position: relative;
 	white-space: pre-wrap;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -89,15 +89,13 @@ function Editor( {
 		);
 
 	const { updatePreferredStyleVariations } = useDispatch( editPostStore );
-	const defaultRenderingMode =
-		currentPost.postType === 'wp_template' ? 'all' : 'post-only';
 
 	const editorSettings = useMemo(
 		() => ( {
 			...settings,
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
-			defaultRenderingMode,
+			defaultRenderingMode: 'post-only',
 			__experimentalPreferredStyleVariations: {
 				value: preferredStyleVariations,
 				onChange: updatePreferredStyleVariations,
@@ -111,7 +109,6 @@ function Editor( {
 			updatePreferredStyleVariations,
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
-			defaultRenderingMode,
 		]
 	);
 

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -103,10 +103,7 @@ export function initializeEditor(
 		'blockEditor.__unstableCanInsertBlockType',
 		'removeTemplatePartsFromInserter',
 		( canInsert, blockType ) => {
-			if (
-				select( editorStore ).getRenderingMode() === 'post-only' &&
-				blockType.name === 'core/template-part'
-			) {
+			if ( blockType.name === 'core/template-part' ) {
 				return false;
 			}
 			return canInsert;
@@ -128,10 +125,7 @@ export function initializeEditor(
 			rootClientId,
 			{ getBlockParentsByBlockName }
 		) => {
-			if (
-				select( editorStore ).getRenderingMode() === 'post-only' &&
-				blockType.name === 'core/post-content'
-			) {
+			if ( blockType.name === 'core/post-content' ) {
 				return (
 					getBlockParentsByBlockName( rootClientId, 'core/query' )
 						.length > 0

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -556,7 +556,7 @@ export const isEditingTemplate = createRegistrySelector( ( select ) => () => {
 		since: '6.5',
 		alternative: `select( 'core/editor' ).getRenderingMode`,
 	} );
-	return select( editorStore ).getRenderingMode() !== 'post-only';
+	return select( editorStore ).getCurrentPostType() !== 'post-only';
 } );
 
 /**

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -144,7 +144,9 @@ export function useSpecificEditorSettings() {
 		[]
 	);
 	const archiveLabels = useArchiveLabel( templateSlug );
-	const defaultRenderingMode = postWithTemplate ? 'template-locked' : 'all';
+	const defaultRenderingMode = postWithTemplate
+		? 'template-locked'
+		: 'post-only';
 	const onNavigateToPreviousEntityRecord =
 		useNavigateToPreviousEntityRecord();
 	const defaultEditorSettings = useMemo( () => {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -61,15 +61,6 @@ function FontLibraryProvider( { children } ) {
 		setRefreshKey( Date.now() );
 	};
 
-	// Reset notice on dismiss.
-	useEffect( () => {
-		if ( notice ) {
-			notice.onRemove = () => {
-				setNotice( null );
-			};
-		}
-	}, [ notice, setNotice ] );
-
 	const {
 		records: libraryPosts = [],
 		isResolving: isResolvingLibrary,

--- a/packages/edit-site/src/components/global-styles/font-library-modal/tab-panel-layout.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/tab-panel-layout.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useContext } from '@wordpress/element';
 import {
 	__experimentalText as Text,
 	__experimentalHeading as Heading,
@@ -14,6 +15,11 @@ import {
 import { chevronLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { FontLibraryContext } from './context';
+
 function TabPanelLayout( {
 	title,
 	description,
@@ -22,6 +28,8 @@ function TabPanelLayout( {
 	children,
 	footer,
 } ) {
+	const { setNotice } = useContext( FontLibraryContext );
+
 	return (
 		<div className="font-library-modal__tabpanel-layout">
 			<Spacer margin={ 4 } />
@@ -53,7 +61,7 @@ function TabPanelLayout( {
 							<Spacer margin={ 1 } />
 							<Notice
 								status={ notice.type }
-								onRemove={ notice.onRemove }
+								onRemove={ () => setNotice( null ) }
 							>
 								{ notice.message }
 							</Notice>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -63,6 +63,12 @@ function UploadFonts() {
 		} );
 		if ( allowedFiles.length > 0 ) {
 			loadFiles( allowedFiles );
+		} else {
+			setNotice( {
+				type: 'error',
+				message: __( 'No fonts found to install.' ),
+			} );
+			setIsUploading( false );
 		}
 	};
 

--- a/packages/edit-site/src/components/start-template-options/index.js
+++ b/packages/edit-site/src/components/start-template-options/index.js
@@ -4,10 +4,7 @@
 import { Modal, Flex, FlexItem, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
-import {
-	__experimentalBlockPatternsList as BlockPatternsList,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useAsyncList } from '@wordpress/compose';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -42,14 +39,13 @@ function useFallbackTemplateContent( slug, isCustom = false ) {
 function useStartPatterns( fallbackContent ) {
 	const { slug, patterns } = useSelect( ( select ) => {
 		const { getEditedPostType, getEditedPostId } = select( editSiteStore );
-		const { getEntityRecord } = select( coreStore );
+		const { getEntityRecord, getBlockPatterns } = select( coreStore );
 		const postId = getEditedPostId();
 		const postType = getEditedPostType();
 		const record = getEntityRecord( 'postType', postType, postId );
-		const { getSettings } = select( blockEditorStore );
 		return {
 			slug: record.slug,
-			patterns: getSettings().__experimentalBlockPatterns,
+			patterns: getBlockPatterns(),
 		};
 	}, [] );
 

--- a/packages/editor/src/bindings/index.js
+++ b/packages/editor/src/bindings/index.js
@@ -7,7 +7,9 @@ import { dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
+import patternOverrides from './pattern-overrides';
 import postMeta from './post-meta';
 
 const { registerBlockBindingsSource } = unlock( dispatch( blockEditorStore ) );
+registerBlockBindingsSource( patternOverrides );
 registerBlockBindingsSource( postMeta );

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { _x } from '@wordpress/i18n';
+
+export default {
+	name: 'core/pattern-overrides',
+	label: _x( 'Pattern Overrides', 'block bindings source' ),
+	useSource: null,
+	lockAttributesEditing: false,
+};

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -3,7 +3,7 @@
  */
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -11,7 +11,7 @@ import { store as editorStore } from '../store';
 
 export default {
 	name: 'core/post-meta',
-	label: __( 'Post Meta' ),
+	label: _x( 'Post Meta', 'block bindings source' ),
 	useSource( props, sourceAttributes ) {
 		const { getCurrentPostType } = useSelect( editorStore );
 		const { context } = props;
@@ -38,5 +38,4 @@ export default {
 			useValue: [ metaValue, updateMetaValue ],
 		};
 	},
-	lockAttributesEditing: true,
 };

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -41,6 +41,17 @@ const {
 const noop = () => {};
 
 /**
+ * These post types have a special editor where they don't allow you to fill the title
+ * and they don't apply the layout styles.
+ */
+const DESIGN_POST_TYPES = [
+	'wp_block',
+	'wp_template',
+	'wp_navigation',
+	'wp_template_part',
+];
+
+/**
  * Given an array of nested blocks, find the first Post Content
  * block inside it, recursing through any nesting levels,
  * and return its attributes.
@@ -93,6 +104,7 @@ function EditorCanvas( {
 		wrapperUniqueId,
 		deviceType,
 		showEditorPadding,
+		isDesignPostType,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostId,
@@ -130,6 +142,7 @@ function EditorCanvas( {
 		return {
 			renderingMode: _renderingMode,
 			postContentAttributes: editorSettings.postContentAttributes,
+			isDesignPostType: DESIGN_POST_TYPES.includes( postTypeSlug ),
 			// Post template fetch returns a 404 on classic themes, which
 			// messes with e2e tests, so check it's a block theme first.
 			editedPostTemplate:
@@ -164,7 +177,7 @@ function EditorCanvas( {
 	// fallbackLayout is used if there is no Post Content,
 	// and for Post Title.
 	const fallbackLayout = useMemo( () => {
-		if ( renderingMode !== 'post-only' ) {
+		if ( renderingMode !== 'post-only' || isDesignPostType ) {
 			return { type: 'default' };
 		}
 
@@ -175,7 +188,12 @@ function EditorCanvas( {
 		}
 		// Set default layout for classic themes so all alignments are supported.
 		return { type: 'default' };
-	}, [ renderingMode, themeSupportsLayout, globalLayoutSettings ] );
+	}, [
+		renderingMode,
+		themeSupportsLayout,
+		globalLayoutSettings,
+		isDesignPostType,
+	] );
 
 	const newestPostContentAttributes = useMemo( () => {
 		if (
@@ -318,7 +336,8 @@ function EditorCanvas( {
 		>
 			{ themeSupportsLayout &&
 				! themeHasDisabledLayoutStyles &&
-				renderingMode === 'post-only' && (
+				renderingMode === 'post-only' &&
+				! isDesignPostType && (
 					<>
 						<LayoutStyle
 							selector=".editor-editor-canvas__post-title-wrapper"
@@ -337,7 +356,7 @@ function EditorCanvas( {
 						) }
 					</>
 				) }
-			{ renderingMode === 'post-only' && (
+			{ renderingMode === 'post-only' && ! isDesignPostType && (
 				<div
 					className={ classnames(
 						'editor-editor-canvas__post-title-wrapper',
@@ -367,7 +386,7 @@ function EditorCanvas( {
 					className={ classnames(
 						className,
 						'is-' + deviceType.toLowerCase() + '-preview',
-						renderingMode !== 'post-only'
+						renderingMode !== 'post-only' || isDesignPostType
 							? 'wp-site-blocks'
 							: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
 					) }

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -110,7 +110,7 @@ function EditorCanvas( {
 
 		if ( postTypeSlug === 'wp_block' ) {
 			_wrapperBlockName = 'core/block';
-		} else if ( ! _renderingMode === 'post-only' ) {
+		} else if ( _renderingMode === 'post-only' ) {
 			_wrapperBlockName = 'core/post-content';
 		}
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -585,7 +585,7 @@ export function updateEditorSettings( settings ) {
  * -   `post-only`: This mode extracts the post blocks from the template and renders only those. The idea is to allow the user to edit the post/page in isolation without the wrapping template.
  * -   `template-locked`: This mode renders both the template and the post blocks but the template blocks are locked and can't be edited. The post blocks are editable.
  *
- * @param {string} mode Mode (one of 'post-only', 'template-locked' or 'all').
+ * @param {string} mode Mode (one of 'post-only' or 'template-locked').
  */
 export const setRenderingMode =
 	( mode ) =>

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -266,7 +266,7 @@ export function editorSettings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
 	return state;
 }
 
-export function renderingMode( state = 'all', action ) {
+export function renderingMode( state = 'post-only', action ) {
 	switch ( action.type ) {
 		case 'SET_RENDERING_MODE':
 			return action.mode;

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -48,17 +48,6 @@ function Edit( {
 			return;
 		}
 
-		// Close the Link popover if there is no active selection
-		// after the link was added - this can happen if the user
-		// adds a link without any text selected.
-		// We assume that if there is no active selection after
-		// link insertion there are no active formats.
-		if ( ! value.activeFormats ) {
-			editableContentElement.focus();
-			setAddingLink( false );
-			return;
-		}
-
 		function handleClick( event ) {
 			// There is a situation whereby there is an existing link in the rich text
 			// and the user clicks on the leftmost edge of that link and fails to activate
@@ -78,7 +67,7 @@ function Edit( {
 		return () => {
 			editableContentElement.removeEventListener( 'click', handleClick );
 		};
-	}, [ contentRef, isActive, addingLink, value ] );
+	}, [ contentRef, isActive ] );
 
 	function addLink( target ) {
 		const text = getTextContent( slice( value ) );

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -21,7 +21,6 @@ import {
 import {
 	__experimentalLinkControl as LinkControl,
 	store as blockEditorStore,
-	useCachedTruthy,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
@@ -195,27 +194,8 @@ function InlineLinkUI( {
 
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
-		settings,
+		settings: { ...settings, isActive },
 	} );
-
-	//  As you change the link by interacting with the Link UI
-	//  the return value of document.getSelection jumps to the field you're editing,
-	//  not the highlighted text. Given that useAnchor uses document.getSelection,
-	//  it will return null, since it can't find the <mark> element within the Link UI.
-	//  This caches the last truthy value of the selection anchor reference.
-	// This ensures the Popover is positioned correctly on initial submission of the link.
-	const cachedRect = useCachedTruthy( popoverAnchor.getBoundingClientRect() );
-
-	// If the link is not active (i.e. it is a new link) then we need to
-	// override the getBoundingClientRect method on the anchor element
-	// to return the cached value of the selection represented by the text
-	// that the user selected to be linked.
-	// If the link is active (i.e. it is an existing link) then we allow
-	// the default behaviour of the popover anchor to be used. This will get
-	// the anchor based on the `<a>` element in the rich text.
-	if ( ! isActive ) {
-		popoverAnchor.getBoundingClientRect = () => cachedRect;
-	}
 
 	async function handleCreate( pageTitle ) {
 		const page = await createPageEntity( {

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -120,6 +120,7 @@ function TextColorEdit( {
 					value={ value }
 					onChange={ onChange }
 					contentRef={ contentRef }
+					isActive={ isActive }
 				/>
 			) }
 		</>

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -15,7 +15,6 @@ import {
 	getColorObjectByColorValue,
 	getColorObjectByAttributeValues,
 	store as blockEditorStore,
-	useCachedTruthy,
 } from '@wordpress/block-editor';
 import {
 	Popover,
@@ -147,21 +146,12 @@ export default function InlineColorUI( {
 	onChange,
 	onClose,
 	contentRef,
+	isActive,
 } ) {
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
-		settings,
+		settings: { ...settings, isActive },
 	} );
-
-	/*
-	 As you change the text color by typing a HEX value into a field,
-	 the return value of document.getSelection jumps to the field you're editing,
-	 not the highlighted text. Given that useAnchor uses document.getSelection,
-	 it will return null, since it can't find the <mark> element within the HEX input.
-	 This caches the last truthy value of the selection anchor reference.
-	 */
-	const cachedRect = useCachedTruthy( popoverAnchor.getBoundingClientRect() );
-	popoverAnchor.getBoundingClientRect = () => cachedRect;
 
 	return (
 		<Popover

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { usePrevious } from '@wordpress/compose';
 import { useState, useLayoutEffect } from '@wordpress/element';
 
 /** @typedef {import('../register-format-type').WPFormat} WPFormat */
@@ -137,44 +138,31 @@ function getAnchor( editableContentElement, tagName, className ) {
  * @return {Element|VirtualAnchorElement|undefined|null} The active element or selection range.
  */
 export function useAnchor( { editableContentElement, settings = {} } ) {
-	const { tagName, className } = settings;
+	const { tagName, className, isActive } = settings;
 	const [ anchor, setAnchor ] = useState( () =>
 		getAnchor( editableContentElement, tagName, className )
 	);
+	const wasActive = usePrevious( isActive );
 
 	useLayoutEffect( () => {
 		if ( ! editableContentElement ) return;
 
 		const { ownerDocument } = editableContentElement;
 
-		function callback() {
+		if (
+			editableContentElement === ownerDocument.activeElement ||
+			// When a link is created, we need to attach the popover to the newly created anchor.
+			( ! wasActive && isActive ) ||
+			// Sometimes we're _removing_ an active anchor, such as the inline color popover.
+			// When we add the color, it switches from a virtual anchor to a `<mark>` element.
+			// When we _remove_ the color, it switches from a `<mark>` element to a virtual anchor.
+			( wasActive && ! isActive )
+		) {
 			setAnchor(
 				getAnchor( editableContentElement, tagName, className )
 			);
 		}
-
-		function attach() {
-			ownerDocument.addEventListener( 'selectionchange', callback );
-		}
-
-		function detach() {
-			ownerDocument.removeEventListener( 'selectionchange', callback );
-		}
-
-		if ( editableContentElement === ownerDocument.activeElement ) {
-			attach();
-		}
-
-		editableContentElement.addEventListener( 'focusin', attach );
-		editableContentElement.addEventListener( 'focusout', detach );
-
-		return () => {
-			detach();
-
-			editableContentElement.removeEventListener( 'focusin', attach );
-			editableContentElement.removeEventListener( 'focusout', detach );
-		};
-	}, [ editableContentElement, tagName, className ] );
+	}, [ editableContentElement, tagName, className, isActive, wasActive ] );
 
 	return anchor;
 }

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -86,7 +86,7 @@ HTML;
 		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
 		$this->assertSame( '{}', $p->get_attribute( 'data-wp-context' ) );
 		$this->assertSame( 'query-0', $p->get_attribute( 'data-wp-router-region' ) );
-		$this->assertSame( '{"namespace":"core/query"}', $p->get_attribute( 'data-wp-interactive' ) );
+		$this->assertSame( 'core/query', $p->get_attribute( 'data-wp-interactive' ) );
 
 		$p->next_tag( array( 'class_name' => 'wp-block-post' ) );
 		$this->assertSame( 'post-template-item-' . self::$posts[1], $p->get_attribute( 'data-wp-key' ) );

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -1026,8 +1026,8 @@ test.describe( 'Links', () => {
 			pageUtils,
 			editor,
 		} ) => {
-			const textToSelect = `\u2003\u2003 spaces\u2003 `;
-			const textWithWhitespace = `Text with leading and trailing       spaces    `;
+			const textToSelect = `         spaces     `;
+			const textWithWhitespace = `Text with leading and trailing${ textToSelect }`;
 
 			// Create a block with some text.
 			await editor.insertBlock( {


### PR DESCRIPTION
It includes this list:
 
   #58505 – Restore default border and focus style on image url input field.
   #58909 – Spacer block: Fix `null` label in tooltip when horizontal layout
   #58921 – Fix Spacer orientation when inside a block with default flex layout.
   #58792 – Revert "Rich text: pad multiple spaces through en/em replacement"
   #58813 – Site editor: fix start patterns store selector
   #58932 – Upgrade Floating UI packages, fix nested iframe positioning bug
   #58900 – Fix incorrect useAnchor positioning when switching from virtual to rich text elements
   #58896 – Close link preview if collapsed selection when creating link
   #58189 – Pagination Numbers: Add `data-wp-key` to pagination numbers if enhanced pagination is enabled
   #58935 – Editor: Remove the 'all' rendering mode
   #58787 – Block Bindings: lock editing of blocks by default
   #58914 – Font Library: Show error message when no fonts found to install
   #58934 – Clean up link control CSS.
   #58943 – Use `data_wp_context` helper in core blocks and remove `data-wp-interactive` object
   #58962 – Fix layout for non viewable post types
   #58960 - Remove second `reset filter` button in filter dialog

---

I'm targeting release/17.7 for now but I'll keep this in sync with wp/latest and I'll will create wp/6.5 afterwards.