### PR TITLE
Shadows: disable shadow in theme.json block settings and in classic themes

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -871,6 +871,10 @@ class WP_Theme_JSON_Gutenberg {
 		$schema['settings']['blocks']                     = $schema_settings_blocks;
 		$schema['settings']['typography']['fontFamilies'] = static::schema_in_root_and_per_origin( static::FONT_FAMILY_SCHEMA );
 
+		if ( ! wp_theme_has_theme_json() ) {
+			$schema['settings']['shadow'] = null;
+		}
+
 		// Remove anything that's not present in the schema.
 		foreach ( array( 'styles', 'settings' ) as $subtree ) {
 			if ( ! isset( $input[ $subtree ] ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -871,9 +871,7 @@ class WP_Theme_JSON_Gutenberg {
 		$schema['settings']['blocks']                     = $schema_settings_blocks;
 		$schema['settings']['typography']['fontFamilies'] = static::schema_in_root_and_per_origin( static::FONT_FAMILY_SCHEMA );
 
-		if ( ! wp_theme_has_theme_json() ) {
-			$schema['settings']['shadow'] = null;
-		}
+		// $schema['settings']['shadow'] = null;
 
 		// Remove anything that's not present in the schema.
 		foreach ( array( 'styles', 'settings' ) as $subtree ) {
@@ -1079,7 +1077,13 @@ class WP_Theme_JSON_Gutenberg {
 					}
 				}
 			} elseif ( is_array( $schema[ $key ] ) && ! is_array( $tree[ $key ] ) ) {
-				unset( $tree[ $key ] );
+				// special case for shadow, it can either be boolean or object
+				if ( 'shadow' === $key && ! $tree[ $key ] ) {
+					// Do not unset
+				} else {
+					// If the schema is an array and the value is not, remove the key.
+					unset( $tree[ $key ] );
+				}
 			}
 		}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -339,6 +339,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				);
 			}
 
+			// Disable shadow support for themes without theme.json.
+			$theme_support_data['settings']['shadow'] = false;
+
 			// BEGIN EXPERIMENTAL.
 			// Allow themes to enable appearance tools via theme_support.
 			// This feature was backported for WordPress 6.2 as of https://core.trac.wordpress.org/ticket/56487

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -72,38 +72,47 @@
 			"properties": {
 				"shadow": {
 					"description": "Settings related to shadows.",
-					"type": "object",
-					"properties": {
-						"defaultPresets": {
-							"description": "Allow users to choose shadows from the default shadow presets.",
-							"type": "boolean",
-							"default": true
-						},
-						"presets": {
-							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",
-							"type": "array",
-							"items": {
-								"type": "object",
-								"properties": {
-									"name": {
-										"description": "Name of the shadow preset, translatable.",
-										"type": "string"
-									},
-									"slug": {
-										"description": "Kebab-case unique identifier for the shadow preset.",
-										"type": "string"
-									},
-									"shadow": {
-										"description": "CSS box-shadow value",
-										"type": "string"
-									}
+					"oneOf": [
+						{ "type": "boolean" },
+						{
+							"type": "object",
+							"properties": {
+								"defaultPresets": {
+									"description": "Allow users to choose shadows from the default shadow presets.",
+									"type": "boolean",
+									"default": true
 								},
-								"required": [ "name", "slug", "shadow" ],
-								"additionalProperties": false
-							}
+								"presets": {
+									"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the shadow preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case unique identifier for the shadow preset.",
+												"type": "string"
+											},
+											"shadow": {
+												"description": "CSS box-shadow value",
+												"type": "string"
+											}
+										},
+										"required": [
+											"name",
+											"slug",
+											"shadow"
+										],
+										"additionalProperties": false
+									}
+								}
+							},
+							"additionalProperties": false
 						}
-					},
-					"additionalProperties": false
+					]
 				}
 			}
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR addresses the following

1. Allow the shadow control to be removed based on the block settings in `theme.json`

```
{
  "settings": {
     "blocks": {
        "core/button": {
           "border": {
		"radius": false
           },
           "shadow": false
        }
     }
  }
}
```

2. Remove shadow control in classic themes as the [default presets are disabled by default](https://github.com/WordPress/gutenberg/pull/58766) and classic themes cannot opt-in (for now)

**WORK IN PROGRESS**

Fixes: #58908
