### PR TITLE
Components: Try fixing some flaky `Composite` and `Tabs` tests

### DIFF
--- a/packages/components/src/composite/legacy/test/index.tsx
+++ b/packages/components/src/composite/legacy/test/index.tsx
@@ -275,7 +275,7 @@ describe.each( [
 		const { item2 } = getOneDimensionalItems();
 
 		await press.Tab();
-		expect( item2 ).toHaveFocus();
+		await waitFor( () => expect( item2 ).toHaveFocus() );
 	} );
 } );
 

--- a/packages/components/src/composite/legacy/test/index.tsx
+++ b/packages/components/src/composite/legacy/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { queryByAttribute, render, screen } from '@testing-library/react';
-import { press, waitFor } from '@ariakit/test';
+import { press, sleep, waitFor } from '@ariakit/test';
 
 /**
  * Internal dependencies
@@ -274,6 +274,7 @@ describe.each( [
 		renderAndValidate( <Test /> );
 		const { item2 } = getOneDimensionalItems();
 
+		await sleep();
 		await press.Tab();
 		await waitFor( () => expect( item2 ).toHaveFocus() );
 	} );

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1319,6 +1319,7 @@ describe( 'Tabs', () => {
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 
 				// Tab key should focus the currently selected tab, which is Beta.
+				await sleep();
 				await press.Tab();
 				await waitFor( async () =>
 					expect(

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1320,9 +1320,11 @@ describe( 'Tabs', () => {
 
 				// Tab key should focus the currently selected tab, which is Beta.
 				await press.Tab();
-				expect(
-					await screen.findByRole( 'tab', { name: 'Beta' } )
-				).toHaveFocus();
+				await waitFor( async () =>
+					expect(
+						await screen.findByRole( 'tab', { name: 'Beta' } )
+					).toHaveFocus()
+				);
 
 				// Arrow key should move focus but not automatically change the selected tab.
 				await press.ArrowRight();


### PR DESCRIPTION
## What?
This PR adds some flexibility to a few `Composite` and `Tabs` tests.

## Why?
To reduce the test flakiness.

## How?
We're adding some wait time before checking focus right after tabbing.

## Testing Instructions
Verify all tests pass.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None