### PR TITLE
Revert "Block Hooks: Set ignoredHookedBlocks metada attr upon insertion"

### DIFF
--- a/docs/reference-guides/data/data-core-blocks.md
+++ b/docs/reference-guides/data/data-core-blocks.md
@@ -504,54 +504,6 @@ _Returns_
 
 -   `string?`: Name of the block for handling the grouping of blocks.
 
-### getHookedBlocks
-
-Returns the hooked blocks for a given anchor block.
-
-Given an anchor block name, returns an object whose keys are relative positions, and whose values are arrays of block names that are hooked to the anchor block at that relative position.
-
-_Usage_
-
-```js
-import { store as blocksStore } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
-
-const ExampleComponent = () => {
-	const hookedBlockNames = useSelect(
-		( select ) =>
-			select( blocksStore ).getHookedBlocks( 'core/navigation' ),
-		[]
-	);
-
-	return (
-		<ul>
-			{ Object.keys( hookedBlockNames ).length &&
-				Object.keys( hookedBlockNames ).map( ( relativePosition ) => (
-					<li key={ relativePosition }>
-						{ relativePosition }>
-						<ul>
-							{ hookedBlockNames[ relativePosition ].map(
-								( hookedBlock ) => (
-									<li key={ hookedBlock }>{ hookedBlock }</li>
-								)
-							) }
-						</ul>
-					</li>
-				) ) }
-		</ul>
-	);
-};
-```
-
-_Parameters_
-
--   _state_ `Object`: Data state.
--   _blockName_ `string`: Anchor block type name.
-
-_Returns_
-
--   `Object`: Lists of hooked block names for each relative position.
-
 ### getUnregisteredFallbackBlockName
 
 Returns the name of the block for handling unregistered blocks.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -10,7 +10,6 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getBlockVariations,
-	getHookedBlocks,
 	hasBlockSupport,
 	getPossibleBlockTransformations,
 	parse,
@@ -1937,16 +1936,9 @@ const buildBlockTypeItem =
 			blockType.name,
 			'inserter'
 		);
-
-		const ignoredHookedBlocks = [
-			...new Set( Object.values( getHookedBlocks( id ) ).flat() ),
-		];
-
 		return {
 			...blockItemBase,
-			initialAttributes: ignoredHookedBlocks.length
-				? { metadata: { ignoredHookedBlocks } }
-				: {},
+			initialAttributes: {},
 			description: blockType.description,
 			category: blockType.category,
 			keywords: blockType.keywords,

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -234,20 +234,6 @@ _Returns_
 
 -   `?string`: Block name.
 
-### getHookedBlocks
-
-Returns the hooked blocks for a given anchor block.
-
-Given an anchor block name, returns an object whose keys are relative positions, and whose values are arrays of block names that are hooked to the anchor block at that relative position.
-
-_Parameters_
-
--   _name_ `string`: Anchor block name.
-
-_Returns_
-
--   `Object`: Lists of hooked block names for each relative position.
-
 ### getPhrasingContentSchema
 
 Undocumented declaration.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -124,7 +124,6 @@ export {
 	getBlockTypes,
 	getBlockSupport,
 	hasBlockSupport,
-	getHookedBlocks,
 	getBlockVariations,
 	isReusableBlock,
 	isTemplatePart,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -551,21 +551,6 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
 }
 
 /**
- * Returns the hooked blocks for a given anchor block.
- *
- * Given an anchor block name, returns an object whose keys are relative positions,
- * and whose values are arrays of block names that are hooked to the anchor block
- * at that relative position.
- *
- * @param {string} name Anchor block name.
- *
- * @return {Object} Lists of hooked block names for each relative position.
- */
-export function getHookedBlocks( name ) {
-	return select( blocksStore ).getHookedBlocks( name );
-}
-
-/**
  * Determines whether or not the given block is a reusable block. This is a
  * special block type that is used to point to a global block stored via the
  * API.

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -8,7 +8,7 @@ import { renderToString } from '@wordpress/element';
  */
 import { convertLegacyBlockNameAndAttributes } from './parser/convert-legacy-block';
 import { createBlock } from './factory';
-import { getBlockType, getHookedBlocks } from './registration';
+import { getBlockType } from './registration';
 
 /**
  * Checks whether a list of blocks matches a template by comparing the block names.
@@ -114,35 +114,6 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 					name,
 					normalizedAttributes
 				);
-
-			const ignoredHookedBlocks = [
-				...new Set(
-					Object.values( getHookedBlocks( blockName ) ).flat()
-				),
-			];
-
-			if ( ignoredHookedBlocks.length ) {
-				const { metadata = {}, ...otherAttributes } = blockAttributes;
-				const {
-					ignoredHookedBlocks: ignoredHookedBlocksFromTemplate = [],
-					...otherMetadata
-				} = metadata;
-
-				const newIgnoredHookedBlocks = [
-					...new Set( [
-						...ignoredHookedBlocks,
-						...ignoredHookedBlocksFromTemplate,
-					] ),
-				];
-
-				blockAttributes = {
-					metadata: {
-						ignoredHookedBlocks: newIgnoredHookedBlocks,
-						...otherMetadata,
-					},
-					...otherAttributes,
-				};
-			}
 
 			// If a Block is undefined at this point, use the core/missing block as
 			// a placeholder for a better user experience.

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -28,11 +28,7 @@ describe( 'templates', () => {
 
 	beforeEach( () => {
 		registerBlockType( 'core/test-block', {
-			attributes: {
-				metadata: {
-					type: 'object',
-				},
-			},
+			attributes: {},
 			save: noop,
 			category: 'text',
 			title: 'test block',
@@ -131,80 +127,6 @@ describe( 'templates', () => {
 				synchronizeBlocksWithTemplate( blockList, template )
 			).toMatchObject( [
 				{ name: 'core/test-block' },
-				{ name: 'core/test-block-2' },
-				{ name: 'core/test-block-2' },
-			] );
-		} );
-
-		it( 'should set ignoredHookedBlocks metadata if a block has hooked blocks', () => {
-			registerBlockType( 'core/hooked-block', {
-				attributes: {},
-				save: noop,
-				category: 'text',
-				title: 'hooked block',
-				blockHooks: { 'core/test-block': 'after' },
-			} );
-
-			const template = [
-				[ 'core/test-block' ],
-				[ 'core/test-block-2' ],
-				[ 'core/test-block-2' ],
-			];
-			const blockList = [];
-
-			expect(
-				synchronizeBlocksWithTemplate( blockList, template )
-			).toMatchObject( [
-				{
-					name: 'core/test-block',
-					attributes: {
-						metadata: {
-							ignoredHookedBlocks: [ 'core/hooked-block' ],
-						},
-					},
-				},
-				{ name: 'core/test-block-2' },
-				{ name: 'core/test-block-2' },
-			] );
-		} );
-
-		it( 'retains previously set ignoredHookedBlocks metadata', () => {
-			registerBlockType( 'core/hooked-block', {
-				attributes: {},
-				save: noop,
-				category: 'text',
-				title: 'hooked block',
-				blockHooks: { 'core/test-block': 'after' },
-			} );
-
-			const template = [
-				[
-					'core/test-block',
-					{
-						metadata: {
-							ignoredHookedBlocks: [ 'core/other-hooked-block' ],
-						},
-					},
-				],
-				[ 'core/test-block-2' ],
-				[ 'core/test-block-2' ],
-			];
-			const blockList = [];
-
-			expect(
-				synchronizeBlocksWithTemplate( blockList, template )
-			).toMatchObject( [
-				{
-					name: 'core/test-block',
-					attributes: {
-						metadata: {
-							ignoredHookedBlocks: [
-								'core/hooked-block',
-								'core/other-hooked-block',
-							],
-						},
-					},
-				},
 				{ name: 'core/test-block-2' },
 				{ name: 'core/test-block-2' },
 			] );

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -107,68 +107,6 @@ export function getBlockType( state, name ) {
 }
 
 /**
- * Returns the hooked blocks for a given anchor block.
- *
- * Given an anchor block name, returns an object whose keys are relative positions,
- * and whose values are arrays of block names that are hooked to the anchor block
- * at that relative position.
- *
- * @param {Object} state     Data state.
- * @param {string} blockName Anchor block type name.
- *
- * @example
- * ```js
- * import { store as blocksStore } from '@wordpress/blocks';
- * import { useSelect } from '@wordpress/data';
- *
- * const ExampleComponent = () => {
- *     const hookedBlockNames = useSelect( ( select ) =>
- *         select( blocksStore ).getHookedBlocks( 'core/navigation' ),
- *         []
- *     );
- *
- *     return (
- *         <ul>
- *             { Object.keys( hookedBlockNames ).length &&
- *                 Object.keys( hookedBlockNames ).map( ( relativePosition ) => (
- *                     <li key={ relativePosition }>{ relativePosition }>
- *                         <ul>
- *                             { hookedBlockNames[ relativePosition ].map( ( hookedBlock ) => (
- *                                 <li key={ hookedBlock }>{ hookedBlock }</li>
- *                             ) ) }
- *                         </ul>
- *                     </li>
- *             ) ) }
- *         </ul>
- *     );
- * };
- * ```
- *
- * @return {Object} Lists of hooked block names for each relative position.
- */
-export const getHookedBlocks = createSelector(
-	( state, blockName ) => {
-		const hookedBlockTypes = getBlockTypes( state ).filter(
-			( { blockHooks } ) => blockHooks && blockName in blockHooks
-		);
-
-		let hookedBlocks = {};
-		for ( const blockType of hookedBlockTypes ) {
-			const relativePosition = blockType.blockHooks[ blockName ];
-			hookedBlocks = {
-				...hookedBlocks,
-				[ relativePosition ]: [
-					...( hookedBlocks[ relativePosition ] ?? [] ),
-					blockType.name,
-				],
-			};
-		}
-		return hookedBlocks;
-	},
-	( state ) => [ state.blockTypes ]
-);
-
-/**
  * Returns block styles by block name.
  *
  * @param {Object} state Data state.

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -12,7 +12,6 @@ import {
 	getBlockVariations,
 	getDefaultBlockVariation,
 	getGroupingBlockName,
-	getHookedBlocks,
 	isMatchingSearchTerm,
 	getCategories,
 	getActiveBlockVariation,
@@ -226,111 +225,6 @@ describe( 'selectors', () => {
 			expect( getChildBlockNames( state, 'parent2' ) ).toEqual( [
 				'child2',
 			] );
-		} );
-	} );
-
-	describe( 'getHookedBlocks', () => {
-		it( 'should return an empty object if state is empty', () => {
-			const state = {
-				blockTypes: {},
-			};
-
-			expect( getHookedBlocks( state, 'anchor' ) ).toEqual( {} );
-		} );
-
-		it( 'should return an empty object if the anchor block is not found', () => {
-			const state = {
-				blockTypes: {
-					anchor: {
-						name: 'anchor',
-					},
-					hookedBlock: {
-						name: 'hookedBlock',
-						blockHooks: {
-							anchor: 'after',
-						},
-					},
-				},
-			};
-
-			expect( getHookedBlocks( state, 'otherAnchor' ) ).toEqual( {} );
-		} );
-
-		it( "should return the anchor block name even if the anchor block doesn't exist", () => {
-			const state = {
-				blockTypes: {
-					hookedBlock: {
-						name: 'hookedBlock',
-						blockHooks: {
-							anchor: 'after',
-						},
-					},
-				},
-			};
-
-			expect( getHookedBlocks( state, 'anchor' ) ).toEqual( {
-				after: [ 'hookedBlock' ],
-			} );
-		} );
-
-		it( 'should return an array with the hooked block names', () => {
-			const state = {
-				blockTypes: {
-					anchor: {
-						name: 'anchor',
-					},
-					hookedBlock1: {
-						name: 'hookedBlock1',
-						blockHooks: {
-							anchor: 'after',
-						},
-					},
-					hookedBlock2: {
-						name: 'hookedBlock2',
-						blockHooks: {
-							anchor: 'before',
-						},
-					},
-				},
-			};
-
-			expect( getHookedBlocks( state, 'anchor' ) ).toEqual( {
-				after: [ 'hookedBlock1' ],
-				before: [ 'hookedBlock2' ],
-			} );
-		} );
-
-		it( 'should return an array with the hooked block names, even if multiple blocks are in the same relative position', () => {
-			const state = {
-				blockTypes: {
-					anchor: {
-						name: 'anchor',
-					},
-					hookedBlock1: {
-						name: 'hookedBlock1',
-						blockHooks: {
-							anchor: 'after',
-						},
-					},
-					hookedBlock2: {
-						name: 'hookedBlock2',
-						blockHooks: {
-							anchor: 'before',
-						},
-					},
-					hookedBlock3: {
-						name: 'hookedBlock3',
-						blockHooks: {
-							anchor: 'after',
-						},
-					},
-				},
-			};
-
-			expect( getHookedBlocks( state, 'anchor' ) ).toEqual( {
-				after: [ 'hookedBlock1', 'hookedBlock3' ],
-				before: [ 'hookedBlock2' ],
-			} );
 		} );
 	} );
 


### PR DESCRIPTION
Reverts WordPress/gutenberg#58553

This has been superseded by https://github.com/WordPress/wordpress-develop/pull/6087. As such, I'd like to revert this PR in order not to introduce a new selector (`getHookedBlocks`) that we won't actually need.

Note that this code has so far only been part of 17.7 RC1, so `getHookedBlocks` hasn't been part of any stable releases yet.

Once this PR has been merged, it should be cherry-picked to the `release/17.7` branch, and included in the next package sync for WP 6.5. I'll set the relevant labels.

cc/ @gziolo @tjcafferkey 