### PR TITLE
Update cherry pick script to add `Backported to WP Core` label for backports

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -334,6 +334,11 @@ function reportSummaryNextSteps( successes, failures ) {
 		nextSteps.push( 'Push this branch' );
 		nextSteps.push( 'Go to each of the cherry-picked Pull Requests' );
 		nextSteps.push( `Remove the ${ LABEL } label` );
+
+		if ( LABEL === 'Backport to WP Beta/RC' ) {
+			nextSteps.push( 'Add the "Backported to WP Core" label' );
+		}
+
 		nextSteps.push( 'Request a backport to wordpress-develop if required' );
 		nextSteps.push( 'Comment, say that PR just got cherry-picked' );
 	}
@@ -363,6 +368,17 @@ function GHcommentAndRemoveLabel( pr ) {
 	try {
 		cli( 'gh', [ 'pr', 'comment', number, '--body', comment ] );
 		cli( 'gh', [ 'pr', 'edit', number, '--remove-label', LABEL ] );
+
+		if ( LABEL === 'Backport to WP Beta/RC' ) {
+			cli( 'gh', [
+				'pr',
+				'edit',
+				number,
+				'--add-label',
+				'Backported to WP Core',
+			] );
+		}
+
 		console.log( `✅ ${ number }: ${ comment }` );
 	} catch ( e ) {
 		console.log( `❌ ${ number }. ${ comment } ` );

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -7,6 +7,7 @@ import readline from 'readline';
 import { spawnSync } from 'node:child_process';
 
 const LABEL = process.argv[ 2 ] || 'Backport to WP Beta/RC';
+const BACKPORT_COMPLETED_LABEL = 'Backported to WP Core';
 const BRANCH = getCurrentBranch();
 const GITHUB_CLI_AVAILABLE = spawnSync( 'gh', [ 'auth', 'status' ] )
 	?.stdout?.toString()
@@ -336,7 +337,7 @@ function reportSummaryNextSteps( successes, failures ) {
 		nextSteps.push( `Remove the ${ LABEL } label` );
 
 		if ( LABEL === 'Backport to WP Beta/RC' ) {
-			nextSteps.push( 'Add the "Backported to WP Core" label' );
+			nextSteps.push( `Add the "${ BACKPORT_COMPLETED_LABEL }" label` );
 		}
 
 		nextSteps.push( 'Request a backport to wordpress-develop if required' );
@@ -375,7 +376,7 @@ function GHcommentAndRemoveLabel( pr ) {
 				'edit',
 				number,
 				'--add-label',
-				'Backported to WP Core',
+				BACKPORT_COMPLETED_LABEL,
 			] );
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the cherry picking script to also add the `Backported to WP Core` label when cherry picking a PR for a backport during a WP release cycle.



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because we established a new convention whereby this label would be applied. In the future, usage of this label will help us to avoid false positives when building the PHP Sync Issue as it will allow us to omit PR which have this label from the list of commits that need manually syncing to WP Core.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses [GH Cli to edit the PR](https://cli.github.com/manual/gh_pr_edit) and add the label

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Good question. There are no automated tests...

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


Co-authored-by: getdave <get_dave@git.wordpress.org>
Co-authored-by: youknowriad <youknowriad@git.wordpress.org>
