### PR TITLE
Inserter: Don't select the closest block with 'disabled' editing mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -81,11 +81,16 @@ function InbetweenInsertionPointPopover( {
 			isInserterShown: insertionPoint?.__unstableWithInserter,
 		};
 	}, [] );
+	const { getBlockEditingMode } = useSelect( blockEditorStore );
 
 	const disableMotion = useReducedMotion();
 
 	function onClick( event ) {
-		if ( event.target === ref.current && nextClientId ) {
+		if (
+			event.target === ref.current &&
+			nextClientId &&
+			getBlockEditingMode( nextClientId ) !== 'disabled'
+		) {
 			selectBlock( nextClientId, -1 );
 		}
 	}


### PR DESCRIPTION
## What?
Fixes #57227.

PR updates the `onClick` handler for the `InbetweenInsertionPointPopover` component to only select the closest block if it has editing mode enabled.

## Why?
Users shouldn't be able to select the disabled blocks.

## Testing Instructions
1. Open a post or page.
2. Add heading and image blocks.
3. Disabled editing for the image blocks. See the snippet below.
4. Hover above the image block so that the in-between inserter appears.
5. Click anywhere between the second block and the first block except for the blue line and insert button. This must be in the center within the bounds of the blue line, not to the left or right of it.
6. The image block shouldn't be selected.

### Snippet

```js
const blocks = wp.data.select( 'core/block-editor' ).getBlocksByName( 'core/image' );
wp.data.dispatch( 'core/block-editor' ).setBlockEditingMode( blocks[0], 'disabled' );
```


### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/240569/ec5dde66-1600-43e0-944b-a10fb320875e

**After**

https://github.com/WordPress/gutenberg/assets/240569/821f8c37-bde9-444f-85f7-51be9a9a2794

