### PR TITLE
Fix Global Styles controller incompatible with extended Core classes

### DIFF
--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php
@@ -15,6 +15,10 @@
  * @see WP_REST_Controller
  */
 class Gutenberg_REST_Global_Styles_Revisions_Controller_6_4 extends WP_REST_Global_Styles_Revisions_Controller {
+
+
+	private $parent_post_type;
+
 	/**
 	 * Prepares the revision for the REST response.
 	 *

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php
@@ -17,7 +17,7 @@
 class Gutenberg_REST_Global_Styles_Revisions_Controller_6_4 extends WP_REST_Global_Styles_Revisions_Controller {
 
 
-	protected $parent_post_type = 'wp_global_styles';
+	protected $parent_post_type;
 
 	/**
 	 * Prepares the revision for the REST response.

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php
@@ -17,7 +17,7 @@
 class Gutenberg_REST_Global_Styles_Revisions_Controller_6_4 extends WP_REST_Global_Styles_Revisions_Controller {
 
 
-	private $parent_post_type;
+	protected $parent_post_type = 'wp_global_styles';
 
 	/**
 	 * Prepares the revision for the REST response.

--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Registers the Global Styles Revisions REST API routes.
  */
 function gutenberg_register_global_styles_revisions_endpoints() {
-	$global_styles_revisions_controller = new Gutenberg_REST_Global_Styles_Revisions_Controller_6_5();
+	$global_styles_revisions_controller = new Gutenberg_REST_Global_Styles_Revisions_Controller_6_5( 'wp_global_styles' );
 	$global_styles_revisions_controller->register_routes();
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function WP_REST_Global_Styles_Revisions_Controller::__construct(), 0
```

This is because the 6.5 class didn't pass the parent post type argument and the 6.4 class didn't define the property.

See https://wordpress.slack.com/archives/C02RQBWTW/p1707834984621719.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- run latest wordpress `trunk`.
- check out Gutenberg `trunk`.
- visit Site Editor
- see errors
- apply this PR
- don't see errors

Note that it's possible WP Core `trunk` will have [patched this already](https://github.com/WordPress/wordpress-develop/pull/6106).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
