### PR TITLE
Shadows: Don't assume that core provides default shadows

### DIFF
--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -19,13 +19,13 @@ import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
 import classNames from 'classnames';
 
 export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
-	const defaultShadows = settings?.shadow?.presets?.default;
-	const themeShadows = settings?.shadow?.presets?.theme;
+	const defaultShadows = settings?.shadow?.presets?.default || [];
+	const themeShadows = settings?.shadow?.presets?.theme || [];
 	const defaultPresetsEnabled = settings?.shadow?.defaultPresets;
 
 	const shadows = [
 		...( defaultPresetsEnabled ? defaultShadows : [] ),
-		...( themeShadows || [] ),
+		...themeShadows,
 	];
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Handle the case where core doesn't provide a default shadow.

## Why?
When I was testing https://github.com/WordPress/gutenberg/pull/58951 I discovered that removing the shadows from the core theme.json throws a javascript error.

## How?
Set defaultShadows to an empty array if it's undefined.

## Testing Instructions
1. Add a button block
2. Go to the styles tab
3. Enable shadows
4. Click on "drop shadow"
5. Confirm that there is no JS error.
