### PR TITLE
Inserter: Fix title condition for media tab previews

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -195,7 +195,12 @@ export function MediaPreview( { media, onClick, category } ) {
 			createSuccessNotice,
 		]
 	);
-	const title = media.title?.rendered || media.title;
+
+	const title =
+		typeof media.title === 'string'
+			? media.title
+			: media.title?.rendered || __( 'no title' );
+
 	let truncatedTitle;
 	if ( title.length > MAXIMUM_TITLE_LENGTH ) {
 		const omission = '...';


### PR DESCRIPTION
## What?
Fixes #58982.

PR avoids crashing the editor when media has no title and adds a fallback string to display in the tooltip.

**Note:** We can't use `ID` or `slug` for the fallback string since media sources like "Openverse" don't provide these values.

## Why?
The previous fallback condition resulted in the `title` being an object.

## Testing Instructions
1. Remove an image title via `/wp-admin/upload.php`.
2. Open a post or page.
3. Open Inserter > Media > Images.
4. Hover on the image with no title.
5. It now should display a new fallback - "no title".

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/318356a3-5e86-4e97-aab8-e9392680ce34

