### PR TITLE
Allow editing of image block alt and title attributes in content only mode

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -181,3 +181,8 @@ figure.wp-block-image:not(.wp-block) {
 		padding-right: 0;
 	}
 }
+
+.wp-block-image__toolbar_content_textarea {
+	// Corresponds to the size of the textarea in the block inspector.
+	width: 250px;
+}

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -537,8 +537,8 @@ export default function Image( {
 								} }
 							>
 								{ _x(
-									'Alt text',
-									'Alternative text for an image'
+									'Alt. text',
+									'Alternative text for an image. Block toolbar label, a low character count is preferred.'
 								) }
 							</ToolbarButton>
 						) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -9,6 +9,7 @@ import {
 	TextareaControl,
 	TextControl,
 	ToolbarButton,
+	ToolbarDropdownMenu,
 	ToolbarGroup,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -177,6 +178,7 @@ export default function Image( {
 	const [ externalBlob, setExternalBlob ] = useState();
 	const clientWidth = useClientWidth( containerRef, [ align ] );
 	const hasNonContentControls = blockEditingMode === 'default';
+	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 	const isResizable =
 		allowResize &&
 		hasNonContentControls &&
@@ -512,6 +514,88 @@ export default function Image( {
 							label={ __( 'Upload to Media Library' ) }
 						/>
 					</ToolbarGroup>
+				</BlockControls>
+			) }
+			{ isContentOnlyMode && (
+				// Add some extra controls for content attributes when content only mode is active.
+				// With content only mode active, the inspector is hidden, so users need another way
+				// to edit these attributes.
+				<BlockControls group="other">
+					<ToolbarDropdownMenu
+						label={ __( 'Alt' ) }
+						text={ __( 'Alt' ) }
+						icon={ null }
+						popoverProps={ { position: 'bottom right' } }
+					>
+						{ () => (
+							<TextareaControl
+								className="wp-block-image__toolbar_content_textarea"
+								label={ __( 'Alternative text' ) }
+								value={ alt || '' }
+								onChange={ updateAlt }
+								disabled={ lockAltControls }
+								help={
+									lockAltControls ? (
+										<>
+											{ __(
+												'Connected to a custom field'
+											) }
+										</>
+									) : (
+										<>
+											<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
+												{ __(
+													'Describe the purpose of the image.'
+												) }
+											</ExternalLink>
+											<br />
+											{ __(
+												'Leave empty if decorative.'
+											) }
+										</>
+									)
+								}
+								__nextHasNoMarginBottom
+							/>
+						) }
+					</ToolbarDropdownMenu>
+					<ToolbarDropdownMenu
+						label={ __( 'Title' ) }
+						text={ __( 'Title' ) }
+						icon={ null }
+						popoverProps={ { position: 'bottom right' } }
+					>
+						{ () => (
+							<TextControl
+								className="wp-block-image__toolbar_content_textarea"
+								__nextHasNoMarginBottom
+								label={ __( 'Title attribute' ) }
+								value={ title || '' }
+								onChange={ onSetTitle }
+								disabled={ lockTitleControls }
+								help={
+									lockTitleControls ? (
+										<>
+											{ __(
+												'Connected to a custom field'
+											) }
+										</>
+									) : (
+										<>
+											{ __(
+												'Describe the role of this image on the page.'
+											) }
+											<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
+												{ __(
+													'(Note: many devices and browsers do not display this text.)'
+												) }
+											</ExternalLink>
+										</>
+									)
+								}
+							/>
+						) }
+					</ToolbarDropdownMenu>
 				</BlockControls>
 			) }
 			<InspectorControls>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -9,8 +9,8 @@ import {
 	TextareaControl,
 	TextControl,
 	ToolbarButton,
-	ToolbarDropdownMenu,
 	ToolbarGroup,
+	Dropdown,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUseCustomUnits as useCustomUnits,
@@ -31,6 +31,7 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
+import { DOWN } from '@wordpress/keycodes';
 import { getFilename } from '@wordpress/url';
 import { switchToBlockType } from '@wordpress/blocks';
 import { crop, overlayText, upload } from '@wordpress/icons';
@@ -521,13 +522,27 @@ export default function Image( {
 				// With content only mode active, the inspector is hidden, so users need another way
 				// to edit these attributes.
 				<BlockControls group="other">
-					<ToolbarDropdownMenu
-						label={ __( 'Alt' ) }
-						text={ __( 'Alt' ) }
-						icon={ null }
+					<Dropdown
 						popoverProps={ { position: 'bottom right' } }
-					>
-						{ () => (
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<ToolbarButton
+								onClick={ onToggle }
+								aria-haspopup="true"
+								aria-expanded={ isOpen }
+								onKeyDown={ ( event ) => {
+									if ( ! isOpen && event.keyCode === DOWN ) {
+										event.preventDefault();
+										onToggle();
+									}
+								} }
+							>
+								{ _x(
+									'Alt text',
+									'Alternative text for an image'
+								) }
+							</ToolbarButton>
+						) }
+						renderContent={ () => (
 							<TextareaControl
 								className="wp-block-image__toolbar_content_textarea"
 								label={ __( 'Alternative text' ) }
@@ -558,14 +573,25 @@ export default function Image( {
 								__nextHasNoMarginBottom
 							/>
 						) }
-					</ToolbarDropdownMenu>
-					<ToolbarDropdownMenu
-						label={ __( 'Title' ) }
-						text={ __( 'Title' ) }
-						icon={ null }
+					/>
+					<Dropdown
 						popoverProps={ { position: 'bottom right' } }
-					>
-						{ () => (
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<ToolbarButton
+								onClick={ onToggle }
+								aria-haspopup="true"
+								aria-expanded={ isOpen }
+								onKeyDown={ ( event ) => {
+									if ( ! isOpen && event.keyCode === DOWN ) {
+										event.preventDefault();
+										onToggle();
+									}
+								} }
+							>
+								{ __( 'Title' ) }
+							</ToolbarButton>
+						) }
+						renderContent={ () => (
 							<TextControl
 								className="wp-block-image__toolbar_content_textarea"
 								__nextHasNoMarginBottom
@@ -595,7 +621,7 @@ export default function Image( {
 								}
 							/>
 						) }
-					</ToolbarDropdownMenu>
+					/>
 				</BlockControls>
 			) }
 			<InspectorControls>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -537,7 +537,7 @@ export default function Image( {
 								} }
 							>
 								{ _x(
-									'Alt. text',
+									'Alt',
 									'Alternative text for an image. Block toolbar label, a low character count is preferred.'
 								) }
 							</ToolbarButton>


### PR DESCRIPTION
## What?
Part of #53705

One of the challenges of editing a block in `contentOnly` mode is that the entire block inspector is unavailable. The mode has an assumption that there are no 'content' controls within the block inspector.

For the image block there are some content controls, 'Title' and 'Alternative text'. That they're unavailable has a direct impact on pattern overrides, as it uses contentOnly mode.

## How?
For this PR, I've added the controls to the block toolbar, but only when contentOnly mode is active:
![Screenshot 2024-02-14 at 3 18 36 pm](https://github.com/WordPress/gutenberg/assets/677833/3ff4bc05-f23e-4eef-81ea-7bc2bca6a31b)

![Screenshot 2024-02-14 at 3 18 45 pm](https://github.com/WordPress/gutenberg/assets/677833/74349776-40db-4d12-aa47-a0f5cae1aa73)

When the image block isn't in content only mode they appear back in the inspector as normal.

## Testing Instructions
1. Create a new synced pattern
2. Add an image block to the pattern, upload an image to it
3. With the image block still selected, in the inspector open advanced tools and check 'Allow instance overrides'
4. Save the pattern
5. Insert the pattern into a post
6. Select the image
7. Add an 'Alt' and a 'Title' using the toolbar buttons
8. Preview the post
9. Inspect the HTML for the image, it should have alt and title attributes matching what you entered
