### PR TITLE
Site Editor: Don't memoize the canvas container title

### DIFF
--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Children, cloneElement, useState, useMemo } from '@wordpress/element';
+import { Children, cloneElement, useState } from '@wordpress/element';
 import {
 	Button,
 	privateApis as componentsPrivateApis,
@@ -82,10 +82,6 @@ function EditorCanvasContainer( {
 
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const sectionFocusReturnRef = useFocusReturn();
-	const title = useMemo(
-		() => getEditorCanvasContainerTitle( editorCanvasContainerView ),
-		[ editorCanvasContainerView ]
-	);
 
 	function onCloseContainer() {
 		setIsListViewOpened( showListViewByDefault );
@@ -119,6 +115,7 @@ function EditorCanvasContainer( {
 		return null;
 	}
 
+	const title = getEditorCanvasContainerTitle( editorCanvasContainerView );
 	const shouldShowCloseButton = onClose || closeButtonLabel;
 
 	return (


### PR DESCRIPTION
## What?
Removes memoization around the `getEditorCanvasContainerTitle` method in the `EditorCanvasContainer` component.

## Why?
The function returns a string; there's no need to memorize primitive values.

## Testing Instructions
1. Open the Site Editor.
2. Switch to Styles Revisions and Style Book.
3. Confirm that the `.edit-site-editor-canvas-container` section has the correct label.

### Testing Instructions for Keyboard
Same
