### PR TITLE
Components: Add sleep() before all Tab() to fix flaky tests

### DIFF
--- a/packages/components/src/alignment-matrix-control/test/index.tsx
+++ b/packages/components/src/alignment-matrix-control/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen, waitFor, within } from '@testing-library/react';
-import { press, click } from '@ariakit/test';
+import { press, click, sleep } from '@ariakit/test';
 
 /**
  * Internal dependencies
@@ -39,6 +39,7 @@ describe( 'AlignmentMatrixControl', () => {
 		it( 'should be centered by default', async () => {
 			await renderAndInitCompositeStore( <AlignmentMatrixControl /> );
 
+			await sleep();
 			await press.Tab();
 
 			expect( getCell( 'center center' ) ).toHaveFocus();
@@ -109,6 +110,7 @@ describe( 'AlignmentMatrixControl', () => {
 						<AlignmentMatrixControl onChange={ spy } />
 					);
 
+					await sleep();
 					await press.Tab();
 					await press[ keyRef ]();
 

--- a/packages/components/src/circular-option-picker/test/index.tsx
+++ b/packages/components/src/circular-option-picker/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
-import { press } from '@ariakit/test';
+import { press, sleep } from '@ariakit/test';
 
 /**
  * Internal dependencies
@@ -78,6 +78,7 @@ describe( 'CircularOptionPicker', () => {
 				/>
 			);
 
+			await sleep();
 			await press.Tab();
 			expect( getOption( 'Option One' ) ).toHaveFocus();
 			await press.ArrowRight();
@@ -97,6 +98,7 @@ describe( 'CircularOptionPicker', () => {
 				/>
 			);
 
+			await sleep();
 			await press.Tab();
 			expect( getOption( 'Option One' ) ).toHaveFocus();
 			await press.ArrowRight();
@@ -116,6 +118,7 @@ describe( 'CircularOptionPicker', () => {
 				/>
 			);
 
+			await sleep();
 			await press.Tab();
 			expect( getOption( 'Option One' ) ).toHaveFocus();
 			await press.ArrowRight();

--- a/packages/components/src/composite/legacy/test/index.tsx
+++ b/packages/components/src/composite/legacy/test/index.tsx
@@ -178,10 +178,13 @@ describe.each( [
 		);
 		renderAndValidate( <Test /> );
 
+		await sleep();
 		await press.Tab();
 		expect( screen.getByText( 'Before' ) ).toHaveFocus();
+		await sleep();
 		await press.Tab();
 		expect( screen.getByText( 'Item 1' ) ).toHaveFocus();
+		await sleep();
 		await press.Tab();
 		expect( screen.getByText( 'After' ) ).toHaveFocus();
 		await press.ShiftTab();
@@ -210,6 +213,7 @@ describe.each( [
 
 		expect( item2 ).toBeDisabled();
 
+		await sleep();
 		await press.Tab();
 		expect( item1 ).toHaveFocus();
 		await press.ArrowDown();
@@ -239,6 +243,7 @@ describe.each( [
 		expect( item2 ).toBeEnabled();
 		expect( item2 ).toHaveAttribute( 'aria-disabled', 'true' );
 
+		await sleep();
 		await press.Tab();
 		expect( item1 ).toHaveFocus();
 		await press.ArrowDown();
@@ -318,6 +323,7 @@ describe.each( [
 		test( 'All directions work with no orientation', async () => {
 			const { item1, item2, item3 } = useOneDimensionalTest();
 
+			await sleep();
 			await press.Tab();
 			expect( item1 ).toHaveFocus();
 			await press.ArrowDown();
@@ -355,6 +361,7 @@ describe.each( [
 				orientation: 'horizontal',
 			} );
 
+			await sleep();
 			await press.Tab();
 			expect( item1 ).toHaveFocus();
 			await press.ArrowDown();
@@ -384,6 +391,7 @@ describe.each( [
 				orientation: 'vertical',
 			} );
 
+			await sleep();
 			await press.Tab();
 			expect( item1 ).toHaveFocus();
 			await press( next );
@@ -413,6 +421,7 @@ describe.each( [
 				loop: true,
 			} );
 
+			await sleep();
 			await press.Tab();
 			expect( item1 ).toHaveFocus();
 			await press.ArrowDown();
@@ -435,6 +444,7 @@ describe.each( [
 			const { itemA1, itemA2, itemA3, itemB1, itemB2, itemC1, itemC3 } =
 				useTwoDimensionalTest();
 
+			await sleep();
 			await press.Tab();
 			expect( itemA1 ).toHaveFocus();
 			await press.ArrowUp();
@@ -471,6 +481,7 @@ describe.each( [
 			const { itemA1, itemA2, itemA3, itemB1, itemC1, itemC3 } =
 				useTwoDimensionalTest( { loop: true } );
 
+			await sleep();
 			await press.Tab();
 			expect( itemA1 ).toHaveFocus();
 			await press( next );
@@ -495,6 +506,7 @@ describe.each( [
 			const { itemA1, itemA2, itemA3, itemB1, itemC1, itemC3 } =
 				useTwoDimensionalTest( { wrap: true } );
 
+			await sleep();
 			await press.Tab();
 			expect( itemA1 ).toHaveFocus();
 			await press( next );
@@ -527,6 +539,7 @@ describe.each( [
 				wrap: true,
 			} );
 
+			await sleep();
 			await press.Tab();
 			expect( itemA1 ).toHaveFocus();
 			await press( previous );
@@ -542,6 +555,7 @@ describe.each( [
 		test( 'Focus shifts if vertical neighbour unavailable when shift enabled', async () => {
 			const { itemA1, itemB1, itemB2, itemC1 } = useShiftTest( true );
 
+			await sleep();
 			await press.Tab();
 			expect( itemA1 ).toHaveFocus();
 			await press.ArrowDown();
@@ -563,6 +577,7 @@ describe.each( [
 		test( 'Focus does not shift if vertical neighbour unavailable when shift not enabled', async () => {
 			const { itemA1, itemB1, itemB2 } = useShiftTest( false );
 
+			await sleep();
 			await press.Tab();
 			expect( itemA1 ).toHaveFocus();
 			await press.ArrowDown();

--- a/packages/components/src/custom-select-control-v2/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
-import { click, press, type } from '@ariakit/test';
+import { click, press, sleep, type } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -106,6 +106,7 @@ describe( 'With Legacy Props', () => {
 				expanded: false,
 			} );
 
+			await sleep();
 			await press.Tab();
 			await press.Enter();
 			expect(
@@ -315,6 +316,7 @@ describe( 'With Legacy Props', () => {
 				<CustomSelect { ...legacyProps } onChange={ mockOnChange } />
 			);
 
+			await sleep();
 			await press.Tab();
 			expect(
 				screen.getByRole( 'combobox', {
@@ -336,6 +338,7 @@ describe( 'With Legacy Props', () => {
 					expanded: false,
 				} );
 
+				await sleep();
 				await press.Tab();
 				expect( currentSelectedItem ).toHaveFocus();
 
@@ -361,6 +364,7 @@ describe( 'With Legacy Props', () => {
 					expanded: false,
 				} );
 
+				await sleep();
 				await press.Tab();
 				await press.Enter();
 				expect(
@@ -381,6 +385,7 @@ describe( 'With Legacy Props', () => {
 					expanded: false,
 				} );
 
+				await sleep();
 				await press.Tab();
 				expect( currentSelectedItem ).toHaveFocus();
 
@@ -544,6 +549,7 @@ describe( 'With Default Props', () => {
 				expanded: false,
 			} );
 
+			await sleep();
 			await press.Tab();
 			await press.Enter();
 			expect(
@@ -572,6 +578,7 @@ describe( 'With Default Props', () => {
 					expanded: false,
 				} );
 
+				await sleep();
 				await press.Tab();
 				expect( currentSelectedItem ).toHaveFocus();
 
@@ -597,6 +604,7 @@ describe( 'With Default Props', () => {
 					expanded: false,
 				} );
 
+				await sleep();
 				await press.Tab();
 				await press.Enter();
 				expect(
@@ -617,6 +625,7 @@ describe( 'With Default Props', () => {
 					expanded: false,
 				} );
 
+				await sleep();
 				await press.Tab();
 				expect( currentSelectedItem ).toHaveFocus();
 

--- a/packages/components/src/dropdown-menu-v2/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen, waitFor } from '@testing-library/react';
-import { press, click, hover, type } from '@ariakit/test';
+import { press, click, hover, sleep, type } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -123,6 +123,7 @@ describe( 'DropdownMenu', () => {
 			} );
 
 			// Move focus on the toggle
+			await sleep();
 			await press.Tab();
 
 			expect( toggleButton ).toHaveFocus();
@@ -153,6 +154,7 @@ describe( 'DropdownMenu', () => {
 			} );
 
 			// Move focus on the toggle
+			await sleep();
 			await press.Tab();
 
 			expect( toggleButton ).toHaveFocus();
@@ -908,6 +910,7 @@ describe( 'DropdownMenu', () => {
 
 			// The outer button can be focused by pressing tab. Doing so will cause
 			// the DropdownMenu to close.
+			await sleep();
 			await press.Tab();
 			expect( outerButton ).toBeInTheDocument();
 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();

--- a/packages/components/src/tab-panel/test/index.tsx
+++ b/packages/components/src/tab-panel/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen, waitFor } from '@testing-library/react';
-import { press, hover, click } from '@ariakit/test';
+import { press, hover, click, sleep } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -155,6 +155,7 @@ describe.each( [
 			// Tab to focus the tablist. Make sure alpha is focused, and that the
 			// corresponding tooltip is shown.
 			expect( screen.queryByText( 'Alpha' ) ).not.toBeInTheDocument();
+			await sleep();
 			await press.Tab();
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByText( 'Alpha' ) ).toBeInTheDocument();
@@ -626,6 +627,7 @@ describe.each( [
 			// Tab to focus the tablist. Make sure alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+			await sleep();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 
@@ -663,6 +665,7 @@ describe.each( [
 			// Tab to focus the tablist. Make sure Alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+			await sleep();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 
@@ -700,6 +703,7 @@ describe.each( [
 			// Tab to focus the tablist. Make sure alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+			await sleep();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 
@@ -795,6 +799,7 @@ describe.each( [
 			// Tab to focus the tablist. Make sure Alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+			await sleep();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
@@ -836,6 +841,7 @@ describe.each( [
 
 			// Tab should initially focus the first tab in the tablist, which
 			// is Alpha.
+			await sleep();
 			await press.Tab();
 			expect(
 				await screen.findByRole( 'tab', { name: 'Alpha' } )
@@ -843,6 +849,7 @@ describe.each( [
 
 			// Because all other tabs should have `tabindex=-1`, pressing Tab
 			// should NOT move the focus to the next tab, which is Beta.
+			await sleep();
 			await press.Tab();
 			expect(
 				await screen.findByRole( 'tab', { name: 'Beta' } )

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -194,12 +194,14 @@ describe( 'Tabs', () => {
 
 			// Tab should initially focus the first tab in the tablist, which
 			// is Alpha.
+			await sleep();
 			await press.Tab();
 			expect(
 				await screen.findByRole( 'tab', { name: 'Alpha' } )
 			).toHaveFocus();
 
 			// By default the tabpanel should receive focus
+			await sleep();
 			await press.Tab();
 			expect( selectedTabPanel ).toHaveFocus();
 		} );
@@ -229,12 +231,14 @@ describe( 'Tabs', () => {
 
 			// Tab should initially focus the first tab in the tablist, which
 			// is Alpha.
+			await sleep();
 			await press.Tab();
 			expect(
 				await screen.findByRole( 'tab', { name: 'Alpha' } )
 			).toHaveFocus();
 			// Because the alpha tabpanel is set to `focusable: false`, pressing
 			// the Tab key should focus the button, not the tabpanel
+			await sleep();
 			await press.Tab();
 			expect( alphaButton ).toHaveFocus();
 		} );
@@ -305,6 +309,7 @@ describe( 'Tabs', () => {
 			// Tab to focus the tablist. Make sure alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+			await sleep();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 
@@ -338,6 +343,7 @@ describe( 'Tabs', () => {
 			// Tab to focus the tablist. Make sure Alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+			await sleep();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 
@@ -373,6 +379,7 @@ describe( 'Tabs', () => {
 			// Tab to focus the tablist. Make sure alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+			await sleep();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 
@@ -472,6 +479,7 @@ describe( 'Tabs', () => {
 			// Tab to focus the tablist. Make sure Alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+			await sleep();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 			// Confirm onSelect has not been re-called
@@ -514,6 +522,7 @@ describe( 'Tabs', () => {
 
 			// Tab should initially focus the first tab in the tablist, which
 			// is Alpha.
+			await sleep();
 			await press.Tab();
 			expect(
 				await screen.findByRole( 'tab', { name: 'Alpha' } )
@@ -522,6 +531,7 @@ describe( 'Tabs', () => {
 			// Because all other tabs should have `tabindex=-1`, pressing Tab
 			// should NOT move the focus to the next tab, which is Beta.
 			// Instead, focus should go to the currently selected tabpanel (alpha).
+			await sleep();
 			await press.Tab();
 			expect(
 				await screen.findByRole( 'tabpanel', {
@@ -832,6 +842,7 @@ describe( 'Tabs', () => {
 				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
 				// Move focus to the tablist, make sure alpha is focused.
+				await sleep();
 				await press.Tab();
 				expect(
 					screen.getByRole( 'tab', { name: 'Alpha' } )
@@ -1238,7 +1249,9 @@ describe( 'Tabs', () => {
 						);
 
 						// Tab key should focus the currently selected tab, which is Beta.
+						await sleep();
 						await press.Tab();
+						await sleep();
 						await press.Tab();
 						expect( await getSelectedTab() ).toHaveTextContent(
 							'Beta'
@@ -1273,6 +1286,7 @@ describe( 'Tabs', () => {
 						).toHaveFocus();
 
 						// Press tab, move focus back to the tablist
+						await sleep();
 						await press.Tab();
 
 						const betaTab = screen.getByRole( 'tab', {
@@ -1294,6 +1308,7 @@ describe( 'Tabs', () => {
 			it( 'should automatically select a newly focused tab', async () => {
 				render( <ControlledTabs tabs={ TABS } selectedTabId="beta" /> );
 
+				await sleep();
 				await press.Tab();
 
 				// Tab key should focus the currently selected tab, which is Beta.

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -334,9 +334,11 @@ describe.each( [
 					name: 'R',
 				} );
 
+				await sleep();
 				await press.Tab();
 				expect( rigas ).toHaveFocus();
 
+				await sleep();
 				await press.Tab();
 
 				// When in controlled mode, there is an additional "Reset" button.
@@ -392,6 +394,7 @@ describe.each( [
 					</Component>
 				);
 
+				await sleep();
 				await press.Tab();
 				expect(
 					screen.getByRole( 'button', {
@@ -400,6 +403,7 @@ describe.each( [
 					} )
 				).toHaveFocus();
 
+				await sleep();
 				await press.Tab();
 				expect(
 					screen.getByRole( 'button', {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -67,6 +67,7 @@ describe( 'Tooltip', () => {
 				screen.getByRole( 'button', { name: 'Second button' } )
 			).toBeVisible();
 
+			await sleep();
 			await press.Tab();
 
 			expectTooltipToBeHidden();
@@ -134,6 +135,7 @@ describe( 'Tooltip', () => {
 			);
 
 			// Focus the anchor, tooltip should show
+			await sleep();
 			await press.Tab();
 			expect(
 				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
@@ -141,6 +143,7 @@ describe( 'Tooltip', () => {
 			await waitExpectTooltipToShow();
 
 			// Focus the other button, tooltip should hide
+			await sleep();
 			await press.Tab();
 			expect(
 				screen.getByRole( 'button', { name: 'Focus me' } )
@@ -166,11 +169,13 @@ describe( 'Tooltip', () => {
 			expect( anchor ).toHaveAttribute( 'aria-disabled', 'true' );
 
 			// Focus anchor, tooltip should show
+			await sleep();
 			await press.Tab();
 			expect( anchor ).toHaveFocus();
 			await waitExpectTooltipToShow();
 
 			// Focus another button, tooltip should hide
+			await sleep();
 			await press.Tab();
 			expect(
 				screen.getByRole( 'button', {


### PR DESCRIPTION
## What?
This PR adds some additional `sleep()` calls before all `press.Tab()` calls to fix the flakiness.

## Why?
To reduce the test flakiness. Another `press.Tab()` test failed right during merging #58968 to trunk so I think we should apply this everywhere and see how it goes.

## How?
We're adding some wait time (10ms which is [the default](https://github.com/ariakit/ariakit/blob/ec8d74af772a5c88198d8c078d98f24f754d393c/packages/ariakit-test/src/sleep.ts#L3) of `sleep()`) before tabbing.

This doesn't really fix the root cause, but we're aiming to fix the flaky tests for now.

We also did this in #58629 and #58968.

## Testing Instructions
Verify all tests pass.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None