### PR TITLE
Correct the PHP version check for `woff` and `woff2` MIME types.

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -233,8 +233,8 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 			return array(
 				'otf'   => 'application/vnd.ms-opentype',
 				'ttf'   => PHP_VERSION_ID >= 70400 ? 'font/sfnt' : $php_7_ttf_mime_type,
-				'woff'  => PHP_VERSION_ID >= 80100 ? 'font/woff' : 'application/font-woff',
-				'woff2' => PHP_VERSION_ID >= 80100 ? 'font/woff2' : 'application/font-woff2',
+				'woff'  => PHP_VERSION_ID >= 80112 ? 'font/woff' : 'application/font-woff',
+				'woff2' => PHP_VERSION_ID >= 80112 ? 'font/woff2' : 'application/font-woff2',
 			);
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In #58997, a bug was reported where fonts could not be installed in PHP 8.1.0 through 8.1.11 due to incorrect MIME type assignment. This PR corrects a PHP version check to resolve the issue.

## Why?

While `WP_Font_Utils::get_allowed_font_mime_types()` conditionally sets the MIME type for `woff` and `woff2`, it incorrectly checks against PHP 8.1.0. The MIME type change did not occur until PHP 8.1.12.

See:
- [PHP-src: finfo returns wrong mime type for woff/woff2 files](https://github.com/php/php-src/issues/8805)
- [PHP 8.1.12 changelog](https://www.php.net/ChangeLog-8.php#8.1.12)
- [Tests: Adjust the expected mime type for WOFF fonts on PHP 8.1.12+.](https://github.com/WordPress/wordpress-develop/commit/5eefddf4afcd738abd52fe5b7ebbe163412532ad)

## How?
This changes the checked `PHP_VERSION_ID` from `80100` to `80112` when choosing the correct MIME type for `woff` and `woff2`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Ensure that you are running a PHP version between PHP 8.1.0 and 8.1.11.
2. Open the Site Editor.
3. Navigate to Global Styles, then Typography.
4. Click the button beside the **Fonts** heading.
5. Navigate to the **Install Fonts** tab, and enable the connection to Google Fonts if requested.
6. Click the first font in the list, check the boxes and click **Install**.
7. 🐞 The installation will fail and the message will say that you can't upload a file of this type.
8. Apply the PR.
9. Repeat steps 2-7. The font should install without error. ✅