### PR TITLE
Editor: Do not open list view by default on mobile

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -77,6 +77,7 @@ export function initializeEditor(
 
 	// Check if the block list view should be open by default.
 	// If `distractionFree` mode is enabled, the block list view should not be open.
+	// This behavior is disabled for small viewports.
 	if (
 		isMediumOrBigger &&
 		select( preferencesStore ).get( 'core', 'showListViewByDefault' ) &&

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -49,6 +49,7 @@ export function initializeEditor(
 	settings,
 	initialEdits
 ) {
+	const isMediumOrBigger = window.matchMedia( '(min-width: 782px)' ).matches;
 	const target = document.getElementById( id );
 	const root = createRoot( target );
 
@@ -77,6 +78,7 @@ export function initializeEditor(
 	// Check if the block list view should be open by default.
 	// If `distractionFree` mode is enabled, the block list view should not be open.
 	if (
+		isMediumOrBigger &&
 		select( preferencesStore ).get( 'core', 'showListViewByDefault' ) &&
 		! select( preferencesStore ).get( 'core', 'distractionFree' )
 	) {

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -22,6 +22,8 @@ import { TEMPLATE_POST_TYPE } from '../utils/constants';
 export const setCanvasMode =
 	( mode ) =>
 	( { registry, dispatch } ) => {
+		const isMediumOrBigger =
+			window.matchMedia( '(min-width: 782px)' ).matches;
 		registry.dispatch( blockEditorStore ).__unstableSetEditorMode( 'edit' );
 		dispatch( {
 			type: 'SET_CANVAS_MODE',
@@ -30,6 +32,7 @@ export const setCanvasMode =
 		// Check if the block list view should be open by default.
 		// If `distractionFree` mode is enabled, the block list view should not be open.
 		if (
+			isMediumOrBigger &&
 			mode === 'edit' &&
 			registry
 				.select( preferencesStore )

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -31,6 +31,7 @@ export const setCanvasMode =
 		} );
 		// Check if the block list view should be open by default.
 		// If `distractionFree` mode is enabled, the block list view should not be open.
+		// This behavior is disabled for small viewports.
 		if (
 			isMediumOrBigger &&
 			mode === 'edit' &&


### PR DESCRIPTION
## What?

In the editor (post and site) we have a preference that indicates whether we should open the list view by default or not.
In some very small viewport the list view button is not even available so taking this preference into consideration in smaller viewports doesn't make sense. 

This PR makes this preference only work for desktops.

## Testing Instructions

1- Check the "open list view by default" preference
2- Open the editor on mobile
3- The list view shouldn't be open by default.