### PR TITLE
Font Library: fixes installed font families not rendering in the editor or frontend.

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -221,7 +221,9 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 					array(
 						'font_family_settings' => array(
 							'name'       => 'sanitize_text_field',
-							'slug'       => 'sanitize_title',
+							'slug'       => static function ( $value ) {
+								return _wp_to_kebab_case( sanitize_title( $value ) );
+							},
 							'fontFamily' => 'WP_Font_Utils::sanitize_font_family',
 							'preview'    => 'sanitize_url',
 							'fontFace'   => array(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 						'font_family_settings' => array(
 							'name'       => 'sanitize_text_field',
 							'slug'       => 'sanitize_title',
-							'fontFamily' => 'sanitize_text_field',
+							'fontFamily' => 'WP_Font_Utils::sanitize_font_family',
 							'preview'    => 'sanitize_url',
 							'fontFace'   => array(
 								array(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 				$items = explode( ',', $output );
 				foreach ( $items as $item ) {
 					$formatted_item = self::maybe_add_quotes( $item );
-					if ( $formatted_item !== '' ) {
+					if ( !empty ( $formatted_item ) ) {
 						$formatted_items[] = $formatted_item;
 					}
 				}

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -20,11 +20,41 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 	 * @access private
 	 */
 	class WP_Font_Utils {
+
+		/**
+		 * Adds surrounding quotes to font family names that contain special characters.
+		 *
+		 * It follows the recommendations from the CSS Fonts Module Level 4.
+		 * https://www.w3.org/TR/css-fonts-4/#font-family-prop
+		 *
+		 * @since 6.5.0
+		 * @access private
+		 *
+		 * @see sanitize_font_family()
+		 *
+		 * @param string $item A font family name.
+		 * @return string The font family name with surrounding quotes if necessary.
+		 */
+		private static function maybe_add_quotes( $item ) {
+			// Match any non alphabetic characters (a-zA-Z), dashes -, or parenthesis ().
+			$regex = '/[^a-zA-Z\-()]+/';
+			$item  = trim( $item );
+			if ( preg_match( $regex, $item ) ) {
+				// Removes leading and trailing quotes.
+				$item = preg_replace( '/^["\']|["\']$/', '', $item );
+				return "\"$item\"";
+			}
+			return $item;
+		}
+
 		/**
 		 * Sanitizes and formats font family names.
 		 *
 		 * - Applies `sanitize_text_field`
-		 * - Adds surrounding quotes to names that contain spaces and are not already quoted
+		 * - Adds surrounding quotes to names that special
+		 *
+		 * It follows the recommendations from the CSS Fonts Module Level 4.
+		 * https://www.w3.org/TR/css-fonts-4/#font-family-prop
 		 *
 		 * @since 6.5.0
 		 * @access private
@@ -39,26 +69,19 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 				return '';
 			}
 
-			$font_family           = sanitize_text_field( $font_family );
-			$font_families         = explode( ',', $font_family );
-			$wrapped_font_families = array_map(
-				function ( $family ) {
-					$trimmed = trim( $family );
-					if ( ! empty( $trimmed ) && str_contains( $trimmed, ' ' ) && ! str_contains( $trimmed, "'" ) && ! str_contains( $trimmed, '"' ) ) {
-							return '"' . $trimmed . '"';
+			$output         = trim( sanitize_text_field( $font_family ) );
+			$formattedItems = array();
+			if ( str_contains( $output, ',' ) ) {
+				$items = explode( ',', $output );
+				foreach ( $items as $item ) {
+					$formattedItem = self::maybe_add_quotes( $item );
+					if ( $formattedItem !== '' ) {
+						$formattedItems[] = $formattedItem;
 					}
-					return $trimmed;
-				},
-				$font_families
-			);
-
-			if ( count( $wrapped_font_families ) === 1 ) {
-				$font_family = $wrapped_font_families[0];
-			} else {
-				$font_family = implode( ', ', $wrapped_font_families );
+				}
+				return implode( ', ', $formattedItems );
 			}
-
-			return $font_family;
+			return self::maybe_add_quotes( $output );
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -70,16 +70,16 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 			}
 
 			$output         = trim( sanitize_text_field( $font_family ) );
-			$formattedItems = array();
+			$formatted_items = array();
 			if ( str_contains( $output, ',' ) ) {
 				$items = explode( ',', $output );
 				foreach ( $items as $item ) {
-					$formattedItem = self::maybe_add_quotes( $item );
-					if ( $formattedItem !== '' ) {
-						$formattedItems[] = $formattedItem;
+					$formatted_item = self::maybe_add_quotes( $item );
+					if ( $formatted_item !== '' ) {
+						$formatted_items[] = $formatted_item;
 					}
 				}
-				return implode( ', ', $formattedItems );
+				return implode( ', ', $formatted_items );
 			}
 			return self::maybe_add_quotes( $output );
 		}

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 				return '';
 			}
 
-			$output         = trim( sanitize_text_field( $font_family ) );
+			$output          = trim( sanitize_text_field( $font_family ) );
 			$formatted_items = array();
 			if ( str_contains( $output, ',' ) ) {
 				$items = explode( ',', $output );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * Adds surrounding quotes to font family names that contain special characters.
 		 *
 		 * It follows the recommendations from the CSS Fonts Module Level 4.
-		 * https://www.w3.org/TR/css-fonts-4/#font-family-prop
+		 * @link https://www.w3.org/TR/css-fonts-4/#font-family-prop
 		 *
 		 * @since 6.5.0
 		 * @access private
@@ -54,7 +54,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * - Adds surrounding quotes to names that special
 		 *
 		 * It follows the recommendations from the CSS Fonts Module Level 4.
-		 * https://www.w3.org/TR/css-fonts-4/#font-family-prop
+		 * @link https://www.w3.org/TR/css-fonts-4/#font-family-prop
 		 *
 		 * @since 6.5.0
 		 * @access private

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 				$items = explode( ',', $output );
 				foreach ( $items as $item ) {
 					$formatted_item = self::maybe_add_quotes( $item );
-					if ( !empty ( $formatted_item ) ) {
+					if ( ! empty( $formatted_item ) ) {
 						$formatted_items[] = $formatted_item;
 					}
 				}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -392,7 +392,7 @@ function FontLibraryProvider( { children } ) {
 					loadFontFaceInBrowser(
 						face,
 						getDisplaySrcFromFontFace( face.src ),
-						'iframe'
+						'all'
 					);
 				} );
 			}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -9,7 +9,7 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { FONT_WEIGHTS, FONT_STYLES } from './constants';
 import { unlock } from '../../../../lock-unlock';
 import { fetchInstallFontFace } from '../resolvers';
-import { formatFontFamily } from './preview-styles';
+import { formatFontFaceName } from './preview-styles';
 
 /**
  * Browser dependencies
@@ -99,7 +99,7 @@ export async function loadFontFaceInBrowser( fontFace, source, addTo = 'all' ) {
 	}
 
 	const newFont = new window.FontFace(
-		formatFontFamily( fontFace.fontFamily ),
+		formatFontFaceName( fontFace.fontFamily ),
 		dataSource,
 		{
 			style: fontFace.fontStyle,

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/make-families-from-faces.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/make-families-from-faces.js
@@ -1,10 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../../../lock-unlock';
+
+const { kebabCase } = unlock( componentsPrivateApis );
+
 export default function makeFamiliesFromFaces( fontFaces ) {
 	const fontFamiliesObject = fontFaces.reduce( ( acc, item ) => {
 		if ( ! acc[ item.fontFamily ] ) {
 			acc[ item.fontFamily ] = {
 				name: item.fontFamily,
 				fontFamily: item.fontFamily,
-				slug: item.fontFamily.replace( /\s+/g, '-' ).toLowerCase(),
+				slug: kebabCase( item.fontFamily.toLowerCase() ),
 				fontFace: [],
 			};
 		}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -30,22 +30,76 @@ function extractFontWeights( fontFaces ) {
 	return result;
 }
 
+/*
+ * Format the font family to use in the CSS font-family property of a CSS rule.
+ *
+ * The input can be a string with the font family name or a string with multiple font family names separated by commas.
+ * It follows the recommendations from the CSS Fonts Module Level 4.
+ * https://www.w3.org/TR/css-fonts-4/#font-family-prop
+ *
+ * @param {string} input - The font family.
+ * @return {string} The formatted font family.
+ *
+ * Example:
+ * formatFontFamily( "Open Sans, Font+Name, sans-serif" ) => '"Open Sans", "Font+Name", sans-serif'
+ * formatFontFamily( "'Open Sans', sans-serif" ) => '"Open Sans", sans-serif'
+ * formatFontFamily( "DotGothic16, Slabo 27px, serif" ) => '"DotGothic16","Slabo 27px",serif'
+ * formatFontFamily( "Mine's, Moe's Typography" ) => `"mine's","Moe's Typography"`
+ */
 export function formatFontFamily( input ) {
-	return input
-		.split( ',' )
-		.map( ( font ) => {
-			font = font.trim(); // Remove any leading or trailing white spaces
-			// If the font doesn't start with quotes and contains a space, then wrap in quotes.
-			// Check that string starts with a single or double quote and not a space
-			if (
-				! ( font.startsWith( '"' ) || font.startsWith( "'" ) ) &&
-				font.indexOf( ' ' ) !== -1
-			) {
-				return `"${ font }"`;
-			}
-			return font; // Return font as is if no transformation is needed
-		} )
-		.join( ', ' );
+	// Matchs any non alphabetic characters (a-zA-Z), dashes - , or parenthesis ()
+	const regex = /[^a-zA-Z\-()]+/;
+	const output = input.trim();
+
+	const formatItem = ( item ) => {
+		item = item.trim();
+		if ( item.match( regex ) ) {
+			// removes leading and trailing quotes.
+			item = item.replace( /^["']|["']$/g, '' );
+			return `"${ item }"`;
+		}
+		return item;
+	};
+
+	if ( output.includes( ',' ) ) {
+		return output
+			.split( ',' )
+			.map( formatItem )
+			.filter( ( item ) => item !== '' )
+			.join( ', ' );
+	}
+
+	return formatItem( output );
+}
+
+/*
+ * Format the font face name to use in the font-family property of a font face.
+ *
+ * The input can be a string with the font face name or a string with multiple font face names separated by commas.
+ * It removes the leading and trailing quotes from the font face name.
+ *
+ * @param {string} input - The font face name.
+ * @return {string} The formatted font face name.
+ *
+ * Example:
+ * formatFontFaceName("Open Sans") => "Open Sans"
+ * formatFontFaceName("'Open Sans', sans-serif") => "Open Sans"
+ * formatFontFaceName("'Open Sans', 'Helvetica Neue', sans-serif") => "Open Sans"
+ */
+export function formatFontFaceName( input ) {
+	const output = input.trim();
+	if ( output.includes( ',' ) ) {
+		return (
+			output
+				.split( ',' )
+				.find( ( item ) => item.trim() !== '' )
+				.trim()
+				// removes leading and trailing quotes.
+				.replace( /^["']|["']$/g, '' )
+		);
+	}
+	// removes leading and trailing quotes.
+	return output.replace( /^["']|["']$/g, '' );
 }
 
 export function getFamilyPreviewStyle( family ) {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -99,7 +99,7 @@ export function formatFontFaceName( input ) {
 	output = output.replace( /^["']|["']$/g, '' );
 
 	// Firefox needs the font name to be wrapped in double quotes meanwhile other browsers don't.
-	if ( window.navigator.userAgent.toLowerCase().includes( 'gecko' ) ) {
+	if ( window.navigator.userAgent.toLowerCase().match( /firefox|fxios/i ) ) {
 		output = `"${ output }"`;
 	}
 	return output;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -101,7 +101,7 @@ export function formatFontFaceName( input ) {
 	output = output.replace( /^["']|["']$/g, '' );
 
 	// Firefox needs the font name to be wrapped in double quotes meanwhile other browsers don't.
-	if ( window.navigator.userAgent.toLowerCase().includes( 'firefox' ) ) {
+	if ( window.navigator.userAgent.toLowerCase().includes( 'gecko' ) ) {
 		output = `"${ output }"`;
 	}
 	return output;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -84,22 +84,27 @@ export function formatFontFamily( input ) {
  * Example:
  * formatFontFaceName("Open Sans") => "Open Sans"
  * formatFontFaceName("'Open Sans', sans-serif") => "Open Sans"
- * formatFontFaceName("'Open Sans', 'Helvetica Neue', sans-serif") => "Open Sans"
+ * formatFontFaceName(", 'Open Sans', 'Helvetica Neue', sans-serif") => "Open Sans"
  */
 export function formatFontFaceName( input ) {
-	const output = input.trim();
+	let output = input.trim();
 	if ( output.includes( ',' ) ) {
-		return (
-			output
-				.split( ',' )
-				.find( ( item ) => item.trim() !== '' )
-				.trim()
-				// removes leading and trailing quotes.
-				.replace( /^["']|["']$/g, '' )
-		);
+		output = output
+			.split( ',' )
+			// finds the first item that is not an empty string.
+			.find( ( item ) => item.trim() !== '' )
+			.trim()
+			// removes leading and trailing quotes.
+			.replace( /^["']|["']$/g, '' );
 	}
 	// removes leading and trailing quotes.
-	return output.replace( /^["']|["']$/g, '' );
+	output = output.replace( /^["']|["']$/g, '' );
+
+	// Firefox needs the font name to be wrapped in double quotes meanwhile other browsers don't.
+	if ( window.navigator.userAgent.toLowerCase().includes( 'firefox' ) ) {
+		output = `"${ output }"`;
+	}
+	return output;
 }
 
 export function getFamilyPreviewStyle( family ) {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -93,9 +93,7 @@ export function formatFontFaceName( input ) {
 			.split( ',' )
 			// finds the first item that is not an empty string.
 			.find( ( item ) => item.trim() !== '' )
-			.trim()
-			// removes leading and trailing quotes.
-			.replace( /^["']|["']$/g, '' );
+			.trim();
 	}
 	// removes leading and trailing quotes.
 	output = output.replace( /^["']|["']$/g, '' );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
@@ -190,4 +190,17 @@ describe( 'formatFontFaceName', () => {
 			'Font+Name 24'
 		);
 	} );
+
+	it( 'should ouput the font face name with quotes on Firefox', () => {
+		const mockUserAgent =
+			'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0';
+
+		// Mock the userAgent for this test
+		Object.defineProperty( window.navigator, 'userAgent', {
+			value: mockUserAgent,
+			configurable: true,
+		} );
+
+		expect( formatFontFaceName( 'Open Sans' ) ).toBe( '"Open Sans"' );
+	} );
 } );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { getFamilyPreviewStyle, formatFontFamily } from '../preview-styles';
+import {
+	getFamilyPreviewStyle,
+	formatFontFamily,
+	formatFontFaceName,
+} from '../preview-styles';
 
 describe( 'getFamilyPreviewStyle', () => {
 	it( 'should return default fontStyle and fontWeight if fontFace is not provided', () => {
@@ -139,7 +143,7 @@ describe( 'formatFontFamily', () => {
 				"Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif"
 			)
 		).toBe(
-			"Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif"
+			'Seravek, "Gill Sans Nova", Ubuntu, Calibri, "DejaVu Sans", source-sans-pro, sans-serif'
 		);
 	} );
 
@@ -153,9 +157,37 @@ describe( 'formatFontFamily', () => {
 		);
 	} );
 
-	it( 'should wrap only those font names with spaces which are not already quoted', () => {
-		expect( formatFontFamily( 'Baloo Bhai 2, Arial' ) ).toBe(
-			'"Baloo Bhai 2", Arial'
+	it( 'should wrap names with special characters in quotes', () => {
+		expect(
+			formatFontFamily(
+				'Font+Name, Font*Name, _Font_Name_, generic(kai), sans-serif'
+			)
+		).toBe(
+			'"Font+Name", "Font*Name", "_Font_Name_", generic(kai), sans-serif'
+		);
+	} );
+
+	it( 'should fix empty wrong formatted font family', () => {
+		expect( formatFontFamily( ', Abril Fatface,Times,serif' ) ).toBe(
+			'"Abril Fatface", Times, serif'
+		);
+	} );
+} );
+
+describe( 'formatFontFaceName', () => {
+	it( 'should remove leading and trailing quotes', () => {
+		expect( formatFontFaceName( '"Open Sans"' ) ).toBe( 'Open Sans' );
+	} );
+
+	it( 'should remove leading and trailing quotes from multiple font face names', () => {
+		expect(
+			formatFontFaceName( "'Open Sans', 'Helvetica Neue', sans-serif" )
+		).toBe( 'Open Sans' );
+	} );
+
+	it( 'should remove leading and trailing quotes even from names with spaces and special characters', () => {
+		expect( formatFontFaceName( "'Font+Name 24', sans-serif" ) ).toBe(
+			'Font+Name 24'
 		);
 	} );
 } );


### PR DESCRIPTION
## What?
Fixes installed font families not rendering in the editor or frontend.

This is an alternative fix https://github.com/WordPress/gutenberg/pull/58853

## Why?
Fixes: https://github.com/WordPress/gutenberg/issues/58765
Fixes: https://github.com/WordPress/gutenberg/issues/59010

## How?
- Improving the format/sanitization functions to output valid CSS properties. Uses the quotes in all the cases needed.
It follows the recommendations from the CSS spec: https://www.w3.org/TR/css-fonts-4/#font-family-prop
- Using the kebab case function formatter to sanitize or create the font family slugs in the frontend and backend to avoid edge cases around slugs. (example: 'dotgothic16' is converted to 'dotgothic-16' because the `theme.json` presets renderer uses that format)
- Firefox-specific fix for loading font faces using JS for 'live' preview. (because Firefox needs quotes in the font faces loaded by JS when the other browsers need to avoid quotes on font faces loaded by JS).

## Testing Instructions
**Test with Firefox, Chrome and Safari** 
- Use WordPress 6.4.3
- Use Gutenberg in this branch.
- Install several font families and check that they load correctly in the editor; as a guide, you can see the screencast below.
Use font faces that demonstrated to produce errors i.e.:  Abril Fatface, Rock 3D, DotGothic16, Slabo 27px, Baloo 2, etc.

## Screenshots or screencast <!-- if applicable -->
Screencast of the fix working:

https://github.com/WordPress/gutenberg/assets/1310626/392df090-fd53-464e-a80d-d99fafae8bf2


