### PR TITLE
Add stylelint rule to prevent theme CSS vars outside of wp-components

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,6 +4,14 @@
 		"at-rule-empty-line-before": null,
 		"at-rule-no-unknown": null,
 		"comment-empty-line-before": null,
+		"declaration-property-value-disallowed-list": [
+			{
+				"/.*/": [ "/--wp-components-color-/" ]
+			},
+			{
+				"message": "--wp-components-color-* variables are not ready to be used outside of the components package."
+			}
+		],
 		"font-weight-notation": null,
 		"max-line-length": null,
 		"no-descending-specificity": null,

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -64,7 +64,7 @@
  */
 
 @mixin block-toolbar-button-style__focus() {
-	box-shadow: inset 0 0 0 $border-width var(--wp-components-color-background, $white), 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+	box-shadow: inset 0 0 0 $border-width $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -67,7 +67,7 @@
 	}
 	th {
 		text-align: left;
-		color: var(--wp-components-color-foreground, $gray-900);
+		color: $gray-900;
 		font-weight: normal;
 		font-size: $default-font-size;
 	}
@@ -527,7 +527,7 @@
 		&:hover,
 		&[data-active-item],
 		&:focus {
-			background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+			background-color: var(--wp-admin-theme-color);
 			color: $white;
 
 			.dataviews-search-widget-filter-combobox-item-check {
@@ -587,7 +587,7 @@
 
 		&:focus {
 			background: $white;
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 
 		&::placeholder {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -49,7 +49,7 @@
 		outline: 3px solid transparent;
 		outline-offset: -2px;
 
-		color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+		color: var(--wp-admin-theme-color);
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 
 		.edit-site-global-styles-screen-revisions__revision-button {
@@ -61,7 +61,7 @@
 		}
 
 		&::before {
-			background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+			background: var(--wp-admin-theme-color);
 		}
 
 		.edit-site-global-styles-screen-revisions__changes,

--- a/packages/edit-site/src/components/sidebar-button/style.scss
+++ b/packages/edit-site/src/components/sidebar-button/style.scss
@@ -10,7 +10,7 @@
 	&:focus-visible:not(:disabled) {
 		box-shadow:
 			0 0 0 var(--wp-admin-border-width-focus)
-			var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+			var(--wp-admin-theme-color);
 		outline: 3px solid transparent;
 	}
 


### PR DESCRIPTION
Part of #44116
Follow-up to #58098

## What?

Adds a stylelint rule to catch premature usages of the components theming CSS variables (`wp-components-color-*`) outside of the components package.

## Why?

These CSS variables are still experimental, and there is still no reason to use them outside of the components package unless it's part of a coordinated effort to use a particular package component with the `<Theme>` component.

None of the existing usages (lint rule violations) are part of an intentional theming effort, and seem to be copy & pasting the variable (complete with fallbacks) from wp-component CSS, assuming that is the new way to do things.

This lint rule is meant to inform developers that this is not necessary.

## How?

Although we are restricting variable access through `var()`, at the moment I would still like to allow overriding definitions (`--wp-components-color-foo: #000`). Nobody has tried this yet, but it would be useful to monitor these to better understand the use cases for theming.

## Testing Instructions

1. On the first commit where the lint rule is added (4083e3ac1dd7c5a4ccdafed15689bb8920fb018e), run `npm run lint:css`. The violations should be caught.
2. After the commit where the violations are fixed (5492949cb9465eb8fe019383217adbfff1466cb7), the linter should pass.