### PR TITLE
Block Hooks: Fix in Navigation block

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1449,10 +1449,6 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 			'post_content' => $serialized_inner_blocks,
 		)
 	);
-
-	// TODO: wp_update_post() to set the post_content to the updated markup (to include the ignoredHookedBlocks metadata).
-	// We need to remove the markup for the root Nav block wrapper like we do in block_core_navigation_insert_hooked_blocks_into_rest_response,
-	// or alternatively via serialize_blocks( $root_nav_block['innerBlocks'] ), but that's probably more expensive.
 }
 
 // Before adding our filter, we verify if it's already added in Core.


### PR DESCRIPTION
## What?
Update the Block Hooks mechanism as used in the Navigation block upon writing the REST API response received from a client to the DB.

## Why?
The Block Hooks mechanism recently underwent some overhaul (in https://github.com/WordPress/wordpress-develop/pull/6087), which decoupled hooked block injection from setting the `ignoredHookedBlocks` metadata. The latter is no longer done by `insert_hooked_blocks` but by a separate function called `set_ignored_hooked_blocks_metadata` (that can be passed as a callback to the `make_{before|after}_block` visitor factories).

Since the implementation of the Navigation block relied on the previous functionality, it needs to be updated to work properly.

## How?
We need to run block tree traversal with `set_ignored_hooked_blocks_metadata` rather than `insert_hooked_blocks` on the template content received from the endpoint for the Navigation post type, upon persisting to the DB.

## Testing Instructions
Verify that with current Core `trunk`, current versions of GB _don't_ work properly w.r.t. hooked blocks insertion into the Navigation block (specifically when making changes to the Nav block).

1. Add the below code to your themes `functions.php`
2. Load frontend and check the Login/Logout block is an inner block of the core Navigation block and hasn't been added twice.
3. Load the Header template part in the Site Editor and check that the Login/Logout block is present as an inner block of the core Navigation and hasn't been added twice.
4. Make customisations to move the block and check it persists between reloads.
5. Make customisations to remove the block completely and check it persists between reloads.
6. Remove the PHP code added in step 1, and now add the below JSON to the same blocks `block.json` file and retest starting from step 2.

```php
function register_logout_block_as_navigation_last_child( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'core/navigation' && $position === 'last_child' ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'register_logout_block_as_navigation_last_child', 10, 4 );
```

```json
"blockHooks": {
	"core/navigation": "lastChild"
}
```
