### PR TITLE
Edit Post: Try displaying offline status through a `useNetworkConnectivity()` hook

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -450,19 +450,6 @@ _Returns_
 
 -   `import('react').RefCallback<TypeFromRef<TRef>>`: The merged ref callback.
 
-### useObservableValue
-
-React hook that lets you observe an entry in an `ObservableMap`. The hook returns the current value corresponding to the key, or `undefined` when there is no value stored. It also observes changes to the value and triggers an update of the calling component in case the value changes.
-
-_Parameters_
-
--   _map_ `ObservableMap< K, V >`: The `ObservableMap` to observe.
--   _name_ `K`: The map key to observe.
-
-_Returns_
-
--   `V | undefined`: The value corresponding to the map key requested.
-
 ### useNetworkConnectivity
 
 Returns the current network connectivity status provided by `window.navigator`.
@@ -476,6 +463,19 @@ const { isConnected } = useNetworkConnectivity();
 _Returns_
 
 -   `NetworkInformation`: Network information.
+
+### useObservableValue
+
+React hook that lets you observe an entry in an `ObservableMap`. The hook returns the current value corresponding to the key, or `undefined` when there is no value stored. It also observes changes to the value and triggers an update of the calling component in case the value changes.
+
+_Parameters_
+
+-   _map_ `ObservableMap< K, V >`: The `ObservableMap` to observe.
+-   _name_ `K`: The map key to observe.
+
+_Returns_
+
+-   `V | undefined`: The value corresponding to the map key requested.
 
 ### usePrevious
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -465,7 +465,7 @@ _Returns_
 
 ### useNetworkConnectivity
 
-Returns the current network connectivity status provided by the native bridge.
+Returns the current network connectivity status provided by `window.navigator`.
 
 _Usage_
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -463,6 +463,20 @@ _Returns_
 
 -   `V | undefined`: The value corresponding to the map key requested.
 
+### useNetworkConnectivity
+
+Returns the current network connectivity status provided by the native bridge.
+
+_Usage_
+
+```jsx
+const { isConnected } = useNetworkConnectivity();
+```
+
+_Returns_
+
+-   `NetworkInformation`: Network information.
+
 ### usePrevious
 
 Use something's value from the previous render. Based on <https://usehooks.com/usePrevious/>.

--- a/packages/compose/src/hooks/use-network-connectivity/index.js
+++ b/packages/compose/src/hooks/use-network-connectivity/index.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * @typedef {Object} NetworkInformation
+ *
+ * @property {boolean} [isConnected] Whether the device is connected to a network.
+ */
+
+/**
+ * Returns the current network connectivity status provided by the native bridge.
+ *
+ * @example
+ *
+ * ```jsx
+ * const { isConnected } = useNetworkConnectivity();
+ * ```
+ *
+ * @return {NetworkInformation} Network information.
+ */
+export default function useNetworkConnectivity() {
+	const [ isConnected, setIsConnected ] = useState( window.navigator.onLine );
+
+	const setOnline = () => {
+		setIsConnected( true );
+	};
+
+	const setOffline = () => {
+		setIsConnected( false );
+	};
+
+	useEffect( () => {
+		window.addEventListener( 'online', setOnline );
+		window.addEventListener( 'offline', setOffline );
+
+		return () => {
+			window.removeEventListener( 'online', setOnline );
+			window.removeEventListener( 'offline', setOffline );
+		};
+	}, [] );
+
+	return { isConnected };
+}

--- a/packages/compose/src/hooks/use-network-connectivity/index.js
+++ b/packages/compose/src/hooks/use-network-connectivity/index.js
@@ -10,7 +10,7 @@ import { useEffect, useState } from '@wordpress/element';
  */
 
 /**
- * Returns the current network connectivity status provided by the native bridge.
+ * Returns the current network connectivity status provided by `window.navigator`.
  *
  * @example
  *

--- a/packages/compose/src/hooks/use-network-connectivity/test/index.js
+++ b/packages/compose/src/hooks/use-network-connectivity/test/index.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useNetworkConnectivity from '../index';
+
+describe( 'useNetworkConnectivity', () => {
+	describe( 'when network connectivity is available', () => {
+		beforeAll( () => {
+			jest.spyOn( window.navigator, 'onLine', 'get' ).mockReturnValue(
+				true
+			);
+		} );
+		it( 'should return true', () => {
+			const { result } = renderHook( () => useNetworkConnectivity() );
+
+			expect( result.current.isConnected ).toBe( true );
+		} );
+
+		it( 'should update the status when network connectivity changes', () => {
+			let { result } = renderHook( () => useNetworkConnectivity() );
+
+			expect( result.current.isConnected ).toBe( true );
+
+			jest.spyOn( window.navigator, 'onLine', 'get' ).mockReturnValue(
+				false
+			);
+
+			result = renderHook( () => useNetworkConnectivity() ).result;
+
+			expect( result.current.isConnected ).toBe( false );
+		} );
+	} );
+
+	describe( 'when network connectivity is unavailable', () => {
+		beforeAll( () => {
+			jest.spyOn( window.navigator, 'onLine', 'get' ).mockReturnValue(
+				false
+			);
+		} );
+		it( 'should return false', () => {
+			const { result } = renderHook( () => useNetworkConnectivity() );
+
+			expect( result.current.isConnected ).toBe( false );
+		} );
+
+		it( 'should update the status when network connectivity changes', () => {
+			let { result } = renderHook( () => useNetworkConnectivity() );
+
+			expect( result.current.isConnected ).toBe( false );
+
+			jest.spyOn( window.navigator, 'onLine', 'get' ).mockReturnValue(
+				true
+			);
+
+			result = renderHook( () => useNetworkConnectivity() ).result;
+
+			expect( result.current.isConnected ).toBe( true );
+		} );
+	} );
+} );

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -49,3 +49,4 @@ export { default as __experimentalUseDropZone } from './hooks/use-drop-zone';
 export { default as useFocusableIframe } from './hooks/use-focusable-iframe';
 export { default as __experimentalUseFixedWindowList } from './hooks/use-fixed-window-list';
 export { default as useObservableValue } from './hooks/use-observable-value';
+export { default as useNetworkConnectivity } from './hooks/use-network-connectivity';

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -517,6 +517,10 @@ _Parameters_
 
 > **Deprecated** since 5.3, use `wp.blockEditor.ObserveTyping` instead.
 
+### OfflineStatus
+
+Undocumented declaration.
+
 ### PageAttributesCheck
 
 Wrapper component that renders its children only if the post type supports page attributes.

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -27,6 +27,7 @@ import PostPublishButtonOrToggle from '../post-publish-button/post-publish-butto
 import PostSavedState from '../post-saved-state';
 import PostViewLink from '../post-view-link';
 import PreviewDropdown from '../preview-dropdown';
+import OfflineStatus from '../offline-status';
 import { store as editorStore } from '../../store';
 
 const toolbarVariations = {
@@ -125,6 +126,7 @@ function Header( {
 				transition={ { type: 'tween' } }
 				className="editor-header__settings"
 			>
+				<OfflineStatus />
 				{ ! customSaveButton && ! isPublishSidebarOpened && (
 					// This button isn't completely hidden by the publish sidebar.
 					// We can't hide the whole toolbar when the publish sidebar is open because

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -100,6 +100,7 @@ export { default as UnsavedChangesWarning } from './unsaved-changes-warning';
 export { default as WordCount } from './word-count';
 export { default as TimeToRead } from './time-to-read';
 export { default as CharacterCount } from './character-count';
+export { default as OfflineStatus } from './offline-status';
 
 // State Related Components.
 export { default as EditorProvider } from './provider';

--- a/packages/editor/src/components/offline-status/index.js
+++ b/packages/editor/src/components/offline-status/index.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { useNetworkConnectivity, useViewportMatch } from '@wordpress/compose';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const OfflineStatus = () => {
+	const { isConnected } = useNetworkConnectivity();
+	const isLargeViewport = useViewportMatch( 'small' );
+
+	if ( isConnected ) {
+		return null;
+	}
+
+	const label = isLargeViewport ? __( 'Working offline' ) : null;
+
+	return (
+		<Button
+			className="offline-status"
+			variant="tertiary"
+			size="compact"
+			icon="airplane"
+			label={ label }
+			aria-disabled
+		>
+			{ label }
+		</Button>
+	);
+};
+
+export default OfflineStatus;


### PR DESCRIPTION
## What?
This PR suggests displaying an offline status if the user ends up being offline.

This is an experiment and is by no means finished or ready to merge. 

DO NOT MERGE!

## Why?
As we're starting to look into collaborative editing, we have to consider implementing proper offline support. While researching what we have in place, I spotted we already have an implementation of displaying online status for React Native:

* A `useNetworkConnectivity()` hook
* A `withNetworkConnectivity` HoC
* An `<OfflineStatus />` component.

However, we don't have them for the web version. This PR experiments with adding them, as a first step towards better offline support for the editor.

We could afterwards do a bunch of stuff with this hook, like for example stop trying any requests if we know we're offline. Right now, if an autosave request fails, we suspect that the user is offline and render a warning, but that's not necessarily the case.

## How?
We're introducing:
* A simple `useNetworkConnectivity()` hook that utilizes `window.navigator.onLine` and `online` and `offline` events. I'm also adding basic tests.
* A simple `OfflineStatus` component that will render an offline status if the user is offline. That component is mostly for presentational purposes, I'm not certain this is the best way or best place to notify the user that they're online. But we're using that component for demonstrating the `useNetworkConnectivity()` hook.

We're also utilizing the `OfflineStatus` component in the post editor header.

## Testing Instructions
* Checkout this PR
* Open the post editor
* Go offline (could be simulated from the [Network tab of your dev tools](https://developer.chrome.com/docs/devtools/network/reference#offline)).
* Verify the offline status appears.
* Go online.
* Verify the offline status disappears.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-02-14 at 18 47 24](https://github.com/WordPress/gutenberg/assets/8436925/8371d440-5716-4363-8dc6-f2b7b37098f3)
![Screenshot 2024-02-14 at 18 47 42](https://github.com/WordPress/gutenberg/assets/8436925/ad129081-e3bb-4416-9470-968a71b28d83)
