### PR TITLE
Interactivity API: Fix server side rendering for Search block

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -188,7 +188,7 @@ function render_block_core_search( $attributes ) {
 			)
 		);
 		$form_directives      = '
-		 data-wp-interactive=\'"core/search"\''
+		 data-wp-interactive="core/search"'
 		. $form_context .
 		'data-wp-class--wp-block-search__searchfield-hidden="!context.isSearchInputVisible"
 		 data-wp-on--keydown="actions.handleSearchKeydown"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
https://github.com/WordPress/gutenberg/pull/58943 introduced a reversion on the search block, SSR is not working in Search block due to a escaping commas issue.
![Screenshot 2024-02-14 at 19 15 52](https://github.com/WordPress/gutenberg/assets/37012961/6c317120-6c75-46bc-8eea-953057bf86f6)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Insert search block, only button, with text instead of an icon.
- Check that in `trunk` you have a movement on the input.
- Check that in this PR that movement does not happen.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/37012961/cfd5f4ef-8519-413f-b80f-eb5a89624431

After:

https://github.com/WordPress/gutenberg/assets/37012961/04830dea-51e1-48f4-ba9e-35f3af778253

