### PR TITLE
Interactivity API: Remove `data-wp-interactive` object for core/router.

### DIFF
--- a/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
@@ -800,14 +800,14 @@ CSS;
 			echo <<<HTML
 			<div
 				class="wp-interactivity-router-loading-bar"
-				data-wp-interactive='{"namespace":"core/router"}'
+				data-wp-interactive="core/router"
 				data-wp-class--start-animation="state.navigation.hasStarted"
 				data-wp-class--finish-animation="state.navigation.hasFinished"
 			></div>
 			<div
 				class="screen-reader-text"
 				aria-live="polite"
-				data-wp-interactive='{"namespace":"core/router"}'
+				data-wp-interactive="core/router"
 				data-wp-text="state.navigation.message"
 			></div>
 HTML;

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -18,7 +18,7 @@ if ( $attributes['disableNavigation'] ) {
 ?>
 
 <div
-	data-wp-interactive='{ "namespace": "router" }'
+	data-wp-interactive="router"
 	data-wp-router-region="region-1"
 >
 	<h2 data-testid="title"><?php echo $attributes['title']; ?></h2>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Refactor to use the simplified string version.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the site editor, deactivate "Force page reload" for the Query block.
2. Visit the homepage.
3. In the browser dev tools, add a network throttling (e.g. Slow 3G).
4. In the Query block, navigate to the Next page.
5. Ensure the loading bar appears and start an animation.
6. Ensure the loading bar disappears when the next page is loaded.

## Backport PR
https://github.com/WordPress/wordpress-develop/pull/6111
