### PR TITLE
Relocate 'ErrorBoundary' component unit test folders

### DIFF
--- a/packages/customize-widgets/src/components/error-boundary/test/error-boundary.js
+++ b/packages/customize-widgets/src/components/error-boundary/test/error-boundary.js
@@ -1,15 +1,17 @@
 /**
- * WordPress dependencies
- */
-import * as wpHooks from '@wordpress/hooks';
-/**
- * Internal dependencies
- */
-import ErrorBoundary from '../error-boundary';
-/**
  * External dependencies
  */
 import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import * as wpHooks from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import ErrorBoundary from '../index';
 
 const theError = new Error( 'Kaboom' );
 

--- a/packages/edit-site/src/components/error-boundary/test/error-boundary.js
+++ b/packages/edit-site/src/components/error-boundary/test/error-boundary.js
@@ -1,15 +1,17 @@
 /**
- * WordPress dependencies
- */
-import * as wpHooks from '@wordpress/hooks';
-/**
- * Internal dependencies
- */
-import ErrorBoundary from '../error-boundary';
-/**
  * External dependencies
  */
 import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import * as wpHooks from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import ErrorBoundary from '../index';
 
 const theError = new Error( 'Kaboom' );
 

--- a/packages/edit-widgets/src/components/error-boundary/test/error-boundary.js
+++ b/packages/edit-widgets/src/components/error-boundary/test/error-boundary.js
@@ -1,15 +1,17 @@
 /**
- * WordPress dependencies
- */
-import * as wpHooks from '@wordpress/hooks';
-/**
- * Internal dependencies
- */
-import ErrorBoundary from '../error-boundary';
-/**
  * External dependencies
  */
 import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import * as wpHooks from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import ErrorBoundary from '../index';
 
 const theError = new Error( 'Kaboom' );
 


### PR DESCRIPTION
## What?
This is a follow-up to #42024.

PR moves the `ErrorBoundary` unit tests into the component folders + minor coding standard updates.

## Why?
Matches to the guidelines the project uses for other component unit tests.

## Testing Instructions
CI cheks are green.