### PR TITLE
Font Library: do not match firefox for iOS in the JS loading font face name formatting exception.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -99,7 +99,7 @@ export function formatFontFaceName( input ) {
 	output = output.replace( /^["']|["']$/g, '' );
 
 	// Firefox needs the font name to be wrapped in double quotes meanwhile other browsers don't.
-	if ( window.navigator.userAgent.toLowerCase().match( /firefox|fxios/i ) ) {
+	if ( window.navigator.userAgent.toLowerCase().includes( 'firefox' ) ) {
 		output = `"${ output }"`;
 	}
 	return output;


### PR DESCRIPTION
## What?
Do not match Firefox for iOS in the conditional formatting for font face name needed for Firefox Gecko browsers.
This change was added here: https://github.com/WordPress/gutenberg/pull/59019.

Props to @creativecoder for [noticing that](https://github.com/WordPress/gutenberg/pull/59019#discussion_r1490015874).

## Why?
Firefox for iOS should not be targeted because it is not Gecko-based but WebKit based.
Reference: https://firefox-source-docs.mozilla.org/overview/ios.html

## How?
Removing the user agent name used by Firefox for iOS.
