### PR TITLE
Patterns: Avoid showing block removal warning when deleting a pattern instance that has overrides

### DIFF
--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -140,6 +140,15 @@ export const privateRemoveBlocks =
 				}
 
 				if ( rules[ 'bindings/core/pattern-overrides' ] ) {
+					const parentPatternBlocks =
+						select.getBlockParentsByBlockName(
+							clientId,
+							'core/block'
+						);
+					// If the overriden block is a child of a core/block, skip it.
+					if ( parentPatternBlocks?.length > 0 ) {
+						continue;
+					}
 					const blockAttributes =
 						select.getBlockAttributes( clientId );
 					if (

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -145,7 +145,7 @@ export const privateRemoveBlocks =
 							clientId,
 							'core/block'
 						);
-					// If the overriden block is a child of a core/block, skip it.
+					// We only need to run this check when editing the original pattern, not pattern instances.
 					if ( parentPatternBlocks?.length > 0 ) {
 						continue;
 					}


### PR DESCRIPTION
## What?
Checks we are not within a pattern instance before running block deletion rules.

## Why?
Currently a user gets a warning then they try to delete a pattern block if it contains blocks with content overrides, but this warning only makes sense if the user is editing the original pattern.

## How?
Checks to make sure the block does not have a parent of `core/block` before running the deletion prompt.

## Testing Instructions

- Create a synced pattern with overrides on some of the blocks
- Insert the pattern in a post and then delete it and make sure no warning appears
- Insert it again and this time choose the option to `Edit original` and then try deleting one of the overridden blocks and make sure the warning displays

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/363eb436-d3f7-4ee4-b19e-1455beb8c6e7

