### PR TITLE
Tweak link focus outline styles in HTML anchor and custom CSS

### DIFF
--- a/packages/block-editor/src/hooks/anchor.scss
+++ b/packages/block-editor/src/hooks/anchor.scss
@@ -1,4 +1,4 @@
 .html-anchor-control .components-external-link {
-	display: block;
+	display: inline-block;
 	margin-top: $grid-unit-10;
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -173,7 +173,7 @@
 }
 
 .edit-site-global-styles-screen-css-help-link {
-	display: block;
+	display: inline-block;
 	margin-top: $grid-unit-10;
 }
 .edit-site-global-styles-screen-variations {


### PR DESCRIPTION
## What?

This PR This PR improves the consistency of the focus outline style of external links in the following two places.

### Learn more about anchors

| Before| After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/d4777483-a3bc-4b71-8341-28a6e8772e33) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/245772da-d55c-45b4-a059-3eebd4d3f310) | 

### Learn more about CSS

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/ae3eb57e-d7e3-4585-9307-c406f168770f) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/23cc1829-2fb3-4cae-9189-b7397f5f6533) | 

## Why?

I noticed that some external links have `display:block` applied, so the focus outline is longer than the actual text.

## How?

Change `display:block` to `display:inline-block`.

## Testing Instructions

- Open the site editor.
- Use the Tab key on your keyboard to move focus to the link below.
  - Block > Advanced panel > "Learn more about anchors"
  - Styles > Additional CSS > Learn more about CSS
- Check the focus outline.