### PR TITLE
Global styles revisions Controller: return single revision only when it matches the parent id 

### DIFF
--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php
@@ -69,6 +69,15 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_6_5 extends Gutenberg_RE
 			return $revision;
 		}
 
+		if ( (int) $parent->ID !== (int) $revision->post_parent ) {
+			return new WP_Error(
+				'rest_revision_parent_id_mismatch',
+				/* translators: %d: A post id. */
+				sprintf( __( 'The revision does not belong to the specified parent with id of "%d"' ), $parent->ID ),
+				array( 'status' => 404 )
+			);
+		}
+
 		$response = $this->prepare_item_for_response( $revision, $request );
 		return rest_ensure_response( $response );
 	}

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -20,6 +20,11 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	protected static $global_styles_id;
 
 	/**
+	 * @var int
+	 */
+	protected static $global_styles_id_2;
+
+	/**
 	 * @var array
 	 */
 	private $revision_1;
@@ -50,6 +55,20 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 				'post_title'   => __( 'Custom Styles', 'default' ),
 				'post_type'    => 'wp_global_styles',
 				'post_name'    => 'wp-global-styles-tt1-blocks-revisions',
+				'tax_input'    => array(
+					'wp_theme' => 'tt1-blocks',
+				),
+			)
+		);
+
+		// This creates another global styles post for the current theme.
+		self::$global_styles_id_2 = $factory->post->create(
+			array(
+				'post_content' => '{"version": ' . WP_Theme_JSON::LATEST_SCHEMA . ', "isGlobalStylesUserThemeJSON": true }',
+				'post_status'  => 'publish',
+				'post_title'   => __( 'Custom Styles', 'default' ),
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => 'wp-global-styles-tt1-blocks-revisions-2',
 				'tax_input'    => array(
 					'wp_theme' => 'tt1-blocks',
 				),
@@ -187,6 +206,36 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 			$routes,
 			'Single global style revisions based on the given parentID and revision ID route does not exist.'
 		);
+	}
+
+	/**
+	 * @ticket 59810
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_item_valid_parent_id() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions/' . $this->revision_1_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( self::$global_styles_id, $data['parent'], "The returned revision's id should match the parent id." );
+		$this->check_get_revision_response( $data, $this->revision_1 );
+	}
+
+	/**
+	 * @ticket 59810
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_item_invalid_parent_id() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id_2 . '/revisions/' . $this->revision_1_id );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_revision_parent_id_mismatch', $response, 404 );
+
+		$expected_message = 'The revision does not belong to the specified parent with id of "' . self::$global_styles_id_2 . '"';
+		$this->assertSame( $expected_message, $response->as_error()->get_error_messages()[0], 'The message must contain the correct parent ID.' );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Brings global styles revisions controller `Gutenberg_REST_Global_Styles_Revisions_Controller_6_5` in line with the changes from:

- https://github.com/WordPress/wordpress-develop/pull/5655

This change is required as `WP_REST_Global_Styles_Revisions_Controller` doesn't inherit `WP_REST_Revisions_Controller`.

Core backport:

- https://github.com/WordPress/wordpress-develop/pull/6108

Trac ticket

- https://core.trac.wordpress.org/ticket/59810


## Why? And how?
https://github.com/WordPress/wordpress-develop/pull/5655 explains:

> 
> This PR adds a condition to `get_item` that checks the revision parent id against the supplied parent id. 
> 
> If it doesn't match, the method returns a 404.
> 
> This is to ensure that  `get_item` does not return a revision whose parent does not match the `parent` route fragment.


## Testing Instructions

`npm run test:unit:php:base -- --filter Gutenberg_REST_Global_Styles_Revisions_Controller_Test`
