### PR TITLE
Background image support: Fix issue with background position keyboard entry

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -374,11 +374,14 @@ function backgroundSizeHelpText( value ) {
 }
 
 export const coordsToBackgroundPosition = ( value ) => {
-	if ( ! value || isNaN( value.x ) || isNaN( value.y ) ) {
+	if ( ! value || ( isNaN( value.x ) && isNaN( value.y ) ) ) {
 		return undefined;
 	}
 
-	return `${ value.x * 100 }% ${ value.y * 100 }%`;
+	const x = isNaN( value.x ) ? 0.5 : value.x;
+	const y = isNaN( value.y ) ? 0.5 : value.y;
+
+	return `${ x * 100 }% ${ y * 100 }%`;
 };
 
 export const backgroundPositionToCoords = ( value ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: #54336 

Fix keyboard entry for the background image block support's position controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If a user has not yet interacted with the background position controls via the mouse, then when entering a number in one of the "left" or "top" fields, we need to update the opposing side to a default value, otherwise it is set to `NaN` and fails to update the block attributes.

Currently, for folks entering numbers by keyboard and not interacting via the mouse, it's impossible to set any values.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* When converting coords to a background position value, if one of the coords is set but not the other, set the other to a default value of `0.5` (50%) so that the controls become usable again.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the post or site editors add a Group block and give it a background image.
2. In the block inspector controls for background, enable background size.
3. Tab over to or click into the Left field for the background position, without interacting with the main background position control with the mouse.
4. Go to type a value into the Left field. On `trunk`, note that once you tab out of the field, the value does not stick. With this PR applied, when you add a value, the empty value on the other side should default to `50%`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

As above.

## Screenshots or screencast <!-- if applicable -->

### Trunk

https://github.com/WordPress/gutenberg/assets/14988353/40b5f724-407b-4f88-b929-fd42cc125acb

### This PR

https://github.com/WordPress/gutenberg/assets/14988353/841674a5-2e6e-413d-8124-390417c7c0bc