### PR TITLE
Global style changes: refactor output for a more flexible UI and grouping

### DIFF
--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -199,13 +199,14 @@ export default function getGlobalStylesChanges( next, previous, options = {} ) {
 			}, {} )
 		).map( ( [ key, changeValues ] ) => {
 			const changeValuesLength = changeValues.length;
+			const joinedChangesValue = changeValues.join( __( ', ' ) );
 			switch ( key ) {
 				case 'blocks': {
 					return sprintf(
 						// translators: %2$s: a list of block names separated by a comma.
 						_n( '%2$s block.', '%2$s blocks.', changeValuesLength ),
 						changeValuesLength,
-						changeValues.join( ', ' )
+						joinedChangesValue
 					);
 				}
 				case 'elements': {
@@ -217,25 +218,29 @@ export default function getGlobalStylesChanges( next, previous, options = {} ) {
 							changeValuesLength
 						),
 						changeValuesLength,
-						changeValues.join( ', ' )
+						joinedChangesValue
 					);
 				}
 				case 'settings': {
 					return sprintf(
 						// translators: %s: a list of theme.json setting labels separated by a comma.
 						__( '%s settings.' ),
-						changeValues.join( ', ' )
+						joinedChangesValue
 					);
 				}
 				case 'styles': {
 					return sprintf(
 						// translators: %s: a list of theme.json top-level styles labels separated by a comma.
 						__( '%s styles.' ),
-						changeValues.join( ', ' )
+						joinedChangesValue
 					);
 				}
 				default: {
-					return `${ changeValues.join( ', ' ) }.`;
+					return sprintf(
+						// translators: %s: a list of global styles changes separated by a comma.
+						__( '%s.' ),
+						joinedChangesValue
+					);
 				}
 			}
 		} );

--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -171,8 +171,8 @@ export function getGlobalStylesChangelist( next, previous ) {
 }
 
 /**
- * From a getGlobalStylesChangelist() result, returns a truncated array of translated changes.
- * Appends a translated string indicating the number of changes that were truncated.
+ * From a getGlobalStylesChangelist() result, returns an array of translated global styles changes, grouped by type.
+ * The types are 'blocks', 'elements', 'settings', and 'styles'.
  *
  * @param {Object}              next     The changed object to compare.
  * @param {Object}              previous The original object to compare against.
@@ -235,7 +235,7 @@ export default function getGlobalStylesChanges( next, previous, options = {} ) {
 					);
 				}
 				default: {
-					return changeValues.join( ', ' );
+					return `${ changeValues.join( ', ' ) }.`;
 				}
 			}
 		} );

--- a/packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import getGlobalStylesChanges from '../get-global-styles-changes';
+import getGlobalStylesChanges, {
+	getGlobalStylesChangelist,
+} from '../get-global-styles-changes';
 
 /**
  * WordPress dependencies
@@ -12,24 +14,8 @@ import {
 	getBlockTypes,
 } from '@wordpress/blocks';
 
-describe( 'getGlobalStylesChanges', () => {
-	beforeEach( () => {
-		registerBlockType( 'core/test-fiori-di-zucca', {
-			save: () => {},
-			category: 'text',
-			title: 'Test pumpkin flowers',
-			edit: () => {},
-		} );
-	} );
-
-	afterEach( () => {
-		getBlockTypes().forEach( ( block ) => {
-			unregisterBlockType( block.name );
-		} );
-	} );
-
-	const revision = {
-		id: 10,
+describe( 'getGlobalStylesChanges and utils', () => {
+	const next = {
 		styles: {
 			typography: {
 				fontSize: 'var(--wp--preset--font-size--potato)',
@@ -85,11 +71,18 @@ describe( 'getGlobalStylesChanges', () => {
 						},
 					],
 				},
+				gradients: [
+					{
+						name: 'Something something',
+						gradient:
+							'linear-gradient(105deg,rgba(6,147,100,1) 0%,rgb(155,81,100) 100%)',
+						slug: 'something-something',
+					},
+				],
 			},
 		},
 	};
-	const previousRevision = {
-		id: 9,
+	const previous = {
 		styles: {
 			typography: {
 				fontSize: 'var(--wp--preset--font-size--fungus)',
@@ -161,74 +154,116 @@ describe( 'getGlobalStylesChanges', () => {
 							color: 'blue',
 						},
 					],
+					custom: [
+						{
+							slug: 'one',
+							color: 'tomato',
+						},
+					],
 				},
+				gradients: [
+					{
+						name: 'Vivid cyan blue to vivid purple',
+						gradient:
+							'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+						slug: 'vivid-cyan-blue-to-vivid-purple',
+					},
+				],
 			},
 		},
 	};
 
-	it( 'returns a list of changes and caches them', () => {
-		const resultA = getGlobalStylesChanges( revision, previousRevision );
-		expect( resultA ).toEqual( [
-			'Colors',
-			'Typography',
-			'Test pumpkin flowers',
-			'H3 element',
-			'Caption element',
-			'H6 element',
-			'Link element',
-			'Color settings',
-		] );
-
-		const resultB = getGlobalStylesChanges( revision, previousRevision );
-
-		expect( resultA ).toBe( resultB );
-	} );
-
-	it( 'returns a list of truncated changes', () => {
-		const resultA = getGlobalStylesChanges( revision, previousRevision, {
-			maxResults: 3,
+	beforeEach( () => {
+		registerBlockType( 'core/test-fiori-di-zucca', {
+			save: () => {},
+			category: 'text',
+			title: 'Test pumpkin flowers',
+			edit: () => {},
 		} );
-		expect( resultA ).toEqual( [
-			'Colors',
-			'Typography',
-			'Test pumpkin flowers',
-			'…and 5 more changes',
-		] );
 	} );
 
-	it( 'skips unknown and unchanged keys', () => {
-		const result = getGlobalStylesChanges(
-			{
-				styles: {
-					frogs: {
-						legs: 'green',
-					},
-					typography: {
-						fontSize: '1rem',
-					},
-					settings: {
-						'': {
-							'': 'foo',
+	afterEach( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'getGlobalStylesChanges()', () => {
+		it( 'returns a list of changes', () => {
+			const result = getGlobalStylesChanges( next, previous );
+			expect( result ).toEqual( [
+				'Colors, Typography styles.',
+				'Test pumpkin flowers block.',
+				'H3, Caption, H6, Link elements.',
+				'Color settings.',
+			] );
+		} );
+
+		it( 'returns a list of truncated changes', () => {
+			const resultA = getGlobalStylesChanges( next, previous, {
+				maxResults: 3,
+			} );
+			expect( resultA ).toEqual( [
+				'Colors, Typography styles.',
+				'Test pumpkin flowers block.',
+			] );
+		} );
+
+		it( 'skips unknown and unchanged keys', () => {
+			const result = getGlobalStylesChanges(
+				{
+					styles: {
+						frogs: {
+							legs: 'green',
+						},
+						typography: {
+							fontSize: '1rem',
+						},
+						settings: {
+							'': {
+								'': 'foo',
+							},
 						},
 					},
 				},
-			},
-			{
-				styles: {
-					frogs: {
-						legs: 'yellow',
-					},
-					typography: {
-						fontSize: '1rem',
-					},
-					settings: {
-						'': {
-							'': 'bar',
+				{
+					styles: {
+						frogs: {
+							legs: 'yellow',
+						},
+						typography: {
+							fontSize: '1rem',
+						},
+						settings: {
+							'': {
+								'': 'bar',
+							},
 						},
 					},
-				},
-			}
-		);
-		expect( result ).toEqual( [] );
+				}
+			);
+			expect( result ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'getGlobalStylesChangelist()', () => {
+		it( 'compares two objects and returns a cached list of changed keys', () => {
+			const resultA = getGlobalStylesChangelist( next, previous );
+
+			expect( resultA ).toEqual( [
+				[ 'styles', 'Colors' ],
+				[ 'styles', 'Typography' ],
+				[ 'blocks', 'Test pumpkin flowers' ],
+				[ 'elements', 'H3' ],
+				[ 'elements', 'Caption' ],
+				[ 'elements', 'H6' ],
+				[ 'elements', 'Link' ],
+				[ 'settings', 'Color' ],
+			] );
+
+			const resultB = getGlobalStylesChangelist( next, previous );
+
+			expect( resultB ).toEqual( resultA );
+		} );
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js
@@ -170,6 +170,9 @@ describe( 'getGlobalStylesChanges and utils', () => {
 					},
 				],
 			},
+			typography: {
+				fluid: true,
+			},
 		},
 	};
 
@@ -195,7 +198,7 @@ describe( 'getGlobalStylesChanges and utils', () => {
 				'Colors, Typography styles.',
 				'Test pumpkin flowers block.',
 				'H3, Caption, H6, Link elements.',
-				'Color settings.',
+				'Color, Typography settings.',
 			] );
 		} );
 
@@ -259,6 +262,7 @@ describe( 'getGlobalStylesChanges and utils', () => {
 				[ 'elements', 'H6' ],
 				[ 'elements', 'Link' ],
 				[ 'settings', 'Color' ],
+				[ 'settings', 'Typography' ],
 			] );
 
 			const resultB = getGlobalStylesChangelist( next, previous );

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -220,6 +220,7 @@ function RevisionsButtons( {
 							) : (
 								<Button
 									disabled={ areStylesEqual }
+									size="compact"
 									variant="primary"
 									className="edit-site-global-styles-screen-revisions__apply-button"
 									onClick={ onApplyRevision }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -25,19 +25,20 @@ function ChangesSummary( { revision, previousRevision } ) {
 	const changes = getGlobalStylesChanges( revision, previousRevision, {
 		maxResults: 7,
 	} );
-	const changesLength = changes.length;
 
-	if ( ! changesLength ) {
+	if ( ! changes.length ) {
 		return null;
 	}
 
 	return (
-		<span
+		<ul
 			data-testid="global-styles-revision-changes"
 			className="edit-site-global-styles-screen-revisions__changes"
 		>
-			{ changes.join( ', ' ) }.
-		</span>
+			{ changes.map( ( change ) => (
+				<li key={ change }>{ change }</li>
+			) ) }
+		</ul>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -64,7 +64,7 @@
 			background: var(--wp-admin-theme-color);
 		}
 
-		.edit-site-global-styles-screen-revisions__changes,
+		.edit-site-global-styles-screen-revisions__changes > li,
 		.edit-site-global-styles-screen-revisions__meta,
 		.edit-site-global-styles-screen-revisions__applied-text {
 			color: $gray-900;
@@ -92,7 +92,7 @@
 		width: 100%;
 		height: auto;
 		display: block;
-		padding: $grid-unit-15 $grid-unit-15 $grid-unit-10 $grid-unit-50;
+		padding: $grid-unit-15 $grid-unit-15 $grid-unit-05 $grid-unit-50;
 		z-index: 1;
 		position: relative;
 		outline-offset: -2px;
@@ -103,7 +103,7 @@
 .edit-site-global-styles-screen-revisions__applied-text {
 	align-self: flex-start;
 	// Left margin = left padding of .edit-site-global-styles-screen-revisions__revision-button.
-	margin: 0 $grid-unit-15 $grid-unit-15 $grid-unit-50;
+	margin: $grid-unit-05 $grid-unit-15 $grid-unit-15 $grid-unit-50;
 }
 
 .edit-site-global-styles-screen-revisions__changes,
@@ -125,13 +125,14 @@
 	}
 }
 
-.edit-site-global-styles-screen-revisions__changes,
 .edit-site-global-styles-screen-revisions__meta {
 	display: flex;
 	justify-content: start;
 	width: 100%;
 	align-items: flex-start;
 	text-align: left;
+	margin-bottom: $grid-unit-05;
+
 	img {
 		width: $grid-unit-20;
 		height: $grid-unit-20;
@@ -145,10 +146,14 @@
 }
 
 .edit-site-global-styles-screen-revisions__changes {
-	margin-bottom: $grid-unit-05;
 	text-align: left;
-	color: $gray-900;
 	line-height: $default-line-height;
+	margin-left: $grid-unit-10;
+
+	li {
+		list-style: disc;
+		margin-bottom: $grid-unit-05;
+	}
 }
 
 .edit-site-global-styles-screen-revisions__pagination.edit-site-global-styles-screen-revisions__pagination {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -148,10 +148,10 @@
 .edit-site-global-styles-screen-revisions__changes {
 	text-align: left;
 	line-height: $default-line-height;
-	margin-left: $grid-unit-10;
+	margin-left: $grid-unit-15;
+	list-style: disc;
 
 	li {
-		list-style: disc;
 		margin-bottom: $grid-unit-05;
 	}
 }

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -55,13 +55,11 @@ function GlobalStylesDescription( { record } ) {
 		}
 	);
 	return globalStylesChanges.length ? (
-		<PanelRow className="entities-saved-states__change-summary">
-			<ul className="entities-saved-states__changes">
-				{ globalStylesChanges.map( ( change ) => (
-					<li key={ change }>{ change }</li>
-				) ) }
-			</ul>
-		</PanelRow>
+		<ul className="entities-saved-states__changes">
+			{ globalStylesChanges.map( ( change ) => (
+				<li key={ change }>{ change }</li>
+			) ) }
+		</ul>
 	) : null;
 }
 

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -56,7 +56,11 @@ function GlobalStylesDescription( { record } ) {
 	);
 	return globalStylesChanges.length ? (
 		<PanelRow className="entities-saved-states__change-summary">
-			{ globalStylesChanges.join( ', ' ) }.
+			<ul className="entities-saved-states__changes">
+				{ globalStylesChanges.map( ( change ) => (
+					<li key={ change }>{ change }</li>
+				) ) }
+			</ul>
 		</PanelRow>
 	) : null;
 }

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -23,4 +23,9 @@
 .entities-saved-states__change-summary {
 	color: $gray-700;
 	font-size: $helptext-font-size;
+	margin-left: $grid-unit-20;
+	li {
+		list-style: disc;
+		margin-bottom: $grid-unit-05;
+	}
 }

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -24,6 +24,8 @@
 	color: $gray-700;
 	font-size: $helptext-font-size;
 	margin-left: $grid-unit-20;
+	margin-top: 0;
+
 	li {
 		list-style: disc;
 		margin-bottom: $grid-unit-05;

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -20,14 +20,13 @@
 	font-size: $default-font-size;
 }
 
-.entities-saved-states__change-summary {
+.entities-saved-states__changes {
 	color: $gray-700;
 	font-size: $helptext-font-size;
-	margin-left: $grid-unit-20;
-	margin-top: 0;
+	margin: $grid-unit-10 $grid-unit-20 0 $grid-unit-20;
+	list-style: disc;
 
 	li {
-		list-style: disc;
 		margin-bottom: $grid-unit-05;
 	}
 }

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -56,8 +56,11 @@ test.describe( 'Style Revisions', () => {
 
 		// Shows changes made in the revision.
 		await expect(
-			page.getByTestId( 'global-styles-revision-changes' )
-		).toHaveText( 'Colors.' );
+			page
+				.getByTestId( 'global-styles-revision-changes' )
+				.getByRole( 'listitem' )
+				.first()
+		).toHaveText( 'Colors styles.' );
 
 		// There should be 2 revisions not including the reset to theme defaults button.
 		await expect( revisionButtons ).toHaveCount(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?


This PR refactors the return value of `getGlobalStylesChanges` to group changes into 'blocks', 'elements', 'settings', and 'styles'.

## Why?
Follow up to:

- https://github.com/WordPress/gutenberg/pull/58706#issuecomment-1929338999

## How?
Groups concatenated changes into 'blocks', 'elements', 'settings', and 'styles' groups, and adds the "group" name to the end of the concatenated string.

## Testing Instructions

This change affects the save entities panel and the global styles revision items, both of which display global styles changes.

1. Head over to the site editor and make some changes to global styles. 
2. Save these changes.
3. Observe the global styles changes on the first save panel. They should appear as a list, grouped by change type. Check that the "type" appears at the end of the sentence, e.g., "settings" in `"Color, Typography settings."`
4. Save these changes, then open up the global styles revision panel.
5. Similarly, revision changes should appear as a list.

Run the tests!

`npm run test:unit packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js`



## Screenshots or screencast <!-- if applicable -->

### Before

| Save entities panel  | Revisions |
| ------------- | ------------- |
| <img width="280" alt="Screenshot 2024-02-16 at 1 37 10 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/7808985f-f38c-4b75-a74a-a916313f3a57">  | <img width="280" alt="Screenshot 2024-02-16 at 1 37 03 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/7ba05e87-ff8c-45cc-a104-3b5e8cb813df">  |







### After


| Save entities panel  | Revisions |
| ------------- | ------------- |
| <img width="280" alt="Screenshot 2024-02-16 at 1 50 44 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/d3803808-225e-4df0-a46a-1fd8916180bc"> | <img width="280" alt="Screenshot 2024-02-16 at 1 50 56 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/4dbbc4d5-86d8-4322-9ec6-e7dd2b107070"> |







