### PR TITLE
Refactor responsive logic for grid column spans.

### DIFF
--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -42,16 +42,10 @@ export default function ChildLayoutControl( {
 } ) {
 	const { selfStretch, flexSize, columnSpan, rowSpan } = childLayout;
 	const {
-		type: parentLayoutType,
-		minimumColumnWidth = '12rem',
-		columnCount,
-	} = parentLayout;
-
-	/**
-	 * If columnCount is set, the parentColumnwidth isn't needed because
-	 * the grid has a fixed number of columns with responsive widths.
-	 */
-	const parentColumnWidth = columnCount ? null : minimumColumnWidth;
+		type: parentType,
+		default: { type: defaultParentType = 'default' } = {},
+	} = parentLayout ?? {};
+	const parentLayoutType = parentType || defaultParentType;
 
 	useEffect( () => {
 		if ( selfStretch === 'fixed' && ! flexSize ) {
@@ -122,7 +116,6 @@ export default function ChildLayoutControl( {
 							onChange( {
 								rowSpan,
 								columnSpan: value,
-								parentColumnWidth,
 							} );
 						} }
 						value={ columnSpan }
@@ -135,7 +128,6 @@ export default function ChildLayoutControl( {
 						onChange={ ( value ) => {
 							onChange( {
 								columnSpan,
-								parentColumnWidth,
 								rowSpan: value,
 							} );
 						} }

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -97,7 +97,6 @@ function useHasChildLayout( settings ) {
 			defaultParentLayoutType === 'grid' ||
 			parentLayoutType === 'grid' ) &&
 		allowSizingOnChildren;
-
 	return !! settings?.layout && support;
 }
 
@@ -397,13 +396,16 @@ export default function DimensionsPanel( {
 	// Child Layout
 	const showChildLayoutControl = useHasChildLayout( settings );
 	const childLayout = inheritedValue?.layout;
-	const { selfStretch } = childLayout ?? {};
 	const { orientation = 'horizontal' } = settings?.parentLayout ?? {};
+	const {
+		type: parentType,
+		default: { type: defaultParentType = 'default' } = {},
+	} = settings?.parentLayout ?? {};
+	const parentLayoutType = parentType || defaultParentType;
 	const flexResetLabel =
 		orientation === 'horizontal' ? __( 'Width' ) : __( 'Height' );
-	const childLayoutResetLabel = selfStretch
-		? flexResetLabel
-		: __( 'Grid spans' );
+	const childLayoutResetLabel =
+		parentLayoutType === 'flex' ? flexResetLabel : __( 'Grid spans' );
 	const setChildLayout = ( newChildLayout ) => {
 		onChange( {
 			...value,
@@ -418,7 +420,6 @@ export default function DimensionsPanel( {
 			flexSize: undefined,
 			columnSpan: undefined,
 			rowSpan: undefined,
-			parentColumnWidth: undefined,
 		} );
 	};
 	const hasChildLayoutValue = () => !! value?.layout;
@@ -434,7 +435,6 @@ export default function DimensionsPanel( {
 				flexSize: undefined,
 				columnSpan: undefined,
 				rowSpan: undefined,
-				parentColumnWidth: undefined,
 			} ),
 			spacing: {
 				...previousValue?.spacing,

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -9,14 +9,16 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../store';
 import { useStyleOverride } from './utils';
+import { useLayout } from '../components/block-list/layout';
 
 function useBlockPropsChildLayoutStyles( { style } ) {
 	const shouldRenderChildLayoutStyles = useSelect( ( select ) => {
 		return ! select( blockEditorStore ).getSettings().disableLayoutStyles;
 	} );
 	const layout = style?.layout ?? {};
-	const { selfStretch, flexSize, columnSpan, rowSpan, parentColumnWidth } =
-		layout;
+	const { selfStretch, flexSize, columnSpan, rowSpan } = layout;
+	const parentLayout = useLayout() || {};
+	const { columnCount, minimumColumnWidth } = parentLayout;
 	const id = useInstanceId( useBlockPropsChildLayoutStyles );
 	const selector = `.wp-container-content-${ id }`;
 
@@ -37,13 +39,14 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 			}`;
 		}
 		/**
-		 * If parentColumnWidth is set, the grid is responsive
-		 * so a container query is needed for the span to resize.
+		 * If minimumColumnWidth is set on the parent, or if no
+		 * columnCount is set, the grid is responsive so a
+		 * container query is needed for the span to resize.
 		 */
-		if ( columnSpan && parentColumnWidth ) {
+		if ( columnSpan && ( minimumColumnWidth || ! columnCount ) ) {
 			// Calculate the container query value.
 			const columnSpanNumber = parseInt( columnSpan );
-			let parentColumnValue = parseFloat( parentColumnWidth );
+			let parentColumnValue = parseFloat( minimumColumnWidth );
 			/**
 			 * 12rem is the default minimumColumnWidth value.
 			 * If parentColumnValue is not a number, default to 12.
@@ -52,7 +55,7 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 				parentColumnValue = 12;
 			}
 
-			let parentColumnUnit = parentColumnWidth?.replace(
+			let parentColumnUnit = minimumColumnWidth?.replace(
 				parentColumnValue,
 				''
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up on [this discussion](https://github.com/WordPress/gutenberg/pull/58539#discussion_r1482250188); thanks to @noisysocks for suggesting the `render_block_data` approach.

Also fixes a bug introduced in #58539 that caused child controls to not display for blocks that have `flex` as the default layout (see Navigation block).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the Grid Group variation in the Gutenberg > Experiments admin page.
2. Add a Grid to a post or template, throw in a few child blocks, and play with the controls under Dimensions in the child blocks sidebar.
3. Check everything still works as expected.
4. Add a Navigation block and, without making any changes to its layout settings, check that child layout controls display on its children.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
