### PR TITLE
useEntityBlockEditor: Update 'content' type check

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -183,7 +183,7 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return editedBlocks;
 		}
 
-		if ( ! content || typeof content === 'function' ) {
+		if ( ! content || typeof content !== 'string' ) {
 			return EMPTY_ARRAY;
 		}
 


### PR DESCRIPTION
## What?
Part of #58987.

PR updates the `content` type check for `useEntityBlockEditor` and makes it more strict.

## Why?
In rare cases, entity content returned by `getEditedEntityRecord` can be an object. Passing an object or function into the `parse` method will throw an error.

Details - https://github.com/WordPress/gutenberg/issues/58987#issuecomment-1944441376.

## Testing Instructions
1. Create a post or page
2. Using the code editor, insert the navigation block without the `ref` attribute - `<!-- wp:navigation /-->`.
3. Switch to visual mode.
4. Confirm that the Navigation block is loaded using the fallback routine and that the `ref` attribute is set.
5. Confirm there are no errors.

Plus, CI checks should be green.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![test-failed-1](https://github.com/WordPress/gutenberg/assets/240569/1bbf1433-d44b-4811-a4df-aef0395f34e5)

![CleanShot 2024-02-14 at 17 46 06](https://github.com/WordPress/gutenberg/assets/240569/0d666d52-78d1-49a5-ba1b-9f49bde6ff4a)
