### PR TITLE
Image: Mark connected controls as 'readonly'

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -533,7 +533,7 @@ export default function Image( {
 								label={ __( 'Alternative text' ) }
 								value={ alt || '' }
 								onChange={ updateAlt }
-								disabled={ lockAltControls }
+								readOnly={ lockAltControls }
 								help={
 									lockAltControls ? (
 										<>
@@ -575,7 +575,7 @@ export default function Image( {
 					label={ __( 'Title attribute' ) }
 					value={ title || '' }
 					onChange={ onSetTitle }
-					disabled={ lockTitleControls }
+					readOnly={ lockTitleControls }
 					help={
 						lockTitleControls ? (
 							<>{ __( 'Connected to a custom field' ) }</>

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -876,7 +876,7 @@ test.describe( 'Block bindings', () => {
 					page
 						.getByRole( 'tabpanel', { name: 'Settings' } )
 						.getByLabel( 'Alternative text' )
-				).toBeDisabled();
+				).toHaveAttribute( 'readonly' );
 				const altValue = await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByLabel( 'Alternative text' )
@@ -939,7 +939,7 @@ test.describe( 'Block bindings', () => {
 					page
 						.getByRole( 'tabpanel', { name: 'Settings' } )
 						.getByLabel( 'Alternative text' )
-				).toBeDisabled();
+				).toHaveAttribute( 'readonly' );
 				const altValue = await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByLabel( 'Alternative text' )
@@ -1018,7 +1018,7 @@ test.describe( 'Block bindings', () => {
 					page
 						.getByRole( 'tabpanel', { name: 'Settings' } )
 						.getByLabel( 'Title attribute' )
-				).toBeDisabled();
+				).toHaveAttribute( 'readonly' );
 				const titleValue = await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByLabel( 'Title attribute' )
@@ -1081,7 +1081,7 @@ test.describe( 'Block bindings', () => {
 					page
 						.getByRole( 'tabpanel', { name: 'Settings' } )
 						.getByLabel( 'Title attribute' )
-				).toBeDisabled();
+				).toHaveAttribute( 'readonly' );
 				const titleValue = await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByLabel( 'Title attribute' )
@@ -1137,7 +1137,7 @@ test.describe( 'Block bindings', () => {
 					page
 						.getByRole( 'tabpanel', { name: 'Settings' } )
 						.getByLabel( 'Alternative text' )
-				).toBeDisabled();
+				).toHaveAttribute( 'readonly' );
 				const altValue = await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByLabel( 'Alternative text' )
@@ -1545,7 +1545,7 @@ test.describe( 'Block bindings', () => {
 					page
 						.getByRole( 'tabpanel', { name: 'Settings' } )
 						.getByLabel( 'Alternative text' )
-				).toBeDisabled();
+				).toHaveAttribute( 'readonly' );
 				const altValue = await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByLabel( 'Alternative text' )
@@ -1621,7 +1621,7 @@ test.describe( 'Block bindings', () => {
 					page
 						.getByRole( 'tabpanel', { name: 'Settings' } )
 						.getByLabel( 'Title attribute' )
-				).toBeDisabled();
+				).toHaveAttribute( 'readonly' );
 				const titleValue = await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByLabel( 'Title attribute' )
@@ -1691,7 +1691,7 @@ test.describe( 'Block bindings', () => {
 					page
 						.getByRole( 'tabpanel', { name: 'Settings' } )
 						.getByLabel( 'Alternative text' )
-				).toBeDisabled();
+				).toHaveAttribute( 'readonly' );
 				const altValue = await page
 					.getByRole( 'tabpanel', { name: 'Settings' } )
 					.getByLabel( 'Alternative text' )


### PR DESCRIPTION
## What?
Fixes #58673.

PR updates connected attribute controls for the Image block to be marked as `readonly` instead of `disabled`.

## Why?
See #58673.

## Testing Instructions
See testing instructions from #58085.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-02-15 at 12 34 40](https://github.com/WordPress/gutenberg/assets/240569/6f14f395-8ed6-45d8-b142-87684d83e35e)
