### PR TITLE
Block JSON schema:  Add `viewScriptModule` field

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -798,6 +798,20 @@
 				}
 			]
 		},
+		"viewScriptModule": {
+			"description": "Block type frontend script module definition. It will be enqueued only when viewing the content on the front of the site.",
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			]
+		},
 		"editorStyle": {
 			"description": "Block type editor style definition. It will only be enqueued in the context of the editor.",
 			"oneOf": [


### PR DESCRIPTION
Related to #58203

## What?

This PR adds a `viewScriptModule` field to the schema of `block.json`.

## Why?

To enhance the developer experience. My understanding is that `viewScriptModule` is now officially published instead of `viewModule`.

## Testing Instructions

Create a JSON file like the one below and open it in a code editor.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/schema/block-json-view-script-module/schemas/json/block.json",
	"name": "test/test",
	"title": "Test"
}
```

You should see `viewScriptModule` reference.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/54422211/f5c4ec35-32e8-4220-ba86-e60b84621da5)
