### PR TITLE
Fix DFM ui toggling bugs

### DIFF
--- a/packages/edit-post/src/components/editor-initialization/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/listener-hooks.js
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -22,19 +23,25 @@ import {
  * @param {number} postId The current post id.
  */
 export const useBlockSelectionListener = ( postId ) => {
-	const { hasBlockSelection, isEditorSidebarOpened } = useSelect(
-		( select ) => ( {
-			hasBlockSelection:
-				!! select( blockEditorStore ).getBlockSelectionStart(),
-			isEditorSidebarOpened: select( STORE_NAME ).isEditorSidebarOpened(),
-		} ),
-		[ postId ]
-	);
+	const { hasBlockSelection, isEditorSidebarOpened, isDistractionFree } =
+		useSelect(
+			( select ) => {
+				const { get } = select( preferencesStore );
+				return {
+					hasBlockSelection:
+						!! select( blockEditorStore ).getBlockSelectionStart(),
+					isEditorSidebarOpened:
+						select( STORE_NAME ).isEditorSidebarOpened(),
+					isDistractionFree: get( 'core', 'distractionFree' ),
+				};
+			},
+			[ postId ]
+		);
 
 	const { openGeneralSidebar } = useDispatch( STORE_NAME );
 
 	useEffect( () => {
-		if ( ! isEditorSidebarOpened ) {
+		if ( ! isEditorSidebarOpened || isDistractionFree ) {
 			return;
 		}
 		if ( hasBlockSelection ) {

--- a/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
@@ -44,6 +44,12 @@ describe( 'listener hook tests', () => {
 				isViewportMatch: jest.fn(),
 			},
 		},
+		'core/preferences': {
+			...storeConfig,
+			selectors: {
+				get: jest.fn(),
+			},
+		},
 		[ STORE_NAME ]: {
 			...storeConfig,
 			actions: {
@@ -112,6 +118,7 @@ describe( 'listener hook tests', () => {
 				'getBlockSelectionStart',
 				true
 			);
+			setMockReturnValue( 'core/preferences', 'get', false );
 
 			render( <TestedOutput /> );
 
@@ -121,17 +128,50 @@ describe( 'listener hook tests', () => {
 		} );
 		it( 'opens document sidebar if block is not selected', () => {
 			setMockReturnValue( STORE_NAME, 'isEditorSidebarOpened', true );
+			setMockReturnValue( STORE_NAME, 'isEditorSidebarOpened', true );
 			setMockReturnValue(
 				'core/block-editor',
 				'getBlockSelectionStart',
 				false
 			);
+			setMockReturnValue( 'core/preferences', 'get', false );
 
 			render( <TestedOutput /> );
 
 			expect(
 				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
 			).toHaveBeenCalledWith( 'edit-post/document' );
+		} );
+		it( 'does not open block sidebar if block is selected and distraction free mode is on', () => {
+			setMockReturnValue( STORE_NAME, 'isEditorSidebarOpened', true );
+			setMockReturnValue(
+				'core/block-editor',
+				'getBlockSelectionStart',
+				true
+			);
+			setMockReturnValue( 'core/preferences', 'get', true );
+
+			render( <TestedOutput /> );
+
+			expect(
+				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
+			).toHaveBeenCalledTimes( 0 );
+		} );
+		it( 'does not open document sidebar if block is not selected and distraction free is on', () => {
+			setMockReturnValue( STORE_NAME, 'isEditorSidebarOpened', true );
+			setMockReturnValue( STORE_NAME, 'isEditorSidebarOpened', true );
+			setMockReturnValue(
+				'core/block-editor',
+				'getBlockSelectionStart',
+				false
+			);
+			setMockReturnValue( 'core/preferences', 'get', true );
+
+			render( <TestedOutput /> );
+
+			expect(
+				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
+			).toHaveBeenCalledTimes( 0 );
 		} );
 	} );
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -385,7 +385,7 @@ function Layout( { initialPost } ) {
 			<PostSyncStatusModal />
 			<StartPageOptions />
 			<PluginArea onError={ onPluginAreaError } />
-			<SettingsSidebar />
+			{ ! isDistractionFree && <SettingsSidebar /> }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -263,6 +263,7 @@ export default function Editor( { isLoading } ) {
 								( shouldShowListView && <ListViewSidebar /> ) )
 						}
 						sidebar={
+							! isDistractionFree &&
 							isEditMode &&
 							isRightSidebarOpen && (
 								<>

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -46,6 +46,7 @@ function DocumentTools( {
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editorStore );
 	const {
+		isDistractionFree,
 		isInserterOpened,
 		isListViewOpen,
 		listViewShortcut,
@@ -69,6 +70,7 @@ function DocumentTools( {
 			listViewToggleRef: getListViewToggleRef(),
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			showIconLabels: get( 'core', 'showIconLabels' ),
+			isDistractionFree: get( 'core', 'distractionFree' ),
 		};
 	}, [] );
 
@@ -158,22 +160,26 @@ function DocumentTools( {
 							variant={ showIconLabels ? 'tertiary' : undefined }
 							size="compact"
 						/>
-						<ToolbarItem
-							as={ Button }
-							className="editor-document-tools__document-overview-toggle"
-							icon={ listView }
-							disabled={ disableBlockTools }
-							isPressed={ isListViewOpen }
-							/* translators: button label text should, if possible, be under 16 characters. */
-							label={ listViewLabel }
-							onClick={ toggleListView }
-							shortcut={ listViewShortcut }
-							showTooltip={ ! showIconLabels }
-							variant={ showIconLabels ? 'tertiary' : undefined }
-							aria-expanded={ isListViewOpen }
-							ref={ listViewToggleRef }
-							size="compact"
-						/>
+						{ ! isDistractionFree && (
+							<ToolbarItem
+								as={ Button }
+								className="editor-document-tools__document-overview-toggle"
+								icon={ listView }
+								disabled={ disableBlockTools }
+								isPressed={ isListViewOpen }
+								/* translators: button label text should, if possible, be under 16 characters. */
+								label={ listViewLabel }
+								onClick={ toggleListView }
+								shortcut={ listViewShortcut }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+								aria-expanded={ isListViewOpen }
+								ref={ listViewToggleRef }
+								size="compact"
+							/>
+						) }
 					</>
 				) }
 				{ children }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #59028

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To keep the UI distraction free, and to fix the bugs which would prevent sidebars from being closed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to site editor
2. Toggle DFM on
3. **Check the list view toggle does not appear in the header**

1. Go to the site editor
2. Toggle DFM off
3. Toggle the block inspector on
4. Toggle DFM on
5. Go to post editor
6. **Check the block inspector does not show**

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->



https://github.com/WordPress/gutenberg/assets/107534/058a47c4-52f0-487c-b850-4bd9d441ab2f

