### PR TITLE
Rich text: fix link paste for internal paste

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -60,16 +60,16 @@ export function usePasteHandler( props ) {
 
 			function pasteInline( content ) {
 				const transformed = formatTypes.reduce(
-					( accumlator, { __unstablePasteRule } ) => {
+					( accumulator, { __unstablePasteRule } ) => {
 						// Only allow one transform.
-						if ( __unstablePasteRule && accumlator === value ) {
-							accumlator = __unstablePasteRule( value, {
+						if ( __unstablePasteRule && accumulator === value ) {
+							accumulator = __unstablePasteRule( value, {
 								html,
 								plainText,
 							} );
 						}
 
-						return accumlator;
+						return accumulator;
 					},
 					value
 				);

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -58,13 +58,35 @@ export function usePasteHandler( props ) {
 			const isInternal =
 				event.clipboardData.getData( 'rich-text' ) === 'true';
 
+			function pasteInline( content ) {
+				const transformed = formatTypes.reduce(
+					( accumlator, { __unstablePasteRule } ) => {
+						// Only allow one transform.
+						if ( __unstablePasteRule && accumlator === value ) {
+							accumlator = __unstablePasteRule( value, {
+								html,
+								plainText,
+							} );
+						}
+
+						return accumlator;
+					},
+					value
+				);
+				if ( transformed !== value ) {
+					onChange( transformed );
+				} else {
+					const valueToInsert = create( { html: content } );
+					addActiveFormats( valueToInsert, value.activeFormats );
+					onChange( insert( value, valueToInsert ) );
+				}
+			}
+
 			// If the data comes from a rich text instance, we can directly use it
 			// without filtering the data. The filters are only meant for externally
 			// pasted content and remove inline styles.
 			if ( isInternal ) {
-				const pastedValue = create( { html } );
-				addActiveFormats( pastedValue, value.activeFormats );
-				onChange( insert( value, pastedValue ) );
+				pasteInline( html );
 				return;
 			}
 
@@ -135,28 +157,7 @@ export function usePasteHandler( props ) {
 			} );
 
 			if ( typeof content === 'string' ) {
-				const transformed = formatTypes.reduce(
-					( accumlator, { __unstablePasteRule } ) => {
-						// Only allow one transform.
-						if ( __unstablePasteRule && accumlator === value ) {
-							accumlator = __unstablePasteRule( value, {
-								html,
-								plainText,
-							} );
-						}
-
-						return accumlator;
-					},
-					value
-				);
-
-				if ( transformed !== value ) {
-					onChange( transformed );
-				} else {
-					const valueToInsert = create( { html: content } );
-					addActiveFormats( valueToInsert, value.activeFormats );
-					onChange( insert( value, valueToInsert ) );
-				}
+				pasteInline( content );
 			} else if ( content.length > 0 ) {
 				if ( onReplace && isEmpty( value ) ) {
 					onReplace( content, content.length - 1, -1 );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -518,6 +518,30 @@ test.describe( 'Copy/cut/paste', () => {
 		] );
 	} );
 
+	test( 'should link selection on internal paste', async ( {
+		pageUtils,
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'https://w.org' },
+		} );
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+x' );
+		await page.keyboard.type( 'a' );
+		await pageUtils.pressKeys( 'shift+ArrowLeft' );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '<a href="https://w.org">a</a>',
+				},
+			},
+		] );
+	} );
+
 	test( 'should auto-link', async ( { pageUtils, editor } ) => {
 		await editor.insertBlock( {
 			name: 'core/paragraph',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/57487
Alternative to #58786

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Added an e2e test that fails in trunk:

```
  1) [chromium] › editor/various/copy-cut-paste.spec.js:541:2 › Copy/cut/paste › should link selection on internal paste 

    Error: expect(received).toMatchObject(expected)

    - Expected  - 1
    + Received  + 1

      Array [
        Object {
          "attributes": Object {
    -       "content": "<a href=\"https://w.org\">a</a>",
    +       "content": "https://w.org",
          },
          "name": "core/paragraph",
        },
      ]

      553 | 		await pageUtils.pressKeys( 'shift+ArrowLeft' );
      554 | 		await pageUtils.pressKeys( 'primary+v' );
    > 555 | 		expect( await editor.getBlocks() ).toMatchObject( [
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The transforms must be run for external as well as internal paste.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See test and issue linked: type out a link, copy it, then paste it over a word.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
