### PR TITLE
After Enter transform, skip other onEnter actions like splitting

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -316,6 +316,7 @@ export function RichTextWrapper(
 						transformation.transform( { content: value.text } ),
 					] );
 					__unstableMarkAutomaticChange();
+					return;
 				}
 			}
 

--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -61,6 +61,7 @@ export function useEnter( props ) {
 						} ),
 					] );
 					__unstableMarkAutomaticChange();
+					return;
 				}
 			}
 


### PR DESCRIPTION
If I type `---` and then hit Enter, it triggers a block transform that creates the Separator block. This should be the end of it, but currently the `useEnter`/`onEnter` handlers continue handling the Enter keypress and try to do things like block splitting. But they shouldn't do this. It leads to a bogus `REPLACE_BLOCKS` action that tries to do a split, but it does nothing because the blocks to be replaced were already replaced by a previous `REPLACE_BLOCKS` action (which created the Separator).

**How to test:**
Put a logpoint on the `REPLACE_BLOCKS` action. Before this patch, there are two of them dispatched on Enter. After this patch, only one is dispatched.