### PR TITLE
Fix Navigation link control overlapping issue

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -16,8 +16,9 @@ import { useCopyToClipboard } from '@wordpress/compose';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
 import { Icon, globe, info, linkOff, edit, copySmall } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -33,6 +34,12 @@ export default function LinkPreview( {
 	hasUnlinkControl = false,
 	onRemove,
 } ) {
+	const showIconLabels = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', 'showIconLabels' ),
+		[]
+	);
+
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
 
@@ -139,7 +146,7 @@ export default function LinkPreview( {
 					label={ sprintf(
 						// Translators: %s is a placeholder for the link URL and an optional colon, (if a Link URL is present).
 						__( 'Copy link%s' ), // Ends up looking like "Copy link: https://example.com".
-						isEmptyURL ? '' : ': ' + value.url
+						isEmptyURL || showIconLabels ? '' : ': ' + value.url
 					) }
 					ref={ ref }
 					disabled={ isEmptyURL }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -36,7 +36,7 @@ $block-editor-link-control-number-of-actions: 1;
 		}
 
 		.block-editor-link-control__search-item-top {
-			gap: 8px;
+			gap: $grid-unit-10;
 
 			.components-button.has-icon {
 				min-width: inherit;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -34,6 +34,14 @@ $block-editor-link-control-number-of-actions: 1;
 				content: attr(aria-label);
 			}
 		}
+
+		.block-editor-link-control__search-item-top {
+			.components-button.has-icon {
+				min-width: 50px;
+				width: 50px;
+				padding: 0 5px;
+			}
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -36,10 +36,11 @@ $block-editor-link-control-number-of-actions: 1;
 		}
 
 		.block-editor-link-control__search-item-top {
+			gap: 8px;
+
 			.components-button.has-icon {
-				min-width: 50px;
-				width: 50px;
-				padding: 0 5px;
+				min-width: inherit;
+				width: min-content;
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixed https://github.com/WordPress/gutenberg/issues/59054

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
 There was overlapping in link control when "Show button text labels" enable from Preferences.
<img width="407" alt="304975489-f165a62d-fb54-40be-b768-8a07104e08b9" src="https://github.com/WordPress/gutenberg/assets/61308756/dc8eb1af-03bc-4939-91ef-65fb2e554849">

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We are hiding URL from "copy link" button lable when "Show button text labels" enabled. So button text doesn't overlap each other.

## Testing Instructions
 
 1. Go to gutenberg editor
 2. Add navigation block
 3. Enable "Show button text labels" in Preferences > Accessibility.
 4. Add new link in navigation block, it will display link control popover.
 
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-02-15 at 15 39 57@2x](https://github.com/WordPress/gutenberg/assets/61308756/8227bce1-42c7-487b-9b81-d77015f19d78)

