### PR TITLE
DataViews: Add space for focus outline to primary field

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -216,6 +216,10 @@
 	display: block;
 	width: 100%;
 
+	&:has(a) {
+		padding: 0 2px; // space for focus outline to appear.
+	}
+
 	a {
 		text-decoration: none;
 		color: inherit;


### PR DESCRIPTION
Fixes #59053

## What?

This PR adds padding to the left and right of the primary field so that the focus outline of the link is not cut off.

| | Before | After |
|--------|--------|--------|
| Table Layout |  ![image](https://github.com/WordPress/gutenberg/assets/54422211/744bcd00-8371-4585-af32-697dbdd7f9b9)| ![image](https://github.com/WordPress/gutenberg/assets/54422211/2fab26ee-768c-4e04-893c-9a6de7adb901) |
| Grid Layout | ![image](https://github.com/WordPress/gutenberg/assets/54422211/e42f9140-028d-4f17-a781-2cd70781ba2c) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/0b44766b-1226-4c8f-9bd2-358ecbf0513c) | 


## Why?

This link has `overflow:hidden` applied to prevent it from overflowing when the title is long. This also cuts the focus outline.

## How?

I used the `:has` pseudo-class and added 2px padding to the left and right of the wrapper div only if it has a link element. The `:has` pseudo-class [supports major browsers](https://caniuse.com/css-has).

This 2px value is the width of [the new focus outline in the core](https://core.trac.wordpress.org/changeset/57553). There is no variable in Gutenberg that defines the width of this new focus outline. So for now I've hardcoded the value itself.

### Testing Instructions for Keyboard

- Open th Site Editor.
- Access Patterns or Templates or Template Parts.
- Focus on the title in grid view or table view and check the focus outline.

## Screenshots or screencast <!-- if applicable -->

Focus outline when title is long:

![image](https://github.com/WordPress/gutenberg/assets/54422211/634b3497-488a-47d9-ba08-d43a8751365a)

![image](https://github.com/WordPress/gutenberg/assets/54422211/6bc92928-d1d7-4f2f-b426-b3e3c4d0d031)


