### PR TITLE
Ignore the 'twentytwentyfour' test theme dir created by wp-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ test/storybook-playwright/specs/__snapshots__
 test/storybook-playwright/specs/*-snapshots/**
 test/gutenberg-test-themes/twentytwentyone
 test/gutenberg-test-themes/twentytwentythree
+test/gutenberg-test-themes/twentytwentyfour
 packages/react-native-editor/src/setup-local.js


### PR DESCRIPTION
## What?
This is similar to #53031.

Adds `twentytwentyfour` theme to the ignored test theme list.

## Why?
```
→ warning: failed to remove test/gutenberg-test-themes/twentytwentyfour/: Permission denied
```

## Testing Instructions
- Run `npx wp-env start --update` - you should see `twentytwentyfour` downloaded and installed as per [this config](https://github.com/WordPress/gutenberg/blob/acd79ef3d55ca1b96bcfb908e1a10576a2797e9d/.wp-env.json#L14).
- Confirm that the above theme folders have been created inside `/test/gutenberg-test-themes/` folder (they should be empty).
- Make any change to any file and try to commit it - you should be able to do this without the aforementioned issue on this branch and not on `trunk`.
