### PR TITLE
Quote block: button for cite add/remove

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -75,7 +75,6 @@ function removeNativeProps( props ) {
 		fontStyle,
 		minWidth,
 		maxWidth,
-		setRef,
 		disableSuggestions,
 		disableAutocorrection,
 		...restProps

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -655,29 +655,32 @@ export function RichTextWrapper(
 	);
 }
 
-const ForwardedRichTextContainer = withDeprecations(
+// This export does not actually implement a private API, but was exported
+// under this name for interoperability with the web version of the RichText
+// component.
+export const PrivateRichText = withDeprecations(
 	forwardRef( RichTextWrapper )
 );
 
-ForwardedRichTextContainer.Content = Content;
+PrivateRichText.Content = Content;
 
-ForwardedRichTextContainer.isEmpty = ( value ) => {
+PrivateRichText.isEmpty = ( value ) => {
 	return ! value || value.length === 0;
 };
 
-ForwardedRichTextContainer.Content.defaultProps = {
+PrivateRichText.Content.defaultProps = {
 	format: 'string',
 	value: '',
 };
 
-ForwardedRichTextContainer.Raw = forwardRef( ( props, ref ) => (
+PrivateRichText.Raw = forwardRef( ( props, ref ) => (
 	<RichText { ...props } nativeEditorRef={ ref } />
 ) );
 
 /**
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md
  */
-export default ForwardedRichTextContainer;
+export default PrivateRichText;
 export { RichTextShortcut } from './shortcut';
 export { RichTextToolbarButton } from './toolbar-button';
 export { __unstableRichTextInputEvent } from './input-event';

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -94,14 +94,13 @@ export function RichTextWrapper(
 		minWidth,
 		maxWidth,
 		onBlur,
-		setRef,
 		disableSuggestions,
 		disableAutocorrection,
 		containerWidth,
 		onEnter: onCustomEnter,
 		...props
 	},
-	forwardedRef
+	providedRef
 ) {
 	const instanceId = useInstanceId( RichTextWrapper );
 
@@ -529,13 +528,13 @@ export function RichTextWrapper(
 		[ onReplace, __unstableMarkAutomaticChange ]
 	);
 
-	const mergedRef = useMergeRefs( [ forwardedRef, fallbackRef ] );
+	const mergedRef = useMergeRefs( [ providedRef, fallbackRef ] );
 
 	return (
 		<RichText
 			clientId={ clientId }
 			identifier={ identifier }
-			ref={ mergedRef }
+			nativeEditorRef={ mergedRef }
 			value={ adjustedValue }
 			onChange={ adjustedOnChange }
 			selectionStart={ selectionStart }
@@ -586,7 +585,6 @@ export function RichTextWrapper(
 			minWidth={ minWidth }
 			maxWidth={ maxWidth }
 			onBlur={ onBlur }
-			setRef={ setRef }
 			disableSuggestions={ disableSuggestions }
 			disableAutocorrection={ disableAutocorrection }
 			containerWidth={ containerWidth }
@@ -672,7 +670,9 @@ ForwardedRichTextContainer.Content.defaultProps = {
 	value: '',
 };
 
-ForwardedRichTextContainer.Raw = RichText;
+ForwardedRichTextContainer.Raw = forwardRef( ( props, ref ) => (
+	<RichText { ...props } nativeEditorRef={ ref } />
+) );
 
 /**
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md

--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -1222,8 +1222,8 @@ export class RichText extends Component {
 					ref={ ( ref ) => {
 						this._editor = ref;
 
-						if ( this.props.setRef ) {
-							this.props.setRef( ref );
+						if ( this.props.nativeEditorRef ) {
+							this.props.nativeEditorRef( ref );
 						}
 					} }
 					style={ {

--- a/packages/block-editor/src/private-apis.native.js
+++ b/packages/block-editor/src/private-apis.native.js
@@ -5,6 +5,7 @@ import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
 import { getRichTextValues } from './components/rich-text/get-rich-text-values';
 import { lock } from './lock-unlock';
+import { PrivateRichText } from './components/rich-text/';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -14,4 +15,5 @@ lock( privateApis, {
 	...globalStyles,
 	ExperimentalBlockEditorProvider,
 	getRichTextValues,
+	PrivateRichText,
 } );

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -494,7 +494,7 @@ function ButtonEdit( props ) {
 					<View pointerEvents="none" style={ outLineStyles } />
 				) }
 				<RichText
-					setRef={ onSetRef }
+					ref={ onSetRef }
 					placeholder={ placeholderText }
 					value={ text }
 					onChange={ onChangeText }

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -13,7 +13,6 @@ import {
 	RichText,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { Platform } from '@wordpress/element';
 
 /**
@@ -21,6 +20,7 @@ import { Platform } from '@wordpress/element';
  */
 import { Figure } from './figure';
 import { BlockQuote } from './blockquote';
+import { Caption } from '../utils/caption';
 
 const isWebPlatform = Platform.OS === 'web';
 
@@ -30,13 +30,12 @@ function PullQuoteEdit( {
 	isSelected,
 	insertBlocksAfter,
 } ) {
-	const { textAlign, citation, value } = attributes;
+	const { textAlign, value } = attributes;
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
-	const shouldShowCitation = ! RichText.isEmpty( citation ) || isSelected;
 
 	return (
 		<>
@@ -66,32 +65,25 @@ function PullQuoteEdit( {
 						}
 						textAlign="center"
 					/>
-					{ shouldShowCitation && (
-						<RichText
-							identifier="citation"
-							tagName={ isWebPlatform ? 'cite' : undefined }
-							style={ { display: 'block' } }
-							value={ citation }
-							aria-label={ __( 'Pullquote citation text' ) }
-							placeholder={
-								// translators: placeholder text used for the citation
-								__( 'Add citation' )
-							}
-							onChange={ ( nextCitation ) =>
-								setAttributes( {
-									citation: nextCitation,
-								} )
-							}
-							className="wp-block-pullquote__citation"
-							__unstableMobileNoFocusOnMount
-							textAlign="center"
-							__unstableOnSplitAtEnd={ () =>
-								insertBlocksAfter(
-									createBlock( getDefaultBlockName() )
-								)
-							}
-						/>
-					) }
+					<Caption
+						attributeKey="citation"
+						tagName={ isWebPlatform ? 'cite' : undefined }
+						style={ { display: 'block' } }
+						isSelected={ isSelected }
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						label={ __( 'Pullquote citation text' ) }
+						placeholder={
+							// translators: placeholder text used for the citation
+							__( 'Add citation' )
+						}
+						addLabel={ __( 'Add citation' ) }
+						removeLabel={ __( 'Remove citation' ) }
+						className="wp-block-pullquote__citation"
+						__unstableMobileNoFocusOnMount
+						textAlign="center"
+						insertBlocksAfter={ insertBlocksAfter }
+					/>
 				</BlockQuote>
 			</Figure>
 		</>

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -13,15 +13,14 @@ import {
 	RichText,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { Platform } from '@wordpress/element';
-import { verse } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { Figure } from './figure';
 import { BlockQuote } from './blockquote';
-import { Caption } from '../utils/caption';
 
 const isWebPlatform = Platform.OS === 'web';
 
@@ -31,12 +30,13 @@ function PullQuoteEdit( {
 	isSelected,
 	insertBlocksAfter,
 } ) {
-	const { textAlign, value } = attributes;
+	const { textAlign, citation, value } = attributes;
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
+	const shouldShowCitation = ! RichText.isEmpty( citation ) || isSelected;
 
 	return (
 		<>
@@ -66,26 +66,32 @@ function PullQuoteEdit( {
 						}
 						textAlign="center"
 					/>
-					<Caption
-						attributeKey="citation"
-						tagName={ isWebPlatform ? 'cite' : undefined }
-						style={ { display: 'block' } }
-						isSelected={ isSelected }
-						attributes={ attributes }
-						setAttributes={ setAttributes }
-						icon={ verse }
-						label={ __( 'Pullquote citation text' ) }
-						placeholder={
-							// translators: placeholder text used for the citation
-							__( 'Add citation' )
-						}
-						addLabel={ __( 'Add citation' ) }
-						removeLabel={ __( 'Remove citation' ) }
-						className="wp-block-pullquote__citation"
-						__unstableMobileNoFocusOnMount
-						textAlign="center"
-						insertBlocksAfter={ insertBlocksAfter }
-					/>
+					{ shouldShowCitation && (
+						<RichText
+							identifier="citation"
+							tagName={ isWebPlatform ? 'cite' : undefined }
+							style={ { display: 'block' } }
+							value={ citation }
+							aria-label={ __( 'Pullquote citation text' ) }
+							placeholder={
+								// translators: placeholder text used for the citation
+								__( 'Add citation' )
+							}
+							onChange={ ( nextCitation ) =>
+								setAttributes( {
+									citation: nextCitation,
+								} )
+							}
+							className="wp-block-pullquote__citation"
+							__unstableMobileNoFocusOnMount
+							textAlign="center"
+							__unstableOnSplitAtEnd={ () =>
+								insertBlocksAfter(
+									createBlock( getDefaultBlockName() )
+								)
+							}
+						/>
+					) }
 				</BlockQuote>
 			</Figure>
 		</>

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -14,6 +14,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { Platform } from '@wordpress/element';
+import { verse } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -72,6 +73,7 @@ function PullQuoteEdit( {
 						isSelected={ isSelected }
 						attributes={ attributes }
 						setAttributes={ setAttributes }
+						icon={ verse }
 						label={ __( 'Pullquote citation text' ) }
 						placeholder={
 							// translators: placeholder text used for the citation

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -18,6 +18,7 @@ import { BlockQuotation } from '@wordpress/components';
 import { useDispatch, useRegistry } from '@wordpress/data';
 import { Platform, useEffect } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
+import { verse } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -110,6 +111,7 @@ export default function QuoteEdit( {
 					attributes={ attributes }
 					setAttributes={ setAttributes }
 					__unstableMobileNoFocusOnMount
+					icon={ verse }
 					label={ __( 'Quote citation' ) }
 					placeholder={
 						// translators: placeholder text used for the

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -106,7 +106,7 @@ export default function QuoteEdit( {
 				<Caption
 					attributeKey="citation"
 					tagName={ isWebPlatform ? 'cite' : undefined }
-					style={ { display: 'block' } }
+					style={ isWebPlatform && { display: 'block' } }
 					isSelected={ isSelected }
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -10,14 +10,12 @@ import { __ } from '@wordpress/i18n';
 import {
 	AlignmentControl,
 	BlockControls,
-	RichText,
 	useBlockProps,
 	useInnerBlocksProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { Platform, useEffect } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
@@ -25,6 +23,7 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import { migrateToQuoteV2 } from './deprecated';
+import { Caption } from '../utils/caption';
 
 const isWebPlatform = Platform.OS === 'web';
 
@@ -74,7 +73,7 @@ export default function QuoteEdit( {
 	className,
 	style,
 } ) {
-	const { textAlign, citation } = attributes;
+	const { textAlign } = attributes;
 
 	useMigrateOnLoad( attributes, clientId );
 
@@ -114,33 +113,26 @@ export default function QuoteEdit( {
 			</BlockControls>
 			<BlockQuotation { ...innerBlocksProps }>
 				{ innerBlocksProps.children }
-				{ ( ! RichText.isEmpty( citation ) || hasSelection ) && (
-					<RichText
-						identifier="citation"
-						tagName={ isWebPlatform ? 'cite' : undefined }
-						style={ { display: 'block' } }
-						value={ citation }
-						onChange={ ( nextCitation ) => {
-							setAttributes( {
-								citation: nextCitation,
-							} );
-						} }
-						__unstableMobileNoFocusOnMount
-						aria-label={ __( 'Quote citation' ) }
-						placeholder={
-							// translators: placeholder text used for the
-							// citation
-							__( 'Add citation' )
-						}
-						className="wp-block-quote__citation"
-						__unstableOnSplitAtEnd={ () =>
-							insertBlocksAfter(
-								createBlock( getDefaultBlockName() )
-							)
-						}
-						{ ...( ! isWebPlatform ? { textAlign } : {} ) }
-					/>
-				) }
+				<Caption
+					attributeKey="citation"
+					tagName={ isWebPlatform ? 'cite' : undefined }
+					style={ { display: 'block' } }
+					isSelected={ hasSelection }
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					__unstableMobileNoFocusOnMount
+					label={ __( 'Quote citation' ) }
+					placeholder={
+						// translators: placeholder text used for the
+						// citation
+						__( 'Add citation' )
+					}
+					addLabel={ __( 'Add citation' ) }
+					removeLabel={ __( 'Remove citation' ) }
+					className="wp-block-quote__citation"
+					insertBlocksAfter={ insertBlocksAfter }
+					{ ...( ! isWebPlatform ? { textAlign } : {} ) }
+				/>
 			</BlockQuotation>
 		</>
 	);

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -15,7 +15,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
-import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
+import { useDispatch, useRegistry } from '@wordpress/data';
 import { Platform, useEffect } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
@@ -72,22 +72,11 @@ export default function QuoteEdit( {
 	clientId,
 	className,
 	style,
+	isSelected,
 } ) {
 	const { textAlign } = attributes;
 
 	useMigrateOnLoad( attributes, clientId );
-
-	const hasSelection = useSelect(
-		( select ) => {
-			const { isBlockSelected, hasSelectedInnerBlock } =
-				select( blockEditorStore );
-			return (
-				hasSelectedInnerBlock( clientId, true ) ||
-				isBlockSelected( clientId )
-			);
-		},
-		[ clientId ]
-	);
 
 	const blockProps = useBlockProps( {
 		className: classNames( className, {
@@ -117,7 +106,7 @@ export default function QuoteEdit( {
 					attributeKey="citation"
 					tagName={ isWebPlatform ? 'cite' : undefined }
 					style={ { display: 'block' } }
-					isSelected={ hasSelection }
+					isSelected={ isSelected }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
 					__unstableMobileNoFocusOnMount

--- a/packages/block-library/src/quote/test/edit.native.js
+++ b/packages/block-library/src/quote/test/edit.native.js
@@ -10,7 +10,6 @@ import {
 	getEditorHtml,
 	fireEvent,
 	within,
-	waitFor,
 	typeInRichText,
 } from 'test/helpers';
 
@@ -40,14 +39,9 @@ describe( 'Quote', () => {
 				},
 			}
 		);
-		// Await inner blocks to be rendered
-		const citationBlock = await waitFor( () =>
-			screen.getByPlaceholderText( 'Add citation' )
-		);
 
 		// Act
 		fireEvent.press( quoteBlock );
-		// screen.debug();
 		let quoteTextInput =
 			within( quoteBlock ).getByPlaceholderText( 'Start writing…' );
 		typeInRichText( quoteTextInput, 'A great statement.' );
@@ -61,6 +55,10 @@ describe( 'Quote', () => {
 				'Start writing…'
 			)[ 1 ];
 		typeInRichText( quoteTextInput, 'Again.' );
+		fireEvent.press( screen.getByLabelText( 'Navigate Up' ) );
+		fireEvent.press( screen.getByLabelText( 'Add citation' ) );
+		const citationBlock =
+			await screen.findByPlaceholderText( 'Add citation' );
 		const citationTextInput =
 			within( citationBlock ).getByPlaceholderText( 'Add citation' );
 		typeInRichText( citationTextInput, 'A person' );

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -78,7 +78,9 @@ export function Caption( {
 						onClick={ () => {
 							setShowCaption( ! showCaption );
 							if ( showCaption && caption ) {
-								setAttributes( { caption: undefined } );
+								setAttributes( {
+									[ attributeKey ]: undefined,
+								} );
 							}
 						} }
 						icon={ captionIcon }

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -26,7 +26,7 @@ import { unlock } from '../lock-unlock';
 const { PrivateRichText: RichText } = unlock( blockEditorPrivateApis );
 
 export function Caption( {
-	key = 'caption',
+	attributeKey = 'caption',
 	attributes,
 	setAttributes,
 	isSelected,
@@ -36,8 +36,12 @@ export function Caption( {
 	showToolbarButton = true,
 	className,
 	disableEditing,
+	tagName = 'figcaption',
+	addLabel,
+	removeLabel,
+	...props
 } ) {
-	const caption = attributes[ key ];
+	const caption = attributes[ attributeKey ];
 	const prevCaption = usePrevious( caption );
 	const isCaptionEmpty = RichText.isEmpty( caption );
 	const isPrevCaptionEmpty = RichText.isEmpty( prevCaption );
@@ -79,19 +83,15 @@ export function Caption( {
 						} }
 						icon={ captionIcon }
 						isPressed={ showCaption }
-						label={
-							showCaption
-								? __( 'Remove caption' )
-								: __( 'Add caption' )
-						}
+						label={ showCaption ? removeLabel : addLabel }
 					/>
 				</BlockControls>
 			) }
 			{ showCaption &&
 				( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
-						identifier={ key }
-						tagName="figcaption"
+						identifier={ attributeKey }
+						tagName={ tagName }
 						className={ classnames(
 							className,
 							__experimentalGetElementClassName( 'caption' )
@@ -101,7 +101,7 @@ export function Caption( {
 						placeholder={ placeholder }
 						value={ caption }
 						onChange={ ( value ) =>
-							setAttributes( { caption: value } )
+							setAttributes( { [ attributeKey ]: value } )
 						}
 						inlineToolbar
 						__unstableOnSplitAtEnd={ () =>
@@ -110,6 +110,7 @@ export function Caption( {
 							)
 						}
 						disableEditing={ disableEditing }
+						{ ...props }
 					/>
 				) }
 		</>

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -39,6 +39,7 @@ export function Caption( {
 	tagName = 'figcaption',
 	addLabel = __( 'Add caption' ),
 	removeLabel = __( 'Remove caption' ),
+	icon = captionIcon,
 	...props
 } ) {
 	const caption = attributes[ attributeKey ];
@@ -83,7 +84,7 @@ export function Caption( {
 								} );
 							}
 						} }
-						icon={ captionIcon }
+						icon={ icon }
 						isPressed={ showCaption }
 						label={ showCaption ? removeLabel : addLabel }
 					/>

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -37,8 +37,8 @@ export function Caption( {
 	className,
 	disableEditing,
 	tagName = 'figcaption',
-	addLabel,
-	removeLabel,
+	addLabel = __( 'Add caption' ),
+	removeLabel = __( 'Remove caption' ),
 	...props
 } ) {
 	const caption = attributes[ attributeKey ];

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -23,8 +23,6 @@ import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
  */
 import { unlock } from '../lock-unlock';
 
-const { PrivateRichText: RichText } = unlock( blockEditorPrivateApis );
-
 export function Caption( {
 	attributeKey = 'caption',
 	attributes,
@@ -44,6 +42,7 @@ export function Caption( {
 } ) {
 	const caption = attributes[ attributeKey ];
 	const prevCaption = usePrevious( caption );
+	const { PrivateRichText: RichText } = unlock( blockEditorPrivateApis );
 	const isCaptionEmpty = RichText.isEmpty( caption );
 	const isPrevCaptionEmpty = RichText.isEmpty( prevCaption );
 	const [ showCaption, setShowCaption ] = useState( ! isCaptionEmpty );

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -164,7 +164,7 @@ class PostTitle extends Component {
 				accessibilityHint={ __( 'Updates the title.' ) }
 			>
 				<RichText.Raw
-					setRef={ this.setRef }
+					ref={ this.setRef }
 					accessibilityLabel={ this.getTitle( title, postType ) }
 					tagName={ 'p' }
 					tagsToEliminate={ [ 'strong' ] }

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -147,7 +147,7 @@ test.describe( 'Quote', () => {
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'two' );
 			// Navigate to the citation to select the block.
-			await page.keyboard.press( 'ArrowRight' );
+			await page.keyboard.press( 'ArrowUp' );
 			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe(
 				`<!-- wp:paragraph -->
@@ -168,7 +168,8 @@ test.describe( 'Quote', () => {
 			await page.keyboard.type( 'one' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'two' );
-			await page.keyboard.press( 'ArrowRight' );
+			await page.keyboard.press( 'ArrowUp' );
+			await editor.clickBlockToolbarButton( 'Add citation' );
 			await page.keyboard.type( 'cite' );
 			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe(
@@ -191,7 +192,8 @@ test.describe( 'Quote', () => {
 			page,
 		} ) => {
 			await editor.insertBlock( { name: 'core/quote' } );
-			await page.keyboard.press( 'ArrowRight' );
+			await page.keyboard.press( 'ArrowUp' );
+			await editor.clickBlockToolbarButton( 'Add citation' );
 			await page.keyboard.type( 'cite' );
 			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe(
@@ -211,7 +213,7 @@ test.describe( 'Quote', () => {
 		} ) => {
 			await editor.insertBlock( { name: 'core/quote' } );
 			// Select the quote
-			await page.keyboard.press( 'ArrowRight' );
+			await page.keyboard.press( 'ArrowUp' );
 			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe( '' );
 		} );
@@ -238,7 +240,8 @@ test.describe( 'Quote', () => {
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
-		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowUp' );
+		await editor.clickBlockToolbarButton( 'Add citation' );
 		await page.keyboard.type( 'cite' );
 		await editor.transformBlockTo( 'core/pullquote' );
 		expect( await editor.getEditedPostContent() ).toBe(
@@ -301,7 +304,8 @@ test.describe( 'Quote', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/quote' } );
 		await page.keyboard.type( '1' );
-		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowUp' );
+		await editor.clickBlockToolbarButton( 'Add citation' );
 		await page.keyboard.type( '2' );
 		expect( await editor.getEditedPostContent() ).toBe(
 			`<!-- wp:quote -->
@@ -331,7 +335,8 @@ test.describe( 'Quote', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/quote' } );
 		await page.keyboard.type( '1' );
-		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowUp' );
+		await editor.clickBlockToolbarButton( 'Add citation' );
 		await page.keyboard.type( '2' );
 		await pageUtils.pressKeys( 'Shift+ArrowUp' );
 		let error;

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -146,8 +146,9 @@ test.describe( 'Quote', () => {
 			await page.keyboard.type( 'one' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'two' );
-			// Navigate to the citation to select the block.
-			await page.keyboard.press( 'ArrowUp' );
+			await editor.clickBlockToolbarButton(
+				'Select parent block: Quote'
+			);
 			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
 			expect( await editor.getEditedPostContent() ).toBe(
 				`<!-- wp:paragraph -->
@@ -168,7 +169,9 @@ test.describe( 'Quote', () => {
 			await page.keyboard.type( 'one' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'two' );
-			await page.keyboard.press( 'ArrowUp' );
+			await editor.clickBlockToolbarButton(
+				'Select parent block: Quote'
+			);
 			await editor.clickBlockToolbarButton( 'Add citation' );
 			await page.keyboard.type( 'cite' );
 			await editor.clickBlockOptionsMenuItem( 'Ungroup' );
@@ -240,7 +243,7 @@ test.describe( 'Quote', () => {
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
-		await page.keyboard.press( 'ArrowUp' );
+		await editor.clickBlockToolbarButton( 'Select parent block: Quote' );
 		await editor.clickBlockToolbarButton( 'Add citation' );
 		await page.keyboard.type( 'cite' );
 		await editor.transformBlockTo( 'core/pullquote' );

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -133,7 +133,7 @@ test.describe( 'Block variations', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Select the quote block.
-		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowUp' );
 
 		await expect(
 			page

--- a/test/e2e/specs/editor/plugins/inner-blocks-render-appender.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-render-appender.spec.js
@@ -71,41 +71,52 @@ test.describe( 'RenderAppender prop of InnerBlocks', () => {
 			name: 'test/inner-blocks-render-appender-dynamic',
 		} );
 
-		const dynamimcAppender = page.locator( '.my-dynamic-blocks-appender' );
-		const addBlockBtn = dynamimcAppender.getByRole( 'button', {
-			name: 'Add block',
-		} );
+		const addBlockBtn = page
+			.locator( '.my-dynamic-blocks-appender' )
+			.getByRole( 'button', {
+				name: 'Add block',
+			} );
 
 		// Verify if the custom block appender text is the expected one.
-		await expect( dynamimcAppender ).toContainText(
-			'Empty Blocks Appender'
-		);
+		await expect(
+			page.locator( '.my-dynamic-blocks-appender' )
+		).toContainText( 'Empty Blocks Appender' );
 
 		// Open the inserter of our custom block appender.
 		await addBlockBtn.click();
 
 		// Verify if the blocks the custom inserter is rendering are the expected ones.
-		const blockListBox = page.getByRole( 'listbox', { name: 'Blocks' } );
-		await expect( blockListBox.getByRole( 'option' ) ).toHaveText( [
-			'Quote',
-			'Video',
-		] );
+		await expect(
+			page
+				.getByRole( 'listbox', { name: 'Blocks' } )
+				.getByRole( 'option' )
+		).toHaveText( [ 'Quote', 'Video' ] );
 
 		// Insert a quote block.
-		await blockListBox.getByRole( 'option', { name: 'Quote' } ).click();
+		await page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Quote' } )
+			.click();
 
 		// Verify if the custom block appender text changed as expected.
 		await expect(
-			dynamimcAppender.getByText( 'Single Blocks Appender' )
+			page
+				.locator( '.my-dynamic-blocks-appender' )
+				.getByText( 'Single Blocks Appender' )
 		).toBeVisible();
 
 		// Insert a video block.
 		await addBlockBtn.click();
-		await blockListBox.getByRole( 'option', { name: 'Video' } ).click();
+		await page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Video' } )
+			.click();
 
 		// Verify if the custom block appender text changed as expected.
 		await expect(
-			dynamimcAppender.getByText( 'Multiple Blocks Appender' )
+			page
+				.locator( '.my-dynamic-blocks-appender' )
+				.getByText( 'Multiple Blocks Appender' )
 		).toBeVisible();
 
 		// Verify that the custom appender button is now not being rendered.

--- a/test/e2e/specs/editor/plugins/inner-blocks-render-appender.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-render-appender.spec.js
@@ -71,64 +71,48 @@ test.describe( 'RenderAppender prop of InnerBlocks', () => {
 			name: 'test/inner-blocks-render-appender-dynamic',
 		} );
 
+		const dynamimcAppender = page.locator( '.my-dynamic-blocks-appender' );
+		const addBlockBtn = dynamimcAppender.getByRole( 'button', {
+			name: 'Add block',
+		} );
+
 		// Verify if the custom block appender text is the expected one.
-		await expect(
-			page.locator( '.my-dynamic-blocks-appender' )
-		).toContainText( 'Empty Blocks Appender' );
+		await expect( dynamimcAppender ).toContainText(
+			'Empty Blocks Appender'
+		);
 
 		// Open the inserter of our custom block appender.
-		await page
-			.locator( '.my-dynamic-blocks-appender' )
-			.getByRole( 'button', {
-				name: 'Add block',
-			} )
-			.click();
+		await addBlockBtn.click();
 
 		// Verify if the blocks the custom inserter is rendering are the expected ones.
-		await expect(
-			page
-				.getByRole( 'listbox', { name: 'Blocks' } )
-				.getByRole( 'option' )
-		).toHaveText( [ 'Quote', 'Video' ] );
+		const blockListBox = page.getByRole( 'listbox', { name: 'Blocks' } );
+		await expect( blockListBox.getByRole( 'option' ) ).toHaveText( [
+			'Quote',
+			'Video',
+		] );
 
 		// Insert a quote block.
-		await page
-			.getByRole( 'listbox', { name: 'Blocks' } )
-			.getByRole( 'option', { name: 'Quote' } )
-			.click();
+		await blockListBox.getByRole( 'option', { name: 'Quote' } ).click();
+
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
 
 		// Verify if the custom block appender text changed as expected.
 		await expect(
-			page
-				.locator( '.my-dynamic-blocks-appender' )
-				.getByText( 'Single Blocks Appender' )
+			dynamimcAppender.getByText( 'Single Blocks Appender' )
 		).toBeVisible();
 
 		// Insert a video block.
-		await page
-			.locator( '.my-dynamic-blocks-appender' )
-			.getByRole( 'button', {
-				name: 'Add block',
-			} )
-			.click();
-		await page
-			.getByRole( 'listbox', { name: 'Blocks' } )
-			.getByRole( 'option', { name: 'Video' } )
-			.click();
+		await addBlockBtn.click();
+		await blockListBox.getByRole( 'option', { name: 'Video' } ).click();
 
 		// Verify if the custom block appender text changed as expected.
 		await expect(
-			page
-				.locator( '.my-dynamic-blocks-appender' )
-				.getByText( 'Multiple Blocks Appender' )
+			dynamimcAppender.getByText( 'Multiple Blocks Appender' )
 		).toBeVisible();
 
 		// Verify that the custom appender button is now not being rendered.
-		await expect(
-			page.locator( '.my-dynamic-blocks-appender' ).getByRole( 'button', {
-				name: 'Add block',
-			} )
-		).toBeHidden();
+		await expect( addBlockBtn ).toBeHidden();
 
 		// Verify if the post content is the expected one.
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/plugins/inner-blocks-render-appender.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-render-appender.spec.js
@@ -71,19 +71,18 @@ test.describe( 'RenderAppender prop of InnerBlocks', () => {
 			name: 'test/inner-blocks-render-appender-dynamic',
 		} );
 
-		const addBlockBtn = page
-			.locator( '.my-dynamic-blocks-appender' )
-			.getByRole( 'button', {
-				name: 'Add block',
-			} );
-
 		// Verify if the custom block appender text is the expected one.
 		await expect(
 			page.locator( '.my-dynamic-blocks-appender' )
 		).toContainText( 'Empty Blocks Appender' );
 
 		// Open the inserter of our custom block appender.
-		await addBlockBtn.click();
+		await page
+			.locator( '.my-dynamic-blocks-appender' )
+			.getByRole( 'button', {
+				name: 'Add block',
+			} )
+			.click();
 
 		// Verify if the blocks the custom inserter is rendering are the expected ones.
 		await expect(
@@ -106,7 +105,12 @@ test.describe( 'RenderAppender prop of InnerBlocks', () => {
 		).toBeVisible();
 
 		// Insert a video block.
-		await addBlockBtn.click();
+		await page
+			.locator( '.my-dynamic-blocks-appender' )
+			.getByRole( 'button', {
+				name: 'Add block',
+			} )
+			.click();
 		await page
 			.getByRole( 'listbox', { name: 'Blocks' } )
 			.getByRole( 'option', { name: 'Video' } )
@@ -120,7 +124,11 @@ test.describe( 'RenderAppender prop of InnerBlocks', () => {
 		).toBeVisible();
 
 		// Verify that the custom appender button is now not being rendered.
-		await expect( addBlockBtn ).toBeHidden();
+		await expect(
+			page.locator( '.my-dynamic-blocks-appender' ).getByRole( 'button', {
+				name: 'Add block',
+			} )
+		).toBeHidden();
 
 		// Verify if the post content is the expected one.
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/style-variation.spec.js
+++ b/test/e2e/specs/editor/various/style-variation.spec.js
@@ -18,7 +18,7 @@ test.describe( 'adding blocks', () => {
 		} );
 
 		// Select the quote block.
-		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowUp' );
 
 		await editor.clickBlockToolbarButton( 'Quote' );
 

--- a/test/e2e/specs/editor/various/style-variation.spec.js
+++ b/test/e2e/specs/editor/various/style-variation.spec.js
@@ -17,9 +17,6 @@ test.describe( 'adding blocks', () => {
 			attributes: { value: '<p>Quote content</p>' },
 		} );
 
-		// Select the quote block.
-		await page.keyboard.press( 'ArrowUp' );
-
 		await editor.clickBlockToolbarButton( 'Quote' );
 
 		await page.click( 'role=menuitem[name="Plain"i]' );

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -81,6 +81,7 @@ jest.mock( '@wordpress/api-fetch', () => {
 jest.mock( '@wordpress/react-native-bridge', () => {
 	return {
 		addEventListener: jest.fn(),
+		logException: jest.fn(),
 		mediaUploadSync: jest.fn(),
 		removeEventListener: jest.fn(),
 		requestBlockTypeImpressions: jest.fn( ( callback ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

All blocks with caption currently have a button to add/remove the caption. But not quote, which has caption-like logic. Let's do the same for caption and reuse the existing caption util.

Not sure if this helps with #15308.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
