### PR TITLE
Navigation: Avoid using embedded record from fallback API

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -661,42 +661,12 @@ export const getUserPatternCategories =
 
 export const getNavigationFallbackId =
 	() =>
-	async ( { dispatch, select } ) => {
+	async ( { dispatch } ) => {
 		const fallback = await apiFetch( {
-			path: addQueryArgs( '/wp-block-editor/v1/navigation-fallback', {
-				_embed: true,
-			} ),
+			path: addQueryArgs( '/wp-block-editor/v1/navigation-fallback' ),
 		} );
 
-		const record = fallback?._embedded?.self;
-
 		dispatch.receiveNavigationFallbackId( fallback?.id );
-
-		if ( record ) {
-			// If the fallback is already in the store, don't invalidate navigation queries.
-			// Otherwise, invalidate the cache for the scenario where there were no Navigation
-			// posts in the state and the fallback created one.
-			const existingFallbackEntityRecord = select.getEntityRecord(
-				'postType',
-				'wp_navigation',
-				fallback?.id
-			);
-			const invalidateNavigationQueries = ! existingFallbackEntityRecord;
-			dispatch.receiveEntityRecords(
-				'postType',
-				'wp_navigation',
-				record,
-				undefined,
-				invalidateNavigationQueries
-			);
-
-			// Resolve to avoid further network requests.
-			dispatch.finishResolution( 'getEntityRecord', [
-				'postType',
-				'wp_navigation',
-				fallback?.id,
-			] );
-		}
 	};
 
 export const getDefaultTemplateId =


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/58987.

PR removes logic for seeding navigation record cache using an embedded record from fallback API.

## Why?
tl;dr; Currently, the API returns incomplete data due to regression.

See #59058 and #58987 for details.

This should also resolve flaky navigation tests.

## Testing Instructions
1. Create a post or page
2. Using the code editor, insert the navigation block without the `ref` attribute - `<!-- wp:navigation /-->`.
3. Switch to visual mode.
4. Confirm that the Navigation block is loaded using the fallback routine and that the `ref` attribute is set.
5. Confirm there are no errors.

### Testing Instructions for Keyboard
Same.
