### PR TITLE
Update document title position so that it's centrally aligned

### DIFF
--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -28,6 +28,13 @@
 	@include break-large() {
 		width: min(100%, 450px);
 	}
+
+	@include break-xlarge() {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+	}
 }
 
 .editor-document-bar__command {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/29673.

## What?
Align the document title centrally in the viewport.

## Why?
See https://github.com/WordPress/gutenberg/issues/29673.

## How?
On large viewports (`xlarge` breakpoint) absolutely position the container then offset using `transform`.

## Testing Instructions
1. Open the editor and observe the document title is centrally aligned.
2. Check everything works well at different viewport sizes.
3. Toggle editor options like "Top toolbar" and "Distraction free", and ensure everything matches trunk.

## Screenshots
<img width="1820" alt="Screenshot 2024-02-15 at 14 07 13" src="https://github.com/WordPress/gutenberg/assets/846565/8984668b-ed9b-4feb-b442-bfe5ff04e321">


Top is trunk, bottom is this PR. The red line represents the center point.