### PR TITLE
Fix logic error in #58951

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -155,9 +155,7 @@ export default function BorderPanel( {
 	// Shadow
 	const shadow = decodeValue( inheritedValue?.shadow );
 	const shadowPresets = settings?.shadow?.presets ?? {};
-	const overriddenShadowPresets = shadowPresets
-		? overrideOrigins( shadowPresets )
-		: [];
+	const overriddenShadowPresets = overrideOrigins( shadowPresets ) ?? [];
 	const setShadow = ( newValue ) => {
 		const slug = overriddenShadowPresets?.find(
 			( { shadow: shadowName } ) => shadowName === newValue

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -106,7 +106,7 @@ function useHasTextColumnsControl( settings ) {
 
 function getUniqueFontSizesBySlug( settings ) {
 	const fontSizes = settings?.typography?.fontSizes ?? {};
-	const overriddenFontSizes = fontSizes ? overrideOrigins( fontSizes ) : [];
+	const overriddenFontSizes = overrideOrigins( fontSizes ) ?? [];
 	const uniqueSizes = [];
 	for ( const currentSize of overriddenFontSizes ) {
 		if ( ! uniqueSizes.some( ( { slug } ) => slug === currentSize.slug ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix regressions produced by logic errors introduced in https://github.com/WordPress/gutenberg/pull/58951


## Why?
Example of the logic error:
```
	const fontSizes = settings?.typography?.fontSizes ?? {};
	const overriddenFontSizes = fontSizes ? overrideOrigins( fontSizes ) : [];
	for ( const currentSize of overriddenFontSizes ) {
```

If `fontSizes` is an empty object `overrideOrigins( fontSizes )` will be `undefined` and the `for` loop will break.

This pattern repeats a few times in #58951

## How?
Fixing the logic

## Testing Instructions
- Use Gutenberg trunk
- Use empty theme
- Navigate the typography panel


## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/1310626/0b06e267-00a6-454d-ba7a-aeae945b23da

After: 

https://github.com/WordPress/gutenberg/assets/1310626/2532b514-935b-44de-b39d-8524e032baf0


