### PR TITLE
Font Library: adds the ability to use generic() in font family names.

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -28,21 +28,17 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * @link https://www.w3.org/TR/css-fonts-4/#font-family-prop
 		 *
 		 * @since 6.5.0
-		 * @access private
-		 *
-		 * @see sanitize_font_family()
 		 *
 		 * @param string $item A font family name.
-		 * @return string The font family name with surrounding quotes if necessary.
+		 * @return string The font family name with surrounding quotes, if necessary.
 		 */
 		private static function maybe_add_quotes( $item ) {
-			// Match any non alphabetic characters (a-zA-Z), dashes -, or parenthesis ().
-			$regex = '/[^a-zA-Z\-()]+/';
+			// Matches strings that are not exclusively alphabetic characters or hyphens, and do not exactly follow the pattern generic(alphabetic characters or hyphens).
+			$regex = '/^(?!generic\([a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/';
 			$item  = trim( $item );
 			if ( preg_match( $regex, $item ) ) {
-				// Removes leading and trailing quotes.
-				$item = preg_replace( '/^["\']|["\']$/', '', $item );
-				return "\"$item\"";
+				$item = trim( $item, "\"'" );
+				return '"' . $item . '"';
 			}
 			return $item;
 		}
@@ -50,8 +46,8 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		/**
 		 * Sanitizes and formats font family names.
 		 *
-		 * - Applies `sanitize_text_field`
-		 * - Adds surrounding quotes to names that special
+		 * - Applies `sanitize_text_field`.
+		 * - Adds surrounding quotes to names that contain spaces or special characters.
 		 *
 		 * It follows the recommendations from the CSS Fonts Module Level 4.
 		 * @link https://www.w3.org/TR/css-fonts-4/#font-family-prop
@@ -69,7 +65,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 				return '';
 			}
 
-			$output          = trim( sanitize_text_field( $font_family ) );
+			$output          = sanitize_text_field( $font_family );
 			$formatted_items = array();
 			if ( str_contains( $output, ',' ) ) {
 				$items = explode( ',', $output );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * Sanitizes and formats font family names.
 		 *
 		 * - Applies `sanitize_text_field`.
-		 * - Adds surrounding quotes to names that contain spaces or special characters.
+		 * - Adds surrounding quotes to names containing any characters that are not alphabetic or dashes.
 		 *
 		 * It follows the recommendations from the CSS Fonts Module Level 4.
 		 * @link https://www.w3.org/TR/css-fonts-4/#font-family-prop

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -42,13 +42,13 @@ function extractFontWeights( fontFaces ) {
  *
  * Example:
  * formatFontFamily( "Open Sans, Font+Name, sans-serif" ) => '"Open Sans", "Font+Name", sans-serif'
- * formatFontFamily( "'Open Sans', sans-serif" ) => '"Open Sans", sans-serif'
+ * formatFontFamily( "'Open Sans', generic(kai), sans-serif" ) => '"Open Sans", sans-serif'
  * formatFontFamily( "DotGothic16, Slabo 27px, serif" ) => '"DotGothic16","Slabo 27px",serif'
  * formatFontFamily( "Mine's, Moe's Typography" ) => `"mine's","Moe's Typography"`
  */
 export function formatFontFamily( input ) {
-	// Matchs any non alphabetic characters (a-zA-Z), dashes - , or parenthesis ()
-	const regex = /[^a-zA-Z\-()]+/;
+	// Matches strings that are not exclusively alphabetic characters or hyphens, and do not exactly follow the pattern generic(alphabetic characters or hyphens).
+	const regex = /^(?!generic\([ a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/;
 	const output = input.trim();
 
 	const formatItem = ( item ) => {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
@@ -172,6 +172,16 @@ describe( 'formatFontFamily', () => {
 			'"Abril Fatface", Times, serif'
 		);
 	} );
+
+	it( 'should not add quotes to generic names', () => {
+		expect(
+			formatFontFamily(
+				'Paren(thesis)Font, generic(kai), generic(fasongsong), generic( abc ), Helvetica Neue'
+			)
+		).toBe(
+			'"Paren(thesis)Font", generic(kai), generic(fasongsong), generic( abc ), "Helvetica Neue"'
+		);
+	} );
 } );
 
 describe( 'formatFontFaceName', () => {


### PR DESCRIPTION
## What?
- Adds the ability to use `generic()` in font family names following the examples from the CSS level 4 specification.
- Adds some nits from https://github.com/WordPress/gutenberg/pull/59019

Example: 

```css
body { font-family: "Adobe Fangsong Std R", generic(fangsong), serif}
```
Reference: https://www.w3.org/TR/css-fonts-4/#font-family-prop

## Why?
To be compliant with the CSS spec.

## How?
Not adding quotes around generic font families. Example `generic(kai)`

## Testing instructions
Follow testing instructions from 

- Add a font collection featuring `generic()` families.
```php
function register_collections() {
    $ubuntu = array(
        'font_family_settings' => array (
            'name'       => 'Ubuntu',
            'fontFamily' => 'Ubuntu, generic(kai), sans-serif',
            'slug'       => 'ubuntu',
        ),
        'categories' => array(
            'sans-serif',
        ),
    );
    
    $verdana = array(
        'font_family_settings' => array (
            'name'       => 'Verdana',
            'fontFamily' => 'Verdana, generic(fangsong) sans-serif',
            'slug'       => 'verdana',
        ),
        'categories' => array(
            'sans-serif',
        ),
    );
    
    $font_families = array ( $ubuntu, $verdana );
    
    $categories = array(
        array (
            'name' => 'Sans Serif',
            'slug' => 'sans-serif',
        ),
    );
    
    $collection = array(
        'name'          => 'My Custom Collection',
        'description'   => __( 'Custom fonts collection' ),
        'font_families' => $font_families,
        'categories'    => $categories
    );
    
    wp_register_font_collection( 'my-collection', $collection );
}

add_action( 'rest_api_init', 'register_collections' );
```
- Install those families and apply them over editor elements.
- See that the CSS variables from font families contain the right values (generic families should not be wrapped in quotes).

