### PR TITLE
Font upload: check file mods permission and fall back to remote font urls

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -326,6 +326,14 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 			$settings    = $request->get_param( 'font_face_settings' );
 			$file_params = $request->get_file_params();
 
+			if ( ! empty( $file_params ) && ! $this->can_upload_fonts() ) {
+				return new WP_Error(
+					'rest_cannot_upload_fonts',
+					__( 'You are not allowed to upload font files.', 'gutenberg' ),
+					array( 'status' => 403 )
+				);
+			}
+
 			// Check that the necessary font face properties are unique.
 			$query = new WP_Query(
 				array(
@@ -901,6 +909,18 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 			}
 
 			return new WP_Error( $code, $message, array( 'status' => $status ) );
+		}
+
+		/**
+		 * Checks if fonts can be uploaded to the site.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return bool Whether font assets can be upload.
+		 */
+		protected function can_upload_fonts() {
+			$fonts_dir = wp_get_font_dir()['path'];
+			return wp_is_file_mod_allowed( 'can_upload_fonts' ) && wp_is_writable( $fonts_dir );
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -216,6 +216,15 @@ if ( ! function_exists( 'wp_get_font_dir' ) ) {
 	}
 }
 
+function gutenberg_font_upload_settings( $settings ) {
+	$fonts_dir = wp_get_font_dir()['path'];
+
+	$settings['fontUploadEnabled'] = wp_is_file_mod_allowed( 'can_upload_fonts' ) && wp_is_writable( $fonts_dir );
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'gutenberg_font_upload_settings' );
+
 // @core-merge: Filters should go in `src/wp-includes/default-filters.php`,
 // functions in a general file for font library.
 if ( ! function_exists( '_wp_after_delete_font_family' ) ) {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -23,6 +23,8 @@ import {
 import { debounce } from '@wordpress/compose';
 import { sprintf, __, _x } from '@wordpress/i18n';
 import { search, closeSmall } from '@wordpress/icons';
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -161,13 +163,13 @@ function FontCollection( { slug } ) {
 		setFontsToInstall( [] );
 	};
 
-	const handleInstall = async () => {
+	const handleInstall = async ( shouldUpload = true ) => {
 		setNotice( null );
 
 		const fontFamily = fontsToInstall[ 0 ];
 
 		try {
-			if ( fontFamily?.fontFace ) {
+			if ( fontFamily?.fontFace && shouldUpload ) {
 				await Promise.all(
 					fontFamily.fontFace.map( async ( fontFace ) => {
 						if ( fontFace.src ) {
@@ -398,12 +400,17 @@ function PaginationFooter( { page, totalPages, setPage } ) {
 
 function InstallFooter( { handleInstall, isDisabled } ) {
 	const { isInstalling } = useContext( FontLibraryContext );
+	const fontUploadEnabled = useSelect(
+		( select ) =>
+			select( editorStore ).getEditorSettings().fontUploadEnabled,
+		[]
+	);
 
 	return (
 		<Flex justify="flex-end">
 			<Button
 				variant="primary"
-				onClick={ handleInstall }
+				onClick={ () => handleInstall( fontUploadEnabled ) }
 				isBusy={ isInstalling }
 				disabled={ isDisabled || isInstalling }
 				__experimentalIsFocusable

--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -7,6 +7,8 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -24,11 +26,12 @@ const DEFAULT_TABS = [
 		id: 'installed-fonts',
 		title: __( 'Library' ),
 	},
-	{
-		id: 'upload-fonts',
-		title: __( 'Upload' ),
-	},
 ];
+
+const UPLOAD_TAB = {
+	id: 'upload-fonts',
+	title: __( 'Upload' ),
+};
 
 const tabsFromCollections = ( collections ) =>
 	collections.map( ( { slug, name } ) => ( {
@@ -44,9 +47,15 @@ function FontLibraryModal( {
 	defaultTabId = 'installed-fonts',
 } ) {
 	const { collections, setNotice } = useContext( FontLibraryContext );
+	const fontUploadEnabled = useSelect(
+		( select ) =>
+			select( editorStore ).getEditorSettings().fontUploadEnabled,
+		[]
+	);
 
 	const tabs = [
 		...DEFAULT_TABS,
+		...( fontUploadEnabled ? [ UPLOAD_TAB ] : [] ),
 		...tabsFromCollections( collections || [] ),
 	];
 

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -10,6 +10,7 @@ import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
  * @property {boolean}       richEditingEnabled    Whether rich editing is enabled or not
  * @property {boolean}       codeEditingEnabled    Whether code editing is enabled or not
  * @property {boolean}       fontLibraryEnabled    Whether the font library is enabled or not.
+ * @property {boolean}       fontUploadEnabled     Whether uploading fonts in the font library is enabled or not.
  * @property {boolean}       enableCustomFields    Whether the WordPress custom fields are enabled or not.
  *                                                 true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
  *                                                 false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
@@ -28,6 +29,7 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	richEditingEnabled: true,
 	codeEditingEnabled: true,
 	fontLibraryEnabled: true,
+	fontUploadEnabled: true,
 	enableCustomFields: undefined,
 	defaultRenderingMode: 'post-only',
 };


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/55280

## What?

- Disallow uploading fonts when `DISALLOW_FILE_MODS` is set to true or the fonts dir is not writable
- When creating a font face and font uploads are not allowed, fall back to using the remote font url

## Why?

Makes it possible to use font collections when the site does not allow file modification

## How?

- Adds a `fontUploadEnabled` setting to the site editor that is filtered to check the value of `DISALLOW_FILE_MODS` and whether the font dir is writable
- Show the Upload tab in the library only when `fontUploadEnabled` is true
- When installing a font face, upload the font file only when `fontUploadEnabled` is true, otherwise use the remote font url

## Testing Instructions

**Important:** Test with WP 6.4.3 to ensure all PHP files are loaded from the Gutenberg plugin

- Set `define( 'DISALLOW_FILE_MODS', true );` in wp-config.php or remove write permissions from `wp-content/fonts`
- See that the Upload tab does not show in the font library
- Install a font from Google fonts and use the font in Global Styles or in the Typography settings for a block
- On the front end of the site, use the Network tab of browser dev tools to see that the font is loaded directly from Google's CDN

Test the API permissions

- Override the `fontUploadEnabled` setting (see below)
- Refresh the site editor page in your browser
- See that Installing a Google font from the font library shows an error returned from the API that fonts cannot be uploaded.

```php
function my_font_upload_settings( $settings ) {
	$settings['fontUploadEnabled'] = true;

	return $settings;
}
add_filter( 'block_editor_settings_all', 'my_font_upload_settings', 99 );
```