### PR TITLE
Editor: Fix post type check in isEditingTemplate selector

### DIFF
--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -538,7 +538,7 @@ export const isEditingTemplate = createRegistrySelector( ( select ) => () => {
 		since: '6.5',
 		alternative: `select( 'core/editor' ).getRenderingMode`,
 	} );
-	return select( editorStore ).getCurrentPostType() !== 'post-only';
+	return select( editorStore ).getCurrentPostType() === 'wp_template';
 } );
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes what seems to be an invalid check in `isEditingTemplate` that was causing it to return `true`, even when not editing a template. 

## Why?
ACF was using this selector to check if a template was currently being edited instead of a standard post. It looks like this has been deprecated, but in WP 6.5-beta1 it seems to always return `true`, which could cause issues for plugins that haven't updated their code.

## How?
`isEditingTemplate` now checks for the `wp_template` post type instead of `post-only`.

## Testing Instructions
1. In the current 6.5 beta, check the output of the `isEditorTemplate` selector in a standard post or page. It seems to always return `true`.
2. Repeat the same on this branch, noting that it now returns `false`, but still returns `true` when editing a template (via the sidebar -> Post -> Template dropdown -> Create new template)


## Screenshots or screencast <!-- if applicable -->
