### PR TITLE
Interactivity API docs: Fix WP version, update new store docs

### DIFF
--- a/packages/interactivity/docs/1-getting-started.md
+++ b/packages/interactivity/docs/1-getting-started.md
@@ -51,15 +51,13 @@ At this point you should be able to insert the "My First Interactive Block" bloc
 
 To start working with the Interactivity API you'll need to have a [proper WordPress development environment for blocks](https://developer.wordpress.org/block-editor/getting-started/devenv/) and some specific code in your block, which should include:
 
-#### A local WordPress installation
+#### A local 6.5 WordPress installation
 
 You can use [the tools to set your local WordPress environment](https://developer.wordpress.org/block-editor/getting-started/devenv/#wordpress-development-site) you feel more comfortable with.
 
 To get quickly started, [`wp-now`](https://www.npmjs.com/package/@wp-now/wp-now) is the easiest way to get a WordPress site up and running locally.
 
-#### Latest vesion of Gutenberg
-
-The Interactivity API is currently only available as an experimental feature from Gutenberg, so you'll need to have Gutenberg 17.5 or higher version installed and activated in your WordPress installation.
+Interactivity API is included in Core in WordPress 6.5, for versions below, you'll need to have Gutenberg 17.5 or higher version installed and activated in your WordPress installation.
 
 #### Node.js
 

--- a/packages/interactivity/docs/2-api-reference.md
+++ b/packages/interactivity/docs/2-api-reference.md
@@ -944,8 +944,7 @@ wp_interactivity_state( 'favoriteMovies', array(
         "id" => "123-abc",
         "movieName" => __("someMovieName", "textdomain")
       ),
-	)
-);
+) );
 ```
 
 ### Private stores

--- a/packages/interactivity/docs/2-api-reference.md
+++ b/packages/interactivity/docs/2-api-reference.md
@@ -918,38 +918,33 @@ store( "myPlugin", {
 #### On the server side
 
 > **Note**
-> We will rename `wp_store` to `wp_initial_state` in a future version.
+> The store is called wp_interactivity_state
 
-The state can also be initialized on the server using the `wp_store()` function. You would typically do this in the `render.php` file of your block (the `render.php` templates were [introduced](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/) in WordPress 6.1).
+The state can also be initialized on the server using the `wp_interactivity_state()` function. You would typically do this in the `render.php` file of your block (the `render.php` templates were [introduced](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/) in WordPress 6.1).
 
-The state defined on the server with `wp_store()` gets merged with the stores defined in the view.js files.
+The state defined on the server with `wp_interactivity_state()` gets merged with the stores defined in the view.js files.
 
-The `wp_store` function receives an [associative array](https://www.php.net/manual/en/language.types.array.php) as a parameter.
+The `wp_interactivity_state` function receives two arguments, a `string` with the namespace that will be used as a reference and an [associative array](https://www.php.net/manual/en/language.types.array.php) containing the values.
 
 _Example of store initialized from the server with a `state` = `{ someValue: 123 }`_
 
 ```php
 // render.php
-wp_store( array(
-  'myPlugin' => array(
-    'someValue' = 123
-  )
-);
+wp_interactivity_state( 'myPlugin', array (
+	'someValue' => get_some_value()
+));
 ```
 
 Initializing the state in the server also allows you to use any WordPress API. For example, you could use the Core Translation API to translate part of your state:
 
 ```php
 // render.php
-wp_store(
-  array(
-    "favoriteMovies" => array(
+wp_interactivity_state( 'favoriteMovies', array(
       "1" => array(
         "id" => "123-abc",
         "movieName" => __("someMovieName", "textdomain")
       ),
-    ),
-  )
+	)
 );
 ```
 

--- a/packages/interactivity/docs/2-api-reference.md
+++ b/packages/interactivity/docs/2-api-reference.md
@@ -917,9 +917,6 @@ store( "myPlugin", {
 
 #### On the server side
 
-> **Note**
-> The store is called wp_interactivity_state
-
 The state can also be initialized on the server using the `wp_interactivity_state()` function. You would typically do this in the `render.php` file of your block (the `render.php` templates were [introduced](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/) in WordPress 6.1).
 
 The state defined on the server with `wp_interactivity_state()` gets merged with the stores defined in the view.js files.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update docs, mentioning that the Interactivity is included in Core in 6.5.
Update the docs with the replacement of the `wp_store` function to `wp_interactivity_state`.