### PR TITLE
[RNMobile] Prevent JavascriptException on `scrollToSection`

### DIFF
--- a/packages/components/src/mobile/keyboard-aware-flat-list/use-scroll-to-section.native.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/use-scroll-to-section.native.js
@@ -45,7 +45,7 @@ export default function useScrollToSection(
 			if (
 				! scrollViewRef.current ||
 				! scrollEnabled ||
-				! scrollViewMeasurements
+				! scrollViewMeasurements.current
 			) {
 				return;
 			}

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Prevent crash when autoscrolling to blocks [#59110]
 
 ## 1.112.0
 -   [*] [internal] Upgrade React Native to version 0.71.15 [#57667]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: 

* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6605

## Why?
Prevents fatal JavascriptException from firing when `scrollToSection` is invoked.

## How?
Checks if the property `current` exists on the `scrollViewMeasurements` within the `scrollToSection` hook.


## Testing Instructions
To test in general, create a situation where the app invokes `scrollToSection` hook, and observe the app does not crash. This can be done by following the Testing Instruction steps from https://github.com/WordPress/gutenberg/pull/57273, or by the steps below:

1. Go to https://automattic.com/how-we-work/.
2. Copy the first part of the page (from How We Work until the end of the Our development process paragraph).
3. Open the app.
4. Create a new post.
5. Paste content.
6. Save the post.
7. Open the post again and focus the Post Title input
8. Add any of the Media Blocks that appear in the bottom toolbar
9. Observe that the Editor scrolls to the newly added block and does not crash


