### PR TITLE
DataViews: Correctly display featured image that don't have image sizes

### DIFF
--- a/packages/edit-site/src/components/media/index.js
+++ b/packages/edit-site/src/components/media/index.js
@@ -8,18 +8,16 @@ function Media( { id, size = [ 'large', 'medium', 'thumbnail' ], ...props } ) {
 	const currentSize = size.find(
 		( s ) => !! media?.media_details?.sizes[ s ]
 	);
-	const mediaDetails = media?.media_details?.sizes[ currentSize ];
-	if ( ! mediaDetails ) {
+
+	const mediaUrl =
+		media?.media_details?.sizes[ currentSize ]?.source_url ||
+		media?.source_url;
+
+	if ( ! mediaUrl ) {
 		return null;
 	}
 
-	return (
-		<img
-			{ ...props }
-			src={ mediaDetails.source_url }
-			alt={ media.alt_text }
-		/>
-	);
+	return <img { ...props } src={ mediaUrl } alt={ media.alt_text } />;
 }
 
 export default Media;


### PR DESCRIPTION
Fixes #59041

## What?

This PR fixes an issue where when an image that does not have an image size is attached to a page as a featured image, the featured image is not displayed in the data view.

For example, even if an extremely small image (100px x 50px) is registered as shown below, it will now be displayed correctly.

![image](https://github.com/WordPress/gutenberg/assets/54422211/3af02e62-16da-4806-a40a-618b38bc66db)

At the same time, the issue of not displaying all featured images in DataView in Playground should also be resolved. (See [this comment](https://github.com/WordPress/gutenberg/issues/59041#issuecomment-1947678065) for details.)

## Why?

If the uploaded image is smaller than the size set in Thumbnail Size on the Media Settings page, no image size will be generated. However, the current logic relies on this image size, so the featured image may not display correctly.

## How?
As a fallback, I now check for `media.source_url`. However, I am concerned about the blurring caused by stretching the image. If anyone knows of a good approach to this, please advise.

## Testing Instructions

- Set a small image such as `100px x 50px`, `50px x 100px`, etc. as the featured image on the page.
- Go to Site Editor > Pages > Manage all pages.
- Switch to grid view.
- The featured image should appear.
