### PR TITLE
Global Styles: fix console error in block preview

### DIFF
--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -28,7 +28,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 	}, [ name, blockExample, variation ] );
 
 	const viewportWidth = blockExample?.viewportWidth ?? null;
-	const previewHeight = '150px';
+	const previewHeight = 150;
 
 	if ( ! blockExample ) {
 		return null;
@@ -48,7 +48,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 						{
 							css: `
 								body{
-									min-height:${ previewHeight };
+									min-height:${ previewHeight }px;
 									display:flex;align-items:center;justify-content:center;
 								}
 							`,


### PR DESCRIPTION
Fixes #58884

## What?
This PR fixes a console error that the block preview outputs when selecting some blocks in the global styles.

https://github.com/WordPress/gutenberg/assets/54422211/f8e2310b-25f0-480d-ba8c-bcc6cdf06592

## Why?

In #47697, the value of `minHeight` prop was adjusted to prevent infinite rendering of block previews. Although this value is a string, the `BlockPreview` component expects this value to be a number in one place:

https://github.com/WordPress/gutenberg/blob/0e899f76951edd6e4b8ec9cc5d8260b3b7bba0ed/packages/block-editor/src/components/block-preview/auto.js#L106-L109

As a result, if "scale" is a decimal value, for example, the following calculation returns NaN.

```
'150px' / 0.5
```

## How?

I changed it from `150px` to the numerical value `150`.

## Testing Instructions

- Make sure `SCRIPT_DEBUG` is set to `true` in advance. If you are using wp-env, it should be `true` by default.
- Go to the Site Editor> Global Styles > Blocks.
- Click on the Media & Text block, which is the one block where this problem occurs.
- No errors should be logged in the browser console.
- Make sure that the problem fixed in #47697 does not reoccur.