### PR TITLE
Elements: Fix block instance element styles for links applying to buttons

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -142,8 +142,8 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 			'skip'     => $skip_button_color_serialization,
 		),
 		'link'    => array(
-			'selector'       => ".$class_name a",
-			'hover_selector' => ".$class_name a:hover",
+			'selector'       => ".$class_name a:not(.wp-element-button)",
+			'hover_selector' => ".$class_name a:not(.wp-element-button):hover",
 			'skip'           => $skip_link_color_serialization,
 		),
 		'heading' => array(

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -142,8 +142,9 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 			'skip'     => $skip_button_color_serialization,
 		),
 		'link'    => array(
-			'selector'       => ".$class_name a:not(.wp-element-button)",
-			'hover_selector' => ".$class_name a:not(.wp-element-button):hover",
+			// :where(:not) matches theme.json selector.
+			'selector'       => ".$class_name a:where(:not(.wp-element-button))",
+			'hover_selector' => ".$class_name a:where(:not(.wp-element-button)):hover",
 			'skip'           => $skip_link_color_serialization,
 		),
 		'heading' => array(

--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -273,8 +273,8 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} a:not\(.wp-element-button\)' . $color_css_rules .
-					'.wp-elements-[a-f0-9]{32} a:not\(.wp-element-button\):hover' . $color_css_rules . '$/',
+				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} a:where\(:not\(.wp-element-button\)\)' . $color_css_rules .
+					'.wp-elements-[a-f0-9]{32} a:where\(:not\(.wp-element-button\)\):hover' . $color_css_rules . '$/',
 			),
 			'generic heading element styles are applied' => array(
 				'color_settings'  => array( 'heading' => true ),

--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -273,8 +273,8 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} a' . $color_css_rules .
-					'.wp-elements-[a-f0-9]{32} a:hover' . $color_css_rules . '$/',
+				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} a:not\(.wp-element-button\)' . $color_css_rules .
+					'.wp-elements-[a-f0-9]{32} a:not\(.wp-element-button\):hover' . $color_css_rules . '$/',
 			),
 			'generic heading element styles are applied' => array(
 				'color_settings'  => array( 'heading' => true ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Prevents link element styles from applying to buttons. 

## Why?

This brings it in line with link elements styled through theme.json and prevents conflicts between the link and button element styles.

## How?

Apply the same selector to target only links and not buttons that theme.json uses i.e. `a:not(.wp-element-button)`.

## Testing Instructions

1. On trunk, add a paragraph containing a link. and a button, within a group block
2. Select the group block and apply a link color.
3. Save the post and view on the frontend
4. Note that the button got the custom link color while it didn't in the editor
5. Switch to think PR and refresh the frontend, the button should now have the correct color
6. Confirm unit tests are passing: `npm run test:unit:php:base -- --filter WP_Block_Supports_Elements_Test`

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="669" alt="Screenshot 2024-02-16 at 3 00 57 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/e58f92b9-5d25-4346-9c85-320566b6249e"> | <img width="661" alt="Screenshot 2024-02-16 at 3 00 41 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/c65aa12d-657e-48a1-b7e6-2491a5bbd10f"> |
