### PR TITLE
Allow more columns in manual grid layout and change toggle order

### DIFF
--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -201,6 +201,8 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 						value={ value }
 						units={ units }
 						min={ 0 }
+						label={ __( 'Minimum column width' ) }
+						hideLabelFromVision
 					/>
 				</FlexItem>
 				<FlexItem isBlock>
@@ -210,6 +212,8 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 						min={ 0 }
 						max={ RANGE_CONTROL_MAX_VALUES[ unit ] || 600 }
 						withInputField={ false }
+						label={ __( 'Minimum column width' ) }
+						hideLabelFromVision
 					/>
 				</FlexItem>
 			</Flex>
@@ -238,6 +242,8 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 						}
 						value={ columnCount }
 						min={ 1 }
+						label={ __( 'Columns' ) }
+						hideLabelFromVision
 					/>
 				</FlexItem>
 				<FlexItem isBlock>
@@ -252,6 +258,8 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 						min={ 1 }
 						max={ 16 }
 						withInputField={ false }
+						label={ __( 'Columns' ) }
+						hideLabelFromVision
 					/>
 				</FlexItem>
 			</Flex>

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -8,6 +8,7 @@ import {
 	Flex,
 	FlexItem,
 	RangeControl,
+	__experimentalNumberControl as NumberControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalUnitControl as UnitControl,
@@ -221,18 +222,40 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 	const { columnCount = 3 } = layout;
 
 	return (
-		<RangeControl
-			label={ __( 'Columns' ) }
-			value={ columnCount }
-			onChange={ ( value ) =>
-				onChange( {
-					...layout,
-					columnCount: value,
-				} )
-			}
-			min={ 1 }
-			max={ 16 }
-		/>
+		<fieldset>
+			<BaseControl.VisualLabel as="legend">
+				{ __( 'Columns' ) }
+			</BaseControl.VisualLabel>
+			<Flex gap={ 4 }>
+				<FlexItem isBlock>
+					<NumberControl
+						size={ '__unstable-large' }
+						onChange={ ( value ) =>
+							onChange( {
+								...layout,
+								columnCount: value,
+							} )
+						}
+						value={ columnCount }
+						min={ 1 }
+					/>
+				</FlexItem>
+				<FlexItem isBlock>
+					<RangeControl
+						value={ columnCount }
+						onChange={ ( value ) =>
+							onChange( {
+								...layout,
+								columnCount: value,
+							} )
+						}
+						min={ 1 }
+						max={ 16 }
+						withInputField={ false }
+					/>
+				</FlexItem>
+			</Flex>
+		</fieldset>
 	);
 }
 

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -231,7 +231,7 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 				} )
 			}
 			min={ 1 }
-			max={ 6 }
+			max={ 16 }
 		/>
 	);
 }
@@ -276,14 +276,14 @@ function GridLayoutTypeControl( { layout, onChange } ) {
 			isBlock={ true }
 		>
 			<ToggleGroupControlOption
-				key={ 'manual' }
-				value="manual"
-				label={ __( 'Manual' ) }
-			/>
-			<ToggleGroupControlOption
 				key={ 'auto' }
 				value="auto"
 				label={ __( 'Auto' ) }
+			/>
+			<ToggleGroupControlOption
+				key={ 'manual' }
+				value="manual"
+				label={ __( 'Manual' ) }
 			/>
 		</ToggleGroupControl>
 	);

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -234,12 +234,17 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 				<FlexItem isBlock>
 					<NumberControl
 						size={ '__unstable-large' }
-						onChange={ ( value ) =>
+						onChange={ ( value ) => {
+							/**
+							 * If the input is cleared, avoid switching
+							 * back to "Auto" by setting a value of "1".
+							 */
+							const validValue = value !== '' ? value : '1';
 							onChange( {
 								...layout,
-								columnCount: value,
-							} )
-						}
+								columnCount: validValue,
+							} );
+						} }
 						value={ columnCount }
 						min={ 1 }
 						label={ __( 'Columns' ) }
@@ -248,7 +253,7 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 				</FlexItem>
 				<FlexItem isBlock>
 					<RangeControl
-						value={ columnCount }
+						value={ parseInt( columnCount, 10 ) } // RangeControl can't deal with strings.
 						onChange={ ( value ) =>
 							onChange( {
 								...layout,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up from https://github.com/WordPress/gutenberg/pull/59051#pullrequestreview-1884270440.

Switches the order of Manual/Auto in grid layout sidebar controls and increases the RangeControl max columns to 16.

Todo: switch the input with a custom one so it can allow higher values (the default RangeControl input shares the max with the range control itself)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a grid block to a page and play with the controls in the layout sidebar section.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="282" alt="Screenshot 2024-02-16 at 4 54 47 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/8f25e82d-cb80-45c9-a909-c4fac5252a5f">

