### PR TITLE
ToolbarButton: Fix text centering for short labels

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `CustomSelectControl`: Remove deprecated `__nextUnconstrainedWidth` prop and promote to default behavior ([#58974](https://github.com/WordPress/gutenberg/pull/58974)).
 
+### Bug Fix
+
+-   `ToolbarButton`: Center text for short labels ([#59117](https://github.com/WordPress/gutenberg/pull/59117)).
+
 ### Internal
 
 -   `ColorPicker`: Style without accessing internal `InputControl` classes ([#59069](https://github.com/WordPress/gutenberg/pull/59069)).

--- a/packages/components/src/toolbar/toolbar-button/style.scss
+++ b/packages/components/src/toolbar/toolbar-button/style.scss
@@ -1,3 +1,7 @@
+.components-toolbar-button {
+	justify-content: center;
+}
+
 .components-toolbar__control.components-button {
 	position: relative;
 

--- a/packages/components/src/toolbar/toolbar-button/style.scss
+++ b/packages/components/src/toolbar/toolbar-button/style.scss
@@ -1,7 +1,3 @@
-.components-toolbar-button {
-	justify-content: center;
-}
-
 .components-toolbar__control.components-button {
 	position: relative;
 

--- a/packages/components/src/toolbar/toolbar-group/style.scss
+++ b/packages/components/src/toolbar/toolbar-group/style.scss
@@ -20,6 +20,7 @@
 	// Icons are 36px, as set by a 24px icon and 12px padding.
 	.components-button.components-button, // This needs specificity to override padding values inherited from the button component.
 	.components-button.has-icon.has-icon {
+		justify-content: center;
 		min-width: $block-toolbar-height - $grid-unit-15;
 		padding-left: $grid-unit-15 * 0.5; // 6px.
 		padding-right: $grid-unit-15 * 0.5;


### PR DESCRIPTION
## What?
Observed here - https://github.com/WordPress/gutenberg/pull/58998#pullrequestreview-1884211375

When a toolbar button has a short string, the min width css rule can come into action (the button is no longer assuming the size of its content. When that happens it's noticeable that there's no center alignment of the button content.

This PR adds a `justify-content: center;` rule so that content is always centered

> [!NOTE]
> There seem to be a whole bunch of styles for toolbar button that use the `.components-toolbar__control.components-button` class name. Most toolbar buttons use only `components-toolbar-button` now. The former class name seems to be used when the toolbar has an 'inaccessible' state (which is triggered when a toolbar contains something like a regular `Button`). The potential for drift between these styles might be a little bit of a worry. When I tested, the `justify-content` rule wasn't needed for this style of button.
> There are also some places in the codebase where `components-toolbar__control` is manually added, which is quite anti-BEM.

## Testing Instructions
1. Add the following markup to a post in code editor mode:
```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:image {"width":"491px","height":"auto","sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large is-resized"><img src="https://i0.wp.com/wordpress.org/files/2022/08/theme-styles.png?w=960&amp;ssl=1" alt="" style="width:491px;height:auto"/></figure>
<!-- /wp:image --></div>
<!-- /wp:group -->
```

2. Switch back to visual mode
3. Select the image block
4. On the toolbar focus the 'Alt' button
5. Check that the text is centered in the focus ring

## Screenshots or screencast <!-- if applicable -->
### Before
![Screenshot 2024-02-16 at 2 15 47 pm](https://github.com/WordPress/gutenberg/assets/677833/03095582-d1e5-4b92-a563-bfbec3969cb4)

### After
![Screenshot 2024-02-16 at 1 54 40 pm](https://github.com/WordPress/gutenberg/assets/677833/af626890-1c24-46ad-8c18-d2d0a65723ec)
