### PR TITLE
EditorInitialization: Fix ESLint warnings for internal hooks

### DIFF
--- a/packages/edit-post/src/components/editor-initialization/index.js
+++ b/packages/edit-post/src/components/editor-initialization/index.js
@@ -10,11 +10,10 @@ import {
  * Data component used for initializing the editor and re-initializes
  * when postId changes or on unmount.
  *
- * @param {number} postId The id of the post.
  * @return {null} This is a data component so does not render any ui.
  */
-export default function EditorInitialization( { postId } ) {
-	useBlockSelectionListener( postId );
-	useUpdatePostLinkListener( postId );
+export default function EditorInitialization() {
+	useBlockSelectionListener();
+	useUpdatePostLinkListener();
 	return null;
 }

--- a/packages/edit-post/src/components/editor-initialization/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/listener-hooks.js
@@ -19,24 +19,19 @@ import {
 /**
  * This listener hook monitors for block selection and triggers the appropriate
  * sidebar state.
- *
- * @param {number} postId The current post id.
  */
-export const useBlockSelectionListener = ( postId ) => {
+export const useBlockSelectionListener = () => {
 	const { hasBlockSelection, isEditorSidebarOpened, isDistractionFree } =
-		useSelect(
-			( select ) => {
-				const { get } = select( preferencesStore );
-				return {
-					hasBlockSelection:
-						!! select( blockEditorStore ).getBlockSelectionStart(),
-					isEditorSidebarOpened:
-						select( STORE_NAME ).isEditorSidebarOpened(),
-					isDistractionFree: get( 'core', 'distractionFree' ),
-				};
-			},
-			[ postId ]
-		);
+		useSelect( ( select ) => {
+			const { get } = select( preferencesStore );
+			return {
+				hasBlockSelection:
+					!! select( blockEditorStore ).getBlockSelectionStart(),
+				isEditorSidebarOpened:
+					select( STORE_NAME ).isEditorSidebarOpened(),
+				isDistractionFree: get( 'core', 'distractionFree' ),
+			};
+		}, [] );
 
 	const { openGeneralSidebar } = useDispatch( STORE_NAME );
 
@@ -49,21 +44,24 @@ export const useBlockSelectionListener = ( postId ) => {
 		} else {
 			openGeneralSidebar( 'edit-post/document' );
 		}
-	}, [ hasBlockSelection, isEditorSidebarOpened ] );
+	}, [
+		hasBlockSelection,
+		isDistractionFree,
+		isEditorSidebarOpened,
+		openGeneralSidebar,
+	] );
 };
 
 /**
  * This listener hook monitors any change in permalink and updates the view
  * post link in the admin bar.
- *
- * @param {number} postId
  */
-export const useUpdatePostLinkListener = ( postId ) => {
+export const useUpdatePostLinkListener = () => {
 	const { newPermalink } = useSelect(
 		( select ) => ( {
 			newPermalink: select( editorStore ).getCurrentPost().link,
 		} ),
-		[ postId ]
+		[]
 	);
 	const nodeToUpdate = useRef();
 
@@ -71,7 +69,7 @@ export const useUpdatePostLinkListener = ( postId ) => {
 		nodeToUpdate.current =
 			document.querySelector( VIEW_AS_PREVIEW_LINK_SELECTOR ) ||
 			document.querySelector( VIEW_AS_LINK_SELECTOR );
-	}, [ postId ] );
+	}, [] );
 
 	useEffect( () => {
 		if ( ! newPermalink || ! nodeToUpdate.current ) {

--- a/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
@@ -88,14 +88,14 @@ describe( 'listener hook tests', () => {
 	} );
 	describe( 'useBlockSelectionListener', () => {
 		const registry = createRegistry( mockStores );
-		const TestComponent = ( { postId } ) => {
-			useBlockSelectionListener( postId );
+		const TestComponent = () => {
+			useBlockSelectionListener();
 			return null;
 		};
 		const TestedOutput = () => {
 			return (
 				<RegistryProvider value={ registry }>
-					<TestComponent postId={ 10 } />
+					<TestComponent />
 				</RegistryProvider>
 			);
 		};
@@ -177,14 +177,14 @@ describe( 'listener hook tests', () => {
 
 	describe( 'useUpdatePostLinkListener', () => {
 		const registry = createRegistry( mockStores );
-		const TestComponent = ( { postId } ) => {
-			useUpdatePostLinkListener( postId );
+		const TestComponent = () => {
+			useUpdatePostLinkListener();
 			return null;
 		};
-		const TestedOutput = ( { postId = 10 } ) => {
+		const TestedOutput = () => {
 			return (
 				<RegistryProvider value={ registry }>
-					<TestComponent postId={ postId } />
+					<TestComponent />
 				</RegistryProvider>
 			);
 		};

--- a/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
@@ -222,7 +222,7 @@ describe( 'listener hook tests', () => {
 			} );
 			const { rerender } = render( <TestedOutput /> );
 
-			rerender( <TestedOutput id={ 20 } /> );
+			rerender( <TestedOutput /> );
 
 			expect( mockSelector ).toHaveBeenCalledTimes( 1 );
 			act( () => {

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -96,7 +96,7 @@ function Editor( {
 			>
 				<ErrorBoundary>
 					<CommandMenu />
-					<EditorInitialization postId={ currentPost.postId } />
+					<EditorInitialization />
 					<Layout initialPost={ initialPost } />
 				</ErrorBoundary>
 				<PostLockedModal />


### PR DESCRIPTION
## What?
PR fixes ESLint warnings for the `EditorInitialization` component internal hooks. It mainly removes unnecessary `postId` dependency; the hooks don't use the value, and it won't change after the editor is initialized.

## Testing Instructions
1. Open a post or page.
2. Confirm that the settings sidebar tabs selection is updated when switching between block and document (e.g., post title).

**DFM**
1. Go to the site editor
2. Toggle DFM off
3. Toggle the block inspector on
4. Toggle DFM on
5. Go to post editor
6. Check the block inspector does not show

### Testing Instructions for Keyboard
Same.
