### PR TITLE
Font Library: Merge the font faces instead of overriding when parsing settings

### DIFF
--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
@@ -76,7 +76,15 @@ if ( ! class_exists( 'WP_Font_Face_Resolver' ) ) {
 						$fonts[ $font_family_name ] = array();
 					}
 
-					$fonts[ $font_family_name ] = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
+					$font_faces_to_add = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
+					foreach ( $font_faces_to_add as $font_face_to_add ) {
+						$offset = static::search_font_face( $font_face_to_add, $fonts[ $font_family_name ] );
+						if ( false !== $offset ) {
+							$fonts[ $font_family_name ][ $offset ] = array_merge( $fonts[ $font_family_name ][ $offset ], $font_face_to_add );
+						} else {
+							$fonts[ $font_family_name ][] = $font_face_to_add;
+						}
+					}
 				}
 			}
 
@@ -130,6 +138,29 @@ if ( ! class_exists( 'WP_Font_Face_Resolver' ) ) {
 			}
 
 			return $converted_font_faces;
+		}
+
+		/**
+		 * Search the specified font-face from the font-face array.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $font_face The searched font-face.
+		 * @param array $font_faces The font-face array.
+		 * @return integer|boolean Returns the key for the searched font-face if it's found in the array, false otherwise.
+		 */
+		private static function search_font_face( array $font_face, array $font_faces ) {
+			foreach ( $font_faces as $key => $value ) {
+				if (
+					$font_face['font-family'] === $value['font-family'] &&
+					$font_face['font-style'] === $value['font-style'] &&
+					$font_face['font-weight'] === $value['font-weight']
+				) {
+					return $key;
+				}
+			}
+
+			return false;
 		}
 
 		/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR is to combine the font faces provided by ALL origins instead of overriding.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Referring to https://github.com/WordPress/gutenberg/issues/58764#issuecomment-1947778291, the installed font variants override the font variants provided by the theme. For example, if a theme provides a Cardo font with 400, and 500 font variants and people install a new Cardo font with a 600 font variant, then only the Cardo font with a 600 font variant will take effect. As a result, we have to merge the font faces across different origins to prevent this issue.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of overriding, now we check whether the new font face exists or not. If it exists, we will merge the new one into the existing font face. If not, we just add it to the array.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Make this change take effect by commenting out the core files
  * Run `wp-env run cli bash`
  * Open the `wp-settings.php`
  * Comment out the following lines
    ```php
    // require ABSPATH . WPINC . '/fonts/class-wp-font-face-resolver.php';
    // require ABSPATH . WPINC . '/fonts/class-wp-font-face.php';           
    // require ABSPATH . WPINC . '/fonts.php';      
    ```
* Open a site with TT4
* Go to the Editor
* Create the following paragraph:
  * Cardo Normal. Set the Font Family to Cardo, and the Appearance to “Regular”
  * Cardo Bold. Set the Font Family to Cardo, and the Appearance to “Bold”
  * Cardo Normal Italic. Set the Font Family to Cardo, and the Appearance to “Regular Italic”
* Install the Cardo font with 400 font variant from the Install Fonts tab of the Font Library Modal
* Save changes and refresh the page
* Make sure the rendered font of those paragraphs is Cardo-Regular

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Here is the video to reproduce the issue:

https://github.com/WordPress/gutenberg/assets/13596067/11114225-a017-407c-b75b-874ce78257cc