### PR TITLE
Block editor: separate styles store

### DIFF
--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -16,8 +16,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import transformStyles from '../../utils/transform-styles';
-import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
+import { store as stylesStore } from '../../store/styles';
 
 extend( [ namesPlugin, a11yPlugin ] );
 
@@ -69,7 +68,7 @@ function useDarkThemeBodyClassName( styles, scope ) {
 
 export default function EditorStyles( { styles, scope } ) {
 	const overrides = useSelect(
-		( select ) => unlock( select( blockEditorStore ) ).getStyleOverrides(),
+		( select ) => select( stylesStore ).getStyleOverrides(),
 		[]
 	);
 	const [ transformedStyles, transformedSvgs ] = useMemo( () => {

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -18,8 +18,8 @@ import {
 import { useSettings } from '../components';
 import { useSettingsForBlockElement } from '../components/global-styles/hooks';
 import { getValueFromObjectPath, setImmutably } from '../utils/object';
-import { store as blockEditorStore } from '../store';
-import { unlock } from '../lock-unlock';
+import { store as stylesStore } from '../store/styles';
+
 /**
  * External dependencies
  */
@@ -134,9 +134,8 @@ export function shouldSkipSerialization(
 }
 
 export function useStyleOverride( { id, css, assets, __unstableType } = {} ) {
-	const { setStyleOverride, deleteStyleOverride } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { setStyleOverride, deleteStyleOverride } =
+		useDispatch( stylesStore );
 	const fallbackId = useId();
 	useEffect( () => {
 		// Unmount if there is CSS and assets are empty.

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -275,21 +275,6 @@ export function setOpenedBlockSettingsMenu( clientId ) {
 	};
 }
 
-export function setStyleOverride( id, style ) {
-	return {
-		type: 'SET_STYLE_OVERRIDE',
-		id,
-		style,
-	};
-}
-
-export function deleteStyleOverride( id ) {
-	return {
-		type: 'DELETE_STYLE_OVERRIDE',
-		id,
-	};
-}
-
 /**
  * A higher-order action that mark every change inside a callback as "non-persistent"
  * and ignore pushing to the undo history stack. It's primarily used for synchronized

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -175,17 +175,6 @@ export function getOpenedBlockSettingsMenu( state ) {
 	return state.openedBlockSettingsMenu;
 }
 
-/**
- * Returns all style overrides, intended to be merged with global editor styles.
- *
- * @param {Object} state Global application state.
- *
- * @return {Map} A map of style IDs to style overrides.
- */
-export function getStyleOverrides( state ) {
-	return state.styleOverrides;
-}
-
 /** @typedef {import('./actions').InserterMediaCategory} InserterMediaCategory */
 /**
  * Returns the registered inserter media categories through the public API.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2011,27 +2011,6 @@ export function openedBlockSettingsMenu( state = null, action ) {
 }
 
 /**
- * Reducer returning a map of style IDs to style overrides.
- *
- * @param {Map}    state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Map} Updated state.
- */
-export function styleOverrides( state = new Map(), action ) {
-	switch ( action.type ) {
-		case 'SET_STYLE_OVERRIDE':
-			return new Map( state ).set( action.id, action.style );
-		case 'DELETE_STYLE_OVERRIDE': {
-			const newState = new Map( state );
-			newState.delete( action.id );
-			return newState;
-		}
-	}
-	return state;
-}
-
-/**
  * Reducer returning a map of the registered inserter media categories.
  *
  * @param {Array}  state  Current state.
@@ -2092,7 +2071,6 @@ const combinedReducers = combineReducers( {
 	temporarilyEditingFocusModeRevert,
 	blockVisibility,
 	blockEditingModes,
-	styleOverrides,
 	removalPromptData,
 	blockRemovalRules,
 	openedBlockSettingsMenu,

--- a/packages/block-editor/src/store/styles/actions.js
+++ b/packages/block-editor/src/store/styles/actions.js
@@ -1,0 +1,14 @@
+export function setStyleOverride( id, style ) {
+	return {
+		type: 'SET_STYLE_OVERRIDE',
+		id,
+		style,
+	};
+}
+
+export function deleteStyleOverride( id ) {
+	return {
+		type: 'DELETE_STYLE_OVERRIDE',
+		id,
+	};
+}

--- a/packages/block-editor/src/store/styles/index.js
+++ b/packages/block-editor/src/store/styles/index.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+
+// To do: make store private somehow.
+const STORE_NAME = 'core/block-editor/styles';
+
+export const storeConfig = {
+	reducer,
+	selectors,
+	actions,
+};
+
+/**
+ * Store definition for the block editor namespace.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore
+ */
+export const store = createReduxStore( STORE_NAME, storeConfig );
+
+registerStore( STORE_NAME, storeConfig );

--- a/packages/block-editor/src/store/styles/reducer.js
+++ b/packages/block-editor/src/store/styles/reducer.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Reducer returning a map of style IDs to style overrides.
+ *
+ * @param {Map}    state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Map} Updated state.
+ */
+export function styleOverrides( state = new Map(), action ) {
+	switch ( action.type ) {
+		case 'SET_STYLE_OVERRIDE':
+			return new Map( state ).set( action.id, action.style );
+		case 'DELETE_STYLE_OVERRIDE': {
+			const newState = new Map( state );
+			newState.delete( action.id );
+			return newState;
+		}
+	}
+	return state;
+}
+
+export default combineReducers( { styleOverrides } );

--- a/packages/block-editor/src/store/styles/selectors.js
+++ b/packages/block-editor/src/store/styles/selectors.js
@@ -1,0 +1,10 @@
+/**
+ * Returns all style overrides, intended to be merged with global editor styles.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Map} A map of style IDs to style overrides.
+ */
+export function getStyleOverrides( state ) {
+	return state.styleOverrides;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because currently a lot of blocks (esp. from patterns and templates) set styles on mount, causing all selectors to be recalculated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
