### PR TITLE
Fix wp 6.4/6.3 compat for navigation link variations

### DIFF
--- a/lib/compat/wordpress-6.5/navigation-block-variations.php
+++ b/lib/compat/wordpress-6.5/navigation-block-variations.php
@@ -11,7 +11,7 @@ function gutenberg_navigation_link_variations_compat( $args ) {
 	if ( 'core/navigation-link' !== $args['name'] || ! empty( $args['variation_callback'] ) ) {
 		return $args;
 	}
-	$args['variation_callback'] = 'build_navigation_link_block_variations';
+	$args['variation_callback'] = 'gutenberg_block_core_navigation_link_build_variations';
 	return $args;
 }
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -392,7 +392,6 @@ function block_core_navigation_link_build_variations() {
  * Registers the navigation link block.
  *
  * @uses render_block_core_navigation_link()
- * @uses build_navigation_link_block_variations()
  * @throws WP_Error An WP_Error exception parsing the block definition.
  */
 function register_block_core_navigation_link() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a follow up to #58389. It introduced backwards compatibility for the navigation link variations changes for wordpress 6.4/6.3. 
As @jsnajdr [found out](https://github.com/WordPress/gutenberg/pull/58389#discussion_r1492414765), the function name used for the variation_callback was wrong (the unprefixed/unbuilt version). And therefore lead to e2e tests expecting the "Page Link" variation to exist failing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Change function to correct name. Also removed a wrong `@uses` comment missed in the last commit. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Use WordPress 6.4/6.3
2. Go into site-editor and add a navigation block
3. try to search for a block named like "Page Link" or "Post Link"
4. Block is available

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
