### PR TITLE
JSON schema: Update schema for background support

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -107,6 +107,7 @@ Settings related to background.
 | Property  | Type   | Default | Props  |
 | ---       | ---    | ---    |---   |
 | backgroundImage | boolean | false |  |
+| backgroundSize | boolean | false |  |
 
 ---
 

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -352,7 +352,7 @@
 						},
 						"backgroundSize": {
 							"type": "boolean",
-							"description": "Allow blocks to define a background position, size, and whether it repeats.",
+							"description": "Allow blocks to define values related to the size of a background image, including size, position, and repeat controls",
 							"default": false
 						}
 					}

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -341,6 +341,22 @@
 						}
 					}
 				},
+				"background": {
+					"type": "object",
+					"description": "This value signals that a block supports some of the CSS style properties related to background. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific background property, its attributes definition is extended to include the style attribute.",
+					"properties": {
+						"backgroundImage": {
+							"type": "boolean",
+							"description": "Allow blocks to define a background image.",
+							"default": false
+						},
+						"backgroundSize": {
+							"type": "boolean",
+							"description": "Allow blocks to define a background position, size, and whether it repeats.",
+							"default": false
+						}
+					}
+				},
 				"html": {
 					"type": "boolean",
 					"description": "By default, a block’s markup can be edited individually. To disable this behavior, set html to false.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -260,7 +260,7 @@
 							"default": false
 						},
 						"backgroundSize": {
-							"description": "Allow users to set a background position, size, and whether it repeats.",
+							"description": "Allow users to set values related to the size of a background image, including size, position, and repeat controls.",
 							"type": "boolean",
 							"default": false
 						}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -258,6 +258,11 @@
 							"description": "Allow users to set a background image.",
 							"type": "boolean",
 							"default": false
+						},
+						"backgroundSize": {
+							"description": "Allow users to set a background position, size, and whether it repeats.",
+							"type": "boolean",
+							"default": false
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
Follow up #53934 and #57005

## What?

This PR adds and updates background support definitions in theme.json and block.json.

## Why?

To enhance the developer experience.

## How?

I've updated the description to reflect the actual implementation, but one point that confused me is that `backgroundSize` actually covers three things: `background-size`, `background-position`, and `background-repeat`. That's why I mentioned it in the description.

## Testing Instructions

- Create a JSON file locally using the test data below.
- Make sure the code editor properly indicates suggestions, default values, and description.

### theme.json

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/schema/add-background-image/schemas/json/theme.json",
	"version": 2,
	"settings": {
	}
}
```

https://github.com/WordPress/gutenberg/assets/54422211/b5707e78-01d5-42f3-81bb-f599d0568d1f

### block.json

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/schema/add-background-image/schemas/json/block.json",
	"version": "2",
	"name": "test/test",
	"title": "test",
	"supports": {
	}
}
```

https://github.com/WordPress/gutenberg/assets/54422211/b593be7a-6a11-4f8e-8155-a419c11079d9

