### PR TITLE
Center the document title

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -16,7 +16,12 @@ $header-toolbar-min-width: 335px;
 		display: flex;
 		border: none;
 		align-items: center;
+		flex-grow: 1;
 		flex-shrink: 2;
+
+		// Account for the site hub, with is 60x60px.
+		flex-basis: calc(37.5% - 60px);
+
 		// We need this to be overflow hidden so the block toolbar can
 		// overflow scroll. If the overflow is visible, flexbox allows
 		// the toolbar to grow outside of the allowed container space.
@@ -33,20 +38,31 @@ $header-toolbar-min-width: 335px;
 	.edit-site-header-edit-mode__end {
 		display: flex;
 		justify-content: flex-end;
+		height: 100%;
+		flex-grow: 1;
+		flex-shrink: 1;
+		flex-basis: 37.5%;
 	}
 
 	.edit-site-header-edit-mode__center {
-		display: flex;
+		display: none;
 		align-items: center;
 		height: 100%;
-		flex-grow: 1;
-		margin: 0 $grid-unit-20;
+		margin: 0 $grid-unit-10;
 		justify-content: center;
+		flex-grow: 1;
+		flex-shrink: 2;
+		flex-basis: 25%;
+
 		// Flex items will, by default, refuse to shrink below a minimum
 		// intrinsic width. In order to shrink this flexbox item, and
 		// subsequently truncate child text, we set an explicit min-width.
 		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 		min-width: 0;
+
+		@include break-small() {
+			display: flex;
+		}
 	}
 
 }

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -1,5 +1,3 @@
-$header-toolbar-min-width: 335px;
-
 .edit-site-header-edit-mode {
 	height: $header-height;
 	align-items: center;
@@ -18,20 +16,18 @@ $header-toolbar-min-width: 335px;
 		align-items: center;
 		flex-grow: 1;
 		flex-shrink: 2;
-
-		// Account for the site hub, with is 60x60px.
-		flex-basis: calc(37.5% - 60px);
-
-		// We need this to be overflow hidden so the block toolbar can
-		// overflow scroll. If the overflow is visible, flexbox allows
-		// the toolbar to grow outside of the allowed container space.
-		overflow: hidden;
 		// Take up the full height of the header so the border focus
 		// is visible on toolbar buttons.
 		height: 100%;
 		// Allow focus ring to be fully visible on furthest right button.
 		@include break-medium() {
+			// Account for the site hub, which is 60x60px.
+			flex-basis: calc(37.5% - 60px);
 			padding-right: 2px;
+			// We need this to be overflow hidden so the block toolbar can
+			// overflow scroll. If the overflow is visible, flexbox allows
+			// the toolbar to grow outside of the allowed container space.
+			overflow: hidden;
 		}
 	}
 
@@ -41,18 +37,20 @@ $header-toolbar-min-width: 335px;
 		height: 100%;
 		flex-grow: 1;
 		flex-shrink: 1;
-		flex-basis: 37.5%;
+
+		@include break-medium() {
+			flex-basis: 37.5%;
+		}
 	}
 
 	.edit-site-header-edit-mode__center {
-		display: none;
 		align-items: center;
-		height: 100%;
-		margin: 0 $grid-unit-10;
-		justify-content: center;
+		display: flex;
+		flex-basis: 100%;
 		flex-grow: 1;
 		flex-shrink: 2;
-		flex-basis: 25%;
+		height: 100%;
+		justify-content: center;
 
 		// Flex items will, by default, refuse to shrink below a minimum
 		// intrinsic width. In order to shrink this flexbox item, and
@@ -60,18 +58,18 @@ $header-toolbar-min-width: 335px;
 		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 		min-width: 0;
 
-		@include break-small() {
-			display: flex;
+		@include break-medium() {
+			flex-basis: 25%;
 		}
 	}
 
 }
 
 .edit-site-header-edit-mode__toolbar {
-	display: flex;
 	align-items: center;
-	padding-left: $grid-unit-20;
+	display: flex;
 	gap: $grid-unit-10;
+	padding-left: $grid-unit-20;
 
 	@include break-medium() {
 		padding-left: $grid-unit-50 * 0.5;
@@ -103,6 +101,8 @@ $header-toolbar-min-width: 335px;
 	display: inline-flex;
 	align-items: center;
 	flex-wrap: nowrap;
+	// Ensure actions do not press against .edit-site-header-edit-mode__center.
+	padding-left: $grid-unit-10;
 	padding-right: $grid-unit-05;
 
 	@include break-small () {

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -103,12 +103,7 @@
 	flex-wrap: nowrap;
 	// Ensure actions do not press against .edit-site-header-edit-mode__center.
 	padding-left: $grid-unit-10;
-	padding-right: $grid-unit-05;
-
-	@include break-small () {
-		padding-right: $grid-unit-10;
-	}
-
+	padding-right: $grid-unit-10;
 	gap: $grid-unit-10;
 }
 

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -46,7 +46,7 @@
 	align-items: center;
 
 	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
-	@include break-small() {
+	@include break-medium() {
 		padding-left: $grid-unit-40;
 	}
 

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -10,7 +10,7 @@
 	min-width: 0;
 	background: $gray-100;
 	border-radius: $grid-unit-05;
-	width: min(100%, 450px);
+	width: min(100%, 416px);
 
 	&:hover {
 		background-color: $gray-200;

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -47,7 +47,7 @@
 
 	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
 	@include break-medium() {
-		padding-left: $grid-unit-40;
+		padding-left: $grid-unit-30;
 	}
 
 	&:hover {
@@ -67,14 +67,14 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: 50%;
+		max-width: 70%;
 		color: currentColor;
 	}
 }
 
 .editor-document-bar__shortcut {
 	color: $gray-800;
-	min-width: $grid-unit-40;
+	min-width: $grid-unit-30;
 	display: none;
 
 	@include break-medium() {

--- a/packages/editor/src/components/document-tools/style.scss
+++ b/packages/editor/src/components/document-tools/style.scss
@@ -3,10 +3,11 @@
 	align-items: center;
 
 	// Hide all action buttons except the inserter on mobile.
-	.editor-document-tools__left > .components-button {
+	.editor-document-tools__left > .editor-history__redo,
+	.editor-document-tools__left > .editor-history__undo {
 		display: none;
 
-		@include break-small() {
+		@include break-medium() {
 			display: inline-flex;
 		}
 	}
@@ -70,14 +71,6 @@
 	// Some plugins add buttons here despite best practices.
 	// Push them a bit rightwards to fit the top toolbar.
 	margin-right: $grid-unit-10;
-
-	@include break-medium() {
-		padding-left: $grid-unit-50 * 0.5;
-	}
-
-	@include break-wide() {
-		padding-right: $grid-unit-10;
-	}
 }
 
 .editor-document-tools .editor-document-tools__left > .editor-document-tools__inserter-toggle.has-icon {

--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -10,8 +10,7 @@
 		&[aria-controls="edit-post:document"],
 		&[aria-controls="edit-post:block"],
 		&[aria-controls="edit-site:template"],
-		&[aria-controls="edit-site:block-inspector"],
-		&[aria-controls="edit-site:global-styles"] {
+		&[aria-controls="edit-site:block-inspector"] {
 			display: flex;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/29673. 

An alternative to https://github.com/WordPress/gutenberg/pull/59078.  Also consolidates some break points to reduce elements rendering at different viewports. 

## Testing Instructions
- Open the site editor and observe the document title is centrally aligned.
- Check everything works well at different viewport sizes.
- Toggle editor options like "Top toolbar" and "Distraction free", and ensure everything matches trunk.
- Try with a plugin that adds to the right side, like Create Block Theme.


### Before 
https://github.com/WordPress/gutenberg/assets/1813435/90f14b0a-71fe-4d2d-aed8-cbf140d2d312


### After 
https://github.com/WordPress/gutenberg/assets/1813435/658b8baf-f0a2-42e0-be2b-d317fee902f9



