### PR TITLE
RNMobile: Add new Video block capability

### DIFF
--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -9,6 +9,7 @@ data class GutenbergProps @JvmOverloads constructor(
     val enableLayoutGridBlock: Boolean,
     val enableTiledGalleryBlock: Boolean,
     val enableVideoPressBlock: Boolean,
+    val enableVideoPressV5Support: Boolean,
     val enableFacebookEmbed: Boolean,
     val enableInstagramEmbed: Boolean,
     val enableLoomEmbed: Boolean,
@@ -69,6 +70,7 @@ data class GutenbergProps @JvmOverloads constructor(
         putBoolean(PROP_CAPABILITIES_LAYOUT_GRID_BLOCK, enableLayoutGridBlock)
         putBoolean(PROP_CAPABILITIES_TILED_GALLERY_BLOCK, enableTiledGalleryBlock)
         putBoolean(PROP_CAPABILITIES_VIDEOPRESS_BLOCK, enableVideoPressBlock)
+        putBoolean(PROP_CAPABILITIES_VIDEOPRESS_V5_SUPPORT, enableVideoPressV5Support)
         putBoolean(PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, enableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED, isAudioBlockMediaUploadEnabled)
@@ -112,6 +114,7 @@ data class GutenbergProps @JvmOverloads constructor(
         const val PROP_CAPABILITIES_LAYOUT_GRID_BLOCK = "layoutGridBlock"
         const val PROP_CAPABILITIES_TILED_GALLERY_BLOCK = "tiledGalleryBlock"
         const val PROP_CAPABILITIES_VIDEOPRESS_BLOCK = "videoPressBlock"
+        const val PROP_CAPABILITIES_VIDEOPRESS_V5_SUPPORT = "videoPressV5Support"
         const val PROP_CAPABILITIES_FACEBOOK_EMBED_BLOCK = "facebookEmbed"
         const val PROP_CAPABILITIES_INSTAGRAM_EMBED_BLOCK = "instagramEmbed"
         const val PROP_CAPABILITIES_LOOM_EMBED_BLOCK = "loomEmbed"

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -30,6 +30,7 @@ public enum Capabilities: String {
     case layoutGridBlock
     case tiledGalleryBlock
     case videoPressBlock
+    case videoPressV5Support
     case mentions
     case xposts
     case unsupportedBlockEditor

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
@@ -209,6 +209,7 @@ public class MainActivity extends ReactActivity {
         capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED, true);
         capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_TILED_GALLERY_BLOCK, true);
         capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_VIDEOPRESS_BLOCK, true);
+        capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_VIDEOPRESS_V5_SUPPORT, true);
         capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_FACEBOOK_EMBED_BLOCK, true);
         capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_INSTAGRAM_EMBED_BLOCK, true);
         capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_LOOM_EMBED_BLOCK, true);

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -421,6 +421,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
             .canEnableUnsupportedBlockEditor: unsupportedBlockCanBeActivated,
             .tiledGalleryBlock: true,
             .videoPressBlock: true,
+            .videoPressV5Support: true,
             .isAudioBlockMediaUploadEnabled: true,
             .reusableBlock: false,
             .facebookEmbed: true,


### PR DESCRIPTION
## What?

This PR is adding a new capability to enable changes to the Video block.

## Why?

There are times where the Video block doesn't work as expected, this PR helps lay the groundwork for addressing this.

## How?

Previously-used patterns to add a new capability have been followed.

## Testing Instructions

See the related Gutenberg Mobile PR here for an example of when this new capability will be useful: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6634