### PR TITLE
Block Editor: Remove 'BlockSettingsMenu' styles

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -1,3 +1,0 @@
-.block-editor-block-settings-menu__popover .components-dropdown-menu__menu {
-	padding: 0;
-}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -16,7 +16,6 @@
 @import "./components/block-popover/style.scss";
 @import "./components/block-preview/style.scss";
 @import "./components/block-rename/style.scss";
-@import "./components/block-settings-menu/style.scss";
 @import "./components/block-styles/style.scss";
 @import "./components/block-switcher/style.scss";
 @import "./components/block-types-list/style.scss";


### PR DESCRIPTION
## What?
PR removes unnecessary styles for the `BlockSettingsMenu` component.

## Why?
The `components-dropdown-menu__menu` has no padding by default. I couldn't find a reason why this override was used; it was last updated in #15968. As far as I can tell, the style is unnecessary.

## Testing Instructions
1. Open a post or page.
2. Insert a block.
3. Open the block options dropdown.
4. Confirm there's no visual regression.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-02-18 at 12 11 16](https://github.com/WordPress/gutenberg/assets/240569/0455d356-92cf-4d39-93f2-ffd01933fe1d)
