### PR TITLE
BlockSettingsMenu: Combine 'block-editor' store selectors

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -98,6 +98,7 @@ export function BlockSettingsDropdown( {
 		parentBlockType,
 		previousBlockClientId,
 		selectedBlockClientIds,
+		openedBlockSettingsMenu,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -107,7 +108,8 @@ export function BlockSettingsDropdown( {
 				getPreviousBlockClientId,
 				getSelectedBlockClientIds,
 				getBlockAttributes,
-			} = select( blockEditorStore );
+				getOpenedBlockSettingsMenu,
+			} = unlock( select( blockEditorStore ) );
 
 			const { getActiveBlockVariation } = select( blocksStore );
 
@@ -129,18 +131,13 @@ export function BlockSettingsDropdown( {
 				previousBlockClientId:
 					getPreviousBlockClientId( firstBlockClientId ),
 				selectedBlockClientIds: getSelectedBlockClientIds(),
+				openedBlockSettingsMenu: getOpenedBlockSettingsMenu(),
 			};
 		},
 		[ firstBlockClientId ]
 	);
 	const { getBlockOrder, getSelectedBlockClientIds } =
 		useSelect( blockEditorStore );
-
-	const openedBlockSettingsMenu = useSelect(
-		( select ) =>
-			unlock( select( blockEditorStore ) ).getOpenedBlockSettingsMenu(),
-		[]
-	);
 
 	const { setOpenedBlockSettingsMenu } = unlock(
 		useDispatch( blockEditorStore )


### PR DESCRIPTION
## What?
PR moves the `openedBlockSettingsMenu` value selector into the main `mapSelect`.

## Why?
Micro-optimization reduces the number of subscriptions created by the component. Also, there's no need to have a separate `mapSelect` just for private selectors.

## Testing Instructions
Please take a look at the instructions from #54083.

### Testing Instructions for Keyboard
Same.
