### PR TITLE
Block Mover: Unify visual separator when show button label is on

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -207,17 +207,18 @@
 		}
 	}
 
-	.block-editor-block-mover .block-editor-block-mover__move-button-container {
-		width: auto;
-
-		@include break-small() {
+	.block-editor-block-mover {
+		.block-editor-block-mover__move-button-container {
+			width: auto;
 			position: relative;
+		}
 
-			&::before {
+		&:not(.is-horizontal) .block-editor-block-mover__move-button-container::before {
+			@include break-small() {
 				content: "";
 				height: $border-width;
 				width: 100%;
-				background: $gray-900;
+				background: $gray-200;
 				position: absolute;
 				top: 50%;
 				left: 50%;
@@ -225,6 +226,10 @@
 				// X axis allows to make the separator always centered regardless of its width.
 				transform: translate(-50%, 0);
 				margin-top: -$border-width * 0.5;
+			}
+
+			@include break-medium {
+				background: $gray-900;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #58999
Follow-up #57640

## What?

This PR unifies the visual separator between mover buttons when "show button label" is on.

## Why?

The main problem is that when the buttons are placed horizontally, the horizontal border overlaps the text.

![horizontal-scrollbar-overlap-text](https://github.com/WordPress/gutenberg/assets/54422211/3d3dcee8-1173-42fd-9242-bdd51c38e7fe)

There are other consistency issues to resolve as reported in #58999.

## How?

I adjusted the CSS for the separator based on the rules below.

- If the mover button is placed horizontally, the separator is not always displayed.
- If the mover button is placed vertically, always show a separator so that the button is not misunderstood as having multiple lines of text.
- Make the separator color the same as the other borders on the toolbar.

## Testing Instructions

- Enable "Show buttontext labels" from Preferences > Accesibillity tab.
- Create two Group blocks and insert multiple Paragraph blocks into them.
- Apply Row variation to one Group block.
- Click the Paragraph block inside the Group block.
- Change the width of ythe browser to confirm that the separator is displayed as expected.
- It should work similarly when "Top toolbar" is enabled.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/4595c646-f841-49a1-8a7b-73738e8f5f88

