### PR TITLE
Global style changes: update sprintf calls using `_n`

### DIFF
--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -203,21 +203,15 @@ export default function getGlobalStylesChanges( next, previous, options = {} ) {
 			switch ( key ) {
 				case 'blocks': {
 					return sprintf(
-						// translators: %2$s: a list of block names separated by a comma.
-						_n( '%2$s block.', '%2$s blocks.', changeValuesLength ),
-						changeValuesLength,
+						// translators: %s: a list of block names separated by a comma.
+						_n( '%s block.', '%s blocks.', changeValuesLength ),
 						joinedChangesValue
 					);
 				}
 				case 'elements': {
 					return sprintf(
-						// translators: %2$s: a list of element names separated by a comma.
-						_n(
-							'%2$s element.',
-							'%2$s elements.',
-							changeValuesLength
-						),
-						changeValuesLength,
+						// translators: %s: a list of element names separated by a comma.
+						_n( '%s element.', '%s elements.', changeValuesLength ),
 						joinedChangesValue
 					);
 				}


### PR DESCRIPTION

## What?
Follow up for https://github.com/WordPress/gutenberg/pull/59055 to remove first `sprintf` arg



## Why?

@t-hamano very rightly pointed out that I didn't need the first argument as it didn't appear in the string replacement.

I was too busy copying and pasting to notice. 

Thank you!


## Testing Instructions
Covered by unit tests.

`npm run test:unit packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js`

The JS tests should pass. 
