### PR TITLE
Fix move interactivity schema to supports property instead of selectors property

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -594,6 +594,31 @@
 							"default": false
 						}
 					}
+				},
+				"interactivity": {
+					"description": "Indicates if the block is using Interactivity API features.",
+					"oneOf": [
+						{
+							"type": "boolean",
+							"description": "Indicates whether the block is using the Interactivity API directives.",
+							"default": false
+						},
+						{
+							"type": "object",
+							"properties": {
+								"clientNavigation": {
+									"type": "boolean",
+									"description": "Indicates whether a block is compatible with the Interactivity API client-side navigation.\n\nSet it to true only if the block is not interactive or if it is interactive using the Interactivity API. Set it to false if the block is interactive but uses vanilla JS, jQuery or another JS framework/library other than the Interactivity API.",
+									"default": false
+								},
+								"interactive": {
+									"type": "boolean",
+									"description": "Indicates whether the block is using the Interactivity API directives.",
+									"default": false
+								}
+							}
+						}
+					]
 				}
 			},
 			"additionalProperties": true
@@ -691,31 +716,6 @@
 								"letterSpacing": { "type": "string" },
 								"textDecoration": { "type": "string" },
 								"textTransform": { "type": "string" }
-							}
-						}
-					]
-				},
-				"interactivity": {
-					"description": "Indicates if the block is using Interactivity API features.",
-					"oneOf": [
-						{
-							"type": "boolean",
-							"description": "Indicates whether the block is using the Interactivity API directives.",
-							"default": false
-						},
-						{
-							"type": "object",
-							"properties": {
-								"clientNavigation": {
-									"type": "boolean",
-									"description": "Indicates whether a block is compatible with the Interactivity API client-side navigation.\n\nSet it to true only if the block is not interactive or if it is interactive using the Interactivity API. Set it to false if the block is interactive but uses vanilla JS, jQuery or another JS framework/library other than the Interactivity API.",
-									"default": false
-								},
-								"interactive": {
-									"type": "boolean",
-									"description": "Indicates whether the block is using the Interactivity API directives.",
-									"default": false
-								}
 							}
 						}
 					]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Moves the `interactivity` subproperty from the `selectors` property to the `supports`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the property is a block support option. It was missplaced before.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By copying it to the correct spot.
