### PR TITLE
Gallery: Set the 'defaultBlock' setting for inner blocks

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -73,6 +73,7 @@ const MOBILE_CONTROL_PROPS_RANGE_CONTROL = Platform.isNative
 	? { type: 'stepper' }
 	: {};
 
+const DEFAULT_BLOCK = { name: 'core/image' };
 const EMPTY_ARRAY = [];
 
 function GalleryEdit( props ) {
@@ -496,6 +497,7 @@ function GalleryEdit( props ) {
 	};
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		defaultBlock: DEFAULT_BLOCK,
 		orientation: 'horizontal',
 		renderAppender: false,
 		...nativeInnerBlockProps,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -498,6 +498,7 @@ function GalleryEdit( props ) {
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		defaultBlock: DEFAULT_BLOCK,
+		directInsert: true,
 		orientation: 'horizontal',
 		renderAppender: false,
 		...nativeInnerBlockProps,


### PR DESCRIPTION
## What?

PR sets the 'defaultBlock' setting for the Gallery block in preparation for https://github.com/WordPress/gutenberg/pull/59162. 

## Why?

The setting will be needed for https://github.com/WordPress/gutenberg/pull/59162. 

## Testing Instructions

There should be no difference in behaviour between trunk and this PR.

1. Open a post or page. 
2. Insert a Gallery block.
3. Select a few images.
4. Confirm in-between the inserter directly adds the image block.

### Testing Instructions for Keyboard
Same.
