### PR TITLE
Fix upload button on overridden empty image block in patterns

### DIFF
--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -160,7 +160,7 @@ function gutenberg_process_block_bindings( $block_content, $parsed_block, $block
 	$supported_block_attrs = array(
 		'core/paragraph' => array( 'content' ),
 		'core/heading'   => array( 'content' ),
-		'core/image'     => array( 'url', 'title', 'alt' ),
+		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
 		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 	);
 

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -31,6 +31,7 @@ export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 		rel: __( 'Link Relationship' ),
 	},
 	'core/image': {
+		id: __( 'Image ID' ),
 		url: __( 'URL' ),
 		title: __( 'Title' ),
 		alt: __( 'Alt Text' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/58708.

Fix the confusing upload button on the block toolbar for overridden empty image in patterns.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The upload button is confusing and it creates bad UX.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add `id` as a binding attribute for the image block as well.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the testing instructions in https://github.com/WordPress/gutenberg/issues/58708.
Also added an e2e test.

## Screenshots or screencast <!-- if applicable -->
N/A