### PR TITLE
Fix resetting individual blocks to empty optional values for Pattern Overrides

### DIFF
--- a/packages/patterns/src/components/reset-overrides-control.js
+++ b/packages/patterns/src/components/reset-overrides-control.js
@@ -59,7 +59,19 @@ export default function ResetOverridesControl( props ) {
 		const blocks = editedRecord.blocks ?? parse( editedRecord.content );
 		const block = recursivelyFindBlockWithId( blocks, id );
 
-		props.setAttributes( block.attributes );
+		const newAttributes = Object.assign(
+			// Reset every existing attribute to undefined.
+			Object.fromEntries(
+				Object.keys( props.attributes ).map( ( key ) => [
+					key,
+					undefined,
+				] )
+			),
+			// Then assign the original attributes.
+			block.attributes
+		);
+
+		props.setAttributes( newAttributes );
 	};
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix resetting individual blocks to empty optional values for Pattern Overrides.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A bug where clicking the reset button doesn't work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Reset existing attributes to undefined first.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a synced pattern with an empty image block and check the "Allow instance overrides" settings in the advanced panel.
3. Insert the pattern in a post and upload an image to the image block.
4. Click on the "Reset" button on the block toolbar for the image block.
5. The image block should be reset to empty.

## Screenshots or screencast <!-- if applicable -->
N/A