### PR TITLE
Storybook: Add mechanism to redirect moved stories

### DIFF
--- a/packages/components/src/radio-group/stories/index.story.tsx
+++ b/packages/components/src/radio-group/stories/index.story.tsx
@@ -16,6 +16,7 @@ import { useState } from '@wordpress/element';
 
 const meta: Meta< typeof RadioGroup > = {
 	title: 'Components (Deprecated)/RadioGroup',
+	id: 'components-radiogroup',
 	component: RadioGroup,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { Radio },

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,0 +1,35 @@
+<script>
+	( function redirectIfStoryMoved() {
+		const REDIRECTS = [
+			{
+				from: /\/components-deprecated-/,
+				to: '/components-',
+			},
+		];
+
+		const params = new URLSearchParams( window.location.search );
+
+		const matchedRedirect = REDIRECTS.find( ( { from } ) =>
+			from.test( params.get( 'path' ) )
+		);
+
+		if ( ! matchedRedirect ) {
+			return;
+		}
+
+		params.set(
+			'path',
+			params
+				.get( 'path' )
+				.replace( matchedRedirect.from, matchedRedirect.to )
+		);
+
+		const newUrl =
+			window.location.origin +
+			window.location.pathname +
+			'?' +
+			decodeURIComponent( params.toString() );
+
+		window.location.replace( newUrl );
+	} )();
+</script>

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -24,11 +24,10 @@
 				.replace( matchedRedirect.from, matchedRedirect.to )
 		);
 
+		const { pathname, origin } = window.location;
+		// The decodeURIComponent keeps the slashes intact, to match how Storybook presents the `path` param.
 		const newUrl =
-			window.location.origin +
-			window.location.pathname +
-			'?' +
-			decodeURIComponent( params.toString() );
+			new URL( pathname, origin ) + '?' + decodeURIComponent( params );
 
 		window.location.replace( newUrl );
 	} )();


### PR DESCRIPTION
Part of #33111

## What?

Adds a mechanism to "redirect" outdated Storybook URLs to the new canonical URL.

## Why?

With the way we are currently structuring our stories, the sidebar grouping names such as "Components (Experimental)" and "Components (Deprecated)" become part of the story URL. This is bad for permalinks because the URL will change if the grouping of a component changes over time. Now with better labeling systems like sidebar icons and status badges in place, as well as the "Experimental" grouping not being meaningful anymore, we want to move to a structure where all wp-components components have a straightforward, stable ID for permalinks (`components-my-component`).

This PR lays the groundwork so we can move forward with the ID normalization.

## How?

I considered [some approaches](https://github.com/storybookjs/storybook/discussions/23093) suggested in the Storybook repo.

The Express middleware seemed clean, but it won't work for us because the Node server only runs when in dev mode, and is irrelevant for static deploys.

So I ended up with a modified version of the [`manager-head.html` approach](https://github.com/storybookjs/storybook/discussions/23093#discussioncomment-6916812). Instead of listening for all `navigation` events (since the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation) is not ready for production use), we simply run a IIFE on the initial load of the SPA which immediately redirects if applicable. This should be good enough for us, since we can assume there are no outdated links _within_ the SPA — it's only on the initial page load where a user could be arriving from an outdated link somewhere.

## Testing Instructions

Accessing the `RadioGroup` docs or stories from an outdated URL (e.g. `?path=/docs/components-deprecated-radiogroup--docs`) should redirect to their new canonical URL.