### PR TITLE
Bug: Fixed method usage because of method signature change in docker-compose 0.24.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55388,7 +55388,7 @@
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.24.5",
+				"docker-compose": "^0.24.6",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -55418,9 +55418,9 @@
 			}
 		},
 		"packages/env/node_modules/docker-compose": {
-			"version": "0.24.5",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.5.tgz",
-			"integrity": "sha512-cYIi9atSf/J5qhd5/7QMqnyqogkH34TbsoN9Lit1BgEzVlY/Z/Sd0HNOBa6Sk/67YNUjzAKxaz2P1RRSBD42kw==",
+			"version": "0.24.6",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.6.tgz",
+			"integrity": "sha512-VidlUyNzXMaVsuM79sjSvwC4nfojkP2VneL+Zfs538M2XFnffZDhx6veqnz/evCNIYGyz5O+1fgL6+g0NLWTBA==",
 			"dev": true,
 			"dependencies": {
 				"yaml": "^2.2.2"
@@ -70481,7 +70481,7 @@
 			"requires": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.24.5",
+				"docker-compose": "^0.24.6",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -70505,9 +70505,9 @@
 					}
 				},
 				"docker-compose": {
-					"version": "0.24.5",
-					"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.5.tgz",
-					"integrity": "sha512-cYIi9atSf/J5qhd5/7QMqnyqogkH34TbsoN9Lit1BgEzVlY/Z/Sd0HNOBa6Sk/67YNUjzAKxaz2P1RRSBD42kw==",
+					"version": "0.24.6",
+					"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.6.tgz",
+					"integrity": "sha512-VidlUyNzXMaVsuM79sjSvwC4nfojkP2VneL+Zfs538M2XFnffZDhx6veqnz/evCNIYGyz5O+1fgL6+g0NLWTBA==",
 					"dev": true,
 					"requires": {
 						"yaml": "^2.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55388,7 +55388,7 @@
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.24.3",
+				"docker-compose": "^0.24.4",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -70481,7 +70481,7 @@
 			"requires": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.24.3",
+				"docker-compose": "^0.24.4",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55388,7 +55388,7 @@
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.24.4",
+				"docker-compose": "^0.24.5",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -55418,9 +55418,9 @@
 			}
 		},
 		"packages/env/node_modules/docker-compose": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.2.tgz",
-			"integrity": "sha512-2/WLvA7UZ6A2LDLQrYW0idKipmNBWhtfvrn2yzjC5PnHDzuFVj1zAZN6MJxVMKP0zZH8uzAK6OwVZYHGuyCmTw==",
+			"version": "0.24.5",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.5.tgz",
+			"integrity": "sha512-cYIi9atSf/J5qhd5/7QMqnyqogkH34TbsoN9Lit1BgEzVlY/Z/Sd0HNOBa6Sk/67YNUjzAKxaz2P1RRSBD42kw==",
 			"dev": true,
 			"dependencies": {
 				"yaml": "^2.2.2"
@@ -70481,7 +70481,7 @@
 			"requires": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
-				"docker-compose": "^0.24.4",
+				"docker-compose": "^0.24.5",
 				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"inquirer": "^7.1.0",
@@ -70505,8 +70505,9 @@
 					}
 				},
 				"docker-compose": {
-					"version": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.2.tgz",
-					"integrity": "sha512-2/WLvA7UZ6A2LDLQrYW0idKipmNBWhtfvrn2yzjC5PnHDzuFVj1zAZN6MJxVMKP0zZH8uzAK6OwVZYHGuyCmTw==",
+					"version": "0.24.5",
+					"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.5.tgz",
+					"integrity": "sha512-cYIi9atSf/J5qhd5/7QMqnyqogkH34TbsoN9Lit1BgEzVlY/Z/Sd0HNOBa6Sk/67YNUjzAKxaz2P1RRSBD42kw==",
 					"dev": true,
 					"requires": {
 						"yaml": "^2.2.2"

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
-- Update `docker-compose` dependency to `0.24.5` and change method calls from `down()` to the new `downAll()`.
+- Update `docker-compose` dependency to `0.24.6` and change method calls from `down()` to the new `downAll()`.
 
 ## 9.3.0 (2024-02-09)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- Update `docker-compose` dependency to `0.24.5` and change method calls from `down()` to the new `downAll()`.
+
 ## 9.3.0 (2024-02-09)
 
 ## 9.2.0 (2024-01-24)

--- a/packages/env/lib/commands/destroy.js
+++ b/packages/env/lib/commands/destroy.js
@@ -59,7 +59,7 @@ module.exports = async function destroy( { spinner, scripts, debug } ) {
 
 	spinner.text = 'Removing docker images, volumes, and networks.';
 
-	await dockerCompose.down( {
+	await dockerCompose.downAll( {
 		config: config.dockerComposeConfigPath,
 		commandOptions: [ '--volumes', '--remove-orphans', '--rmi', 'all' ],
 		log: debug,

--- a/packages/env/lib/commands/stop.js
+++ b/packages/env/lib/commands/stop.js
@@ -24,7 +24,7 @@ module.exports = async function stop( { spinner, debug } ) {
 
 	spinner.text = 'Stopping WordPress.';
 
-	await dockerCompose.down( {
+	await dockerCompose.downAll( {
 		config: dockerComposeConfigPath,
 		log: debug,
 	} );

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"chalk": "^4.0.0",
 		"copy-dir": "^1.3.0",
-		"docker-compose": "^0.24.3",
+		"docker-compose": "^0.24.4",
 		"extract-zip": "^1.6.7",
 		"got": "^11.8.5",
 		"inquirer": "^7.1.0",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"chalk": "^4.0.0",
 		"copy-dir": "^1.3.0",
-		"docker-compose": "^0.24.4",
+		"docker-compose": "^0.24.5",
 		"extract-zip": "^1.6.7",
 		"got": "^11.8.5",
 		"inquirer": "^7.1.0",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"chalk": "^4.0.0",
 		"copy-dir": "^1.3.0",
-		"docker-compose": "^0.24.5",
+		"docker-compose": "^0.24.6",
 		"extract-zip": "^1.6.7",
 		"got": "^11.8.5",
 		"inquirer": "^7.1.0",


### PR DESCRIPTION
## What?
Due to changes on the method signature in docker-compose 0.24.4, this PR updates the @wordpress/env package to use `downAll()` instead of `down()` which is not available anymore.

## Why?
When installing @wordpress/env over npm in a new project or updating the docker-compose dependency to 0.24.6, it will break the usage of wp-env.

Fixes #59183

## How?
The call to `down()` was changed to `downAll()` was changed in `start.js` and `destroy.js` and the version of `docker-compose` was raised to `0.24.6` in the `package.json`

## Testing Instructions
Create a new project and use the original version of @wordpress/env. It should throw an error message like this:
```
❯ npx wp-env start
✖ dockerCompose.down is not a function
TypeError: dockerCompose.down is not a function
    at stop (/Users/.../node_modules/@wordpress/env/lib/commands/stop.js:27:22)
    at async start (/Users/.../node_modules/@wordpress/env/lib/commands/start.js:111:3)
```

Try to run wp-env with the files from this PR then, which should work flawlessly. 