### PR TITLE
Interactivity API: Improve context merges using proxies

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -554,7 +554,11 @@ class WP_Navigation_Block_Renderer {
 		// When adding to this array be mindful of security concerns.
 		$nav_element_context    = data_wp_context(
 			array(
-				'overlayOpenedBy' => array(),
+				'overlayOpenedBy' => array(
+					'click' => false,
+					'hover' => false,
+					'focus' => false,
+				),
 				'type'            => 'overlay',
 				'roleAttribute'   => '',
 				'ariaLabel'       => __( 'Menu' ),
@@ -764,7 +768,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 	) ) {
 		// Add directives to the parent `<li>`.
 		$tags->set_attribute( 'data-wp-interactive', 'core/navigation' );
-		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": {}, "type": "submenu" }' );
+		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu" }' );
 		$tags->set_attribute( 'data-wp-watch', 'callbacks.initMenu' );
 		$tags->set_attribute( 'data-wp-on--focusout', 'actions.handleMenuFocusout' );
 		$tags->set_attribute( 'data-wp-on--keydown', 'actions.handleMenuKeydown' );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -135,6 +135,10 @@ wp_enqueue_script_module( 'directive-context-view' );
 	data-wp-router-region="navigation"
 	data-wp-context='{ "text": "first page" }'
 >
+	<div data-wp-context='{}'>
+		<div data-testid="navigation inherited text" data-wp-text="context.text"></div>
+		<div data-testid="navigation inherited text2" data-wp-text="context.text2"></div>
+	</div>
 	<div data-testid="navigation text" data-wp-text="context.text"></div>
 	<div data-testid="navigation new text" data-wp-text="context.newText"></div>
 	<button data-testid="toggle text" data-wp-on--click="actions.toggleText">Toggle Text</button>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -143,6 +143,7 @@ wp_enqueue_script_module( 'directive-context-view' );
 	<div data-testid="navigation new text" data-wp-text="context.newText"></div>
 	<button data-testid="toggle text" data-wp-on--click="actions.toggleText">Toggle Text</button>
 	<button data-testid="add new text" data-wp-on--click="actions.addNewText">Add New Text</button>
+	<button data-testid="add text2" data-wp-on--click="actions.addText2">Add Text 2</button>
 	<button data-testid="navigate" data-wp-on--click="actions.navigate">Navigate</button>
 	<button data-testid="async navigate" data-wp-on--click="actions.asyncNavigate">Async Navigate</button>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -18,6 +18,7 @@ wp_enqueue_script_module( 'directive-context-view' );
 		>
 			<!-- rendered during hydration -->
 		</pre>
+		<button data-testid="parent replace" data-wp-on--click="actions.replaceObj">Replace obj</button>
 		<button
 			data-testid="parent prop1"
 			name="prop1"
@@ -67,6 +68,7 @@ wp_enqueue_script_module( 'directive-context-view' );
 			>
 				<!-- rendered during hydration -->
 			</pre>
+			<button data-testid="child replace" data-wp-on--click="actions.replaceObj">Replace obj</button>
 			<button
 				data-testid="child prop1"
 				name="prop1"

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -151,3 +151,15 @@ wp_enqueue_script_module( 'directive-context-view' );
 	<span data-testid="non-default suffix context" data-wp-text="context.text"></span>
 	<span data-testid="default suffix context" data-wp-text="context.defaultText"></span>
 </div>
+
+<div
+	data-wp-interactive='directive-context'
+	data-wp-context='{ "list": [
+		{ "id": 1, "text": "Text 1" },
+		{ "id": 2, "text": "Text 2" }
+	] }'
+>
+	<button data-testid="select 1" data-wp-on--click="actions.selectItem" value=1>Select 1</button>
+	<button data-testid="select 2" data-wp-on--click="actions.selectItem" value=2>Select 2</button>
+	<div data-testid="selected" data-wp-text="state.selected"></div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -50,6 +50,14 @@ wp_enqueue_script_module( 'directive-context-view' );
 		>
 			obj.prop5
 		</button>
+		<button
+			data-testid="parent new"
+			name="new"
+			value="modifiedFromParent"
+			data-wp-on--click="actions.updateContext"
+		>
+			new
+		</button>
 		<div
 			data-wp-context='{ "prop2":"child","prop3":"child","obj":{"prop5":"child","prop6":"child"},"array":[4,5,6] }'
 		>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -9,6 +9,10 @@ store( 'directive-context', {
 			const ctx = getContext();
 			return JSON.stringify( ctx, undefined, 2 );
 		},
+		get selected() {
+			const { list, selected } = getContext();
+			return list.find( ( obj ) => obj === selected )?.text;
+		}
 	},
 	actions: {
 		updateContext( event ) {
@@ -22,6 +26,11 @@ store( 'directive-context', {
 			const ctx = getContext();
 			ctx.text = ctx.text === 'Text 1' ? 'Text 2' : 'Text 1';
 		},
+		selectItem( event ) {
+			const ctx = getContext();
+			const value = parseInt( event.target.value );
+			ctx.selected = ctx.list.find( ( { id } ) => id === value );
+		}
 	},
 } );
 

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -38,8 +38,12 @@ const html = `
 		<div
 			data-wp-interactive="directive-context-navigate"
 			data-wp-router-region="navigation"
-			data-wp-context='{ "text": "second page" }'
+			data-wp-context='{ "text": "second page", "text2": "second page" }'
 		>
+			<div data-wp-context='{}'>
+				<div data-testid="navigation inherited text" data-wp-text="context.text"></div>
+				<div data-testid="navigation inherited text2" data-wp-text="context.text2"></div>
+			</div>
 			<div data-testid="navigation text" data-wp-text="context.text"></div>
 			<div data-testid="navigation new text" data-wp-text="context.newText"></div>
 			<button data-testid="toggle text" data-wp-on--click="actions.toggleText">Toggle Text</button>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -60,11 +60,11 @@ const { actions } = store( 'directive-context-navigate', {
 		},
 		navigate() {
 			return import( '@wordpress/interactivity-router' ).then(
-				( { actions: routerActions } ) =>
-					routerActions.navigate(
-						window.location,
-						{ force: true, html },
-					)
+				( { actions: routerActions } ) => {
+					const url = new URL( window.location.href );
+					url.searchParams.set( 'next_page', 'true' );
+					return routerActions.navigate( url, { force: true, html } );
+				}
 			);
 
 		},

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -30,6 +30,10 @@ store( 'directive-context', {
 			const ctx = getContext();
 			const value = parseInt( event.target.value );
 			ctx.selected = ctx.list.find( ( { id } ) => id === value );
+		},
+		replaceObj() {
+			const ctx = getContext();
+			ctx.obj = { overwritten: true };
 		}
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -47,7 +47,8 @@ const html = `
 			<div data-testid="navigation text" data-wp-text="context.text"></div>
 			<div data-testid="navigation new text" data-wp-text="context.newText"></div>
 			<button data-testid="toggle text" data-wp-on--click="actions.toggleText">Toggle Text</button>
-			<button data-testid="add new text" data-wp-on--click="actions.addNewText">Add new text</button>
+			<button data-testid="add new text" data-wp-on--click="actions.addNewText">Add New Text</button>
+			<button data-testid="add text2" data-wp-on--click="actions.addText2">Add Text 2</button>
 			<button data-testid="navigate" data-wp-on--click="actions.navigate">Navigate</button>
 			<button data-testid="async navigate" data-wp-on--click="actions.asyncNavigate">Async Navigate</button>
 		</div>`;
@@ -61,6 +62,10 @@ const { actions } = store( 'directive-context-navigate', {
 		addNewText() {
 			const ctx = getContext();
 			ctx.newText = 'some new text';
+		},
+		addText2() {
+			const ctx = getContext();
+			ctx.text2 = 'some new text';
 		},
 		navigate() {
 			return import( '@wordpress/interactivity-router' ).then(

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Only add proxies to plain objects inside the store. ([#59039](https://github.com/WordPress/gutenberg/pull/59039))
+-   Improve context merges using proxies. ([59187](https://github.com/WordPress/gutenberg/pull/59187))
 
 ## 5.0.0 (2024-02-09)
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -29,9 +29,10 @@ const contextProxy = ( context, stack = {} ) =>
 			}
 			return stack[ k ];
 		},
-		set: ( target, k, value ) =>
-			( ( k in target || ! ( k in stack ) ? target : stack )[ k ] =
-				value ),
+		set: ( target, k, value ) => {
+			( k in target || ! ( k in stack ) ? target : stack )[ k ] = value;
+			return true;
+		},
 		ownKeys: ( target ) => [
 			...new Set( [ ...Object.keys( stack ), ...Object.keys( target ) ] ),
 		],

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -39,7 +39,7 @@ const descriptor = Reflect.getOwnPropertyDescriptor;
 const proxifyContext = ( current, inherited = {} ) =>
 	new Proxy( current, {
 		get: ( target, k ) => {
-			// Always subscribe to the inherited and current props.
+			// Subscribe to the inherited and current props.
 			const inheritedProp = inherited[ k ];
 			const currentProp = target[ k ];
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -426,17 +426,14 @@ export default () => {
 			return list.map( ( item ) => {
 				const itemProp =
 					suffix === 'default' ? 'item' : kebabToCamelCase( suffix );
-				const itemContext = deepSignal( {
-					[ namespace ]: { [ itemProp ]: item },
-				} );
-				contextIgnores.set(
-					itemContext[ namespace ],
-					new Set( [ itemProp ] )
-				);
+				const itemContext = deepSignal( { [ namespace ]: {} } );
 				const mergedContext = proxifyContext(
 					itemContext,
 					inheritedValue
 				);
+
+				// Set the item after proxifying the context.
+				mergedContext[ namespace ][ itemProp ] = item;
 
 				const scope = { ...getScope(), context: mergedContext };
 				const key = eachKey

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -123,33 +123,21 @@ export default () => {
 			const { Provider } = inheritedContext;
 			const inheritedValue = useContext( inheritedContext );
 			const currentValue = useRef( deepSignal( {} ) );
-			const contextStack = useRef( null );
 			const defaultEntry = context.find(
 				( { suffix } ) => suffix === 'default'
 			);
 
-			currentValue.current = useMemo( () => {
-				if ( ! defaultEntry ) return null;
-				const { namespace, value } = defaultEntry;
-				const newValue = deepSignal( { [ namespace ]: value } );
-				mergeDeepSignals( currentValue.current, newValue, true );
-				return currentValue.current;
-			}, [ defaultEntry ] );
+			// No change should be made if `defaultEntry` does not exist.
+			const contextStack = useMemo( () => {
+				if ( defaultEntry ) {
+					const { namespace, value } = defaultEntry;
+					const newValue = deepSignal( { [ namespace ]: value } );
+					mergeDeepSignals( currentValue.current, newValue, true );
+				}
+				return contextProxy( currentValue.current, inheritedValue );
+			}, [ defaultEntry, inheritedValue ] );
 
-			contextStack.current = useMemo( () => {
-				return (
-					currentValue.current &&
-					contextProxy( currentValue.current, inheritedValue )
-				);
-			}, [ inheritedValue, currentValue.current ] );
-
-			if ( contextStack.current ) {
-				return (
-					<Provider value={ contextStack.current }>
-						{ children }
-					</Provider>
-				);
-			}
+			return <Provider value={ contextStack }>{ children }</Provider>;
 		},
 		{ priority: 5 }
 	);

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -107,6 +107,27 @@ const updateSignals = ( target, source ) => {
 	}
 };
 
+/**
+ * Recursively clone the passed object.
+ *
+ * @param {Object} source Source object.
+ * @return {Object} Cloned object.
+ */
+const deepClone = ( source ) => {
+	if ( isPlainObject( source ) ) {
+		return Object.fromEntries(
+			Object.entries( source ).map( ( [ key, value ] ) => [
+				key,
+				deepClone( value ),
+			] )
+		);
+	}
+	if ( Array.isArray( source ) ) {
+		return source.map( ( i ) => deepClone( i ) );
+	}
+	return source;
+};
+
 const newRule =
 	/(?:([\u0080-\uFFFF\w-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(}\s*)/g;
 const ruleClean = /\/\*[^]*?\*\/|  +/g;
@@ -186,7 +207,7 @@ export default () => {
 				if ( defaultEntry ) {
 					const { namespace, value } = defaultEntry;
 					updateSignals( currentValue.current, {
-						[ namespace ]: value,
+						[ namespace ]: deepClone( value ),
 					} );
 				}
 				return proxifyContext( currentValue.current, inheritedValue );

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -14,7 +14,7 @@ import { useWatch, useInit } from './utils';
 import { directive, getScope, getEvaluate } from './hooks';
 import { kebabToCamelCase } from './utils/kebab-to-camelcase';
 
-const isObject = ( item ) =>
+const isPlainObject = ( item ) =>
 	item && typeof item === 'object' && item.constructor === Object;
 
 const descriptor = Reflect.getOwnPropertyDescriptor;
@@ -26,7 +26,7 @@ const proxifyContext = ( context, stack = {}, { ignore } = {} ) =>
 				return target[ k ];
 			}
 			if ( k in target || ! ( k in stack ) ) {
-				return isObject( peek( target, k ) )
+				return isPlainObject( peek( target, k ) )
 					? proxifyContext( target[ k ], stack[ k ], { ignore } )
 					: target[ k ];
 			}
@@ -45,7 +45,10 @@ const proxifyContext = ( context, stack = {}, { ignore } = {} ) =>
 
 const updateSignals = ( target, source ) => {
 	for ( const k in source ) {
-		if ( isObject( peek( target, k ) ) && isObject( peek( source, k ) ) ) {
+		if (
+			isPlainObject( peek( target, k ) ) &&
+			isPlainObject( peek( source, k ) )
+		) {
 			updateSignals( target[ `$${ k }` ].peek(), source[ k ] );
 		} else {
 			target[ k ] = source[ k ];

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -88,6 +88,12 @@ const proxifyContext = ( current, inherited = {}, { ignore } = {} ) =>
 			descriptor( target, k ) || descriptor( inherited, k ),
 	} );
 
+/**
+ * Recursively update values within a deepSignal object.
+ *
+ * @param {Object} target A deepSignal instance.
+ * @param {Object} source Object with properties to update in `target`
+ */
 const updateSignals = ( target, source ) => {
 	for ( const k in source ) {
 		if (

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -14,8 +14,8 @@ import { useWatch, useInit } from './utils';
 import { directive, getScope, getEvaluate } from './hooks';
 import { kebabToCamelCase } from './utils/kebab-to-camelcase';
 
-// Properties that should be ignore during proxification.
-const contextIgnores = new WeakMap();
+// Assigned objects should be ignore during proxification.
+const contextAssignedObjects = new WeakMap();
 
 const isPlainObject = ( item ) =>
 	item && typeof item === 'object' && item.constructor === Object;
@@ -50,7 +50,7 @@ const proxifyContext = ( current, inherited = {}, { ignore } = {} ) =>
 			// Proxify plain objects that are not listed in `ignore`.
 			if (
 				k in target &&
-				! contextIgnores.get( target )?.has( k ) &&
+				! contextAssignedObjects.get( target )?.has( k ) &&
 				isPlainObject( peek( target, k ) )
 			) {
 				return proxifyContext( target[ k ], inherited[ k ], {
@@ -69,10 +69,10 @@ const proxifyContext = ( current, inherited = {}, { ignore } = {} ) =>
 			// Values that are objects should not be proxified so they point to
 			// the original object and don't inherit unexpected properties.
 			if ( value && typeof value === 'object' ) {
-				if ( ! contextIgnores.has( obj ) ) {
-					contextIgnores.set( obj, new Set() );
+				if ( ! contextAssignedObjects.has( obj ) ) {
+					contextAssignedObjects.set( obj, new Set() );
 				}
-				contextIgnores.get( obj ).add( k );
+				contextAssignedObjects.get( obj ).add( k );
 			}
 
 			obj[ k ] = value;

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -221,6 +221,8 @@ test.describe( 'data-wp-context', () => {
 		await expect( text2 ).toBeEmpty();
 		await page.getByTestId( 'toggle text' ).click();
 		await expect( text ).toHaveText( 'changed dynamically' );
+		await page.getByTestId( 'add text2' ).click();
+		await expect( text2 ).toHaveText( 'some new text' );
 		await page.getByTestId( 'navigate' ).click();
 		await expect( text ).toHaveText( 'second page' );
 		await expect( text2 ).toHaveText( 'second page' );

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -220,4 +220,18 @@ test.describe( 'data-wp-context', () => {
 		const element = page.getByTestId( 'non-default suffix context' );
 		await expect( element ).toHaveText( '' );
 	} );
+
+	test( 'references to objects are kept', async ( { page } ) => {
+		const selected = page.getByTestId( 'selected' );
+		const select1 = page.getByTestId( 'select 1' );
+		const select2 = page.getByTestId( 'select 2' );
+
+		await expect( selected ).toBeEmpty();
+
+		await select1.click();
+		await expect( selected ).toHaveText( 'Text 1' );
+
+		await select2.click();
+		await expect( selected ).toHaveText( 'Text 2' );
+	} );
 } );

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -214,6 +214,25 @@ test.describe( 'data-wp-context', () => {
 		await expect( element ).toHaveText( 'second page' );
 	} );
 
+	test( 'should inherit values on navigation', async ( { page } ) => {
+		const text = page.getByTestId( 'navigation inherited text' );
+		const text2 = page.getByTestId( 'navigation inherited text2' );
+		await expect( text ).toHaveText( 'first page' );
+		await expect( text2 ).toBeEmpty();
+		await page.getByTestId( 'toggle text' ).click();
+		await expect( text ).toHaveText( 'changed dynamically' );
+		await page.getByTestId( 'navigate' ).click();
+		await expect( text ).toHaveText( 'second page' );
+		await expect( text2 ).toHaveText( 'second page' );
+		await page.goBack();
+		await expect( text ).toHaveText( 'first page' );
+		// text2 maintains its value as it is not defined in the first page.
+		await expect( text2 ).toHaveText( 'second page' );
+		await page.goForward();
+		await expect( text ).toHaveText( 'second page' );
+		await expect( text2 ).toHaveText( 'second page' );
+	} );
+
 	test( 'should maintain the same context reference on async actions', async ( {
 		page,
 	} ) => {

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -170,6 +170,52 @@ test.describe( 'data-wp-context', () => {
 		expect( childContext.array ).toMatchObject( [ 4, 5, 6 ] );
 	} );
 
+	test( 'overwritten objects updates inherited values', async ( {
+		page,
+	} ) => {
+		await page.getByTestId( 'parent replace' ).click();
+
+		const childContext = await parseContent(
+			page.getByTestId( 'child context' )
+		);
+
+		expect( childContext.obj.prop4 ).toBeUndefined();
+		expect( childContext.obj.prop5 ).toBe( 'child' );
+		expect( childContext.obj.prop6 ).toBe( 'child' );
+		expect( childContext.obj.overwritten ).toBe( true );
+
+		const parentContext = await parseContent(
+			page.getByTestId( 'parent context' )
+		);
+
+		expect( parentContext.obj.prop4 ).toBeUndefined();
+		expect( parentContext.obj.prop5 ).toBeUndefined();
+		expect( parentContext.obj.prop6 ).toBeUndefined();
+		expect( parentContext.obj.overwritten ).toBe( true );
+	} );
+
+	test( 'overwritten objects do not inherit values', async ( { page } ) => {
+		await page.getByTestId( 'child replace' ).click();
+
+		const childContext = await parseContent(
+			page.getByTestId( 'child context' )
+		);
+
+		expect( childContext.obj.prop4 ).toBeUndefined();
+		expect( childContext.obj.prop5 ).toBeUndefined();
+		expect( childContext.obj.prop6 ).toBeUndefined();
+		expect( childContext.obj.overwritten ).toBe( true );
+
+		const parentContext = await parseContent(
+			page.getByTestId( 'parent context' )
+		);
+
+		expect( parentContext.obj.prop4 ).toBe( 'parent' );
+		expect( parentContext.obj.prop5 ).toBe( 'parent' );
+		expect( parentContext.obj.prop6 ).toBeUndefined();
+		expect( parentContext.obj.overwritten ).toBeUndefined();
+	} );
+
 	test( 'can be accessed in other directives on the same element', async ( {
 		page,
 	} ) => {

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -136,6 +136,27 @@ test.describe( 'data-wp-context', () => {
 		expect( parentContext.obj.prop5 ).toBe( 'modifiedFromParent' );
 	} );
 
+	test( 'new inherited properties update child contexts', async ( {
+		page,
+	} ) => {
+		const childContextBefore = await parseContent(
+			page.getByTestId( 'child context' )
+		);
+		expect( childContextBefore.new ).toBeUndefined();
+
+		await page.getByTestId( 'parent new' ).click();
+
+		const childContextAfter = await parseContent(
+			page.getByTestId( 'child context' )
+		);
+		expect( childContextAfter.new ).toBe( 'modifiedFromParent' );
+
+		const parentContext = await parseContent(
+			page.getByTestId( 'parent context' )
+		);
+		expect( parentContext.new ).toBe( 'modifiedFromParent' );
+	} );
+
 	test( 'Array properties are shadowed', async ( { page } ) => {
 		const parentContext = await parseContent(
 			page.getByTestId( 'parent context' )

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -202,6 +202,18 @@ test.describe( 'data-wp-context', () => {
 		await expect( element ).toHaveText( 'some new text' );
 	} );
 
+	test( 'should update values when navigating back or forward', async ( {
+		page,
+	} ) => {
+		const element = page.getByTestId( 'navigation text' );
+		await page.getByTestId( 'navigate' ).click();
+		await expect( element ).toHaveText( 'second page' );
+		await page.goBack();
+		await expect( element ).toHaveText( 'first page' );
+		await page.goForward();
+		await expect( element ).toHaveText( 'second page' );
+	} );
+
 	test( 'should maintain the same context reference on async actions', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
## What?

Reimplements the context merging algorithm using proxies.

Contexts are defined using the `data-wp-context` directive. A context can inherit properties from upper contexts defined in the DOM. To achieve that, contexts are "merged" top-down.

## Why?

It solves a couple of inconsistencies, like changes in inherited context not being reflected in child contexts and issues during navigations.

These issues are:

- Only properties explicitly defined in `data-wp-context` are inherited. That means newly added properties to parent contexts don't appear in children.
- When an object in the parent context is overwritten, the inherited properties that have been removed are still in the child context.
- When navigating back and forth, the previous context values were not updated properly.

## How?

Implementing a function called `proxifyContext`. It receives two arguments: the `deepSignal` instance for the current context and the inherited context. The proxy makes inherited properties appear like they were defined in the current context.