### PR TITLE
Cover block: clear the min height field when aspect ratio is set

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -105,6 +105,7 @@ export default function CoverInspectorControls( {
 		minHeightUnit,
 		alt,
 		tagName,
+		style,
 	} = attributes;
 	const {
 		isVideoBackground,
@@ -308,7 +309,9 @@ export default function CoverInspectorControls( {
 					panelId={ clientId }
 				>
 					<CoverHeightInput
-						value={ minHeight }
+						value={
+							style?.dimensions?.aspectRatio ? '' : minHeight
+						}
 						unit={ minHeightUnit }
 						onChange={ ( newMinHeight ) =>
 							setAttributes( {

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -105,7 +105,6 @@ export default function CoverInspectorControls( {
 		minHeightUnit,
 		alt,
 		tagName,
-		style,
 	} = attributes;
 	const {
 		isVideoBackground,
@@ -310,7 +309,9 @@ export default function CoverInspectorControls( {
 				>
 					<CoverHeightInput
 						value={
-							style?.dimensions?.aspectRatio ? '' : minHeight
+							attributes?.style?.dimensions?.aspectRatio
+								? ''
+								: minHeight
 						}
 						unit={ minHeightUnit }
 						onChange={ ( newMinHeight ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #58230 and follow-up to #56897

In the Cover block, when the aspect ratio is updated, clear out the value for the minimum height field.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When an aspect ratio is set, it will always override the minimum height value. To make it clearer that this is the case, display the minimum height field as empty. We don't need to "really" clear out the value itself in block attributes, as the minimum height value gets `unset` by the aspect ratio rules.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the Cover block, pass in an empty string to the Cover block's minimum height input field if an aspect ratio value is set.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a cover block to a post, page, or template
2. Adjust its minimum height
3. Give it an aspect ratio
4. With this PR applied, the minimum height field should be empty
5. In the Tools Panel menu, reset the Aspect Ratio field _or_ go to add a value to the minimum height field again
6. The minimum height value should be displayed again

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/bbf9f60e-28f3-41b5-9c40-570a60b07594

### After

https://github.com/WordPress/gutenberg/assets/14988353/0a664782-9dc1-4668-a6ce-6ab76ddeffbb