### PR TITLE
DocumentBar: Fix browser warning error

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -11,7 +11,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
 	__experimentalText as Text,
-	__experimentalHStack as HStack,
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
@@ -155,11 +154,8 @@ export default function DocumentBar() {
 					onClick={ () => openCommandCenter() }
 					size="compact"
 				>
-					<HStack
-						as={ motion.div }
+					<motion.div
 						className="editor-document-bar__title"
-						spacing={ 1 }
-						justify="center"
 						// Force entry animation when the back button is added or removed.
 						key={ hasBackButton }
 						initial={
@@ -193,7 +189,7 @@ export default function DocumentBar() {
 						>
 							{ title }
 						</Text>
-					</HStack>
+					</motion.div>
 					<span className="editor-document-bar__shortcut">
 						{ displayShortcut.primary( 'k' ) }
 					</span>

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -40,6 +40,10 @@
 	flex-grow: 1;
 	overflow: hidden;
 	color: $gray-800;
+	gap: $grid-unit-05;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 
 	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
 	@include break-small() {


### PR DESCRIPTION
Related to #58656

## What?

This PR fixes the browser warning error when the canvas is the edit mode.

https://github.com/WordPress/gutenberg/assets/54422211/63b3e415-6cb3-4190-832e-9f6b15214467

## Why?

The error logged in the browser console is as follows:

<details><summary>Details</summary>

```
Warning: React does not recognize the `isColumn` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `iscolumn` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at div
    at MotionComponent (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:84418:65)
    at http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:681:66
    at UnconnectedHStack (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:38576:71)
    at button
    at Role (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:68161:32)
    at UnforwardedTooltip (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:57277:5)
    at UnforwardedButton (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:25126:7)
    at div
    at DocumentBar (http://localhost:8888/wp-content/plugins/gutenberg/build/editor/index.min.js?ver=18c58bcec6d92493effa:4080:65)
    at div
    at div
    at HeaderEditMode (http://localhost:8888/wp-content/plugins/gutenberg/build/edit-site/index.min.js?ver=528bf73d74e50c9b15ae:17019:65)
    at div
    at MotionComponent (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:84418:65)
    at NavigableRegion (http://localhost:8888/wp-content/plugins/gutenberg/build/edit-site/index.min.js?ver=528bf73d74e50c9b15ae:49553:3)
    at PresenceChild (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:81194:26)
    at AnimatePresence (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:81326:28)
    at div
    at MotionComponent (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:84418:65)
    at div
    at Layout (http://localhost:8888/wp-content/plugins/gutenberg/build/edit-site/index.min.js?ver=528bf73d74e50c9b15ae:18495:100)
    at RouterProvider (http://localhost:8888/wp-content/plugins/gutenberg/build/router/index.min.js?ver=0a2f242ca7c0afbcd06c:180:3)
    at GlobalStylesProvider (http://localhost:8888/wp-content/plugins/gutenberg/build/edit-site/index.min.js?ver=528bf73d74e50c9b15ae:13529:3)
    at SlotFillProvider (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:51179:3)
    at SlotFillProvider (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:51699:3)
    at Provider (http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js?ver=e21b2f5f8ec805698bc5:51555:3)
    at App (http://localhost:8888/wp-content/plugins/gutenberg/build/edit-site/index.min.js?ver=528bf73d74e50c9b15ae:8600:67)
```
</details> 

It seems that for some reason the DOM element is given an incorrect prop called `isColumn`. Using React Dev Tools, you can see that the `View` component, which is rendered as a div element, is given a prop called `isColumn`.

![view-component](https://github.com/WordPress/gutenberg/assets/54422211/b2d30a72-b5ad-4cb2-b338-0279e018ff4c)

## How?

To be honest, I haven't been able to pinpoint the root cause, but in most cases it seems that the `motion.div` itself is being used as a component instead of passing it `as` prop. In fact, this approach solved the console error.

## Testing Instructions

- Access the site editor canvas and confirm that no browser console errors occur.
- The appearance and animation of the document bar should remain unchanged.