### PR TITLE
Fix missing source for binding attributes

### DIFF
--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -57,7 +57,7 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  */
 function gutenberg_block_bindings_replace_html( $block_content, $block_name, string $attribute_name, $source_value ) {
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-	if ( ! isset( $block_type->attributes[ $attribute_name ] ) ) {
+	if ( ! isset( $block_type->attributes[ $attribute_name ]['source'] ) ) {
 		return $block_content;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Continued from https://github.com/WordPress/gutenberg/pull/59169#issuecomment-1953404555.

Fix when the binding attribute doesn't have a `source` field.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To prevent frontend error.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add `source` to the binding check.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the same instructions in https://github.com/WordPress/gutenberg/pull/59169 and expect to see no errors on the frontend.

## Screenshots or screencast <!-- if applicable -->
N/A