### PR TITLE
List block: allow tab to indent/outdent at selection start

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -61,5 +61,7 @@ export default function useIndentListItem( clientId ) {
 				clonedBlocks[ clonedBlocks.length - 1 ].clientId
 			);
 		}
+
+		return true;
 	}, [ clientId ] );
 }

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -93,5 +93,7 @@ export default function useOutdentListItem() {
 				removeBlock( parentListId, shouldSelectParent );
 			}
 		} );
+
+		return true;
 	}, [] );
 }

--- a/packages/block-library/src/list-item/hooks/use-space.js
+++ b/packages/block-library/src/list-item/hooks/use-space.js
@@ -41,8 +41,11 @@ export default function useSpace( clientId ) {
 					selectionEnd.offset === 0
 				) {
 					event.preventDefault();
-					if ( keyCode === TAB && shiftKey ) {
-						outdentListItem();
+					if ( shiftKey ) {
+						// Note that backspace behaviour in defined in onMerge.
+						if ( keyCode === TAB ) {
+							outdentListItem();
+						}
 					} else if ( getBlockIndex( clientId ) !== 0 ) {
 						indentListItem();
 					}

--- a/packages/block-library/src/list-item/hooks/use-space.js
+++ b/packages/block-library/src/list-item/hooks/use-space.js
@@ -40,14 +40,17 @@ export default function useSpace( clientId ) {
 					selectionStart.offset === 0 &&
 					selectionEnd.offset === 0
 				) {
-					event.preventDefault();
 					if ( shiftKey ) {
 						// Note that backspace behaviour in defined in onMerge.
 						if ( keyCode === TAB ) {
-							outdentListItem();
+							if ( outdentListItem() ) {
+								event.preventDefault();
+							}
 						}
 					} else if ( getBlockIndex( clientId ) !== 0 ) {
-						indentListItem();
+						if ( indentListItem() ) {
+							event.preventDefault();
+						}
 					}
 				}
 			}

--- a/packages/block-library/src/list-item/hooks/use-space.js
+++ b/packages/block-library/src/list-item/hooks/use-space.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useRefEffect } from '@wordpress/compose';
-import { SPACE } from '@wordpress/keycodes';
+import { SPACE, TAB } from '@wordpress/keycodes';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
@@ -10,11 +10,13 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import useIndentListItem from './use-indent-list-item';
+import useOutdentListItem from './use-outdent-list-item';
 
 export default function useSpace( clientId ) {
 	const { getSelectionStart, getSelectionEnd, getBlockIndex } =
 		useSelect( blockEditorStore );
 	const indentListItem = useIndentListItem( clientId );
+	const outdentListItem = useOutdentListItem();
 
 	return useRefEffect(
 		( element ) => {
@@ -23,17 +25,12 @@ export default function useSpace( clientId ) {
 
 				if (
 					event.defaultPrevented ||
-					keyCode !== SPACE ||
+					( keyCode !== SPACE && keyCode !== TAB ) ||
 					// Only override when no modifiers are pressed.
-					shiftKey ||
 					altKey ||
 					metaKey ||
 					ctrlKey
 				) {
-					return;
-				}
-
-				if ( getBlockIndex( clientId ) === 0 ) {
 					return;
 				}
 
@@ -44,7 +41,11 @@ export default function useSpace( clientId ) {
 					selectionEnd.offset === 0
 				) {
 					event.preventDefault();
-					indentListItem();
+					if ( keyCode === TAB && shiftKey ) {
+						outdentListItem();
+					} else if ( getBlockIndex( clientId ) !== 0 ) {
+						indentListItem();
+					}
 				}
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Same as #56474, but adds tab to indent and shift+tab to outdent only when the selection is at the start of the list time, which means normal tab/shift+tab behaviour is preserved elsewhere in the list item.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/45404.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
