### PR TITLE
Revert/left aligned save

### DIFF
--- a/packages/edit-site/src/components/save-hub/style.scss
+++ b/packages/edit-site/src/components/save-hub/style.scss
@@ -10,10 +10,6 @@
 	color: inherit;
 	width: 100%;
 
-	&.components-button.components-button {
-		justify-content: center;
-	}
-
 	&[aria-disabled="true"] {
 		opacity: 1;
 	}

--- a/packages/edit-site/src/components/save-hub/style.scss
+++ b/packages/edit-site/src/components/save-hub/style.scss
@@ -9,6 +9,7 @@
 .edit-site-save-hub__button {
 	color: inherit;
 	width: 100%;
+	justify-content: center;
 
 	&[aria-disabled="true"] {
 		opacity: 1;


### PR DESCRIPTION
## What?

Followup to #58917. Keeps the general code cleanups, but keeps the left alignment for the "Saved" state.

Before:

![before, centered](https://github.com/WordPress/gutenberg/assets/1204802/86a41deb-f904-42e1-a9ee-533600ffadd2)

After:

![after, left aligned](https://github.com/WordPress/gutenberg/assets/1204802/e3e12332-2852-424f-a2d5-4270214723f7)

After, save button:

![save](https://github.com/WordPress/gutenberg/assets/1204802/b73a2261-be6a-4530-9f61-2944a90e5197)

## Why?

The Saved state will be seen most of the time, and when it aligns with the column of icons on the left, it looks more intentionally placed, compared to being centered.

## Testing Instructions

* Test the site editor and observe a left aligned "Save" button
* Test changing a style, and observe centered Save text.