### PR TITLE
DataViews: Fix pages list back path

### DIFF
--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -76,6 +76,7 @@ function SidebarScreens() {
 				<SidebarNavigationScreen
 					title={ __( 'Pages' ) }
 					content={ <DataViewsSidebarContent /> }
+					backPath="/page"
 				/>
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page/:postId">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

[Here](https://github.com/WordPress/gutenberg/pull/59151) we reverted footer in pages list with DataViews but it seems there is a small [regression](https://github.com/WordPress/gutenberg/pull/59151#issuecomment-1953875056):

>@ntsekouras I think this may have caused a regression: In the Pages data view clicking the < chevron returns you to the root of Design rather than taking you to the Pages list.
