### PR TITLE
Patterns Page: Make category action button compact

### DIFF
--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -69,6 +69,7 @@ export default function PatternsHeader( {
 								__( 'Action menu for %s pattern category' ),
 								title
 							),
+							size: 'compact',
 						} }
 					>
 						{ ( { onClose } ) => (


### PR DESCRIPTION
Part of #46734

## What?

This PR changes the size of the category action button from 36px to 32px on the Site Editor's Patterns page.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/fdd180a5-c2f9-432e-b3d5-8e3d517134d0)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/8018fbac-29e4-4a74-a79c-62843f156b54)

## Why?

To increase consistency in UI size. All the buttons in the DataView are 32px, so this button, which is 36px, felt more strange.

## Testing Instructions

- Create a pattern and assign custom categories in the Site Editor.
- Open that category and focus on the category action button.
