### PR TITLE
Remove reference to CODE_OF_CONDUCT.md in docs

### DIFF
--- a/docs/contributors/folder-structure.md
+++ b/docs/contributors/folder-structure.md
@@ -7,7 +7,6 @@ The following snippet explains how the Gutenberg repository is structured omitti
     ├── README.md
     ├── SECURITY.md
     ├── CONTRIBUTING.md
-    ├── CODE_OF_CONDUCT.md
     │
     ├── .editorconfig
     ├── .eslintignore


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes a reference to the `CODE_OF_CONDUCT.md` file in the folder structure documentation.

## Why?
This file was removed from this repository in #59027 to allow the default one committed to the WordPress/.github#1 repository to be shown consistently across all organization repositories.