### PR TITLE
test: Expand E2E test utilities

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -203,6 +203,16 @@ exports.galleryBlock = `<!-- wp:gallery {"columns":8,"linkTo":"none","className"
 </figure>
 <!-- /wp:gallery -->`;
 
+exports.galleryBlockTwoImages = `<!-- wp:gallery {"columns":8,"linkTo":"none","className":"alignfull"} -->
+<figure class="wp-block-gallery has-nested-images columns-8 is-cropped alignfull"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
+<!-- /wp:image -->
+<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption">Heading</figcaption></figure>
+<!-- /wp:image -->
+</figure>
+<!-- /wp:gallery -->`;
+
 exports.groupNestedStructure = `<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"style":{"color":{"background":"#f9d0d0"}}} -->
 <p class="has-background" style="background-color:#f9d0d0">Level 1</p>

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -206,24 +206,18 @@ class EditorPage {
 	}
 
 	/**
-	 * Selects a block by its type.
+	 * Selects a block.
 	 *
-	 * @param {string} blockType      The type of the block to select.
-	 * @param {Object} options        Additional options.
-	 * @param {number} options.index  The index of the block to select (default: 1).
-	 * @param {Object} options.offset The offset of the block to select (default: { x: 0, y: 0 }).
+	 * @param {import('webdriverio').ChainablePromiseElement} block                           The block to select.
+	 * @param {Object}                                        options                         Configuration options.
+	 * @param {Object}                                        [options.offset={ x: 0, y: 0 }] The offset for the click position.
+	 * @param {number|Function}                               [options.offset.x=0]            The x-coordinate offset or a function that calculates the offset based on the block's width.
+	 * @param {number|Function}                               [options.offset.y=0]            The y-coordinate offset or a function that calculates the offset based on the block's height.
 	 *
-	 * @return {import('webdriverio').ChainablePromiseArray} The selected block element.
+	 * @return {import('webdriverio').ChainablePromiseElement} The selected block.
 	 */
-	async selectBlockByType(
-		blockType,
-		{ index = 1, offset = { x: 0, y: 0 } } = {}
-	) {
-		const locator = isAndroid()
-			? `//android.widget.Button[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockType } Block. Row ${ index }")]`
-			: `-ios predicate string:label == '${ blockType } Block. Row ${ index }'`;
-		const block = await this.driver.$$( locator )[ 0 ];
-
+	async selectBlock( block, options = {} ) {
+		const { offset = { x: 0, y: 0 } } = options;
 		const size = await block.getSize();
 
 		let offsetX = offset.x;

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -208,20 +208,36 @@ class EditorPage {
 	/**
 	 * Selects a block by its type.
 	 *
-	 * @param {string} blockType     The type of the block to select.
-	 * @param {Object} options       Additional options.
-	 * @param {number} options.index The index of the block to select (default: 1).
-	 * @param {number} options.x     The x-coordinate offset from the center of the element (default: 0).
-	 * @param {number} options.y     The y-coordinate offset from the center of the element (default: 0).
+	 * @param {string} blockType      The type of the block to select.
+	 * @param {Object} options        Additional options.
+	 * @param {number} options.index  The index of the block to select (default: 1).
+	 * @param {Object} options.offset The offset of the block to select (default: { x: 0, y: 0 }).
 	 *
 	 * @return {import('webdriverio').ChainablePromiseArray} The selected block element.
 	 */
-	async selectBlockByType( blockType, { index = 1, x = 0, y = 0 } = {} ) {
+	async selectBlockByType(
+		blockType,
+		{ index = 1, offset = { x: 0, y: 0 } } = {}
+	) {
 		const locator = isAndroid()
 			? `//android.widget.Button[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockType } Block. Row ${ index }")]`
 			: `-ios predicate string:label == '${ blockType } Block. Row ${ index }'`;
 		const block = await this.driver.$$( locator )[ 0 ];
-		await block.click( { x, y } );
+
+		const size = await block.getSize();
+
+		let offsetX = offset.x;
+		if ( typeof offset.x === 'function' ) {
+			offsetX = offset.x( size.width );
+		}
+
+		let offsetY = offset.y;
+		if ( typeof offset.y === 'function' ) {
+			offsetY = offset.y( size.height );
+		}
+
+		await block.click( { x: offsetX, y: offsetY } );
+
 		return block;
 	}
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -205,6 +205,24 @@ class EditorPage {
 		return lastElementFound;
 	}
 
+	/**
+	 * Selects a block by its type.
+	 *
+	 * @param {string} blockType     The type of the block to select.
+	 * @param {Object} options       Additional options.
+	 * @param {number} options.index The index of the block to select (default: 1).
+	 *
+	 * @return {import('webdriverio').ChainablePromiseArray} The selected block element.
+	 */
+	async selectBlockByType( blockType, { index = 1 } = {} ) {
+		const locator = isAndroid()
+			? `//android.widget.Button[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockType } Block. Row ${ index }")]`
+			: `-ios predicate string:label == '${ blockType } Block. Row ${ index }'`;
+		const block = await this.driver.$$( locator )[ 0 ];
+		await block.click();
+		return block;
+	}
+
 	async getFirstBlockVisible() {
 		const firstBlockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, " Block. Row ")]`;
 		return await waitForVisible( this.driver, firstBlockLocator );

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -1096,6 +1096,7 @@ const blockNames = {
 	button: 'Button',
 	preformatted: 'Preformatted',
 	unsupported: 'Unsupported',
+	mediaText: 'Media & Text',
 };
 
 module.exports = { setupEditor, blockNames };

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -1097,6 +1097,7 @@ const blockNames = {
 	preformatted: 'Preformatted',
 	unsupported: 'Unsupported',
 	mediaText: 'Media & Text',
+	quote: 'Quote',
 };
 
 module.exports = { setupEditor, blockNames };

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -211,15 +211,17 @@ class EditorPage {
 	 * @param {string} blockType     The type of the block to select.
 	 * @param {Object} options       Additional options.
 	 * @param {number} options.index The index of the block to select (default: 1).
+	 * @param {number} options.x     The x-coordinate offset from the center of the element (default: 0).
+	 * @param {number} options.y     The y-coordinate offset from the center of the element (default: 0).
 	 *
 	 * @return {import('webdriverio').ChainablePromiseArray} The selected block element.
 	 */
-	async selectBlockByType( blockType, { index = 1 } = {} ) {
+	async selectBlockByType( blockType, { index = 1, x = 0, y = 0 } = {} ) {
 		const locator = isAndroid()
 			? `//android.widget.Button[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockType } Block. Row ${ index }")]`
 			: `-ios predicate string:label == '${ blockType } Block. Row ${ index }'`;
 		const block = await this.driver.$$( locator )[ 0 ];
-		await block.click();
+		await block.click( { x, y } );
 		return block;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Related
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6653
- https://github.com/wordpress-mobile/test-cases/pull/168

## What?
<!-- In a few words, what is the PR actually doing? -->
Expand mobile end-to-end (E2E) test utilities.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Enable additional visual test case in the `gutenberg-mobile` repository.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add Gallery block with two images test fixture
- Add `selectBlockByType` utility
- `selectBlockByType` allows offsetting tap position
- Add Media & Text block name fixture
- Add Quote block name fixture

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
