### PR TITLE
List: simplify indent code & keep client ID

### DIFF
--- a/packages/block-library/src/list-item/hooks/move-blocks-to-nested-list.js
+++ b/packages/block-library/src/list-item/hooks/move-blocks-to-nested-list.js
@@ -21,7 +21,10 @@ export function moveBlocksToNestedList(
 	const { getBlockOrder, getBlock } = registry.select( blockEditorStore );
 	const { moveBlocksToPosition, removeBlocks, insertBlock } =
 		registry.dispatch( blockEditorStore );
-	const [ nestedListId ] = getBlockOrder( listItemId );
+	// A list item can hold more than one nested list; append to the last one,
+	// the same subtree a reader sees at the end of the item.
+	const nestedLists = getBlockOrder( listItemId );
+	const nestedListId = nestedLists[ nestedLists.length - 1 ];
 
 	if ( nestedListId ) {
 		moveBlocksToPosition( clientIds, sourceListId, nestedListId );

--- a/packages/block-library/src/list-item/hooks/move-blocks-to-nested-list.js
+++ b/packages/block-library/src/list-item/hooks/move-blocks-to-nested-list.js
@@ -1,0 +1,46 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { cloneBlock } from '@wordpress/blocks';
+
+/**
+ * Moves blocks into a list item's nested list, keeping their client IDs. If the
+ * list item has no nested list yet, one is created from the source list so it
+ * inherits its attributes.
+ *
+ * @param {Object}   registry     The data registry.
+ * @param {string[]} clientIds    The blocks to move.
+ * @param {string}   sourceListId The list the blocks currently live in, also
+ *                                cloned when a nested list has to be created.
+ * @param {string}   listItemId   The list item to nest the blocks under.
+ */
+export function moveBlocksToNestedList(
+	registry,
+	clientIds,
+	sourceListId,
+	listItemId
+) {
+	const { getBlockOrder, getBlock } = registry.select( blockEditorStore );
+	const { moveBlocksToPosition, removeBlocks, insertBlock } =
+		registry.dispatch( blockEditorStore );
+	const [ nestedListId ] = getBlockOrder( listItemId );
+
+	if ( nestedListId ) {
+		moveBlocksToPosition( clientIds, sourceListId, nestedListId );
+		return;
+	}
+
+	// Insert the list with the items already inside: an empty list would be
+	// scaffolded with the list block type's template, and moving into a freshly
+	// created list would fail its canInsert check. Cloning the source list keeps
+	// its attributes; passing the items as inner blocks keeps their client IDs.
+	const nestedList = cloneBlock(
+		getBlock( sourceListId ),
+		{},
+		clientIds.map( ( id ) => getBlock( id ) )
+	);
+	// Remove and re-insert in one batch so the blocks are never momentarily
+	// detached. A caller batch nests harmlessly: only the outermost flushes.
+	registry.batch( () => {
+		removeBlocks( clientIds, false );
+		insertBlock( nestedList, 0, listItemId, false );
+	} );
+}

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -2,65 +2,40 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock, cloneBlock } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 
 export default function useIndentListItem( clientId ) {
-	const { replaceBlocks, selectionChange, multiSelect } =
+	const registry = useRegistry();
+	const { insertBlock, moveBlocksToPosition, updateBlockListSettings } =
 		useDispatch( blockEditorStore );
 	const {
-		getBlock,
 		getPreviousBlockClientId,
-		getSelectionStart,
-		getSelectionEnd,
-		hasMultiSelection,
-		getMultiSelectedBlockClientIds,
+		getBlockRootClientId,
+		getBlockListSettings,
+		getSelectedBlockClientIds,
 	} = useSelect( blockEditorStore );
 	return useCallback( () => {
-		const _hasMultiSelection = hasMultiSelection();
-		const clientIds = _hasMultiSelection
-			? getMultiSelectedBlockClientIds()
-			: [ clientId ];
-		const clonedBlocks = clientIds.map( ( _clientId ) =>
-			cloneBlock( getBlock( _clientId ) )
-		);
+		const clientIds = getSelectedBlockClientIds();
 		const previousSiblingId = getPreviousBlockClientId( clientId );
-		const newListItem = cloneBlock( getBlock( previousSiblingId ) );
-		// If the sibling has no innerBlocks, create a new `list` block.
-		if ( ! newListItem.innerBlocks?.length ) {
-			newListItem.innerBlocks = [ createBlock( 'core/list' ) ];
-		}
-		// A list item usually has one `list`, but it's possible to have
-		// more. So we need to preserve the previous `list` blocks and
-		// merge the new blocks to the last `list`.
-		newListItem.innerBlocks[
-			newListItem.innerBlocks.length - 1
-		].innerBlocks.push( ...clonedBlocks );
+		const rootClientId = getBlockRootClientId( clientId );
 
-		// We get the selection start/end here, because when
-		// we replace blocks, the selection is updated too.
-		const selectionStart = getSelectionStart();
-		const selectionEnd = getSelectionEnd();
-		// Replace the previous sibling of the block being indented and the indented blocks,
-		// with a new block whose attributes are equal to the ones of the previous sibling and
-		// whose descendants are the children of the previous sibling, followed by the indented blocks.
-		replaceBlocks( [ previousSiblingId, ...clientIds ], [ newListItem ] );
-		if ( ! _hasMultiSelection ) {
-			selectionChange(
-				clonedBlocks[ 0 ].clientId,
-				selectionEnd.attributeKey,
-				selectionEnd.clientId === selectionStart.clientId
-					? selectionStart.offset
-					: selectionEnd.offset,
-				selectionEnd.offset
+		registry.batch( () => {
+			const indentedList = createBlock( 'core/list' );
+			insertBlock( indentedList, 0, previousSiblingId, false );
+			// Immediately update the block list settings, otherwise blocks
+			// can't be moved here due to canInsert checks.
+			updateBlockListSettings(
+				indentedList.clientId,
+				getBlockListSettings( rootClientId )
 			);
-		} else {
-			multiSelect(
-				clonedBlocks[ 0 ].clientId,
-				clonedBlocks[ clonedBlocks.length - 1 ].clientId
+			moveBlocksToPosition(
+				clientIds,
+				rootClientId,
+				indentedList.clientId
 			);
-		}
+		} );
 
 		return true;
 	}, [ clientId ] );

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -35,12 +35,7 @@ export default function useIndentListItem( clientId ) {
 					getBlockListSettings( rootClientId )
 				);
 			}
-			moveBlocksToPosition(
-				clientIds,
-				rootClientId,
-				nestedListId,
-				getBlockOrder( nestedListId ).length
-			);
+			moveBlocksToPosition( clientIds, rootClientId, nestedListId );
 		} );
 
 		return true;

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -15,6 +15,7 @@ export default function useIndentListItem( clientId ) {
 		getBlockRootClientId,
 		getBlockListSettings,
 		getSelectedBlockClientIds,
+		getBlockOrder,
 	} = useSelect( blockEditorStore );
 	return useCallback( () => {
 		const clientIds = getSelectedBlockClientIds();
@@ -22,18 +23,23 @@ export default function useIndentListItem( clientId ) {
 		const rootClientId = getBlockRootClientId( clientId );
 
 		registry.batch( () => {
-			const indentedList = createBlock( 'core/list' );
-			insertBlock( indentedList, 0, previousSiblingId, false );
-			// Immediately update the block list settings, otherwise blocks
-			// can't be moved here due to canInsert checks.
-			updateBlockListSettings(
-				indentedList.clientId,
-				getBlockListSettings( rootClientId )
-			);
+			let nestedListId = getBlockOrder( previousSiblingId )[ 0 ];
+			if ( ! nestedListId ) {
+				const indentedList = createBlock( 'core/list' );
+				nestedListId = indentedList.clientId;
+				insertBlock( indentedList, 0, previousSiblingId, false );
+				// Immediately update the block list settings, otherwise blocks
+				// can't be moved here due to canInsert checks.
+				updateBlockListSettings(
+					nestedListId,
+					getBlockListSettings( rootClientId )
+				);
+			}
 			moveBlocksToPosition(
 				clientIds,
 				rootClientId,
-				indentedList.clientId
+				nestedListId,
+				getBlockOrder( nestedListId ).length
 			);
 		} );
 

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -1,60 +1,77 @@
 import { useCallback } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock, cloneBlock } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 
 export default function useIndentListItem( clientId ) {
-	const { replaceBlocks, selectionChange, multiSelect } =
-		useDispatch( blockEditorStore );
+	const registry = useRegistry();
 	const {
-		getBlock,
+		insertBlock,
+		moveBlocksToPosition,
+		removeBlock,
+		updateBlockListSettings,
+		selectionChange,
+		multiSelect,
+	} = useDispatch( blockEditorStore );
+	const {
 		getPreviousBlockClientId,
+		getBlockRootClientId,
+		getBlockListSettings,
+		getSelectedBlockClientIds,
+		getBlockOrder,
+		getBlockAttributes,
 		getSelectionStart,
 		getSelectionEnd,
 		hasMultiSelection,
 		getMultiSelectedBlockClientIds,
-		getBlockRootClientId,
-		getBlockAttributes,
 	} = useSelect( blockEditorStore );
+
 	return useCallback( () => {
 		const _hasMultiSelection = hasMultiSelection();
 		const clientIds = _hasMultiSelection
 			? getMultiSelectedBlockClientIds()
-			: [ clientId ];
-		const clonedBlocks = clientIds.map( ( _clientId ) =>
-			cloneBlock( getBlock( _clientId ) )
-		);
+			: getSelectedBlockClientIds();
 		const previousSiblingId = getPreviousBlockClientId( clientId );
-		const newListItem = cloneBlock( getBlock( previousSiblingId ) );
-		// Get the parent list's attributes to inherit the ordered property
-		const parentListId = getBlockRootClientId( clientId );
-		const parentListAttributes = getBlockAttributes( parentListId );
-		// If the sibling has no innerBlocks, create a new `list` block.
-		if ( ! newListItem.innerBlocks?.length ) {
-			newListItem.innerBlocks = [
-				createBlock( 'core/list', {
-					ordered: parentListAttributes.ordered,
-				} ),
-			];
-		}
-		// A list item usually has one `list`, but it's possible to have
-		// more. So we need to preserve the previous `list` blocks and
-		// merge the new blocks to the last `list`.
-		newListItem.innerBlocks[
-			newListItem.innerBlocks.length - 1
-		].innerBlocks.push( ...clonedBlocks );
-
-		// We get the selection start/end here, because when
-		// we replace blocks, the selection is updated too.
+		const rootClientId = getBlockRootClientId( clientId );
+		// The selection is read before the move because moving the blocks
+		// updates it.
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
-		// Replace the previous sibling of the block being indented and the indented blocks,
-		// with a new block whose attributes are equal to the ones of the previous sibling and
-		// whose descendants are the children of the previous sibling, followed by the indented blocks.
-		replaceBlocks( [ previousSiblingId, ...clientIds ], [ newListItem ] );
+
+		registry.batch( () => {
+			let nestedListId = getBlockOrder( previousSiblingId )[ 0 ];
+			if ( ! nestedListId ) {
+				// The list is inserted with a placeholder item already inside,
+				// otherwise the empty list would scaffold its own item through
+				// the block type's direct insert. The real items are then moved
+				// in, keeping their client IDs, and the placeholder is removed.
+				const placeholder = createBlock( 'core/list-item' );
+				const indentedList = createBlock(
+					'core/list',
+					{ ordered: getBlockAttributes( rootClientId ).ordered },
+					[ placeholder ]
+				);
+				nestedListId = indentedList.clientId;
+				insertBlock( indentedList, 0, previousSiblingId, false );
+				// Immediately update the block list settings, otherwise blocks
+				// can't be moved here due to canInsert checks.
+				updateBlockListSettings(
+					nestedListId,
+					getBlockListSettings( rootClientId )
+				);
+				moveBlocksToPosition( clientIds, rootClientId, nestedListId );
+				removeBlock( placeholder.clientId, false );
+			} else {
+				moveBlocksToPosition( clientIds, rootClientId, nestedListId );
+			}
+		} );
+
+		// The blocks keep their client IDs through the move, so the selection
+		// is put back on the same blocks: the caret for a single item, a whole
+		// block selection for several.
 		if ( ! _hasMultiSelection ) {
 			selectionChange(
-				clonedBlocks[ 0 ].clientId,
+				clientIds[ 0 ],
 				selectionEnd.attributeKey,
 				selectionEnd.clientId === selectionStart.clientId
 					? selectionStart.offset
@@ -62,10 +79,7 @@ export default function useIndentListItem( clientId ) {
 				selectionEnd.offset
 			);
 		} else {
-			multiSelect(
-				clonedBlocks[ 0 ].clientId,
-				clonedBlocks[ clonedBlocks.length - 1 ].clientId
-			);
+			multiSelect( clientIds[ 0 ], clientIds[ clientIds.length - 1 ] );
 		}
 
 		return true;

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -28,28 +28,35 @@ export default function useIndentListItem( clientId ) {
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
 
-		moveBlocksToNestedList(
-			registry,
-			clientIds,
-			rootClientId,
-			previousSiblingId
-		);
-
-		// The blocks keep their client IDs through the move, so the selection
-		// is put back on the same blocks: the caret for a single item, a whole
+		// The move and the selection are batched together: creating a nested
+		// list removes and re-inserts the items, which drops the selection, so
+		// it is put back in the same pass. The blocks keep their client IDs, so
+		// it lands on the same blocks: the caret for a single item, a whole
 		// block selection for several.
-		if ( ! _hasMultiSelection ) {
-			selectionChange(
-				clientIds[ 0 ],
-				selectionEnd.attributeKey,
-				selectionEnd.clientId === selectionStart.clientId
-					? selectionStart.offset
-					: selectionEnd.offset,
-				selectionEnd.offset
+		registry.batch( () => {
+			moveBlocksToNestedList(
+				registry,
+				clientIds,
+				rootClientId,
+				previousSiblingId
 			);
-		} else {
-			multiSelect( clientIds[ 0 ], clientIds[ clientIds.length - 1 ] );
-		}
+
+			if ( ! _hasMultiSelection ) {
+				selectionChange(
+					clientIds[ 0 ],
+					selectionEnd.attributeKey,
+					selectionEnd.clientId === selectionStart.clientId
+						? selectionStart.offset
+						: selectionEnd.offset,
+					selectionEnd.offset
+				);
+			} else {
+				multiSelect(
+					clientIds[ 0 ],
+					clientIds[ clientIds.length - 1 ]
+				);
+			}
+		} );
 
 		return true;
 	}, [ clientId ] );

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -1,25 +1,23 @@
 import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { cloneBlock } from '@wordpress/blocks';
 
 export default function useIndentListItem( clientId ) {
 	const registry = useRegistry();
 	const {
 		insertBlock,
 		moveBlocksToPosition,
-		removeBlock,
-		updateBlockListSettings,
+		removeBlocks,
 		selectionChange,
 		multiSelect,
 	} = useDispatch( blockEditorStore );
 	const {
 		getPreviousBlockClientId,
 		getBlockRootClientId,
-		getBlockListSettings,
 		getSelectedBlockClientIds,
 		getBlockOrder,
-		getBlockAttributes,
+		getBlock,
 		getSelectionStart,
 		getSelectionEnd,
 		hasMultiSelection,
@@ -39,30 +37,23 @@ export default function useIndentListItem( clientId ) {
 		const selectionEnd = getSelectionEnd();
 
 		registry.batch( () => {
-			let nestedListId = getBlockOrder( previousSiblingId )[ 0 ];
-			if ( ! nestedListId ) {
-				// The list is inserted with a placeholder item already inside,
-				// otherwise the empty list would scaffold its own item through
-				// the block type's direct insert. The real items are then moved
-				// in, keeping their client IDs, and the placeholder is removed.
-				const placeholder = createBlock( 'core/list-item' );
-				const indentedList = createBlock(
-					'core/list',
-					{ ordered: getBlockAttributes( rootClientId ).ordered },
-					[ placeholder ]
-				);
-				nestedListId = indentedList.clientId;
-				insertBlock( indentedList, 0, previousSiblingId, false );
-				// Immediately update the block list settings, otherwise blocks
-				// can't be moved here due to canInsert checks.
-				updateBlockListSettings(
-					nestedListId,
-					getBlockListSettings( rootClientId )
-				);
+			const nestedListId = getBlockOrder( previousSiblingId )[ 0 ];
+			if ( nestedListId ) {
 				moveBlocksToPosition( clientIds, rootClientId, nestedListId );
-				removeBlock( placeholder.clientId, false );
 			} else {
-				moveBlocksToPosition( clientIds, rootClientId, nestedListId );
+				// Insert the list with the items already inside: an empty
+				// list would be scaffolded with the list block type's
+				// template, and moving into a freshly created list would
+				// fail its canInsert check. Cloning the parent list keeps
+				// its attributes; passing the items as inner blocks keeps
+				// their client IDs.
+				const indentedList = cloneBlock(
+					getBlock( rootClientId ),
+					{},
+					clientIds.map( ( id ) => getBlock( id ) )
+				);
+				removeBlocks( clientIds, false );
+				insertBlock( indentedList, 0, previousSiblingId, false );
 			}
 		} );
 

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -1,23 +1,15 @@
 import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { cloneBlock } from '@wordpress/blocks';
+import { moveBlocksToNestedList } from './move-blocks-to-nested-list';
 
 export default function useIndentListItem( clientId ) {
 	const registry = useRegistry();
-	const {
-		insertBlock,
-		moveBlocksToPosition,
-		removeBlocks,
-		selectionChange,
-		multiSelect,
-	} = useDispatch( blockEditorStore );
+	const { selectionChange, multiSelect } = useDispatch( blockEditorStore );
 	const {
 		getPreviousBlockClientId,
 		getBlockRootClientId,
 		getSelectedBlockClientIds,
-		getBlockOrder,
-		getBlock,
 		getSelectionStart,
 		getSelectionEnd,
 		hasMultiSelection,
@@ -36,26 +28,12 @@ export default function useIndentListItem( clientId ) {
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
 
-		registry.batch( () => {
-			const nestedListId = getBlockOrder( previousSiblingId )[ 0 ];
-			if ( nestedListId ) {
-				moveBlocksToPosition( clientIds, rootClientId, nestedListId );
-			} else {
-				// Insert the list with the items already inside: an empty
-				// list would be scaffolded with the list block type's
-				// template, and moving into a freshly created list would
-				// fail its canInsert check. Cloning the parent list keeps
-				// its attributes; passing the items as inner blocks keeps
-				// their client IDs.
-				const indentedList = cloneBlock(
-					getBlock( rootClientId ),
-					{},
-					clientIds.map( ( id ) => getBlock( id ) )
-				);
-				removeBlocks( clientIds, false );
-				insertBlock( indentedList, 0, previousSiblingId, false );
-			}
-		} );
+		moveBlocksToNestedList(
+			registry,
+			clientIds,
+			rootClientId,
+			previousSiblingId
+		);
 
 		// The blocks keep their client IDs through the move, so the selection
 		// is put back on the same blocks: the caret for a single item, a whole

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -1,11 +1,11 @@
 import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { cloneBlock } from '@wordpress/blocks';
+import { moveBlocksToNestedList } from './move-blocks-to-nested-list';
 
 export default function useOutdentListItem() {
 	const registry = useRegistry();
-	const { moveBlocksToPosition, removeBlock, removeBlocks, insertBlock } =
+	const { moveBlocksToPosition, removeBlock } =
 		useDispatch( blockEditorStore );
 	const {
 		getBlockRootClientId,
@@ -13,7 +13,6 @@ export default function useOutdentListItem() {
 		getBlockOrder,
 		getBlockIndex,
 		getSelectedBlockClientIds,
-		getBlock,
 	} = useSelect( blockEditorStore );
 
 	function getParentListItemId( id ) {
@@ -60,28 +59,14 @@ export default function useOutdentListItem() {
 
 		registry.batch( () => {
 			if ( followingListItems.length ) {
-				const nestedListId = getBlockOrder( firstClientId )[ 0 ];
-
-				if ( nestedListId ) {
-					moveBlocksToPosition(
-						followingListItems,
-						parentListId,
-						nestedListId
-					);
-				} else {
-					// Insert the list with the items already inside: an
-					// empty list would be scaffolded with the list block
-					// type's template at insertion. Removing the items
-					// first frees them to be reinserted with their client
-					// IDs kept.
-					const nestedListBlock = cloneBlock(
-						getBlock( parentListId ),
-						{},
-						followingListItems.map( ( id ) => getBlock( id ) )
-					);
-					removeBlocks( followingListItems, false );
-					insertBlock( nestedListBlock, 0, firstClientId, false );
-				}
+				// Nest the items that follow under the outdented item so they
+				// keep their place below it.
+				moveBlocksToNestedList(
+					registry,
+					followingListItems,
+					parentListId,
+					firstClientId
+				);
 			}
 			moveBlocksToPosition(
 				clientIds,

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -894,6 +894,62 @@ test.describe( 'List (@firefox)', () => {
 		);
 	} );
 
+	test( 'should indent into the last nested list when an item has several', async ( {
+		editor,
+	} ) => {
+		// A list item can hold more than one nested list. Indenting a sibling
+		// into it should append to the last nested list, not the first.
+		await editor.setContent(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>A<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>x</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>y</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>B</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
+		await editor.canvas.getByText( 'B', { exact: true } ).click();
+		await editor.clickBlockToolbarButton( 'Indent' );
+
+		// "B" joins "y" in the last nested list, after it.
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>A
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>x</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>y</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>B</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+	} );
+
 	test( 'should outdent with children', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/list' } );
 		await page.keyboard.type( 'a' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We shouldn't clone the list items to indent. Instead we should use the move* action and preserve the original client ID. This turns out to be a nice simplification

@ntsekouras Asking your review because you added the original code in https://github.com/WordPress/gutenberg/pull/40991.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is necessary in the long term to preserve partial multi selection across indent/outdent. For outdent client IDs are already preserved.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Created a utility that can can be used for both indent and outdent.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Everything should still work as before.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list-item indentation by correctly moving selected items into existing or newly created nested lists.
  * Improved multi-selection handling during indentation and restored the selected items afterward.
  * Improved outdent behavior by preserving following list items beneath the outdented item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->