### PR TITLE
Fix: Don't render the Transform Into panel if there are no patterns

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -37,7 +37,7 @@ const CARD_ICONS = {
 
 function TemplatesList( { availableTemplates, onSelect } ) {
 	const shownTemplates = useAsyncList( availableTemplates );
-	if ( ! availableTemplates || availableTemplates?.length < 2 ) {
+	if ( ! availableTemplates || availableTemplates?.length === 0 ) {
 		return null;
 	}
 
@@ -105,22 +105,25 @@ export default function TemplatePanel() {
 					<TemplateAreas />
 				</SidebarCard>
 			</PanelBody>
-			<PanelBody
-				title={ __( 'Transform into:' ) }
-				initialOpen={ postType === TEMPLATE_PART_POST_TYPE }
-			>
-				<PanelRow>
-					<p>
-						{ __(
-							'Choose a predefined pattern to switch up the look of your template.' // TODO - make this dynamic?
-						) }
-					</p>
-				</PanelRow>
-				<TemplatesList
-					availableTemplates={ availablePatterns }
-					onSelect={ onTemplateSelect }
-				/>
-			</PanelBody>
+			{ availablePatterns?.length > 0 && (
+				<PanelBody
+					title={ __( 'Transform into:' ) }
+					initialOpen={ postType === TEMPLATE_PART_POST_TYPE }
+				>
+					<PanelRow>
+						<p>
+							{ __(
+								'Choose a predefined pattern to switch up the look of your template.' // TODO - make this dynamic?
+							) }
+						</p>
+					</PanelRow>
+
+					<TemplatesList
+						availableTemplates={ availablePatterns }
+						onSelect={ onTemplateSelect }
+					/>
+				</PanelBody>
+			) }
 			<PostLastRevisionPanel />
 			<PostTaxonomiesPanel />
 			<PostFeaturedImagePanel />


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/55091.

Fixes a bug where the "Transform into" panel is still displayed even if there are no patterns for a template type.

Updates the code to render patterns even if there is only one pattern for the template type as suggested by @MaggieCabrera. Previously it needed at least two patterns for a template type for patterns to be shown.


## Testing Instructions
When the 2024 theme is active, go to the site editor and check if the "Transforms Into" panel is not displayed on the 404 template.