### PR TITLE
Fix: Logical error in filterPatterns on template-panel/hooks.js

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
@@ -58,11 +58,13 @@ function filterPatterns( patterns, template ) {
 		pattern.templateTypes?.includes( template.slug ) ||
 		pattern.blockTypes?.includes( 'core/template-part/' + template.area );
 
-	return patterns.filter(
-		filterOutDuplicatesByName &&
-			filterOutExcludedPatternSources &&
-			filterCompatiblePatterns
-	);
+	return patterns.filter( ( pattern, index, items ) => {
+		return (
+			filterOutDuplicatesByName( pattern, index, items ) &&
+			filterOutExcludedPatternSources( pattern ) &&
+			filterCompatiblePatterns( pattern )
+		);
+	} );
 }
 
 function preparePatterns( patterns, template, currentThemeStylesheet ) {


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/55091.

Fixes a logical condition in filterPatterns to apply all three filters instead of just the last one.