### PR TITLE
BlockPopover: Remove __unstableCoverTarget and __unstableRefreshSize in favour of BlockPopoverCover

### DIFF
--- a/packages/block-editor/src/components/block-popover/cover.js
+++ b/packages/block-editor/src/components/block-popover/cover.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState, useMemo, forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-block-props/use-block-refs';
+import BlockPopover from '.';
+
+function BlockPopoverCover(
+	{ clientId, bottomClientId, children, shift = false, ...props },
+	ref
+) {
+	bottomClientId ??= clientId;
+
+	const selectedElement = useBlockElement( clientId );
+
+	return (
+		<BlockPopover
+			ref={ ref }
+			clientId={ clientId }
+			bottomClientId={ bottomClientId }
+			shift={ shift }
+			{ ...props }
+		>
+			{ selectedElement && clientId === bottomClientId ? (
+				<CoverContainer selectedElement={ selectedElement }>
+					{ children }
+				</CoverContainer>
+			) : (
+				children
+			) }
+		</BlockPopover>
+	);
+}
+
+function CoverContainer( { selectedElement, children } ) {
+	const [ width, setWidth ] = useState( selectedElement.offsetWidth );
+	const [ height, setHeight ] = useState( selectedElement.offsetHeight );
+
+	useEffect( () => {
+		const observer = new window.ResizeObserver( () => {
+			setWidth( selectedElement.offsetWidth );
+			setHeight( selectedElement.offsetHeight );
+		} );
+		observer.observe( selectedElement, { box: 'border-box' } );
+		return () => observer.disconnect();
+	}, [ selectedElement ] );
+
+	const style = useMemo( () => {
+		return {
+			position: 'absolute',
+			width,
+			height,
+		};
+	}, [ width, height ] );
+
+	return <div style={ style }>{ children }</div>;
+}
+
+export default forwardRef( BlockPopoverCover );

--- a/packages/block-editor/src/components/block-popover/drop-zone.js
+++ b/packages/block-editor/src/components/block-popover/drop-zone.js
@@ -9,7 +9,7 @@ import { __unstableMotion as motion } from '@wordpress/components';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import BlockPopover from './index';
+import BlockPopoverCover from './cover';
 
 const animateVariants = {
 	hide: { opacity: 0, scaleY: 0.75 },
@@ -38,9 +38,8 @@ function BlockDropZonePopover( {
 	const reducedMotion = useReducedMotion();
 
 	return (
-		<BlockPopover
+		<BlockPopoverCover
 			clientId={ clientId }
-			__unstableCoverTarget
 			__unstablePopoverSlot={ __unstablePopoverSlot }
 			__unstableContentRef={ __unstableContentRef }
 			className="block-editor-block-popover__drop-zone"
@@ -56,7 +55,7 @@ function BlockDropZonePopover( {
 				}
 				className="block-editor-block-popover__drop-zone-foreground"
 			/>
-		</BlockPopover>
+		</BlockPopoverCover>
 	);
 }
 

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -13,7 +13,6 @@ import {
 	useMemo,
 	useReducer,
 	useLayoutEffect,
-	useState,
 } from '@wordpress/element';
 
 /**
@@ -29,7 +28,6 @@ function BlockPopover(
 		clientId,
 		bottomClientId,
 		children,
-		__unstableCoverTarget = false,
 		__unstablePopoverSlot,
 		__unstableContentRef,
 		shift = true,
@@ -131,9 +129,6 @@ function BlockPopover(
 		return null;
 	}
 
-	const shouldCoverTarget =
-		__unstableCoverTarget && lastSelectedElement === selectedElement;
-
 	return (
 		<Popover
 			ref={ mergedRefs }
@@ -155,39 +150,9 @@ function BlockPopover(
 			) }
 			variant="unstyled"
 		>
-			{ shouldCoverTarget ? (
-				<CoverTargetContainer selectedElement={ selectedElement }>
-					{ children }
-				</CoverTargetContainer>
-			) : (
-				children
-			) }
+			{ children }
 		</Popover>
 	);
-}
-
-function CoverTargetContainer( { selectedElement, children } ) {
-	const [ width, setWidth ] = useState( selectedElement.offsetWidth );
-	const [ height, setHeight ] = useState( selectedElement.offsetHeight );
-
-	useLayoutEffect( () => {
-		const observer = new window.ResizeObserver( () => {
-			setWidth( selectedElement.offsetWidth );
-			setHeight( selectedElement.offsetHeight );
-		} );
-		observer.observe( selectedElement, { box: 'border-box' } );
-		return () => observer.disconnect();
-	}, [ selectedElement ] );
-
-	const style = useMemo( () => {
-		return {
-			position: 'absolute',
-			width,
-			height,
-		};
-	}, [ width, height ] );
-
-	return <div style={ style }>{ children }</div>;
 }
 
 export default forwardRef( BlockPopover );

--- a/packages/block-editor/src/components/block-tools/empty-block-inserter.js
+++ b/packages/block-editor/src/components/block-tools/empty-block-inserter.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import BlockPopover from '../block-popover';
+import BlockPopoverCover from '../block-popover/cover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import Inserter from '../inserter';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
@@ -28,9 +28,8 @@ export default function EmptyBlockInserter( {
 	} );
 
 	return (
-		<BlockPopover
+		<BlockPopoverCover
 			clientId={ capturingClientId || clientId }
-			__unstableCoverTarget
 			bottomClientId={ lastClientId }
 			className={ classnames(
 				'block-editor-block-list__block-side-inserter-popover',
@@ -39,8 +38,6 @@ export default function EmptyBlockInserter( {
 				}
 			) }
 			__unstableContentRef={ __unstableContentRef }
-			resize={ false }
-			shift={ false }
 			{ ...popoverProps }
 		>
 			<div className="block-editor-block-list__empty-block-inserter">
@@ -51,6 +48,6 @@ export default function EmptyBlockInserter( {
 					__experimentalIsQuick
 				/>
 			</div>
-		</BlockPopover>
+		</BlockPopoverCover>
 	);
 }

--- a/packages/block-editor/src/components/resizable-box-popover/index.js
+++ b/packages/block-editor/src/components/resizable-box-popover/index.js
@@ -6,7 +6,7 @@ import { ResizableBox } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import BlockPopover from '../block-popover';
+import BlockPopoverCover from '../block-popover/cover';
 
 export default function ResizableBoxPopover( {
 	clientId,
@@ -14,14 +14,12 @@ export default function ResizableBoxPopover( {
 	...props
 } ) {
 	return (
-		<BlockPopover
+		<BlockPopoverCover
 			clientId={ clientId }
-			__unstableCoverTarget
 			__unstablePopoverSlot="__unstable-block-tools-after"
-			shift={ false }
 			{ ...props }
 		>
 			<ResizableBox { ...resizableBoxProps } />
-		</BlockPopover>
+		</BlockPopoverCover>
 	);
 }

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -81,7 +81,6 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 		<BlockPopover
 			clientId={ clientId }
 			__unstableCoverTarget
-			__unstableRefreshSize={ margin }
 			__unstablePopoverSlot="block-toolbar"
 			shift={ false }
 		>

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -7,7 +7,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 /**
  * Internal dependencies
  */
-import BlockPopover from '../components/block-popover';
+import BlockPopoverCover from '../components/block-popover/cover';
 import { __unstableUseBlockElement as useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
 
 function getComputedCSS( element, property ) {
@@ -78,13 +78,11 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 	}
 
 	return (
-		<BlockPopover
+		<BlockPopoverCover
 			clientId={ clientId }
-			__unstableCoverTarget
 			__unstablePopoverSlot="block-toolbar"
-			shift={ false }
 		>
 			<div className="block-editor__padding-visualizer" style={ style } />
-		</BlockPopover>
+		</BlockPopoverCover>
 	);
 }

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -72,7 +72,6 @@ export function PaddingVisualizer( { clientId, value, forceShow } ) {
 		<BlockPopover
 			clientId={ clientId }
 			__unstableCoverTarget
-			__unstableRefreshSize={ padding }
 			__unstablePopoverSlot="block-toolbar"
 			shift={ false }
 		>

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -7,7 +7,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 /**
  * Internal dependencies
  */
-import BlockPopover from '../components/block-popover';
+import BlockPopoverCover from '../components/block-popover/cover';
 import { __unstableUseBlockElement as useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
 
 function getComputedCSS( element, property ) {
@@ -69,13 +69,11 @@ export function PaddingVisualizer( { clientId, value, forceShow } ) {
 	}
 
 	return (
-		<BlockPopover
+		<BlockPopoverCover
 			clientId={ clientId }
-			__unstableCoverTarget
 			__unstablePopoverSlot="block-toolbar"
-			shift={ false }
 		>
 			<div className="block-editor__padding-visualizer" style={ style } />
-		</BlockPopover>
+		</BlockPopoverCover>
 	);
 }

--- a/packages/block-library/src/cover/edit/resizable-cover-popover.js
+++ b/packages/block-library/src/cover/edit/resizable-cover-popover.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useMemo, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
@@ -40,10 +40,6 @@ export default function ResizableCoverPopover( {
 	...props
 } ) {
 	const [ isResizing, setIsResizing ] = useState( false );
-	const dimensions = useMemo(
-		() => ( { height, minHeight, width } ),
-		[ minHeight, height, width ]
-	);
 
 	const resizableBoxProps = {
 		className: classnames( className, { 'is-resizing': isResizing } ),
@@ -75,7 +71,6 @@ export default function ResizableCoverPopover( {
 	return (
 		<ResizableBoxPopover
 			className="block-library-cover__resizable-box-popover"
-			__unstableRefreshSize={ dimensions }
 			resizableBoxProps={ resizableBoxProps }
 			{ ...props }
 		/>


### PR DESCRIPTION
## What, why, how?
Two improvements to how `BlockPopover` works and its API. `BlockPopover` is an internal component in `@wordpress/block-editor`. It's used extensively throughout the editor but not exported.

### 1. Remove `__unstableCoverTarget` from `BlockPopover`.

The `__unstableCoverTarget` prop tells `BlockPopover` to position itself entirely over a block (`width: 100%; `height: 100%`). It's used for the empty block inserter, resize handles on the cover block, drop zone indicator, margin visualiser, padding visualiser, and so on.

I've removed the `__unstableCoverTarget` prop in favour of a new `BlockPopoverCover` component that uses `BlockPopover` internally. Using composition instead of a prop makes `BlockPopover` much easier to reason about as it can be focused solely on positioning and not resizing.

Old API:

```jsx
<BlockPopover clientId={ ... } __unstableCoverTarget>
    Cover contents
</BlockPopover>
```

New API:

```jsx
<BlockPopoverCover clientId={ ... }>
    Cover contents
</BlockPopoverCover>
```

### 2. Remove `__unstableRefreshSize` prop, and use a `ResizeObserver` instead.

The `__unstableRefreshSize` prop works a bit like `key` and tells `<BlockPopover __unstableCoverTarget>` to update its size when the value of `__unstableRefreshSize` changes.

We can do away with it altogether by updating `BlockPopover` (well, `BlockPopoverCover`, as above) to use a `ResizeObserver` to automatically resize the cover when the block's size changes. 

As well as resulting in a much cleaner and less confusing API, this lets the cover resize automatically when the intrinsic size of the block changes e.g. when the user types content. We don't currently have a need to support this but will soon when I add `GridVisualizer` in https://github.com/WordPress/gutenberg/pull/59052.

## Testing Instructions
Test all the places that we were using `<BlockPopover __unstableCoverTarget>` for regressions. No behaviour should have changed.

- Dropping a file onto an empty paragraph should show a drop zone that takes up the full width and height of the block.
- Select an empty paragraph block. The appender (black + icon) should appear at the bottom right of the block.
- Select a Cover block. Resize handles should appear at the bottom of the block.
- Adjust a block's margin and padding using the block settings sidebar. A visual representation of the margin and padding should appear on the canvas. (Note: there are bugs in `trunk`, see https://github.com/WordPress/gutenberg/pull/59227).