### PR TITLE
[Pattern Overrides] Only set block editing mode on first load

### DIFF
--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -24,6 +24,11 @@ import {
 	PATTERN_SYNC_TYPES,
 	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
 } from './constants';
+import {
+	hasOverridableAttributes,
+	hasOverridableBlocks,
+	getOverridableAttributes,
+} from './utils';
 
 export const privateApis = {};
 lock( privateApis, {
@@ -43,4 +48,7 @@ lock( privateApis, {
 	EXCLUDED_PATTERN_SOURCES,
 	PATTERN_SYNC_TYPES,
 	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
+	hasOverridableAttributes,
+	hasOverridableBlocks,
+	getOverridableAttributes,
 } );

--- a/packages/patterns/src/utils.js
+++ b/packages/patterns/src/utils.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from './constants';
+
+export function hasOverridableAttributes( block ) {
+	return (
+		Object.keys( PARTIAL_SYNCING_SUPPORTED_BLOCKS ).includes(
+			block.name
+		) &&
+		!! block.attributes.metadata?.bindings &&
+		Object.values( block.attributes.metadata.bindings ).some(
+			( binding ) => binding.source === 'core/pattern-overrides'
+		)
+	);
+}
+
+export function hasOverridableBlocks( blocks ) {
+	return blocks.some( ( block ) => {
+		if ( hasOverridableAttributes( block ) ) return true;
+		return hasOverridableBlocks( block.innerBlocks );
+	} );
+}
+
+export function getOverridableAttributes( block ) {
+	return Object.entries( block.attributes.metadata.bindings )
+		.filter(
+			( [ , binding ] ) => binding.source === 'core/pattern-overrides'
+		)
+		.map( ( [ attributeKey ] ) => attributeKey );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A small performance improvement for pattern overrides.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The original code calls `setBlockEditingMode` multiple times whenever the pattern updates. It'll trigger the subscribers for `block-editor` multiple times which can be a problem later on for large patterns.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Since synced patterns are "locked", we only have to set the editing mode once on the first load (and whenever the editing mode of the pattern itself changes.)

This could be improved when we allow adding blocks in the patterns though.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Everything should work correctly as on trunk and CI should pass.

## Screenshots or screencast <!-- if applicable -->
N/A
