### PR TITLE
env: Fix mariadb version to LTS

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fix
+
+-   Fix `mariadb` version to LTS [#59237](https://github.com/WordPress/gutenberg/pull/59237)
+
 ## 9.3.0 (2024-02-09)
 
 ## 9.2.0 (2024-01-24)

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -172,7 +172,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 		version: '3.7',
 		services: {
 			mysql: {
-				image: 'mariadb',
+				image: 'mariadb:lts',
 				ports: [ '3306' ],
 				environment: {
 					MYSQL_ROOT_HOST: '%',
@@ -183,7 +183,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				volumes: [ 'mysql:/var/lib/mysql' ],
 			},
 			'tests-mysql': {
-				image: 'mariadb',
+				image: 'mariadb:lts',
 				ports: [ '3306' ],
 				environment: {
 					MYSQL_ROOT_HOST: '%',


### PR DESCRIPTION
## What?
This PR fixes the connection failure to the database by pinning the version of mariadb to LTS and testing if GitHub Actions pass.

Please check this out for details: https://wordpress.slack.com/archives/C02QB2JS7/p1708499504613749

Fixes #59232

## Why?

There seems to be a problem with the latest version of the `mariadb` image, as seen in the issue below.

https://github.com/MariaDB/mariadb-docker/issues/560

## How?

Pin the image version to `lts`.

## Testing Instructions

Hopefully, wp-env should now start successfully and pass GitHub Actions successfully.
