### PR TITLE
Zoomed-Out Mode: Don't show blocks in zoomed out view

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -66,10 +66,13 @@ function InserterMenu(
 			insertionIndex: __experimentalInsertionIndex,
 			shouldFocusBlock,
 		} );
-	const { showPatterns } = useSelect(
+	const { showBlocks, showPatterns } = useSelect(
 		( select ) => {
-			const { hasAllowedPatterns } = unlock( select( blockEditorStore ) );
+			const { hasAllowedPatterns, __unstableGetEditorMode } = unlock(
+				select( blockEditorStore )
+			);
 			return {
+				showBlocks: __unstableGetEditorMode() !== 'zoom-out',
 				showPatterns: hasAllowedPatterns( destinationRootClientId ),
 			};
 		},
@@ -248,13 +251,14 @@ function InserterMenu(
 							__experimentalInsertionIndex={
 								__experimentalInsertionIndex
 							}
-							showBlockDirectory
+							showBlockDirectory={ showBlocks }
 							shouldFocusBlock={ shouldFocusBlock }
 						/>
 					</div>
 				) }
 				{ showAsTabs && (
 					<InserterTabs
+						showBlocks={ showBlocks }
 						showPatterns={ showPatterns }
 						showMedia={ showMedia }
 						onSelect={ handleSetSelectedTab }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -266,7 +266,7 @@ function InserterMenu(
 						tabsContents={ inserterTabsContents }
 					/>
 				) }
-				{ ! delayedFilterValue && ! showAsTabs && (
+				{ ! delayedFilterValue && ! showAsTabs && ! isZoomOutMode && (
 					<div className="block-editor-inserter__no-tab-container">
 						{ blocksTab }
 					</div>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -251,7 +251,8 @@ function InserterMenu(
 							__experimentalInsertionIndex={
 								__experimentalInsertionIndex
 							}
-							showBlockDirectory={ showBlocks }
+							showBlockDirectory
+							showBlocks={ showBlocks }
 							shouldFocusBlock={ shouldFocusBlock }
 						/>
 					</div>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -81,6 +81,7 @@ function InserterMenu(
 
 	const mediaCategories = useMediaCategories( destinationRootClientId );
 	const showMedia = mediaCategories.length > 0 && ! isZoomOutMode;
+	const showBlocks = ! isZoomOutMode;
 
 	const onInsert = useCallback(
 		( blocks, meta, shouldForceFocusBlock ) => {
@@ -252,21 +253,21 @@ function InserterMenu(
 								__experimentalInsertionIndex
 							}
 							showBlockDirectory
-							showBlocks={ ! isZoomOutMode }
+							showBlocks={ showBlocks }
 							shouldFocusBlock={ shouldFocusBlock }
 						/>
 					</div>
 				) }
 				{ showAsTabs && (
 					<InserterTabs
-						showBlocks={ ! isZoomOutMode }
+						showBlocks={ showBlocks }
 						showPatterns={ showPatterns }
 						showMedia={ showMedia }
 						onSelect={ handleSetSelectedTab }
 						tabsContents={ inserterTabsContents }
 					/>
 				) }
-				{ ! delayedFilterValue && ! showAsTabs && ! isZoomOutMode && (
+				{ ! delayedFilterValue && ! showAsTabs && showBlocks && (
 					<div className="block-editor-inserter__no-tab-container">
 						{ blocksTab }
 					</div>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -80,7 +80,7 @@ function InserterMenu(
 	);
 
 	const mediaCategories = useMediaCategories( destinationRootClientId );
-	const showMedia = mediaCategories.length > 0;
+	const showMedia = mediaCategories.length > 0 && showBlocks;
 
 	const onInsert = useCallback(
 		( blocks, meta, shouldForceFocusBlock ) => {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -66,13 +66,13 @@ function InserterMenu(
 			insertionIndex: __experimentalInsertionIndex,
 			shouldFocusBlock,
 		} );
-	const { showBlocks, showPatterns } = useSelect(
+	const { isZoomOutMode, showPatterns } = useSelect(
 		( select ) => {
 			const { hasAllowedPatterns, __unstableGetEditorMode } = unlock(
 				select( blockEditorStore )
 			);
 			return {
-				showBlocks: __unstableGetEditorMode() !== 'zoom-out',
+				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
 				showPatterns: hasAllowedPatterns( destinationRootClientId ),
 			};
 		},
@@ -80,7 +80,7 @@ function InserterMenu(
 	);
 
 	const mediaCategories = useMediaCategories( destinationRootClientId );
-	const showMedia = mediaCategories.length > 0 && showBlocks;
+	const showMedia = mediaCategories.length > 0 && ! isZoomOutMode;
 
 	const onInsert = useCallback(
 		( blocks, meta, shouldForceFocusBlock ) => {
@@ -252,14 +252,14 @@ function InserterMenu(
 								__experimentalInsertionIndex
 							}
 							showBlockDirectory
-							showBlocks={ showBlocks }
+							showBlocks={ ! isZoomOutMode }
 							shouldFocusBlock={ shouldFocusBlock }
 						/>
 					</div>
 				) }
 				{ showAsTabs && (
 					<InserterTabs
-						showBlocks={ showBlocks }
+						showBlocks={ ! isZoomOutMode }
 						showPatterns={ showPatterns }
 						showMedia={ showMedia }
 						onSelect={ handleSetSelectedTab }

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -50,6 +50,7 @@ function InserterSearchResults( {
 	shouldFocusBlock = true,
 	prioritizePatterns,
 	selectBlockOnInsert,
+	showBlocks = true,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
@@ -167,7 +168,7 @@ function InserterSearchResults( {
 	const hasItems =
 		filteredBlockTypes.length > 0 || filteredBlockPatterns.length > 0;
 
-	const blocksUI = !! filteredBlockTypes.length && (
+	const blocksUI = showBlocks && !! filteredBlockTypes.length && (
 		<InserterPanel
 			title={ <VisuallyHidden>{ __( 'Blocks' ) }</VisuallyHidden> }
 		>

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -29,13 +29,14 @@ const mediaTab = {
 };
 
 function InserterTabs( {
+	showBlocks = true,
 	showPatterns = false,
 	showMedia = false,
 	onSelect,
 	tabsContents,
 } ) {
 	const tabs = [
-		blocksTab,
+		showBlocks && blocksTab,
 		showPatterns && patternsTab,
 		showMedia && mediaTab,
 	].filter( Boolean );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
If we are in zoomed out view we shouldn't show blocks in the inserter.

## Why?
Zoomed out mode is used for editing your pages and templates at a high level, not for adding single blocks.

## How?
1. Remove the blocks tab from the inserter
2. Don't show blocks when searching in the inserter 

## Testing Instructions
1. Open the site editor
2. Move to zoomed out mode
3. Open the block inserter
4. Check whether the "Blocks" tab exists
5. Search for a block (like Heading)
6. Check whether any blocks appear in the inserter

## Screenshots or screencast <!-- if applicable -->
<img width="1099" alt="Screenshot 2024-02-21 at 16 15 18" src="https://github.com/WordPress/gutenberg/assets/275961/cab6d9d2-2b60-4826-b403-866ac621f9ac">

<img width="1100" alt="Screenshot 2024-02-21 at 16 15 04" src="https://github.com/WordPress/gutenberg/assets/275961/efc0180e-1745-462f-978f-54d994292e24">

