### PR TITLE
Theme JSON: Check for null values to cater for blockGap

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3807,12 +3807,18 @@ class WP_Theme_JSON_Gutenberg {
 	 * Replaces CSS variables with their values in place.
 	 *
 	 * @since 6.3.0
+	 * @since 6.6.0 Check for empty style before processing.
+	 *
 	 * @param array $styles CSS declarations to convert.
 	 * @param array $values key => value pairs to use for replacement.
 	 * @return array
 	 */
 	private static function convert_variables_to_value( $styles, $values ) {
 		foreach ( $styles as $key => $style ) {
+			if ( empty( $style ) ) {
+				continue;
+			}
+
 			if ( is_array( $style ) ) {
 				$styles[ $key ] = self::convert_variables_to_value( $style, $values );
 				continue;

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5070,12 +5070,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 						),
-						'core/post-template'       => array(
+						'core/post-template'   => array(
 							'spacing' => array(
 								'blockGap' => null,
 							),
 						),
-						'core/columns'       => array(
+						'core/columns'         => array(
 							'spacing' => array(
 								'margin' => 'var(--wp--preset--spacing--100)',
 							),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4954,6 +4954,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'var(--wp--preset--color--s)', $styles['blocks']['core/quote']['variations']['plain']['color']['background'], 'Style variations: Assert the internal variables are convert to CSS custom variables.' );
 	}
 
+	/*
+	 * Tests that the theme.json file is correctly parsed and the variables are resolved.
+	 *
+	 * @ticket 58588
+	 *
+	 * @covers WP_Theme_JSON_Gutenberg::resolve_variables
+	 * @covers WP_Theme_JSON_Gutenberg::convert_variables_to_value
+	 */
 	public function test_resolve_variables() {
 		$primary_color   = '#9DFF20';
 		$secondary_color = '#9DFF21';
@@ -5062,6 +5070,16 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 						),
+						'core/post-template'       => array(
+							'spacing' => array(
+								'blockGap' => null,
+							),
+						),
+						'core/columns'       => array(
+							'spacing' => array(
+								'margin' => 'var(--wp--preset--spacing--100)',
+							),
+						),
 					),
 				),
 			)
@@ -5105,6 +5123,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $small_font, $styles['blocks']['core/quote']['variations']['plain']['typography']['fontSize'], 'Block variations: font-size' );
 		$this->assertEquals( $secondary_color, $styles['blocks']['core/quote']['variations']['plain']['color']['background'], 'Block variations: color' );
+		/*
+		 * WP_Theme_JSON_Gutenberg::resolve_variables may be called with merged data from WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()
+		 * WP_Theme_JSON_Resolver_Gutenberg::get_block_data() sets blockGap for supported blocks to `null` if the value is not defined.
+		 */
+		$this->assertNull( $styles['blocks']['core/post-template']['spacing']['blockGap'], 'core/post-template block: blockGap' );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4969,6 +4969,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$raw_color_value = '#efefef';
 		$large_font      = '18px';
 		$small_font      = '12px';
+		$spacing         = 'clamp(1.5rem, 5vw, 2rem)';
 		$theme_json      = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -5005,6 +5006,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								'size' => $large_font,
 								'name' => 'Font size large',
 								'slug' => 'large',
+							),
+						),
+					),
+					'spacing'    => array(
+						'spacingSizes' => array(
+							array(
+								'size' => $spacing,
+								'name' => '100',
+								'slug' => '100',
 							),
 						),
 					),
@@ -5077,7 +5087,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 						'core/columns'         => array(
 							'spacing' => array(
-								'margin' => 'var(--wp--preset--spacing--100)',
+								'blockGap' => 'var(--wp--preset--spacing--100)',
 							),
 						),
 					),
@@ -5128,6 +5138,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		 * WP_Theme_JSON_Resolver_Gutenberg::get_block_data() sets blockGap for supported blocks to `null` if the value is not defined.
 		 */
 		$this->assertNull( $styles['blocks']['core/post-template']['spacing']['blockGap'], 'core/post-template block: blockGap' );
+		$this->assertEquals( $spacing, $styles['blocks']['core/columns']['spacing']['blockGap'], 'core/columns block: blockGap' );
 	}
 
 	/**


### PR DESCRIPTION
## What?

I noticed this PHP error while trying to extract block styles, whose values have a CSS var, using [wp|gutenberg_get_global_styles()](https://github.com/WordPress/gutenberg/blob/d238ce86341b1e7105ccd1c88b9dbcb7ba2de19c/lib/global-styles-and-settings.php#L271-L271).

```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in lib/class-wp-theme-json-gutenberg.php on line 3827

Deprecated: preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in lib/class-wp-theme-json-gutenberg.php on line 3830
```

It's complaining about passing a null value to `strpos()` in [WP_Theme_JSON_Gutenberg::convert_variables_to_value](https://github.com/WordPress/gutenberg/blob/d238ce86341b1e7105ccd1c88b9dbcb7ba2de19c/lib/class-wp-theme-json-gutenberg.php#L3817-L3817)

So I added a check to make sure the value is not empty before we run it through `strpos()`.

## Why

When using `wp|gutenberg_get_global_styles()` with the `resolve-variables` flag like this — 

```php
`gutenberg_get_global_styles( array( 'typography', 'fontSize' ), array( 'block_name' => 'core/search', 'transforms' => array( 'resolve-variables' ) ) );`
```

— it will grab merged Theme JSON data from `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()` and run it through `WP_Theme_JSON_Gutenberg::resolve_variables`, which calls `self::convert_variables_to_value`. 


The snag is that:

1. `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()` calls `static::get_block_data()`
2. `static::get_block_data()` sets [blockGap for supported blocks](https://github.com/WordPress/gutenberg/blob/d238ce86341b1e7105ccd1c88b9dbcb7ba2de19c/lib/class-wp-theme-json-resolver-gutenberg.php#L384-L384) to `null` if the value is not defined.


Because `WP_Theme_JSON_Gutenberg::convert_variables_to_value` is expecting strings as values, it will trigger the error.

## Testing Instructions

Run the tests: `npm run test:unit:php:base -- --filter WP_Theme_JSON_Gutenberg_Test`

If you like, try to call the function from inside a block render/block supports function, or anywhere you're sure that block styles have already been registered

```php
$test = gutenberg_get_global_styles( array( 'spacing', 'blockGap' ), array( 'origin' => 'base', 'block_name' => 'core/post-template', 'transforms' => array( 'resolve-variables' ) ) );
var_dump($test);
```

You should see `NULL` and no errors.

