### PR TITLE
Performance tests: update selectors in site editor pattern loading tests

### DIFF
--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -228,11 +228,6 @@ test.describe( 'Site Editor Performance', () => {
 					canvas: 'edit',
 				} );
 				await editor.openDocumentSettingsSidebar();
-				await page
-					.getByRole( 'button', {
-						name: 'Actions',
-					} )
-					.click();
 
 				// Wait for the browser to be idle before starting the monitoring.
 				// eslint-disable-next-line no-restricted-syntax
@@ -241,7 +236,7 @@ test.describe( 'Site Editor Performance', () => {
 				const startTime = performance.now();
 
 				await page
-					.getByRole( 'menuitem', { name: 'Replace template' } )
+					.getByRole( 'button', { name: 'Transform into:' } )
 					.click();
 
 				const patterns = [


### PR DESCRIPTION


https://github.com/WordPress/gutenberg/pull/55091 updated the way templates can be replaced in the site editor, changing some of the HTML structure, namely removing the replace template button in `sidebar-edit-mode/template-panel/replace-template-button.js` with a "transform into" list.

This PR just updates the performance tests to find the new elements.

## Testing

Wait for 🟢 and 🙏🏻 

`npx playwright test --config test/performance/playwright.config.ts test/performance/specs/site-editor.spec.js`

