### PR TITLE
Style Book: should persist when browsing global styles panels

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -73,7 +73,11 @@ function ScreenRevisions() {
 
 	const onCloseRevisions = () => {
 		goTo( '/' ); // Return to global styles main panel.
-		setEditorCanvasContainerView( undefined );
+		const canvasContainerView =
+			editorCanvasContainerView === 'global-styles-revisions:style-book'
+				? 'style-book'
+				: undefined;
+		setEditorCanvasContainerView( canvasContainerView );
 	};
 
 	const restoreRevision = ( revision ) => {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -99,7 +99,6 @@ function ScreenRevisions() {
 			! editorCanvasContainerView.startsWith( 'global-styles-revisions' )
 		) {
 			goTo( '/' ); // Return to global styles main panel.
-			setEditorCanvasContainerView( editorCanvasContainerView );
 		}
 	}, [ editorCanvasContainerView ] );
 

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -230,12 +230,14 @@ function GlobalStylesBlockLink() {
 }
 
 function GlobalStylesEditorCanvasContainerLink() {
-	const { goTo } = useNavigator();
+	const { goTo, location } = useNavigator();
 	const editorCanvasContainerView = useSelect(
 		( select ) =>
 			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
 		[]
 	);
+	const path = location?.path;
+	const isRevisionsOpen = path === '/revisions';
 
 	// If the user switches the editor canvas container view, redirect
 	// to the appropriate screen. This effectively allows deep linking to the
@@ -249,11 +251,35 @@ function GlobalStylesEditorCanvasContainerLink() {
 			case 'global-styles-css':
 				goTo( '/css' );
 				break;
+			case 'style-book':
+				/*
+				 * The stand-alone style book is open
+				 * and the revisions panel is open,
+				 * close the revisions panel.
+				 * Otherwise keep the style book open while
+				 * browsing global styles panel.
+				 */
+				if ( isRevisionsOpen ) {
+					goTo( '/' );
+				} else {
+					goTo( path );
+				}
+				break;
 			default:
+				/*
+				 * Example: the user has navigated to "Browse styles" or elsewhere
+				 * and changes the editorCanvasContainerView, e.g., closes the style book.
+				 * The panel should not be affected.
+				 * Exclude revisions panel from this behavior,
+				 * as it should close when the editorCanvasContainerView doesn't correspond.
+				 */
+				if ( path !== '/' && ! isRevisionsOpen ) {
+					return;
+				}
 				goTo( '/' );
 				break;
 		}
-	}, [ editorCanvasContainerView, goTo ] );
+	}, [ editorCanvasContainerView, isRevisionsOpen, goTo ] );
 }
 
 function GlobalStylesUI() {

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -261,8 +261,6 @@ function GlobalStylesEditorCanvasContainerLink() {
 				 */
 				if ( isRevisionsOpen ) {
 					goTo( '/' );
-				} else {
-					goTo( path );
 				}
 				break;
 			default:

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -155,6 +155,35 @@ test.describe( 'Style Book', () => {
 			'should close when Escape key is pressed'
 		).toBeHidden();
 	} );
+
+	test( 'should persist when navigating the global styles sidebar', async ( {
+		page,
+	} ) => {
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Browse styles' } )
+			.click();
+
+		const styleBookRegion = page.getByRole( 'region', {
+			name: 'Style Book',
+		} );
+		await expect(
+			styleBookRegion,
+			'style book should be visible'
+		).toBeVisible();
+
+		await page.click( 'role=button[name="Navigate to the previous view"]' );
+
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Typography' } )
+			.click();
+
+		await expect(
+			styleBookRegion,
+			'style book should be visible'
+		).toBeVisible();
+	} );
 } );
 
 class StyleBook {

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -192,6 +192,38 @@ test.describe( 'Style Revisions', () => {
 		).toBeHidden();
 	} );
 
+	test( 'should close revisions panel', async ( {
+		page,
+		editor,
+		userGlobalStylesRevisions,
+	} ) => {
+		await editor.canvas.locator( 'body' ).click();
+		await userGlobalStylesRevisions.openStylesPanel();
+		const revisionsButton = page.getByRole( 'button', {
+			name: 'Revisions',
+		} );
+		const styleBookButton = page.getByRole( 'button', {
+			name: 'Style Book',
+		} );
+		await revisionsButton.click();
+		await styleBookButton.click();
+
+		await expect(
+			page.getByLabel( 'Global styles revisions list' )
+		).toBeVisible();
+
+		await page.click( 'role=button[name="Navigate to the previous view"]' );
+
+		await expect(
+			page.getByLabel( 'Global styles revisions list' )
+		).toBeHidden();
+
+		// The site editor canvas has been restored.
+		await expect(
+			page.locator( 'iframe[name="editor-canvas"]' )
+		).toBeVisible();
+	} );
+
 	test( 'should paginate', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -192,7 +192,7 @@ test.describe( 'Style Revisions', () => {
 		).toBeHidden();
 	} );
 
-	test( 'should close revisions panel', async ( {
+	test( 'should close revisions panel and leave style book open if activated', async ( {
 		page,
 		editor,
 		userGlobalStylesRevisions,
@@ -220,7 +220,7 @@ test.describe( 'Style Revisions', () => {
 
 		// The site editor canvas has been restored.
 		await expect(
-			page.locator( 'iframe[name="editor-canvas"]' )
+			page.locator( 'iframe[name="style-book-canvas"]' )
 		).toBeVisible();
 	} );
 


### PR DESCRIPTION
## What?

Resolves https://github.com/WordPress/gutenberg/issues/59223

Hi!

This PR ensures that the style book remains open, if activated, when browsing around the global styles panel.

## Why?

It could be pretty handy to have the style book remain open when changing global styles, e.g., 

1. Open the style book
2. Navigation to Typography > Text
3. Witness how your changes affect style book elements

## How?
A bit of if else faffery.

If the editor canvas container toggles the "style book", stay on the same global styles panel.

Exceptions:

1. Global style revisions panel and the style book are open, the user closes revisions. The "style book" should remain open, but the global styles panel returns to root `/`


## Testing Instructions

Test cases:
1. Open the site editor, and switch on the style book
2. Navigate through the global styles panel, e.g., Browse styles, Block styles, Color and so on
3. The style book should stay open
4. Navigate through the global styles panel again, e.g., go to Blocks > Button. 
5. Close the style book
6. You should remain on the panel you're on, e.g., Blocks > Button
7. Open global styles revisions
8. Toggle style book on and off, then on again
9. With the style book activated in global styles revisions, apply a revision or navigate back to the main global styles panel using the back arrow. The style book should remain open.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/6458278/20c3f233-7304-4a9f-afcf-c02acba08d53


### After



https://github.com/WordPress/gutenberg/assets/6458278/e7c95f0c-5ccc-4b78-bfdc-637038bee029




