### PR TITLE
Site Editor: Ensure ResizableFrame does not force Cover blocks within the editor to show drag handles

### DIFF
--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -300,6 +300,7 @@ function ResizableFrame( {
 			className={ classnames( 'edit-site-resizable-frame__inner', {
 				'is-resizing': isResizing,
 			} ) }
+			showHandle={ false } // Do not show the default handle, as we're using a custom one.
 		>
 			<motion.div
 				className="edit-site-resizable-frame__inner-content"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the site editor's `ResizableFrame` component, set the `ResizableBox`'s `showHandle` prop to `false` so that CSS rules that show the handles don't flow down to nested resizable boxes that shouldn't display their handles.

This resolves an issue in the site editor where the Cover block will show the handles on its resizable box even when it shouldn't be (i.e. when an aspect ratio is set), because the Cover block is rendered further down the tree from this `ResizableFrame`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

By default, `ResizableBox` treats `showHandle` as `true` and adds a classname that means [some CSS rules](https://github.com/WordPress/gutenberg/blob/c64b75189be3e016040a2dc9393a471705ebcce3/packages/components/src/resizable-box/style.scss#L15-L17) to reveal the handle will apply to any nested resizable box.

To work around this, we can set the `ResizableFrame` to pass in `false` to `showHandle`. Because the site editor's `ResizableFrame` uses its own custom `handleComponent` with the class name of `edit-site-resizable-frame__handle`, it never received the `ResizableBox`'s CSS rules for showing and hiding the drag handle, so this PR shouldn't affect the resizable frame in any way.

While we could potentially resolve this issue over in the resizable box, for 6.5, I think this is likely the safer fix as it's a small change to one component used in one place, where the impact is hopefully fairly well known.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the site editor's `ResizableFrame` component, set the `ResizableBox`'s `showHandle` prop to `false`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the site editor, add a Cover block to a template.
2. Drag the Cover block to be fairly tall using its drag handle.
3. In the block inspector, under Dimensions give the Cover block an aspect ratio
4. On `trunk`, note that the drag handle of the Cover block will still be shown, but it'll be in the wrong position, and dragging it will do nothing
5. With this PR applied, when an aspect ratio is applied, the drag handle should be hidden
6. Reload the site editor in browse mode (its initial state) and double-check that the drag handle for the resizable frame works as on trunk (screenshot below)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

To check for regressions, from the site editor browse mode, make sure that you can still tab all the way over to the drag handle for the resizable frame.

## Screenshots or screencast <!-- if applicable -->

### Before

Note the drag handle that doesn't do anything at the end of this video:

https://github.com/WordPress/gutenberg/assets/14988353/fdb95e5b-6c92-4c65-beb1-a9b5b36daca3

### After

Drag handle is hidden when aspect ratio is applied (same behaviour as in the post editor):

https://github.com/WordPress/gutenberg/assets/14988353/bab6ca71-dacb-4c12-8381-25bbd0286f92

### Drag handle that should be unaffected

This is the drag handle for the resizable frame that should be unaffected, and still be able to be tabbed over to by keyboard.

<img width="1268" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/57da1377-5c83-4b84-a282-34ef8446fb64">
