### PR TITLE
Top Toolbar: Fix 'collapsed' state synchronization

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -61,7 +61,7 @@ function Header( { setEntitiesSavedStatesCallback, initialPost } ) {
 	const blockToolbarRef = useRef();
 	const {
 		isTextEditor,
-		hasBlockSelection,
+		blockSelectionStart,
 		hasActiveMetaboxes,
 		hasFixedToolbar,
 		isPublishSidebarOpened,
@@ -73,8 +73,8 @@ function Header( { setEntitiesSavedStatesCallback, initialPost } ) {
 
 		return {
 			isTextEditor: getEditorMode() === 'text',
-			hasBlockSelection:
-				!! select( blockEditorStore ).getBlockSelectionStart(),
+			blockSelectionStart:
+				select( blockEditorStore ).getBlockSelectionStart(),
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			hasHistory:
 				!! select( editorStore ).getEditorSettings()
@@ -88,13 +88,14 @@ function Header( { setEntitiesSavedStatesCallback, initialPost } ) {
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
+	const hasBlockSelection = !! blockSelectionStart;
 
 	useEffect( () => {
 		// If we have a new block selection, show the block tools
-		if ( hasBlockSelection ) {
+		if ( blockSelectionStart ) {
 			setIsBlockToolsCollapsed( false );
 		}
-	}, [ hasBlockSelection ] );
+	}, [ blockSelectionStart ] );
 
 	return (
 		<div className="edit-post-header">
@@ -121,7 +122,9 @@ function Header( { setEntitiesSavedStatesCallback, initialPost } ) {
 							className={ classnames(
 								'selected-block-tools-wrapper',
 								{
-									'is-collapsed': isBlockToolsCollapsed,
+									'is-collapsed':
+										isBlockToolsCollapsed ||
+										! hasBlockSelection,
 								}
 							) }
 						>

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -134,7 +134,9 @@ export default function HeaderEditMode() {
 								className={ classnames(
 									'selected-block-tools-wrapper',
 									{
-										'is-collapsed': isBlockToolsCollapsed,
+										'is-collapsed':
+											isBlockToolsCollapsed ||
+											! hasBlockSelected,
 									}
 								) }
 							>


### PR DESCRIPTION
## What?
Fixes #59263.

PR fixes 'collapsed' state synchronization for the Top Toolbar in the post editor.

## Why?
The side-effect should react to every block selection state, not only when there is block selection or not.

## How?
* Use `blockSelectionStart` to reset the block toolbar's collapsed state.
* Update condition for `is-collapsed` class. The toolbar always collapses when there's no block selection.

## Testing Instructions
1. Open the post editor and insert multiple paragraph blocks.
2. Enable "Top toolbar".
3. Select one paragraph block. The block toolbar should now be open.
4. Close the block toolbar.
5. Select another paragraph block.
6. The block toolbar should re-open.
7. With the block toolbar open, click the post title.
8. A vertical separator should appear in the header.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/e7019254-441b-4a50-8145-29c0493f465f

