### PR TITLE
Remove unneeded pattern overrides translation strings

### DIFF
--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -17,7 +17,7 @@ import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
 
 function PartialSyncingControls( { name, attributes, setAttributes } ) {
 	const syncedAttributes = PARTIAL_SYNCING_SUPPORTED_BLOCKS[ name ];
-	const attributeSources = Object.keys( syncedAttributes ).map(
+	const attributeSources = syncedAttributes.map(
 		( attributeName ) =>
 			attributes.metadata?.bindings?.[ attributeName ]?.source
 	);
@@ -36,7 +36,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 		};
 
 		if ( ! isChecked ) {
-			for ( const attributeName of Object.keys( syncedAttributes ) ) {
+			for ( const attributeName of syncedAttributes ) {
 				if (
 					updatedBindings[ attributeName ]?.source ===
 					'core/pattern-overrides'
@@ -56,7 +56,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			return;
 		}
 
-		for ( const attributeName of Object.keys( syncedAttributes ) ) {
+		for ( const attributeName of syncedAttributes ) {
 			if ( ! updatedBindings[ attributeName ] ) {
 				updatedBindings[ attributeName ] = {
 					source: 'core/pattern-overrides',

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -1,8 +1,3 @@
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
 export const PATTERN_TYPES = {
 	theme: 'pattern',
 	user: 'wp_block',
@@ -22,18 +17,8 @@ export const PATTERN_SYNC_TYPES = {
 
 // TODO: This should not be hardcoded. Maybe there should be a config and/or an UI.
 export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
-	'core/paragraph': { content: __( 'Content' ) },
-	'core/heading': { content: __( 'Content' ) },
-	'core/button': {
-		text: __( 'Text' ),
-		url: __( 'URL' ),
-		linkTarget: __( 'Link Target' ),
-		rel: __( 'Link Relationship' ),
-	},
-	'core/image': {
-		id: __( 'Image ID' ),
-		url: __( 'URL' ),
-		title: __( 'Title' ),
-		alt: __( 'Alt Text' ),
-	},
+	'core/paragraph': [ 'content' ],
+	'core/heading': [ 'content' ],
+	'core/button': [ 'text', 'url', 'linkTarget', 'rel' ],
+	'core/image': [ 'id', 'url', 'title', 'alt' ],
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As mentioned in https://github.com/WordPress/gutenberg/pull/59169#discussion_r1497095231. These translation strings are not used and needed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because they are not used and they would confuse translators.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove unused strings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Everything should work as expected as on trunk. CI should pass too.

## Screenshots or screencast <!-- if applicable -->
N/A