### PR TITLE
Fix alignment of Group block placeholder text

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -65,7 +65,6 @@
 		margin: 0;
 	}
 	.components-placeholder__instructions {
-		text-align: center;
 		margin-bottom: 18px;
 	}
 	.wp-block-group-placeholder__variations svg {
@@ -92,6 +91,7 @@
 	.components-placeholder {
 		min-height: auto;
 		padding: $grid-unit-30;
+		align-items: center;
 	}
 	.is-small,
 	.is-medium {


### PR DESCRIPTION
## What?

It appears in a recent unrelated PR, the component placeholder container was changed from `block` to `flex`, causing the group block setup state to visually regress. The text in trunk is left aligned, even if it's intended to be centered with the options below:

![group before](https://github.com/WordPress/gutenberg/assets/1204802/da04c8d5-1668-4c93-b6b6-a32c13e53e56)

This PR adjusts the code to the flex context, so the centering works again:

![group after](https://github.com/WordPress/gutenberg/assets/1204802/7c1fbcf1-5f2b-49db-9f38-88f429bbb9f0)

## Testing Instructions

Insert a group block in its setup state, and observe the description to be centered.