### PR TITLE
Interactivity API: Prevent unwanted subscriptions to inherited context props

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -170,3 +170,29 @@ wp_enqueue_script_module( 'directive-context-view' );
 	<button data-testid="select 2" data-wp-on--click="actions.selectItem" value=2>Select 2</button>
 	<div data-testid="selected" data-wp-text="state.selected"></div>
 </div>
+
+<div
+	data-wp-interactive="directive-context-watch"
+	data-wp-context='{"counter":0}'
+>
+	<button
+		data-testid="counter parent"
+		data-wp-on--click="actions.increment"
+		data-wp-text="context.counter"
+	></button>
+	<div
+		data-wp-context='{"counter":0, "changes":0}'
+		data-wp-watch="callbacks.countChanges"
+	>
+		<button
+			data-testid="counter child"
+			data-wp-on--click="actions.increment"
+			data-wp-text="context.counter"
+		>
+		</button>
+		<span
+			data-testid="counter changes"
+			data-wp-text="context.changes"
+		></span>
+	</div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -88,3 +88,21 @@ const { actions } = store( 'directive-context-navigate', {
 		},
 	},
 } );
+
+store( 'directive-context-watch', {
+	actions: {
+		increment: () => {
+			const ctx = getContext();
+			ctx.counter = ctx.counter + 1;
+		},
+	},
+	callbacks: {
+		countChanges: () => {
+			const ctx = getContext();
+			// Subscribe to changes in counter.
+			// eslint-disable-next-line no-unused-expressions
+			ctx.counter;
+			ctx.changes = ctx.changes + 1;
+		},
+	},
+});

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -56,9 +56,11 @@ const proxifyContext = ( current, inherited = {} ) =>
 				return proxifyContext( currentProp, inherited[ k ] );
 			}
 
-			// For other cases, return the value from target, but subscribing
-			// also to changes in the parent context when the current prop is
-			// not defined.
+			/* 
+			 * For other cases, return the value from target, also subscribing
+			 * to changes in the parent context when the current prop is
+			 * not defined.
+			 */
 			return k in target ? currentProp : inherited[ k ];
 		},
 		set: ( target, k, value ) => {

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -56,7 +56,7 @@ const proxifyContext = ( current, inherited = {} ) =>
 				return proxifyContext( currentProp, inherited[ k ] );
 			}
 
-			/* 
+			/*
 			 * For other cases, return the value from target, also subscribing
 			 * to changes in the parent context when the current prop is
 			 * not defined.

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -39,7 +39,7 @@ const descriptor = Reflect.getOwnPropertyDescriptor;
 const proxifyContext = ( current, inherited = {} ) =>
 	new Proxy( current, {
 		get: ( target, k ) => {
-			// Always subscribe to prop changes in the curren context.
+			// Always subscribe to prop changes in the current context.
 			const currentProp = target[ k ];
 
 			// Return the inherited prop when missing in target.

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -313,4 +313,27 @@ test.describe( 'data-wp-context', () => {
 		await select2.click();
 		await expect( selected ).toHaveText( 'Text 2' );
 	} );
+
+	test( 'should not subscribe to parent context props if they exist in child', async ( {
+		page,
+	} ) => {
+		const counterParent = page.getByTestId( 'counter parent' );
+		const counterChild = page.getByTestId( 'counter child' );
+		const changes = page.getByTestId( 'counter changes' );
+
+		await expect( counterParent ).toHaveText( '0' );
+		await expect( counterChild ).toHaveText( '0' );
+		// The first render counts, so the changes counter starts at 1.
+		await expect( changes ).toHaveText( '1' );
+
+		await counterParent.click();
+		await expect( counterParent ).toHaveText( '1' );
+		await expect( counterChild ).toHaveText( '0' );
+		await expect( changes ).toHaveText( '1' );
+
+		await counterChild.click();
+		await expect( counterParent ).toHaveText( '1' );
+		await expect( counterChild ).toHaveText( '1' );
+		await expect( changes ).toHaveText( '2' );
+	} );
 } );

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -314,7 +314,7 @@ test.describe( 'data-wp-context', () => {
 		await expect( selected ).toHaveText( 'Text 2' );
 	} );
 
-	test( 'should not subscribe to parent context props if they exist in child', async ( {
+	test( 'should not subscribe to parent context props if those also exist in child', async ( {
 		page,
 	} ) => {
 		const counterParent = page.getByTestId( 'counter parent' );


### PR DESCRIPTION
## What?

Makes directives subscribe to inherited context props only when they don't exist in the current context.

## Why?

This prevents unwanted subscriptions to changes in inherited properties that are overwritten in the local context, avoiding potential issues with directives that are executed based on property changes.

## How?

Adding a condition when returning the final value. When the property exists in the current context, it is not read from the inherited one, thus preventing the subscription.

I've added a test that reproduces the problem and then fixed the code.
