### PR TITLE
URLPopover: restore min-width style

### DIFF
--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -58,6 +58,7 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	margin-right: $grid-unit-10;
+	min-width: 150px;
 	// Avoids the popover from growing too wide when the URL is long.
 	// See https://github.com/WordPress/gutenberg/issues/58599
 	max-width: $modal-min-width;


### PR DESCRIPTION
Follow up: #57608
Related to #58741

## What?

This PR enforces a minimum width for `URLPopover` components and fixes unintended layout collapse.

## Why?

In #57608, the `URLPopover` component was redesigned. At that time, the CSS that enforces the minimum width appears to be lost.

## How?

I simply restored [the original value](https://github.com/WordPress/gutenberg/pull/57608/files#diff-49bee8a5008288296ba2faca8ec5cb424a7c7d56790d40cf7f28cc6966409662L74).

## Testing Instructions

- Insert an image block and apply an image.
- Click the link button on the block toolbar and enter a short URL.
- Check the width of the popover.

## Screenshots or screencast <!-- if applicable -->

> [!NOTE]
>  The misalignment of the separator when opening the link settings will be fixed with #58906.

| | Before | After |
|--------|--------|--------|
| Link settings is closed| ![before-closed](https://github.com/WordPress/gutenberg/assets/54422211/60463235-e5b4-430a-ba55-a58e190617e7) | ![after-closed](https://github.com/WordPress/gutenberg/assets/54422211/7159bf13-bda4-48d7-ae74-33358c1bf78c)|
| Link settings is opened | ![before-opened](https://github.com/WordPress/gutenberg/assets/54422211/d8f27feb-7cc8-4aec-881c-3f56e9a2306b) | ![after-opened](https://github.com/WordPress/gutenberg/assets/54422211/efdc6e28-1ac1-4793-aede-cd0b67f79283) | 