### PR TITLE
Block Library: Remove redundant copy from PanelBody titles

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -123,7 +123,7 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 	}
 
 	return (
-		<PanelBody title={ __( 'Width settings' ) }>
+		<PanelBody title={ __( 'Settings' ) }>
 			<ButtonGroup aria-label={ __( 'Button width' ) }>
 				{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
 					return (

--- a/packages/block-library/src/comment-author-avatar/edit.js
+++ b/packages/block-library/src/comment-author-avatar/edit.js
@@ -48,7 +48,7 @@ export default function Edit( {
 
 	const inspectorControls = (
 		<InspectorControls>
-			<PanelBody title={ __( 'Avatar Settings' ) }>
+			<PanelBody title={ __( 'Settings' ) }>
 				<RangeControl
 					__nextHasNoMarginBottom
 					__next40pxDefaultSize

--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -35,7 +35,7 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 		<>
 			{ 'hidden' !== type && (
 				<InspectorControls>
-					<PanelBody title={ __( 'Input settings' ) }>
+					<PanelBody title={ __( 'Settings' ) }>
 						{ 'checkbox' !== type && (
 							<CheckboxControl
 								label={ __( 'Inline label' ) }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -12,7 +12,7 @@ import {
 
 const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
 	<InspectorControls>
-		<PanelBody title={ __( 'Ordered list settings' ) }>
+		<PanelBody title={ __( 'Settings' ) }>
 			<TextControl
 				__nextHasNoMarginBottom
 				label={ __( 'Start value' ) }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -400,7 +400,7 @@ export default function SearchEdit( {
 			</BlockControls>
 
 			<InspectorControls>
-				<PanelBody title={ __( 'Display Settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<BaseControl
 						label={ __( 'Width' ) }
 						id={ unitControlInputId }


### PR DESCRIPTION
Similar to #40275, #50186

## What?

This PR simplifies the panel body title containing the word `settings` for each block in the block library. This PR changes the panel body title for the following blocks:

- Button
- Comment Author Avatar (deprecated)
- Input Field (Experimental)
- List
- Search

## Why?

To improve consistency by unifying the title Settings in all blocks.

## Testing Instructions

Insert the block below and check the panel body title in the block sidebar.

- Button
- Input Field: Enable "Form and input blocks" on the Experiments page in advance. Insert a Form block and this block should be included.
- List: Click the "Ordered" button on the block toolbar.
- Search

> [!NOTE]
> We don't need to check the Comment Author Avatar block, as it's deprecated and cannot be inserted.

## Screenshots or screencast <!-- if applicable -->

### Button

Formerly "Width settings"

![image](https://github.com/WordPress/gutenberg/assets/54422211/0d1a4ee2-6149-4aad-8bea-c2b88df6affa)

### Input Field (Experimental)

Formerly "Input settings"

![image](https://github.com/WordPress/gutenberg/assets/54422211/2e409990-3d7c-4b8d-95ac-69a8277afcbd)

### List

Formerly "Ordered list settings"

![image](https://github.com/WordPress/gutenberg/assets/54422211/c4d5f67e-fe99-4388-b566-a5423ecc1761)

### Search

Formerly "Display Settings"

![image](https://github.com/WordPress/gutenberg/assets/54422211/3c1e49ff-9106-42c3-96fd-12af7c44e7b8)