### PR TITLE
Move more actions buttons last in SidebarNavigationScreen header.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -24,13 +24,13 @@ export default function SingleNavigationMenu( {
 		<SidebarNavigationScreenWrapper
 			actions={
 				<>
+					<EditButton postId={ navigationMenu?.id } />
 					<ScreenNavigationMoreMenu
 						menuTitle={ decodeEntities( menuTitle ) }
 						onDelete={ handleDelete }
 						onSave={ handleSave }
 						onDuplicate={ handleDuplicate }
 					/>
-					<EditButton postId={ navigationMenu?.id } />
 				</>
 			}
 			title={ buildNavigationLabel(

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -94,17 +94,17 @@ export default function SidebarNavigationScreenPage( { backPath } ) {
 			) }
 			actions={
 				<>
+					<SidebarButton
+						onClick={ () => setCanvasMode( 'edit' ) }
+						label={ __( 'Edit' ) }
+						icon={ pencil }
+					/>
 					<PageActions
 						postId={ postId }
 						toggleProps={ { as: SidebarButton } }
 						onRemove={ () => {
 							goTo( '/page' );
 						} }
-					/>
-					<SidebarButton
-						onClick={ () => setCanvasMode( 'edit' ) }
-						label={ __( 'Edit' ) }
-						icon={ pencil }
 					/>
 				</>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -43,6 +43,11 @@ export default function SidebarNavigationScreenPattern() {
 		<SidebarNavigationScreen
 			actions={
 				<>
+					<SidebarButton
+						onClick={ () => setCanvasMode( 'edit' ) }
+						label={ __( 'Edit' ) }
+						icon={ pencil }
+					/>
 					<TemplateActions
 						postType={ postType }
 						postId={ postId }
@@ -50,11 +55,6 @@ export default function SidebarNavigationScreenPattern() {
 						onRemove={ () => {
 							navigator.goTo( backPath );
 						} }
-					/>
-					<SidebarButton
-						onClick={ () => setCanvasMode( 'edit' ) }
-						label={ __( 'Edit' ) }
-						icon={ pencil }
 					/>
 				</>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -109,6 +109,11 @@ export default function SidebarNavigationScreenTemplate() {
 			title={ title }
 			actions={
 				<>
+					<SidebarButton
+						onClick={ () => setCanvasMode( 'edit' ) }
+						label={ __( 'Edit' ) }
+						icon={ pencil }
+					/>
 					<TemplateActions
 						postType={ postType }
 						postId={ postId }
@@ -116,11 +121,6 @@ export default function SidebarNavigationScreenTemplate() {
 						onRemove={ () => {
 							navigator.goTo( `/${ postType }/all` );
 						} }
-					/>
-					<SidebarButton
-						onClick={ () => setCanvasMode( 'edit' ) }
-						label={ __( 'Edit' ) }
-						icon={ pencil }
 					/>
 				</>
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/59280

## What?
<!-- In a few words, what is the PR actually doing? -->
Moves the 'more' Actions button in the last position in the `SidebarNavigationScreen` panel header, after the pencil 'Edit' button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All 'more' buttons should be in the last position within the group of controls thei belong to. For consistency with what the editor does in other places and for consistency with a desgin pattern used across any kind of software I can think of.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Move the more button in the last position...
Applies to all the `SidebarNavigationScreen` components that pass more than one control to the `actions` prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue.
- Observe the 'more' Actions button is now last.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
