### PR TITLE
Fix query loop with block bindings not working in the editor as expected

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -19,7 +19,7 @@ import {
 	removeFormat,
 } from '@wordpress/rich-text';
 import { Popover } from '@wordpress/components';
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -151,9 +151,7 @@ export function RichTextWrapper(
 		let disableBoundBlocks = false;
 		if ( blockBindings && blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) {
 			const blockTypeAttributes = getBlockType( blockName ).attributes;
-			const { getBlockBindingsSource } = unlock(
-				select( blockEditorStore )
-			);
+			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
 			for ( const [ attribute, args ] of Object.entries(
 				blockBindings
 			) ) {

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, store as blocksStore } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
@@ -33,18 +33,16 @@ const createEditFunctionWithBindingsAttribute = () =>
 	createHigherOrderComponent(
 		( BlockEdit ) => ( props ) => {
 			const { clientId, name: blockName } = useBlockEditContext();
-			const { getBlockBindingsSource } = unlock(
-				useSelect( blockEditorStore )
-			);
+			const blockBindingsSources = unlock(
+				useSelect( blocksStore )
+			).getAllBlockBindingsSources();
 			const { getBlockAttributes } = useSelect( blockEditorStore );
 
 			const updatedAttributes = getBlockAttributes( clientId );
 			if ( updatedAttributes?.metadata?.bindings ) {
 				Object.entries( updatedAttributes.metadata.bindings ).forEach(
 					( [ attributeName, settings ] ) => {
-						const source = getBlockBindingsSource(
-							settings.source
-						);
+						const source = blockBindingsSources[ settings.source ];
 
 						if ( source && source.useSource ) {
 							// Second argument (`updateMetaValue`) will be used to update the value in the future.

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -355,16 +355,6 @@ export function stopEditingAsBlocks( clientId ) {
 	};
 }
 
-export function registerBlockBindingsSource( source ) {
-	return {
-		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
-		sourceName: source.name,
-		sourceLabel: source.label,
-		useSource: source.useSource,
-		lockAttributesEditing: source.lockAttributesEditing,
-	};
-}
-
 /**
  * Returns an action object used in signalling that the user has begun to drag.
  *

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -341,14 +341,6 @@ export function getLastFocus( state ) {
 	return state.lastFocus;
 }
 
-export function getAllBlockBindingsSources( state ) {
-	return state.blockBindingsSources;
-}
-
-export function getBlockBindingsSource( state, sourceName ) {
-	return state.blockBindingsSources[ sourceName ];
-}
-
 /**
  * Returns true if the user is dragging anything, or false otherwise. It is possible for a
  * user to be dragging data from outside of the editor, so this selector is separate from

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2044,20 +2044,6 @@ export function lastFocus( state = false, action ) {
 	return state;
 }
 
-function blockBindingsSources( state = {}, action ) {
-	if ( action.type === 'REGISTER_BLOCK_BINDINGS_SOURCE' ) {
-		return {
-			...state,
-			[ action.sourceName ]: {
-				label: action.sourceLabel,
-				useSource: action.useSource,
-				lockAttributesEditing: action.lockAttributesEditing ?? true,
-			},
-		};
-	}
-	return state;
-}
-
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2089,7 +2075,6 @@ const combinedReducers = combineReducers( {
 	blockRemovalRules,
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
-	blockBindingsSources,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -45,6 +45,7 @@ import {
 	createBlock,
 	cloneBlock,
 	getDefaultBlockName,
+	store as blocksStore,
 } from '@wordpress/blocks';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -239,7 +240,7 @@ function ButtonEdit( props ) {
 			}
 
 			const blockBindingsSource = unlock(
-				select( blockEditorStore )
+				select( blocksStore )
 			).getBlockBindingsSource( metadata?.bindings?.url?.source );
 
 			return {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
+import { store as blocksStore } from '@wordpress/blocks';
 import { Placeholder } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -342,7 +343,7 @@ export function ImageEdit( {
 			}
 
 			const blockBindingsSource = unlock(
-				select( blockEditorStore )
+				select( blocksStore )
 			).getBlockBindingsSource( metadata?.bindings?.url?.source );
 
 			return {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -33,7 +33,7 @@ import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { getFilename } from '@wordpress/url';
-import { switchToBlockType } from '@wordpress/blocks';
+import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
 import { crop, overlayText, upload } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
@@ -417,9 +417,10 @@ export default function Image( {
 			if ( ! isSingleSelected ) {
 				return {};
 			}
-
-			const { getBlockBindingsSource, getBlockParentsByBlockName } =
-				unlock( select( blockEditorStore ) );
+			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
+			const { getBlockParentsByBlockName } = unlock(
+				select( blockEditorStore )
+			);
 			const {
 				url: urlBinding,
 				alt: altBinding,

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -40,3 +40,18 @@ export function addUnprocessedBlockType( name, blockType ) {
 		dispatch.addBlockTypes( processedBlockType );
 	};
 }
+
+/**
+ * Register new block bindings source.
+ *
+ * @param {string} source Name of the source to register.
+ */
+export function registerBlockBindingsSource( source ) {
+	return {
+		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
+		sourceName: source.name,
+		sourceLabel: source.label,
+		useSource: source.useSource,
+		lockAttributesEditing: source.lockAttributesEditing,
+	};
+}

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -186,3 +186,26 @@ export function getBootstrappedBlockType( state, name ) {
 export function getUnprocessedBlockTypes( state ) {
 	return state.unprocessedBlockTypes;
 }
+
+/**
+ * Returns all the block bindings sources registered.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Object} All the registered sources and their properties.
+ */
+export function getAllBlockBindingsSources( state ) {
+	return state.blockBindingsSources;
+}
+
+/**
+ * Returns a specific block bindings source.
+ *
+ * @param {Object} state      Data state.
+ * @param {string} sourceName Name of the source to get.
+ *
+ * @return {Object} The specific block binding source and its properties.
+ */
+export function getBlockBindingsSource( state, sourceName ) {
+	return state.blockBindingsSources[ sourceName ];
+}

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -383,6 +383,20 @@ export function collections( state = {}, action ) {
 	return state;
 }
 
+export function blockBindingsSources( state = {}, action ) {
+	if ( action.type === 'REGISTER_BLOCK_BINDINGS_SOURCE' ) {
+		return {
+			...state,
+			[ action.sourceName ]: {
+				label: action.sourceLabel,
+				useSource: action.useSource,
+				lockAttributesEditing: action.lockAttributesEditing ?? true,
+			},
+		};
+	}
+	return state;
+}
+
 export default combineReducers( {
 	bootstrappedBlockTypes,
 	unprocessedBlockTypes,
@@ -395,4 +409,5 @@ export default combineReducers( {
 	groupingBlockName,
 	categories,
 	collections,
+	blockBindingsSources,
 } );

--- a/packages/editor/src/bindings/index.js
+++ b/packages/editor/src/bindings/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as blocksStore } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
@@ -10,6 +10,6 @@ import { unlock } from '../lock-unlock';
 import patternOverrides from './pattern-overrides';
 import postMeta from './post-meta';
 
-const { registerBlockBindingsSource } = unlock( dispatch( blockEditorStore ) );
+const { registerBlockBindingsSource } = unlock( dispatch( blocksStore ) );
 registerBlockBindingsSource( patternOverrides );
 registerBlockBindingsSource( postMeta );


### PR DESCRIPTION
## What?
As reported [here](https://github.com/WordPress/gutenberg/pull/58895#issuecomment-1956843541), the Query Loop shows the same value when the blocks are connected to custom fields. It should show each post custom field instead.

This is a first step to solve the issue, it will fully fixed after [this refactoring of the block editor hook](https://github.com/WordPress/gutenberg/pull/58895). This PR solves it for blocks like heading or paragraph but the issue still persists in images. That is a different there are two technical issues, one solved by this PR, and the other one solved in the linked one. 
 
## Why?
The current UX is confusing and block bindings feel broken.

## How?
After triaging it with @gziolo , it seems that the [`useSelect` used in the bindings hook](https://github.com/WordPress/gutenberg/blob/3bb8b94f8962fd2dc8057f5ef240457360715e66/packages/block-editor/src/hooks/use-bindings-attributes.js#L36-L38) doesn't have the registered sources when it is used in a post template preview.

This is caused because:
* [the PostTemplateBlockPreview component](https://github.com/WordPress/gutenberg/blob/5f11e5f3eb1641fb2ff800ca19d42d33f91b43e8/packages/block-library/src/post-template/edit.js#L38-L70), uses [useBlockPreview](https://github.com/WordPress/gutenberg/blob/5f11e5f3eb1641fb2ff800ca19d42d33f91b43e8/packages/block-editor/src/components/block-preview/index.js#L115-L156).
* [useBlockPreview](https://github.com/WordPress/gutenberg/blob/5f11e5f3eb1641fb2ff800ca19d42d33f91b43e8/packages/block-editor/src/components/block-preview/index.js#L115-L156) uses [ExperimentalBlockEditorProvider](https://github.com/WordPress/gutenberg/blob/5f11e5f3eb1641fb2ff800ca19d42d33f91b43e8/packages/block-editor/src/components/provider/index.js#L20-L57).
* [ExperimentalBlockEditorProvider](https://github.com/WordPress/gutenberg/blob/5f11e5f3eb1641fb2ff800ca19d42d33f91b43e8/packages/block-editor/src/components/provider/index.js#L20-L57) uses [withRegistryProvider](https://github.com/WordPress/gutenberg/blob/5f11e5f3eb1641fb2ff800ca19d42d33f91b43e8/packages/block-editor/src/components/provider/with-registry-provider.js#L18-L55).
* [withRegistryProvider](https://github.com/WordPress/gutenberg/blob/5f11e5f3eb1641fb2ff800ca19d42d33f91b43e8/packages/block-editor/src/components/provider/with-registry-provider.js#L18-L55) replaces the current store with a [new store](https://github.com/WordPress/gutenberg/blob/5f11e5f3eb1641fb2ff800ca19d42d33f91b43e8/packages/block-editor/src/components/provider/with-registry-provider.js#L31-L35).

It seems that the best option to solve this problem is to move the actions and selectors used by the block bindings to the `blocks` packages instead of the `block-editor`.

## Testing Instructions
1. Register some custom fields to test it. You can use something like this (changing the ids for your post ids):

```
$id_the_godfather            = 6;
$id_goncharov                = 9;

// // Update movie title
update_post_meta( $id_the_godfather, 'movie_title', 'The Godfather' );
update_post_meta( $id_goncharov, 'movie_title', 'Goncharov' );

// // Update release date
update_post_meta( $id_the_godfather, 'release', '14th March 1972' );
update_post_meta( $id_goncharov, 'release', '15th January 1973' );
```

2. Go to a page and add a query loop showing the posts.
3. In the post template, dd a heading block bound to the movie title and paragraph block bound to the release custom fields.

```
<!-- wp:heading {"level":3,"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"movie_title"}}}}} -->
<h3 class="wp-block-heading">Goncharov</h3>
<!-- /wp:heading -->

<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"release"}}}}} -->
<p>15th January 1973</p>
<!-- /wp:paragraph -->
```

4. Check that the correct values are shown for each of the items.
