### PR TITLE
Update page selector appearance

### DIFF
--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -27,7 +27,12 @@ const Pagination = memo( function Pagination( {
 				justify="end"
 				className="dataviews-pagination"
 			>
-				<HStack justify="flex-start" expanded={ false } spacing={ 2 }>
+				<HStack
+					justify="flex-start"
+					expanded={ false }
+					spacing={ 2 }
+					className="dataviews-pagination__page-selection"
+				>
 					{ createInterpolateElement(
 						sprintf(
 							// translators: %s: Total number of pages.

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -44,6 +44,13 @@
 	color: $gray-700;
 }
 
+.dataviews-pagination__page-selection {
+	font-size: 11px;
+	text-transform: uppercase;
+	font-weight: 500;
+	color: $gray-900;
+}
+
 .dataviews-filters-options {
 	margin: $grid-unit-40 0 $grid-unit-20;
 }


### PR DESCRIPTION
## What?
Update the typography in the page selector UI.

## Why?
So that it visually resembles other labels.

| Before | After |
| --- | --- |
| <img width="294" alt="Screenshot 2024-02-22 at 16 17 20" src="https://github.com/WordPress/gutenberg/assets/846565/2faa7c29-10b0-41b3-b5a3-b42de6251274"> | <img width="392" alt="Screenshot 2024-02-22 at 16 08 10" src="https://github.com/WordPress/gutenberg/assets/846565/355505b6-46ba-4922-ac45-579a52d2ab4f"> |
