### PR TITLE
Update pages dataview icons, add 'drafts' icon

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { trash } from '@wordpress/icons';
+import { trash, pages, drafts } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -51,11 +51,13 @@ export const DEFAULT_VIEWS = {
 		{
 			title: __( 'All pages' ),
 			slug: 'all',
+			icon: pages,
 			view: DEFAULT_PAGE_BASE,
 		},
 		{
 			title: __( 'Drafts' ),
 			slug: 'drafts',
+			icon: drafts,
 			view: {
 				...DEFAULT_PAGE_BASE,
 				filters: [

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -68,6 +68,7 @@ export { default as currencyPound } from './library/currency-pound';
 export { default as customPostType } from './library/custom-post-type';
 export { default as desktop } from './library/desktop';
 export { default as details } from './library/details';
+export { default as drafts } from './library/drafts';
 export { default as dragHandle } from './library/drag-handle';
 export { default as drawerLeft } from './library/drawer-left';
 export { default as drawerRight } from './library/drawer-right';

--- a/packages/icons/src/library/drafts.js
+++ b/packages/icons/src/library/drafts.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const drafts = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M8 2H6a2 2 0 0 0-2 2v2.4h1.5V4a.5.5 0 0 1 .5-.5h2V2ZM4 13.6V16a2 2 0 0 0 2 2h2v-1.5H6a.5.5 0 0 1-.5-.5v-2.4H4Zm0-1.2h1.5V7.6H4v4.8ZM9 2v1.5h4V2H9Zm5 0v1.5h2a.5.5 0 0 1 .5.5v2.4H18V4a2 2 0 0 0-2-2h-2Zm4 5.6h-1.5v4.8H18V7.6Zm0 6h-1.5V16a.5.5 0 0 1-.5.5h-2V18h2a2 2 0 0 0 2-2v-2.4ZM13 18v-1.5H9V18h4ZM7 7.25h8v-1.5H7v1.5Zm0 3.25h6V9H7v1.5ZM21.75 19V6h-1.5v13c0 .69-.56 1.25-1.25 1.25H8v1.5h11A2.75 2.75 0 0 0 21.75 19Z"
+		/>
+	</SVG>
+);
+
+export default drafts;


### PR DESCRIPTION
## What?
Update the decorative icon assigned to the "All pages" and "Drafts" page views.

## Why?
The current `blockTable` icon doesn't communicate context in the same way the Trash icon does. This change aligns the icon purpose across the buttons.

## How?
A new `drafts` icon has been added to the library. This is an initial take on the design amongst several explorations:

<img width="234" alt="drafts" src="https://github.com/WordPress/gutenberg/assets/846565/f02cd2a3-b925-4276-b223-b79ef18667e4">

The appearance and name of this icon can be discussed further in this PR.

| Before | After |
| --- | --- |
| <img width="358" alt="Screenshot 2024-02-22 at 16 20 10" src="https://github.com/WordPress/gutenberg/assets/846565/4784800e-dee9-410a-adb1-88152fe648b4"> | <img width="358" alt="Screenshot 2024-02-22 at 16 28 22" src="https://github.com/WordPress/gutenberg/assets/846565/951967de-00e4-406b-aa55-5fb9baa58a2b"> |
