### PR TITLE
Add `@global` to PHP doc comments

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -47,6 +47,9 @@ function gutenberg_build_files_notice() {
  * Verify that we can initialize the Gutenberg editor , then load it.
  *
  * @since 1.5.0
+ * 
+ * @global string $wp_version             The WordPress version string.
+ * 
  */
 function gutenberg_pre_init() {
 	global $wp_version;

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -47,9 +47,9 @@ function gutenberg_build_files_notice() {
  * Verify that we can initialize the Gutenberg editor , then load it.
  *
  * @since 1.5.0
- * 
+ *
  * @global string $wp_version             The WordPress version string.
- * 
+ *
  */
 function gutenberg_pre_init() {
 	global $wp_version;

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/block` block on server.
  *
  * @global WP_Embed $wp_embed
- * 
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Rendered HTML of the referenced block.

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/block` block on server.
  *
+ * @global WP_Embed $wp_embed
+ * 
  * @param array $attributes The block attributes.
  *
  * @return string Rendered HTML of the referenced block.

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/calendar` block on server.
  *
  * @global int $monthnum.
- * @global int $year
+ * @global int $year.
  *
  * @param array $attributes The block attributes.
  *
@@ -119,7 +119,7 @@ function block_core_calendar_has_published_posts() {
 /**
  * Queries the database for any published post and saves
  * a flag whether any published post exists or not.
- * 
+ *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @return bool Has any published posts or not.

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -8,6 +8,9 @@
 /**
  * Renders the `core/calendar` block on server.
  *
+ * @global int $monthnum.
+ * @global int $year
+ * 
  * @param array $attributes The block attributes.
  *
  * @return string Returns the block content.
@@ -116,6 +119,8 @@ function block_core_calendar_has_published_posts() {
 /**
  * Queries the database for any published post and saves
  * a flag whether any published post exists or not.
+ * 
+ * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @return bool Has any published posts or not.
  */

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -10,7 +10,7 @@
  *
  * @global int $monthnum.
  * @global int $year
- * 
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the block content.

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -16,6 +16,8 @@
  * the block is in legacy mode. If not, the HTML generated in the editor is
  * returned instead.
  *
+ * @global WP_Post  $post     Global post object.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.

--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -7,6 +7,8 @@
 
 /**
  * Renders the 'core/legacy-widget' block.
+ * 
+ * @global int $wp_widget_factory.
  *
  * @param array $attributes The block attributes.
  *

--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -7,7 +7,7 @@
 
 /**
  * Renders the 'core/legacy-widget' block.
- * 
+ *
  * @global int $wp_widget_factory.
  *
  * @param array $attributes The block attributes.


### PR DESCRIPTION
Added Global documentation according to [PHP Documentation Standards.](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)

**Fixes:** https://github.com/WordPress/gutenberg/issues/59286