### PR TITLE
Title & Featured Image: Hide non content controls when block editing mode is 'contentOnly'

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -24,6 +24,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 	__experimentalUseBorderProps as useBorderProps,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -143,6 +144,7 @@ export default function PostFeaturedImageEdit( {
 		style: { width, height, aspectRatio },
 	} );
 	const borderProps = useBorderProps( attributes );
+	const blockEditingMode = useBlockEditingMode();
 
 	const placeholder = ( content ) => {
 		return (
@@ -174,8 +176,13 @@ export default function PostFeaturedImageEdit( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
-	const controls = (
+	const controls = blockEditingMode === 'default' && (
 		<>
+			<Overlay
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				clientId={ clientId }
+			/>
 			<DimensionControls
 				clientId={ clientId }
 				attributes={ attributes }
@@ -224,6 +231,7 @@ export default function PostFeaturedImageEdit( {
 			</InspectorControls>
 		</>
 	);
+
 	let image;
 
 	/**
@@ -251,11 +259,6 @@ export default function PostFeaturedImageEdit( {
 					) : (
 						placeholder()
 					) }
-					<Overlay
-						attributes={ attributes }
-						setAttributes={ setAttributes }
-						clientId={ clientId }
-					/>
 				</div>
 			</>
 		);
@@ -360,11 +363,6 @@ export default function PostFeaturedImageEdit( {
 				) : (
 					image
 				) }
-				<Overlay
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					clientId={ clientId }
-				/>
 			</figure>
 		</>
 	);

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -115,53 +115,59 @@ export default function PostTitleEdit( {
 	return (
 		<>
 			{ blockEditingMode === 'default' && (
-				<BlockControls group="block">
-					<HeadingLevelDropdown
-						value={ level }
-						onChange={ ( newLevel ) =>
-							setAttributes( { level: newLevel } )
-						}
-					/>
-					<AlignmentControl
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
-					/>
-				</BlockControls>
-			) }
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Make title a link' ) }
-						onChange={ () => setAttributes( { isLink: ! isLink } ) }
-						checked={ isLink }
-					/>
-					{ isLink && (
-						<>
+				<>
+					<BlockControls group="block">
+						<HeadingLevelDropdown
+							value={ level }
+							onChange={ ( newLevel ) =>
+								setAttributes( { level: newLevel } )
+							}
+						/>
+						<AlignmentControl
+							value={ textAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { textAlign: nextAlign } );
+							} }
+						/>
+					</BlockControls>
+					<InspectorControls>
+						<PanelBody title={ __( 'Settings' ) }>
 							<ToggleControl
 								__nextHasNoMarginBottom
-								label={ __( 'Open in new tab' ) }
-								onChange={ ( value ) =>
-									setAttributes( {
-										linkTarget: value ? '_blank' : '_self',
-									} )
+								label={ __( 'Make title a link' ) }
+								onChange={ () =>
+									setAttributes( { isLink: ! isLink } )
 								}
-								checked={ linkTarget === '_blank' }
+								checked={ isLink }
 							/>
-							<TextControl
-								__nextHasNoMarginBottom
-								label={ __( 'Link rel' ) }
-								value={ rel }
-								onChange={ ( newRel ) =>
-									setAttributes( { rel: newRel } )
-								}
-							/>
-						</>
-					) }
-				</PanelBody>
-			</InspectorControls>
+							{ isLink && (
+								<>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										label={ __( 'Open in new tab' ) }
+										onChange={ ( value ) =>
+											setAttributes( {
+												linkTarget: value
+													? '_blank'
+													: '_self',
+											} )
+										}
+										checked={ linkTarget === '_blank' }
+									/>
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Link rel' ) }
+										value={ rel }
+										onChange={ ( newRel ) =>
+											setAttributes( { rel: newRel } )
+										}
+									/>
+								</>
+							) }
+						</PanelBody>
+					</InspectorControls>
+				</>
+			) }
 			{ titleElement }
 		</>
 	);


### PR DESCRIPTION
**[View diff without whitespace](https://github.com/WordPress/gutenberg/pull/59295/files?diff=split&w=1)**

## What?
Fixes https://github.com/WordPress/gutenberg/issues/59291.

## How?
Updates the Title and Featured Image blocks to hide the 'Link to', Overlay, and Dimensions panels when the block's `blockEditingMode` is `'contentOnly'`.

It's up to each block to check `blockEditingMode` and hide and show the controls that are appropriate for that editing mode. Most blocks and block supports correctly check the mode and hide controls that are not content related if `blockEditingMode` is `'contentOnly'`.

Something that has come up before is whether we should simply hide all `InspectorControls` when `blockEditingMode` is `'contentOnly'`. It's debatable because it isn't necessarily the case that all inspector controls have nothing to do with editing content. What is content and what is not content is difficult to say at a global level which is why we leave it up to the blocks. I'm on the fence. At any rate I think it's better to just do the simple fix for 6.5.

## Testing Instructions
1. Go to Appearance → Editor → Pages and edit a page.
2. Select the Title, Featured Image, and Content blocks. Only minimal controls to do with editing the content should appear in the block toolbar and block inspector.