### PR TITLE
Command Palette: Prevent mode switching if only one editor mode is available

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -25,9 +25,12 @@ function useEditorCommandLoader() {
 		isFocusMode,
 		isPreviewMode,
 		isViewable,
+		isCodeEditingEnabled,
+		isRichEditingEnabled,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
-		const { isListViewOpened, getCurrentPostType } = select( editorStore );
+		const { isListViewOpened, getCurrentPostType, getEditorSettings } =
+			select( editorStore );
 		const { getSettings } = select( blockEditorStore );
 		const { getPostType } = select( coreStore );
 
@@ -40,6 +43,8 @@ function useEditorCommandLoader() {
 			isTopToolbar: get( 'core', 'fixedToolbar' ),
 			isPreviewMode: getSettings().__unstableIsPreviewMode,
 			isViewable: getPostType( getCurrentPostType() )?.viewable ?? false,
+			isCodeEditingEnabled: getEditorSettings().codeEditingEnabled,
+			isRichEditingEnabled: getEditorSettings().richEditingEnabled,
 		};
 	}, [] );
 	const { toggle } = useDispatch( preferencesStore );
@@ -51,6 +56,7 @@ function useEditorCommandLoader() {
 		toggleDistractionFree,
 	} = useDispatch( editorStore );
 	const { getCurrentPostId } = useSelect( editorStore );
+	const allowSwitchEditorMode = isCodeEditingEnabled && isRichEditingEnabled;
 
 	if ( isPreviewMode ) {
 		return { commands: [], isLoading: false };
@@ -141,18 +147,20 @@ function useEditorCommandLoader() {
 		},
 	} );
 
-	commands.push( {
-		name: 'core/toggle-code-editor',
-		label:
-			editorMode === 'visual'
-				? __( 'Open code editor' )
-				: __( 'Exit code editor' ),
-		icon: code,
-		callback: ( { close } ) => {
-			switchEditorMode( editorMode === 'visual' ? 'text' : 'visual' );
-			close();
-		},
-	} );
+	if ( allowSwitchEditorMode ) {
+		commands.push( {
+			name: 'core/toggle-code-editor',
+			label:
+				editorMode === 'visual'
+					? __( 'Open code editor' )
+					: __( 'Exit code editor' ),
+			icon: code,
+			callback: ( { close } ) => {
+				switchEditorMode( editorMode === 'visual' ? 'text' : 'visual' );
+				close();
+			},
+		} );
+	}
 
 	commands.push( {
 		name: 'core/toggle-breadcrumbs',


### PR DESCRIPTION
Part of #57604

## What?
This PR fixes an issue where it was possible to switch modes via the command palette even though either visual mode or code editor mode was disabled.

![command-palette](https://github.com/WordPress/gutenberg/assets/54422211/3d358974-3133-4005-a665-3fe8f21980d9)

## Why?

The options menu [refers to the editor settings and determines](https://github.com/WordPress/gutenberg/blob/671fbf961a7a091a3163ecf25e1a045973f458d1/packages/editor/src/components/mode-switcher/index.js#L57-L77) whether the button to toggle editor mode is enabled. However, the editor settings are not referenced in the command palette.

## How?

Refer to the editor settings and add a command to toggle the code editor only if both modes are enabled.

## Testing Instructions

In advance, write the following code into `gutenberg.php` to disable code editor mode:

```php
function disable_code_editor( $settings, $context ) {
	$settings['codeEditingEnabled'] = false;
	return $settings;
}
add_filter( 'block_editor_settings_all', 'disable_code_editor' , 10, 2 );
```

- Open the Site Editor or Post Editor.
- Start the command palette and enter "code".
- The command should not be displayed.
- If you remove the hook mentioned above, you should see the command.
