### PR TITLE
Columns: Correctly recalculate column widths when the column count is increased by more than 2 at once

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -139,18 +139,19 @@ function ColumnsEditContainer( { attributes, setAttributes, clientId } ) {
 			// If adding a new column, assign width to the new column equal to
 			// as if it were `1 / columns` of the total available space.
 			const newColumnWidth = toWidthPrecision( 100 / newColumns );
+			const newlyAddedColumns = newColumns - previousColumns;
 
 			// Redistribute in consideration of pending block insertion as
 			// constraining the available working width.
 			const widths = getRedistributedColumnWidths(
 				innerBlocks,
-				100 - newColumnWidth
+				100 - newColumnWidth * newlyAddedColumns
 			);
 
 			innerBlocks = [
 				...getMappedColumnWidths( innerBlocks, widths ),
 				...Array.from( {
-					length: newColumns - previousColumns,
+					length: newlyAddedColumns,
 				} ).map( () => {
 					return createBlock( 'core/column', {
 						width: `${ newColumnWidth }%`,

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -175,6 +175,75 @@ test.describe( 'Columns', () => {
 		] );
 	} );
 
+	test.describe( 'should update the column widths correctly', () => {
+		const initialColumnWidths = [ '10%', '20%', '30%', '40%' ];
+
+		const expected = [
+			{
+				newColumnCount: 2,
+				newColumnWidths: [ '33.33%', '66.67%' ],
+			},
+			{
+				newColumnCount: 3,
+				newColumnWidths: [ '16.67%', '33.33%', '50%' ],
+			},
+			{
+				newColumnCount: 5,
+				newColumnWidths: [ '8%', '16%', '24%', '32%', '20%' ],
+			},
+			{
+				newColumnCount: 6,
+				newColumnWidths: [
+					'6.67%',
+					'13.33%',
+					'20%',
+					'26.66%',
+					'16.67%',
+					'16.67%',
+				],
+			},
+		];
+
+		expected.forEach( ( { newColumnCount, newColumnWidths } ) => {
+			test( `when the column count is changed to ${ newColumnCount }`, async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/columns',
+					attributes: {
+						columns: initialColumnWidths.length,
+					},
+					innerBlocks: initialColumnWidths.map( ( width ) => ( {
+						name: 'core/column',
+						attributes: { width },
+					} ) ),
+				} );
+
+				await editor.selectBlocks(
+					editor.canvas.getByRole( 'document', {
+						name: 'Block: Columns',
+					} )
+				);
+				await editor.openDocumentSettingsSidebar();
+
+				await page
+					.getByRole( 'spinbutton', { name: 'Columns' } )
+					.fill( newColumnCount.toString() );
+
+				await expect( editor.getBlocks() ).resolves.toMatchObject( [
+					{
+						name: 'core/columns',
+						innerBlocks: newColumnWidths.map( ( width ) => ( {
+							name: 'core/column',
+							attributes: { width },
+						} ) ),
+					},
+				] );
+			} );
+		} );
+	} );
+
 	test( 'should not split in middle', async ( { editor, page } ) => {
 		await editor.insertBlock( {
 			name: 'core/columns',


### PR DESCRIPTION
Fixes #58824

## What?

This PR will correctly update the percentage width of each column to add up to 100% when two or more columns are added.

For example, if the widths of each of the four columns are `10%`, `20%`, `30%`, and `40%`, and the number of columns is increased to 6, each column width will be:

- trunk: `8.33%`, `16.67%`, `25%`, `33.33%`, `16.67%`, `16.67%` ( ❌ Total `116.67%` )
- This PR: `6.67%`, `13.33%`, `20%`, `26.66%`, `16.67%`, `16.67%` ( ✅ Total `100%` )

## Why?

If all columns have percentage widths and a column is added, the width of the existing columns will be recalculated to account for the width of the newly added column. However, it appears that the current logic did not take into account the scenario where more than one column was added.

## How?

I have taken into account the logic so that no matter how many newly added columns there are, the total value will always be 100%.

Additionally, since this scenario cannot be covered by unit tests, I added e2e tests.

## Testing Instructions

- Insert a Columns block with any number of columns.
- Applies a percentage width to all columns so that the column widths add up to 100%.
- Change the number of columns.
- The sum of all column widths should be 100%.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/05945f20-0428-4092-b5ae-940b11814809
