### PR TITLE
Replace Navigator isSmall prop WordPress/gutenberg#53560

### DIFF
--- a/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
+++ b/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
@@ -31,7 +31,7 @@ function ScreenHeader( { title } ) {
 								{ minWidth: 24, padding: 0 }
 							}
 							icon={ isRTL() ? chevronRight : chevronLeft }
-							isSmall
+							size="small"
 							aria-label={ __( 'Navigate to the previous view' ) }
 						/>
 						<Spacer>

--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -25,7 +25,7 @@ function ScreenHeader( { title, description, onBack } ) {
 								{ minWidth: 24, padding: 0 }
 							}
 							icon={ isRTL() ? chevronRight : chevronLeft }
-							isSmall
+							size="small"
 							aria-label={ __( 'Navigate to the previous view' ) }
 							onClick={ onBack }
 						/>


### PR DESCRIPTION
## What?
Replaced the isSmall property with size="small" for `Navigator` button components.

## Why?
https://github.com/WordPress/gutenberg/issues/53560