### PR TITLE
Remove scrolling of empty image blocks.

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -33,7 +33,6 @@
 			opacity: 0;
 		}
 	}
-
 	.block-bindings-media-placeholder-message {
 		opacity: 0;
 	}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,6 +1,12 @@
 // Provide special styling for the placeholder.
 // @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-image.wp-block-image {
+
+	&:not(.is-selected) .components-placeholder__fieldset {
+		// Show only is selected.
+		display: none;
+	}
+
 	// Show Placeholder style on-select.
 	&.is-selected .components-placeholder {
 		// Block UI appearance.
@@ -27,6 +33,8 @@
 			opacity: 0;
 		}
 	}
+
+
 	.block-bindings-media-placeholder-message {
 		opacity: 0;
 	}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -34,7 +34,6 @@
 		}
 	}
 
-
 	.block-bindings-media-placeholder-message {
 		opacity: 0;
 	}

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -183,6 +183,9 @@
 	}
 
 	.components-placeholder__fieldset {
+		// Show only is selected.
+		display: none;
+
 		width: auto;
 
 		// Unset intrinsic margins.
@@ -207,6 +210,10 @@
 		.components-button {
 			opacity: 1;
 			pointer-events: auto;
+		}
+
+		.components-placeholder__fieldset {
+			display: flex;
 		}
 	}
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -183,9 +183,6 @@
 	}
 
 	.components-placeholder__fieldset {
-		// Show only is selected.
-		display: none;
-
 		width: auto;
 
 		// Unset intrinsic margins.
@@ -210,10 +207,6 @@
 		.components-button {
 			opacity: 1;
 			pointer-events: auto;
-		}
-
-		.components-placeholder__fieldset {
-			display: flex;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Remove scrolling of empty image blocks.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix #59226.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Show `.components-placeholder__fieldset` only `is-selected`.

## Testing Instructions

It seems easiest to produce with the 'Team members' pattern that's included with WordPress 6.4/6.5 by default.

1. Insert that pattern
2. Resize the viewport until the scrollbars appear


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![スクリーンショット 2024-02-23 16 59 52](https://github.com/WordPress/gutenberg/assets/1908815/baeea448-b85f-44e3-9b2b-708b348817fd)


