### PR TITLE
Shadow: fix ui shifting when switching between shadow options

### DIFF
--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -95,7 +95,7 @@ export function ShadowIndicator( { label, isActive, onSelect, shadow } ) {
 					style={ { boxShadow: shadow } }
 					showTooltip
 				>
-					{ isActive && <Icon icon={ check } /> }
+					{ isActive && <Icon icon={ check } size={ 22 } /> }
 				</Button>
 			}
 		/>

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -31,6 +31,9 @@
 	margin-right: $grid-unit-15;
 	margin-bottom: $grid-unit-15;
 
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	height: $button-size-small + 2 * $border-width;
 	width: $button-size-small + 2 * $border-width;
 	box-sizing: border-box;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a followup fix for #58828

**Before**

![shadow-fix-before](https://github.com/WordPress/gutenberg/assets/1935113/f1a74c6c-420d-4428-b068-19b6084d4322)

**After**

![shadow-after-fix](https://github.com/WordPress/gutenberg/assets/1935113/889f4ac3-63a6-48f0-805e-0235a9a13a38)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open shadow from global or block styles (under Border & shadow panel)
2. Use keyboard left and right arrows to switch between the shadows.
3. There is a small ui shift before this fix and it should not be seen after this fix.
