### PR TITLE
Fix tooltip font

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fix
 
+-   `Tooltip`: Explicitly set system font to avoid CSS bleed ([#59307](https://github.com/WordPress/gutenberg/pull/59307)).
 -   `ToolbarButton`: Center text for short labels ([#59117](https://github.com/WordPress/gutenberg/pull/59117)).
 
 ### Internal

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `Tooltip`: Explicitly set system font to avoid CSS bleed ([#59307](https://github.com/WordPress/gutenberg/pull/59307)).
+
 ## 27.0.0 (2024-02-21)
 
 ### Breaking Changes
@@ -10,7 +14,6 @@
 
 ### Bug Fix
 
--   `Tooltip`: Explicitly set system font to avoid CSS bleed ([#59307](https://github.com/WordPress/gutenberg/pull/59307)).
 -   `ToolbarButton`: Center text for short labels ([#59117](https://github.com/WordPress/gutenberg/pull/59117)).
 
 ### Internal

--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -1,5 +1,6 @@
 .components-tooltip {
-	background: $black; // TODO: Discuss with designers.
+	background: $black;
+	font-family: $default-font;
 	border-radius: $radius-block-ui;
 	color: $gray-100;
 	text-align: center;


### PR DESCRIPTION
## What?

The tooltip component is affected by CSS bleed when invoked inside the canvas. This is the case in a few places, one of them being tooltips attached to placeholder variations:
![group block with variation focused and tooltip with incorrect font](https://github.com/WordPress/gutenberg/assets/1204802/b672cfdc-0825-4284-af3d-37986eac9437)

This PR explicitly sets the default font for the tooltip component to fix this:

![same as above, but with the correct font](https://github.com/WordPress/gutenberg/assets/1204802/4246df1a-9970-43b5-a3b5-c2c899692bec)

## Testing Instructions

Insert an empty group block, focus a variation, and observe the font for the tooltip no longer being affected by the theme font.

