### PR TITLE
Shadow: Fix layout collapse when indicator is selected

### DIFF
--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -2,8 +2,18 @@
 	fill: currentColor;
 }
 
+// @todo: Ideally, popover, swatch size, and gap values should be CSS variables
+// to apply precise grid layouts.
+// https://github.com/WordPress/gutenberg/blob/954ecae571abbddc113d3a4bd8e1a72230180554/packages/block-editor/src/components/duotone-control/style.scss#L3-L9
 .block-editor-global-styles__shadow-popover-container {
 	width: 230px;
+}
+
+.block-editor-global-styles__shadow__list {
+	display: flex;
+	gap: 12px;
+	flex-wrap: wrap;
+	padding-bottom: $grid-unit-10;
 }
 
 .block-editor-global-styles-filters-panel__dropdown,
@@ -28,8 +38,6 @@
 	border-radius: $radius-block-ui;
 	cursor: pointer;
 	padding: 0;
-	margin-right: $grid-unit-15;
-	margin-bottom: $grid-unit-15;
 
 	height: $button-size-small + 2 * $border-width;
 	width: $button-size-small + 2 * $border-width;


### PR DESCRIPTION
Follow up #58828

## What?

This PR fixes layout corruption when an indicator is selected in a shadow popover.

| Before | Header |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/4d05b47d-3362-4e09-a1a8-a0a518ea3aab) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/1313fd4b-701e-4f31-adcb-676d02236439) |

## Why?

As far as I can tell, this problem is caused by the indicator [margin](https://github.com/WordPress/gutenberg/pull/58828/files#diff-bd8c41ed80c9a311a6260e15c83b21bdd44de2db3a7c42d76324ea45395ad281R31-R32) added in #58828.

## How?

I removed the indicator margin and applied a flex layout. This is a minimal fix for WP6.5. In the future, popover width/gap and swatch width should be made into CSS variables and a calculated grid layout should be applied, like in [the duotone picker](https://github.com/WordPress/gutenberg/blob/954ecae571abbddc113d3a4bd8e1a72230180554/packages/block-editor/src/components/duotone-control/style.scss#L1-L9).

## Testing Instructions

- Open Global Styles and select the Button block.
- Open the shadow panel and click on any indicator.