### PR TITLE
Fix: Multi line comment format on footnotes block.

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -105,7 +105,7 @@ function register_block_core_footnotes_post_meta() {
 		}
 	}
 }
-/**
+/*
  * Most post types are registered at priority 10, so use priority 20 here in
  * order to catch them.
 */


### PR DESCRIPTION
Applies the feedback from @peterwilsoncc at https://github.com/WordPress/gutenberg/pull/58882#discussion_r1496539023.

Fixes the multiline comment format on the footnotes block.
