### PR TITLE
Fix canvas iframe button accessibility and silent tab stops

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -107,6 +107,7 @@ function Iframe( {
 	shouldZoom = false,
 	readonly,
 	forwardedRef: ref,
+	title = __( 'Editor canvas' ),
 	...props
 } ) {
 	const { resolvedAssets, isPreviewMode, isZoomOutMode } = useSelect(
@@ -301,7 +302,7 @@ function Iframe( {
 				// mode. Also preload the styles to avoid a flash of unstyled
 				// content.
 				src={ src }
-				title={ __( 'Editor canvas' ) }
+				title={ title }
 				onKeyDown={ ( event ) => {
 					if ( props.onKeyDown ) {
 						props.onKeyDown( event );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -284,9 +284,13 @@ function Iframe( {
 		}
 	}, [ scale, frameSize, marginFromScaling, iframeDocument ] );
 
+	// Make sure to not render the before and after focusable div elements in view
+	// mode. They're only needed to capture focus in edit mode.
+	const shouldRenderFocusCaptureElements = tabIndex >= 0 && ! isPreviewMode;
+
 	return (
 		<>
-			{ tabIndex >= 0 && before }
+			{ shouldRenderFocusCaptureElements && before }
 			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
 			<iframe
 				{ ...props }
@@ -347,7 +351,7 @@ function Iframe( {
 						iframeDocument.documentElement
 					) }
 			</iframe>
-			{ tabIndex >= 0 && after }
+			{ shouldRenderFocusCaptureElements && after }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -52,8 +52,11 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 		}
 	}, [ canvasMode ] );
 
-	const viewModeProps = {
-		'aria-label': __( 'Editor Canvas' ),
+	// In view mode, make the canvas iframe be perceived and behave as a button
+	// to switch to edit mode, with a meaningful label and no title attribute.
+	const viewModeIframeProps = {
+		'aria-label': __( 'Edit' ),
+		title: null,
 		role: 'button',
 		tabIndex: 0,
 		onFocus: () => setIsFocused( true ),
@@ -115,7 +118,7 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 					}
 				),
 				...props,
-				...( canvasMode === 'view' ? viewModeProps : {} ),
+				...( canvasMode === 'view' ? viewModeIframeProps : {} ),
 			} }
 		>
 			{ children }

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -45,12 +45,26 @@ test.describe( 'Site editor navigation', () => {
 			page.getByRole( 'button', { name: 'Pages' } )
 		).toBeFocused();
 
-		// Test: Can navigate into the iframe using the keyboard
-		await editorNavigationUtils.tabToLabel( 'Editor Canvas' );
-		const editorCanvasButton = page.getByRole( 'button', {
-			name: 'Editor Canvas',
+		// Navigate to the Saved button first, as it precedes the editor iframe.
+		await editorNavigationUtils.tabToLabel( 'Saved' );
+		const savedButton = page.getByRole( 'button', {
+			name: 'Saved',
+		} );
+		await expect( savedButton ).toBeFocused();
+
+		// Test: Can navigate into the iframe using the keyboard.
+		// At this point the iframe has an ARIA role=button and it's labeled 'Edit'.
+		await editorNavigationUtils.tabToLabel( 'Edit' );
+
+		// Make sure to get the iframe with role=button.
+		const editorCanvasRegion = page.getByRole( 'region', {
+			name: 'Editor content',
+		} );
+		const editorCanvasButton = editorCanvasRegion.getByRole( 'button', {
+			name: 'Edit',
 		} );
 		await expect( editorCanvasButton ).toBeFocused();
+
 		// Enter into the site editor frame
 		await pageUtils.pressKeys( 'Enter' );
 		// Focus should be on the iframe without the button role

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -52,18 +52,27 @@ test.describe( 'Site editor navigation', () => {
 		} );
 		await expect( savedButton ).toBeFocused();
 
-		// Test: Can navigate into the iframe using the keyboard.
-		// At this point the iframe has an ARIA role=button and it's labeled 'Edit'.
-		await editorNavigationUtils.tabToLabel( 'Edit' );
-
-		// Make sure to get the iframe with role=button.
+		// Get the iframe when it has a role=button and Edit label.
 		const editorCanvasRegion = page.getByRole( 'region', {
 			name: 'Editor content',
 		} );
 		const editorCanvasButton = editorCanvasRegion.getByRole( 'button', {
 			name: 'Edit',
 		} );
+
+		// Test that there are no tab stops between the Saved button and the
+		// focusable iframe with role=button.
+		await pageUtils.pressKeys( 'Tab' );
 		await expect( editorCanvasButton ).toBeFocused();
+
+		// Tab to the Pages item to move focus back in the UI.
+		await editorNavigationUtils.tabToLabel( 'Pages' );
+		await expect(
+			page.getByRole( 'button', { name: 'Pages' } )
+		).toBeFocused();
+
+		// Test again can navigate into the iframe using the keyboard.
+		await editorNavigationUtils.tabToLabel( 'Edit' );
 
 		// Enter into the site editor frame
 		await pageUtils.pressKeys( 'Enter' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/47780
Fixes https://github.com/WordPress/gutenberg/issues/51540

## What?
<!-- In a few words, what is the PR actually doing? -->
In the Site editor, in view mode, the preview iframe behaves like a button to switch the editor to edit mode. That's mainly for keyboard interaction and screen reader users. However:
- Its labeling is 'Editor canvas', which doesn't make much sense for a button.
- There are to silent tab stope, one before the iframe and one after.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Buttons should be labeled accordingly to what they do ie. the available action.
- Silent tab stops are a subpar experience for all keyboard users, including users of assistive technologu.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- In view mode, when the iframe has a `role=button`:
  - Make the button label 'Edit', for consistnecy with other buttons that switch the editor to edit mode.
  - Avoid to render a title attribute as this is a button.
- In other modes e.g. edit mode, when the iframe keeps its native role:
  - Keep rendering the title attribute: iframes need a title attribute
- Renames a variable from `viewModeProps` to `viewModeIframeProps` as those ar props for the iframe.
- Prevents fro rendering the 'before' and 'after' focusable div elements when the editor is in view mode. Those elements are necessary to capture the focus for writingFlow only when editing. They're not necessary in view mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Terminology reminder; the 'view mode' is the initial state fo the Site editor, the one that shows the navigation panel and the site preview.

- Go to the Site editor, in view mode.
- Inspect the source and observe the iframe with CSS class `edit-site-visual-editor__editor-canvas`:
  - Has a role="button"
  - Has an aria-label="Edit"
  - Does not have a title attribute
  - Does not have focusable div elements before and after. See screenshot: those elements should NOT be rendered in view mode:

![Screenshot 2024-02-23 at 11 19 36](https://github.com/WordPress/gutenberg/assets/1682452/d0a65bdc-29ca-4117-9e68-3041a70226cd)

- Use the Tabkey to navigate the UI and observe there's no silent tab stop between the 'Saved' button in the navigation panel  and the iframe preview.
- CLick the preview to switch the editor to edit mode.
- Inspect the source and observe the focusable div elements before and after the editor are now rendered.
- Observe the iframe element does have a title attribute 'Editor canvas'.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
