### PR TITLE
Font face resolver: print font faces from font families defined in all theme.json origins

### DIFF
--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
@@ -71,12 +71,7 @@ if ( ! class_exists( 'WP_Font_Face_Resolver' ) ) {
 						continue;
 					}
 
-					// Prepare the fonts array structure for this font-family.
-					if ( ! array_key_exists( $font_family_name, $fonts ) ) {
-						$fonts[ $font_family_name ] = array();
-					}
-
-					$fonts[ $font_family_name ] = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
+					$fonts[] = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
 				}
 			}
 

--- a/lib/compat/wordpress-6.4/fonts/fonts.php
+++ b/lib/compat/wordpress-6.4/fonts/fonts.php
@@ -21,16 +21,16 @@ if ( ! function_exists( 'wp_print_font_faces' ) ) {
 	 * @since 6.4.0
 	 *
 	 * @param array[][] $fonts {
-	 *     Optional. The font-families and their font variations. Default empty array.
+	 *     Optional. The font-families and their font faces. Default empty array.
 	 *
-	 *     @type string $font-family => array[] $variations {
-	 *         Optional. An associated array of font variations for this font-family.
-	 *         Each variation has the following structure.
+	 *     @type array {
+	 *         An indexed or associative (keyed by font-family) array of font variations for this font-family.
+	 *         Each font face has the following structure.
 	 *
-	 *         @type array $font_variation {
+	 *         @type array {
 	 *             @type string          $font-family             The font-family property.
 	 *             @type string|string[] $src                     The URL(s) to each resource containing the font data.
-	 *             @type string          $font_style              Optional. The font-style property. Default 'normal'.
+	 *             @type string          $font-style              Optional. The font-style property. Default 'normal'.
 	 *             @type string          $font-weight             Optional. The font-weight property. Default '400'.
 	 *             @type string          $font-display            Optional. The font-display property. Default 'fallback'.
 	 *             @type string          $ascent-override         Optional. The ascent-override property.


### PR DESCRIPTION
## What?
Font face resolver: print font faces from font families defined in all theme.json origins


## Why?
Porting this fix from core PR: https://github.com/WordPress/wordpress-develop/pull/6161


## How?
see https://github.com/WordPress/wordpress-develop/pull/6161

## Testing Instructions
see https://github.com/WordPress/wordpress-develop/pull/6161

