### PR TITLE
fix: UBE hides post title input

### DIFF
--- a/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
@@ -8,6 +8,7 @@
     display: none;
 }
 
+.edit-post-visual-editor__post-title-wrapper,
 .editor-editor-canvas__post-title-wrapper {
     display: none;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Hide the post title input when the editor is displayed for the context of the
unsupported block editor (UBE) for sites running older versions of Gutenberg
— e.g., the block editor in WordPress core rather than a plugin.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The post title is distracting when editing a single block. The erroneous
visibility of the post title field currently only occurs for older versions of
the Gutenberg plugin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Apply the hidden styles to the legacy post title class name that is present for
older plugin versions.

https://github.com/WordPress/gutenberg/blob/0b8c3adb264d8c551b583eef7b75c31af699bf3d/packages/editor/src/components/editor-canvas/index.js#L363-L365

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

> [!TIP]
> Use a prototype build: [iOS](https://github.com/wordpress-mobile/WordPress-Android/pull/20265#issuecomment-1961772019) or [Android](https://github.com/wordpress-mobile/WordPress-iOS/pull/22699#issuecomment-1961762695). 

1. Use a site with block editor features enabled via core but _without_ the Gutenberg plugin enabled. 
1. Attempt to edit an unsupported block with the UBE.
1. Verify the post title field is invisible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no changes to keyboard flow.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| - | - |
| ![before-ube-with-visible-post-title](https://github.com/WordPress/gutenberg/assets/438664/269f13be-10ce-4225-8d2a-42970bee72eb) | ![after-ube-with-hidden-post-title](https://github.com/WordPress/gutenberg/assets/438664/5378d6d6-a356-4f1f-96f8-e7556ca95562) |
