### PR TITLE
Block Bindings: Don't show protected fields that are bound to blocks

### DIFF
--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -15,7 +15,7 @@
  */
 function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_instance ) {
 	if ( empty( $source_attrs['key'] ) ) {
-		return '';
+		return null;
 	}
 
 	if ( empty( $block_instance->context['postId'] ) ) {

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -19,18 +19,18 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 	}
 
 	if ( empty( $block_instance->context['postId'] ) ) {
-		return '';
+		return null;
 	}
 	$post_id = $block_instance->context['postId'];
 	// If a post isn't public, we need to prevent unauthorized users from accessing the post meta.
 	$post = get_post( $post_id );
 	if ( ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) || post_password_required( $post ) ) {
-		return '';
+		return null;
 	}
 
 	// Check if the meta field is protected.
 	if ( is_protected_meta( $source_attrs['key'], 'post' ) ) {
-		return '';
+		return null;
 	}
 
 	// Check if the meta field is registered to be shown in REST.
@@ -38,7 +38,7 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 	// Add fields registered for all subtypes.
 	$meta_keys = array_merge( $meta_keys, get_registered_meta_keys( 'post', '' ) );
 	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) || false === $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) {
-		return '';
+		return null;
 	}
 
 	return get_post_meta( $post_id, $source_attrs['key'], true );

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -15,22 +15,22 @@
  */
 function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_instance ) {
 	if ( empty( $source_attrs['key'] ) ) {
-		return null;
+		return '';
 	}
 
 	if ( empty( $block_instance->context['postId'] ) ) {
-		return null;
+		return '';
 	}
 	$post_id = $block_instance->context['postId'];
 	// If a post isn't public, we need to prevent unauthorized users from accessing the post meta.
 	$post = get_post( $post_id );
 	if ( ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) || post_password_required( $post ) ) {
-		return null;
+		return '';
 	}
 
 	// Check if the meta field is protected.
 	if ( is_protected_meta( $source_attrs['key'], 'post' ) ) {
-		return null;
+		return '';
 	}
 
 	// Check if the meta field is registered to be shown in REST.
@@ -38,7 +38,7 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 	// Add fields registered for all subtypes.
 	$meta_keys = array_merge( $meta_keys, get_registered_meta_keys( 'post', '' ) );
 	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) || false === $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) {
-		return null;
+		return '';
 	}
 
 	return get_post_meta( $post_id, $source_attrs['key'], true );

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -34,10 +34,10 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 	}
 
 	// Check if the meta field is registered to be shown in REST.
-	// It follows the format: $wp_meta_keys[ $object_type ][ $object_subtype ][ $meta_key ].
-	global $wp_meta_keys;
-	$object_subtype = 'post' === $block_instance->context['postType'] ? '' : $block_instance->context['postType'];
-	if ( empty( $wp_meta_keys['post'][ $object_subtype ][ $source_attrs['key'] ]['show_in_rest'] ) || false === $wp_meta_keys['post'][ $object_subtype ][ $source_attrs['key'] ]['show_in_rest'] ) {
+	$meta_keys = get_registered_meta_keys( 'post', $block_instance->context['postType'] );
+	// Add fields registered for all subtypes.
+	$meta_keys = array_merge( $meta_keys, get_registered_meta_keys( 'post', '' ) );
+	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) || false === $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) {
 		return null;
 	}
 

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -28,6 +28,11 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 		return null;
 	}
 
+	// Check if the meta field is protected.
+	if ( is_protected_meta( $source_attrs['key'], 'post' ) ) {
+		return null;
+	}
+
 	return get_post_meta( $post_id, $source_attrs['key'], true );
 }
 

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -33,6 +33,14 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 		return null;
 	}
 
+	// Check if the meta field is registered to be shown in REST.
+	// It follows the format: $wp_meta_keys[ $object_type ][ $object_subtype ][ $meta_key ].
+	global $wp_meta_keys;
+	$object_subtype = 'post' === $block_instance->context['postType'] ? '' : $block_instance->context['postType'];
+	if ( empty( $wp_meta_keys['post'][ $object_subtype ][ $source_attrs['key'] ]['show_in_rest'] ) || false === $wp_meta_keys['post'][ $object_subtype ][ $source_attrs['key'] ]['show_in_rest'] ) {
+		return null;
+	}
+
 	return get_post_meta( $post_id, $source_attrs['key'], true );
 }
 

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -37,7 +37,7 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 	$meta_keys = get_registered_meta_keys( 'post', $block_instance->context['postType'] );
 	// Add fields registered for all subtypes.
 	$meta_keys = array_merge( $meta_keys, get_registered_meta_keys( 'post', '' ) );
-	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) || false === $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) {
+	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) ) {
 		return null;
 	}
 

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -21,7 +21,6 @@ function gutenberg_test_block_bindings_register_custom_fields() {
 			'default'      => 'Value of the text_custom_field',
 		)
 	);
-	// TODO: Change url.
 	register_meta(
 		'post',
 		'url_custom_field',
@@ -30,6 +29,25 @@ function gutenberg_test_block_bindings_register_custom_fields() {
 			'type'         => 'string',
 			'single'       => true,
 			'default'      => '#url-custom-field',
+		)
+	);
+	register_meta(
+		'post',
+		'_protected_field',
+		array(
+			'type'    => 'string',
+			'single'  => true,
+			'default' => 'protected field value',
+		)
+	);
+	register_meta(
+		'post',
+		'show_in_rest_false_field',
+		array(
+			'show_in_rest' => false,
+			'type'         => 'string',
+			'single'       => true,
+			'default'      => 'show_in_rest false field value',
 		)
 	);
 }

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1218,7 +1218,7 @@ test.describe( 'Block bindings', () => {
 					name: 'core/paragraph',
 					attributes: {
 						anchor: 'paragraph-binding',
-						content: 'p',
+						content: 'fallback value',
 						metadata: {
 							bindings: {
 								content: {
@@ -1244,9 +1244,73 @@ test.describe( 'Block bindings', () => {
 				// Check the frontend doesn't show the content.
 				const postId = await editor.publishPost();
 				await page.goto( `/?p=${ postId }` );
-				await expect(
-					page.locator( '#paragraph-binding' )
-				).toBeHidden();
+				await expect( page.locator( '#paragraph-binding' ) ).toHaveText(
+					'fallback value'
+				);
+			} );
+
+			test( 'should not show the value of a protected meta field', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						anchor: 'paragraph-binding',
+						content: 'fallback value',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: { key: '_protected_field' },
+								},
+							},
+						},
+					},
+				} );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+				await expect( paragraphBlock ).toHaveText( '_protected_field' );
+				// Check the frontend doesn't show the content.
+				const postId = await editor.publishPost();
+				await page.goto( `/?p=${ postId }` );
+				await expect( page.locator( '#paragraph-binding' ) ).toHaveText(
+					'fallback value'
+				);
+			} );
+
+			test( 'should not show the value of a meta field with `show_in_rest` false', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						anchor: 'paragraph-binding',
+						content: 'fallback value',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: { key: 'show_in_rest_false_field' },
+								},
+							},
+						},
+					},
+				} );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+				await expect( paragraphBlock ).toHaveText(
+					'show_in_rest_false_field'
+				);
+				// Check the frontend doesn't show the content.
+				const postId = await editor.publishPost();
+				await page.goto( `/?p=${ postId }` );
+				await expect( page.locator( '#paragraph-binding' ) ).toHaveText(
+					'fallback value'
+				);
 			} );
 		} );
 

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1245,7 +1245,7 @@ test.describe( 'Block bindings', () => {
 				const postId = await editor.publishPost();
 				await page.goto( `/?p=${ postId }` );
 				await expect( page.locator( '#paragraph-binding' ) ).toHaveText(
-					'fallback value'
+					'non_existing_custom_field'
 				);
 			} );
 
@@ -1276,7 +1276,7 @@ test.describe( 'Block bindings', () => {
 				const postId = await editor.publishPost();
 				await page.goto( `/?p=${ postId }` );
 				await expect( page.locator( '#paragraph-binding' ) ).toHaveText(
-					'fallback value'
+					'_protected_field'
 				);
 			} );
 
@@ -1309,7 +1309,7 @@ test.describe( 'Block bindings', () => {
 				const postId = await editor.publishPost();
 				await page.goto( `/?p=${ postId }` );
 				await expect( page.locator( '#paragraph-binding' ) ).toHaveText(
-					'fallback value'
+					'show_in_rest_false_field'
 				);
 			} );
 		} );


### PR DESCRIPTION
## What?
This pull request adds two safety checks to ensure block bindings don't leak private post meta:
* Check if the meta field is protected.
* Check if the meta field is available through the REST API.

## Why?
It seems safer to add these limitations to ensure no unwanted data is leaked. And we can explore later how to to loosen these restrictions.

## How?
* Use the [is_protected_meta function](https://developer.wordpress.org/reference/functions/is_protected_meta/) to check if it is protected.
* Access the `$meta_keys` through [get_registered_meta_keys function](https://developer.wordpress.org/reference/functions/get_registered_meta_keys/) to check if the specific key has the `show_in_rest` property enabled.

## Testing Instructions

**Test it doesn't show the protected value when `show_in_rest` is false**


1. Register a custom field with `show_in_rest` set to false:

```PHP
register_meta(
	'post',
	'protected',
	array(
		'show_in_rest'   => false,
		'single'         => true,
		'type'           => 'string',
		'default'        => 'Protected value',
	)
);
```

3. Add a paragraph block in a page pointing to the protected block:

```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"protected"}}}}} -->
<p>Text</p>
<!-- /wp:paragraph -->
```

4. Save the page, go to the front and check it doesn't show the protected value.

**Test protected custom field**

1. Change the register source to `show_in_rest` true but protect it. It can be done adding a `_` at the beginning of the key or using a filter like this one:

```php
function protect_meta( $protected, $meta_key, $meta_type ) {
        return true;
}
add_filter( 'is_protected_meta', 'protect_meta', 10, 3 );
```

2. Check that the paragraph bound to the protected field doesn't show the protected value in the frontend.