### PR TITLE
Adds import statement to code usage example

### DIFF
--- a/packages/html-entities/README.md
+++ b/packages/html-entities/README.md
@@ -23,6 +23,8 @@ Decodes the HTML entities from a given string.
 _Usage_
 
 ```js
+import { decodeEntities } from "@wordpress/html-entities";
+
 const result = decodeEntities( '&aacute;' );
 console.log( result ); // result will be "á"
 ```

--- a/packages/html-entities/README.md
+++ b/packages/html-entities/README.md
@@ -23,7 +23,7 @@ Decodes the HTML entities from a given string.
 _Usage_
 
 ```js
-import { decodeEntities } from "@wordpress/html-entities";
+import { decodeEntities } from '@wordpress/html-entities';
 
 const result = decodeEntities( '&aacute;' );
 console.log( result ); // result will be "á"

--- a/packages/html-entities/src/index.js
+++ b/packages/html-entities/src/index.js
@@ -8,6 +8,8 @@ let _decodeTextArea;
  *
  * @example
  * ```js
+ * import { decodeEntities } from '@wordpress/html-entities';
+ *
  * const result = decodeEntities( '&aacute;' );
  * console.log( result ); // result will be "á"
  * ```


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a minor documentation change to add the `import` statement to the code example. This seems to be a consistent pattern. Examples from other packages:

- https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
- https://developer.wordpress.org/block-editor/reference-guides/packages/packages-autop/

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Added for consistency and because import statements in the example code can be  helpful for newer developers.
