### PR TITLE
Block Bindings: Add connection icon to list view

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -290,7 +290,6 @@ function ListViewBlockSelectButton(
 					{ positionLabel && isSticky && (
 						<Tooltip text={ positionLabel }>
 							<Icon icon={ pinSmall } />
-							text
 						</Tooltip>
 					) }
 					{ images.length ? (

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -14,7 +14,12 @@ import {
 	Tooltip,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { Icon, lockSmall as lock, pinSmall } from '@wordpress/icons';
+import {
+	Icon,
+	connection,
+	lockSmall as lock,
+	pinSmall,
+} from '@wordpress/icons';
 import { SPACE, ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
@@ -66,6 +71,7 @@ function ListViewBlockSelectButton(
 		getBlockRootClientId,
 		getBlockOrder,
 		getBlocksByClientId,
+		getBlockAttributes,
 		canRemoveBlocks,
 	} = useSelect( blockEditorStore );
 	const { duplicateBlocks, multiSelect, removeBlocks } =
@@ -74,6 +80,8 @@ function ListViewBlockSelectButton(
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
 	const { rootClientId } = useListViewContext();
+
+	const isConnected = getBlockAttributes( clientId )?.metadata?.bindings;
 
 	const positionLabel = blockInformation?.positionLabel
 		? sprintf(
@@ -278,9 +286,11 @@ function ListViewBlockSelectButton(
 							</Truncate>
 						</span>
 					) }
+					{ isConnected && <Icon icon={ connection } /> }
 					{ positionLabel && isSticky && (
 						<Tooltip text={ positionLabel }>
 							<Icon icon={ pinSmall } />
+							text
 						</Tooltip>
 					) }
 					{ images.length ? (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds a connection icon to the list view when block bindings are active.
Related to UI improvements in https://github.com/WordPress/gutenberg/pull/59185 and is part of improvements proposed in https://github.com/WordPress/gutenberg/issues/58978.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To provide better visual indications of when blocks are connected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Checks to see if bindings are present, and if so, adds the icon in the `block-select-button.js` file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Please use instructions from https://github.com/WordPress/gutenberg/pull/58085, then check to see that the connection icon appears in the list view.

## Screenshots or screencast <!-- if applicable -->
<img width="1404" alt="Screenshot 2024-02-23 at 5 16 36 PM" src="https://github.com/WordPress/gutenberg/assets/5360536/5e17b724-972d-4482-b5e1-877e1f1d3684">
