### PR TITLE
Font Library: create post types on init hook

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -86,18 +86,21 @@ function gutenberg_create_initial_post_types() {
 
 /**
  * Initializes REST routes.
- *
- * @since 6.5
  */
 function gutenberg_create_initial_rest_routes() {
-	$font_collections_controller = new WP_REST_Font_Collections_Controller();
-	$font_collections_controller->register_routes();
+	global $wp_version;
+
+	// Runs only if the Font Library is not available in core ( i.e. in core < 6.5-alpha ).
+	if ( version_compare( $wp_version, '6.5-alpha', '<' ) ) {
+		$font_collections_controller = new WP_REST_Font_Collections_Controller();
+		$font_collections_controller->register_routes();
+	}
 }
+
+add_action( 'rest_api_init', 'gutenberg_create_initial_rest_routes' );
 
 /**
  * Initializes REST routes and post types.
- *
- * @since 6.5
  */
 function gutenberg_init_font_library() {
 	global $wp_version;
@@ -105,11 +108,10 @@ function gutenberg_init_font_library() {
 	// Runs only if the Font Library is not available in core ( i.e. in core < 6.5-alpha ).
 	if ( version_compare( $wp_version, '6.5-alpha', '<' ) ) {
 		gutenberg_create_initial_post_types();
-		gutenberg_create_initial_rest_routes();
 	}
 }
 
-add_action( 'rest_api_init', 'gutenberg_init_font_library' );
+add_action( 'init', 'gutenberg_init_font_library' );
 
 
 if ( ! function_exists( 'wp_register_font_collection' ) ) {


### PR DESCRIPTION
## What?

Register font post types for all requests.

## Why?

To ensure the post types are available to inspect or customize.

Found while working on https://github.com/WordPress/gutenberg/pull/59294. `$post_type = get_post_type_object( 'wp_font_face' );` did not work outside of REST API routes.

## How?

Register `wp_font_family` and `wp_font_face` post types on the `init` hook.

## Testing Instructions

Test with WP 6.4: ensure font library continues to work as expected
