### PR TITLE
View zoom out canvas while inserting patterns

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -767,3 +767,13 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 }
+
+.is-zoom-out {
+	.block-editor-inserter__menu {
+		display: flex;
+	}
+
+	.block-editor-inserter__patterns-category-dialog {
+		position: static;
+	}
+}

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -70,7 +70,7 @@ export default function Layout() {
 
 	const {
 		isDistractionFree,
-		isZoomOut,
+		isZoomOutMode,
 		hasFixedToolbar,
 		hasBlockSelected,
 		canvasMode,
@@ -97,7 +97,7 @@ export default function Layout() {
 				'core',
 				'distractionFree'
 			),
-			isZoomOut:
+			isZoomOutMode:
 				select( blockEditorStore ).__unstableGetEditorMode() ===
 				'zoom-out',
 			hasBlockSelected:
@@ -176,7 +176,7 @@ export default function Layout() {
 						'is-full-canvas': canvasMode === 'edit',
 						'has-fixed-toolbar': hasFixedToolbar,
 						'is-block-toolbar-visible': hasBlockSelected,
-						'is-zoom-out': isZoomOut,
+						'is-zoom-out': isZoomOutMode,
 					}
 				) }
 			>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -70,6 +70,7 @@ export default function Layout() {
 
 	const {
 		isDistractionFree,
+		isZoomOut,
 		hasFixedToolbar,
 		hasBlockSelected,
 		canvasMode,
@@ -96,6 +97,9 @@ export default function Layout() {
 				'core',
 				'distractionFree'
 			),
+			isZoomOut:
+				select( blockEditorStore ).__unstableGetEditorMode() ===
+				'zoom-out',
 			hasBlockSelected:
 				select( blockEditorStore ).getBlockSelectionStart(),
 		};
@@ -172,6 +176,7 @@ export default function Layout() {
 						'is-full-canvas': canvasMode === 'edit',
 						'has-fixed-toolbar': hasFixedToolbar,
 						'is-block-toolbar-visible': hasBlockSelected,
+						'is-zoom-out': isZoomOut,
 					}
 				) }
 			>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allow full zoom out mode canvas to be visible while inserting patterns from the inserter sidebar

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Exploring [improved UX for pattern insertion with zoom out mode ](https://github.com/WordPress/gutenberg/issues/59336)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds top level classname for `is-zoom-out` at the same level as `is-distraction-free`, etc.
- Pushes zoom out mode canvas to be fully visible while pattern inserter is open

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Enable zoom out mode Gutenberg experiment
- Site editor in edit mode
- Enter zoom out mode
- Toggle Block inserter
- Open Pattern tab
- Zoom out mode canvas should shrink to available area

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/1813435/4f1390f3-c209-4a3b-bc39-8526e04cb1bb



