### PR TITLE
Upgrade Playwright to v1.42

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.6.0",
-				"@playwright/test": "1.39.0",
+				"@playwright/test": "1.41.2",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -7179,12 +7179,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
-			"integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
+			"integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.39.0"
+				"playwright": "1.41.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -43858,12 +43858,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-			"integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
+			"integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.39.0"
+				"playwright-core": "1.41.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -43875,10 +43875,10 @@
 				"fsevents": "2.3.2"
 			}
 		},
-		"node_modules/playwright/node_modules/playwright-core": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-			"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+		"node_modules/playwright-core": {
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
+			"integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -57088,7 +57088,6 @@
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
-				"playwright-core": "1.39.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
@@ -57115,7 +57114,7 @@
 				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.39.0",
+				"@playwright/test": "^1.41.2",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -57185,18 +57184,6 @@
 				"@sideway/address": "^4.1.3",
 				"@sideway/formula": "^3.0.1",
 				"@sideway/pinpoint": "^2.0.0"
-			}
-		},
-		"packages/scripts/node_modules/playwright-core": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-			"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
-			"dev": true,
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"packages/scripts/node_modules/rxjs": {
@@ -62424,12 +62411,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
-			"integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
+			"integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.39.0"
+				"playwright": "1.41.2"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -72497,7 +72484,6 @@
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
-				"playwright-core": "1.39.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
@@ -72571,12 +72557,6 @@
 						"@sideway/formula": "^3.0.1",
 						"@sideway/pinpoint": "^2.0.0"
 					}
-				},
-				"playwright-core": {
-					"version": "1.39.0",
-					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-					"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
-					"dev": true
 				},
 				"rxjs": {
 					"version": "7.8.1",
@@ -91323,22 +91303,20 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-			"integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
+			"integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.39.0"
-			},
-			"dependencies": {
-				"playwright-core": {
-					"version": "1.39.0",
-					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-					"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
-					"dev": true
-				}
+				"playwright-core": "1.41.2"
 			}
+		},
+		"playwright-core": {
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
+			"integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+			"dev": true
 		},
 		"please-upgrade-node": {
 			"version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.6.0",
-				"@playwright/test": "1.41.2",
+				"@playwright/test": "1.42.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -7179,12 +7179,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-			"integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.0.tgz",
+			"integrity": "sha512-2k1HzC28Fs+HiwbJOQDUwrWMttqSLUVdjCqitBOjdCD0svWOMQUVqrXX6iFD7POps6xXAojsX/dGBpKnjZctLA==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.41.2"
+				"playwright": "1.42.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -43858,12 +43858,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-			"integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.0.tgz",
+			"integrity": "sha512-Ko7YRUgj5xBHbntrgt4EIw/nE//XBHOKVKnBjO1KuZkmkhlbgyggTe5s9hjqQ1LpN+Xg+kHsQyt5Pa0Bw5XpvQ==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.41.2"
+				"playwright-core": "1.42.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -43876,9 +43876,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-			"integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.0.tgz",
+			"integrity": "sha512-0HD9y8qEVlcbsAjdpBaFjmaTHf+1FeIddy8VJLeiqwhcNqGCBe4Wp2e8knpqiYbzxtxarxiXyNDw2cG8sCaNMQ==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -57114,7 +57114,7 @@
 				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.41.2",
+				"@playwright/test": "^1.42.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -62411,12 +62411,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-			"integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.0.tgz",
+			"integrity": "sha512-2k1HzC28Fs+HiwbJOQDUwrWMttqSLUVdjCqitBOjdCD0svWOMQUVqrXX6iFD7POps6xXAojsX/dGBpKnjZctLA==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.41.2"
+				"playwright": "1.42.0"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -91303,19 +91303,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-			"integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.0.tgz",
+			"integrity": "sha512-Ko7YRUgj5xBHbntrgt4EIw/nE//XBHOKVKnBjO1KuZkmkhlbgyggTe5s9hjqQ1LpN+Xg+kHsQyt5Pa0Bw5XpvQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.41.2"
+				"playwright-core": "1.42.0"
 			}
 		},
 		"playwright-core": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-			"integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.0.tgz",
+			"integrity": "sha512-0HD9y8qEVlcbsAjdpBaFjmaTHf+1FeIddy8VJLeiqwhcNqGCBe4Wp2e8knpqiYbzxtxarxiXyNDw2cG8sCaNMQ==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.6.0",
-				"@playwright/test": "1.42.0",
+				"@playwright/test": "1.42.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -7179,12 +7179,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.0.tgz",
-			"integrity": "sha512-2k1HzC28Fs+HiwbJOQDUwrWMttqSLUVdjCqitBOjdCD0svWOMQUVqrXX6iFD7POps6xXAojsX/dGBpKnjZctLA==",
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
+			"integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.42.0"
+				"playwright": "1.42.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -43858,12 +43858,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.0.tgz",
-			"integrity": "sha512-Ko7YRUgj5xBHbntrgt4EIw/nE//XBHOKVKnBjO1KuZkmkhlbgyggTe5s9hjqQ1LpN+Xg+kHsQyt5Pa0Bw5XpvQ==",
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
+			"integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.42.0"
+				"playwright-core": "1.42.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -43876,9 +43876,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.0.tgz",
-			"integrity": "sha512-0HD9y8qEVlcbsAjdpBaFjmaTHf+1FeIddy8VJLeiqwhcNqGCBe4Wp2e8knpqiYbzxtxarxiXyNDw2cG8sCaNMQ==",
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
+			"integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -57114,7 +57114,7 @@
 				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.42.0",
+				"@playwright/test": "^1.42.1",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -62411,12 +62411,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.0.tgz",
-			"integrity": "sha512-2k1HzC28Fs+HiwbJOQDUwrWMttqSLUVdjCqitBOjdCD0svWOMQUVqrXX6iFD7POps6xXAojsX/dGBpKnjZctLA==",
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
+			"integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.42.0"
+				"playwright": "1.42.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -91303,19 +91303,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.0.tgz",
-			"integrity": "sha512-Ko7YRUgj5xBHbntrgt4EIw/nE//XBHOKVKnBjO1KuZkmkhlbgyggTe5s9hjqQ1LpN+Xg+kHsQyt5Pa0Bw5XpvQ==",
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
+			"integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.42.0"
+				"playwright-core": "1.42.1"
 			}
 		},
 		"playwright-core": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.0.tgz",
-			"integrity": "sha512-0HD9y8qEVlcbsAjdpBaFjmaTHf+1FeIddy8VJLeiqwhcNqGCBe4Wp2e8knpqiYbzxtxarxiXyNDw2cG8sCaNMQ==",
+			"version": "1.42.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
+			"integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",
-		"@playwright/test": "1.42.0",
+		"@playwright/test": "1.42.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",
-		"@playwright/test": "1.39.0",
+		"@playwright/test": "1.41.2",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",
-		"@playwright/test": "1.41.2",
+		"@playwright/test": "1.42.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -72,7 +72,6 @@
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^6.4.0",
 		"npm-packlist": "^3.0.0",
-		"playwright-core": "1.39.0",
 		"postcss": "^8.4.5",
 		"postcss-loader": "^6.2.1",
 		"prettier": "npm:wp-prettier@3.0.3",
@@ -92,7 +91,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.39.0",
+		"@playwright/test": "^1.41.2",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -91,7 +91,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.41.2",
+		"@playwright/test": "^1.42.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -91,7 +91,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.42.0",
+		"@playwright/test": "^1.42.1",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/packages/scripts/scripts/test-playwright.js
+++ b/packages/scripts/scripts/test-playwright.js
@@ -12,7 +12,6 @@ process.on( 'unhandledRejection', ( err ) => {
 /**
  * External dependencies
  */
-const path = require( 'path' );
 const { resolve } = require( 'node:path' );
 const { sync: spawn } = require( 'cross-spawn' );
 
@@ -28,20 +27,9 @@ const {
 } = require( '../utils' );
 
 if ( ! getAsBooleanFromENV( 'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD' ) ) {
-	const result = spawn(
-		'node',
-		[
-			path.resolve(
-				require.resolve( 'playwright-core' ),
-				'..',
-				'cli.js'
-			),
-			'install',
-		],
-		{
-			stdio: 'inherit',
-		}
-	);
+	const result = spawn( 'npx', [ 'playwright', 'install' ], {
+		stdio: 'inherit',
+	} );
 
 	if ( result.status > 0 ) {
 		process.exit( result.status );

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -123,6 +123,7 @@ test.describe( 'Block Switcher', () => {
 	test( 'Should show Columns block only if selected blocks are between limits (1-6)', async ( {
 		editor,
 		page,
+		pageUtils,
 	} ) => {
 		await editor.canvas
 			.getByRole( 'button', { name: 'Add default block' } )
@@ -131,9 +132,7 @@ test.describe( 'Block Switcher', () => {
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '## I am a header' );
-		await page.keyboard.down( 'Shift' );
-		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.up( 'Shift' );
+		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
 
 		await page
 			.getByRole( 'toolbar', { name: 'Block tools' } )


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.41.2

## What's new?

https://github.com/microsoft/playwright/releases/tag/v1.41.0
https://github.com/microsoft/playwright/releases/tag/v1.42.0

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.
