### PR TITLE
Don't navigate to navigation post type

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -162,7 +162,7 @@ function useDuplicateNavigationMenu() {
 				createSuccessNotice( __( 'Duplicated Navigation menu' ), {
 					type: 'snackbar',
 				} );
-				goTo( `/navigation/${ postType }/${ savedRecord.id }` );
+				goTo( `/navigation/${ savedRecord.id }` );
 			}
 		} catch ( error ) {
 			createErrorNotice(

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -150,9 +150,6 @@ export function SidebarNavigationScreenWrapper( {
 }
 
 const NavMenuItem = ( { postId, ...props } ) => {
-	const linkInfo = useLink( {
-		postId,
-		postType: NAVIGATION_POST_TYPE,
-	} );
+	const linkInfo = useLink( { path: `/navigation/${ postId }` } );
 	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
 };

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -62,7 +62,7 @@ function SidebarScreens() {
 			<SidebarScreenWrapper path="/navigation">
 				<SidebarNavigationScreenNavigationMenus />
 			</SidebarScreenWrapper>
-			<SidebarScreenWrapper path="/navigation/:postType/:postId">
+			<SidebarScreenWrapper path="/navigation/:postId">
 				<SidebarNavigationScreenNavigationMenu />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/wp_global_styles">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the site editor when using the sidebar to go to Navigation>[Single navigation] the frame would show the contents of the `wp_navigation` post type.  This PR keeps the frame showing the homepage.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The original intent was to allow a sort of zoomed in editing for the navigation. This has not amounted to much and now it's a confusing screen which does more harm than good.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the route for single navigation in the site editor to not include a post type so that the editor in the frame does not try to edit it. Updates the path of navigations in the list of navigations in the site editor sidebar Navigation section.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Make sure to have some navigations
2. Go to the site editor 
3. Go to Navigation
4. Click on a navigation
5. **Notice the right side preview is still showing the homepage**
6. **Notice the navigation editing in the sidebar still works**

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/dbf7896b-a6a7-4a7d-b46d-e6901cf19614

