### PR TITLE
DataViews: Don't use combobox when there are few available options

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -640,7 +640,6 @@
 	&:has(+ .dataviews-search-widget-listbox) {
 		border-bottom: 1px solid $gray-200;
 		padding-bottom: $grid-unit-10;
-		margin-bottom: $grid-unit-05;
 	}
 
 	&:empty {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -524,55 +524,61 @@
 	overflow: auto;
 	border-top: 1px solid $gray-200;
 
-	.dataviews-search-widget-filter-combobox-item {
-		display: flex;
-		align-items: center;
-		gap: $grid-unit-10;
-		border-radius: $radius-block-ui;
-		box-sizing: border-box;
-		padding: $grid-unit-10 $grid-unit-15;
-		cursor: default;
-		margin-block-end: 2px;
+	.dataviews-search-widget-filter-combobox-item-value {
+		[data-user-value] {
+			font-weight: 600;
+		}
+	}
+}
 
-		&:last-child {
-			margin-block-end: 0;
+.dataviews-search-widget-listbox {
+	max-height: $grid-unit * 23;
+	padding: $grid-unit-05;
+	overflow: auto;
+}
+
+.dataviews-search-widget-listitem {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+	border-radius: $radius-block-ui;
+	box-sizing: border-box;
+	padding: $grid-unit-10 $grid-unit-15;
+	cursor: default;
+	margin-block-end: 2px;
+
+	&:last-child {
+		margin-block-end: 0;
+	}
+
+	&:hover,
+	&[data-active-item],
+	&:focus {
+		background-color: var(--wp-admin-theme-color);
+		color: $white;
+
+		.dataviews-search-widget-listitem-check {
+			fill: $white;
 		}
 
-		&:hover,
-		&[data-active-item],
-		&:focus {
-			background-color: var(--wp-admin-theme-color);
+		.dataviews-search-widget-listitem-description {
 			color: $white;
-
-			.dataviews-search-widget-filter-combobox-item-check {
-				fill: $white;
-			}
-
-			.dataviews-search-widget-filter-combobox-item-description {
-				color: $white;
-			}
 		}
+	}
 
-		.dataviews-search-widget-filter-combobox-item-check {
-			width: 24px;
-			height: 24px;
-			flex-shrink: 0;
-		}
+	.dataviews-search-widget-listitem-check {
+		width: 24px;
+		height: 24px;
+		flex-shrink: 0;
+	}
 
-		.dataviews-search-widget-filter-combobox-item-value {
-			[data-user-value] {
-				font-weight: 600;
-			}
-		}
-
-		.dataviews-search-widget-filter-combobox-item-description {
-			display: block;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			font-size: $helptext-font-size;
-			line-height: 16px;
-			color: $gray-700;
-		}
+	.dataviews-search-widget-listitem-description {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		font-size: $helptext-font-size;
+		line-height: 16px;
+		color: $gray-700;
 	}
 }
 
@@ -629,8 +635,13 @@
 }
 
 .dataviews-filter-summary__operators-container {
-	padding: $grid-unit-10 $grid-unit-10 $grid-unit-05;
-	padding-bottom: 0;
+	padding: $grid-unit-10 $grid-unit-10 0;
+
+	&:has(+ .dataviews-search-widget-listbox) {
+		border-bottom: 1px solid $gray-200;
+		padding-bottom: $grid-unit-10;
+		margin-bottom: $grid-unit-05;
+	}
 
 	&:empty {
 		display: none;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/59230

This PR updates the DataViews search widget of filters, not to use a combobox when we have few options available(now the limit is hardcoded to `10` options).





These are the four possible versions of a filter.
1. Have more than one possible operators and more than `10` options: Show operators->combobox input+list
2. Have more than one possible operators and less than `10` options: Show operators->listbox
3. Have only one operator and more than `10` options: Show combobox input+list
4. Have only one operator and less than `10` options: Show listbox

## Testing Instructions
1. Test the filters in our lists with DataViews and observe everything looks and works as expected
2. Test with keyboard navigation

## Screenshots or screencast <!-- if applicable -->
**The video is not what's in trunk! It just showcases the four possible versions of a filter.**

https://github.com/WordPress/gutenberg/assets/16275880/90f7d62d-38db-4bc8-bc26-7a522985e4f7

