### PR TITLE
Add `.github` folder owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -125,7 +125,7 @@
 /packages/block-editor/src/components/rich-text @ellatrix @fluiddot @dcalhoun
 
 # Project Management
-/.github
+/.github                                        @desrosj
 /packages/project-management-automation
 /packages/report-flaky-tests                    @kevin940726
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds myself as an owner for the `.github` directory.

## Why?
As a Build/Test Tools component maintainer on Trac, I spend a good deal of time maintaining GitHub Action workflows on both Trac and in GitHub repositories for the organization. This makes it more clear that I regularly perform a lot of the custodial duties associated with GitHub Actions.