### PR TITLE
Fix failing Dropdown Menu e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/dropdown-menu.spec.js
+++ b/test/e2e/specs/editor/various/dropdown-menu.spec.js
@@ -13,9 +13,11 @@ test.describe( 'Dropdown Menu', () => {
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Options' } )
 			.click();
-		const menuItems = page.locator(
-			'[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
-		);
+		const menuItems = page
+			.getByRole( 'menu', { name: 'Options' } )
+			.locator(
+				'[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
+			);
 		const totalItems = await menuItems.count();
 
 		// Catch any issues with the selector, which could cause a false positive test result.


### PR DESCRIPTION
## What?
PR fixes [failing](https://github.com/WordPress/gutenberg/actions/runs/8043715676/job/21966566295?pr=59355) Dropdown Menu e2e tests.

## Why?
Core made [a11y improvements](https://github.com/WordPress/wordpress-develop/commit/eb33c60eaa0111bac7d98a84fd0cf067cd9c8571) to the WP toolbar, and the e2e test used a general locator for roles, which caused asserting wrong items in DOM.

## How?
Adds scope to the menu items locator.

## Testing Instructions
```
npm run test:e2e:playwright -- editor/various/dropdown-menu.spec.js
```
