### PR TITLE
Reposition pattern detail icon

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -210,6 +210,26 @@ function Title( { item, categoryId } ) {
 	}
 	return (
 		<HStack alignment="center" justify="flex-start" spacing={ 2 }>
+			<Flex
+				as="div"
+				gap={ 0 }
+				justify="left"
+				className="edit-site-patterns__pattern-title"
+			>
+				{ item.type === PATTERN_TYPES.theme ? (
+					item.title
+				) : (
+					<Button
+						variant="link"
+						onClick={ onClick }
+						// Required for the grid's roving tab index system.
+						// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
+						tabIndex="-1"
+					>
+						{ item.title || item.name }
+					</Button>
+				) }
+			</Flex>
 			{ itemIcon && ! isNonUserPattern && (
 				<Tooltip
 					placement="top"
@@ -235,26 +255,6 @@ function Title( { item, categoryId } ) {
 					/>
 				</Tooltip>
 			) }
-			<Flex
-				as="div"
-				gap={ 0 }
-				justify="left"
-				className="edit-site-patterns__pattern-title"
-			>
-				{ item.type === PATTERN_TYPES.theme ? (
-					item.title
-				) : (
-					<Button
-						variant="link"
-						onClick={ onClick }
-						// Required for the grid's roving tab index system.
-						// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
-						tabIndex="-1"
-					>
-						{ item.title || item.name }
-					</Button>
-				) }
-			</Flex>
 		</HStack>
 	);
 }


### PR DESCRIPTION
## What?
Move pattern detail icons (locked, synced, template part) to the right of the title.

## Why?
With the addition of bulk actions (checkboxes) the appearance on trunk is a little uncanny:

<img src="https://github.com/WordPress/gutenberg/assets/846565/9e9a6381-089b-4640-b2ba-f4363ad42f87" width="300">


## How?
Place the logic that displays the icons after `.edit-site-patterns__pattern-title`.


<img src="https://github.com/WordPress/gutenberg/assets/846565/c3ea5046-32fc-4174-9d45-b4819f8a75f8" width="300">

