### PR TITLE
Data views: Use aria-disabled on disabled checkboxes and add tooltips

### DIFF
--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { CheckboxControl, Tooltip } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 
 export default function SingleSelectionCheckbox( {
 	selection,
@@ -29,39 +29,33 @@ export default function SingleSelectionCheckbox( {
 			: __( 'Deselect item' );
 	}
 	return (
-		<Tooltip
-			text={ disabled ? __( 'Bulk actions are not applicable' ) : null }
-		>
-			<CheckboxControl
-				className="dataviews-view-table-selection-checkbox"
-				__nextHasNoMarginBottom
-				label={ selectionLabel }
-				aria-disabled={ disabled }
-				checked={ disabled ? false : isSelected }
-				onChange={ () => {
-					if ( ! isSelected ) {
-						onSelectionChange(
-							data.filter( ( _item ) => {
-								const itemId = getItemId?.( _item );
-								return (
-									itemId === id ||
-									selection.includes( itemId )
-								);
-							} )
-						);
-					} else {
-						onSelectionChange(
-							data.filter( ( _item ) => {
-								const itemId = getItemId?.( _item );
-								return (
-									itemId !== id &&
-									selection.includes( itemId )
-								);
-							} )
-						);
-					}
-				} }
-			/>
-		</Tooltip>
+		<CheckboxControl
+			className="dataviews-view-table-selection-checkbox"
+			__nextHasNoMarginBottom
+			label={ selectionLabel }
+			aria-disabled={ disabled }
+			checked={ disabled ? false : isSelected }
+			onChange={ () => {
+				if ( ! isSelected ) {
+					onSelectionChange(
+						data.filter( ( _item ) => {
+							const itemId = getItemId?.( _item );
+							return (
+								itemId === id || selection.includes( itemId )
+							);
+						} )
+					);
+				} else {
+					onSelectionChange(
+						data.filter( ( _item ) => {
+							const itemId = getItemId?.( _item );
+							return (
+								itemId !== id && selection.includes( itemId )
+							);
+						} )
+					);
+				}
+			} }
+		/>
 	);
 }

--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, Tooltip } from '@wordpress/components';
 
 export default function SingleSelectionCheckbox( {
 	selection,
@@ -29,33 +29,39 @@ export default function SingleSelectionCheckbox( {
 			: __( 'Deselect item' );
 	}
 	return (
-		<CheckboxControl
-			className="dataviews-view-table-selection-checkbox"
-			__nextHasNoMarginBottom
-			checked={ isSelected }
-			label={ selectionLabel }
-			disabled={ disabled }
-			onChange={ () => {
-				if ( ! isSelected ) {
-					onSelectionChange(
-						data.filter( ( _item ) => {
-							const itemId = getItemId?.( _item );
-							return (
-								itemId === id || selection.includes( itemId )
-							);
-						} )
-					);
-				} else {
-					onSelectionChange(
-						data.filter( ( _item ) => {
-							const itemId = getItemId?.( _item );
-							return (
-								itemId !== id && selection.includes( itemId )
-							);
-						} )
-					);
-				}
-			} }
-		/>
+		<Tooltip
+			text={ disabled ? __( 'Bulk actions are not applicable' ) : null }
+		>
+			<CheckboxControl
+				className="dataviews-view-table-selection-checkbox"
+				__nextHasNoMarginBottom
+				checked={ isSelected }
+				label={ selectionLabel }
+				aria-disabled={ disabled }
+				onChange={ () => {
+					if ( ! isSelected ) {
+						onSelectionChange(
+							data.filter( ( _item ) => {
+								const itemId = getItemId?.( _item );
+								return (
+									itemId === id ||
+									selection.includes( itemId )
+								);
+							} )
+						);
+					} else {
+						onSelectionChange(
+							data.filter( ( _item ) => {
+								const itemId = getItemId?.( _item );
+								return (
+									itemId !== id &&
+									selection.includes( itemId )
+								);
+							} )
+						);
+					}
+				} }
+			/>
+		</Tooltip>
 	);
 }

--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -35,9 +35,9 @@ export default function SingleSelectionCheckbox( {
 			<CheckboxControl
 				className="dataviews-view-table-selection-checkbox"
 				__nextHasNoMarginBottom
-				checked={ isSelected }
 				label={ selectionLabel }
 				aria-disabled={ disabled }
+				checked={ disabled ? false : isSelected }
 				onChange={ () => {
 					if ( ! isSelected ) {
 						onSelectionChange(

--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -34,7 +34,7 @@ export default function SingleSelectionCheckbox( {
 			__nextHasNoMarginBottom
 			label={ selectionLabel }
 			aria-disabled={ disabled }
-			checked={ disabled ? false : isSelected }
+			checked={ isSelected }
 			onChange={ () => {
 				if ( disabled ) {
 					return;

--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -36,6 +36,10 @@ export default function SingleSelectionCheckbox( {
 			aria-disabled={ disabled }
 			checked={ disabled ? false : isSelected }
 			onChange={ () => {
+				if ( disabled ) {
+					return;
+				}
+
 				if ( ! isSelected ) {
 					onSelectionChange(
 						data.filter( ( _item ) => {


### PR DESCRIPTION
## What?
1. Use `aria-disabled` instead of `disabled` on checkboxes in data views.
2. ~Add a tooltip to explain why the checkbox is disabled.~ [Removed](https://github.com/WordPress/gutenberg/pull/59364#issuecomment-1966258638).

## Why?
The first change is important because `disabled` checkboxes cannot be focused. For users of assistive technologies this can result in a broken experience as the checkboxes disappear with no explanation. `aria-disabled` means the element can still be focused, but communicates that it's not interaction.

The second change clarifies _why_ checkboxes are not interactive in this context. I'm unsure how helpful this is so would welcome feedback.

## How?
Use `aria-disabled` instead of `disabled` on checkboxes in data views. Wrap checkboxes in a `Tooltip` instance.

## Testing Instructions
1. Open the Patterns page in the Site Editor.
2. Check that disabled checkboxes appear in the tab index and the tooltip displays.

<img width="634" alt="Screenshot 2024-02-26 at 12 26 36" src="https://github.com/WordPress/gutenberg/assets/846565/86a7e574-b22a-45bb-8f22-15bfb2a2c84f">
