### PR TITLE
Block Hooks: Take controlled blocks into account for toggle state

### DIFF
--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -35,12 +35,12 @@ function BlockHooksControlPure( { name, clientId } ) {
 
 	const { blockIndex, rootClientId, innerBlocksLength } = useSelect(
 		( select ) => {
-			const { getBlock, getBlockIndex, getBlockRootClientId } =
+			const { getBlocks, getBlockIndex, getBlockRootClientId } =
 				select( blockEditorStore );
 
 			return {
 				blockIndex: getBlockIndex( clientId ),
-				innerBlocksLength: getBlock( clientId )?.innerBlocks?.length,
+				innerBlocksLength: getBlocks( clientId )?.length,
 				rootClientId: getBlockRootClientId( clientId ),
 			};
 		},
@@ -49,7 +49,7 @@ function BlockHooksControlPure( { name, clientId } ) {
 
 	const hookedBlockClientIds = useSelect(
 		( select ) => {
-			const { getBlock, getGlobalBlockCount } =
+			const { getBlocks, getGlobalBlockCount } =
 				select( blockEditorStore );
 
 			const _hookedBlockClientIds = hookedBlocksForCurrentBlock.reduce(
@@ -69,7 +69,7 @@ function BlockHooksControlPure( { name, clientId } ) {
 							// Any of the current block's siblings (with the right block type) qualifies
 							// as a hooked block (inserted `before` or `after` the current one), as the block
 							// might've been automatically inserted and then moved around a bit by the user.
-							candidates = getBlock( rootClientId )?.innerBlocks;
+							candidates = getBlocks( rootClientId );
 							break;
 
 						case 'first_child':
@@ -77,7 +77,7 @@ function BlockHooksControlPure( { name, clientId } ) {
 							// Any of the current block's child blocks (with the right block type) qualifies
 							// as a hooked first or last child block, as the block might've been automatically
 							// inserted and then moved around a bit by the user.
-							candidates = getBlock( clientId ).innerBlocks;
+							candidates = getBlocks( clientId );
 							break;
 					}
 


### PR DESCRIPTION
## What?
When setting the Block Hooks toggle state, take controlled blocks into account.

## Why?
To fix https://github.com/WordPress/gutenberg/issues/59001, i.e. the toggle state for hooked blocks inserted as first child or last child of the Navigation block.

## How?
By using the `getBlocks( clientId )` selector instead of `getBlock( clientId ).innerBlocks` (note the singular: `getBlock()`).

This PR is based on @tjcafferkey's https://github.com/WordPress/gutenberg/pull/59277. See https://github.com/WordPress/gutenberg/pull/59277#pullrequestreview-1900919723 for more detail.

## Testing Instructions

Verify that #59001 is fixed:

_(Copied from https://github.com/WordPress/gutenberg/pull/59277.)_

1. Add the below code to the `core/loginout` blocks `block.json` file.
2. Load the header template part and select the Navigation block. Check its toggle is toggled on and that toggling it off removes the hooked block
3. Toggle it back on, check the hooked block returns to its correct position.
4. Change the below value to `firstChild`, `before` and `after` and retest the above steps for each position.

```json
	"blockHooks": {
		"core/navigation": "lastChild"
	}
```

Additionally, verify that the toggle still works as before for blocks inserted as _un_controlled inner blocks, e.g. as the Comment Template block's last child. (You can use [this plugin](https://github.com/ockham/like-button/releases/tag/v0.8.0) to test.)
