### PR TITLE
Block Hooks: Add help text to Plugins panel.

### DIFF
--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -6,7 +6,6 @@ import { Fragment, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	PanelBody,
-	PanelRow,
 	ToggleControl,
 } from '@wordpress/components';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
@@ -162,13 +161,11 @@ function BlockHooksControlPure( { name, clientId } ) {
 				title={ __( 'Plugins' ) }
 				initialOpen={ true }
 			>
-				<PanelRow>
-					<p className="block-editor-hooks__block-hooks-helptext">
-						{ __(
-							'Manage the inclusion of blocks added automatically by plugins.'
-						) }
-					</p>
-				</PanelRow>
+				<p className="block-editor-hooks__block-hooks-helptext">
+					{ __(
+						'Manage the inclusion of blocks added automatically by plugins.'
+					) }
+				</p>
 				{ Object.keys( groupedHookedBlocks ).map( ( vendor ) => {
 					return (
 						<Fragment key={ vendor }>

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -6,6 +6,7 @@ import { Fragment, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	PanelBody,
+	PanelRow,
 	ToggleControl,
 } from '@wordpress/components';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
@@ -161,6 +162,13 @@ function BlockHooksControlPure( { name, clientId } ) {
 				title={ __( 'Plugins' ) }
 				initialOpen={ true }
 			>
+				<PanelRow>
+					<p className="block-editor-hooks__block-hooks-helptext">
+						{ __(
+							'Manage the inclusion of blocks added automatically by plugins.'
+						) }
+					</p>
+				</PanelRow>
 				{ Object.keys( groupedHookedBlocks ).map( ( vendor ) => {
 					return (
 						<Fragment key={ vendor }>

--- a/packages/block-editor/src/hooks/block-hooks.scss
+++ b/packages/block-editor/src/hooks/block-hooks.scss
@@ -13,4 +13,10 @@
 	.components-toggle-control .components-h-stack .components-h-stack {
 		flex-direction: row;
 	}
+
+	.block-editor-hooks__block-hooks-helptext {
+		color: $gray-700;
+		font-size: $helptext-font-size;
+		margin-bottom: $grid-unit-20;
+	}
 }


### PR DESCRIPTION
## What?
Add a help text to the Plugins panel.

## Why?
To provide users with an explanation where the blocks listed in that panel are coming from. Fixes #59328.

## How?
By adding a help text 😬 

## Testing Instructions
- Install the latest version of the [Like Button plugin](https://github.com/ockham/like-button/releases/latest), and activate it.
- Make sure you're using a block theme (e.g. TT4).
- Open "Single Posts" template in the Site Editor.
- Verify that the Like Button block is being inserted as the Comment Template block's last child.
- Click on the Comment Template block, and open the block inspector. Verify that you see the "Plugins" panel, and that it now has the help text added.

## Screenshots

<img width="280" alt="image" src="https://github.com/WordPress/gutenberg/assets/96308/829481c8-2840-4671-b349-83597fcc5baa">
