### PR TITLE
Create block interactivity: Fix minimum versions

### DIFF
--- a/packages/create-block-interactive-template/README.md
+++ b/packages/create-block-interactive-template/README.md
@@ -10,7 +10,7 @@ This block template can be used by running the following command:
 npx @wordpress/create-block --template @wordpress/create-block-interactive-template
 ```
 
-It requires at least WordPress 16.5 or Gutenberg 17.7.
+It requires at least WordPress 6.5 or Gutenberg 17.7.
 
 ## Contributing to this package
 

--- a/packages/create-block-interactive-template/README.md
+++ b/packages/create-block-interactive-template/README.md
@@ -10,7 +10,7 @@ This block template can be used by running the following command:
 npx @wordpress/create-block --template @wordpress/create-block-interactive-template
 ```
 
-It requires Gutenberg 17.5 or higher.
+It requires at least WordPress 16.5 or Gutenberg 17.7.
 
 ## Contributing to this package
 


### PR DESCRIPTION
## What?

The template uses `viewScriptModule` which is available in Core 6.5 or Gutenberg 17.7. Update the README accordingly.