### PR TITLE
RNMobile: Remove redundant code in Video block

### DIFF
--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -212,7 +212,7 @@ class VideoEdit extends Component {
 	render() {
 		const { setAttributes, attributes, isSelected, wasBlockJustInserted } =
 			this.props;
-		const { id, src, guid } = attributes;
+		const { id, src } = attributes;
 		const { videoContainerHeight } = this.state;
 
 		const toolbarEditButton = (
@@ -236,10 +236,7 @@ class VideoEdit extends Component {
 			></MediaUpload>
 		);
 
-		// NOTE: `guid` is not part of the block's attribute definition. This case
-		// handled here is a temporary fix until a we find a better approach.
-		const isSourcePresent = src || ( guid && id );
-		if ( ! isSourcePresent ) {
+		if ( ! src ) {
 			return (
 				<View style={ { flex: 1 } }>
 					<MediaPlaceholder

--- a/packages/block-library/src/video/test/edit.native.js
+++ b/packages/block-library/src/video/test/edit.native.js
@@ -50,18 +50,4 @@ describe( 'Video block', () => {
 		const addVideoButton = screen.queryByText( 'Add video' );
 		expect( addVideoButton ).toBeNull();
 	} );
-
-	it( `should not render empty state when 'guid' and 'id' attributes are present`, async () => {
-		await initializeEditor( {
-			initialHtml: `
-<!-- wp:video {"guid":"ABCD1234","id":1234 -->
-<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">
-https://videopress.com/<VIDEO_ID>
-</div></figure>
-<!-- /wp:video -->
-		`,
-		} );
-		const addVideoButton = screen.queryByText( 'Add video' );
-		expect( addVideoButton ).toBeNull();
-	} );
 } );


### PR DESCRIPTION
* `Gutenberg Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6675

## What?

Removes now-redundant code in the Video block, specifically the `isSourcePresent` logic that was first introduced in https://github.com/WordPress/gutenberg/pull/58015.

## Why?

As mentioned in the code's comments and the PR where the code was introduced, it was always intended to be temporary while we sought a better approach for handling videos with a GUID. We introduced a better approach in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6634.

## How?

The now-redundant code has simply been removed with this PR.

## Testing Instructions

The removal of this unused code should not cause any issues issues, however it'd be helpful to test uploading to the video block to ensure it continues to function as before.