### PR TITLE
Fixed the font family modal to open in  state when a font is already selected.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -103,7 +103,9 @@ function InstalledFonts() {
 				</HStack>
 			) }
 
-			<NavigatorProvider initialPath="/">
+			<NavigatorProvider
+				initialPath={ libraryFontSelected ? '/fontFamily' : '/' }
+			>
 				<NavigatorScreen path="/">
 					{ notice && (
 						<>


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When a Font Family has been selected BEFORE the Font Library Modal has been opened (for instance when clicking on one of the font families here:)

<img width="295" alt="image" src="https://github.com/WordPress/gutenberg/assets/146530/f239665f-e610-4670-a88d-6845244992b7">

the modal should open to the `font family details` panel.

## Why?
This fixes breakage introduced in #59036 ([comment](https://github.com/WordPress/gutenberg/pull/59036#issuecomment-1964566387))

## How?
Set the 'initial path' of the Navigator based on a font being already selected or not.

## Testing Instructions
Click on a Font in the 'Fonts' list in Global Styles.
The Font Library panel should open to the font you just clicked
It should otherwise work as it had.

