### PR TITLE
Site Logo: Update capitalization of Use as Site Icon toggle

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -331,7 +331,7 @@ const SiteLogo = ( {
 						<>
 							<ToggleControl
 								__nextHasNoMarginBottom
-								label={ __( 'Use as site icon' ) }
+								label={ __( 'Use as Site Icon' ) }
 								onChange={ ( value ) => {
 									setAttributes( { shouldSyncIcon: value } );
 									setIcon( value ? logoId : undefined );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update capitalization of of Site Icon in the toggle for the Site Logo block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in https://github.com/WordPress/gutenberg/issues/59382, elsewhere in core it's capitalized, so here it's updated for consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the string.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the site editor and select the Site Logo block (or add the block first if you don't already have one in the template). In the block inspector on the right, take a look a the toggle and check that the toggle is now capitalized correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/db1a56d1-d968-4727-9e03-19e9f01b8290) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/2f22be0c-6531-4c5b-883a-2495e1297540) |