### PR TITLE
Cover Block: Restore overflow: clip rule to allow border radius again

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -9,8 +9,7 @@
 	padding: 1em;
 	// Prevent the `wp-block-cover__background` span from overflowing the container when border-radius is applied.
 	// Use clip instead of overflow: hidden so that sticky position works on child elements.
-	// Use overflow-x instead of overflow so that aspect-ratio allows content to expand the area of the cover block.
-	overflow-x: clip;
+	overflow: clip;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 	// Keep the flex layout direction to the physical direction (LTR) in RTL languages.

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -8,6 +8,8 @@
 	align-items: center;
 	padding: 1em;
 	// Prevent the `wp-block-cover__background` span from overflowing the container when border-radius is applied.
+	// `overflow: hidden` is provided as a fallback for browsers that don't support `overflow: clip`.
+	overflow: hidden;
 	// Use clip instead of overflow: hidden so that sticky position works on child elements.
 	overflow: clip;
 	// This block has customizable padding, border-box makes that more predictable.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/59366

Fix border radius for the Cover block by restoring the previous `overflow: clip` CSS rule.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the aspect ratio block support was introduced in https://github.com/WordPress/gutenberg/pull/56897, it turns out the behaviour depended on a _bug_ in Chrome that (incorrectly) allowed `overflow-x: clip` to apply rounded edges to a clipping region while still allowing the content area to expand vertically. As of Chrome `122.x` that bug has been resolved, which means that `overflow-x: clip` now results in border radius not clipping the image for the Cover block as it's expected to.

This fix proposes restoring the `overflow: clip` rule for 6.5 to fix the border radius issue. The downside of doing this is that on smaller viewports, the content area of the block with an aspect ratio will not expand beyond its aspect ratio proportions. However, since aspect ratio is a new feature in 6.5, I believe it's preferable for us to restore behaviour that preserves border-radius for now.

We could potentially look at further follow-ups to the aspect ratio support in 6.6.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Restore `overflow: clip` rule in the Cover block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Make sure you're running the latest version of Google Chrome (`122.x`)
2. Add a Cover block to a post or template, and give it a border radius and a background image, and an aspect ratio
3. Prior to this PR being applied, note that the image is _not_ clipped by the border radius
4. With this PR applied, the border radius should be clipped
5. This PR now means that content in Cover blocks in smaller viewports will not expand beyond the proportions of the block. Does this feel like a blocker for this fix, or is it reasonable enough?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="559" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/4b756550-9af0-47b4-9b2a-4ef4415efe45"> | <img width="550" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/5b43ad29-e7ea-4c16-ad57-5c35871db3c9"> |