### PR TITLE
Core Block Reference: Add ancestor status and refactor generation logic

### DIFF
--- a/bin/api-docs/gen-block-lib-list.js
+++ b/bin/api-docs/gen-block-lib-list.js
@@ -148,29 +148,52 @@ function getSourceFromFile( filename ) {
  */
 function readBlockJSON( filename ) {
 	const blockjson = require( filename );
-
+	const {
+		name,
+		category,
+		supports,
+		attributes,
+		parent,
+		ancestor,
+		__experimental,
+	} = blockjson;
 	const sourcefile = getSourceFromFile( filename );
-	const supportsList =
-		blockjson.supports !== undefined
-			? processObjWithInnerKeys( augmentSupports( blockjson.supports ) )
-			: [];
-	const attributes = getTruthyKeys( blockjson.attributes );
-	const parent = blockjson.parent
-		? '\n' + `-	**Parent:** ${ blockjson.parent.join( ', ' ) }`
-		: '';
-	const experimental = blockjson.__experimental
-		? '\n' + `-	**Experimental:** ${ blockjson.__experimental }`
-		: '';
+	const blockInfoList = [ `-	**Name:** ${ name }` ];
+
+	if ( __experimental ) {
+		blockInfoList.push( `-	**Experimental:** ${ __experimental }` );
+	}
+	if ( category?.length > 0 ) {
+		blockInfoList.push( `-	**Category:** ${ category }` );
+	}
+	if ( parent?.length > 0 ) {
+		blockInfoList.push( `-	**Parent:** ${ parent.join( ', ' ) }` );
+	}
+	if ( ancestor?.length > 0 ) {
+		blockInfoList.push( `-	**Ancestor:** ${ ancestor.join( ', ' ) }` );
+	}
+	if ( supports ) {
+		blockInfoList.push(
+			`-	**Supports:** ${ processObjWithInnerKeys(
+				augmentSupports( supports )
+			)
+				.sort()
+				.join( ', ' ) }`
+		);
+	}
+	const truthyAttributes = getTruthyKeys( attributes );
+	if ( truthyAttributes.length ) {
+		blockInfoList.push(
+			`-	**Attributes:** ${ truthyAttributes.sort().join( ', ' ) }`
+		);
+	}
 
 	return `
 ## ${ blockjson.title }
 
 ${ blockjson.description } ([Source](${ sourcefile }))
 
--	**Name:** ${ blockjson.name }${ experimental }
--	**Category:** ${ blockjson.category }${ parent }
--	**Supports:** ${ supportsList.sort().join( ', ' ) }
--	**Attributes:** ${ attributes.sort().join( ', ' ) }
+${ blockInfoList.join( '\n' ) }
 `;
 }
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -61,7 +61,6 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** 
 
 ## Calendar
 
@@ -116,6 +115,7 @@ This block is deprecated. Please use the Avatar block instead. ([Source](https:/
 -	**Name:** core/comment-author-avatar
 -	**Experimental:** fse
 -	**Category:** theme
+-	**Ancestor:** core/comment-template
 -	**Supports:** color (background, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), ~~html~~, ~~inserter~~
 -	**Attributes:** height, width
 
@@ -125,6 +125,7 @@ Displays the name of the author of the comment. ([Source](https://github.com/Wor
 
 -	**Name:** core/comment-author-name
 -	**Category:** theme
+-	**Ancestor:** core/comment-template
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** isLink, linkTarget, textAlign
 
@@ -134,6 +135,7 @@ Displays the contents of a comment. ([Source](https://github.com/WordPress/guten
 
 -	**Name:** core/comment-content
 -	**Category:** theme
+-	**Ancestor:** core/comment-template
 -	**Supports:** color (background, gradients, link, text), spacing (padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
@@ -143,6 +145,7 @@ Displays the date on which the comment was posted. ([Source](https://github.com/
 
 -	**Name:** core/comment-date
 -	**Category:** theme
+-	**Ancestor:** core/comment-template
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** format, isLink
 
@@ -152,6 +155,7 @@ Displays a link to edit the comment in the WordPress Dashboard. This link is onl
 
 -	**Name:** core/comment-edit-link
 -	**Category:** theme
+-	**Ancestor:** core/comment-template
 -	**Supports:** color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** linkTarget, textAlign
 
@@ -161,6 +165,7 @@ Displays a link to reply to a comment. ([Source](https://github.com/WordPress/gu
 
 -	**Name:** core/comment-reply-link
 -	**Category:** theme
+-	**Ancestor:** core/comment-template
 -	**Supports:** color (background, gradients, link, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
@@ -172,7 +177,6 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Category:** design
 -	**Parent:** core/comments
 -	**Supports:** align, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
 
 ## Comments
 
@@ -211,7 +215,6 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 -	**Category:** theme
 -	**Parent:** core/comments-pagination
 -	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
 
 ## Comments Previous Page
 
@@ -229,6 +232,7 @@ Displays a title with the number of comments. ([Source](https://github.com/WordP
 
 -	**Name:** core/comments-title
 -	**Category:** theme
+-	**Ancestor:** core/comments
 -	**Supports:** align, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~anchor~~, ~~html~~
 -	**Attributes:** level, showCommentsCount, showPostTitle, textAlign
 
@@ -275,7 +279,6 @@ Display footnotes added to the page. ([Source](https://github.com/WordPress/gute
 -	**Name:** core/footnotes
 -	**Category:** text
 -	**Supports:** color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~, ~~multiple~~, ~~reusable~~
--	**Attributes:** 
 
 ## Form
 
@@ -294,6 +297,7 @@ The basic building block for forms. ([Source](https://github.com/WordPress/guten
 -	**Name:** core/form-input
 -	**Experimental:** true
 -	**Category:** common
+-	**Ancestor:** core/form
 -	**Supports:** anchor, spacing (margin), ~~reusable~~
 -	**Attributes:** inlineLabel, label, name, placeholder, required, type, value, visibilityPermissions
 
@@ -304,7 +308,7 @@ Provide a notification message after the form has been submitted. ([Source](http
 -	**Name:** core/form-submission-notification
 -	**Experimental:** true
 -	**Category:** common
--	**Supports:** 
+-	**Ancestor:** core/form
 -	**Attributes:** type
 
 ## Form Submit Button
@@ -314,8 +318,7 @@ A submission button for forms. ([Source](https://github.com/WordPress/gutenberg/
 -	**Name:** core/form-submit-button
 -	**Experimental:** true
 -	**Category:** common
--	**Supports:** 
--	**Attributes:** 
+-	**Ancestor:** core/form
 
 ## Classic
 
@@ -491,7 +494,6 @@ Separate your content into a multi-page experience. ([Source](https://github.com
 -	**Category:** design
 -	**Parent:** core/post-content
 -	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:** 
 
 ## Page List
 
@@ -603,7 +605,6 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Name:** core/post-content
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** 
 
 ## Date
 
@@ -649,7 +650,6 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Category:** theme
 -	**Parent:** core/query
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
 
 ## Post Terms
 
@@ -714,7 +714,6 @@ Contains the block elements used to render content when no query results are fou
 -	**Category:** theme
 -	**Parent:** core/query
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
 
 ## Pagination
 
@@ -722,6 +721,7 @@ Displays a paginated navigation to next/previous set of posts, when applicable. 
 
 -	**Name:** core/query-pagination
 -	**Category:** theme
+-	**Ancestor:** core/query
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** paginationArrow, showLabel
 


### PR DESCRIPTION
Fixes: #58603

## What?

This PR makes two changes to [the core block reference page](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/):

- Add `ancestor` field
- Prevent generation of fields without values

## Why?

I think the `ancestor` field is important information for developers, just like the already existing `parent` field.

Also, the current logic produces Attributes/Supports fields with no values, which seems unnecessary:

![core-block-reference](https://github.com/WordPress/gutenberg/assets/54422211/f9e8a196-c0fe-4f2e-ab8a-bd74d457e529)

## How?

The previous logic seemed unstable because newline characters were added dynamically.

This PR first defines an array to display the block information list. After that, if there is any information that can be displayed, push it into the array. Finally, it outputs the elements of that array separated by newlines.

This should also make it easier to add fields in the future.

## Testing Instructions

Compare the readme files.

- trunk: https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/core-blocks.md
- This PR: https://github.com/WordPress/gutenberg/blob/556ef80247ac3b20dbdb91a0489dbe122d1e8a2c/docs/reference-guides/core-blocks.md