### PR TITLE
Button: Fix focus outline in disabled primary variant

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   `Tooltip`: Explicitly set system font to avoid CSS bleed ([#59307](https://github.com/WordPress/gutenberg/pull/59307)).
+-   `Button`: Fix focus outline in disabled primary variant ([#59391](https://github.com/WordPress/gutenberg/pull/59391)).
 
 ## 27.0.0 (2024-02-21)
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -84,9 +84,7 @@
 			outline: none;
 
 			&:focus:enabled {
-				box-shadow:
-					0 0 0 $border-width $components-color-background,
-					0 0 0 3px $components-color-accent;
+				box-shadow: inset 0 0 0 1px $components-color-background, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 			}
 		}
 


### PR DESCRIPTION
Fixes #58632

## What?

This PR fixes the focus style of a `Button` component with the following three props;

- `variant="primary"`
- `disabled`
- `__experimentalIsFocusable`

## Why?

Only this pattern seems to have different values for the box-shadow style.

## How?

I applied the same focus style as the other patterns.

## Testing Instructions

- Check out this branch.
- Run `run storybook:e2e:dev`.
- Access `http://localhost:50241/?path=/story/components-button--variant-states`.
- Focus on the button in the second row and third column. It should match the focus style of the other buttons.

### Testing Instructions for Keyboard

Same

## Screenshots or screencast <!-- if applicable -->

In the screenshot below, all buttons have focus.

### Before

![before](https://github.com/WordPress/gutenberg/assets/54422211/a4d18bc0-b309-4ff9-92d0-6303b1aa15d6)

### After

![after](https://github.com/WordPress/gutenberg/assets/54422211/8c1b721f-6026-440e-8e44-bbd8244ea9c7)

