### PR TITLE
Block Hooks: Display toggle for hooked blocks added via filter

### DIFF
--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -89,6 +89,16 @@ function BlockHooksControlPure( {
 							// inserted and then moved around a bit by the user.
 							candidates = getBlocks( clientId );
 							break;
+
+						default:
+							// If we haven't found a blockHooks field with a relative position for the hooked
+							// block, it means that it was added by a filter. In this case, we look for the block
+							// both among the current block's siblings and its children.
+							candidates = [
+								...getBlocks( rootClientId ),
+								...getBlocks( clientId ),
+							];
+							break;
 					}
 
 					const hookedBlock = candidates?.find(

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -171,6 +171,18 @@ function BlockHooksControlPure( {
 					false
 				);
 				break;
+
+			default:
+				// If we do not know the relative position, it is because the block was
+				// added via a filter. In this case, we default to inserting it after the
+				// current block.
+				insertBlock(
+					block,
+					blockIndex + 1,
+					rootClientId, // Insert as a child of the current block's parent
+					false
+				);
+				break;
 		}
 	};
 

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -90,7 +90,7 @@ function BlockHooksControlPure( {
 							candidates = getBlocks( clientId );
 							break;
 
-						default:
+						case undefined:
 							// If we haven't found a blockHooks field with a relative position for the hooked
 							// block, it means that it was added by a filter. In this case, we look for the block
 							// both among the current block's siblings and its children.
@@ -172,7 +172,7 @@ function BlockHooksControlPure( {
 				);
 				break;
 
-			default:
+			case undefined:
 				// If we do not know the relative position, it is because the block was
 				// added via a filter. In this case, we default to inserting it after the
 				// current block.


### PR DESCRIPTION
## What?
Show the Block Hooks toggle for hooked blocks that were added via the `hooked_block_types` filter (rather than at block registration time, i.e. via the `blockHooks` field in `block.json`).

## Why?
To improve UX. It is otherwise somewhat surprising for users that the toggle doesn't show up.

## How?
By evaluating the anchor block's `ignoredHookedBlocks` metadata attribute. This attribute is only present if the containing template/part/pattern has user modifications, which causes the following limitations:

## Limitations

**Note that this only works for templates/parts/patterns that have been modified by the user.** 
**Furthermore, note that for hooked blocks added by filters, the client does not know their relative positions, so when enabling the toggle, it will default to inserting the hooked block _after_ the current (anchor) block.**

## Question

Are those limitations problematic? Will it make things even more confusing to users that the toggles now show up for blocks added by filters, but only if the template has modifications? Or is it still a net win?

## Testing Instructions
- **Make sure you're testing Gutenberg with either Core `trunk`, or the [latest WP 6.5 Beta](https://wordpress.org/news/2024/02/wordpress-6-5-beta-3/).**
- Install the latest version of the [Like Button plugin](https://github.com/ockham/like-button/releases/latest), and activate it.
- Make sure you're using a block theme (e.g. TT4).
- Open "Single Posts" template in the Site Editor.
- Verify that the Like Button block is being inserted after the Post Content block.
- Make some change to the Single Posts template, save it, and reload.
- Click on the Post Content block, and open the block inspector. Verify that you see the "Plugins" panel, and that the toggle for the Like Button is present and enabled.
- Click the toggle to disable it, and verify that it removes the button.
- Click it again to re-enable it, and verify that it re-inserts the button.

To ensure that this is indeed due to this PR, switch to `trunk` and verify that the Plugins panel is absent for the Like Button.

## Screenshots or screencast

| Before | After |
|--------|------|
| <img width="914" alt="image" src="https://github.com/WordPress/gutenberg/assets/96308/c8bed51f-d9a5-43a2-a0ce-d16bda44aa38"> | <img width="916" alt="image" src="https://github.com/WordPress/gutenberg/assets/96308/d05bc065-2e20-4f51-9398-18f479e21bee"> |