### PR TITLE
Block Editor: Don't memoize callbacks in 'BlockSettingsDropdown'

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -224,7 +224,8 @@ export function BlockSettingsDropdown( {
 								canRemove
 							) {
 								event.preventDefault();
-								updateSelectionAfterRemove( onRemove() );
+								onRemove();
+								updateSelectionAfterRemove();
 							} else if (
 								isMatch(
 									'core/block-editor/duplicate',

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -9,7 +9,7 @@ import {
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
-import { Children, cloneElement, useCallback } from '@wordpress/element';
+import { Children, cloneElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	store as keyboardShortcutsStore,
@@ -127,41 +127,35 @@ export function BlockSettingsDropdown( {
 	const isMatch = __unstableUseShortcutEventMatch();
 	const hasSelectedBlocks = selectedBlockClientIds.length > 0;
 
-	const updateSelectionAfterDuplicate = useCallback(
-		async ( clientIdsPromise ) => {
-			if ( __experimentalSelectBlock ) {
-				const ids = await clientIdsPromise;
-				if ( ids && ids[ 0 ] ) {
-					__experimentalSelectBlock( ids[ 0 ], false );
-				}
-			}
-		},
-		[ __experimentalSelectBlock ]
-	);
-
-	const updateSelectionAfterRemove = useCallback( () => {
-		if ( __experimentalSelectBlock ) {
-			let blockToFocus = previousBlockClientId || firstParentClientId;
-
-			// Focus the first block if there's no previous block nor parent block.
-			if ( ! blockToFocus ) {
-				blockToFocus = getBlockOrder()[ 0 ];
-			}
-
-			// Only update the selection if the original selection is removed.
-			const shouldUpdateSelection =
-				hasSelectedBlocks && getSelectedBlockClientIds().length === 0;
-
-			__experimentalSelectBlock( blockToFocus, shouldUpdateSelection );
+	async function updateSelectionAfterDuplicate( clientIdsPromise ) {
+		if ( ! __experimentalSelectBlock ) {
+			return;
 		}
-	}, [
-		__experimentalSelectBlock,
-		previousBlockClientId,
-		firstParentClientId,
-		getBlockOrder,
-		hasSelectedBlocks,
-		getSelectedBlockClientIds,
-	] );
+
+		const ids = await clientIdsPromise;
+		if ( ids && ids[ 0 ] ) {
+			__experimentalSelectBlock( ids[ 0 ], false );
+		}
+	}
+
+	function updateSelectionAfterRemove() {
+		if ( ! __experimentalSelectBlock ) {
+			return;
+		}
+
+		let blockToFocus = previousBlockClientId || firstParentClientId;
+
+		// Focus the first block if there's no previous block nor parent block.
+		if ( ! blockToFocus ) {
+			blockToFocus = getBlockOrder()[ 0 ];
+		}
+
+		// Only update the selection if the original selection is removed.
+		const shouldUpdateSelection =
+			hasSelectedBlocks && getSelectedBlockClientIds().length === 0;
+
+		__experimentalSelectBlock( blockToFocus, shouldUpdateSelection );
+	}
 
 	// This can occur when the selected block (the parent)
 	// displays child blocks within a List View.
@@ -179,20 +173,17 @@ export function BlockSettingsDropdown( {
 		? undefined
 		: openedBlockSettingsMenu === currentClientId || false;
 
-	const onToggle = useCallback(
-		( localOpen ) => {
-			if ( localOpen && openedBlockSettingsMenu !== currentClientId ) {
-				setOpenedBlockSettingsMenu( currentClientId );
-			} else if (
-				! localOpen &&
-				openedBlockSettingsMenu &&
-				openedBlockSettingsMenu === currentClientId
-			) {
-				setOpenedBlockSettingsMenu( undefined );
-			}
-		},
-		[ currentClientId, openedBlockSettingsMenu, setOpenedBlockSettingsMenu ]
-	);
+	function onToggle( localOpen ) {
+		if ( localOpen && openedBlockSettingsMenu !== currentClientId ) {
+			setOpenedBlockSettingsMenu( currentClientId );
+		} else if (
+			! localOpen &&
+			openedBlockSettingsMenu &&
+			openedBlockSettingsMenu === currentClientId
+		) {
+			setOpenedBlockSettingsMenu( undefined );
+		}
+	}
 
 	return (
 		<BlockActions


### PR DESCRIPTION
## What?
PR removes unnecessary callback memoization in the `BlockSettingsDropdown` component.

## Why?
These callbacks aren't passed as effect dependencies or memoized component props. There's no need to ensure their stable reference.

## Testing Instructions
1. Open a post or page.
2. Add a few blocks.
3. Open the List View.
4. Removing a block moves selection to the previous block on Canvas and in the List View.
5. Duplicating a block moves the selection to the duplicate on Canvas and in the List View.
6. Confirm you can only open one settings menu from the List View. See #54083.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-02-27 at 15 14 15](https://github.com/WordPress/gutenberg/assets/240569/53b32250-13c2-451a-94d8-85dfc914870b)

