### PR TITLE
fix: Outline selected, failed Gallery block items

### DIFF
--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -289,13 +289,9 @@ const ImageComponent = ( {
 				key={ url }
 				style={ imageContainerStyles }
 			>
-				{ isSelected &&
-					highlightSelected &&
-					! (
-						isUploadInProgress ||
-						isUploadFailed ||
-						isUploadPaused
-					) && <View style={ imageSelectedStyles } /> }
+				{ isSelected && highlightSelected && (
+					<View style={ imageSelectedStyles } />
+				) }
 
 				{ ! imageData ? (
 					<View style={ placeholderStyles }>

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Improve consistency of the block outline indicating the currently selected block [#59415]
+-   [*] Gallery block items with in-progress, paused, or failed media uploads correctly display an highlight outline when selected [#59423]
 
 ## 1.114.0
 -   [*] Prevent crash when autoscrolling to blocks [#59110]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Indicate which Gallery block item is selected, even when an individual
item is has an in-progress, paused, or failed media upload.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes #59392. Avoids confusion as to which item is selected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove conditional logic removing the selection outline when the item's upload
is in-progress, paused, or failed. 

> It also adds a blue image highlight around images in the image block when they are selected.

This logic was originally added in #18493, as referenced above, but the original 
intent for disabling for in-progress or failed uploads is not clear.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add a Gallery block. 
2. Attach a view images to the gallery. 
3. Manually [toggle the values](https://github.com/WordPress/gutenberg/blob/28295ee43b04104bbde8cf3014b2daaecade61df/packages/block-library/src/image/edit.native.js#L847-L851) controlling in-progress, paused, and failed media. 
4. Select individual photos and verify the border is displayed. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no changes to the user flow. 

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/438664/540297d2-41aa-490e-9dc0-ccd8db866570

