### PR TITLE
Allow uploading fonts from multiple font families at once using the Uploads tab

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -143,19 +143,12 @@ function UploadFonts() {
 	const handleInstall = async ( fontFaces ) => {
 		const fontFamilies = makeFamiliesFromFaces( fontFaces );
 
-		if ( fontFamilies.length > 1 ) {
-			setNotice( {
-				type: 'error',
-				message: __(
-					'Variants from only one font family can be uploaded at a time.'
-				),
-			} );
-			setIsUploading( false );
-			return;
-		}
+		const installPromises = fontFamilies.map( ( fontFamily ) =>
+			installFont( fontFamily )
+		);
 
 		try {
-			await installFont( fontFamilies[ 0 ] );
+			await Promise.all( installPromises );
 			setNotice( {
 				type: 'success',
 				message: __( 'Fonts were installed successfully.' ),


### PR DESCRIPTION
## What?
Allow uploading fonts from multiple font families at once using the Uploads tab

## Why?
To improve the UX around uploading font file assets.

## How?
By creating an array of promises to handle the API requests.

:warning: this is a draft

## Testing Instructions
1. Go to the 'Upload' tab of the font library.
2. Select multiple files from **different** font families.
3. Check that they are installed as expected.

## Screenshots or screencast <!-- if applicable -->
