### PR TITLE
useMovingAnimation: Ensure transform is removed when the animation is stopped

### DIFF
--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -70,6 +70,7 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 			return;
 		}
 
+		const currentRef = ref.current;
 		const scrollContainer = getScrollContainer( ref.current );
 		const isSelected = isBlockSelected( clientId );
 		const adjustScrolling =
@@ -141,6 +142,10 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 		controller.start( { x: 0, y: 0, from: { x, y } } );
 
 		return () => {
+			// Ensure that transform is removed when the animation is stopped.
+			if ( currentRef ) {
+				currentRef.style.transform = null;
+			}
 			controller.stop();
 		};
 	}, [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 WIP: I'm not sure if this is the right fix as it might clear things out too frequently 🚧 🚧 🚧 🚧 

Fix a subtle bug with `useMovingAnimation` where if the cleanup on the `useEffect` fires before an animation has finished, then the element can be stuck with a stale `transform` value.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

WIth the list view open on a post with enough blocks that the list view gets a scrollbar, if you click somewhere within the editor canvas and press ENTER rapidly to create new paragraph blocks, the newly created blocks can result in the animation not finishing on previously added blocks. The result is that the list view can get "stuck" in a state where some of the list view items are in the wrong position vertically.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Get a reference to the current ref element.
* In the `useEffect`'s cleanup function, explicitly set `transform` to `null` to clean up any stray styles left over there.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add enough blocks to a post that you get a scrollbar in the list view.
2. With the list view open click somewhere in the editor canvas and then press ENTER rapidly to create a bunch of new paragraphs.
3. On `trunk` (or WP 6.5 Beta 3) notice that there'll be at least one paragraph block in the wrong position vertically, overlapping over list view items.
4. With this PR applied, if you repeat the same steps, the paragraph block shouldn't get stuck in the wrong position.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

This is the issue, that 🤞 shouldn't be possible to encounter if this PR works correctly:

<img width="347" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/531c55d9-527e-430f-9033-0329c8d6f1b3">

