### PR TITLE
Restore site editor navigation panel edit button.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/edit-button.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/edit-button.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import SidebarButton from '../sidebar-button';
+import { useLink } from '../routes/link';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
+
+export default function EditButton( { postId } ) {
+	const linkInfo = useLink( {
+		postId,
+		postType: NAVIGATION_POST_TYPE,
+		canvas: 'edit',
+	} );
+	return (
+		<SidebarButton { ...linkInfo } label={ __( 'Edit' ) } icon={ pencil } />
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
+
 /**
  * Internal dependencies
  */
@@ -10,6 +11,7 @@ import { SidebarNavigationScreenWrapper } from '../sidebar-navigation-screen-nav
 import ScreenNavigationMoreMenu from './more-menu';
 import NavigationMenuEditor from './navigation-menu-editor';
 import buildNavigationLabel from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
+import EditButton from './edit-button';
 
 export default function SingleNavigationMenu( {
 	navigationMenu,
@@ -29,6 +31,7 @@ export default function SingleNavigationMenu( {
 						onSave={ handleSave }
 						onDuplicate={ handleDuplicate }
 					/>
+					<EditButton postId={ navigationMenu?.id } />
 				</>
 			}
 			title={ buildNavigationLabel(

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -19,8 +19,8 @@ test.describe( 'Editing Navigation Menus', () => {
 		requestUtils,
 		editor,
 	} ) => {
-		await test.step( 'Check Navigation block is present and locked', async () => {
-			// Create a Navigation Menu called "Primary Menu" using the REST API helpers.
+		await test.step( 'Manually browse to focus mode for a Navigation Menu', async () => {
+			// create a Navigation Menu called "Test Menu" using the REST API helpers
 			const createdMenu = await requestUtils.createNavigationMenu( {
 				title: 'Primary Menu',
 				content:
@@ -34,12 +34,69 @@ test.describe( 'Editing Navigation Menus', () => {
 					'<!-- wp:navigation-link {"label":"Another Item","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
 			} );
 
-			await admin.visitSiteEditor( {
-				postId: createdMenu?.id,
-				postType: 'wp_navigation',
-				canvas: 'edit',
+			// We could Navigate directly to editing the Navigation Menu but we intentionally do not do this.
+			//
+			// Why? To provide coverage for a bug that caused the Navigation Editor behaviours to fail
+			// only when navigating through the editor screens (rather than going directly to the editor by URL).
+			// See: https://github.com/WordPress/gutenberg/pull/56856.
+			//
+			// Example (what we could do):
+			// await admin.visitSiteEditor( {
+			// 	postId: createdMenu?.id,
+			// 	postType: 'wp_navigation',
+			// } );
+			//
+			await admin.visitSiteEditor();
+
+			const editorSidebar = page.getByRole( 'region', {
+				name: 'Navigation',
 			} );
 
+			await editorSidebar
+				.getByRole( 'button', {
+					name: 'Navigation',
+				} )
+				.click();
+
+			// Wait for list of Navigations to appear.
+			await expect(
+				editorSidebar.getByRole( 'heading', {
+					name: 'Navigation',
+					level: 1,
+				} )
+			).toBeVisible();
+
+			await expect( page ).toHaveURL(
+				`wp-admin/site-editor.php?path=%2Fnavigation`
+			);
+
+			await editorSidebar
+				.getByRole( 'button', {
+					name: 'Primary Menu',
+				} )
+				.click();
+
+			await expect( page ).toHaveURL(
+				`wp-admin/site-editor.php?postId=${ createdMenu?.id }&postType=wp_navigation`
+			);
+
+			// Wait for list of Navigations to appear.
+			await expect(
+				editorSidebar.getByRole( 'heading', {
+					name: 'Primary Menu',
+					level: 1,
+				} )
+			).toBeVisible();
+
+			// Switch to editing the Navigation Menu
+			await editorSidebar
+				.getByRole( 'link', {
+					name: 'Edit',
+				} )
+				.click();
+		} );
+
+		await test.step( 'Check Navigation block is present and locked', async () => {
 			// Open List View.
 			await pageUtils.pressKeys( 'access+o' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/59372

## What?
<!-- In a few words, what is the PR actually doing? -->
Reverts the changes from https://github.com/WordPress/gutenberg/pull/59335
Restores the 'Edit' icon button in the site editor navigation panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Consistency is key. An user interfaces should be consistent and predictable. Controsl that are sometimes shown and sometimes not in similar screens contribute to make an user interface more confusing for users.
- The mechanism to switch the site editor from 'view' mode to 'edit' mode should be made more clear rather than more obscure.
- Some things in a navigation menu can only be edited in the edit mode, e.g.: add a link, rename a link, change a link, delete a link, etc.. As such, removing one of the controls to switch to edit mode doesn't help users understand how to edit their menus.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Reverts the changes from https://github.com/WordPress/gutenberg/pull/59335

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Make sure you have at least one navigation menu.
- Go to Site Editor > Design > Navigation > any menu
- Observe that in the navigation panel, after the navigation menu title and the ellipsis icon button, there is a pencil icon button labeled 'Edit'.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/WordPress/gutenberg/assets/1682452/5c0e4977-7537-43ce-ae00-4cb7af4b6a98)

After:

![after](https://github.com/WordPress/gutenberg/assets/1682452/7243fdd4-fbe0-4e86-afdb-47817708c57e)
