### PR TITLE
Update 'Add filter' button in data views

### DIFF
--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -5,7 +5,6 @@ import {
 	privateApis as componentsPrivateApis,
 	Button,
 } from '@wordpress/components';
-import { plus } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
 
@@ -31,7 +30,6 @@ function AddFilter( { filters, view, onChangeView, setOpenedFilter }, ref ) {
 				<Button
 					__experimentalIsFocusable
 					size="compact"
-					icon={ plus }
 					className="dataviews-filters-button"
 					variant="tertiary"
 					disabled={ ! inactiveFilters.length }


### PR DESCRIPTION
## What?
Remove the `+` icon from the 'Add filter' button.

## Why?
1. The `+` icon and the word 'Add' are a bit duplicative.
2. There's a little visual tension between the `+` and the `x` icons when filters are set.
3. Alignment with the reset button which has no icon.

## Testing Instructions
1. Open a data view like Manage all pages
2. Notice the 'Add filter' button has no `+` icon:

<img width="611" alt="Screenshot 2024-02-28 at 12 24 27" src="https://github.com/WordPress/gutenberg/assets/846565/f9b45d00-0f75-44f9-93d0-33034bb08a1d">

