### PR TITLE
Change default "Connected to a custom field" message in bindings

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -20,7 +20,7 @@ import {
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { image as icon, plugins as pluginsIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -336,7 +336,7 @@ export function ImageEdit( {
 	} );
 
 	// Much of this description is duplicated from MediaPlaceholder.
-	const { lockUrlControls = false } = useSelect(
+	const { lockUrlControls = false, lockUrlControlsMessage } = useSelect(
 		( select ) => {
 			if ( ! isSingleSelected ) {
 				return {};
@@ -351,6 +351,13 @@ export function ImageEdit( {
 					!! metadata?.bindings?.url &&
 					( ! blockBindingsSource ||
 						blockBindingsSource?.lockAttributesEditing ),
+				lockUrlControlsMessage: sprintf(
+					/* translators: %s: Label of the bindings source if exists */
+					__( 'Connected to %s' ),
+					blockBindingsSource?.label
+						? blockBindingsSource.label
+						: 'dynamic data'
+				),
 			};
 		},
 		[ isSingleSelected ]
@@ -387,7 +394,7 @@ export function ImageEdit( {
 					<span
 						className={ 'block-bindings-media-placeholder-message' }
 					>
-						{ __( 'Connected to a custom field' ) }
+						{ lockUrlControlsMessage }
 					</span>
 				) : (
 					content

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -354,9 +354,7 @@ export function ImageEdit( {
 				lockUrlControlsMessage: sprintf(
 					/* translators: %s: Label of the bindings source if exists */
 					__( 'Connected to %s' ),
-					blockBindingsSource?.label
-						? blockBindingsSource.label
-						: 'dynamic data'
+					blockBindingsSource?.label || __( 'dynamic data' )
 				),
 			};
 		},

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -351,11 +351,13 @@ export function ImageEdit( {
 					!! metadata?.bindings?.url &&
 					( ! blockBindingsSource ||
 						blockBindingsSource?.lockAttributesEditing ),
-				lockUrlControlsMessage: sprintf(
-					/* translators: %s: Label of the bindings source if exists */
-					__( 'Connected to %s' ),
-					blockBindingsSource?.label || __( 'dynamic data' )
-				),
+				lockUrlControlsMessage: blockBindingsSource?.label
+					? sprintf(
+							/* translators: %s: Label of the bindings source. */
+							__( 'Connected to %s' ),
+							blockBindingsSource.label
+					  )
+					: __( 'Connected to dynamic data' ),
 			};
 		},
 		[ isSingleSelected ]

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -410,7 +410,9 @@ export default function Image( {
 		lockUrlControls = false,
 		lockHrefControls = false,
 		lockAltControls = false,
+		lockAltControlsMessage,
 		lockTitleControls = false,
+		lockTitleControlsMessage,
 		lockCaption = false,
 	} = useSelect(
 		( select ) => {
@@ -454,10 +456,24 @@ export default function Image( {
 					!! altBinding &&
 					( ! altBindingSource ||
 						altBindingSource?.lockAttributesEditing ),
+				lockAltControlsMessage: sprintf(
+					/* translators: %s: Label of the bindings source if exists */
+					__( 'Connected to %s' ),
+					altBindingSource?.label
+						? altBindingSource.label
+						: 'dynamic data'
+				),
 				lockTitleControls:
 					!! titleBinding &&
 					( ! titleBindingSource ||
 						titleBindingSource?.lockAttributesEditing ),
+				lockTitleControlsMessage: sprintf(
+					/* translators: %s: Label of the bindings source if exists */
+					__( 'Connected to %s' ),
+					titleBindingSource?.label
+						? titleBindingSource.label
+						: 'dynamic data'
+				),
 			};
 		},
 		[ clientId, isSingleSelected, metadata?.bindings ]
@@ -557,11 +573,7 @@ export default function Image( {
 								disabled={ lockAltControls }
 								help={
 									lockAltControls ? (
-										<>
-											{ __(
-												'Connected to a custom field'
-											) }
-										</>
+										<>{ lockAltControlsMessage }</>
 									) : (
 										<>
 											<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
@@ -607,11 +619,7 @@ export default function Image( {
 								disabled={ lockTitleControls }
 								help={
 									lockTitleControls ? (
-										<>
-											{ __(
-												'Connected to a custom field'
-											) }
-										</>
+										<>{ lockTitleControlsMessage }</>
 									) : (
 										<>
 											{ __(
@@ -652,11 +660,7 @@ export default function Image( {
 								readOnly={ lockAltControls }
 								help={
 									lockAltControls ? (
-										<>
-											{ __(
-												'Connected to a custom field'
-											) }
-										</>
+										<>{ lockAltControlsMessage }</>
 									) : (
 										<>
 											<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
@@ -694,7 +698,7 @@ export default function Image( {
 					readOnly={ lockTitleControls }
 					help={
 						lockTitleControls ? (
-							<>{ __( 'Connected to a custom field' ) }</>
+							<>{ lockTitleControlsMessage }</>
 						) : (
 							<>
 								{ __(

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -456,20 +456,24 @@ export default function Image( {
 					!! altBinding &&
 					( ! altBindingSource ||
 						altBindingSource?.lockAttributesEditing ),
-				lockAltControlsMessage: sprintf(
-					/* translators: %s: Label of the bindings source if exists */
-					__( 'Connected to %s' ),
-					altBindingSource?.label || __( 'dynamic data' )
-				),
+				lockAltControlsMessage: altBindingSource?.label
+					? sprintf(
+							/* translators: %s: Label of the bindings source. */
+							__( 'Connected to %s' ),
+							altBindingSource.label
+					  )
+					: __( 'Connected to dynamic data' ),
 				lockTitleControls:
 					!! titleBinding &&
 					( ! titleBindingSource ||
 						titleBindingSource?.lockAttributesEditing ),
-				lockTitleControlsMessage: sprintf(
-					/* translators: %s: Label of the bindings source if exists */
-					__( 'Connected to %s' ),
-					titleBindingSource?.label || __( 'dynamic data' )
-				),
+				lockTitleControlsMessage: titleBindingSource?.label
+					? sprintf(
+							/* translators: %s: Label of the bindings source. */
+							__( 'Connected to %s' ),
+							titleBindingSource.label
+					  )
+					: __( 'Connected to dynamic data' ),
 			};
 		},
 		[ clientId, isSingleSelected, metadata?.bindings ]

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -459,9 +459,7 @@ export default function Image( {
 				lockAltControlsMessage: sprintf(
 					/* translators: %s: Label of the bindings source if exists */
 					__( 'Connected to %s' ),
-					altBindingSource?.label
-						? altBindingSource.label
-						: 'dynamic data'
+					altBindingSource?.label || __( 'dynamic data' )
 				),
 				lockTitleControls:
 					!! titleBinding &&
@@ -470,9 +468,7 @@ export default function Image( {
 				lockTitleControlsMessage: sprintf(
 					/* translators: %s: Label of the bindings source if exists */
 					__( 'Connected to %s' ),
-					titleBindingSource?.label
-						? titleBindingSource.label
-						: 'dynamic data'
+					titleBindingSource?.label || __( 'dynamic data' )
 				),
 			};
 		},


### PR DESCRIPTION
## What?
Right now, for all the sources, we are showing “Connected to a custom field”: [link](https://github.com/WordPress/gutenberg/blob/11ee353116ac925c9c9cd8c16c70900368936d24/packages/block-library/src/image/edit.js#L390). This means that, if I use a different source, it still shows the same message, which is not correct because it might not be a custom field.

## Why?
It might be confusing for users when they use a source that is not "Post meta".

## How?
I suggested using a more generic message that looks like "Connected to { source_label }". And, if the label doesn't exist because the source hasn't been registered in the editor, shows "Connected to dynamic data".

## Testing Instructions
1. Go to the Site Editor and visit a template.
2. Insert an image and add a binding to the "post meta" source.

```html
<!-- wp:image {"metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"custom_field"}}}}} -->
<figure class="wp-block-image"><img alt="" title=""/></figure>
<!-- /wp:image -->
```

3. In the visual editor, click on the image and check it shows "Connected to Post Meta".
4. In the code editor, change the source for a non-existing one, like "my-custom-source". Check that in the visual editor it shows "Connected to dynamic data".

Repeat the process but connecting the alt and title attributes instead.
