### PR TITLE
Avoid creating font families without font faces.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -202,6 +202,7 @@ function FontLibraryProvider( { children } ) {
 
 	async function installFont( fontFamilyToInstall ) {
 		setIsInstalling( true );
+		let isANewFontFamily = false;
 		try {
 			// Get the font family if it already exists.
 			let installedFontFamily = await fetchGetFontFamilyBySlug(
@@ -210,6 +211,7 @@ function FontLibraryProvider( { children } ) {
 
 			// Otherwise create it.
 			if ( ! installedFontFamily ) {
+				isANewFontFamily = true;
 				// Prepare font family form data to install.
 				installedFontFamily = await fetchInstallFontFamily(
 					makeFontFamilyFormData( fontFamilyToInstall )
@@ -268,6 +270,11 @@ function FontLibraryProvider( { children } ) {
 				sucessfullyInstalledFontFaces.length === 0 &&
 				alreadyInstalledFontFaces.length === 0
 			) {
+				if ( isANewFontFamily ) {
+					// If the font family is new, delete it to avoid having font families without font faces.
+					await fetchUninstallFontFamily( installedFontFamily.id );
+				}
+
 				throw new Error(
 					sprintf(
 						/* translators: %s: Specific error message returned from server. */


### PR DESCRIPTION
## What?
Avoid creating font families without font faces.

## Why?
There could be cases where the user can create font families but no font faces. For example, the user could be able to have permission to create font families in the database, but the filesystem permissions could be wrong in their server. This could lead to font families without any font face.

There are explorations around hiding the install-related UI when the user doesn't have permission to write the fonts folder. Those explorations haven't landed yet; this safe-guard probably won't hurt when those changes land and may still be useful in some cases, such as uploading font faces with wrong mime types.

## How?
With this change, if the user is installing a font family but the installation of all font faces failed, the font family just created is removed from the database.


## Testing Instructions
1. Disallow writing in your server's `wp-content/fonts` folder.
2. Install a font family with a few font faces.
3. Check that the font family is not listed as an installed family if the font faces failed to be installed.



## Screenshots or screencast <!-- if applicable -->
The screencasts are feature installing fonts in 2 scenarios:
1. with everything working as expected.
2. with font face creation failing for some reason. (To record these screencasts, the failure is generated by manually restricting the writing permissions in the fonts directory).


Compare the behavior in `trunk`

https://github.com/WordPress/gutenberg/assets/1310626/a30d630d-fbc2-498a-b0ed-2cf401fe023b



vs the be behavior in this branch:

https://github.com/WordPress/gutenberg/assets/1310626/a33352e5-496e-4849-9c27-b5b6ef5c50d0

