### PR TITLE
Data views: Update empty/loading states

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -51,6 +51,9 @@
 
 .dataviews-view-table-wrapper {
 	overflow-x: auto;
+	flex-grow: 1;
+	display: flex;
+	flex-direction: column;
 }
 
 .dataviews-view-table {
@@ -473,6 +476,10 @@
 .dataviews-no-results,
 .dataviews-loading {
 	padding: 0 $grid-unit-40;
+	flex-grow: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .dataviews-view-table-selection-checkbox label {

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -11,6 +11,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Tooltip,
+	Spinner,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
@@ -190,7 +191,7 @@ export default function ViewGrid( {
 						'dataviews-no-results': ! isLoading,
 					} ) }
 				>
-					<p>{ isLoading ? __( 'Loading…' ) : __( 'No results' ) }</p>
+					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
 				</div>
 			) }
 		</>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -11,6 +11,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
+	Spinner,
 } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { info } from '@wordpress/icons';
@@ -60,7 +61,7 @@ export default function ViewList( {
 				} ) }
 			>
 				{ ! hasData && (
-					<p>{ isLoading ? __( 'Loading…' ) : __( 'No results' ) }</p>
+					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
 				) }
 			</div>
 		);

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -14,6 +14,7 @@ import {
 	Icon,
 	privateApis as componentsPrivateApis,
 	CheckboxControl,
+	Spinner,
 } from '@wordpress/components';
 import {
 	forwardRef,
@@ -464,7 +465,7 @@ function ViewTable( {
 				id={ tableNoticeId }
 			>
 				{ ! hasData && (
-					<p>{ isLoading ? __( 'Loading…' ) : __( 'No results' ) }</p>
+					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
 				) }
 			</div>
 		</div>


### PR DESCRIPTION
## What?
1. Replace 'Loading...' text with a `Spinner`
2. Centrally align spinner / 'No results' text.

## Why?
1. A `Spinner` is more consistent with loading states found elsewhere
2. Centrally aligning these elements decreases the likelihood of them being visually obscured, e.g.:

<img width="1078" alt="Screenshot 2024-02-28 at 13 47 45" src="https://github.com/WordPress/gutenberg/assets/846565/5a36c026-d5e7-40ed-9e81-1a72e81036a3">

## Testing Instructions
1. Open a data view e.g. "Manage all pages"
2. As data loads, observe a `Spinner` 
3. Configure the data view so no results are found
4. Observe the 'No results' message in the center of the view.


https://github.com/WordPress/gutenberg/assets/846565/d0dda75d-0484-481b-9afe-03f4c6a38935

Note: It would be nice to delay the appearance of the spinner by a second or two, then fade it in. Often times the data loads quickly and the display of the spinner (or 'Loading...' text) is a bit distracting.

Note 2: We might embellish the 'No results' state to include conditional messaging. E.g. when there are no records at all include an 'Add' button. When the lack of results is due to filter config; display a prominent 'Reset filters' button. 
