### PR TITLE
Move Navigation menu title and state info out from Actions button label.

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -143,7 +143,10 @@ const MenuInspectorControls = ( props ) => {
 	return (
 		<InspectorControls group="list">
 			<PanelBody title={ null }>
-				<HStack className="wp-block-navigation-off-canvas-editor__header">
+				<HStack
+					wrap={ true }
+					className="wp-block-navigation-off-canvas-editor__header"
+				>
 					<Heading
 						className="wp-block-navigation-off-canvas-editor__title"
 						level={ 2 }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -144,7 +144,7 @@ const MenuInspectorControls = ( props ) => {
 		<InspectorControls group="list">
 			<PanelBody title={ null }>
 				<HStack
-					wrap={ true }
+					wrap
 					className="wp-block-navigation-off-canvas-editor__header"
 				>
 					<Heading

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -6,6 +6,7 @@ import {
 	MenuItem,
 	MenuItemsChoice,
 	DropdownMenu,
+	FlexItem,
 } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
@@ -107,16 +108,18 @@ function NavigationMenuSelector( {
 	const menuUnavailable =
 		hasResolvedNavigationMenus && currentMenuId === null;
 
-	let selectorLabel = '';
+	let currentMenuTitleOrMenuState = '';
 
 	if ( isResolvingNavigationMenus ) {
-		selectorLabel = __( 'Loading…' );
+		currentMenuTitleOrMenuState = __( 'Loading…' );
 	} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
 		// Note: classic Menus may be available.
-		selectorLabel = __( 'Choose or create a Navigation Menu' );
+		currentMenuTitleOrMenuState = __(
+			'Choose or create a Navigation Menu'
+		);
 	} else {
 		// Current Menu's title.
-		selectorLabel = currentTitle;
+		currentMenuTitleOrMenuState = currentTitle;
 	}
 
 	useEffect( () => {
@@ -138,77 +141,88 @@ function NavigationMenuSelector( {
 	] );
 
 	const NavigationMenuSelectorDropdown = (
-		<DropdownMenu
-			label={ selectorLabel }
-			icon={ moreVertical }
-			toggleProps={ { size: 'small' } }
-		>
-			{ ( { onClose } ) => (
-				<>
-					{ showNavigationMenus && hasNavigationMenus && (
-						<MenuGroup label={ __( 'Menus' ) }>
-							<MenuItemsChoice
-								value={ currentMenuId }
-								onSelect={ ( menuId ) => {
-									onSelectNavigationMenu( menuId );
-									onClose();
-								} }
-								choices={ menuChoices }
-							/>
-						</MenuGroup>
-					) }
-					{ showClassicMenus && hasClassicMenus && (
-						<MenuGroup label={ __( 'Import Classic Menus' ) }>
-							{ classicMenus?.map( ( menu ) => {
-								const label = decodeEntities( menu.name );
-								return (
-									<MenuItem
-										onClick={ async () => {
-											setIsUpdatingMenuRef( true );
-											await onSelectClassicMenu( menu );
-											setIsUpdatingMenuRef( false );
-											onClose();
-										} }
-										key={ menu.id }
-										aria-label={ sprintf(
-											createActionLabel,
-											label
-										) }
-										disabled={
-											isUpdatingMenuRef ||
-											isResolvingNavigationMenus ||
-											! hasResolvedNavigationMenus
-										}
-									>
-										{ label }
-									</MenuItem>
-								);
-							} ) }
-						</MenuGroup>
-					) }
-
-					{ canUserCreateNavigationMenus && (
-						<MenuGroup label={ __( 'Tools' ) }>
-							<MenuItem
-								onClick={ async () => {
-									setIsUpdatingMenuRef( true );
-									await onCreateNew();
-									setIsUpdatingMenuRef( false );
-									onClose();
-								} }
-								disabled={
-									isUpdatingMenuRef ||
-									isResolvingNavigationMenus ||
-									! hasResolvedNavigationMenus
-								}
-							>
-								{ __( 'Create new menu' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
-				</>
-			) }
-		</DropdownMenu>
+		<>
+			<DropdownMenu
+				label={ __( 'Actions' ) }
+				icon={ moreVertical }
+				toggleProps={ { size: 'small' } }
+			>
+				{ ( { onClose } ) => (
+					<>
+						{ showNavigationMenus && hasNavigationMenus && (
+							<MenuGroup label={ __( 'Available Menus' ) }>
+								<MenuItemsChoice
+									value={ currentMenuId }
+									onSelect={ ( menuId ) => {
+										onSelectNavigationMenu( menuId );
+										onClose();
+									} }
+									choices={ menuChoices }
+								/>
+							</MenuGroup>
+						) }
+						{ showClassicMenus && hasClassicMenus && (
+							<MenuGroup label={ __( 'Import Classic Menus' ) }>
+								{ classicMenus?.map( ( menu ) => {
+									const label = decodeEntities( menu.name );
+									return (
+										<MenuItem
+											onClick={ async () => {
+												setIsUpdatingMenuRef( true );
+												await onSelectClassicMenu(
+													menu
+												);
+												setIsUpdatingMenuRef( false );
+												onClose();
+											} }
+											key={ menu.id }
+											aria-label={ sprintf(
+												createActionLabel,
+												label
+											) }
+											disabled={
+												isUpdatingMenuRef ||
+												isResolvingNavigationMenus ||
+												! hasResolvedNavigationMenus
+											}
+										>
+											{ label }
+										</MenuItem>
+									);
+								} ) }
+							</MenuGroup>
+						) }
+						{ canUserCreateNavigationMenu && (
+							<MenuGroup label={ __( 'Tools' ) }>
+								<MenuItem
+									onClick={ async () => {
+										setIsUpdatingMenuRef( true );
+										await onCreateNew();
+										setIsUpdatingMenuRef( false );
+										onClose();
+									} }
+									disabled={
+										isUpdatingMenuRef ||
+										isResolvingNavigationMenus ||
+										! hasResolvedNavigationMenus
+									}
+								>
+									{ __( 'Create new menu' ) }
+								</MenuItem>
+							</MenuGroup>
+						) }
+					</>
+				) }
+			</DropdownMenu>
+			<FlexItem
+				style={ {
+					minWidth: '100%',
+				} }
+				as="p"
+			>
+				{ currentMenuTitleOrMenuState }
+			</FlexItem>
+		</>
 	);
 
 	return NavigationMenuSelectorDropdown;

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -192,7 +192,7 @@ function NavigationMenuSelector( {
 								} ) }
 							</MenuGroup>
 						) }
-						{ canUserCreateNavigationMenu && (
+						{ canUserCreateNavigationMenus && (
 							<MenuGroup label={ __( 'Tools' ) }>
 								<MenuItem
 									onClick={ async () => {

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -72,7 +72,7 @@ const classicMenusFixture = [
 
 describe( 'NavigationMenuSelector', () => {
 	describe( 'Toggle', () => {
-		it( 'should show dropdown toggle with loading message when menus have not resolved', async () => {
+		it( 'should show paragraph with loading message when menus have not resolved', async () => {
 			useNavigationMenu.mockReturnValue( {
 				navigationMenus: [],
 				isResolvingNavigationMenus: true,
@@ -82,14 +82,10 @@ describe( 'NavigationMenuSelector', () => {
 
 			render( <NavigationMenuSelector /> );
 
-			expect(
-				screen.getByRole( 'button', {
-					name: /Loading/,
-				} )
-			).toBeInTheDocument();
+			expect( screen.getByText( /Loading/ ) ).toBeVisible();
 		} );
 
-		it( 'should show correct dropdown toggle prompt to choose a menu when Navigation Menus have resolved', async () => {
+		it( 'should show correct paragraph message to choose a menu when Navigation Menus have resolved', async () => {
 			useNavigationMenu.mockReturnValue( {
 				navigationMenus: [],
 				hasResolvedNavigationMenus: true,
@@ -98,12 +94,9 @@ describe( 'NavigationMenuSelector', () => {
 			} );
 
 			render( <NavigationMenuSelector /> );
-
 			expect(
-				screen.getByRole( 'button', {
-					name: 'Choose or create a Navigation Menu',
-				} )
-			).toBeInTheDocument();
+				screen.getByText( 'Choose or create a Navigation Menu' )
+			).toBeVisible();
 		} );
 	} );
 
@@ -126,12 +119,14 @@ describe( 'NavigationMenuSelector', () => {
 
 			expect(
 				screen.getByRole( 'menu', {
-					name: /Loading/,
+					name: 'Actions',
 				} )
 			).toBeInTheDocument();
 
 			// Check that all the option groups are *not* present.
-			const menusGroup = screen.queryByRole( 'group', { name: 'Menus' } );
+			const menusGroup = screen.queryByRole( 'group', {
+				name: 'Available Menus',
+			} );
 			expect( menusGroup ).not.toBeInTheDocument();
 
 			const classicMenusGroup = screen.queryByRole( 'group', {
@@ -159,23 +154,22 @@ describe( 'NavigationMenuSelector', () => {
 				render( <NavigationMenuSelector /> );
 
 				const toggleButton = screen.getByRole( 'button', {
-					name: 'Choose or create a Navigation Menu',
+					name: 'Actions',
 				} );
+
+				expect(
+					screen.getByText( 'Choose or create a Navigation Menu' )
+				).toBeVisible();
 
 				await user.click( toggleButton );
 
-				const menuPopover = screen.getByRole( 'menu' );
-
-				expect( menuPopover ).toHaveAttribute(
-					'aria-label',
-					expect.stringContaining(
-						'Choose or create a Navigation Menu'
-					)
-				);
+				expect(
+					screen.getByText( 'Choose or create a Navigation Menu' )
+				).toBeVisible();
 
 				// Check that all the option groups are *not* present.
 				const menusGroup = screen.queryByRole( 'group', {
-					name: 'Menus',
+					name: 'Available Menus',
 				} );
 				expect( menusGroup ).not.toBeInTheDocument();
 
@@ -341,7 +335,7 @@ describe( 'NavigationMenuSelector', () => {
 				await user.click( toggleButton );
 
 				const menusGroup = screen.queryByRole( 'group', {
-					name: 'Menus',
+					name: 'Available Menus',
 				} );
 				expect( menusGroup ).not.toBeInTheDocument();
 			} );
@@ -362,7 +356,7 @@ describe( 'NavigationMenuSelector', () => {
 				await user.click( toggleButton );
 
 				const menusGroup = screen.queryByRole( 'group', {
-					name: 'Menus',
+					name: 'Available Menus',
 				} );
 				expect( menusGroup ).toBeInTheDocument();
 
@@ -401,7 +395,7 @@ describe( 'NavigationMenuSelector', () => {
 				await user.click( toggleButton );
 
 				const menusGroup = screen.queryByRole( 'group', {
-					name: 'Menus',
+					name: 'Available Menus',
 				} );
 				expect( menusGroup ).toBeInTheDocument();
 
@@ -612,7 +606,7 @@ describe( 'NavigationMenuSelector', () => {
 				// Check the dropdown is open and is in the "loading" state.
 				expect(
 					screen.getByRole( 'menu', {
-						name: /Loading/,
+						name: 'Actions',
 					} )
 				).toBeInTheDocument();
 
@@ -641,13 +635,6 @@ describe( 'NavigationMenuSelector', () => {
 						createNavigationMenuIsSuccess // classic menu import creates a Navigation menu.
 					/>
 				);
-
-				// Todo: fix bug where aria label is not updated.
-				// expect(
-				// 	screen.getByRole( 'menu', {
-				// 		name: `You are currently editing ${ classicMenusFixture[ 0 ].name }`,
-				// 	} )
-				// ).toBeInTheDocument();
 
 				// Check all menu items are re-enabled.
 				screen.getAllByRole( 'menuitem' ).forEach( ( item ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/59431

## What?
<!-- In a few words, what is the PR actually doing? -->
The label of the Navigation menu 'actions' button in the settings panel provides information about the currently selected menu title or state rather than the _what_ the button does.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Any control must be labeled based on what it does or on what actions it gives access to. It's not a place to report selected values or states.
Also, consistency is key.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Change button label to 'Actions'.
- Moves the information about the currently selected menu or the state to a description after the panel heading.

Note:
the latest commit improves a little the 'Loading...' indicator. Previously, this 'Loading...' text stayed there forever after switching to another menu. It is now a little better but I don't think the underlying bug is fully solved. Specifically, I'm not sure the state props `isCreatingMenu`, `isResolvingNavigationMenus`, and `hasResolvedNavigationMenus` work as intended. Basically, when switching to another menu, `isCreatingMenu` is always true, which doesn't seem correct to me and causes at least another bug. I will split this to a separate issue with more details.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to Site editor, edit mode.
- Select a navigation block.
- In the settings panel, observe the currently selected navigation menu name is shown under the heading 'Menu'.
- Onserve the label of the ellipsis button after the heading 'Menu' is now 'Actions'.
- Open the Actions menu.
- Click Create a new menu.
- Observe the currently selected navigation menu name changes to `Loading...`.
- Onbserve that when the new menu is created, the `Loading...` text changes to the new menu name e.g. 'Header navigation 2'.
- Open the Actions menu.
- Switch to another menu.
- Observe the currently selected menu name under the heading changes to the new selected menu name.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
