### PR TITLE
Block bindings: Don't use `useEffect` in the block bindings editor hook

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -85,10 +85,6 @@ const BindingConnector = ( {
 
 	const updateBoundAttibute = useCallback(
 		( newAttrValue, prevAttrValue ) => {
-			// Bail early if the attribute value is the same.
-			if ( prevAttrValue === newAttrValue ) {
-				return;
-			}
 			/*
 			 * If the attribute is a RichTextData instance,
 			 * (core/paragraph, core/heading, core/button, etc.)
@@ -113,6 +109,11 @@ const BindingConnector = ( {
 				 * convert the new value to a RichTextData instance.
 				 */
 				newAttrValue = RichTextData.fromHTMLString( newAttrValue );
+			}
+
+			// Bail early if the attribute value is the same.
+			if ( prevAttrValue === newAttrValue ) {
+				return;
 			}
 
 			onPropValueChange( { [ attrName ]: newAttrValue } );

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -191,8 +191,8 @@ function BlockBindingBridge( { blockProps, bindings, onPropValueChange } ) {
 
 const withBlockBindingSupport = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		function attributeReducer( state, action ) {
-			return { ...state, ...action };
+		function attributeReducer( state, newAttibutes ) {
+			return { ...state, ...newAttibutes };
 		}
 
 		/*

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -95,6 +95,7 @@ const BindingConnector = ( {
 			 * compare its HTML representation with the new value.
 			 */
 			if ( prevAttrValue instanceof RichTextData ) {
+				// If the new value is also a RichTextData instance and the value is the same, bail early.
 				if (
 					newAttrValue instanceof RichTextData &&
 					prevAttrValue.toHTMLString() === newAttrValue.toHTMLString()


### PR DESCRIPTION
This is an enhancement to https://github.com/WordPress/gutenberg/pull/59403 which avoids using `useEffect()` to sync the block attributes with custom field values.

As discussed in https://github.com/WordPress/gutenberg/pull/59403#discussion_r1504772501

### Why?

Using a `useEffect()` to synchronize the value from the custom field with the attribute means that on the initial render (before the effect runs) the value rendered in the editor will be incorrect (not coming from the custom field).

It's also marginally better for performance.

### How ?

We can update the local state directly in the render function. This is a [recognized React pattern](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes). We just have to be careful not to introduce an infinite loop.

### Testing

1. Register a custom field e.g:
    ```php
    register_meta(
	    'post',
	    'protected',
	    array(
		    'show_in_rest'   => true,
		    'single'         => true,
		    'type'           => 'string',
		    'default'        => 'Custom field value',
	    )
    );
    ```

2. Add a connected block, e.g.:
    ```
    <!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
    <p>Value provided by the source (core/post-meta)</p>
    <!-- /wp:paragraph -->
    ```

3. Check that the editor displays the value from the custom field.
4. Try out other blocks: Button, Image and using `src` or `url` attributes.
5. Try connecting blocks that should **not** allow being connected, e.g.: `Pullquote` or `Code` (using instructions from step 2.) and verify that there are no errors.
6. Try connecting attributes that should **not** allow being connected (using instructions from 2.) and verify that there are no errors.