### PR TITLE
Refactor: useBlockTools cleanup

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
+++ b/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
@@ -21,11 +21,10 @@ export function useHasBlockToolbar() {
 			const {
 				getBlockEditingMode,
 				getBlockName,
-				getSelectedBlockClientIds,
+				getBlockSelectionStart,
 			} = select( blockEditorStore );
 
-			const selectedBlockClientIds = getSelectedBlockClientIds();
-			const selectedBlockClientId = selectedBlockClientIds[ 0 ];
+			const selectedBlockClientId = getBlockSelectionStart();
 			const isDefaultEditingMode =
 				getBlockEditingMode( selectedBlockClientId ) === 'default';
 			const blockType =

--- a/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
+++ b/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
@@ -24,6 +24,9 @@ export function useHasBlockToolbar() {
 				getBlockSelectionStart,
 			} = select( blockEditorStore );
 
+			// we only care about the 1st selected block
+			// for the toolbar, so we use getBlockSelectionStart
+			// instead of getSelectedBlockClientIds
 			const selectedBlockClientId = getBlockSelectionStart();
 			const isDefaultEditingMode =
 				getBlockEditingMode( selectedBlockClientId ) === 'default';

--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -34,18 +34,15 @@ export function useShowBlockTools() {
 				getSelectedBlockClientId() ||
 				getFirstMultiSelectedBlockClientId();
 
-			const { name = '', attributes = {} } = getBlock( clientId ) || {};
+			const block = getBlock( clientId ) || { name: '', attributes: {} };
 			const editorMode = __unstableGetEditorMode();
-			const hasSelectedBlock = clientId && name;
-			const isEmptyDefaultBlock = isUnmodifiedDefaultBlock( {
-				name,
-				attributes,
-			} );
+			const hasSelectedBlock = clientId && block?.name;
+			const isEmptyDefaultBlock = isUnmodifiedDefaultBlock( block );
 			const _showEmptyBlockSideInserter =
 				clientId &&
 				! isTyping() &&
 				editorMode === 'edit' &&
-				isUnmodifiedDefaultBlock( { name, attributes } );
+				isUnmodifiedDefaultBlock( block );
 			const maybeShowBreadcrumb =
 				hasSelectedBlock &&
 				! hasMultiSelection() &&

--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -42,7 +42,7 @@ export function useShowBlockTools() {
 				clientId &&
 				! isTyping() &&
 				editorMode === 'edit' &&
-				isUnmodifiedDefaultBlock( block );
+				isEmptyDefaultBlock;
 			const maybeShowBreadcrumb =
 				hasSelectedBlock &&
 				! hasMultiSelection() &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Follow-up to https://github.com/WordPress/gutenberg/pull/58979. @Mamaduka proposed some good ideas for improvements, but I wanted to do them in follow-ups instead of putting the changes into the first refactor.

## Why?/How?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Future-proofing `isUnmodifiedDefaultBlock` by passing the full block object.
- Performance by using `getBlockSelectionStart()` instead of `selectedBlockClientIds()`

## Testing Instructions
Toolbar should work in the same way as before.
