### PR TITLE
l10n: Unify terminology to `screen size`

### DIFF
--- a/packages/block-editor/src/components/responsive-block-control/README.md
+++ b/packages/block-editor/src/components/responsive-block-control/README.md
@@ -2,7 +2,7 @@
 
 `ResponsiveBlockControl` provides a standardised interface for the creation of Block controls that require **different settings per viewport** (ie: "responsive" settings).
 
-For example, imagine your Block provides a control which affords the ability to change a "padding" value used in the Block display. Consider that whilst this setting may work well on "large" screens, the same value may not work well on smaller screens (it may be too large for example). As a result, you now need to provide a padding control _per viewport/screensize_.
+For example, imagine your Block provides a control which affords the ability to change a "padding" value used in the Block display. Consider that whilst this setting may work well on "large" screens, the same value may not work well on smaller screens (it may be too large for example). As a result, you now need to provide a padding control _per viewport/screen size_.
 
 `ResponsiveBlockControl` provides a standardised component for the creation of such interfaces within Gutenberg.
 
@@ -194,7 +194,7 @@ const renderResponsiveControls = ( viewports ) => {
 ### `toggleLabel`
 
 -   **Type:** `String`
--   **Default:** `Use the same %s on all screensizes.` (where "%s" is the `property` prop - see above )
+-   **Default:** `Use the same %s on all screen sizes.` (where "%s" is the `property` prop - see above )
 -   **Required:** `false`
 
 Optional label used for the toggle control which switches the interface between showing responsive controls or not.
@@ -213,7 +213,7 @@ Optional label used for the toggle control which switches the interface between 
 
 -   **Required:** `false`
 
-Optional object describing the attributes of the default value. By default this is `All` which indicates the control will affect "all viewports/screensizes".
+Optional object describing the attributes of the default value. By default this is `All` which indicates the control will affect "all viewports/screen sizes".
 
 ### `viewports`
 

--- a/packages/block-editor/src/components/responsive-block-control/README.md
+++ b/packages/block-editor/src/components/responsive-block-control/README.md
@@ -25,7 +25,7 @@ import { useState } from 'react';
 import { registerBlockType } from '@wordpress/blocks';
 import {
 	InspectorControls,
-	ResponsiveBlockControl,
+	__experimentalResponsiveBlockControl as ResponsiveBlockControl,
 } from '@wordpress/block-editor';
 import {
 	DimensionControl,

--- a/packages/block-editor/src/components/responsive-block-control/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/index.js
@@ -52,7 +52,7 @@ function ResponsiveBlockControl( props ) {
 		toggleLabel ||
 		sprintf(
 			/* translators: %s: Property value for the control (eg: margin, padding, etc.). */
-			__( 'Use the same %s on all screensizes.' ),
+			__( 'Use the same %s on all screen sizes.' ),
 			property
 		);
 

--- a/packages/block-editor/src/components/responsive-block-control/test/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.js
@@ -81,7 +81,7 @@ describe( 'Basic rendering', () => {
 		} );
 
 		const toggleState = screen.getByRole( 'checkbox', {
-			name: 'Use the same padding on all screensizes.',
+			name: 'Use the same padding on all screen sizes.',
 			checked: true,
 		} );
 
@@ -268,7 +268,7 @@ describe( 'Default and Responsive modes', () => {
 
 		// Select elements based on what the user can see.
 		const toggleInput = screen.getByRole( 'checkbox', {
-			name: 'Use the same padding on all screensizes.',
+			name: 'Use the same padding on all screen sizes.',
 			checked: true,
 		} );
 


### PR DESCRIPTION
Fixes #58192

## What?
This PR unifies the two mixed variations (`screen size(s)` / `screensize(s)`) into `screen size(s)`.

## Why?

To improve terminology consistency.

## How?

I'm not a native English speaker, but it seems like everything is unified by "screen size(s)" in the core.

| screen size | screensize |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/4c25bd1e-2946-48e3-9774-df1c6aa42078) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/bfbdee87-a1c5-44dc-8233-f450c7cf7118)| 

## Testing Instructions

This PR causes a visual change only for the `ResponsiveBlockControl` component. Although this component is public, it doesn't seem to be used anywhere in the Gutenberg project. If used, it would look like this: This is a temporary rewrite of the code block.

<details><summary>Code</summary>

```javascript
/**
 * WordPress dependencies
 */
import {
	useBlockProps,
	InspectorControls,
	__experimentalResponsiveBlockControl as ResponsiveBlockControl,
} from '@wordpress/block-editor';
import { PanelBody, SelectControl } from '@wordpress/components';

export default function CodeEdit() {
	const blockProps = useBlockProps();

	return (
		<>
			<InspectorControls>
				<PanelBody>
					<ResponsiveBlockControl
						title="Block Padding"
						property="padding"
						renderDefaultControl={ ( labelComponent ) => (
							<SelectControl
								label={ labelComponent }
								options={ [
									{
										label: 'Please select',
										value: '',
									},
									{
										label: 'Small',
										value: 'small',
									},
									{
										label: 'Medium',
										value: 'medium',
									},
									{
										label: 'Large',
										value: 'large',
									},
								] }
							/>
						) }
					/>
				</PanelBody>
			</InspectorControls>
			<div { ...blockProps }>Test</div>
		</>
	);
}
```

</details> 

![image](https://github.com/WordPress/gutenberg/assets/54422211/b54073bf-a1a7-4d0f-ad86-df13728d4f0f)