### PR TITLE
Reduce specificity of block library styles conflicting with block supports

### DIFF
--- a/packages/block-library/src/audio/theme.scss
+++ b/packages/block-library/src/audio/theme.scss
@@ -2,6 +2,6 @@
 	@include caption-style-theme();
 }
 
-.wp-block-audio {
+:where(.wp-block-audio) {
 	margin: 0 0 1em 0;
 }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -1,12 +1,16 @@
+// Lowest specificity styles are used to ensure that the default styles for the cover block can be overridden by global styles.
+:where(.wp-block-cover-image, .wp-block-cover) {
+	min-height: 430px;
+	padding: 1em;
+}
+
 .wp-block-cover-image,
 .wp-block-cover {
 	position: relative;
 	background-position: center center;
-	min-height: 430px;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	padding: 1em;
 	// Prevent the `wp-block-cover__background` span from overflowing the container when border-radius is applied.
 	// `overflow: hidden` is provided as a fallback for browsers that don't support `overflow: clip`.
 	overflow: hidden;

--- a/packages/block-library/src/embed/theme.scss
+++ b/packages/block-library/src/embed/theme.scss
@@ -2,6 +2,6 @@
 	@include caption-style-theme();
 }
 
-.wp-block-embed {
+:where(.wp-block-embed) {
 	margin: 0 0 1em 0;
 }

--- a/packages/block-library/src/image/theme.scss
+++ b/packages/block-library/src/image/theme.scss
@@ -2,6 +2,6 @@
 	@include caption-style-theme();
 }
 
-.wp-block-image {
+:where(.wp-block-image) {
 	margin: 0 0 1em 0;
 }

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -1,9 +1,11 @@
-.wp-block-pullquote {
+:where(.wp-block-pullquote) {
 	border-top: 4px solid currentColor;
 	border-bottom: 4px solid currentColor;
 	margin-bottom: 1.75em;
 	color: currentColor;
+}
 
+.wp-block-pullquote {
 	cite,
 	footer,
 	&__citation {

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -1,8 +1,7 @@
-.wp-block-quote {
+:where(.wp-block-quote) {
 	border-left: 0.25em solid currentColor;
 	margin: 0 0 1.75em 0;
 	padding-left: 1em;
-
 	cite,
 	footer {
 		color: currentColor;

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -4,13 +4,6 @@
 		display: inline-block;
 		margin-left: $grid-unit-10;
 	}
-
-	// Unset background colors that can be inherited from Global Styles.
-	// This is a duplicate of a rule in style.scss, as it needs higher specificity in the editor.
-	// The rule can be removed if editor styles get lowered in specificity.
-	&.wp-block-social-links {
-		background: none;
-	}
 }
 
 // Prevent toolbar from jumping when selecting / hovering a link.

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -1,6 +1,4 @@
 .wp-block-table {
-	margin: 0 0 1em 0;
-
 	td,
 	th {
 		word-break: normal;
@@ -9,4 +7,8 @@
 	figcaption {
 		@include caption-style-theme();
 	}
+}
+
+:where(.wp-block-table) {
+	margin: 0 0 1em 0;
 }

--- a/packages/block-library/src/template-part/theme.scss
+++ b/packages/block-library/src/template-part/theme.scss
@@ -1,5 +1,5 @@
 // Same as the group block styles.
-.wp-block-template-part {
+:where(.wp-block-template-part) {
 	&.has-background {
 		// Matches paragraph Block padding
 		padding: $block-bg-padding--v $block-bg-padding--h;

--- a/packages/block-library/src/video/theme.scss
+++ b/packages/block-library/src/video/theme.scss
@@ -2,6 +2,6 @@
 	@include caption-style-theme();
 }
 
-.wp-block-video {
+:where(.wp-block-video) {
 	margin: 0 0 1em 0;
 }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Starts breaking down #57841 into its component parts.

This PR only addresses block-library styles, reducing specificity of rules that might conflict with global styles added to those blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This can be tested on classic and block themes, but particular attention should be given to those that add support for `wp-block-styles` (that's what enqueues the `theme.css` files from each block).

Check that the blocks with style changes in this PR still display as expected. Global styles should work as well in this branch as they do on trunk, because their specificity hasn't been changed in this PR.

