### PR TITLE
Query Loop: Don't show publicly non-queryable taxonomies

### DIFF
--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -131,16 +131,16 @@ export const useTaxonomies = ( postType ) => {
 	const taxonomies = useSelect(
 		( select ) => {
 			const { getTaxonomies } = select( coreStore );
-			const filteredTaxonomies = getTaxonomies( {
+			return getTaxonomies( {
 				type: postType,
 				per_page: -1,
-				context: 'view',
 			} );
-			return filteredTaxonomies;
 		},
 		[ postType ]
 	);
-	return taxonomies;
+	return taxonomies?.filter(
+		( { visibility } ) => !! visibility?.publicly_queryable
+	);
 };
 
 /**

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -138,9 +138,11 @@ export const useTaxonomies = ( postType ) => {
 		},
 		[ postType ]
 	);
-	return taxonomies?.filter(
-		( { visibility } ) => !! visibility?.publicly_queryable
-	);
+	return useMemo( () => {
+		return taxonomies?.filter(
+			( { visibility } ) => !! visibility?.publicly_queryable
+		);
+	}, [ taxonomies ] );
 };
 
 /**


### PR DESCRIPTION
Fixes #59257

## What?

This PR excludes taxonomies with `publicly_queryable` set to `false` from the Filter panel in the Query Loop block.

## Why?

The behavior of the Query Loop block must be consistent in the editor and front end. My understanding is that `publicly_queryable` defines whether it is queryable on the front end, and if the value is `false`, the query results will not be displayed. Therefore, I don't think the editor should display taxonomies where `publicly_queryable` is `false` in the first place.

## How?

Display only taxonomies for which `publicly_queryable` is `true` in the Filters panel. This approach is consistent elsewhere, as noted in [this comment](https://github.com/WordPress/gutenberg/issues/59257#issuecomment-1958671953).

## Testing Instructions

- Add the following code to the `gutenberg.php` file. This code adds queryable and non-queryable taxonomies to Post and Page, respectively.
  ```php
  function add_taxonomies() {
  	register_taxonomy( 'queryable_post_taxonomy', array( 'post' ), array(
  		'public'             => true,
  		'publicly_queryable' => true,
  		'show_in_rest' 		   => true,
  		'label'              => 'Queryable Post Taxonomy',
  	) );
  	register_taxonomy( 'non_queryable_post_taxonomy', array( 'post' ), array(
  		'public'             => true,
  		'publicly_queryable' => false,
  		'show_in_rest' 		   => true,
  		'label'              => 'Non Queryable Post Taxonomy',
  	) );
  	register_taxonomy( 'queryable_page_taxonomy', array( 'page' ), array(
  		'public'             => true,
  		'publicly_queryable' => true,
  		'show_in_rest' 		   => true,
  		'label'              => 'Queryable Page Taxonomy',
  	) );
  	register_taxonomy( 'non_queryable_page_taxonomy', array( 'page' ), array(
  		'public'             => true,
  		'publicly_queryable' => false,
  		'show_in_rest' 		   => true,
  		'label'              => 'Non Queryable Page Taxonomy',
  	) );
  }
  add_action( 'init', 'add_taxonomies' );
  ```
- Insert a Query Loop block in the Post Editor.
- Open the Filters panel. Taxonomies where `publicly_queryable` is `false` should not be displayed.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/273d93ab-fe8e-4242-9525-42cd1d5b7c0f)| ![image](https://github.com/WordPress/gutenberg/assets/54422211/92dcacde-7a95-4ed6-aab1-64e4b8c94e17) | 