### PR TITLE
Playwright: Pass the payload to createPost in data instead of query params to avoid URI too long errors.

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
@@ -64,7 +64,7 @@ export async function createPost(
 	const post = await this.rest< Post >( {
 		method: 'POST',
 		path: `/wp/v2/posts`,
-		params: { ...payload },
+		data: { ...payload },
 	} );
 
 	return post;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This adjusts the playwright request utility to pass post params as data instead of as query params in the uri.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Because the post params are currently sent in query params, if you wanted to create a large post via this API you will encounter URI too long errors. I ran into this problem in https://github.com/WordPress/gutenberg/issues/59427

## How?
By passing the post attributes in the `data` attribute instead it will not cause URI too long errors no matter how long the post is that you want to create via the API.

## Testing Instructions
I believe that seeing the Playwright e2e tests pass in CI will be sufficient to prove that this still works as it should.

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
