### PR TITLE
Interactivity API: Rename `data_wp_context` function

### DIFF
--- a/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
@@ -151,7 +151,7 @@ if ( ! function_exists( 'wp_interactivity_config' ) ) {
 	}
 }
 
-if ( ! function_exists( 'data_wp_context' ) ) {
+if ( ! function_exists( 'wp_interactivity_data_wp_context' ) ) {
 	/**
 	 * Generates a `data-wp-context` directive attribute by encoding a context
 	 * array.
@@ -162,7 +162,7 @@ if ( ! function_exists( 'data_wp_context' ) ) {
 	 *
 	 * Example:
 	 *
-	 *     <div <?php echo data_wp_context( array( 'isOpen' => true, 'count' => 0 ) ); ?>>
+	 *     <div <?php echo wp_interactivity_data_wp_context( array( 'isOpen' => true, 'count' => 0 ) ); ?>>
 	 *
 	 * @since 6.5.0
 	 *
@@ -171,7 +171,7 @@ if ( ! function_exists( 'data_wp_context' ) ) {
 	 * @return string A complete `data-wp-context` directive with a JSON encoded value representing the context array and
 	 *                the store namespace if specified.
 	 */
-	function data_wp_context( array $context, string $store_namespace = '' ): string {
+	function wp_interactivity_data_wp_context( array $context, string $store_namespace = '' ): string {
 		return 'data-wp-context=\'' .
 		( $store_namespace ? $store_namespace . '::' : '' ) .
 		( empty( $context ) ? '{}' : wp_json_encode( $context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) ) .

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -552,7 +552,7 @@ class WP_Navigation_Block_Renderer {
 			return '';
 		}
 		// When adding to this array be mindful of security concerns.
-		$nav_element_context    = data_wp_context(
+		$nav_element_context    = wp_interactivity_data_wp_context(
 			array(
 				'overlayOpenedBy' => array(
 					'click' => false,

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -179,7 +179,7 @@ function render_block_core_search( $attributes ) {
 	if ( $is_expandable_searchfield ) {
 		$aria_label_expanded  = __( 'Submit Search' );
 		$aria_label_collapsed = __( 'Expand search field' );
-		$form_context         = data_wp_context(
+		$form_context         = wp_interactivity_data_wp_context(
 			array(
 				'isSearchInputVisible' => $open_by_default,
 				'inputId'              => $input_id,

--- a/packages/interactivity/docs/api-reference.md
+++ b/packages/interactivity/docs/api-reference.md
@@ -125,7 +125,7 @@ Different contexts can be defined at different levels, and deeper levels will me
 
 ### `wp-bind`
 
-This directive allows setting HTML attributes on elements based on a boolean or string value. It follows the syntax `data-wp-bind--attribute`. 
+This directive allows setting HTML attributes on elements based on a boolean or string value. It follows the syntax `data-wp-bind--attribute`.
 
 ```html
 <li data-wp-context='{ "isMenuOpen": false }'>
@@ -225,7 +225,7 @@ The boolean value received by the directive is used to toggle (add when `true` o
 
 ### `wp-style`
 
-This directive adds or removes inline style to an HTML element, depending on its value. It follows the syntax `data-wp-style--css-property`. 
+This directive adds or removes inline style to an HTML element, depending on its value. It follows the syntax `data-wp-style--css-property`.
 
 ```html
 <div data-wp-context='{ "color": "red" }' >
@@ -299,7 +299,7 @@ The returned value is used to change the inner content of the element: `<div>val
 
 ### `wp-on`
 
-This directive runs code on dispatched DOM events like `click` or `keyup`. The syntax is `data-wp-on--[event]` (like `data-wp-on--click` or `data-wp-on--keyup`). 
+This directive runs code on dispatched DOM events like `click` or `keyup`. The syntax is `data-wp-on--[event]` (like `data-wp-on--click` or `data-wp-on--keyup`).
 
 ```php
 <button data-wp-on--click="actions.logTime" >
@@ -387,7 +387,7 @@ The callback passed as the reference receives [the event](https://developer.mozi
 
 It runs a callback **when the node is created and runs it again when the state or context changes**.
 
-You can attach several side effects to the same DOM element by using the syntax `data-wp-watch--[unique-id]`. 
+You can attach several side effects to the same DOM element by using the syntax `data-wp-watch--[unique-id]`.
 
 The `unique-id` doesn't need to be unique globally. It just needs to be different from the other unique IDs of the `wp-watch` directives of that DOM element.
 
@@ -491,7 +491,7 @@ This directive runs the passed callback **during the node's render execution**.
 
 You can use and compose hooks like `useState`, `useWatch`, or `useEffect` inside the passed callback and create your own logic, providing more flexibility than previous directives.
 
-You can attach several `wp-run` to the same DOM element by using the syntax `data-wp-run--[unique-id]`. 
+You can attach several `wp-run` to the same DOM element by using the syntax `data-wp-run--[unique-id]`.
 
 The `unique-id` doesn't need to be unique globally. It just needs to be different from the other unique IDs of the `wp-run` directives of that DOM element.
 
@@ -1091,4 +1091,27 @@ echo $processed_html;
 will output:
 ```html
 <div data-wp-text="create-block::state.greeting">Hello, World!</div>
+```
+
+### wp_interactivity_data_wp_context
+
+`wp_interactivity_data_wp_context` returns a stringified JSON of a context directive.
+This function is the recommended way to print the `data-wp-context` attribute in the server side rendedered markup.
+
+```php
+
+$my_context = array(
+	'counter' => 0,
+	'isOpen'  => true,
+);
+<div
+ echo wp_interactivity_data_wp_context($my_context)
+>
+</div>
+```
+
+will output:
+
+```html
+<div data-wp-context='{"counter":0,"isOpen":true}'>
 ```


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update Core blocks to be compatible with the refactor done in Core.

https://github.com/WordPress/wordpress-develop/pull/6205

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Check ticket: https://core.trac.wordpress.org/ticket/60575

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Contexts should appear in Navigation and Search block.
These should work as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
