### PR TITLE
Navigation Link UI: Focus the parent block when a block is removed.

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -576,7 +576,7 @@ export default function NavigationLinkEdit( {
 								// This avoids empty blocks which can provided a poor UX.
 								if ( ! url ) {
 									onReplace( [] );
-									// Focus the parent navigation block.
+									// Focus the parent block.
 									selectBlock( firstParentClientId );
 								}
 							} }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -30,6 +30,7 @@ import {
 import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import {
+	focus,
 	placeCaretAtHorizontalEdge,
 	__unstableStripHTML as stripHTML,
 } from '@wordpress/dom';
@@ -568,7 +569,29 @@ export default function NavigationLinkEdit( {
 								// This avoids empty blocks which can provided a poor UX.
 								if ( ! url ) {
 									// Need to handle refocusing the Nav block or the inserter?
+									const previousElement =
+										focus.tabbable.findNext(
+											listItemRef.current
+										);
+									const previousPreviousElement =
+										focus.tabbable.findPrevious(
+											previousElement
+										);
+									const previousPreviousPreviousElement =
+										focus.tabbable.findPrevious(
+											previousPreviousElement
+										);
+									const previousPreviousPreviousPreviousElement =
+										focus.tabbable.findPrevious(
+											previousPreviousPreviousElement
+										);
+
+									previousPreviousPreviousPreviousElement?.focus();
 									onReplace( [] );
+									const nextElement = focus.tabbable.findNext(
+										previousPreviousPreviousPreviousElement
+									);
+									nextElement?.focus();
 								}
 							} }
 							anchor={ popoverAnchor }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When a Navigation Link block is removed, focus the parent block.

Fixes https://github.com/WordPress/gutenberg/issues/58820

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We don't want to cause focus-loss by removing this block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Get the clientId of the parent block and then select it.

## Testing Instructions
1. Add a navigation block
2. Click the inserter in the navigation block to add a new link
3. Press escape or click elsewhere on the canvas
4. Confirm that the new block is removed
5. Check that focus is returned to the parent block

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/275961/49a13a80-1dd8-4c76-ad27-f19f6e0e531d


