### PR TITLE
Theme JSON: add localized css variables to inline classes

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1767,6 +1767,10 @@ class WP_Theme_JSON_Gutenberg {
 								'name'  => $property,
 								'value' => 'var(' . $css_var . ') !important',
 							),
+							array(
+								'name'  => '--' . $property,
+								'value' => 'var(' . $css_var . ')',
+							),
 						)
 					);
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds a localized CSS variable for a given CSS variable under an automatically generated theme.json class name. 
I don't expect the first commit of this PR to be final. I expect there to be a need to conditionally set if the variable should be created or not based on what the property is.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I was looking at ways of making the button styles more flexible, especially with things like psuedo classes (:hover, etc) and getting around the issue that there is no way to style these presently when also setting colors directly in the block control.

I am aware there is some open discussions on adding hover controls etc. to buttons and other elements but as far as I've seen they are not close to resolution. 

So I came up with this change in the code which results in outputting a variable ready for use.
With this, I was able to use dynamic color manipulation to allow my buttons psuedo classes to modify the buttons look nicely regardless of what color combination I add from the color palette. 
Here's a nice article on color manipulation: https://blog.jim-nielsen.com/2021/css-relative-colors/

Here's a sample of what the output CSS classes would look like:
```css
.has-secondary-400-background-color {
    background-color: var(--wp--preset--color--secondary-400) !important;
    --background-color: var(--wp--preset--color--secondary-400);
}

.has-secondary-200-color {
    color: var(--wp--preset--color--secondary-200) !important;
    --color: var(--wp--preset--color--secondary-200);
}

```

And here's some sample use case with the `:hover` psuedo class:
```css
/* important is needed because the colors set by Gutenberg is also set to important. */
.wp-block-button .wp-block-button__link.has-text-color:hover {
	color: hsl(from var(--color) h s l / .15) !important;
}

.wp-block-button .wp-block-button__link.has-background-color:hover {
	background-color: hsl(from var(--background-color) calc(h + 180deg) s l) !important;
}
```

Using this I can actually achieve a dynamic standardised look for my hover effects in my theme with any colors!

This is also just one example use case based on my own experience, I am sure there are other examples where localized CSS variables would be very useful. 

Another example that comes to mind would be adding content, usually icons, with the `:before` or `:after` psuedo element. 
```css
.wp-block-button .wp-block-button__link.has-text-color:after{
	/* This is our color manipulation, our icon have 20% less saturation than our text. */
	color: hsl(from var(--color) h calc(s - 20%) l);
	/* regular dashicons stuff… */
	content: "\f319";
	font-family: dashicons;
	display: inline-block;
	line-height: 1;
	font-weight: 400;
	font-style: normal;
	width: 20px;
	height: 20px;
	font-size: 20px;
	vertical-align: top;
	text-align:center;
}
```

And since CSS variable scoping goes "element -> child elements" this would even work if we have an inline SVG with a fill color we want to change based on the text color of our button.
For example:
```css
.wp-block-button .wp-block-button__link.has-text-color svg path{
	/* Let's make sure our path fill is the same as the parent elements color. */
	fill: var(--color);
}

/* A more complex example where we have classes for layers of our icon. */
.wp-block-button .wp-block-button__link.has-background-color svg .icon__background{
	/* background should be the buttons background but slightly darker. */
	fill: color: hsl(from var(--background-color) h s calc(l - 20%) );
}
.wp-block-button .wp-block-button__link.has-text-color svg .icon__symbol{
	/* the symbol on our background should use the text color with less alpha */
	fill: rgb(from var(--color) r g b / .5);
}
```

I'm using buttons as the example here because they're typical interactive elements that we may want to manipulate based on state, but the logic applies to any element.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR adds the property with the css variable syntax by appending the `--` prefix and uses the same variable value `var()` that we are already using to set the property itself. 

One thing that needs to be considered more deeply is probably variable scoping and how that could have unwanted effects.. but from my testing and thinking about it I don't think it should be an issue. 
This implementation is always scoped to the generated classes and therefore the elements using them and their child elements. 

The only way I can see a theoretical problem is if a developer have in their theme set a CSS Variable on a higher level parent element, then use the variable on some child elements in their CSS and we override their variables with these classes because our element is inserted inbetween their expected parent and the child. 

My personal opinion is that this is a very edge case scenario unlikely to be an actual real world issue and therefore shouldn't be a dealbreaker for implementing something like this.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page in the block editor.
2. Insert a button block.
3. Manually set a color and background color
4. Check the applied dynamically created style in the web tools inspector on the frontend (or backend).

OR 
simply check the rendered inline theme.json CSS on the frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
Result in browser for custom text and background color classes:

<img width="672" alt="Screenshot 2024-02-29 at 10 58 32" src="https://github.com/WordPress/gutenberg/assets/1508751/12c7ae60-cbbb-4088-8364-c95794d6abcb">


