### PR TITLE
Update style.scss

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -38,6 +38,7 @@
 	position: relative;
 	margin-right: $grid-unit-20;
 	align-self: flex-start;
+	max-width: 60px;
 
 	.block-directory-downloadable-block-list-item__spinner {
 		position: absolute;


### PR DESCRIPTION
Added maximum width to the preview images of "available to install" block list to avoid heterogeneous image sizes

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added maximum width to the preview images of "available to install" block list 


## Why?
To avoid heterogeneous image sizes

## How?
Set a maximum width of 60px for the image container

## Testing Instructions
1. Click the "add block" button
2. Type something, linke 'short'
3. Wait for the list below to populate



## Screenshots or screencast 
Before![SCR-20240229-nwlz](https://github.com/WordPress/gutenberg/assets/1872936/4fe84d26-aac3-409d-902e-f4cc02483740)

After
![SCR-20240229-nwon](https://github.com/WordPress/gutenberg/assets/1872936/8956ebe4-28b9-4216-850a-c1cfd8e0624a)


