### PR TITLE
docs: Fix inaccurate release group

### DIFF
--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,12 +10,12 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Improve consistency of the block outline indicating the currently selected block [#59415]
 
 ## 1.114.0
 -   [*] Prevent crash when autoscrolling to blocks [#59110]
 -   [*] Remove opacity change when images are being uploaded [#59264]
 -   [*] Media & Text blocks correctly show an error message when the attached video upload fails [#59288]
--   [*] Improve consistency of the block outline indicating the currently selected block [#59415]
 
 ## 1.112.0
 -   [*] [internal] Upgrade React Native to version 0.71.15 [#57667]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Relocate a mobile editor change log entry out of the incorrect release group.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The relocated entry was not included in the 1.114.0 release. Presumably
it was misplaced during an erroneous automatic Git merge resolution.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Relocate the entry to the "unreleased" group.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
