### PR TITLE
Raw handling: preserve empty paragraphs

### DIFF
--- a/packages/blocks/src/api/raw-handling/blockquote-normaliser.js
+++ b/packages/blocks/src/api/raw-handling/blockquote-normaliser.js
@@ -3,10 +3,12 @@
  */
 import normaliseBlocks from './normalise-blocks';
 
-export default function blockquoteNormaliser( node ) {
-	if ( node.nodeName !== 'BLOCKQUOTE' ) {
-		return;
-	}
+export default function blockquoteNormaliser( options ) {
+	return ( node ) => {
+		if ( node.nodeName !== 'BLOCKQUOTE' ) {
+			return;
+		}
 
-	node.innerHTML = normaliseBlocks( node.innerHTML );
+		node.innerHTML = normaliseBlocks( node.innerHTML, options );
+	};
 }

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -65,11 +65,11 @@ export function rawHandler( { HTML = '' } ) {
 				figureContentReducer,
 				// Needed to create the quote block, which cannot handle text
 				// without wrapper paragraphs.
-				blockquoteNormaliser,
+				blockquoteNormaliser( { raw: true } ),
 			];
 
 			piece = deepFilterHTML( piece, filters, blockContentSchema );
-			piece = normaliseBlocks( piece );
+			piece = normaliseBlocks( piece, { raw: true } );
 
 			return htmlToBlocks( piece, rawHandler );
 		} )

--- a/packages/blocks/src/api/raw-handling/normalise-blocks.js
+++ b/packages/blocks/src/api/raw-handling/normalise-blocks.js
@@ -3,7 +3,7 @@
  */
 import { isEmpty, isPhrasingContent } from '@wordpress/dom';
 
-export default function normaliseBlocks( HTML ) {
+export default function normaliseBlocks( HTML, options = {} ) {
 	const decuDoc = document.implementation.createHTMLDocument( '' );
 	const accuDoc = document.implementation.createHTMLDocument( '' );
 
@@ -47,7 +47,7 @@ export default function normaliseBlocks( HTML ) {
 				}
 			} else if ( node.nodeName === 'P' ) {
 				// Only append non-empty paragraph nodes.
-				if ( isEmpty( node ) ) {
+				if ( isEmpty( node ) && ! options.raw ) {
 					decu.removeChild( node );
 				} else {
 					accu.appendChild( node );

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -191,7 +191,7 @@ export function pasteHandler( {
 				commentRemover,
 				iframeRemover,
 				figureContentReducer,
-				blockquoteNormaliser,
+				blockquoteNormaliser(),
 				divNormaliser,
 			];
 

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -14,6 +14,9 @@ import { applyBuiltInValidationFixes } from '../parser/apply-built-in-validation
 const castArray = ( maybeArray ) =>
 	Array.isArray( maybeArray ) ? maybeArray : [ maybeArray ];
 
+const beforeLineRegexp = /(\n|<p>)\s*$/;
+const afterLineRegexp = /^\s*(\n|<\/p>)/;
+
 function segmentHTMLToShortcodeBlock(
 	HTML,
 	lastIndex = 0,
@@ -56,8 +59,8 @@ function segmentHTMLToShortcodeBlock(
 		if (
 			! match.shortcode.content?.includes( '<' ) &&
 			! (
-				/(\n|<p>)\s*$/.test( beforeHTML ) &&
-				/^\s*(\n|<\/p>)/.test( afterHTML )
+				beforeLineRegexp.test( beforeHTML ) &&
+				afterLineRegexp.test( afterHTML )
 			)
 		) {
 			return segmentHTMLToShortcodeBlock( HTML, lastIndex );
@@ -143,9 +146,13 @@ function segmentHTMLToShortcodeBlock(
 		}
 
 		return [
-			...segmentHTMLToShortcodeBlock( beforeHTML ),
+			...segmentHTMLToShortcodeBlock(
+				beforeHTML.replace( beforeLineRegexp, '' )
+			),
 			...blocks,
-			...segmentHTMLToShortcodeBlock( afterHTML ),
+			...segmentHTMLToShortcodeBlock(
+				afterHTML.replace( afterLineRegexp, '' )
+			),
 		];
 	}
 

--- a/packages/blocks/src/api/raw-handling/special-comment-converter.js
+++ b/packages/blocks/src/api/raw-handling/special-comment-converter.js
@@ -33,8 +33,10 @@ export default function specialCommentConverter( node, doc ) {
 	const block = createBlock( node, doc );
 
 	// If our `<!--more-->` comment is in the middle of a paragraph, we should
-	// split the paragraph in two and insert the more block in between. If not,
-	// the more block will eventually end up being inserted after the paragraph.
+	// split the paragraph in two and insert the more block in between. If it's
+	// inside an empty paragraph, we should still move it out of the paragraph
+	// and remove the paragraph. If there's no paragraph, fall back to simply
+	// replacing the comment.
 	if ( ! node.parentNode || node.parentNode.nodeName !== 'P' ) {
 		replace( node, block );
 	} else {

--- a/packages/blocks/src/api/raw-handling/special-comment-converter.js
+++ b/packages/blocks/src/api/raw-handling/special-comment-converter.js
@@ -69,11 +69,7 @@ function moreCommentConverter( node, doc ) {
 	// If our `<!--more-->` comment is in the middle of a paragraph, we should
 	// split the paragraph in two and insert the more block in between. If not,
 	// the more block will eventually end up being inserted after the paragraph.
-	if (
-		! node.parentNode ||
-		node.parentNode.nodeName !== 'P' ||
-		node.parentNode.childNodes.length === 1
-	) {
+	if ( ! node.parentNode || node.parentNode.nodeName !== 'P' ) {
 		replace( node, moreBlock );
 	} else {
 		const childNodes = Array.from( node.parentNode.childNodes );

--- a/packages/blocks/src/api/raw-handling/special-comment-converter.js
+++ b/packages/blocks/src/api/raw-handling/special-comment-converter.js
@@ -71,10 +71,7 @@ export default function specialCommentConverter( node, doc ) {
 
 function createBlock( commentNode, doc ) {
 	if ( commentNode.nodeValue === 'nextpage' ) {
-		const node = doc.createElement( 'wp-block' );
-		node.dataset.block = 'core/nextpage';
-
-		return node;
+		return createNextpage( doc );
 	}
 
 	// Grab any custom text in the comment.
@@ -98,6 +95,10 @@ function createBlock( commentNode, doc ) {
 		}
 	}
 
+	return createMore( customText, noTeaser, doc );
+}
+
+function createMore( customText, noTeaser, doc ) {
 	const node = doc.createElement( 'wp-block' );
 	node.dataset.block = 'core/more';
 	if ( customText ) {
@@ -107,5 +108,12 @@ function createBlock( commentNode, doc ) {
 		// "Boolean" data attribute.
 		node.dataset.noTeaser = '';
 	}
+	return node;
+}
+
+function createNextpage( doc ) {
+	const node = doc.createElement( 'wp-block' );
+	node.dataset.block = 'core/nextpage';
+
 	return node;
 }

--- a/packages/blocks/src/api/raw-handling/test/blockquote-normaliser.js
+++ b/packages/blocks/src/api/raw-handling/test/blockquote-normaliser.js
@@ -8,7 +8,7 @@ describe( 'blockquoteNormaliser', () => {
 	it( 'should normalise blockquote', () => {
 		const input = '<blockquote>test</blockquote>';
 		const output = '<blockquote><p>test</p></blockquote>';
-		expect( deepFilterHTML( input, [ blockquoteNormaliser ] ) ).toEqual(
+		expect( deepFilterHTML( input, [ blockquoteNormaliser() ] ) ).toEqual(
 			output
 		);
 	} );

--- a/packages/blocks/src/api/raw-handling/test/special-comment-converter.js
+++ b/packages/blocks/src/api/raw-handling/test/special-comment-converter.js
@@ -8,7 +8,7 @@ describe( 'specialCommentConverter', () => {
 	it( 'should convert a single "more" comment into a basic block', () => {
 		expect(
 			deepFilterHTML( '<p><!--more--></p>', [ specialCommentConverter ] )
-		).toEqual( '<p></p><wp-block data-block="core/more"></wp-block>' );
+		).toEqual( '<wp-block data-block="core/more"></wp-block>' );
 	} );
 	it( 'should convert a single "nextpage" comment into a basic block', () => {
 		expect(
@@ -23,7 +23,7 @@ describe( 'specialCommentConverter', () => {
 				specialCommentConverter,
 			] )
 		).toEqual(
-			'<p></p><wp-block data-block="core/more" data-no-teaser=""></wp-block>'
+			'<wp-block data-block="core/more" data-no-teaser=""></wp-block>'
 		);
 	} );
 	it( 'should pass custom text to the block', () => {
@@ -33,7 +33,7 @@ describe( 'specialCommentConverter', () => {
 				[ specialCommentConverter ]
 			)
 		).toEqual(
-			'<p></p><wp-block data-block="core/more" data-custom-text="Read all about it!" data-no-teaser=""></wp-block>'
+			'<wp-block data-block="core/more" data-custom-text="Read all about it!" data-no-teaser=""></wp-block>'
 		);
 	} );
 	it( 'should not break content order', () => {
@@ -95,7 +95,7 @@ describe( 'specialCommentConverter', () => {
 				[ specialCommentConverter ]
 			);
 			expect( output ).toEqual(
-				'<p></p><wp-block data-block="core/more" data-no-teaser=""></wp-block>'
+				'<wp-block data-block="core/more" data-no-teaser=""></wp-block>'
 			);
 		} );
 		it( 'should not break content order', () => {
@@ -108,7 +108,7 @@ describe( 'specialCommentConverter', () => {
 			);
 			expect( output ).toEqual(
 				`<p>First paragraph.</p>
-				<p></p><wp-block data-block=\"core/more\"></wp-block>
+				<wp-block data-block=\"core/more\"></wp-block>
 				<p>Second paragraph</p>
 				<p>Third paragraph</p>`
 			);

--- a/packages/blocks/src/api/raw-handling/test/special-comment-converter.js
+++ b/packages/blocks/src/api/raw-handling/test/special-comment-converter.js
@@ -15,7 +15,7 @@ describe( 'specialCommentConverter', () => {
 			deepFilterHTML( '<p><!--nextpage--></p>', [
 				specialCommentConverter,
 			] )
-		).toEqual( '<p></p><wp-block data-block="core/nextpage"></wp-block>' );
+		).toEqual( '<wp-block data-block="core/nextpage"></wp-block>' );
 	} );
 	it( 'should convert two comments into a block', () => {
 		expect(
@@ -124,9 +124,9 @@ describe( 'specialCommentConverter', () => {
 			);
 			expect( output ).toEqual(
 				`<p>First page.</p>
-				<p></p><wp-block data-block=\"core/nextpage\"></wp-block>
+				<wp-block data-block=\"core/nextpage\"></wp-block>
 				<p>Second page</p>
-				<p></p><wp-block data-block=\"core/nextpage\"></wp-block>
+				<wp-block data-block=\"core/nextpage\"></wp-block>
 				<p>Third page</p>`
 			);
 		} );

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -198,3 +198,21 @@ exports[`rawHandler should preserve alignment 1`] = `
 <p class="has-text-align-center">center</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`rawHandler should preserve all paragraphs 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>&nbsp;&nbsp;</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -560,4 +560,12 @@ describe( 'rawHandler', () => {
 		const HTML = '<p style="text-align:center">center</p>';
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
+
+	it( 'should preserve all paragraphs', () => {
+		const HTML = `<p></p>
+<p>&nbsp;&nbsp;</p>
+<p class="p"></p>
+<p style="border: 1px solid tomato;"></p>`;
+		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
+	} );
 } );

--- a/test/integration/shortcode-converter.test.js
+++ b/test/integration/shortcode-converter.test.js
@@ -106,18 +106,14 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 <p>Bar</p>`;
 		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
 		expect( transformed ).toHaveLength( 3 );
-		expect( transformed[ 0 ] ).toBe( `<p>Foo</p>
-
-` );
+		expect( transformed[ 0 ] ).toBe( `<p>Foo</p>` );
 		const expectedBlock = createBlock( 'core/shortcode', {
 			text: '[foo bar="apple"]',
 		} );
 		// clientId will always be random.
 		expectedBlock.clientId = transformed[ 1 ].clientId;
 		expect( transformed[ 1 ] ).toEqual( expectedBlock );
-		expect( transformed[ 2 ] ).toBe( `
-
-<p>Bar</p>` );
+		expect( transformed[ 2 ] ).toBe( `<p>Bar</p>` );
 	} );
 
 	it( 'should convert a shortcode to a block type with a passing `isMatch`', () => {
@@ -165,22 +161,22 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 <p>[foo two]</p>`;
 
 		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
-		expect( transformed[ 0 ] ).toEqual( '<p>' );
+		expect( transformed[ 0 ] ).toEqual( '' );
 		const firstExpectedBlock = createBlock( 'core/shortcode', {
 			text: '[foo one]',
 		} );
 		// clientId will always be random.
 		firstExpectedBlock.clientId = transformed[ 1 ].clientId;
 		expect( transformed[ 1 ] ).toEqual( firstExpectedBlock );
-		expect( transformed[ 2 ] ).toEqual( `</p>
-<p>` );
+		expect( transformed[ 2 ] ).toEqual( `
+` );
 		const secondExpectedBlock = createBlock( 'core/shortcode', {
 			text: '[foo two]',
 		} );
 		// clientId will always be random.
 		secondExpectedBlock.clientId = transformed[ 3 ].clientId;
 		expect( transformed[ 3 ] ).toEqual( secondExpectedBlock );
-		expect( transformed[ 4 ] ).toEqual( '</p>' );
+		expect( transformed[ 4 ] ).toEqual( '' );
 		expect( transformed ).toHaveLength( 5 );
 	} );
 
@@ -191,38 +187,38 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 <p>[foo four]</p>`;
 
 		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
-		expect( transformed[ 0 ] ).toEqual( '<p>' );
+		expect( transformed[ 0 ] ).toEqual( '' );
 		const firstExpectedBlock = createBlock( 'core/shortcode', {
 			text: '[foo one]',
 		} );
 		// clientId will always be random.
 		firstExpectedBlock.clientId = transformed[ 1 ].clientId;
 		expect( transformed[ 1 ] ).toEqual( firstExpectedBlock );
-		expect( transformed[ 2 ] ).toEqual( `</p>
-<p>` );
+		expect( transformed[ 2 ] ).toEqual( `
+` );
 		const secondExpectedBlock = createBlock( 'core/shortcode', {
 			text: '[foo two]',
 		} );
 		// clientId will always be random.
 		secondExpectedBlock.clientId = transformed[ 3 ].clientId;
 		expect( transformed[ 3 ] ).toEqual( secondExpectedBlock );
-		expect( transformed[ 4 ] ).toEqual( `</p>
-<p>` );
+		expect( transformed[ 4 ] ).toEqual( `
+` );
 		const thirdExpectedBlock = createBlock( 'core/shortcode', {
 			text: '[foo three]',
 		} );
 		// clientId will always be random.
 		thirdExpectedBlock.clientId = transformed[ 5 ].clientId;
 		expect( transformed[ 5 ] ).toEqual( thirdExpectedBlock );
-		expect( transformed[ 6 ] ).toEqual( `</p>
-<p>` );
+		expect( transformed[ 6 ] ).toEqual( `
+` );
 		const fourthExpectedBlock = createBlock( 'core/shortcode', {
 			text: '[foo four]',
 		} );
 		// clientId will always be random.
 		fourthExpectedBlock.clientId = transformed[ 7 ].clientId;
 		expect( transformed[ 7 ] ).toEqual( fourthExpectedBlock );
-		expect( transformed[ 8 ] ).toEqual( '</p>' );
+		expect( transformed[ 8 ] ).toEqual( '' );
 		expect( transformed ).toHaveLength( 9 );
 	} );
 
@@ -242,11 +238,11 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		const original = `<p>[my-gallery ids="1,2,3"]</p>
 <p>[my-bunch-of-images ids="4,5,6"]</p>`;
 		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
-		expect( transformed[ 0 ] ).toBe( '<p>' );
+		expect( transformed[ 0 ] ).toBe( '' );
 		expect( transformed[ 1 ] ).toHaveProperty( 'name', 'test/gallery' );
-		expect( transformed[ 2 ] ).toBe( '</p>\n<p>' );
+		expect( transformed[ 2 ] ).toBe( '\n' );
 		expect( transformed[ 3 ] ).toHaveProperty( 'name', 'test/gallery' );
-		expect( transformed[ 4 ] ).toBe( '</p>' );
+		expect( transformed[ 4 ] ).toBe( '' );
 	} );
 
 	it( 'should convert regardless of shortcode order', () => {
@@ -255,7 +251,7 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 
 		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
 
-		expect( transformed[ 0 ] ).toBe( '<p>' );
+		expect( transformed[ 0 ] ).toBe( '' );
 
 		let firstExpectedBlock = createBlock( 'test/gallery', {
 			ids: [ 4, 5, 6 ],
@@ -264,14 +260,14 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		firstExpectedBlock.clientId = transformed[ 1 ].clientId;
 		expect( transformed[ 1 ] ).toEqual( firstExpectedBlock );
 
-		expect( transformed[ 2 ] ).toBe( '</p>\n<p>' );
+		expect( transformed[ 2 ] ).toBe( '\n' );
 
 		let secondExpectedBlock = createBlock( 'test/broccoli', { id: 42 } );
 		// clientId will always be random.
 		secondExpectedBlock.clientId = transformed[ 3 ].clientId;
 		expect( transformed[ 3 ] ).toEqual( secondExpectedBlock );
 
-		expect( transformed[ 4 ] ).toBe( '</p>' );
+		expect( transformed[ 4 ] ).toBe( '' );
 		expect( transformed ).toHaveLength( 5 );
 
 		// Flip the order of the shortcodes.
@@ -280,14 +276,14 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 
 		const reverseTransformed = segmentHTMLToShortcodeBlock( reversed, 0 );
 
-		expect( reverseTransformed[ 0 ] ).toBe( '<p>' );
+		expect( reverseTransformed[ 0 ] ).toBe( '' );
 
 		firstExpectedBlock = createBlock( 'test/broccoli', { id: 42 } );
 		// clientId will always be random.
 		firstExpectedBlock.clientId = reverseTransformed[ 1 ].clientId;
 		expect( reverseTransformed[ 1 ] ).toEqual( firstExpectedBlock );
 
-		expect( reverseTransformed[ 2 ] ).toBe( '</p>\n<p>' );
+		expect( reverseTransformed[ 2 ] ).toBe( '\n' );
 
 		secondExpectedBlock = createBlock( 'test/gallery', {
 			ids: [ 4, 5, 6 ],
@@ -296,7 +292,7 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		secondExpectedBlock.clientId = reverseTransformed[ 3 ].clientId;
 		expect( reverseTransformed[ 3 ] ).toEqual( secondExpectedBlock );
 
-		expect( reverseTransformed[ 4 ] ).toBe( '</p>' );
+		expect( reverseTransformed[ 4 ] ).toBe( '' );
 		expect( reverseTransformed ).toHaveLength( 5 );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #11211.

For raw handling (not paste!) we should preserve the original content as much as possible. That means also preserving empty or empty looking paragraphs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The philosophy of raw handling, as opposed to paste, is to preserve as much legacy content as possible while also converting to blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Pass a flag. We also need to strip the paragraphs around short codes and handle special comments better.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
