### PR TITLE
useMovingAnimation: Try removing cleanup function to allow animations to finish

### DIFF
--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -139,10 +139,6 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 		const y = Math.round( previous.top - destination.top );
 
 		controller.start( { x: 0, y: 0, from: { x, y } } );
-
-		return () => {
-			controller.stop();
-		};
 	}, [
 		previous,
 		prevRect,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Possibly fixes #59481 

Remove the cleanup function in `useMovingAnimation` so that animations will finish / not be left in a state where a transform rule is still applied.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in #59481, it's possible to get into a state with list view items and blocks in the editor canvas where a stray transform rule is still applied if blocks are added very rapidly (i.e. by pressing ENTER rapidly in the editor canvas). Blocks being created rapidly means that the previous animation doesn't have time to be completed before the cleanup function is called, which appears to result in the styling rules not being cleared out.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the cleanup function so that the animation can finish on its own accord. I _think_ the animation should naturally finish in its own time, and it looks like the `onChange` function only does anything if the `ref.current` still exists, so I'm wondering if it's safe to simply go without the cleanup function. It'd be good to confirm with @ellatrix if this is the case, or if there's another reason why we need the cleanup function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a post (or template), add enough blocks to create a scrollbar in the list view (note: the overall post needs to have fewer than 200 blocks, otherwise the useMovingAnimation is skipped, so test with a couple of dozen blocks)
2. Click somewhere in the editor canvas with the list view open, and then press ENTER rapidly several times to add a few paragraph blocks
3. On `trunk` Notice that it's possible for the list view items and the blocks in the editor canvas to wind up in a state where they're overlapping — this is the moving animation not completing, so there'll be stray transform rules left over
4. With this PR applied, the items should never be stuck in a state where they overlap

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/308cc6ce-6c5a-4d99-9cb2-1542f8cf3b0f

### After

https://github.com/WordPress/gutenberg/assets/14988353/604b0070-08a7-4d36-b0ae-79b6170d862e


