### PR TITLE
Add Column Start and Row Start controls to Grid children

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -610,13 +610,16 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$column_count         = isset( $block['attrs']['style']['layout']['columnCount'] ) ? $block['attrs']['style']['layout']['columnCount'] : null;
 
 	/*
-	 * If columnSpan is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
-	 * the columnSpan should be removed on small grids. If there's a minimumColumnWidth, the grid is responsive.
-	 * But if the minimumColumnWidth value wasn't changed, it won't be set. In that case, if columnCount doesn't
-	 * exist, we can assume that the grid is responsive.
+	 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
+	 * the columnSpan should be removed once the grid is smaller than the span, and columnStart should be removed
+	 * once the grid has less columns than the start.
+	 * If there's a minimumColumnWidth, the grid is responsive. But if the minimumColumnWidth value wasn't changed, it won't be set.
+	 * In that case, if columnCount doesn't exist, we can assume that the grid is responsive.
 	 */
-	if ( $column_span && ( $minimum_column_width || ! $column_count ) ) {
+	if ( ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
 		$column_span_number  = floatval( $column_span );
+		$column_start_number = floatval( $column_start );
+		$highest_number      = max( $column_span_number, $column_start_number );
 		$parent_column_width = $minimum_column_width ? $minimum_column_width : '12rem';
 		$parent_column_value = floatval( $parent_column_width );
 		$parent_column_unit  = explode( $parent_column_value, $parent_column_width );
@@ -642,14 +645,16 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		 * viable to use in the computation of the container query value.
 		 */
 		$default_gap_value     = 'px' === $parent_column_unit ? 24 : 1.5;
-		$container_query_value = $column_span_number * $parent_column_value + ( $column_span_number - 1 ) * $default_gap_value;
+		$container_query_value = $highest_number * $parent_column_value + ( $highest_number - 1 ) * $default_gap_value;
 		$container_query_value = $container_query_value . $parent_column_unit;
+		// If a span is set we want to preserve it as long as possible, otherwise we just reset the value.
+		$grid_column_value = $column_span ? '1/-1' : 'auto';
 
 		$child_layout_styles[] = array(
 			'rules_group'  => "@container (max-width: $container_query_value )",
 			'selector'     => ".$container_content_class",
 			'declarations' => array(
-				'grid-column' => '1/-1',
+				'grid-column' => $grid_column_value,
 			),
 		);
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -581,28 +581,26 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$child_layout_declarations['flex-grow'] = '1';
 	}
 
-	if ( isset( $block['attrs']['style']['layout']['columnStart'] ) && isset( $block['attrs']['style']['layout']['columnSpan'] ) ) {
-		$column_start                             = $block['attrs']['style']['layout']['columnStart'];
-		$column_span                              = $block['attrs']['style']['layout']['columnSpan'];
+	$column_start = isset( $block['attrs']['style']['layout']['columnStart'] ) ? $block['attrs']['style']['layout']['columnStart'] : null;
+	$column_span  = isset( $block['attrs']['style']['layout']['columnSpan'] ) ? $block['attrs']['style']['layout']['columnSpan'] : null;
+	if ( $column_start && $column_span ) {
 		$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
-	} elseif ( isset( $block['attrs']['style']['layout']['columnStart'] ) ) {
-		$column_start                             = $block['attrs']['style']['layout']['columnStart'];
+	} elseif ( $column_start ) {
 		$child_layout_declarations['grid-column'] = "$column_start";
-	} elseif ( isset( $block['attrs']['style']['layout']['columnSpan'] ) ) {
-		$column_span                              = $block['attrs']['style']['layout']['columnSpan'];
+	} elseif ( $column_span ) {
 		$child_layout_declarations['grid-column'] = "span $column_span";
 	}
-	if ( isset( $block['attrs']['style']['layout']['rowStart'] ) && isset( $block['attrs']['style']['layout']['rowSpan'] ) ) {
-		$row_start                             = $block['attrs']['style']['layout']['rowStart'];
-		$row_span                              = $block['attrs']['style']['layout']['rowSpan'];
+
+	$row_start = isset( $block['attrs']['style']['layout']['rowStart'] ) ? $block['attrs']['style']['layout']['rowStart'] : null;
+	$row_span  = isset( $block['attrs']['style']['layout']['rowSpan'] ) ? $block['attrs']['style']['layout']['rowSpan'] : null;
+	if ( $row_start && $row_span ) {
 		$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
-	} elseif ( isset( $block['attrs']['style']['layout']['rowStart'] ) ) {
-		$row_start                             = $block['attrs']['style']['layout']['rowStart'];
+	} elseif ( $row_start ) {
 		$child_layout_declarations['grid-row'] = "$row_start";
-	} elseif ( isset( $block['attrs']['style']['layout']['rowSpan'] ) ) {
-		$row_span                              = $block['attrs']['style']['layout']['rowSpan'];
+	} elseif ( $row_span ) {
 		$child_layout_declarations['grid-row'] = "span $row_span";
 	}
+
 	$child_layout_styles[] = array(
 		'selector'     => ".$container_content_class",
 		'declarations' => $child_layout_declarations,

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -581,11 +581,25 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$child_layout_declarations['flex-grow'] = '1';
 	}
 
-	if ( isset( $block['attrs']['style']['layout']['columnSpan'] ) ) {
+	if ( isset( $block['attrs']['style']['layout']['columnStart'] ) && isset( $block['attrs']['style']['layout']['columnSpan'] ) ) {
+		$column_start                             = $block['attrs']['style']['layout']['columnStart'];
+		$column_span                              = $block['attrs']['style']['layout']['columnSpan'];
+		$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
+	} elseif ( isset( $block['attrs']['style']['layout']['columnStart'] ) ) {
+		$column_start                             = $block['attrs']['style']['layout']['columnStart'];
+		$child_layout_declarations['grid-column'] = "$column_start";
+	} elseif ( isset( $block['attrs']['style']['layout']['columnSpan'] ) ) {
 		$column_span                              = $block['attrs']['style']['layout']['columnSpan'];
 		$child_layout_declarations['grid-column'] = "span $column_span";
 	}
-	if ( isset( $block['attrs']['style']['layout']['rowSpan'] ) ) {
+	if ( isset( $block['attrs']['style']['layout']['rowStart'] ) && isset( $block['attrs']['style']['layout']['rowSpan'] ) ) {
+		$row_start                             = $block['attrs']['style']['layout']['rowStart'];
+		$row_span                              = $block['attrs']['style']['layout']['rowSpan'];
+		$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
+	} elseif ( isset( $block['attrs']['style']['layout']['rowStart'] ) ) {
+		$row_start                             = $block['attrs']['style']['layout']['rowStart'];
+		$child_layout_declarations['grid-row'] = "$row_start";
+	} elseif ( isset( $block['attrs']['style']['layout']['rowSpan'] ) ) {
 		$row_span                              = $block['attrs']['style']['layout']['rowSpan'];
 		$child_layout_declarations['grid-row'] = "span $row_span";
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -606,15 +606,18 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		'declarations' => $child_layout_declarations,
 	);
 
+	$minimum_column_width = isset( $block['attrs']['style']['layout']['minimumColumnWidth'] ) ? $block['attrs']['style']['layout']['minimumColumnWidth'] : null;
+	$column_count         = isset( $block['attrs']['style']['layout']['columnCount'] ) ? $block['attrs']['style']['layout']['columnCount'] : null;
+
 	/*
 	 * If columnSpan is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
 	 * the columnSpan should be removed on small grids. If there's a minimumColumnWidth, the grid is responsive.
 	 * But if the minimumColumnWidth value wasn't changed, it won't be set. In that case, if columnCount doesn't
 	 * exist, we can assume that the grid is responsive.
 	 */
-	if ( isset( $block['attrs']['style']['layout']['columnSpan'] ) && ( isset( $block['parentLayout']['minimumColumnWidth'] ) || ! isset( $block['parentLayout']['columnCount'] ) ) ) {
-		$column_span_number  = floatval( $block['attrs']['style']['layout']['columnSpan'] );
-		$parent_column_width = isset( $block['parentLayout']['minimumColumnWidth'] ) ? $block['parentLayout']['minimumColumnWidth'] : '12rem';
+	if ( $column_span && ( $minimum_column_width || ! $column_count ) ) {
+		$column_span_number  = floatval( $column_span );
+		$parent_column_width = $minimum_column_width ? $minimum_column_width : '12rem';
 		$parent_column_value = floatval( $parent_column_width );
 		$parent_column_unit  = explode( $parent_column_value, $parent_column_width );
 

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -130,6 +130,7 @@ export default function ChildLayoutControl( {
 							} }
 							value={ columnStart }
 							min={ 1 }
+							max={ parentLayout?.columnCount }
 						/>
 						<InputControl
 							size={ '__unstable-large' }
@@ -145,6 +146,7 @@ export default function ChildLayoutControl( {
 							} }
 							value={ rowStart }
 							min={ 1 }
+							max={ parentLayout?.columnCount }
 						/>
 					</HStack>
 					<HStack>
@@ -162,6 +164,7 @@ export default function ChildLayoutControl( {
 							} }
 							value={ columnSpan }
 							min={ 1 }
+							max={ parentLayout?.columnCount }
 						/>
 						<InputControl
 							size={ '__unstable-large' }
@@ -177,6 +180,7 @@ export default function ChildLayoutControl( {
 							} }
 							value={ rowSpan }
 							min={ 1 }
+							max={ parentLayout?.columnCount }
 						/>
 					</HStack>
 				</>

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -9,6 +9,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	Flex,
+	FlexItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
@@ -156,7 +158,10 @@ export default function ChildLayoutControl( {
 			{ parentLayoutType === 'grid' && (
 				<>
 					{ window.__experimentalEnableGridInteractivity && (
-						<HStack
+						// Use Flex with an explicit width on the FlexItem instead of HStack to
+						// work around an issue in webkit where inputs with a max attribute are
+						// sized incorrectly.
+						<Flex
 							as={ ToolsPanelItem }
 							hasValue={ hasStartValue }
 							label={ __( 'Grid placement' ) }
@@ -164,39 +169,43 @@ export default function ChildLayoutControl( {
 							isShownByDefault={ false }
 							panelId={ panelId }
 						>
-							<InputControl
-								size={ '__unstable-large' }
-								label={ __( 'Column' ) }
-								type="number"
-								onChange={ ( value ) => {
-									onChange( {
-										columnStart: value,
-										rowStart,
-										columnSpan,
-										rowSpan,
-									} );
-								} }
-								value={ columnStart }
-								min={ 1 }
-								max={ parentLayout?.columnCount }
-							/>
-							<InputControl
-								size={ '__unstable-large' }
-								label={ __( 'Row' ) }
-								type="number"
-								onChange={ ( value ) => {
-									onChange( {
-										columnStart,
-										rowStart: value,
-										columnSpan,
-										rowSpan,
-									} );
-								} }
-								value={ rowStart }
-								min={ 1 }
-								max={ parentLayout?.columnCount }
-							/>
-						</HStack>
+							<FlexItem style={ { width: '50%' } }>
+								<InputControl
+									size={ '__unstable-large' }
+									label={ __( 'Column' ) }
+									type="number"
+									onChange={ ( value ) => {
+										onChange( {
+											columnStart: value,
+											rowStart,
+											columnSpan,
+											rowSpan,
+										} );
+									} }
+									value={ columnStart }
+									min={ 1 }
+									max={ parentLayout?.columnCount }
+								/>
+							</FlexItem>
+							<FlexItem style={ { width: '50%' } }>
+								<InputControl
+									size={ '__unstable-large' }
+									label={ __( 'Row' ) }
+									type="number"
+									onChange={ ( value ) => {
+										onChange( {
+											columnStart,
+											rowStart: value,
+											columnSpan,
+											rowSpan,
+										} );
+									} }
+									value={ rowStart }
+									min={ 1 }
+									max={ parentLayout?.columnCount }
+								/>
+							</FlexItem>
+						</Flex>
 					) }
 					<HStack
 						as={ ToolsPanelItem }

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -165,7 +165,7 @@ export default function ChildLayoutControl( {
 					>
 						<InputControl
 							size={ '__unstable-large' }
-							label={ __( 'Column start' ) }
+							label={ __( 'Column' ) }
 							type="number"
 							onChange={ ( value ) => {
 								onChange( {
@@ -182,7 +182,7 @@ export default function ChildLayoutControl( {
 
 						<InputControl
 							size={ '__unstable-large' }
-							label={ __( 'Row start' ) }
+							label={ __( 'Row' ) }
 							type="number"
 							onChange={ ( value ) => {
 								onChange( {

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -7,6 +7,8 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalInputControl as InputControl,
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
@@ -28,24 +30,55 @@ function helpText( selfStretch, parentLayout ) {
 /**
  * Form to edit the child layout value.
  *
- * @param {Object}   props              Props.
- * @param {Object}   props.value        The child layout value.
- * @param {Function} props.onChange     Function to update the child layout value.
- * @param {Object}   props.parentLayout The parent layout value.
+ * @param {Object}   props                  Props.
+ * @param {Object}   props.value            The child layout value.
+ * @param {Function} props.onChange         Function to update the child layout value.
+ * @param {Object}   props.parentLayout     The parent layout value.
  *
+ * @param {boolean}  props.isShownByDefault
+ * @param {string}   props.panelId
  * @return {Element} child layout edit element.
  */
 export default function ChildLayoutControl( {
 	value: childLayout = {},
 	onChange,
 	parentLayout,
+	isShownByDefault,
+	panelId,
 } ) {
 	const { selfStretch, flexSize, columnSpan, rowSpan } = childLayout;
 	const {
 		type: parentType,
 		default: { type: defaultParentType = 'default' } = {},
+		orientation = 'horizontal',
 	} = parentLayout ?? {};
 	const parentLayoutType = parentType || defaultParentType;
+
+	const hasFlexValue = () => !! selfStretch;
+	const flexResetLabel =
+		orientation === 'horizontal' ? __( 'Width' ) : __( 'Height' );
+	const resetFlex = () => {
+		onChange( {
+			selfStretch: undefined,
+			flexSize: undefined,
+		} );
+	};
+
+	const hasColumnSpanValue = () => !! columnSpan;
+	const resetColumnSpan = () => {
+		onChange( {
+			rowSpan,
+			columnSpan: undefined,
+		} );
+	};
+
+	const hasRowSpanValue = () => !! rowSpan;
+	const resetRowSpan = () => {
+		onChange( {
+			columnSpan,
+			rowSpan: undefined,
+		} );
+	};
 
 	useEffect( () => {
 		if ( selfStretch === 'fixed' && ! flexSize ) {
@@ -59,7 +92,15 @@ export default function ChildLayoutControl( {
 	return (
 		<>
 			{ parentLayoutType === 'flex' && (
-				<>
+				<VStack
+					as={ ToolsPanelItem }
+					spacing={ 2 }
+					hasValue={ hasFlexValue }
+					label={ flexResetLabel }
+					onDeselect={ resetFlex }
+					isShownByDefault={ isShownByDefault }
+					panelId={ panelId }
+				>
 					<ToggleGroupControl
 						__nextHasNoMarginBottom
 						size={ '__unstable-large' }
@@ -104,36 +145,52 @@ export default function ChildLayoutControl( {
 							value={ flexSize }
 						/>
 					) }
-				</>
+				</VStack>
 			) }
 			{ parentLayoutType === 'grid' && (
-				<HStack>
-					<InputControl
-						size={ '__unstable-large' }
+				<HStack style={ { gridColumn: '1 / -1' } }>
+					<ToolsPanelItem
+						hasValue={ hasColumnSpanValue }
 						label={ __( 'Column Span' ) }
-						type="number"
-						onChange={ ( value ) => {
-							onChange( {
-								rowSpan,
-								columnSpan: value,
-							} );
-						} }
-						value={ columnSpan }
-						min={ 1 }
-					/>
-					<InputControl
-						size={ '__unstable-large' }
+						onDeselect={ resetColumnSpan }
+						isShownByDefault={ isShownByDefault }
+						panelId={ panelId }
+					>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Column Span' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									rowSpan,
+									columnSpan: value,
+								} );
+							} }
+							value={ columnSpan }
+							min={ 1 }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ hasRowSpanValue }
 						label={ __( 'Row Span' ) }
-						type="number"
-						onChange={ ( value ) => {
-							onChange( {
-								columnSpan,
-								rowSpan: value,
-							} );
-						} }
-						value={ rowSpan }
-						min={ 1 }
-					/>
+						onDeselect={ resetRowSpan }
+						isShownByDefault={ isShownByDefault }
+						panelId={ panelId }
+					>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Row Span' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									columnSpan,
+									rowSpan: value,
+								} );
+							} }
+							value={ rowSpan }
+							min={ 1 }
+						/>
+					</ToolsPanelItem>
 				</HStack>
 			) }
 		</>

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -40,7 +40,14 @@ export default function ChildLayoutControl( {
 	onChange,
 	parentLayout,
 } ) {
-	const { selfStretch, flexSize, columnSpan, rowSpan } = childLayout;
+	const {
+		selfStretch,
+		flexSize,
+		columnStart,
+		rowStart,
+		columnSpan,
+		rowSpan,
+	} = childLayout;
 	const {
 		type: parentType,
 		default: { type: defaultParentType = 'default' } = {},
@@ -107,34 +114,72 @@ export default function ChildLayoutControl( {
 				</>
 			) }
 			{ parentLayoutType === 'grid' && (
-				<HStack>
-					<InputControl
-						size={ '__unstable-large' }
-						label={ __( 'Column Span' ) }
-						type="number"
-						onChange={ ( value ) => {
-							onChange( {
-								rowSpan,
-								columnSpan: value,
-							} );
-						} }
-						value={ columnSpan }
-						min={ 1 }
-					/>
-					<InputControl
-						size={ '__unstable-large' }
-						label={ __( 'Row Span' ) }
-						type="number"
-						onChange={ ( value ) => {
-							onChange( {
-								columnSpan,
-								rowSpan: value,
-							} );
-						} }
-						value={ rowSpan }
-						min={ 1 }
-					/>
-				</HStack>
+				<>
+					<HStack>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Column Start' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									columnStart: value,
+									rowStart,
+									columnSpan,
+									rowSpan,
+								} );
+							} }
+							value={ columnStart }
+							min={ 1 }
+						/>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Row Start' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									columnStart,
+									rowStart: value,
+									columnSpan,
+									rowSpan,
+								} );
+							} }
+							value={ rowStart }
+							min={ 1 }
+						/>
+					</HStack>
+					<HStack>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Column Span' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									columnStart,
+									rowStart,
+									columnSpan: value,
+									rowSpan,
+								} );
+							} }
+							value={ columnSpan }
+							min={ 1 }
+						/>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Row Span' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									columnStart,
+									rowStart,
+									columnSpan,
+									rowSpan: value,
+								} );
+							} }
+							value={ rowSpan }
+							min={ 1 }
+						/>
+					</HStack>
+				</>
 			) }
 		</>
 	);

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -155,48 +155,49 @@ export default function ChildLayoutControl( {
 			) }
 			{ parentLayoutType === 'grid' && (
 				<>
-					<HStack
-						as={ ToolsPanelItem }
-						hasValue={ hasStartValue }
-						label={ __( 'Grid placement' ) }
-						onDeselect={ resetGridStarts }
-						isShownByDefault={ false }
-						panelId={ panelId }
-					>
-						<InputControl
-							size={ '__unstable-large' }
-							label={ __( 'Column' ) }
-							type="number"
-							onChange={ ( value ) => {
-								onChange( {
-									columnStart: value,
-									rowStart,
-									columnSpan,
-									rowSpan,
-								} );
-							} }
-							value={ columnStart }
-							min={ 1 }
-							max={ parentLayout?.columnCount }
-						/>
-
-						<InputControl
-							size={ '__unstable-large' }
-							label={ __( 'Row' ) }
-							type="number"
-							onChange={ ( value ) => {
-								onChange( {
-									columnStart,
-									rowStart: value,
-									columnSpan,
-									rowSpan,
-								} );
-							} }
-							value={ rowStart }
-							min={ 1 }
-							max={ parentLayout?.columnCount }
-						/>
-					</HStack>
+					{ window.__experimentalEnableGridInteractivity && (
+						<HStack
+							as={ ToolsPanelItem }
+							hasValue={ hasStartValue }
+							label={ __( 'Grid placement' ) }
+							onDeselect={ resetGridStarts }
+							isShownByDefault={ false }
+							panelId={ panelId }
+						>
+							<InputControl
+								size={ '__unstable-large' }
+								label={ __( 'Column' ) }
+								type="number"
+								onChange={ ( value ) => {
+									onChange( {
+										columnStart: value,
+										rowStart,
+										columnSpan,
+										rowSpan,
+									} );
+								} }
+								value={ columnStart }
+								min={ 1 }
+								max={ parentLayout?.columnCount }
+							/>
+							<InputControl
+								size={ '__unstable-large' }
+								label={ __( 'Row' ) }
+								type="number"
+								onChange={ ( value ) => {
+									onChange( {
+										columnStart,
+										rowStart: value,
+										columnSpan,
+										rowSpan,
+									} );
+								} }
+								value={ rowStart }
+								min={ 1 }
+								max={ parentLayout?.columnCount }
+							/>
+						</HStack>
+					) }
 					<HStack
 						as={ ToolsPanelItem }
 						hasValue={ hasSpanValue }
@@ -220,7 +221,6 @@ export default function ChildLayoutControl( {
 							value={ columnSpan }
 							min={ 1 }
 						/>
-
 						<InputControl
 							size={ '__unstable-large' }
 							label={ __( 'Row span' ) }

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -158,14 +158,14 @@ export default function ChildLayoutControl( {
 					<HStack
 						as={ ToolsPanelItem }
 						hasValue={ hasStartValue }
-						label={ __( 'Grid starts' ) }
+						label={ __( 'Grid position' ) }
 						onDeselect={ resetGridStarts }
 						isShownByDefault={ isShownByDefault }
 						panelId={ panelId }
 					>
 						<InputControl
 							size={ '__unstable-large' }
-							label={ __( 'Column Start' ) }
+							label={ __( 'Column start' ) }
 							type="number"
 							onChange={ ( value ) => {
 								onChange( {
@@ -182,7 +182,7 @@ export default function ChildLayoutControl( {
 
 						<InputControl
 							size={ '__unstable-large' }
-							label={ __( 'Row Start' ) }
+							label={ __( 'Row start' ) }
 							type="number"
 							onChange={ ( value ) => {
 								onChange( {
@@ -200,14 +200,14 @@ export default function ChildLayoutControl( {
 					<HStack
 						as={ ToolsPanelItem }
 						hasValue={ hasSpanValue }
-						label={ __( 'Grid spans' ) }
+						label={ __( 'Grid span' ) }
 						onDeselect={ resetGridSpans }
 						isShownByDefault={ isShownByDefault }
 						panelId={ panelId }
 					>
 						<InputControl
 							size={ '__unstable-large' }
-							label={ __( 'Column Span' ) }
+							label={ __( 'Column span' ) }
 							type="number"
 							onChange={ ( value ) => {
 								onChange( {
@@ -223,7 +223,7 @@ export default function ChildLayoutControl( {
 
 						<InputControl
 							size={ '__unstable-large' }
-							label={ __( 'Row Span' ) }
+							label={ __( 'Row span' ) }
 							type="number"
 							onChange={ ( value ) => {
 								onChange( {

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -158,7 +158,7 @@ export default function ChildLayoutControl( {
 					<HStack
 						as={ ToolsPanelItem }
 						hasValue={ hasStartValue }
-						label={ __( 'Grid position' ) }
+						label={ __( 'Grid placement' ) }
 						onDeselect={ resetGridStarts }
 						isShownByDefault={ false }
 						panelId={ panelId }

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -64,18 +64,10 @@ export default function ChildLayoutControl( {
 		} );
 	};
 
-	const hasColumnSpanValue = () => !! columnSpan;
-	const resetColumnSpan = () => {
+	const hasSpanValue = () => !! columnSpan || !! rowSpan;
+	const resetGridSpans = () => {
 		onChange( {
-			rowSpan,
 			columnSpan: undefined,
-		} );
-	};
-
-	const hasRowSpanValue = () => !! rowSpan;
-	const resetRowSpan = () => {
-		onChange( {
-			columnSpan,
 			rowSpan: undefined,
 		} );
 	};
@@ -148,49 +140,41 @@ export default function ChildLayoutControl( {
 				</VStack>
 			) }
 			{ parentLayoutType === 'grid' && (
-				<HStack style={ { gridColumn: '1 / -1' } }>
-					<ToolsPanelItem
-						hasValue={ hasColumnSpanValue }
+				<HStack
+					as={ ToolsPanelItem }
+					hasValue={ hasSpanValue }
+					label={ __( 'Grid spans' ) }
+					onDeselect={ resetGridSpans }
+					isShownByDefault={ isShownByDefault }
+					panelId={ panelId }
+				>
+					<InputControl
+						size={ '__unstable-large' }
 						label={ __( 'Column Span' ) }
-						onDeselect={ resetColumnSpan }
-						isShownByDefault={ isShownByDefault }
-						panelId={ panelId }
-					>
-						<InputControl
-							size={ '__unstable-large' }
-							label={ __( 'Column Span' ) }
-							type="number"
-							onChange={ ( value ) => {
-								onChange( {
-									rowSpan,
-									columnSpan: value,
-								} );
-							} }
-							value={ columnSpan }
-							min={ 1 }
-						/>
-					</ToolsPanelItem>
-					<ToolsPanelItem
-						hasValue={ hasRowSpanValue }
+						type="number"
+						onChange={ ( value ) => {
+							onChange( {
+								rowSpan,
+								columnSpan: value,
+							} );
+						} }
+						value={ columnSpan }
+						min={ 1 }
+					/>
+
+					<InputControl
+						size={ '__unstable-large' }
 						label={ __( 'Row Span' ) }
-						onDeselect={ resetRowSpan }
-						isShownByDefault={ isShownByDefault }
-						panelId={ panelId }
-					>
-						<InputControl
-							size={ '__unstable-large' }
-							label={ __( 'Row Span' ) }
-							type="number"
-							onChange={ ( value ) => {
-								onChange( {
-									columnSpan,
-									rowSpan: value,
-								} );
-							} }
-							value={ rowSpan }
-							min={ 1 }
-						/>
-					</ToolsPanelItem>
+						type="number"
+						onChange={ ( value ) => {
+							onChange( {
+								columnSpan,
+								rowSpan: value,
+							} );
+						} }
+						value={ rowSpan }
+						min={ 1 }
+					/>
 				</HStack>
 			) }
 		</>

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -160,7 +160,7 @@ export default function ChildLayoutControl( {
 						hasValue={ hasStartValue }
 						label={ __( 'Grid position' ) }
 						onDeselect={ resetGridStarts }
-						isShownByDefault={ isShownByDefault }
+						isShownByDefault={ false }
 						panelId={ panelId }
 					>
 						<InputControl

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -157,6 +157,45 @@ export default function ChildLayoutControl( {
 			) }
 			{ parentLayoutType === 'grid' && (
 				<>
+					<HStack
+						as={ ToolsPanelItem }
+						hasValue={ hasSpanValue }
+						label={ __( 'Grid span' ) }
+						onDeselect={ resetGridSpans }
+						isShownByDefault={ isShownByDefault }
+						panelId={ panelId }
+					>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Column span' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									columnStart,
+									rowStart,
+									rowSpan,
+									columnSpan: value,
+								} );
+							} }
+							value={ columnSpan }
+							min={ 1 }
+						/>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Row span' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									columnStart,
+									rowStart,
+									columnSpan,
+									rowSpan: value,
+								} );
+							} }
+							value={ rowSpan }
+							min={ 1 }
+						/>
+					</HStack>
 					{ window.__experimentalEnableGridInteractivity && (
 						// Use Flex with an explicit width on the FlexItem instead of HStack to
 						// work around an issue in webkit where inputs with a max attribute are
@@ -207,45 +246,6 @@ export default function ChildLayoutControl( {
 							</FlexItem>
 						</Flex>
 					) }
-					<HStack
-						as={ ToolsPanelItem }
-						hasValue={ hasSpanValue }
-						label={ __( 'Grid span' ) }
-						onDeselect={ resetGridSpans }
-						isShownByDefault={ isShownByDefault }
-						panelId={ panelId }
-					>
-						<InputControl
-							size={ '__unstable-large' }
-							label={ __( 'Column span' ) }
-							type="number"
-							onChange={ ( value ) => {
-								onChange( {
-									columnStart,
-									rowStart,
-									rowSpan,
-									columnSpan: value,
-								} );
-							} }
-							value={ columnSpan }
-							min={ 1 }
-						/>
-						<InputControl
-							size={ '__unstable-large' }
-							label={ __( 'Row span' ) }
-							type="number"
-							onChange={ ( value ) => {
-								onChange( {
-									columnStart,
-									rowStart,
-									columnSpan,
-									rowSpan: value,
-								} );
-							} }
-							value={ rowSpan }
-							min={ 1 }
-						/>
-					</HStack>
 				</>
 			) }
 		</>

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -418,6 +418,8 @@ export default function DimensionsPanel( {
 		setChildLayout( {
 			selfStretch: undefined,
 			flexSize: undefined,
+			columnStart: undefined,
+			rowStart: undefined,
 			columnSpan: undefined,
 			rowSpan: undefined,
 		} );
@@ -433,6 +435,8 @@ export default function DimensionsPanel( {
 				wideSize: undefined,
 				selfStretch: undefined,
 				flexSize: undefined,
+				columnStart: undefined,
+				rowStart: undefined,
 				columnSpan: undefined,
 				rowSpan: undefined,
 			} ),

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -12,7 +12,6 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalBoxControl as BoxControl,
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalView as View,
@@ -396,16 +395,7 @@ export default function DimensionsPanel( {
 	// Child Layout
 	const showChildLayoutControl = useHasChildLayout( settings );
 	const childLayout = inheritedValue?.layout;
-	const { orientation = 'horizontal' } = settings?.parentLayout ?? {};
-	const {
-		type: parentType,
-		default: { type: defaultParentType = 'default' } = {},
-	} = settings?.parentLayout ?? {};
-	const parentLayoutType = parentType || defaultParentType;
-	const flexResetLabel =
-		orientation === 'horizontal' ? __( 'Width' ) : __( 'Height' );
-	const childLayoutResetLabel =
-		parentLayoutType === 'flex' ? flexResetLabel : __( 'Grid spans' );
+
 	const setChildLayout = ( newChildLayout ) => {
 		onChange( {
 			...value,
@@ -414,15 +404,6 @@ export default function DimensionsPanel( {
 			},
 		} );
 	};
-	const resetChildLayoutValue = () => {
-		setChildLayout( {
-			selfStretch: undefined,
-			flexSize: undefined,
-			columnSpan: undefined,
-			rowSpan: undefined,
-		} );
-	};
-	const hasChildLayoutValue = () => !! value?.layout;
 
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {
@@ -650,24 +631,16 @@ export default function DimensionsPanel( {
 				</ToolsPanelItem>
 			) }
 			{ showChildLayoutControl && (
-				<VStack
-					as={ ToolsPanelItem }
-					spacing={ 2 }
-					hasValue={ hasChildLayoutValue }
-					label={ childLayoutResetLabel }
-					onDeselect={ resetChildLayoutValue }
+				<ChildLayoutControl
+					value={ childLayout }
+					onChange={ setChildLayout }
+					parentLayout={ settings?.parentLayout }
+					panelId={ panelId }
 					isShownByDefault={
 						defaultControls.childLayout ??
 						DEFAULT_CONTROLS.childLayout
 					}
-					panelId={ panelId }
-				>
-					<ChildLayoutControl
-						value={ childLayout }
-						onChange={ setChildLayout }
-						parentLayout={ settings?.parentLayout }
-					/>
-				</VStack>
+				/>
 			) }
 			{ showMinHeightControl && (
 				<ToolsPanelItem

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -59,9 +59,20 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 		 * columnCount is set, the grid is responsive so a
 		 * container query is needed for the span to resize.
 		 */
-		if ( columnSpan && ( minimumColumnWidth || ! columnCount ) ) {
-			// Calculate the container query value.
-			const columnSpanNumber = parseInt( columnSpan );
+		if (
+			( columnSpan || columnStart ) &&
+			( minimumColumnWidth || ! columnCount )
+		) {
+			// Check if columnSpan and columnStart are numbers so Math.max doesn't break.
+			const columnSpanNumber = columnSpan ? parseInt( columnSpan ) : null;
+			const columnStartNumber = columnStart
+				? parseInt( columnStart )
+				: null;
+			const highestNumber = Math.max(
+				columnSpanNumber,
+				columnStartNumber
+			);
+
 			let parentColumnValue = parseFloat( minimumColumnWidth );
 			/**
 			 * 12rem is the default minimumColumnWidth value.
@@ -85,12 +96,14 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 
 			const defaultGapValue = parentColumnUnit === 'px' ? 24 : 1.5;
 			const containerQueryValue =
-				columnSpanNumber * parentColumnValue +
-				( columnSpanNumber - 1 ) * defaultGapValue;
+				highestNumber * parentColumnValue +
+				( highestNumber - 1 ) * defaultGapValue;
+			// If a span is set we want to preserve it as long as possible, otherwise we just reset the value.
+			const gridColumnValue = columnSpan ? '1/-1' : 'auto';
 
 			css += `@container (max-width: ${ containerQueryValue }${ parentColumnUnit }) {
 				${ selector } {
-					grid-column: 1 / -1;
+					grid-column: ${ gridColumnValue };
 				}
 			}`;
 		}

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -17,7 +17,14 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 		return ! select( blockEditorStore ).getSettings().disableLayoutStyles;
 	} );
 	const layout = style?.layout ?? {};
-	const { selfStretch, flexSize, columnSpan, rowSpan } = layout;
+	const {
+		selfStretch,
+		flexSize,
+		columnStart,
+		rowStart,
+		columnSpan,
+		rowSpan,
+	} = layout;
 	const parentLayout = useLayout() || {};
 	const { columnCount, minimumColumnWidth } = parentLayout;
 	const id = useInstanceId( useBlockPropsChildLayoutStyles );
@@ -33,6 +40,14 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 		} else if ( selfStretch === 'fill' ) {
 			css = `${ selector } {
 				flex-grow: 1;
+			}`;
+		} else if ( columnStart && columnSpan ) {
+			css = `${ selector } {
+				grid-column: ${ columnStart } / span ${ columnSpan };
+			}`;
+		} else if ( columnStart ) {
+			css = `${ selector } {
+				grid-column: ${ columnStart };
 			}`;
 		} else if ( columnSpan ) {
 			css = `${ selector } {
@@ -79,7 +94,15 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 				}
 			}`;
 		}
-		if ( rowSpan ) {
+		if ( rowStart && rowSpan ) {
+			css += `${ selector } {
+				grid-row: ${ rowStart } / span ${ rowSpan };
+			}`;
+		} else if ( rowStart ) {
+			css += `${ selector } {
+				grid-row: ${ rowStart };
+			}`;
+		} else if ( rowSpan ) {
 			css += `${ selector } {
 				grid-row: span ${ rowSpan };
 			}`;


### PR DESCRIPTION
## What?
Largely follow https://github.com/WordPress/gutenberg/pull/58539. Part of https://github.com/WordPress/gutenberg/issues/57478.

Adds Column Start and Row Start controls to the block inspector for items that are a child of grid layout.

Also rejigs the grouping of the existing Tool Panel items so that we have _Grid position_ and _Grid span_ in the menu. See https://github.com/WordPress/gutenberg/pull/59488. Props @tellthemachines.

## Why?
As part of https://github.com/WordPress/gutenberg/issues/57478 I'm working on letting the user drag and drop items within a grid to position them manually. For this to work we need to be able to set `style.layout.columnStart` and `style.layout.rowStart` and we'll need a keyboard accessible alternative for setting these attributes. This PR adds both.

## How?
Most of the work is already done by https://github.com/WordPress/gutenberg/pull/58539. I'm just adjusting how we output `grid-column` and `grid-row` and adding two new `InputControls`.

## Testing Instructions
1. Insert a Grid block.
2. Add some child blocks to the Grid.
3. Select one of the children. 
4. The Column Start and Row Start controls should appear  in the block inspector.

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/612155/a6a15279-c62e-455b-a993-1d5bd8d96407