### PR TITLE
Site Logo: Update url for site icon settings with fallback for WP core versions earlier than 6.5

### DIFF
--- a/lib/compat/wordpress-6.5/compat.php
+++ b/lib/compat/wordpress-6.5/compat.php
@@ -36,3 +36,18 @@ if ( ! function_exists( 'array_is_list' ) ) {
 		return true;
 	}
 }
+
+/**
+ * Sets a global JS variable used to flag whether to direct the Site Logo block's admin urls
+ * to the Customizer. This allows Gutenberg running on versions of WordPress < 6.5.0 to
+ * support the previous location for the Site Icon settings. This function should not be
+ * backported to core, and should be removed when the required WP core version for Gutenberg
+ * is >= 6.5.0.
+ */
+function gutenberg_add_use_customizer_site_logo_url_flag() {
+	if ( ! is_wp_version_compatible( '6.5' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalUseCustomizerSiteLogoUrl = true', 'before' );
+	}
+}
+
+add_action( 'admin_init', 'gutenberg_add_use_customizer_site_logo_url_flag' );

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -28,12 +28,6 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalDisableTinymce = true', 'before' );
 	}
-
-	// Support the previous location for the Site Icon settings. To be removed
-	// when the required WP core version for Gutenberg is >= 6.5.0.
-	if ( ! is_wp_version_compatible( '6.5' ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalUseCustomizerSiteLogoUrl = true', 'before' );
-	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -28,6 +28,12 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalDisableTinymce = true', 'before' );
 	}
+
+	// Support the previous location for the Site Icon settings. To be removed
+	// when the required WP core version for Gutenberg is >= 6.5.0.
+	if ( ! is_wp_version_compatible( '6.5' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalUseCustomizerSiteLogoUrl = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -268,6 +268,14 @@ const SiteLogo = ( {
 			</ResizableBox>
 		);
 
+	// Support the previous location for the Site Icon settings. To be removed
+	// when the required WP core version for Gutenberg is >= 6.5.0.
+	const shouldUseNewUrl = ! window?.__experimentalUseCustomizerSiteLogoUrl;
+
+	const siteIconSettingsUrl = shouldUseNewUrl
+		? siteUrl + '/wp-admin/options-general.php'
+		: siteUrl + '/wp-admin/customize.php?autofocus[section]=title_tagline';
+
 	const syncSiteIconHelpText = createInterpolateElement(
 		__(
 			'Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. To use a custom icon that is different from your site logo, use the <a>Site Icon settings</a>.'
@@ -276,10 +284,7 @@ const SiteLogo = ( {
 			a: (
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
 				<a
-					href={
-						siteUrl +
-						'/wp-admin/customize.php?autofocus[section]=title_tagline'
-					}
+					href={ siteIconSettingsUrl }
 					target="_blank"
 					rel="noopener noreferrer"
 				/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Resolves #59382 

Update the site icon settings url for the Site Logo block to point to the general settings page, now that WP core 6.5 includes the ability to update the site icon there. Do so while preserving the old URL on Gutenberg when running WP Core < 6.5.

Note: there were other options to this PR suggested over in #59382. I think this approach is likely one of the least disruptive, since it doesn't require any PHP changes in core for 6.5. I may not have time to iterate on this PR, so if anyone feels strongly about going with a different approach, feel free to close this one out!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For 6.5, it'd be good for the url to point to the general settings so that users aren't directed to the customizer. However, it's important to preserve Gutenberg compatibility with earlier WP core versions, until the required core version is at least 6.5.0.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In Gutenberg, add an experimental `window.__experimentalUseCustomizerSiteLogoUrl` value, that only exists if the current WP core version is not compatible with `6.5`.
* In the Site Logo block, check for this global before determining which URL to use. If this flag isn't present, then default to the new url.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a site running WP 6.5 Beta 3, with the Gutenberg plugin active and this PR applied, the URL in the Site Logo block's `Use as Site Icon` toggle should direct to the general settings page of `wp-admin`.
2. In a site running WP 6.4 (or earlier) with the Gutenberg plugin active and this PR applied, the URL in that toggle should still direct to the customizer.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Running WP 6.5 Beta 3

The url should direct to the general options page in `wp-admin`:

![image](https://github.com/WordPress/gutenberg/assets/14988353/430fa7e7-9ba7-4567-a12e-cc3226f30a9e)

### Running WP 6.4.3

In this version, the url should still direct to the customizer:

![image](https://github.com/WordPress/gutenberg/assets/14988353/8c434349-a633-431c-8802-367559565299)
