### PR TITLE
Separate layout child controls so each has its own reset.

### DIFF
--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -7,6 +7,8 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalInputControl as InputControl,
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
@@ -28,24 +30,55 @@ function helpText( selfStretch, parentLayout ) {
 /**
  * Form to edit the child layout value.
  *
- * @param {Object}   props              Props.
- * @param {Object}   props.value        The child layout value.
- * @param {Function} props.onChange     Function to update the child layout value.
- * @param {Object}   props.parentLayout The parent layout value.
+ * @param {Object}   props                  Props.
+ * @param {Object}   props.value            The child layout value.
+ * @param {Function} props.onChange         Function to update the child layout value.
+ * @param {Object}   props.parentLayout     The parent layout value.
  *
+ * @param {boolean}  props.isShownByDefault
+ * @param {string}   props.panelId
  * @return {Element} child layout edit element.
  */
 export default function ChildLayoutControl( {
 	value: childLayout = {},
 	onChange,
 	parentLayout,
+	isShownByDefault,
+	panelId,
 } ) {
 	const { selfStretch, flexSize, columnSpan, rowSpan } = childLayout;
 	const {
 		type: parentType,
 		default: { type: defaultParentType = 'default' } = {},
+		orientation = 'horizontal',
 	} = parentLayout ?? {};
 	const parentLayoutType = parentType || defaultParentType;
+
+	const hasFlexValue = () => !! selfStretch;
+	const flexResetLabel =
+		orientation === 'horizontal' ? __( 'Width' ) : __( 'Height' );
+	const resetFlex = () => {
+		onChange( {
+			selfStretch: undefined,
+			flexSize: undefined,
+		} );
+	};
+
+	const hasColumnSpanValue = () => !! columnSpan;
+	const resetColumnSpan = () => {
+		onChange( {
+			rowSpan,
+			columnSpan: undefined,
+		} );
+	};
+
+	const hasRowSpanValue = () => !! rowSpan;
+	const resetRowSpan = () => {
+		onChange( {
+			columnSpan,
+			rowSpan: undefined,
+		} );
+	};
 
 	useEffect( () => {
 		if ( selfStretch === 'fixed' && ! flexSize ) {
@@ -59,7 +92,15 @@ export default function ChildLayoutControl( {
 	return (
 		<>
 			{ parentLayoutType === 'flex' && (
-				<>
+				<VStack
+					as={ ToolsPanelItem }
+					spacing={ 2 }
+					hasValue={ hasFlexValue }
+					label={ flexResetLabel }
+					onDeselect={ resetFlex }
+					isShownByDefault={ isShownByDefault }
+					panelId={ panelId }
+				>
 					<ToggleGroupControl
 						__nextHasNoMarginBottom
 						size={ '__unstable-large' }
@@ -104,36 +145,52 @@ export default function ChildLayoutControl( {
 							value={ flexSize }
 						/>
 					) }
-				</>
+				</VStack>
 			) }
 			{ parentLayoutType === 'grid' && (
-				<HStack>
-					<InputControl
-						size={ '__unstable-large' }
+				<HStack style={ { gridColumn: '1 / -1' } }>
+					<ToolsPanelItem
+						hasValue={ hasColumnSpanValue }
 						label={ __( 'Column Span' ) }
-						type="number"
-						onChange={ ( value ) => {
-							onChange( {
-								rowSpan,
-								columnSpan: value,
-							} );
-						} }
-						value={ columnSpan }
-						min={ 1 }
-					/>
-					<InputControl
-						size={ '__unstable-large' }
+						onDeselect={ resetColumnSpan }
+						isShownByDefault={ isShownByDefault }
+						panelId={ panelId }
+					>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Column Span' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									rowSpan,
+									columnSpan: value,
+								} );
+							} }
+							value={ columnSpan }
+							min={ 1 }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ hasRowSpanValue }
 						label={ __( 'Row Span' ) }
-						type="number"
-						onChange={ ( value ) => {
-							onChange( {
-								columnSpan,
-								rowSpan: value,
-							} );
-						} }
-						value={ rowSpan }
-						min={ 1 }
-					/>
+						onDeselect={ resetRowSpan }
+						isShownByDefault={ isShownByDefault }
+						panelId={ panelId }
+					>
+						<InputControl
+							size={ '__unstable-large' }
+							label={ __( 'Row Span' ) }
+							type="number"
+							onChange={ ( value ) => {
+								onChange( {
+									columnSpan,
+									rowSpan: value,
+								} );
+							} }
+							value={ rowSpan }
+							min={ 1 }
+						/>
+					</ToolsPanelItem>
 				</HStack>
 			) }
 		</>

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -64,18 +64,10 @@ export default function ChildLayoutControl( {
 		} );
 	};
 
-	const hasColumnSpanValue = () => !! columnSpan;
-	const resetColumnSpan = () => {
+	const hasSpanValue = () => !! columnSpan || !! rowSpan;
+	const resetGridSpans = () => {
 		onChange( {
-			rowSpan,
 			columnSpan: undefined,
-		} );
-	};
-
-	const hasRowSpanValue = () => !! rowSpan;
-	const resetRowSpan = () => {
-		onChange( {
-			columnSpan,
 			rowSpan: undefined,
 		} );
 	};
@@ -148,49 +140,41 @@ export default function ChildLayoutControl( {
 				</VStack>
 			) }
 			{ parentLayoutType === 'grid' && (
-				<HStack style={ { gridColumn: '1 / -1' } }>
-					<ToolsPanelItem
-						hasValue={ hasColumnSpanValue }
+				<HStack
+					as={ ToolsPanelItem }
+					hasValue={ hasSpanValue }
+					label={ __( 'Grid spans' ) }
+					onDeselect={ resetGridSpans }
+					isShownByDefault={ isShownByDefault }
+					panelId={ panelId }
+				>
+					<InputControl
+						size={ '__unstable-large' }
 						label={ __( 'Column Span' ) }
-						onDeselect={ resetColumnSpan }
-						isShownByDefault={ isShownByDefault }
-						panelId={ panelId }
-					>
-						<InputControl
-							size={ '__unstable-large' }
-							label={ __( 'Column Span' ) }
-							type="number"
-							onChange={ ( value ) => {
-								onChange( {
-									rowSpan,
-									columnSpan: value,
-								} );
-							} }
-							value={ columnSpan }
-							min={ 1 }
-						/>
-					</ToolsPanelItem>
-					<ToolsPanelItem
-						hasValue={ hasRowSpanValue }
+						type="number"
+						onChange={ ( value ) => {
+							onChange( {
+								rowSpan,
+								columnSpan: value,
+							} );
+						} }
+						value={ columnSpan }
+						min={ 1 }
+					/>
+
+					<InputControl
+						size={ '__unstable-large' }
 						label={ __( 'Row Span' ) }
-						onDeselect={ resetRowSpan }
-						isShownByDefault={ isShownByDefault }
-						panelId={ panelId }
-					>
-						<InputControl
-							size={ '__unstable-large' }
-							label={ __( 'Row Span' ) }
-							type="number"
-							onChange={ ( value ) => {
-								onChange( {
-									columnSpan,
-									rowSpan: value,
-								} );
-							} }
-							value={ rowSpan }
-							min={ 1 }
-						/>
-					</ToolsPanelItem>
+						type="number"
+						onChange={ ( value ) => {
+							onChange( {
+								columnSpan,
+								rowSpan: value,
+							} );
+						} }
+						value={ rowSpan }
+						min={ 1 }
+					/>
 				</HStack>
 			) }
 		</>

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -12,7 +12,6 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalBoxControl as BoxControl,
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalView as View,
@@ -396,16 +395,7 @@ export default function DimensionsPanel( {
 	// Child Layout
 	const showChildLayoutControl = useHasChildLayout( settings );
 	const childLayout = inheritedValue?.layout;
-	const { orientation = 'horizontal' } = settings?.parentLayout ?? {};
-	const {
-		type: parentType,
-		default: { type: defaultParentType = 'default' } = {},
-	} = settings?.parentLayout ?? {};
-	const parentLayoutType = parentType || defaultParentType;
-	const flexResetLabel =
-		orientation === 'horizontal' ? __( 'Width' ) : __( 'Height' );
-	const childLayoutResetLabel =
-		parentLayoutType === 'flex' ? flexResetLabel : __( 'Grid spans' );
+
 	const setChildLayout = ( newChildLayout ) => {
 		onChange( {
 			...value,
@@ -414,15 +404,6 @@ export default function DimensionsPanel( {
 			},
 		} );
 	};
-	const resetChildLayoutValue = () => {
-		setChildLayout( {
-			selfStretch: undefined,
-			flexSize: undefined,
-			columnSpan: undefined,
-			rowSpan: undefined,
-		} );
-	};
-	const hasChildLayoutValue = () => !! value?.layout;
 
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {
@@ -650,24 +631,16 @@ export default function DimensionsPanel( {
 				</ToolsPanelItem>
 			) }
 			{ showChildLayoutControl && (
-				<VStack
-					as={ ToolsPanelItem }
-					spacing={ 2 }
-					hasValue={ hasChildLayoutValue }
-					label={ childLayoutResetLabel }
-					onDeselect={ resetChildLayoutValue }
+				<ChildLayoutControl
+					value={ childLayout }
+					onChange={ setChildLayout }
+					parentLayout={ settings?.parentLayout }
+					panelId={ panelId }
 					isShownByDefault={
 						defaultControls.childLayout ??
 						DEFAULT_CONTROLS.childLayout
 					}
-					panelId={ panelId }
-				>
-					<ChildLayoutControl
-						value={ childLayout }
-						onChange={ setChildLayout }
-						parentLayout={ settings?.parentLayout }
-					/>
-				</VStack>
+				/>
 			) }
 			{ showMinHeightControl && (
 				<ToolsPanelItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Addresses issue noticed here: https://github.com/WordPress/gutenberg/pull/59483#pullrequestreview-1910103113

Separates each layout child control into its own `ToolsPanelItem`, so that each can be reset independently.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Group block with some children to a post or template and cycle through its Row, Stack and Grid variations. Test the child controls (under the sidebar Dimensions panel) in each of the variations and ensure they're still working and can be correctly reset.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="558" alt="Screenshot 2024-03-01 at 11 45 08 am" src="https://github.com/WordPress/gutenberg/assets/8096000/7fb70fae-44b9-49cc-bfaf-4e7bf7c18b39">
