### PR TITLE
Button: Place children before the icon when `iconPosition` is "right"

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `Tooltip`: Explicitly set system font to avoid CSS bleed ([#59307](https://github.com/WordPress/gutenberg/pull/59307)).
 -   `HStack`, `VStack`: Stop passing invalid props to underlying element ([#59416](https://github.com/WordPress/gutenberg/pull/59416)).
 -   `Button`: Fix focus outline in disabled primary variant ([#59391](https://github.com/WordPress/gutenberg/pull/59391)).
+-   `Button`: Place `children` before the icon when `iconPosition` is `right`  ([#59489](https://github.com/WordPress/gutenberg/pull/59489)).
 
 ### Internal
 

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -223,10 +223,10 @@ export function UnforwardedButton(
 				<Icon icon={ icon } size={ iconSize } />
 			) }
 			{ text && <>{ text }</> }
+			{ children }
 			{ icon && iconPosition === 'right' && (
 				<Icon icon={ icon } size={ iconSize } />
 			) }
-			{ children }
 		</>
 	);
 


### PR DESCRIPTION
Should be able to close #44042

## What?

This PR renders children in front of the icon in the `Button` component when `iconPosition` is set to `right`. This change will always render the icon last if both `children`, `text` are used and `iconPositon` is `right`.

Example code:

```javascript
<Button
	variant="primary"
	icon={ help }
	text="TextProp"
	iconPosition="right"
>
	TextChildren
</Button>
```

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/30cfdd24-db2e-4a6a-ad0a-487e992d6505)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/15312d7c-94c2-4504-a8fc-b74778a8270b)


## Why?

In #44042, when the `Button` component has an icon, some issues were reported regarding the spacing and ordering between the icon and text.

These issues have been fixed in stages as a result of the following PRs.

- `gap` is applied if the button has an icon: #50277
- The `has-text` class is now applied not only when `children` is present, but also when the `text` prop is present: #56949

However, the only problem still unresolved is that the icon is rendered before the `children`, even though the `iconPosition` is `right`.

## How?

Simply swapped the order in which `children` is rendered. This change will result in a visual change for consumers using `children`, `text`, `icon`, `iconPosition="right"`. However, there are probably no users who use both children and text and expect an icon to appear between them.

> [!NOTE]
> As discussed in #56949, it seems that deprecation of the `text` prop is also being considered.

## Testing Instructions

- Access Storybook and open the default story for the Button component: http://localhost:50240/?path=/story/components-button--default
- Enter a string into the `text` prop and apply an icon via the control panel.
- Manipulate the `iconPosition` prop to ensure that it is always rendered to the left or right.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/290dc711-8e06-4e2d-bc9f-ce5fad111649

