### PR TITLE
Add a fixture for the wp/block pattern block current version with overrides

### DIFF
--- a/test/integration/fixtures/blocks/core__block__overrides.html
+++ b/test/integration/fixtures/blocks/core__block__overrides.html
@@ -1,0 +1,1 @@
+<!-- wp:core/block {"ref":123,"content":{"Nice paragraph":{"content":"Some value"}}} /-->

--- a/test/integration/fixtures/blocks/core__block__overrides.json
+++ b/test/integration/fixtures/blocks/core__block__overrides.json
@@ -1,0 +1,15 @@
+[
+	{
+		"name": "core/block",
+		"isValid": true,
+		"attributes": {
+			"ref": 123,
+			"content": {
+				"Nice paragraph": {
+					"content": "Some value"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__block__overrides.parsed.json
+++ b/test/integration/fixtures/blocks/core__block__overrides.parsed.json
@@ -1,0 +1,16 @@
+[
+	{
+		"blockName": "core/block",
+		"attrs": {
+			"ref": 123,
+			"content": {
+				"Nice paragraph": {
+					"content": "Some value"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__block__overrides.serialized.html
+++ b/test/integration/fixtures/blocks/core__block__overrides.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:block {"ref":123,"content":{"Nice paragraph":{"content":"Some value"}}} /-->


### PR DESCRIPTION
## What?
Addresses the review comment here - https://github.com/WordPress/gutenberg/pull/59268#pullrequestreview-1910413772.

Adds an extra fixture that was missing for the pattern block.