### PR TITLE
Tweak: Sidebar categories panel

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -439,6 +439,7 @@ export function HierarchicalTermSelector( { slug } ) {
 				<form onSubmit={ onAddTerm }>
 					<Flex direction="column" gap="4">
 						<TextControl
+							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							className="editor-post-taxonomies__hierarchical-terms-input"
 							label={ newTermLabel }
@@ -448,6 +449,7 @@ export function HierarchicalTermSelector( { slug } ) {
 						/>
 						{ !! availableTerms.length && (
 							<TreeSelect
+								__next40pxDefaultSize
 								__nextHasNoMarginBottom
 								label={ parentSelectLabel }
 								noOptionLabel={ noParentOption }
@@ -458,6 +460,7 @@ export function HierarchicalTermSelector( { slug } ) {
 						) }
 						<FlexItem>
 							<Button
+								__next40pxDefaultSize
 								variant="secondary"
 								type="submit"
 								className="editor-post-taxonomies__hierarchical-terms-submit"


### PR DESCRIPTION
## What?

Part of #46734
<!-- In a few words, what is the PR actually doing? -->

## Why?

To make the height uniform at 40px like other panel elements.

## How?

Added `__next40pxDefaultSize` to the following elements:

- "NEW CATEGORY NAME" text box
- "PARENT CATEGORY" select box
- "Add New Category" button

## Testing Instructions

- Open the post editor.
- Click the Post tab.
- Check the Categories panel.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/0ad231f1-5e4b-481e-87f2-e787f10ce570) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/1ea5c428-ae48-4b49-b92e-995a9e9d8881) | 
