### PR TITLE
theme.json schema: Update `appearanceTools` description

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -33,11 +33,12 @@ Setting that enables the following UI tools:
 
 - background: backgroundImage, backgroundSize
 - border: color, radius, style, width
-- color: link
+- color: link, heading, button, caption
 - dimensions: aspectRatio, minHeight
 - position: sticky
 - spacing: blockGap, margin, padding
 - typography: lineHeight
+- shadow: defaultPresets
 
 
 ---

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -20,7 +20,7 @@
 			"type": "object",
 			"properties": {
 				"appearanceTools": {
-					"description": "Setting that enables the following UI tools:\n\n- background: backgroundImage, backgroundSize\n- border: color, radius, style, width\n- color: link\n- dimensions: aspectRatio, minHeight\n- position: sticky\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
+					"description": "Setting that enables the following UI tools:\n\n- background: backgroundImage, backgroundSize\n- border: color, radius, style, width\n- color: link, heading, button, caption\n- dimensions: aspectRatio, minHeight\n- position: sticky\n- spacing: blockGap, margin, padding\n- typography: lineHeight\n- shadow: defaultPresets",
 					"type": "boolean",
 					"default": false
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds the missing setting in the theme.json schema that `settings.apperanceTools` actually enables:

- `color.heading`
- `color.button`
- `color.caption`
- `shadow.defaultPresets`

## How?

Referenced [APPEARANCE_TOOLS_OPT_INS](https://github.com/WordPress/gutenberg/blob/8c77df8c1052015f26b57d65fe5f043cd4f774ac/lib/class-wp-theme-json-gutenberg.php#L661-L686) variable and added missing settings.

## Testing Instructions

Create a JSON file like below locally and make sure `settings.apperanceTools` displays the correct description text.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/theme-json/update-appearance-tools/schemas/json/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": false
	}
}
```

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/0f3e4725-542f-4ff9-ba70-0fd3300a0c4f)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/ce1933fe-84ed-4e0b-b5c5-c08fd6fa9239)

