### PR TITLE
Form Block: correction of the contact form block descriptive text

### DIFF
--- a/packages/block-library/src/form/variations.js
+++ b/packages/block-library/src/form/variations.js
@@ -13,8 +13,8 @@ import {
 const variations = [
 	{
 		name: 'comment-form',
-		title: __( 'Experimental Comment form' ),
-		description: __( 'A comment form for posts and pages.' ),
+		title: __( 'Experimental Contact Form' ),
+		description: __( 'A contact form for posts and pages.' ),
 		attributes: {
 			submissionMethod: 'custom',
 			action: '{SITE_URL}/wp-comments-post.php',


### PR DESCRIPTION
Correction of the contact form block descptive text.

## What?
The descriptive text of the form block describes the block as a comment form, but it is a contact form.

Only those two lines of text have been changed.

## Screenshots or screencast <!-- if applicable -->
![xxxxxxxxx](https://github.com/WordPress/gutenberg/assets/83702259/e5e6204c-7f8f-4184-a6aa-fd738b29fb38)
