### PR TITLE
Global Styles: Remove preset headers

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -5,19 +5,16 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import Subtitle from '../subtitle';
 import Variation from './variation';
 import StylesPreviewColors from '../preview-colors';
 
 export default function ColorVariations( { variations } ) {
 	return (
 		<VStack spacing={ 3 }>
-			<Subtitle level={ 3 }>{ __( 'Presets' ) }</Subtitle>
 			<Grid columns={ 3 }>
 				{ variations.map( ( variation, index ) => (
 					<Variation key={ index } variation={ variation }>

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -6,7 +6,6 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
@@ -17,7 +16,6 @@ import { unlock } from '../../../lock-unlock';
 import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import TypographyExample from '../typography-example';
 import PreviewIframe from '../preview-iframe';
-import Subtitle from '../subtitle';
 import { getFontFamilies } from '../utils';
 import Variation from './variation';
 
@@ -64,7 +62,6 @@ export default function TypographyVariations() {
 
 	return (
 		<VStack spacing={ 3 }>
-			<Subtitle level={ 3 }>{ __( 'Presets' ) }</Subtitle>
 			<Grid
 				columns={ 3 }
 				className="edit-site-global-styles-style-variations-container"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the "Preset" headers from Color and Typography sections.

## Why?
They are unnecessary.

## How?
Removes the code

## Testing Instructions
1. Open Global Styles
2. Open Colors
3. Check that the "Presets" header is removed
4. Open Typography
5. Check that the "Presets" header is removed

## Screenshots or screencast <!-- if applicable -->
<img width="289" alt="Screenshot 2024-03-01 at 13 27 37" src="https://github.com/WordPress/gutenberg/assets/275961/3387143b-748f-4836-8cc7-1806f55aa796">

<img width="292" alt="Screenshot 2024-03-01 at 13 27 25" src="https://github.com/WordPress/gutenberg/assets/275961/f92a62ea-bae3-4ce5-bcaf-c43e531b23c9">
