### PR TITLE
Fix accessibility of the edit site global styles Variation 

### DIFF
--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -41,7 +41,11 @@ export default function StyleVariationsContainer() {
 			className="edit-site-global-styles-style-variations-container"
 		>
 			{ withEmptyVariation.map( ( variation, index ) => (
-				<Variation key={ index } variation={ variation }>
+				<Variation
+					key={ index }
+					variation={ variation }
+					shouldShowTooltip={ false }
+				>
 					{ ( isFocused ) => (
 						<PreviewStyles
 							label={ variation?.title }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -1,11 +1,3 @@
-.edit-site-global-styles-preview {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	line-height: 1;
-	cursor: pointer;
-}
-
 .edit-site-global-styles-preview__iframe {
 	max-width: 100%;
 	display: block;

--- a/packages/edit-site/src/components/global-styles/typography-example.js
+++ b/packages/edit-site/src/components/global-styles/typography-example.js
@@ -36,7 +36,8 @@ export default function PreviewTypography( { fontSize, variation } ) {
 	}
 
 	return (
-		<motion.div
+		<motion.span
+			className="edit-site-global-styles_preview-typography"
 			animate={ {
 				scale: 1,
 				opacity: 1,
@@ -50,6 +51,7 @@ export default function PreviewTypography( { fontSize, variation } ) {
 				type: 'tween',
 			} }
 			style={ {
+				display: 'block',
 				fontSize: '22px',
 				lineHeight: '44px',
 				textAlign: 'center',
@@ -61,6 +63,6 @@ export default function PreviewTypography( { fontSize, variation } ) {
 			<span style={ bodyPreviewStyle }>
 				{ _x( 'a', 'Lowercase letter A' ) }
 			</span>
-		</motion.div>
+		</motion.span>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -1,38 +1,30 @@
-.edit-site-global-styles-variations_item {
-	box-sizing: border-box;
-	// To round the outline in Windows 10 high contrast mode.
-	border-radius: $radius-block-ui;
-	cursor: pointer;
+// Higher specificity to override some Button styles.
+.edit-site-global-styles-variations_item.edit-site-global-styles-variations_item {
+	display: inline-block;
+	position: relative;
+	height: auto;
+	padding: 1px;
+	box-shadow: inset 0 0 0 1px $gray-600;
+	// Show the boundary of the button, in Windows High Contrast Mode.
+	outline: 1px solid transparent;
 
 	.edit-site-global-styles-variations_item-preview {
+		display: block;
 		padding: $border-width * 2;
-		border-radius: $radius-block-ui;
-		box-shadow: 0 0 0 $border-width $gray-200;
-		// Shown in Windows 10 high contrast mode.
-		outline: 1px solid transparent;
 
 		.edit-site-global-styles-color-variations & {
 			padding: $grid-unit-10;
 		}
 	}
 
-	&.is-active .edit-site-global-styles-variations_item-preview {
-		box-shadow: 0 0 0 $border-width $gray-900;
-		// Shown in Windows 10 high contrast mode.
-		outline-width: 3px;
-	}
-
-	&:hover .edit-site-global-styles-variations_item-preview {
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-	}
-
-	&:focus .edit-site-global-styles-variations_item-preview {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-	}
-
-	&:focus-visible {
-		// Shown in Windows 10 high contrast mode.
-		outline: 3px solid transparent;
-		outline-offset: 0;
+	& .edit-site-global-styles-variations_active-icon {
+		position: absolute;
+		top: -7px;
+		right: -7px;
+		display: block;
+		box-shadow: inset 0 0 0 1px $gray-800, inset 0 0 0 2px $white;
+		border-radius: 100%;
+		background: $gray-800;
+		fill: $white;
 	}
 }

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useMemo, useContext, useState } from '@wordpress/element';
-import { ENTER } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { Button, Icon } from '@wordpress/components';
+import { check } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -21,7 +17,11 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
 
-export default function Variation( { variation, children } ) {
+export default function Variation( {
+	variation,
+	children,
+	shouldShowTooltip = true,
+} ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
 	const context = useMemo(
@@ -44,13 +44,6 @@ export default function Variation( { variation, children } ) {
 		} ) );
 	};
 
-	const selectOnEnter = ( event ) => {
-		if ( event.keyCode === ENTER ) {
-			event.preventDefault();
-			selectVariation();
-		}
-	};
-
 	const isActive = useMemo(
 		() => areGlobalStyleConfigsEqual( user, variation ),
 		[ user, variation ]
@@ -68,26 +61,26 @@ export default function Variation( { variation, children } ) {
 
 	return (
 		<GlobalStylesContext.Provider value={ context }>
-			<div
-				className={ classnames(
-					'edit-site-global-styles-variations_item',
-					{
-						'is-active': isActive,
-					}
-				) }
-				role="button"
+			<Button
+				className="edit-site-global-styles-variations_item"
 				onClick={ selectVariation }
-				onKeyDown={ selectOnEnter }
-				tabIndex="0"
-				aria-label={ label }
+				label={ label }
 				aria-current={ isActive }
 				onFocus={ () => setIsFocused( true ) }
 				onBlur={ () => setIsFocused( false ) }
+				showTooltip={ shouldShowTooltip }
 			>
-				<div className="edit-site-global-styles-variations_item-preview">
+				<span className="edit-site-global-styles-variations_item-preview">
 					{ children( isFocused ) }
-				</div>
-			</div>
+				</span>
+				{ isActive && (
+					<Icon
+						icon={ check }
+						size={ 16 }
+						className="edit-site-global-styles-variations_active-icon"
+					/>
+				) }
+			</Button>
 		</GlobalStylesContext.Provider>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -2,10 +2,10 @@
  * WordPress dependencies
  */
 import { useMemo, useContext, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { Button, Icon } from '@wordpress/components';
 import { check } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -22,6 +22,11 @@ export default function Variation( {
 	children,
 	shouldShowTooltip = true,
 } ) {
+	const instanceId = useInstanceId(
+		Variation,
+		'edit-site-global-styles-variations_item'
+	);
+	const descriptionId = variation?.description ? instanceId : undefined;
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
 	const context = useMemo(
@@ -49,26 +54,17 @@ export default function Variation( {
 		[ user, variation ]
 	);
 
-	let label = variation?.title;
-	if ( variation?.description ) {
-		label = sprintf(
-			/* translators: %1$s: variation title. %2$s variation description. */
-			__( '%1$s (%2$s)' ),
-			variation?.title,
-			variation?.description
-		);
-	}
-
 	return (
 		<GlobalStylesContext.Provider value={ context }>
 			<Button
 				className="edit-site-global-styles-variations_item"
 				onClick={ selectVariation }
-				label={ label }
+				label={ variation?.title }
 				aria-current={ isActive }
 				onFocus={ () => setIsFocused( true ) }
 				onBlur={ () => setIsFocused( false ) }
 				showTooltip={ shouldShowTooltip }
+				aria-describedby={ descriptionId }
 			>
 				<span className="edit-site-global-styles-variations_item-preview">
 					{ children( isFocused ) }
@@ -81,6 +77,11 @@ export default function Variation( {
 					/>
 				) }
 			</Button>
+			{ descriptionId && (
+				<div hidden id={ descriptionId }>
+					{ variation?.description }
+				</div>
+			) }
 		</GlobalStylesContext.Provider>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -5,6 +5,7 @@ import { useContext } from '@wordpress/element';
 import {
 	__experimentalGrid as Grid,
 	__experimentalVStack as VStack,
+	__unstableMotion as motion,
 } from '@wordpress/components';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -5,7 +5,6 @@ import { useContext } from '@wordpress/element';
 import {
 	__experimentalGrid as Grid,
 	__experimentalVStack as VStack,
-	__unstableMotion as motion,
 } from '@wordpress/components';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -91,17 +91,13 @@
 		max-width: 292px;
 	}
 
-	.edit-site-global-styles-variations_item-preview {
-		box-shadow: 0 0 0 $border-width $gray-900;
-	}
-	.edit-site-global-styles-variations_item.is-active .edit-site-global-styles-variations_item-preview {
-		box-shadow: 0 0 0 $border-width $gray-100;
-	}
-	.edit-site-global-styles-variations_item:hover .edit-site-global-styles-variations_item-preview {
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-	}
-	.edit-site-global-styles-variations_item:focus .edit-site-global-styles-variations_item-preview {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	// Variation items in the site editor navigation panel have slightly different styling.
+	.edit-site-global-styles-variations_item {
+		padding: 0;
+
+		&:not(:focus) {
+			box-shadow: none;
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/59459

## What?
<!-- In a few words, what is the PR actually doing? -->
The global styles Varaition are made with foucsable `div` elements instead of native buttons. 
When using `div` rather than a button, _all_ the native button features and intereaction should be re-implemented. That appears to not be the case with the current implementation.
- Variations don't work with the Space bar, they only work with the Enter key.
- There's no Tooltip or any other text to visually expose the accessible name.
- The focus style is inconsistend, as it's a custom style and not the standard one implemented for buttons.
- The active state is communicated only with a color change of the visual outline, which i sinsufficient.
- The variant description, if any, is appended to the label. This is far from ideal. Labels are meant to provide the accessible name of a control, that's not the place for descriptions. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Overall, given the amount of code that would be required to make a focusable `div` element fully accessible and behave like a button, it's way better to use a button element. There's no reason to not use a button element a smodern browsers allow to fully style them.

More importantly, custom implementation should be avoided as they defeat the purpose of building a library of reusable component in the first place. It's unlikely that custom implementations have the same level of accessibility and the same design consistnecy of the base components. Instead of implementing custom interactive controls in the UI, the base component should be used and if a new variant of a base component is desired that should be added to the base component.

This PR replaces the focusable `div` elements with a Button compoennt, becuase the Button brings in all the accessibility, interaction, and base styles like focus style that we need to make a better usable and accessible UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Replaces the focusable `div` custom implementation with a Button component.
- Moves the description out from the label to a visually hidden description referenced by aria-describedby.
- Removes no longer necessary JS and CSS.
- Changes the active styling to use a _shape_ instead of just a color change. I opted to use the checkmark icon as that's already used as a pattern to indicate 'selected' in other parts of hte editor e.g. dropdown menus and elsewhere.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Set Twenty Twenty-Four as active theme.
- Edit the `src/wp-content/themes/twentytwentyfour/styles/maelstrom.json` file and add a description to the style variant e.g.: `"description": "This is the Maelstrom description"`
- Go to Site Editor > Design > Styles
- Observe the styles variations in the navigation panel have no relevant visual changes.
- Inspect the source and observe the variations are now button elements.
- Check the variations work with click, Enter key and Space bar key.
- Check these instances of the variations don't show a tooltip because the variation name is already shown on hover and focus.
- Check the focus style is consistent with one used for other controls, as it's now the default focus style of the Button component.
- Inspect the source and observe the `Maelstrom` variant button does have a visually hidden description `This is the Maelstrom description`.
- Select one of the variations and observe the active state is visually provided by a checkmark icon at the top right of the variation. Semantically it's an `aria-current="true"` attribute, this hasn't changed.
- Switch the Site Editor to edit mode.
- Go to Styles > Typography > Presets
- Observe the variations are not button elements and don't have relevant visual changes.
- Check the variations work with click, Enter key and Space bar key.
- Check these instances of the variations do show a tooltip to visually expose the variation name.
- Check the focus style is consistent.
- Inspect the source and observe the `Maelstrom` variant button does have a visually hidden description.
- Select one of the variations and observe the active state is visually provided by a checkmark icon.
- Go to Styles > Typography > Presets
- Repeat the steps above.
- Go to Styles > Browse styles
- Repeat the steps above.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before with focus and active states. Notice the states difference is _basically_ only a color change of the visual outline (although there's a barely noticeable change in the outline thickness). Basically this is color alone, which is insufficient.

![before](https://github.com/WordPress/gutenberg/assets/1682452/1cfc5a8c-e983-47ed-aee5-ae2b5a334dfe)


Before with focus and active states:

![after](https://github.com/WordPress/gutenberg/assets/1682452/78d95e7c-526c-4253-a897-c45d36f33ffc)
