### PR TITLE
Expand main content area to viewport when zoomed out

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -360,6 +360,22 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	z-index: z-index("{core/image aligned left or right} .wp-block");
 }
 
+body.is-zoomed-out {
+	display: flex;
+	flex-direction: column;
+
+	> .is-root-container {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+
+		> main {
+			flex: 1;
+		}
+	}
+}
+
 .wp-site-blocks > [data-align="left"] {
 	float: left;
 	margin-right: 2em;

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -103,6 +103,17 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 		[ settings.styles, enableResizing, canvasMode ]
 	);
 
+	const frameSize = isZoomOutMode ? 20 : undefined;
+
+	const scale = isZoomOutMode
+		? ( contentWidth ) =>
+				computeIFrameScale(
+					{ width: 1000, scale: 0.45 },
+					{ width: 400, scale: 0.9 },
+					contentWidth
+				)
+		: undefined;
+
 	return (
 		<EditorCanvasRoot
 			className={ classnames( 'edit-site-editor-canvas__block-list', {
@@ -111,15 +122,8 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 			renderAppender={ showBlockAppender }
 			styles={ styles }
 			iframeProps={ {
-				scale: isZoomOutMode
-					? ( contentWidth ) =>
-							computeIFrameScale(
-								{ width: 1000, scale: 0.45 },
-								{ width: 400, scale: 0.9 },
-								contentWidth
-							)
-					: undefined,
-				frameSize: isZoomOutMode ? 100 : undefined,
+				scale,
+				frameSize,
 				className: classnames(
 					'edit-site-visual-editor__editor-canvas',
 					{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

@richtabor asked if this was possible, so here it is. 

![zoom-out-expand](https://github.com/WordPress/gutenberg/assets/4710635/95c7bb1e-3460-418d-b82f-eb269ab6d640)


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I think the primary reason is to make the drop target for patterns larger, but it also makes the site look better when empty (just header/footer).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. We need to expand the canvas to fix the screen. This can only be done through the `body` element because it must be an element with the scaled element (`html` element). We can do this for any theme I think.
2. Now we need to push the footer down to the bottom of the body element / expand the main area to fit. This is the most tricky part because the styles may clash with existing theme styles. I wonder if we should make this opt-in: a theme should decide exactly how and what to expand/push down. This is actually useful on the front-end as well: if there's limited content, it's nice to push down the footer.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Enable the zoom-out mode experiment.
Create an empty page in the site editor (for a block based theme).
Click the zoom-out mode button in the top toolbar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
