### PR TITLE
Global Styles: Use text and button background color for color indicators

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -65,6 +65,13 @@ export function useStylesPreviewColors() {
 	const [ headingColor = textColor ] = useGlobalStyle(
 		'elements.h1.color.text'
 	);
+	const [ linkColor = headingColor ] = useGlobalStyle(
+		'elements.link.color.text'
+	);
+
+	const [ buttonBackgroundColor = linkColor ] = useGlobalStyle(
+		'elements.button.color.background'
+	);
 	const [ coreColors ] = useGlobalSetting( 'color.palette.core' );
 	const [ themeColors ] = useGlobalSetting( 'color.palette.theme' );
 	const [ customColors ] = useGlobalSetting( 'color.palette.custom' );
@@ -72,10 +79,20 @@ export function useStylesPreviewColors() {
 	const paletteColors = ( themeColors ?? [] )
 		.concat( customColors ?? [] )
 		.concat( coreColors ?? [] );
-	const highlightedColors = paletteColors
+
+	const textColorObject = paletteColors.filter(
+		( { color } ) => color === textColor
+	);
+	const buttonBackgroundColorObject = paletteColors.filter(
+		( { color } ) => color === buttonBackgroundColor
+	);
+
+	const highlightedColors = textColorObject
+		.concat( buttonBackgroundColorObject )
+		.concat( paletteColors )
 		.filter(
-			// we exclude these two colors because they are already visible in the preview.
-			( { color } ) => color !== backgroundColor && color !== headingColor
+			// we exclude these background color because it is already visible in the preview.
+			( { color } ) => color !== backgroundColor
 		)
 		.slice( 0, 2 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes the color indicators for style panels.
Fixes #59444.

## Why?
The aim is to make the color palette selection clearer, but I'm not yet convinced this is the right solution.

## How?
The two colors are `styles.text.color` and `styles.elements.button.background`.

## Testing Instructions
1. Open Global Styles
2. Look at the color circles on the style tiles and check that the colors match the body text color and button background color.

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="283" alt="Screenshot 2024-03-01 at 20 35 26" src="https://github.com/WordPress/gutenberg/assets/275961/87650200-8fe6-4a8d-b84c-1e32f06c2e84">

After:
<img width="276" alt="Screenshot 2024-03-01 at 20 34 50" src="https://github.com/WordPress/gutenberg/assets/275961/72a6a073-df8d-4e47-a2b8-d8ed387db3f0">
