### PR TITLE
ES Lint: Add a rule to prevent use of the disabled attribute

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -172,6 +172,11 @@ module.exports = {
 					'Do not use string literals for IDs; use withInstanceId instead.',
 			},
 			{
+				selector: 'JSXAttribute[name.name="disabled"]',
+				message:
+					'Do not use the disabled attribute; use aria-disabled instead.',
+			},
+			{
 				// Discourage the usage of `Math.random()` as it's a code smell
 				// for UUID generation, for which we already have a higher-order
 				// component: `withInstanceId`.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a rule to prevent the use of the disabled attribute.

## Why?
> The disabled attribute should be banned in this project. It causes accessibility issues for keyboard and screen reader users but offers developers a very nice shortcut.

- @alexstine 

## How?
Adds a new ES Lint rule to catch this.

## Testing Instructions
1. Add `disabled` to any React component
2. Try to commit your change
3. The linter should stop you
