### PR TITLE
Add @global to PHP doc comments

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -86,6 +86,8 @@ function gutenberg_create_initial_post_types() {
 
 /**
  * Initializes REST routes.
+ *
+ * @global string $wp_version The WordPress version string.
  */
 function gutenberg_create_initial_rest_routes() {
 	global $wp_version;
@@ -101,6 +103,8 @@ add_action( 'rest_api_init', 'gutenberg_create_initial_rest_routes' );
 
 /**
  * Initializes REST routes and post types.
+ *
+ * @global string $wp_version The WordPress version string.
  */
 function gutenberg_init_font_library() {
 	global $wp_version;

--- a/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
@@ -77,9 +77,9 @@ if ( ! function_exists( 'wp_interactivity' ) ) {
 	 * It provides access to the WP_Interactivity_API instance, creating one if it
 	 * doesn't exist yet.
 	 *
-	 * @global WP_Interactivity_API $wp_interactivity
-	 *
 	 * @since 6.5.0
+	 *
+	 * @global WP_Interactivity_API $wp_interactivity
 	 *
 	 * @return WP_Interactivity_API The main WP_Interactivity_API instance.
 	 */

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -36,6 +36,8 @@ function block_core_post_template_uses_featured_image( $inner_blocks ) {
  *
  * @since 6.3.0 Changed render_block_context priority to `1`.
  *
+ * @global WP_Query $wp_query WordPress Query object.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.


### PR DESCRIPTION
**1. Added @global to PHP doc comments in below files**

-  lib/compat/wordpress-6.5/fonts/fonts.php
-  packages/block-library/src/post-template/index.php

**2. Added @global After Since as per [PHP Doc Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) in lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php file**

**Fixes:**  https://github.com/WordPress/gutenberg/issues/59521