### PR TITLE
Update an anchor link in block-in-the-editor.md

### DIFF
--- a/docs/getting-started/fundamentals/block-in-the-editor.md
+++ b/docs/getting-started/fundamentals/block-in-the-editor.md
@@ -1,6 +1,6 @@
 # The block in the Editor
 
-The Block Editor is a React Single Page Application (SPA). Every block in the Editor is displayed through a React component defined in the `edit` property of the settings object used to [register the block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/registration-of-a-block/#registration-of-the-block-with-javascript-client-side) on the client. 
+The Block Editor is a React Single Page Application (SPA). Every block in the Editor is displayed through a React component defined in the `edit` property of the settings object used to [register the block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/registration-of-a-block/#registering-a-block-with-javascript-client-side) on the client. 
 
 The `props` object received by the block's `Edit` React component includes:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The PR updates an anchor link in [this page](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-in-the-editor/) of the docs.

## Why?
The old anchor link was no longer valid, hence it's not moving to the right section on the page linked.

## How?
The PR adds the correct anchor link.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open [the page](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-in-the-editor/).
2. Click on the link modified (link text is `register the block`, so you can do a find in page for that) and see if it jumps to the right section on the page linked.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
