### PR TITLE
Font Library: Replace deprecated isSmall prop with size="small" prop

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -358,7 +358,7 @@ function FontCollection( { slug } ) {
 					<Flex justify="flex-start">
 						<NavigatorToParentButton
 							icon={ chevronLeft }
-							isSmall
+							size="small"
 							onClick={ () => {
 								setSelectedFont( null );
 							} }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -198,7 +198,7 @@ function InstalledFonts() {
 					<Flex justify="flex-start">
 						<NavigatorToParentButton
 							icon={ chevronLeft }
-							isSmall
+							size="small"
 							onClick={ () => {
 								handleSetLibraryFontSelected( null );
 							} }


### PR DESCRIPTION
Part of #53560

## What?

Replaces the `isSmall` deprecated prop in the Font Library modal component with size="small".

## Why?

The core should avoid using the deprecated method and props.

## Testing Instructions

- Open the Font Library.
- Select one of the fonts in the Library tab.
- Make sure the back button remains at 24px size.
- Select one of the fonts in the Install fonts tab.
- Make sure the back button remains at 24px size.
- 
## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/54422211/01f60565-6321-4594-877a-35504faca83c)

![image](https://github.com/WordPress/gutenberg/assets/54422211/4759c63f-9f46-447f-8689-f02b15c966c8)


