### PR TITLE
Generate element classnames from element-specific data

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -91,7 +91,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 				 */
 				$tags = new WP_HTML_Tag_Processor( $block_content );
 				if ( $tags->next_tag() ) {
-					$tags->add_class( wp_get_elements_class_name( $block ) );
+					$tags->add_class( wp_get_elements_class_name( $elements_style_attributes ) );
 				}
 
 				return $tags->get_updated_html();
@@ -134,7 +134,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 		return null;
 	}
 
-	$class_name = wp_get_elements_class_name( $block );
+	$class_name = wp_get_elements_class_name( $element_block_styles );
 
 	$element_types = array(
 		'button'  => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #59462.

Classname generation for block-specific element (e.g. link, heading) styles was dependent on the block array being identical between `pre_render_block` and `render_block` filters. That can't be assured, because between those two filters, the `render_block_data` filter also runs and the block array can be modified within it.

This PR updates the element classname hash generation to use only the `style.elements` array instead of the full block, because that is less likely to change between filters.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a post or page, add a Group block with a Paragraph inside it.
2. Add a link to the Paragraph.
3. under the sidebar Color panel, add link color for both the Group and the Paragraph.
4. Check that the correct link color displays in both editor and front end (it should be the color added to the Paragraph, which overrides the one added to the Group.
5. Add a second Paragraph with a link inside the Group without setting its link color. Verify that it uses the Group link color.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
