### PR TITLE
(POC) Block Bindings: edit external prop value/block attribute

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -190,8 +190,31 @@ const withBlockBindingSupport = createHigherOrderComponent(
 		// Pick bound attributes from the (memoized) bindings object.
 		const boundAttributes = Object.fromEntries(
 			Object.entries( bindings ).map( ( [ attrName, settings ] ) => {
-				const { value } = settings;
-				return [ attrName, value ];
+				const { value, placeholder } = settings;
+				if ( typeof value !== 'undefined' ) {
+					return [ attrName, value ];
+				}
+
+				if ( ! placeholder ) {
+					return [ attrName, undefined ];
+				}
+
+				/*
+				 * Placeholder fallback.
+				 * If the attribute is `src` or `href`,
+				 * a placeholder can't be used because it is not a valid url.
+				 * Adding this workaround until
+				 * attributes and metadata fields types are improved and include `url`.
+				 */
+				const htmlAttribute = getBlockType( props.name ).attributes[
+					attrName
+				].attribute;
+
+				if ( htmlAttribute === 'src' || htmlAttribute === 'href' ) {
+					return [ attrName, null ];
+				}
+
+				return [ attrName, placeholder ];
 			} )
 		);
 

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -184,8 +184,8 @@ const withBlockBindingSupport = createHigherOrderComponent(
 		// Pick bound attributes from the (memoized) bindings object.
 		const boundAttributes = Object.fromEntries(
 			Object.entries( bindings ).map( ( [ attrName, settings ] ) => {
-				const { get } = settings;
-				return [ attrName, get() ];
+				const { value } = settings;
+				return [ attrName, value ];
 			} )
 		);
 

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -126,6 +126,12 @@ const withBlockBindingSupport = createHigherOrderComponent(
 			useSelect( blocksStore )
 		).getAllBlockBindingsSources();
 
+		/*
+		 * A trigger to refresh
+		 * the bound attributesvalues
+		 * when the source data changes.
+		 * It is used to force the re-render of the BlockEdit component.
+		 */
 		const [ refreshTrigger, setTrigger ] = useState( 1 );
 		const refreshExternalSourceData = setTrigger.bind(
 			null,
@@ -223,15 +229,17 @@ const withBlockBindingSupport = createHigherOrderComponent(
 			[ bindings, props ]
 		);
 
+		if ( Object.keys( bindings ).length <= 0 ) {
+			return <BlockEdit { ...props } />;
+		}
+
 		return (
 			<>
-				{ Object.keys( bindings ).length > 0 && (
-					<BlockBindingBridge
-						blockProps={ props }
-						bindings={ bindings }
-						onPropValueChange={ refreshExternalSourceData }
-					/>
-				) }
+				<BlockBindingBridge
+					blockProps={ props }
+					bindings={ bindings }
+					onPropValueChange={ refreshExternalSourceData }
+				/>
 
 				<BlockEdit
 					{ ...props }

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -52,7 +52,7 @@ export function registerBlockBindingsSource( source ) {
 		sourceName: source.name,
 		sourceLabel: source.label,
 		useSource: source.useSource,
-		helper: source.helper,
+		handler: source.handler,
 		lockAttributesEditing: source.lockAttributesEditing,
 	};
 }

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -51,8 +51,7 @@ export function registerBlockBindingsSource( source ) {
 		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
 		sourceName: source.name,
 		sourceLabel: source.label,
-		useSource: source.useSource,
-		handler: source.handler,
+		init: source.init,
 		lockAttributesEditing: source.lockAttributesEditing,
 	};
 }

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -52,6 +52,7 @@ export function registerBlockBindingsSource( source ) {
 		sourceName: source.name,
 		sourceLabel: source.label,
 		useSource: source.useSource,
+		helper: source.helper,
 		lockAttributesEditing: source.lockAttributesEditing,
 	};
 }

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -390,7 +390,7 @@ export function blockBindingsSources( state = {}, action ) {
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
 				useSource: action.useSource,
-				helper: action.helper,
+				handler: action.handler,
 				lockAttributesEditing: action.lockAttributesEditing ?? true,
 			},
 		};

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -390,6 +390,7 @@ export function blockBindingsSources( state = {}, action ) {
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
 				useSource: action.useSource,
+				helper: action.helper,
 				lockAttributesEditing: action.lockAttributesEditing ?? true,
 			},
 		};

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -389,8 +389,7 @@ export function blockBindingsSources( state = {}, action ) {
 			...state,
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
-				useSource: action.useSource,
-				handler: action.handler,
+				init: action.init,
 				lockAttributesEditing: action.lockAttributesEditing ?? true,
 			},
 		};

--- a/packages/data/src/redux-store/metadata/actions.js
+++ b/packages/data/src/redux-store/metadata/actions.js
@@ -116,6 +116,9 @@ export function failResolutions( selectorName, args, errors ) {
  * @return {{ type: 'INVALIDATE_RESOLUTION', selectorName: string, args: any[] }} Action object.
  */
 export function invalidateResolution( selectorName, args ) {
+	console.log( 'selectorName', selectorName );
+	console.log( 'args', args );
+
 	return {
 		type: 'INVALIDATE_RESOLUTION',
 		selectorName,

--- a/packages/data/src/redux-store/metadata/actions.js
+++ b/packages/data/src/redux-store/metadata/actions.js
@@ -116,9 +116,6 @@ export function failResolutions( selectorName, args, errors ) {
  * @return {{ type: 'INVALIDATE_RESOLUTION', selectorName: string, args: any[] }} Action object.
  */
 export function invalidateResolution( selectorName, args ) {
-	console.log( 'selectorName', selectorName );
-	console.log( 'args', args );
-
 	return {
 		type: 'INVALIDATE_RESOLUTION',
 		selectorName,

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -19,60 +19,41 @@ export default {
 
 		const kind = 'postType';
 		const postType = context.postType ?? getCurrentPostType();
-		const postId = context.postId ?? getCurrentPostId();
-		const prop = 'meta';
+		const id = context.postId ?? getCurrentPostId();
 
 		const { getEntityRecord, getEditedEntityRecord } = select( coreStore );
 
-		const record = getEntityRecord( kind, postType, postId );
-		const editedRecord = getEditedEntityRecord( kind, postType, postId );
+		const record = getEntityRecord( kind, postType, id );
+		const editedRecord = getEditedEntityRecord( kind, postType, id );
 
 		return {
 			get() {
-				const propValue =
-					record && editedRecord
-						? {
-								value: editedRecord[ prop ]?.[ metaKey ],
-								fullValue: record[ prop ]?.[ metaKey ],
-						  }
-						: {};
+				return editedRecord.meta?.[ metaKey ];
+			},
 
-				return propValue.value;
+			getPlaceholder() {
+				return metaKey;
 			},
 
 			update( newValue ) {
 				const { editEntityRecord } = dispatch( coreStore );
 
-				editEntityRecord( kind, postType, postId, {
+				editEntityRecord( kind, postType, id, {
 					meta: {
-						...record[ prop ],
+						...record.meta,
 						[ metaKey ]: newValue,
 					},
 				} );
 			},
 
 			useSource() {
-				const [ meta, setMeta ] = useEntityProp(
-					'postType',
-					context.postType,
-					'meta',
-					context.postId
-				);
+				const [ meta ] = useEntityProp( kind, postType, 'meta', id );
 
 				if ( postType === 'wp_template' ) {
 					return { placeholder: metaKey };
 				}
 
-				const metaValue = meta[ metaKey ];
-				const updateMetaValue = ( newValue ) => {
-					setMeta( { ...meta, [ metaKey ]: newValue } );
-				};
-
-				return {
-					placeholder: metaKey,
-					value: metaValue,
-					updateValue: updateMetaValue,
-				};
+				return meta[ metaKey ];
 			},
 		};
 	},

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { select, useSelect, dispatch } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -41,4 +41,47 @@ export default {
 			updateValue: updateMetaValue,
 		};
 	},
+
+	helper( props, sourceAttributes ) {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+		const { context } = props;
+		const { key: metaKey } = sourceAttributes;
+
+		const kind = 'postType';
+		const postType = context.postType ?? getCurrentPostType();
+		const postId = context.postId ?? getCurrentPostId();
+		const prop = 'meta';
+
+		const { getEntityRecord, getEditedEntityRecord } = select( coreStore );
+
+		const record = getEntityRecord( kind, postType, postId );
+		const editedRecord = getEditedEntityRecord( kind, postType, postId );
+
+		return {
+			get() {
+				const propValue =
+					record && editedRecord
+						? {
+								value: editedRecord[ prop ]?.[ metaKey ],
+								fullValue: record[ prop ]?.[ metaKey ],
+						  }
+						: {};
+
+				return propValue.value;
+			},
+
+			update( newValue ) {
+				const { editEntityRecord } = dispatch( coreStore );
+
+				editEntityRecord( kind, postType, postId, {
+					meta: {
+						...record[ prop ],
+						[ metaKey ]: newValue,
+					},
+				} );
+			},
+		};
+	},
+
+	lockAttributesEditing: false,
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -27,13 +27,9 @@ export default {
 		const editedRecord = getEditedEntityRecord( kind, postType, id );
 
 		return {
-			get() {
-				return editedRecord.meta?.[ metaKey ];
-			},
+			value: editedRecord.meta?.[ metaKey ],
 
-			getPlaceholder() {
-				return metaKey;
-			},
+			placeholder: metaKey,
 
 			update( newValue ) {
 				const { editEntityRecord } = dispatch( coreStore );

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { select, useSelect, dispatch } from '@wordpress/data';
+import { select, dispatch } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -12,37 +12,7 @@ import { store as editorStore } from '../store';
 export default {
 	name: 'core/post-meta',
 	label: _x( 'Post Meta', 'block bindings source' ),
-	useSource( props, sourceAttributes ) {
-		const { getCurrentPostType } = useSelect( editorStore );
-		const { context } = props;
-		const { key: metaKey } = sourceAttributes;
-		const postType = context.postType
-			? context.postType
-			: getCurrentPostType();
-
-		const [ meta, setMeta ] = useEntityProp(
-			'postType',
-			context.postType,
-			'meta',
-			context.postId
-		);
-
-		if ( postType === 'wp_template' ) {
-			return { placeholder: metaKey };
-		}
-		const metaValue = meta[ metaKey ];
-		const updateMetaValue = ( newValue ) => {
-			setMeta( { ...meta, [ metaKey ]: newValue } );
-		};
-
-		return {
-			placeholder: metaKey,
-			value: metaValue,
-			updateValue: updateMetaValue,
-		};
-	},
-
-	helper( props, sourceAttributes ) {
+	handler( props, sourceAttributes ) {
 		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
 		const { context } = props;
 		const { key: metaKey } = sourceAttributes;
@@ -79,6 +49,30 @@ export default {
 						[ metaKey ]: newValue,
 					},
 				} );
+			},
+
+			useSource() {
+				const [ meta, setMeta ] = useEntityProp(
+					'postType',
+					context.postType,
+					'meta',
+					context.postId
+				);
+
+				if ( postType === 'wp_template' ) {
+					return { placeholder: metaKey };
+				}
+
+				const metaValue = meta[ metaKey ];
+				const updateMetaValue = ( newValue ) => {
+					setMeta( { ...meta, [ metaKey ]: newValue } );
+				};
+
+				return {
+					placeholder: metaKey,
+					value: metaValue,
+					updateValue: updateMetaValue,
+				};
 			},
 		};
 	},

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -12,7 +12,7 @@ import { store as editorStore } from '../store';
 export default {
 	name: 'core/post-meta',
 	label: _x( 'Post Meta', 'block bindings source' ),
-	handler( props, sourceAttributes ) {
+	init( props, sourceAttributes ) {
 		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
 		const { context } = props;
 		const { key: metaKey } = sourceAttributes;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR allows not only read but edit the external source bound to the block attribute, from the block edit component context.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because editing the property value of the external source is required for the Block Binding API.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR changes considerably the handler API. There are a few reasons why we should do this. [This thread](https://github.com/WordPress/gutenberg/pull/59403#pullrequestreview-1904550501) and [especially this comment](https://github.com/WordPress/gutenberg/pull/59403#discussion_r1504909554) motivates the introductions of these changes:

> I'm not sure I have a good solution about how to implement this, it might mean chaining the useSource API. That said, I'd be ok with the "useEffect" for initial version but we should keep an eye on it and not open the API publicly until it's proven bug free.

First, the init() function returns the `value` and `placeholder` valles. Also, the `update()` helper and `useSource()` react hook:

* The `update()` allows updating the prop value of the external source.
* The `useSource()` possibilities re-rendering the component when the external value change.

### Handler API

```es6
export default {
  name: 'namesace/external-source',
  label: 'The external source handler',
  lockAttributesEditing: false,
  init( props, sourceAttributes ) {
    return {
      value: <any>;
      placeholder: <any>;
      update: ( value: any ) => { ... },
      useSource: () => { ... },
	};
  },
};
```

### Reading data workflow

Reading the data from the external source is straightforward since the `value` is not provided by the react hook now. 

### Updating data from the block

It still does uses the effect hook to detect new changes in the external source to re-render the component. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

0. Register a new custom field however you prefer. You can use a snippet similar to this:

```PHP
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'This is the content of the text custom field',
	)
);
register_meta(
	'post',
	'url_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

1. Create/edit a post
2. Go to the editor mode
3. Add the following markup:

```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<p>STATIC <strong>field</strong> value</p>
<!-- /wp:paragraph -->

<!-- wp:image {"id":248,"width":"168px","height":"auto","sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}},"alt":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg" alt="STATIC <strong&gt;field</strong&gt; value" class="wp-image-248" style="width:168px;height:auto"/></figure>
<!-- /wp:image -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"bindings":{"text":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">STATIC <strong>field</strong> value</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

4. Go back to visual mode
5. Confirm it's possible to edit the attributes bound to the external source:
  * `content` in the core/paragraph block instance
  * `src` in the core/image block
  *  `alt` in the core/image block
  *  `text` in the core/button block
6. Confirm the unique source value is propagated to all block attributes
7. Confirm Undo/Redo should work as expected
8. Save the post
9. Confirm the meta data is persistently saved (take a look at the client request)
10. Hard-reffresh
11. Confirm the last modifications are there
12. Confirm there is not any undo action in editor history
13. COnfirm the Update button keeps disabled

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/77539/ab5d801f-8287-4287-bfff-b893ceef8b8f


