### PR TITLE
Elements: Deprecate old block support filter callbacks

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -8,13 +8,13 @@
 /**
  * Update the block content with elements class names.
  *
- * @deprecated 6.6.0 Use WP_Duotone_Gutenberg::register_duotone_support() instead.
+ * @deprecated 6.6.0 Use `gutenberg_render_elements_class_name` instead.
  *
  * @param  string $block_content Rendered block content.
  * @return string                Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content ) {
-	_deprecated_function( __FUNCTION__, '6.6.0', 'gutenberg_render_elements_support' );
+	_deprecated_function( __FUNCTION__, '6.6.0', 'gutenberg_render_elements_class_name' );
 	return $block_content;
 }
 

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -8,13 +8,13 @@
 /**
  * Update the block content with elements class names.
  *
- * @deprecated 6.5.0 Use WP_Duotone_Gutenberg::register_duotone_support() instead.
+ * @deprecated 6.6.0 Use WP_Duotone_Gutenberg::register_duotone_support() instead.
  *
  * @param  string $block_content Rendered block content.
  * @return string                Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content ) {
-	_deprecated_function( __FUNCTION__, '6.5.0', 'gutenberg_render_elements_support' );
+	_deprecated_function( __FUNCTION__, '6.6.0', 'gutenberg_render_elements_support' );
 	return $block_content;
 }
 
@@ -99,7 +99,7 @@ function gutenberg_should_add_elements_class_name( $block, $options ) {
  * This solves the issue of an element (e.g.: link color) being styled in both the parent and a descendant:
  * we want the descendant style to take priority, and this is done by loading it after, in DOM order.
  *
- * @since 6.5.0 Element block support class and styles are generated via the `render_block_data` filter instead of `pre_render_block`
+ * @since 6.6.0 Element block support class and styles are generated via the `render_block_data` filter instead of `pre_render_block`
  *
  * @param array $parsed_block The parsed block.
  *
@@ -108,7 +108,7 @@ function gutenberg_should_add_elements_class_name( $block, $options ) {
 function gutenberg_render_elements_support_styles( $parsed_block ) {
 	/*
 	 * The generation of element styles and classname were moved to the
-	 * `render_block_data` filter in 6.5.0 to avoid filtered attributes
+	 * `render_block_data` filter in 6.6.0 to avoid filtered attributes
 	 * breaking the application of the elements CSS class.
 	 *
 	 * @see https://github.com/WordPress/gutenberg/pull/59535.
@@ -119,7 +119,7 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 	if ( is_string( $parsed_block ) ) {
 		_deprecated_argument(
 			__FUNCTION__,
-			'6.5.0',
+			'6.6.0',
 			__( 'Use as a `pre_render_block` filter is deprecated. Use with `render_block_data` instead.', 'gutenberg' )
 		);
 	}

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -120,7 +120,7 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 		_deprecated_argument(
 			__FUNCTION__,
 			'6.5.0',
-			__( 'Use as a `pre_render_block` filter is deprecated. Use with `render_block_data` instead.' )
+			__( 'Use as a `pre_render_block` filter is deprecated. Use with `render_block_data` instead.', 'gutenberg' )
 		);
 	}
 

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -6,6 +6,19 @@
  */
 
 /**
+ * Update the block content with elements class names.
+ *
+ * @deprecated 6.5.0 Use WP_Duotone_Gutenberg::register_duotone_support() instead.
+ *
+ * @param  string $block_content Rendered block content.
+ * @return string                Filtered block content.
+ */
+function gutenberg_render_elements_support( $block_content ) {
+	_deprecated_function( __FUNCTION__, '6.5.0', 'gutenberg_render_elements_class_name' );
+	return $block_content;
+}
+
+/**
  * Determines whether an elements class name should be added to the block.
  *
  * @param  array $block   Block object.
@@ -86,11 +99,31 @@ function gutenberg_should_add_elements_class_name( $block, $options ) {
  * This solves the issue of an element (e.g.: link color) being styled in both the parent and a descendant:
  * we want the descendant style to take priority, and this is done by loading it after, in DOM order.
  *
+ * @since 6.5.0 Element block support class and styles are generated via the `render_block_data` filter instead of `pre_render_block`
+ *
  * @param array $parsed_block The parsed block.
  *
  * @return array The same parsed block with elements classname added if appropriate.
  */
 function gutenberg_render_elements_support_styles( $parsed_block ) {
+	/*
+	 * The generation of element styles and classname were moved to the
+	 * `render_block_data` filter in 6.5.0 to avoid filtered attributes
+	 * breaking the application of the elements CSS class.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/pull/59535.
+	 *
+	 * The change in filter means, the argument types for this function
+	 * have changed and require deprecating.
+	 */
+	if ( is_string( $parsed_block ) ) {
+		_deprecated_argument(
+			__FUNCTION__,
+			'6.5.0',
+			__( 'Use as a `pre_render_block` filter is deprecated. Use with `render_block_data` instead.' )
+		);
+	}
+
 	$block_type           = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
 	$element_block_styles = $parsed_block['attrs']['style']['elements'] ?? null;
 
@@ -221,9 +254,13 @@ function gutenberg_render_elements_class_name( $block_content, $block ) {
 	return $tags->get_updated_html();
 }
 
-// Remove WordPress core filters to avoid rendering duplicate elements stylesheet & attaching classes twice.
+// Remove deprecated WordPress core filters.
 remove_filter( 'render_block', 'wp_render_elements_support', 10, 2 );
 remove_filter( 'pre_render_block', 'wp_render_elements_support_styles', 10, 2 );
+
+// Remove WordPress core filters to avoid rendering duplicate elements stylesheet & attaching classes twice.
 remove_filter( 'render_block', 'wp_render_elements_class_name', 10, 2 );
+remove_filter( 'render_block_data', 'wp_render_elements_support_styles', 10, 1 );
+
 add_filter( 'render_block', 'gutenberg_render_elements_class_name', 10, 2 );
-add_filter( 'render_block_data', 'gutenberg_render_elements_support_styles', 10, 2 );
+add_filter( 'render_block_data', 'gutenberg_render_elements_support_styles', 10, 1 );

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -14,7 +14,7 @@
  * @return string                Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content ) {
-	_deprecated_function( __FUNCTION__, '6.5.0', 'gutenberg_render_elements_class_name' );
+	_deprecated_function( __FUNCTION__, '6.5.0', 'gutenberg_render_elements_support' );
 	return $block_content;
 }
 

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -193,8 +193,8 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 }
 
 /**
- * Ensure the elements block support class name generated and added to
- * block attributes in the `render_block_data` filter gets applied to the
+ * Ensure the elements block support class name generated, and added to
+ * block attributes, in the `render_block_data` filter gets applied to the
  * block's markup.
  *
  * @see gutenberg_render_elements_support_styles
@@ -215,8 +215,6 @@ function gutenberg_render_elements_class_name( $block_content, $block ) {
 	$tags = new WP_HTML_Tag_Processor( $block_content );
 
 	if ( $tags->next_tag() ) {
-		// Ensure the elements class name set in render_block_data filter is applied in markup.
-		// See `gutenberg_render_elements_support_styles`.
 		$tags->add_class( $matches[0] );
 	}
 

--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -72,10 +72,12 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 			),
 		);
 
-		// To ensure a consistent elements class name it is generated within a
-		// `render_block_data` filter and stored in the `className` attribute.
-		// As a result the block data needs to be passed through the same
-		// function for this test.
+		/*
+		 * To ensure a consistent elements class name it is generated within a
+		 * `render_block_data` filter and stored in the `className` attribute.
+		 * As a result the block data needs to be passed through the same
+		 * function for this test.
+		 */
 		$filtered_block = gutenberg_render_elements_support_styles( $block );
 		$actual         = gutenberg_render_elements_class_name( $block_markup, $filtered_block );
 


### PR DESCRIPTION
Addresses: https://github.com/WordPress/gutenberg/pull/59535#issuecomment-1975689098

## What?

- Deprecates remove block support filter callback function
- Deprecates argument for callback function that was moved to a different filter
- Fixes some code style issues

## Why?

Whether the callback functions were part of a private API and not documented publicly or not, if it could be used, it might have been so better to deprecate the function or argument as required.

## How?

- Deprecates `gutenberg_render_elements_support`
- Deprecates string value for first argument for `gutenberg_render_elements_support_styles` (now it is used with `render_block_data` the arg should be an array).
- Fixes some code style issues

## Testing Instructions

1. Run unit tests: `npm run test:unit:php:base -- --filter WP_Block_Supports_Elements_Test`
2. Test element styles can still be applied and rendered correctly on the frontend following the steps over on https://github.com/WordPress/gutenberg/pull/59535.

## Next Steps

- [x] Iterate on this alongside the corresponding backport of https://github.com/WordPress/gutenberg/pull/59535
