### PR TITLE
Update PHP Sync Issue generation script to ignore PRs with given labels

### DIFF
--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -108,10 +108,6 @@ async function main() {
 		commits.map( async ( commit ) => {
 			const commitData = await fetchCommit( commit.sha );
 
-			// In the future we will want to exclude PRs based on label
-			// so we will need to fetch the full PR data for each commit.
-			// For now we can just set this to null.
-			// const fullPRData = null;
 			const fullPRData = await getPullRequestDataForCommit( commit.sha );
 
 			if ( commit.sha === '40ec1e317fc7bcad394d83ff0dfe064c847c93da' ) {

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -110,9 +110,6 @@ async function main() {
 
 			const fullPRData = await getPullRequestDataForCommit( commit.sha );
 
-			if ( commit.sha === '40ec1e317fc7bcad394d83ff0dfe064c847c93da' ) {
-				console.log( fullPRData );
-			}
 			// Our Issue links to the PRs associated with the commits so we must
 			// provide this data. We could also get the PR data from the commit data,
 			// using getPullRequestDataForCommit, but that requires yet another

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -392,12 +392,8 @@ function processCommits( commits ) {
 	return result;
 }
 
-function formatPRLine( { pullRequest: pr, isBeforeLastRCDate } ) {
-	return `- [ ] ${ pr.url } - @${
-		pr.creator
-	} | Trac ticket | Core backport PR ${
-		isBeforeLastRCDate ? '(⚠️ Check for existing WP Core backport)' : ''
-	}\n`;
+function formatPRLine( { pullRequest: pr } ) {
+	return `- [ ] ${ pr.url } - @${ pr.creator } | Trac ticket | Core backport PR \n`;
 }
 
 function formatHeading( level, key ) {

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -17,7 +17,7 @@ function getArg( argName ) {
 
 const OWNER = 'wordpress';
 const REPO = 'gutenberg';
-const MAX_MONTHS_TO_QUERY = 6;
+const MAX_MONTHS_TO_QUERY = 4;
 
 // The following paths will be ignored when generating the issue content.
 const IGNORED_PATHS = [

--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
 		"preother:check-local-changes": "npm run docs:build",
 		"other:check-local-changes": "node ./bin/check-local-changes.js",
 		"other:cherry-pick": "node ./bin/cherry-pick.mjs",
+		"other:generate-php-sync-issue": "node ./bin/generate-php-sync-issue.mjs",
 		"other:update-packages:php": "wp-env run --env-cwd='wp-content/plugins/gutenberg' cli composer update --no-interaction",
 		"postinstall": "patch-package && node ./patches/patch-xcode.js",
 		"prepare": "husky install",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the script which generates the list of PRs requiring manual backporting to WP Core for a given release to ignore PRs with known labels.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As part of changes to the process for syncing Gutenberg to WP Core we now add a `Backported to WP Core` label to any PRs that have been backported. This is done either manually or [automatically via the Cherry Picking script](https://github.com/WordPress/gutenberg/pull/58970).

As a result, we should update the script to ignore any PRs that have this label as we _know_ they have already been backported to Core.

As a consequence we can also remove the `lastRcDate` required arg as this was a temp hack in place during 6.5 because the PRs from the 6.4 cycle didn't have the `Backported to WP Core` label  (as this convention was adopted only during the 6.5 release).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Fetches full PR info for all commits 
- Checks labels and omits any PRs which don't need to be processed based on those labels
- Updates labels to include the `Backported to WP Core` label.
- A few other tweaks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Get GH token
- Run script:
```
node bin/generate-php-sync-issue.mjs --token=YOUR_TOKEN_HERE --since=2023-09-23  --wpstable=6.4
```
- Check that PRs listed do not have the `Backported to WP Core` label 
- Check that PRs listed do not have the `Backport from WordPress Core` label 


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
