### PR TITLE
Interactivity API: Fix context object proxy references

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -117,6 +117,24 @@ wp_enqueue_script_module( 'directive-context-view' );
 			>
 				obj.prop6
 			</button>
+			<button
+				data-testid="child copy obj"
+				data-wp-on--click="actions.copyObj"
+			>
+				Copy obj
+			</button>
+			<div>
+				Is proxy preserved? <span
+					data-testid="is proxy preserved"
+					data-wp-text="state.isProxyPreserved"
+				></span>
+			</div>
+			<div>
+				Is proxy preserved on copy? <span
+					data-testid="is proxy preserved on copy"
+					data-wp-text="state.isProxyPreservedOnCopy"
+				></span>
+			</div>
 		</div>
 		<br />
 
@@ -129,13 +147,6 @@ wp_enqueue_script_module( 'directive-context-view' );
 		>
 			Toggle Context Text
 		</button>
-
-		<div>
-			Is proxy preserved? <span
-				data-testid="is proxy preserved"
-				data-wp-text="state.isProxyPreserved"
-			></span>
-		</div>
 	</div>
 </div>
 

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -129,6 +129,13 @@ wp_enqueue_script_module( 'directive-context-view' );
 		>
 			Toggle Context Text
 		</button>
+
+		<div>
+			Is proxy preserved? <span
+				data-testid="is proxy preserved"
+				data-wp-text="state.isProxyPreserved"
+			></span>
+		</div>
 	</div>
 </div>
 

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -17,6 +17,10 @@ store( 'directive-context', {
 			const ctx = getContext();
 			const pointer = ctx.obj;
 			return pointer === ctx.obj;
+		},
+		get isProxyPreservedOnCopy() {
+			const { obj, obj2 } = getContext();
+			return obj === obj2;
 		}
 	},
 	actions: {
@@ -39,6 +43,10 @@ store( 'directive-context', {
 		replaceObj() {
 			const ctx = getContext();
 			ctx.obj = { overwritten: true };
+		},
+		copyObj() {
+			const ctx = getContext();
+			ctx.obj2 = ctx.obj;
 		}
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -12,6 +12,11 @@ store( 'directive-context', {
 		get selected() {
 			const { list, selected } = getContext();
 			return list.find( ( obj ) => obj === selected )?.text;
+		},
+		get isProxyPreserved() {
+			const ctx = getContext();
+			const pointer = ctx.obj;
+			return pointer === ctx.obj;
 		}
 	},
 	actions: {

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Prevent passing state proxies as receivers to deepSignal proxy handlers. ([#57134](https://github.com/WordPress/gutenberg/pull/57134))
+-   Keep the same references to objects defined inside the context. ([#59553](https://github.com/WordPress/gutenberg/pull/59553))
 
 ## 5.1.0 (2024-02-21)
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -56,7 +56,7 @@ const proxifyContext = ( current, inherited = {} ) => {
 					return fallback[ k ];
 				}
 
-				// Proxify plain objects that are not listed in `ignore`.
+				// Proxify plain objects that were not directly assigned.
 				if (
 					k in target &&
 					! contextAssignedObjects.get( target )?.has( k ) &&

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -343,4 +343,39 @@ test.describe( 'data-wp-context', () => {
 		const isProxyPreserved = page.getByTestId( 'is proxy preserved' );
 		await expect( isProxyPreserved ).toHaveText( 'true' );
 	} );
+
+	test( 'references to copied context objects should be preserved', async ( {
+		page,
+	} ) => {
+		await page.getByTestId( 'child copy obj' ).click();
+		const isProxyPreservedOnCopy = page.getByTestId(
+			'is proxy preserved on copy'
+		);
+		await expect( isProxyPreservedOnCopy ).toHaveText( 'true' );
+	} );
+
+	test( 'objects referenced from the context inherit properties where they are originally defined ', async ( {
+		page,
+	} ) => {
+		await page.getByTestId( 'child copy obj' ).click();
+
+		const childContextBefore = await parseContent(
+			page.getByTestId( 'child context' )
+		);
+
+		expect( childContextBefore.obj2.prop4 ).toBe( 'parent' );
+		expect( childContextBefore.obj2.prop5 ).toBe( 'child' );
+		expect( childContextBefore.obj2.prop6 ).toBe( 'child' );
+
+		await page.getByTestId( 'parent replace' ).click();
+
+		const childContextAfter = await parseContent(
+			page.getByTestId( 'child context' )
+		);
+
+		expect( childContextAfter.obj2.prop4 ).toBeUndefined();
+		expect( childContextAfter.obj2.prop5 ).toBe( 'child' );
+		expect( childContextAfter.obj2.prop6 ).toBe( 'child' );
+		expect( childContextAfter.obj2.overwritten ).toBe( true );
+	} );
 } );

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -336,4 +336,11 @@ test.describe( 'data-wp-context', () => {
 		await expect( counterChild ).toHaveText( '1' );
 		await expect( changes ).toHaveText( '2' );
 	} );
+
+	test( 'references to the same context object should be preserved', async ( {
+		page,
+	} ) => {
+		const isProxyPreserved = page.getByTestId( 'is proxy preserved' );
+		await expect( isProxyPreserved ).toHaveText( 'true' );
+	} );
 } );


### PR DESCRIPTION
## What?

Fixes a bug with context references not being preserved.

When reading a property from the context whose value is an object, the current implementation wraps that object with a `Proxy` to handle context inheritance. That "proxification" happens every time the property is accessed, instantiating a new `Proxy`, thus changing the returned reference.

For instance, the following state getter accessing the context always returns false.

 ```js
store( 'test', {
  state: {
    get isReferencePreserved() {
      const ctx = getContext();
      const objRef = ctx.anyObject;
      return objRef === ctx.anyObject; // always false ❌ 
    }
  }
} );
 ```

## Why?

Context properties should allow storing references to other context objects. This is something that Interactive Block developers would expect.

## How?

Using some `WeakMap` instances to keep track of the objects inside the context to always return the same proxy.

