### PR TITLE
Pages data view: Make 'View' button open a new tab

### DIFF
--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -362,7 +362,7 @@ export const viewPostAction = {
 	},
 	callback( posts ) {
 		const post = posts[ 0 ];
-		document.location.href = post.link;
+		window.open( post.link, '_blank' );
 	},
 };
 


### PR DESCRIPTION
## What?
Update the 'View' button to open a new tab.

## Why?
1. The icon suggests this behavior.
2. The action is different to others in that it takes you to the frontend rather than performing an administrative task.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open the Pages data view
2. Click the 'View' button
3. See the page in a new tab.

