### PR TITLE
Block Preview: Optimize default additional styles

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -20,11 +20,13 @@ import EditorStyles from '../editor-styles';
 import { store as blockEditorStore } from '../../store';
 import { BlockListItems } from '../block-list';
 
+const EMPTY_ADDITIONAL_STYLES = [];
+
 export function BlockPreview( {
 	blocks,
 	viewportWidth = 1200,
 	minHeight,
-	additionalStyles = [],
+	additionalStyles = EMPTY_ADDITIONAL_STYLES,
 	// Deprecated props:
 	__experimentalMinHeight,
 	__experimentalPadding,


### PR DESCRIPTION
## What?
This PR suggests that in `BlockPreview` we always default to the same empty array for `additionalStyles` if no other styles are specified.

This is a complement to #58244.

## Why?
Currently, every `BlockPreview` rerender without specified `additionalStyles` will cause a rerender, because `additionalStyles` will then default to a new array. Even after #58244 this continues to be a problem because a new fresh empty array will be passed from `BlockPreview` to `AutoHeightBlockPreview` on every rerender when the block preview has no additional styles.

I don't see a major performance impact, but this is still worth doing since this affects most block previews as they don't have additional styles. 

## How?
We're defaulting to the same empty array.

Similar to #58244, but for the parent component.

Potential follow-up: reusing the same `EMPTY_ADDITIONAL_STYLES` for both components.

## Testing Instructions
Verify block previews work still well for the inserter and patterns.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
