### PR TITLE
ESLint: Enable `react/jsx-boolean-value` for the Gutenberg codebase and fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,6 +97,7 @@ module.exports = {
 	},
 	rules: {
 		'jest/expect-expect': 'off',
+		'react/jsx-boolean-value': 'error',
 		'@wordpress/dependency-group': 'error',
 		'@wordpress/is-gutenberg-plugin': 'error',
 		'@wordpress/react-no-unsafe-timeout': 'error',

--- a/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
+++ b/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
@@ -37,7 +37,7 @@ export default function InstalledBlocksPrePublishPanel() {
 				),
 				newBlockTypes.length
 			) }
-			initialOpen={ true }
+			initialOpen
 		>
 			<p className="installed-blocks-pre-publish-panel__copy">
 				{ _n(

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.native.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.native.js
@@ -53,7 +53,7 @@ export default function BlockInvalidWarning( { clientId } ) {
 	return (
 		<TouchableWithoutFeedback
 			onPress={ attemptBlockRecovery }
-			accessible={ true }
+			accessible
 			accessibilityRole={ 'button' }
 		>
 			<Warning

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.js
@@ -40,9 +40,7 @@ const BlockSelectionButton = ( {
 				onPress={ () => {
 					/* Open BottomSheet with markup. */
 				} }
-				disabled={
-					true
-				} /* Disable temporarily since onPress function is empty. */
+				disabled /* Disable temporarily since onPress function is empty. */
 			>
 				{ rootClientId &&
 					rootBlockIcon && [

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -133,7 +133,7 @@ export const BlockMover = ( {
 				options={ blockPageMoverOptions }
 				onChange={ onPickerSelect }
 				title={ __( 'Change block position' ) }
-				leftAlign={ true }
+				leftAlign
 				hideCancelButton={ Platform.OS !== 'ios' }
 			/>
 		</ToolbarGroup>

--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -91,7 +91,7 @@ export default function BlockRenameModal( {
 						__next40pxDefaultSize
 						value={ editedBlockName }
 						label={ __( 'Block name' ) }
-						hideLabelFromVision={ true }
+						hideLabelFromVision
 						placeholder={ originalBlockName }
 						onChange={ setEditedBlockName }
 						onFocus={ autoSelectInputText }

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.native.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.native.js
@@ -80,7 +80,7 @@ const BlockTransformationsMenu = ( {
 			options={ pickerOptions() }
 			onChange={ onPickerSelect }
 			hideCancelButton={ Platform.OS !== 'ios' }
-			leftAlign={ true }
+			leftAlign
 			getAnchor={ getAnchor }
 			// translators: %s: block title e.g: "Paragraph".
 			title={ sprintf( __( 'Transform %s to' ), blockTitle ) }

--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
@@ -256,7 +256,7 @@ const BlockActionsMenu = ( {
 				<ToolbarButton
 					title={ __( 'Open Block Actions Menu' ) }
 					icon={ moreHorizontalMobile }
-					disabled={ true }
+					disabled
 				/>
 			</ToolbarGroup>
 		);
@@ -311,7 +311,7 @@ const BlockActionsMenu = ( {
 				destructiveButtonIndex={ options.length }
 				disabledButtonIndices={ disabledButtonIndices }
 				hideCancelButton={ Platform.OS !== 'ios' }
-				leftAlign={ true }
+				leftAlign
 				getAnchor={ getAnchor }
 				// translators: %s: block title e.g: "Paragraph".
 				title={ sprintf( __( '%s block options' ), blockTitle ) }

--- a/packages/block-editor/src/components/caption/index.native.js
+++ b/packages/block-editor/src/components/caption/index.native.js
@@ -53,7 +53,7 @@ const Caption = ( {
 			__unstableOnSplitAtEnd={ () =>
 				insertBlocksAfter( createBlock( 'core/paragraph' ) )
 			}
-			deleteEnter={ true }
+			deleteEnter
 		/>
 	</View>
 );

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -74,7 +74,7 @@ export default function ChildLayoutControl( {
 								flexSize: newFlexSize,
 							} );
 						} }
-						isBlock={ true }
+						isBlock
 					>
 						<ToggleGroupControlOption
 							key={ 'fit' }

--- a/packages/block-editor/src/components/color-palette/control.js
+++ b/packages/block-editor/src/components/color-palette/control.js
@@ -14,7 +14,7 @@ export default function ColorPaletteControl( {
 			onColorChange={ onChange }
 			colorValue={ value }
 			gradients={ [] }
-			disableCustomGradients={ true }
+			disableCustomGradients
 		/>
 	);
 }

--- a/packages/block-editor/src/components/colors-gradients/test/control.js
+++ b/packages/block-editor/src/components/colors-gradients/test/control.js
@@ -64,7 +64,7 @@ describe( 'ColorPaletteControl', () => {
 				] }
 				gradients={ [] }
 				disableCustomColors={ false }
-				disableCustomGradients={ true }
+				disableCustomGradients
 				onColorChange={ noop }
 				onGradientChange={ noop }
 			/>
@@ -102,7 +102,7 @@ describe( 'ColorPaletteControl', () => {
 						slug: 'light-green-cyan-to-vivid-green-cyan',
 					},
 				] }
-				disableCustomColors={ true }
+				disableCustomColors
 				disableCustomGradients={ false }
 				onColorChange={ noop }
 				onGradientChange={ noop }

--- a/packages/block-editor/src/components/contrast-checker/test/index.js
+++ b/packages/block-editor/src/components/contrast-checker/test/index.js
@@ -221,7 +221,7 @@ describe( 'ContrastChecker', () => {
 			<ContrastChecker
 				backgroundColor="#C44B4B"
 				textColor="#000000"
-				isLargeText={ true }
+				isLargeText
 			/>
 		);
 
@@ -263,7 +263,7 @@ describe( 'ContrastChecker', () => {
 				backgroundColor="#C44B4B"
 				textColor="#000000"
 				fontSize={ 23 }
-				isLargeText={ true }
+				isLargeText
 			/>
 		);
 
@@ -363,7 +363,7 @@ describe( 'ContrastChecker', () => {
 				backgroundColor={ backgroundColor }
 				textColor={ textColor }
 				isLargeText={ isLargeText }
-				enableAlphaChecker={ true }
+				enableAlphaChecker
 			/>
 		);
 
@@ -378,7 +378,7 @@ describe( 'ContrastChecker', () => {
 				textColor={ 'rgba(0,0,0,0.9)' }
 				linkColor={ linkColor }
 				isLargeText={ isLargeText }
-				enableAlphaChecker={ true }
+				enableAlphaChecker
 			/>
 		);
 
@@ -399,7 +399,7 @@ describe( 'ContrastChecker', () => {
 				linkColor={ 'rgba(0,0,0,0.9)' }
 				textColor={ textColor }
 				isLargeText={ isLargeText }
-				enableAlphaChecker={ true }
+				enableAlphaChecker
 			/>
 		);
 
@@ -420,7 +420,7 @@ describe( 'ContrastChecker', () => {
 				textColor={ textColor }
 				linkColor={ linkColor }
 				isLargeText={ isLargeText }
-				enableAlphaChecker={ true }
+				enableAlphaChecker
 			/>
 		);
 
@@ -437,7 +437,7 @@ describe( 'ContrastChecker', () => {
 				isLargeText={ isLargeText }
 				fallbackBackgroundColor={ fallbackBackgroundColor }
 				fallbackTextColor={ fallbackTextColor }
-				enableAlphaChecker={ true }
+				enableAlphaChecker
 			/>
 		);
 
@@ -454,7 +454,7 @@ describe( 'ContrastChecker', () => {
 				isLargeText={ isLargeText }
 				fallbackBackgroundColor={ fallbackBackgroundColor }
 				fallbackTextColor={ fallbackTextColor }
-				enableAlphaChecker={ true }
+				enableAlphaChecker
 			/>
 		);
 
@@ -477,7 +477,7 @@ describe( 'ContrastChecker', () => {
 				isLargeText={ isLargeText }
 				fallbackBackgroundColor={ fallbackBackgroundColor }
 				fallbackTextColor={ fallbackTextColor }
-				enableAlphaChecker={ true }
+				enableAlphaChecker
 			/>
 		);
 
@@ -498,7 +498,7 @@ describe( 'ContrastChecker', () => {
 				linkColor={ 'rgba(0,0,0,0.7)' }
 				textColor={ 'rgba(0,0,0,0.7)' }
 				isLargeText={ isLargeText }
-				enableAlphaChecker={ true }
+				enableAlphaChecker
 			/>
 		);
 

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -251,13 +251,13 @@ export default function BorderPanel( {
 				>
 					<BorderBoxControl
 						colors={ colors }
-						enableAlpha={ true }
+						enableAlpha
 						enableStyle={ showBorderStyle }
 						onChange={ onBorderChange }
 						popoverOffset={ 40 }
 						popoverPlacement="left-start"
 						value={ border }
-						__experimentalIsRenderedInSidebar={ true }
+						__experimentalIsRenderedInSidebar
 						size={ '__unstable-large' }
 						hideLabelFromVision={ ! hasShadowControl }
 						label={ __( 'Border' ) }

--- a/packages/block-editor/src/components/global-styles/image-settings-panel.js
+++ b/packages/block-editor/src/components/global-styles/image-settings-panel.js
@@ -62,7 +62,7 @@ export default function ImageSettingsPanel( {
 					hasValue={ () => !! value?.lightbox }
 					label={ __( 'Expand on click' ) }
 					onDeselect={ resetLightbox }
-					isShownByDefault={ true }
+					isShownByDefault
 					panelId={ panelId }
 				>
 					<ToggleControl

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -211,7 +211,7 @@ export function MediaPreview( { media, onClick, category } ) {
 	const onMouseLeave = useCallback( () => setIsHovered( false ), [] );
 	return (
 		<>
-			<InserterDraggableBlocks isEnabled={ true } blocks={ [ block ] }>
+			<InserterDraggableBlocks isEnabled blocks={ [ block ] }>
 				{ ( { draggable, onDragStart, onDragEnd } ) => (
 					<div
 						className={ classnames(

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -177,7 +177,7 @@ function InserterMenu( {
 
 	return (
 		<BottomSheet
-			isVisible={ true }
+			isVisible
 			onClose={ onClose }
 			onKeyboardShow={ onKeyboardShow }
 			onKeyboardHide={ onKeyboardHide }
@@ -198,10 +198,10 @@ function InserterMenu( {
 				</>
 			}
 			hasNavigation
-			setMinHeightToMaxHeight={ true }
+			setMinHeightToMaxHeight
 			contentStyle={ styles[ 'inserter-menu__list' ] }
 			isFullScreen={ isFullScreen }
-			allowDragIndicator={ true }
+			allowDragIndicator
 		>
 			<BottomSheetConsumer>
 				{ ( { listProps } ) => (

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -68,8 +68,8 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 			resetAll={ resetAll }
 			key={ panelId }
 			panelId={ panelId }
-			hasInnerWrapper={ true }
-			shouldRenderPlaceholderItems={ true } // Required to maintain fills ordering.
+			hasInnerWrapper
+			shouldRenderPlaceholderItems // Required to maintain fills ordering.
 			__experimentalFirstVisibleItemClass="first"
 			__experimentalLastVisibleItemClass="last"
 			dropdownMenuProps={ TOOLSPANEL_DROPDOWNMENU_PROPS }

--- a/packages/block-editor/src/components/line-height-control/test/index.js
+++ b/packages/block-editor/src/components/line-height-control/test/index.js
@@ -23,7 +23,7 @@ const ControlledLineHeightControl = () => {
 		<LineHeightControl
 			value={ value }
 			onChange={ setValue }
-			__nextHasNoMarginBottom={ true }
+			__nextHasNoMarginBottom
 		/>
 	);
 };

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -130,7 +130,7 @@ const LinkControlSearchInput = forwardRef(
 						showSuggestions ? handleRenderSuggestions : null
 					}
 					__experimentalFetchLinkSuggestions={ searchHandler }
-					__experimentalHandleURLSuggestions={ true }
+					__experimentalHandleURLSuggestions
 					__experimentalShowInitialSuggestions={
 						showInitialSuggestions
 					}

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -251,7 +251,7 @@ function ListViewBranch( props ) {
 					level={ level }
 					setSize={ rowCount }
 					positionInSet={ rowCount }
-					isExpanded={ true }
+					isExpanded
 				>
 					<TreeGridCell>
 						{ ( treeGridCellProps ) => (

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -298,7 +298,7 @@ export default function ListViewDropIndicatorPreview( {
 			className="block-editor-list-view-drop-indicator--preview"
 			variant="unstyled"
 			flip={ false }
-			resize={ true }
+			resize
 		>
 			<div
 				style={ style }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -336,7 +336,7 @@ function ListViewComponent(
 		description && `block-editor-list-view-description-${ instanceId }`;
 
 	return (
-		<AsyncModeProvider value={ true }>
+		<AsyncModeProvider value>
 			<ListViewDropIndicatorPreview
 				draggedBlockClientId={ firstDraggedBlockClientId }
 				listViewRef={ elementRef }

--- a/packages/block-editor/src/components/panel-color-settings/index.js
+++ b/packages/block-editor/src/components/panel-color-settings/index.js
@@ -19,7 +19,7 @@ const PanelColorSettings = ( { colorSettings, ...props } ) => {
 		<PanelColorGradientSettings
 			settings={ settings }
 			gradients={ [] }
-			disableCustomGradients={ true }
+			disableCustomGradients
 			{ ...props }
 		/>
 	);

--- a/packages/block-editor/src/components/panel-color-settings/test/index.js
+++ b/packages/block-editor/src/components/panel-color-settings/test/index.js
@@ -16,7 +16,7 @@ describe( 'PanelColorSettings', () => {
 			<PanelColorSettings
 				title="Test Title"
 				colors={ [] }
-				disableCustomColors={ true }
+				disableCustomColors
 				colorSettings={ [
 					{
 						value: '#000',
@@ -39,7 +39,7 @@ describe( 'PanelColorSettings', () => {
 			<PanelColorSettings
 				title="Test Title"
 				colors={ [] }
-				disableCustomColors={ true }
+				disableCustomColors
 				colorSettings={ [
 					{
 						value: '#000',
@@ -63,7 +63,7 @@ describe( 'PanelColorSettings', () => {
 			<PanelColorSettings
 				title="Test Title"
 				colors={ [] }
-				disableCustomColors={ true }
+				disableCustomColors
 				colorSettings={ [
 					{
 						value: '#000',

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -57,10 +57,7 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 
 export const BlockEditorProvider = ( props ) => {
 	return (
-		<ExperimentalBlockEditorProvider
-			{ ...props }
-			stripExperimentalSettings={ true }
-		>
+		<ExperimentalBlockEditorProvider { ...props } stripExperimentalSettings>
 			{ props.children }
 		</ExperimentalBlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/responsive-block-control/test/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.js
@@ -177,7 +177,7 @@ describe( 'Default and Responsive modes', () => {
 			<ResponsiveBlockControl
 				title="Padding"
 				property="padding"
-				isResponsive={ true }
+				isResponsive
 				renderDefaultControl={ renderTestDefaultControlComponent }
 			/>
 		);
@@ -217,7 +217,7 @@ describe( 'Default and Responsive modes', () => {
 			<ResponsiveBlockControl
 				title="Padding"
 				property="padding"
-				isResponsive={ true }
+				isResponsive
 				renderDefaultControl={ mockRenderDefaultControl }
 				viewports={ customViewportSet }
 			/>
@@ -319,7 +319,7 @@ describe( 'Default and Responsive modes', () => {
 			<ResponsiveBlockControl
 				title="Padding"
 				property="padding"
-				isResponsive={ true }
+				isResponsive
 				renderDefaultControl={ spyRenderDefaultControl }
 				renderResponsiveControls={ mockRenderResponsiveControls }
 			/>

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -426,7 +426,7 @@ export function RichTextWrapper(
 					anchorRef,
 				] ) }
 				contentEditable={ ! shouldDisableEditing }
-				suppressContentEditableWarning={ true }
+				suppressContentEditableWarning
 				className={ classnames(
 					'block-editor-rich-text__editable',
 					props.className,

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -226,7 +226,7 @@ export default function SpacingInputControl( {
 						placeholder={ allPlaceholder }
 						disableUnits={ isMixed }
 						label={ ariaLabel }
-						hideLabelFromVision={ true }
+						hideLabelFromVision
 						className="spacing-sizes-control__custom-value-input"
 						size={ '__unstable-large' }
 					/>
@@ -272,8 +272,8 @@ export default function SpacingInputControl( {
 					max={ spacingSizes.length - 1 }
 					marks={ marks }
 					label={ ariaLabel }
-					hideLabelFromVision={ true }
-					__nextHasNoMarginBottom={ true }
+					hideLabelFromVision
+					__nextHasNoMarginBottom
 					onFocus={ onMouseOver }
 					onBlur={ onMouseOut }
 				/>
@@ -296,7 +296,7 @@ export default function SpacingInputControl( {
 					} }
 					options={ options }
 					label={ ariaLabel }
-					hideLabelFromVision={ true }
+					hideLabelFromVision
 					size={ '__unstable-large' }
 					onMouseOver={ onMouseOver }
 					onMouseOut={ onMouseOut }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -526,7 +526,7 @@ function BackgroundSizePanelItem( {
 				label={ __( 'Size' ) }
 				value={ currentValueForToggle }
 				onChange={ updateBackgroundSize }
-				isBlock={ true }
+				isBlock
 				help={ backgroundSizeHelpText( sizeValue ) }
 			>
 				<ToggleGroupControlOption

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -191,7 +191,7 @@ function BlockHooksControlPure( {
 			<PanelBody
 				className="block-editor-hooks__block-hooks"
 				title={ __( 'Plugins' ) }
-				initialOpen={ true }
+				initialOpen
 			>
 				<p className="block-editor-hooks__block-hooks-helptext">
 					{ __(

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -39,7 +39,7 @@ export function LineHeightEdit( props ) {
 	return (
 		<LineHeightControl
 			__unstableInputWidth="100%"
-			__nextHasNoMarginBottom={ true }
+			__nextHasNoMarginBottom
 			value={ style?.typography?.lineHeight }
 			onChange={ onChange }
 			size="__unstable-large"

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -310,11 +310,11 @@ function GridLayoutTypeControl( { layout, onChange } ) {
 
 	return (
 		<ToggleGroupControl
-			__nextHasNoMarginBottom={ true }
+			__nextHasNoMarginBottom
 			label={ __( 'Type' ) }
 			value={ isManual }
 			onChange={ onChangeType }
-			isBlock={ true }
+			isBlock
 		>
 			<ToggleGroupControlOption
 				key={ 'auto' }

--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -212,13 +212,13 @@ function AudioEdit( {
 									label: _x( 'None', '"Preload" value' ),
 								},
 							] }
-							hideCancelButton={ true }
+							hideCancelButton
 						/>
 					</PanelBody>
 				</InspectorControls>
 				<MediaUpload
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					isReplacingMedia={ true }
+					isReplacingMedia
 					onSelect={ onSelectAudio }
 					onSelectURL={ onSelectURL }
 					render={ ( { open, getMediaOptions } ) => {
@@ -226,7 +226,7 @@ function AudioEdit( {
 					} }
 				/>
 				<BlockCaption
-					accessible={ true }
+					accessible
 					accessibilityLabelCreator={ ( caption ) =>
 						RichText.isEmpty( caption )
 							? /* translators: accessibility text. Empty Audio caption. */

--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -187,7 +187,7 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 	return (
 		<>
 			<AvatarInspectorControls
-				selectUser={ true }
+				selectUser
 				attributes={ attributes }
 				avatar={ avatar }
 				setAttributes={ setAttributes }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -329,7 +329,7 @@ function ButtonEdit( props ) {
 						title={ __( 'Unlink' ) }
 						shortcut={ displayShortcut.primaryShift( 'k' ) }
 						onClick={ unlink }
-						isActive={ true }
+						isActive
 					/>
 				) }
 			</BlockControls>

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -106,7 +106,7 @@ export default function ButtonsEdit( {
 	const renderFooterAppender = useRef( () => (
 		<View style={ styles.appenderContainer }>
 			<InnerBlocks.ButtonBlockAppender
-				isFloating={ true }
+				isFloating
 				onAddBlock={ onAddNextButton }
 			/>
 		</View>

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -538,7 +538,7 @@ const Cover = ( {
 						<BottomSheetConsumer>
 							{ ( { shouldEnableBottomSheetScroll } ) => (
 								<ColorPalette
-									enableCustomColor={ true }
+									enableCustomColor
 									customColorIndicatorStyles={
 										styles.paletteColorIndicator
 									}

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -464,7 +464,7 @@ function CoverEdit( {
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette
-								disableCustomColors={ true }
+								disableCustomColors
 								value={ overlayColor.color }
 								onChange={ onSetOverlayColor }
 								clearable={ false }
@@ -525,7 +525,7 @@ function CoverEdit( {
 				{ ! url && useFeaturedImage && (
 					<Placeholder
 						className="wp-block-cover__image--placeholder-image"
-						withIllustration={ true }
+						withIllustration
 					/>
 				) }
 

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -304,7 +304,7 @@ export default function CoverInspectorControls( {
 						minHeight: undefined,
 						minHeightUnit: undefined,
 					} ) }
-					isShownByDefault={ true }
+					isShownByDefault
 					panelId={ clientId }
 				>
 					<CoverHeightInput

--- a/packages/block-library/src/file/deprecated.js
+++ b/packages/block-library/src/file/deprecated.js
@@ -131,7 +131,7 @@ const v3 = {
 								'wp-block-file__button',
 								__experimentalGetElementClassName( 'button' )
 							) }
-							download={ true }
+							download
 							aria-describedby={ describedById }
 						>
 							<RichText.Content value={ downloadButtonText } />
@@ -259,7 +259,7 @@ const v2 = {
 						<a
 							href={ href }
 							className="wp-block-file__button"
-							download={ true }
+							download
 							aria-describedby={ describedById }
 						>
 							<RichText.Content value={ downloadButtonText } />
@@ -372,7 +372,7 @@ const v1 = {
 						<a
 							href={ href }
 							className="wp-block-file__button"
-							download={ true }
+							download
 						>
 							<RichText.Content value={ downloadButtonText } />
 						</a>

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -282,7 +282,7 @@ export class FileEdit extends Component {
 						value={ textLinkHref }
 						onChange={ this.onChangeLinkDestinationOption }
 						options={ linkDestinationOptions }
-						hideCancelButton={ true }
+						hideCancelButton
 					/>
 					<ToggleControl
 						icon={ external }
@@ -469,7 +469,7 @@ export class FileEdit extends Component {
 										tagName="p"
 										underlineColorAndroid="transparent"
 										value={ fileName }
-										deleteEnter={ true }
+										deleteEnter
 										textAlign={ this.getTextAlignmentForAlignment(
 											align
 										) }
@@ -505,7 +505,7 @@ export class FileEdit extends Component {
 												textAlign="center"
 												minWidth={ minWidth }
 												maxWidth={ this.state.maxWidth }
-												deleteEnter={ true }
+												deleteEnter
 												style={ styles.buttonText }
 												value={ downloadButtonText }
 												placeholder={ placeholderText }
@@ -565,7 +565,7 @@ export class FileEdit extends Component {
 		return (
 			<MediaUpload
 				allowedTypes={ [ MEDIA_TYPE_ANY ] }
-				isReplacingMedia={ true }
+				isReplacingMedia
 				onSelect={ this.onSelectFile }
 				render={ ( { open, getMediaOptions } ) => {
 					return this.getFileComponent( open, getMediaOptions );

--- a/packages/block-library/src/file/save.js
+++ b/packages/block-library/src/file/save.js
@@ -73,7 +73,7 @@ export default function save( { attributes } ) {
 							'wp-block-file__button',
 							__experimentalGetElementClassName( 'button' )
 						) }
-						download={ true }
+						download
 						aria-describedby={ describedById }
 					>
 						<RichText.Content value={ downloadButtonText } />

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -546,7 +546,7 @@ function GalleryEdit( props ) {
 							value={ sizeSlug }
 							options={ imageSizeOptions }
 							onChange={ updateImagesSize }
-							hideCancelButton={ true }
+							hideCancelButton
 							size="__unstable-large"
 						/>
 					) }
@@ -556,7 +556,7 @@ function GalleryEdit( props ) {
 						value={ linkTo }
 						onChange={ setLinkTo }
 						options={ linkOptions }
-						hideCancelButton={ true }
+						hideCancelButton
 						size="__unstable-large"
 					/>
 					<ToggleControl
@@ -602,7 +602,7 @@ function GalleryEdit( props ) {
 								handleUpload={ false }
 								onSelect={ updateImages }
 								name={ __( 'Add' ) }
-								multiple={ true }
+								multiple
 								mediaIds={ images
 									.filter( ( image ) => image.id )
 									.map( ( image ) => image.id ) }

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -100,7 +100,7 @@ export const Gallery = ( props ) => {
 			<BlockCaption
 				clientId={ clientId }
 				isSelected={ isCaptionSelected }
-				accessible={ true }
+				accessible
 				accessibilityLabelCreator={ ( caption ) =>
 					RichText.isEmpty( caption )
 						? /* translators: accessibility text. Empty gallery caption. */

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -411,7 +411,7 @@ function GalleryEdit( props ) {
 						value={ linkTo }
 						onChange={ setLinkTo }
 						options={ linkOptions }
-						hideCancelButton={ true }
+						hideCancelButton
 					/>
 					{ shouldShowSizeOptions && (
 						<SelectControl
@@ -420,7 +420,7 @@ function GalleryEdit( props ) {
 							value={ sizeSlug }
 							options={ imageSizeOptions }
 							onChange={ updateImagesSize }
-							hideCancelButton={ true }
+							hideCancelButton
 						/>
 					) }
 				</PanelBody>

--- a/packages/block-library/src/gallery/v1/gallery.native.js
+++ b/packages/block-library/src/gallery/v1/gallery.native.js
@@ -140,7 +140,7 @@ export const Gallery = ( props ) => {
 			<BlockCaption
 				clientId={ clientId }
 				isSelected={ isCaptionSelected }
-				accessible={ true }
+				accessible
 				accessibilityLabelCreator={ ( caption ) =>
 					RichText.isEmpty( caption )
 						? /* translators: accessibility text. Empty gallery caption. */

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -369,7 +369,7 @@ export function ImageEdit( {
 					[ borderProps.className ]:
 						!! borderProps.className && ! isSingleSelected,
 				} ) }
-				withIllustration={ true }
+				withIllustration
 				icon={ lockUrlControls ? pluginsIcon : icon }
 				label={ __( 'Image' ) }
 				instructions={

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -889,7 +889,7 @@ export class ImageEdit extends Component {
 		return (
 			<MediaUpload
 				allowedTypes={ [ MEDIA_TYPE_IMAGE ] }
-				isReplacingMedia={ true }
+				isReplacingMedia
 				onSelect={ this.onSelectMediaUploadOption }
 				onSelectURL={ this.onSelectURL }
 				render={ ( { open, getMediaOptions } ) => {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -78,7 +78,7 @@ const ImageWrapper = ( { href, children } ) => {
 		<a
 			href={ href }
 			onClick={ ( event ) => event.preventDefault() }
-			aria-disabled={ true }
+			aria-disabled
 			style={ {
 				// When the Image block is linked,
 				// it's wrapped with a disabled <a /> tag.
@@ -647,7 +647,7 @@ export default function Image( {
 					{ isSingleSelected && (
 						<ToolsPanelItem
 							label={ __( 'Alternative text' ) }
-							isShownByDefault={ true }
+							isShownByDefault
 							hasValue={ () => !! alt }
 							onDeselect={ () =>
 								setAttributes( { alt: undefined } )

--- a/packages/block-library/src/latest-posts/edit.native.js
+++ b/packages/block-library/src/latest-posts/edit.native.js
@@ -201,7 +201,7 @@ class LatestPostsEdit extends Component {
 								value={ featuredImageAlign }
 								onChange={ this.onSetFeaturedImageAlign }
 								controls={ [ 'left', 'center', 'right' ] }
-								isBottomSheetControl={ true }
+								isBottomSheetControl
 							/>
 							<ToggleControl
 								label={ __( 'Add link to featured image' ) }

--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -181,7 +181,7 @@ export default function ListItemEdit( {
 						onReplace={ onReplaceList }
 						onEnter={ onEnter }
 						style={ styleWithPlaceholderOpacity }
-						deleteEnter={ true }
+						deleteEnter
 						containerWidth={ contentWidth }
 					/>
 				</View>

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -265,7 +265,7 @@ class MediaContainer extends Component {
 										isSelected={ isSelected }
 										style={ styles.video }
 										source={ { uri: mediaUrl } }
-										paused={ true }
+										paused
 									/>
 								</View>
 							) }
@@ -329,7 +329,7 @@ class MediaContainer extends Component {
 		if ( mediaUrl ) {
 			return (
 				<MediaUpload
-					isReplacingMedia={ true }
+					isReplacingMedia
 					onSelect={ this.onSelectMediaUploadOption }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ mediaId }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -137,7 +137,7 @@ function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
 				clientId={ clientId }
 				isAppender={ false }
 				prioritizePatterns={ false }
-				selectBlockOnInsert={ true }
+				selectBlockOnInsert
 				hasSearch={ false }
 				onSelect={ onSelectBlock }
 			/>
@@ -247,7 +247,7 @@ export function LinkUI( props ) {
 							hasTextControl
 							hasRichPreviews
 							value={ link }
-							showInitialSuggestions={ true }
+							showInitialSuggestions
 							withCreateSuggestion={ userCanCreate }
 							createSuggestion={ handleCreate }
 							createSuggestionButtonText={ ( searchTerm ) => {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -672,7 +672,7 @@ function Navigation( {
 						panelId={ clientId }
 						{ ...colorGradientSettings }
 						gradients={ [] }
-						disableCustomGradients={ true }
+						disableCustomGradients
 					/>
 					{ enableContrastChecking && (
 						<>

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -288,7 +288,7 @@ describe( 'NavigationMenuSelector', () => {
 				rerender(
 					<NavigationMenuSelector
 						onCreateNew={ handler }
-						createNavigationMenuIsSuccess={ true }
+						createNavigationMenuIsSuccess
 					/>
 				);
 
@@ -475,7 +475,7 @@ describe( 'NavigationMenuSelector', () => {
 				// // Simulate the menu being created and component being re-rendered.
 				rerender(
 					<NavigationMenuSelector
-						createNavigationMenuIsSuccess={ true } // classic menu import creates a Navigation menu.
+						createNavigationMenuIsSuccess // classic menu import creates a Navigation menu.
 					/>
 				);
 
@@ -616,7 +616,7 @@ describe( 'NavigationMenuSelector', () => {
 				// Simulate the menu being created and component being re-rendered.
 				rerender(
 					<NavigationMenuSelector
-						createNavigationMenuIsSuccess={ true } // classic menu import creates a Navigation menu.
+						createNavigationMenuIsSuccess // classic menu import creates a Navigation menu.
 					/>
 				);
 

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -65,7 +65,7 @@ function ParagraphBlock( {
 				identifier="content"
 				tagName="p"
 				value={ content }
-				deleteEnter={ true }
+				deleteEnter
 				style={ styles }
 				onChange={ ( nextContent ) => {
 					setAttributes( {

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -135,7 +135,7 @@ export default function PostExcerptEditor( {
 			onChange={ ( newMoreText ) =>
 				setAttributes( { moreText: newMoreText } )
 			}
-			withoutInteractiveFormatting={ true }
+			withoutInteractiveFormatting
 		/>
 	);
 	const excerptClassName = classnames( 'wp-block-post-excerpt__excerpt', {

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -83,7 +83,7 @@ const DimensionControls = ( {
 				resetAllFilter={ () => ( {
 					aspectRatio: undefined,
 				} ) }
-				isShownByDefault={ true }
+				isShownByDefault
 				panelId={ clientId }
 			>
 				<SelectControl
@@ -138,7 +138,7 @@ const DimensionControls = ( {
 				resetAllFilter={ () => ( {
 					height: undefined,
 				} ) }
-				isShownByDefault={ true }
+				isShownByDefault
 				panelId={ clientId }
 			>
 				<UnitControl
@@ -160,7 +160,7 @@ const DimensionControls = ( {
 				resetAllFilter={ () => ( {
 					width: undefined,
 				} ) }
-				isShownByDefault={ true }
+				isShownByDefault
 				panelId={ clientId }
 			>
 				<UnitControl
@@ -186,7 +186,7 @@ const DimensionControls = ( {
 					resetAllFilter={ () => ( {
 						scale: DEFAULT_SCALE,
 					} ) }
-					isShownByDefault={ true }
+					isShownByDefault
 					panelId={ clientId }
 				>
 					<ToggleGroupControl

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -153,7 +153,7 @@ export default function PostFeaturedImageEdit( {
 					'block-editor-media-placeholder',
 					borderProps.className
 				) }
-				withIllustration={ true }
+				withIllustration
 				style={ {
 					height: !! aspectRatio && '100%',
 					width: !! aspectRatio && '100%',

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -207,7 +207,7 @@ export default function PostNavigationLinkEdit( {
 				{ isNext && displayArrow && (
 					<span
 						className={ `wp-block-post-navigation-link__arrow-next is-arrow-${ arrow }` }
-						aria-hidden={ true }
+						aria-hidden
 					>
 						{ displayArrow }
 					</span>

--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -37,7 +37,7 @@ export default function QueryPaginationNextEdit( {
 			{ displayArrow && (
 				<span
 					className={ `wp-block-query-pagination-next-arrow is-arrow-${ paginationArrow }` }
-					aria-hidden={ true }
+					aria-hidden
 				>
 					{ displayArrow }
 				</span>

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -25,7 +25,7 @@ export default function QueryPaginationPreviousEdit( {
 			{ displayArrow && (
 				<span
 					className={ `wp-block-query-pagination-previous-arrow is-arrow-${ paginationArrow }` }
-					aria-hidden={ true }
+					aria-hidden
 				>
 					{ displayArrow }
 				</span>

--- a/packages/block-library/src/query/edit/pattern-selection-modal.js
+++ b/packages/block-library/src/query/edit/pattern-selection-modal.js
@@ -62,7 +62,7 @@ export default function PatternSelectionModal( {
 			overlayClassName="block-library-query-pattern__selection-modal"
 			title={ __( 'Choose a pattern' ) }
 			onRequestClose={ () => setIsPatternSelectionModalOpen( false ) }
-			isFullScreen={ true }
+			isFullScreen
 		>
 			<div className="block-library-query-pattern__selection-content">
 				<div className="block-library-query-pattern__selection-search">

--- a/packages/block-library/src/read-more/edit.js
+++ b/packages/block-library/src/read-more/edit.js
@@ -43,7 +43,7 @@ export default function ReadMore( {
 				__unstableOnSplitAtEnd={ () =>
 					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
 				}
-				withoutInteractiveFormatting={ true }
+				withoutInteractiveFormatting
 				{ ...blockProps }
 			/>
 		</>

--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -192,7 +192,7 @@ export default function SearchEdit( {
 						} );
 					} }
 					options={ BUTTON_OPTIONS }
-					hideCancelButton={ true }
+					hideCancelButton
 				/>
 				{ buttonPosition !== 'no-button' && (
 					<ToggleControl
@@ -294,7 +294,7 @@ export default function SearchEdit( {
 		return (
 			<View
 				style={ styles.searchInputContainer }
-				accessible={ true }
+				accessible
 				accessibilityRole="none"
 				accessibilityHint={
 					isScreenReaderEnabled
@@ -383,7 +383,7 @@ export default function SearchEdit( {
 
 				{ ! buttonUseIcon && (
 					<View
-						accessible={ true }
+						accessible
 						accessibilityRole="none"
 						accessibilityHint={
 							isScreenReaderEnabled
@@ -438,7 +438,7 @@ export default function SearchEdit( {
 
 			{ showLabel && (
 				<View
-					accessible={ true }
+					accessible
 					accessibilityRole="none"
 					accessibilityHint={
 						isScreenReaderEnabled

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -574,7 +574,7 @@ export default function LogoEdit( {
 			<Placeholder
 				className={ placeholderClassName }
 				preview={ logoImage }
-				withIllustration={ true }
+				withIllustration
 				style={ {
 					width,
 				} }

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -59,7 +59,7 @@ const SocialLinkURLPopover = ( {
 							setAttributes( { url: nextURL } )
 						}
 						placeholder={ __( 'Enter address' ) }
-						disableSuggestions={ true }
+						disableSuggestions
 						onKeyDown={ ( event ) => {
 							if (
 								!! url ||

--- a/packages/block-library/src/social-links/edit.native.js
+++ b/packages/block-library/src/social-links/edit.native.js
@@ -53,7 +53,7 @@ function SocialLinksEdit( {
 
 	const renderFooterAppender = useRef( () => (
 		<View style={ styles.footerAppenderContainer }>
-			<InnerBlocks.ButtonBlockAppender isFloating={ true } />
+			<InnerBlocks.ButtonBlockAppender isFloating />
 		</View>
 	) );
 

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -67,7 +67,7 @@ const ResizableSpacer = ( {
 				onResizeStop( `${ nextVal }px` );
 				setIsResizing( false );
 			} }
-			__experimentalShowTooltip={ true }
+			__experimentalShowTooltip
 			__experimentalTooltipProps={ {
 				axis: orientation === 'horizontal' ? 'x' : 'y',
 				position: 'corner',

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -160,7 +160,7 @@ export default function TableOfContentsEdit( {
 				<ol>
 					<TableOfContentsList
 						nestedHeadingList={ headingTree }
-						disableLinkActivation={ true }
+						disableLinkActivation
 						onClick={ showRedirectionPreventedNotice }
 					/>
 				</ol>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -320,7 +320,7 @@ export default function TemplatePartEdit( {
 					onRequestClose={ () =>
 						setIsTemplatePartSelectionOpen( false )
 					}
-					isFullScreen={ true }
+					isFullScreen
 				>
 					<TemplatePartSelectionModal
 						templatePartId={ templatePartId }

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -84,7 +84,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 				value={ preload }
 				onChange={ onChangePreload }
 				options={ options }
-				hideCancelButton={ true }
+				hideCancelButton
 			/>
 		</>
 	);

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -47,7 +47,7 @@ const placeholder = ( content ) => {
 	return (
 		<Placeholder
 			className="block-editor-media-placeholder"
-			withIllustration={ true }
+			withIllustration
 			icon={ icon }
 			label={ __( 'Video' ) }
 			instructions={ __(

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -218,7 +218,7 @@ class VideoEdit extends Component {
 		const toolbarEditButton = (
 			<MediaUpload
 				allowedTypes={ [ MEDIA_TYPE_VIDEO ] }
-				isReplacingMedia={ true }
+				isReplacingMedia
 				onSelect={ this.onSelectMediaUploadOption }
 				onSelectURL={ this.onSelectURL }
 				render={ ( { open, getMediaOptions } ) => {
@@ -332,7 +332,7 @@ class VideoEdit extends Component {
 												}
 												style={ videoStyle }
 												source={ { uri: src } }
-												paused={ true }
+												paused
 											/>
 										</View>
 									) }
@@ -365,7 +365,7 @@ class VideoEdit extends Component {
 						} }
 					/>
 					<BlockCaption
-						accessible={ true }
+						accessible
 						accessibilityLabelCreator={ ( caption ) =>
 							RichText.isEmpty( caption )
 								? /* translators: accessibility text. Empty video caption. */

--- a/packages/components/src/base-control/index.native.js
+++ b/packages/components/src/base-control/index.native.js
@@ -5,7 +5,7 @@ import { Text, View } from 'react-native';
 
 export default function BaseControl( { label, help, children } ) {
 	return (
-		<View accessible={ true } accessibilityLabel={ label }>
+		<View accessible accessibilityLabel={ label }>
 			{ label && <Text>{ label }</Text> }
 			{ children }
 			{ help && <Text>{ help }</Text> }

--- a/packages/components/src/base-control/test/index.tsx
+++ b/packages/components/src/base-control/test/index.tsx
@@ -14,7 +14,7 @@ const MyBaseControl = ( props: Omit< BaseControlProps, 'children' > ) => {
 	const { baseControlProps, controlProps } = useBaseControlProps( props );
 
 	return (
-		<BaseControl { ...baseControlProps } __nextHasNoMarginBottom={ true }>
+		<BaseControl { ...baseControlProps } __nextHasNoMarginBottom>
 			<textarea { ...controlProps } />
 		</BaseControl>
 	);

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -76,7 +76,7 @@ const BorderBoxControlSplitControls = (
 			<BorderBoxControlVisualizer value={ value } size={ size } />
 			<BorderControl
 				className={ centeredClassName }
-				hideLabelFromVision={ true }
+				hideLabelFromVision
 				label={ __( 'Top border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'top' ) }
 				__unstablePopoverProps={ popoverProps }
@@ -84,7 +84,7 @@ const BorderBoxControlSplitControls = (
 				{ ...sharedBorderControlProps }
 			/>
 			<BorderControl
-				hideLabelFromVision={ true }
+				hideLabelFromVision
 				label={ __( 'Left border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
 				__unstablePopoverProps={ popoverProps }
@@ -93,7 +93,7 @@ const BorderBoxControlSplitControls = (
 			/>
 			<BorderControl
 				className={ rightAlignedClassName }
-				hideLabelFromVision={ true }
+				hideLabelFromVision
 				label={ __( 'Right border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'right' ) }
 				__unstablePopoverProps={ popoverProps }
@@ -102,7 +102,7 @@ const BorderBoxControlSplitControls = (
 			/>
 			<BorderControl
 				className={ centeredClassName }
-				hideLabelFromVision={ true }
+				hideLabelFromVision
 				label={ __( 'Bottom border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'bottom' ) }
 				__unstablePopoverProps={ popoverProps }

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -111,7 +111,7 @@ const UnconnectedBorderBoxControl = (
 						__unstablePopoverProps={ popoverProps }
 						shouldSanitizeBorder={ false } // This component will handle that.
 						value={ linkedValue }
-						withSlider={ true }
+						withSlider
 						width={
 							size === '__unstable-large' ? '116px' : '110px'
 						}

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -179,7 +179,7 @@ const BorderControlDropdown = (
 			aria-label={ toggleAriaLabel }
 			tooltipPosition={ dropdownPosition }
 			label={ __( 'Border color and style picker' ) }
-			showTooltip={ true }
+			showTooltip
 			__next40pxDefaultSize={ size === '__unstable-large' ? true : false }
 		>
 			<span className={ indicatorWrapperClassName }>

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -180,7 +180,7 @@ export function Button( props ) {
 	const element = (
 		<TouchableOpacity
 			activeOpacity={ 0.7 }
-			accessible={ true }
+			accessible
 			accessibilityLabel={ label }
 			accessibilityStates={ states }
 			accessibilityRole={ 'button' }

--- a/packages/components/src/circular-option-picker/test/index.tsx
+++ b/packages/components/src/circular-option-picker/test/index.tsx
@@ -59,9 +59,7 @@ describe( 'CircularOptionPicker', () => {
 
 	describe( 'when `asButtons` is true', () => {
 		it( 'should render as buttons', async () => {
-			render(
-				<CircularOptionPicker { ...DEFAULT_PROPS } asButtons={ true } />
-			);
+			render( <CircularOptionPicker { ...DEFAULT_PROPS } asButtons /> );
 
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 			expect( screen.queryByRole( 'option' ) ).not.toBeInTheDocument();
@@ -94,7 +92,7 @@ describe( 'CircularOptionPicker', () => {
 				<CircularOptionPicker
 					{ ...DEFAULT_PROPS }
 					options={ MULTIPLE_OPTIONS }
-					loop={ true }
+					loop
 				/>
 			);
 

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -98,7 +98,7 @@ describe.each( [
 			<Component
 				options={ timezones }
 				label={ defaultLabelText }
-				hideLabelFromVision={ true }
+				hideLabelFromVision
 			/>
 		);
 		const label = getLabel( defaultLabelText );

--- a/packages/components/src/confirm-dialog/component.tsx
+++ b/packages/components/src/confirm-dialog/component.tsx
@@ -86,7 +86,7 @@ const UnconnectedConfirmDialog = (
 					onRequestClose={ handleEvent( onCancel ) }
 					onKeyDown={ handleEnter }
 					closeButtonLabel={ cancelLabel }
-					isDismissible={ true }
+					isDismissible
 					ref={ forwardedRef }
 					overlayClassName={ wrapperClassName }
 					__experimentalHideHeader

--- a/packages/components/src/confirm-dialog/test/index.tsx
+++ b/packages/components/src/confirm-dialog/test/index.tsx
@@ -235,11 +235,7 @@ describe( 'Confirm', () => {
 	describe( 'When controlled (isOpen is not `undefined`)', () => {
 		it( 'should render when `isOpen` is set to `true`', async () => {
 			render(
-				<ConfirmDialog
-					isOpen={ true }
-					onConfirm={ noop }
-					onCancel={ noop }
-				>
+				<ConfirmDialog isOpen onConfirm={ noop } onCancel={ noop }>
 					Are you sure?
 				</ConfirmDialog>
 			);
@@ -273,7 +269,7 @@ describe( 'Confirm', () => {
 			const onConfirm = jest.fn().mockName( 'onConfirm()' );
 
 			render(
-				<ConfirmDialog isOpen={ true } onConfirm={ onConfirm }>
+				<ConfirmDialog isOpen onConfirm={ onConfirm }>
 					Are you sure?
 				</ConfirmDialog>
 			);
@@ -291,11 +287,7 @@ describe( 'Confirm', () => {
 			const onCancel = jest.fn().mockName( 'onCancel()' );
 
 			render(
-				<ConfirmDialog
-					isOpen={ true }
-					onConfirm={ noop }
-					onCancel={ onCancel }
-				>
+				<ConfirmDialog isOpen onConfirm={ noop } onCancel={ onCancel }>
 					Are you sure?
 				</ConfirmDialog>
 			);
@@ -312,11 +304,7 @@ describe( 'Confirm', () => {
 			const onCancel = jest.fn().mockName( 'onCancel()' );
 
 			render(
-				<ConfirmDialog
-					isOpen={ true }
-					onConfirm={ noop }
-					onCancel={ onCancel }
-				>
+				<ConfirmDialog isOpen onConfirm={ noop } onCancel={ onCancel }>
 					Are you sure?
 				</ConfirmDialog>
 			);
@@ -352,11 +340,7 @@ describe( 'Confirm', () => {
 			const onConfirm = jest.fn().mockName( 'onConfirm()' );
 
 			render(
-				<ConfirmDialog
-					isOpen={ true }
-					onConfirm={ onConfirm }
-					onCancel={ noop }
-				>
+				<ConfirmDialog isOpen onConfirm={ onConfirm } onCancel={ noop }>
 					Are you sure?
 				</ConfirmDialog>
 			);

--- a/packages/components/src/disabled/test/index.tsx
+++ b/packages/components/src/disabled/test/index.tsx
@@ -94,7 +94,7 @@ describe( 'Disabled', () => {
 			'This is contentEditable.'
 		);
 
-		rerender( <MaybeDisable isDisabled={ true } /> );
+		rerender( <MaybeDisable isDisabled /> );
 		expect( getInput() ).toHaveValue( 'This is input.' );
 		expect( getContentEditable() ).toHaveTextContent(
 			'This is contentEditable.'

--- a/packages/components/src/draggable/test/index.native.js
+++ b/packages/components/src/draggable/test/index.native.js
@@ -43,7 +43,7 @@ describe( 'Draggable', () => {
 			<Draggable>
 				<DraggableTrigger
 					id={ triggerId }
-					enabled={ true }
+					enabled
 					minDuration={ 500 }
 					onLongPress={ onLongPress }
 					testID="draggableTrigger"

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -108,7 +108,7 @@ function DropdownMenu( {
 			renderContent={ ( { isOpen, onClose, ...props } ) => {
 				return (
 					<BottomSheet
-						hideHeader={ true }
+						hideHeader
 						isVisible={ isOpen }
 						onClose={ onClose }
 					>
@@ -135,7 +135,7 @@ function DropdownMenu( {
 												} }
 												editable={ false }
 												icon={ control.icon }
-												leftAlign={ true }
+												leftAlign
 												isSelected={ control.isActive }
 												separatorType={
 													Platform.OS === 'android'

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -111,7 +111,7 @@ function FontSizePicker( {
 						separatorType="none"
 						label={ __( 'Default' ) }
 						onPress={ onChangeValue( undefined ) }
-						leftAlign={ true }
+						leftAlign
 						key={ 'default' }
 						accessibilityRole={ 'button' }
 						accessibilityLabel={ __( 'Selected: Default' ) }
@@ -137,7 +137,7 @@ function FontSizePicker( {
 								label={ item.name }
 								subLabel={ item.sizePx }
 								onPress={ onChangeValue( item.sizePx ) }
-								leftAlign={ true }
+								leftAlign
 								key={ index }
 								accessibilityRole={ 'button' }
 								accessibilityLabel={

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -711,7 +711,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 					justify="flex-start"
 					align="center"
 					gap={ 1 }
-					wrap={ true }
+					wrap
 					__next40pxDefaultSize={ __next40pxDefaultSize }
 					hasTokens={ !! value.length }
 				>

--- a/packages/components/src/item-group/test/index.js
+++ b/packages/components/src/item-group/test/index.js
@@ -29,7 +29,7 @@ describe( 'ItemGroup', () => {
 			);
 
 			const { container: withBorders } = render(
-				<ItemGroup isBordered={ true }>
+				<ItemGroup isBordered>
 					<Item>Code is poetry</Item>
 				</ItemGroup>
 			);
@@ -63,7 +63,7 @@ describe( 'ItemGroup', () => {
 			);
 
 			const { container: separatedItems } = render(
-				<ItemGroup isSeparated={ true }>
+				<ItemGroup isSeparated>
 					<Item>Code is poetry</Item>
 				</ItemGroup>
 			);

--- a/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
@@ -91,7 +91,7 @@ const BottomSheetSelectControl = ( {
 							label={ item.label }
 							icon={ item.icon }
 							onPress={ onChangeValue( item.value ) }
-							leftAlign={ true }
+							leftAlign
 							key={ index }
 							accessibilityRole={ 'button' }
 							accessibilityLabel={

--- a/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-text-control/index.native.js
@@ -82,7 +82,7 @@ const BottomSheetTextControl = ( {
 						label={ label }
 						onChangeText={ ( text ) => onChange( text ) }
 						defaultValue={ initialValue }
-						multiline={ true }
+						multiline
 						placeholder={ placeholder }
 						placeholderTextColor={ '#87a6bc' }
 						style={ textEditorStyle }

--- a/packages/components/src/mobile/bottom-sheet/button.native.js
+++ b/packages/components/src/mobile/bottom-sheet/button.native.js
@@ -9,11 +9,7 @@ import { TouchableOpacity, View, Text } from 'react-native';
 import styles from './styles.scss';
 
 const BottomSheetButton = ( { onPress, disabled, text, color } ) => (
-	<TouchableOpacity
-		accessible={ true }
-		onPress={ onPress }
-		disabled={ disabled }
-	>
+	<TouchableOpacity accessible onPress={ onPress } disabled={ disabled }>
 		<View style={ { flexDirection: 'row', justifyContent: 'center' } }>
 			<Text style={ { ...styles.buttonText, color } }>{ text }</Text>
 		</View>

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -540,8 +540,8 @@ class BottomSheet extends Component {
 				}
 				onAccessibilityEscape={ this.onCloseBottomSheet }
 				testID="bottom-sheet"
-				hardwareAccelerated={ true }
-				useNativeDriverForBackdrop={ true }
+				hardwareAccelerated
+				useNativeDriverForBackdrop
 				{ ...rest }
 			>
 				<KeyboardAvoidingView

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -181,7 +181,7 @@ class BottomSheetRangeCell extends Component {
 
 		return (
 			<View
-				accessible={ true }
+				accessible
 				accessibilityRole="adjustable"
 				accessibilityActions={ [
 					{ name: 'increment' },

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
@@ -174,7 +174,7 @@ class BottomSheetStepperCell extends Component {
 
 		return (
 			<View
-				accessible={ true }
+				accessible
 				accessibilityRole="adjustable"
 				accessibilityLabel={ accessibilityLabel }
 				accessibilityHint={ getAccessibilityHint() }
@@ -214,7 +214,7 @@ class BottomSheetStepperCell extends Component {
 						icon={ icon }
 						label={ label }
 						labelStyle={ labelStyle }
-						leftAlign={ true }
+						leftAlign
 						separatorType={ separatorType }
 						disabled={ disabled }
 					>

--- a/packages/components/src/mobile/gradient/index.native.js
+++ b/packages/components/src/mobile/gradient/index.native.js
@@ -135,7 +135,7 @@ function Gradient( {
 		return (
 			<RNLinearGradient
 				colors={ colors }
-				useAngle={ true }
+				useAngle
 				angle={ getGradientAngle( gradientValue ) }
 				locations={ locations }
 				angleCenter={ angleCenter }

--- a/packages/components/src/mobile/media-edit/index.native.js
+++ b/packages/components/src/mobile/media-edit/index.native.js
@@ -103,7 +103,7 @@ export class MediaEdit extends Component {
 				hideCancelButton
 				ref={ ( instance ) => ( this.picker = instance ) }
 				options={ this.getMediaOptionsItems() }
-				leftAlign={ true }
+				leftAlign
 				onChange={ this.onPickerSelect }
 				// translators: %s: block title e.g: "Paragraph".
 				title={ __( 'Media options' ) }

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -335,7 +335,7 @@ describe( 'Modal', () => {
 		it( 'should focus the Modal dialog when `true` passed as value for `focusOnMount` prop', async () => {
 			const user = userEvent.setup();
 
-			render( <FocusMountDemo focusOnMount={ true } /> );
+			render( <FocusMountDemo focusOnMount /> );
 
 			const opener = screen.getByRole( 'button', {
 				name: 'Toggle Modal',

--- a/packages/components/src/navigation/stories/utils/hide-if-empty.tsx
+++ b/packages/components/src/navigation/stories/utils/hide-if-empty.tsx
@@ -42,11 +42,7 @@ export const HideIfEmptyStory: StoryFn< typeof Navigation > = ( {
 					/>
 				</NavigationMenu>
 
-				<NavigationMenu
-					menu="root-sub-1"
-					parentMenu="root"
-					isEmpty={ true }
-				/>
+				<NavigationMenu menu="root-sub-1" parentMenu="root" isEmpty />
 				<NavigationMenu
 					menu="root-sub-2"
 					parentMenu="root"
@@ -57,7 +53,7 @@ export const HideIfEmptyStory: StoryFn< typeof Navigation > = ( {
 				<NavigationMenu
 					menu="root-sub-1-sub-1"
 					parentMenu="root-sub-1"
-					isEmpty={ true }
+					isEmpty
 				/>
 			</Navigation>
 

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -592,14 +592,14 @@ export function PaletteEdit( {
 								gradients={ gradients }
 								onChange={ onSelectPaletteItem }
 								clearable={ false }
-								disableCustomGradients={ true }
+								disableCustomGradients
 							/>
 						) : (
 							<ColorPalette
 								colors={ colors }
 								onChange={ onSelectPaletteItem }
 								clearable={ false }
-								disableCustomColors={ true }
+								disableCustomColors
 							/>
 						) ) }
 				</>

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -182,10 +182,7 @@ describe( 'Popover', () => {
 		describe( 'focus behavior', () => {
 			it( 'should focus the popover container when opened', async () => {
 				render(
-					<Popover
-						focusOnMount={ true }
-						data-testid="popover-element"
-					>
+					<Popover focusOnMount data-testid="popover-element">
 						Popover content
 					</Popover>
 				);

--- a/packages/components/src/query-controls/index.native.js
+++ b/packages/components/src/query-controls/index.native.js
@@ -69,7 +69,7 @@ const QueryControls = memo(
 						value={ `${ orderBy }/${ order }` }
 						options={ options }
 						onChange={ onChange }
-						hideCancelButton={ true }
+						hideCancelButton
 					/>
 				) }
 				{ onCategoryChange && (
@@ -79,7 +79,7 @@ const QueryControls = memo(
 						noOptionLabel={ _x( 'All', 'categories' ) }
 						selectedCategoryId={ selectedCategoryId }
 						onChange={ onCategoryChange }
-						hideCancelButton={ true }
+						hideCancelButton
 					/>
 				) }
 				{ onNumberOfItemsChange && (

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -253,7 +253,7 @@ function UnforwardedRangeControl(
 						value={ inputSliderValue ?? undefined }
 					/>
 					<RangeRail
-						aria-hidden={ true }
+						aria-hidden
 						disabled={ disabled }
 						marks={ marks }
 						max={ max }
@@ -263,7 +263,7 @@ function UnforwardedRangeControl(
 						value={ rangeFillValue }
 					/>
 					<Track
-						aria-hidden={ true }
+						aria-hidden
 						className="components-range-control__track"
 						disabled={ disabled }
 						style={ { width: fillValueOffset } }
@@ -275,7 +275,7 @@ function UnforwardedRangeControl(
 						disabled={ disabled }
 					>
 						<Thumb
-							aria-hidden={ true }
+							aria-hidden
 							isFocused={ isThumbFocused }
 							disabled={ disabled }
 						/>

--- a/packages/components/src/range-control/test/index.tsx
+++ b/packages/components/src/range-control/test/index.tsx
@@ -297,7 +297,7 @@ describe( 'RangeControl', () => {
 			render(
 				<RangeControl
 					initialPosition={ 10 }
-					allowReset={ true }
+					allowReset
 					onChange={ spy }
 					resetFallbackValue={ 33 }
 				/>
@@ -320,7 +320,7 @@ describe( 'RangeControl', () => {
 					initialPosition={ undefined }
 					min={ 0 }
 					max={ 100 }
-					allowReset={ true }
+					allowReset
 					resetFallbackValue={ undefined }
 				/>
 			);

--- a/packages/components/src/search-control/index.native.js
+++ b/packages/components/src/search-control/index.native.js
@@ -235,7 +235,7 @@ function SearchControl( {
 				<Text
 					onPress={ onCancel }
 					style={ cancelButtonTextStyle }
-					accessible={ true }
+					accessible
 					accessibilityRole={ 'button' }
 					accessibilityLabel={ __( 'Cancel search' ) }
 					accessibilityHint={ __( 'Cancel search' ) }

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -73,7 +73,7 @@ const DisabledTabTemplate: StoryFn< typeof Tabs > = ( props ) => {
 	return (
 		<Tabs { ...props }>
 			<Tabs.TabList>
-				<Tabs.Tab tabId="tab1" disabled={ true }>
+				<Tabs.Tab tabId="tab1" disabled>
 					Tab 1
 				</Tabs.Tab>
 				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -71,7 +71,7 @@ const optionsWithTooltip = (
 			value="gnocchi"
 			label="Delicious Gnocchi"
 			aria-label="Click for Delicious Gnocchi"
-			showTooltip={ true }
+			showTooltip
 		/>
 		<ToggleGroupControlOption
 			value="caponata"

--- a/packages/components/src/tools-panel/stories/index.story.tsx
+++ b/packages/components/src/tools-panel/stories/index.story.tsx
@@ -71,7 +71,7 @@ export const Default: StoryFn< typeof ToolsPanel > = ( {
 						hasValue={ () => !! width }
 						label="Width"
 						onDeselect={ () => setWidth( undefined ) }
-						isShownByDefault={ true }
+						isShownByDefault
 					>
 						<UnitControl
 							label="Width"
@@ -83,7 +83,7 @@ export const Default: StoryFn< typeof ToolsPanel > = ( {
 						hasValue={ () => !! height }
 						label="Height"
 						onDeselect={ () => setHeight( undefined ) }
-						isShownByDefault={ true }
+						isShownByDefault
 					>
 						<UnitControl
 							label="Height"
@@ -95,7 +95,7 @@ export const Default: StoryFn< typeof ToolsPanel > = ( {
 						hasValue={ () => !! minHeight }
 						label="Minimum height"
 						onDeselect={ () => setMinHeight( undefined ) }
-						isShownByDefault={ true }
+						isShownByDefault
 					>
 						<UnitControl
 							label="Minimum height"
@@ -163,7 +163,7 @@ export const WithNonToolsPanelItems: StoryFn< typeof ToolsPanel > = ( {
 						hasValue={ () => !! width }
 						label="Width"
 						onDeselect={ () => setWidth( undefined ) }
-						isShownByDefault={ true }
+						isShownByDefault
 					>
 						<UnitControl
 							label="Width"
@@ -175,7 +175,7 @@ export const WithNonToolsPanelItems: StoryFn< typeof ToolsPanel > = ( {
 						hasValue={ () => !! height }
 						label="Height"
 						onDeselect={ () => setHeight( undefined ) }
-						isShownByDefault={ true }
+						isShownByDefault
 					>
 						<UnitControl
 							label="Height"
@@ -437,7 +437,7 @@ export const WithConditionalDefaultControl: StoryFn< typeof ToolsPanel > = ( {
 					onDeselect={ () => updateAttribute( 'height', undefined ) }
 					resetAllFilter={ () => ( { height: undefined } ) }
 					panelId={ panelId }
-					isShownByDefault={ true }
+					isShownByDefault
 				>
 					<UnitControl
 						label="Injected Height"
@@ -536,7 +536,7 @@ export const WithConditionallyRenderedControl: StoryFn<
 					} }
 					resetAllFilter={ () => ( { height: undefined } ) }
 					panelId={ panelId }
-					isShownByDefault={ true }
+					isShownByDefault
 				>
 					<UnitControl
 						label="Injected Height"
@@ -555,7 +555,7 @@ export const WithConditionallyRenderedControl: StoryFn<
 						}
 						resetAllFilter={ () => ( { scale: undefined } ) }
 						panelId={ panelId }
-						isShownByDefault={ true }
+						isShownByDefault
 					>
 						<ToggleGroupControl
 							__nextHasNoMarginBottom

--- a/packages/components/src/tools-panel/test/index.tsx
+++ b/packages/components/src/tools-panel/test/index.tsx
@@ -222,10 +222,7 @@ describe( 'ToolsPanel', () => {
 					<ToolsPanelItem { ...controlProps }>
 						<div>Example control</div>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						{ ...altControlProps }
-						isShownByDefault={ true }
-					>
+					<ToolsPanelItem { ...altControlProps } isShownByDefault>
 						<div>Alt control</div>
 					</ToolsPanelItem>
 				</ToolsPanel>
@@ -413,10 +410,7 @@ describe( 'ToolsPanel', () => {
 		it( 'should continue to render shown by default item after it is toggled off via menu item', async () => {
 			render(
 				<ToolsPanel { ...defaultProps }>
-					<ToolsPanelItem
-						{ ...controlProps }
-						isShownByDefault={ true }
-					>
+					<ToolsPanelItem { ...controlProps } isShownByDefault>
 						<div>Default control</div>
 					</ToolsPanelItem>
 				</ToolsPanel>
@@ -440,10 +434,7 @@ describe( 'ToolsPanel', () => {
 		it( 'should render appropriate menu groups', async () => {
 			render(
 				<ToolsPanel { ...defaultProps }>
-					<ToolsPanelItem
-						{ ...controlProps }
-						isShownByDefault={ true }
-					>
+					<ToolsPanelItem { ...controlProps } isShownByDefault>
 						<div>Default control</div>
 					</ToolsPanelItem>
 					<ToolsPanelItem { ...altControlProps }>
@@ -461,10 +452,7 @@ describe( 'ToolsPanel', () => {
 
 		it( 'should not render contents of items when in placeholder state', () => {
 			render(
-				<ToolsPanel
-					{ ...defaultProps }
-					shouldRenderPlaceholderItems={ true }
-				>
+				<ToolsPanel { ...defaultProps } shouldRenderPlaceholderItems>
 					<ToolsPanelItem { ...altControlProps }>
 						<div>Optional control</div>
 					</ToolsPanelItem>
@@ -493,10 +481,7 @@ describe( 'ToolsPanel', () => {
 
 			const TestPanel = () => (
 				<ToolsPanel { ...defaultProps }>
-					<ToolsPanelItem
-						{ ...altControlProps }
-						isShownByDefault={ true }
-					>
+					<ToolsPanelItem { ...altControlProps } isShownByDefault>
 						<div>Default control</div>
 					</ToolsPanelItem>
 					<ToolsPanelItem
@@ -568,16 +553,13 @@ describe( 'ToolsPanel', () => {
 
 			const TestPanel = () => (
 				<ToolsPanel { ...defaultProps }>
-					<ToolsPanelItem
-						{ ...altControlProps }
-						isShownByDefault={ true }
-					>
+					<ToolsPanelItem { ...altControlProps } isShownByDefault>
 						<div>Default control</div>
 					</ToolsPanelItem>
 					{ !! altControlValue && (
 						<ToolsPanelItem
 							{ ...conditionalControlProps }
-							isShownByDefault={ true }
+							isShownByDefault
 						>
 							<div>Conditional control</div>
 						</ToolsPanelItem>
@@ -1340,7 +1322,7 @@ describe( 'ToolsPanel', () => {
 							{ ...altControlProps }
 							label="Item 3"
 							data-testid="item-3"
-							isShownByDefault={ true }
+							isShownByDefault
 						>
 							<div>Item 3</div>
 						</ToolsPanelItem>
@@ -1352,8 +1334,8 @@ describe( 'ToolsPanel', () => {
 					</ToolsPanelItems>
 					<ToolsPanel
 						{ ...defaultProps }
-						hasInnerWrapper={ true }
-						shouldRenderPlaceholderItems={ true }
+						hasInnerWrapper
+						shouldRenderPlaceholderItems
 						__experimentalFirstVisibleItemClass="first"
 						__experimentalLastVisibleItemClass="last"
 					>

--- a/packages/components/src/tooltip/test/index.native.js
+++ b/packages/components/src/tooltip/test/index.native.js
@@ -44,7 +44,7 @@ afterAll( () => {
 it( 'displays the message', () => {
 	const screen = render(
 		<TooltipSlot>
-			<Tooltip visible={ true } text="A helpful message">
+			<Tooltip visible text="A helpful message">
 				<Text>I need help</Text>
 			</Tooltip>
 		</TooltipSlot>
@@ -56,7 +56,7 @@ it( 'displays the message', () => {
 it( 'dismisses when the screen is tapped', () => {
 	const screen = render(
 		<TooltipSlot>
-			<Tooltip visible={ true } text="A helpful message">
+			<Tooltip visible text="A helpful message">
 				<Text>I need help</Text>
 			</Tooltip>
 		</TooltipSlot>
@@ -72,7 +72,7 @@ it( 'dismisses when the screen is tapped', () => {
 it( 'dismisses when the keyboard closes', () => {
 	const screen = render(
 		<TooltipSlot>
-			<Tooltip visible={ true } text="A helpful message">
+			<Tooltip visible text="A helpful message">
 				<Text>I need help</Text>
 			</Tooltip>
 		</TooltipSlot>

--- a/packages/components/src/tree-grid/test/index.tsx
+++ b/packages/components/src/tree-grid/test/index.tsx
@@ -123,7 +123,7 @@ describe( 'TreeGrid', () => {
 						level={ 1 }
 						positionInSet={ 1 }
 						setSize={ 3 }
-						isExpanded={ true }
+						isExpanded
 					>
 						<TreeGridCell withoutGridItem>
 							<TestButton aria-expanded="true">Row 1</TestButton>

--- a/packages/compose/src/hooks/use-disabled/test/index.js
+++ b/packages/compose/src/hooks/use-disabled/test/index.js
@@ -19,7 +19,7 @@ describe( 'useDisabled', () => {
 			<form ref={ ref }>
 				<input />
 				<a href="https://wordpress.org/">A link</a>
-				<p role="document" contentEditable={ true } tabIndex="0"></p>
+				<p role="document" contentEditable tabIndex="0"></p>
 				{ showButton && <button>Button</button> }
 			</form>
 		);
@@ -48,7 +48,7 @@ describe( 'useDisabled', () => {
 		);
 
 		expect( screen.queryByText( 'Button' ) ).not.toBeInTheDocument();
-		rerender( <DisabledComponent showButton={ true } /> );
+		rerender( <DisabledComponent showButton /> );
 
 		const button = screen.getByText( 'Button' );
 		await waitFor( () => {

--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -129,7 +129,7 @@ describe( 'useEntityRecord', () => {
 			</RegistryProvider>
 		);
 
-		const { rerender } = render( <UI enabled={ true } /> );
+		const { rerender } = render( <UI enabled /> );
 
 		// A minimum delay for a fetch request. The same delay is used again as a control.
 		await act(

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -86,7 +86,7 @@ describe( 'useSelect', () => {
 
 		const { rerender } = render(
 			<RegistryProvider value={ registry }>
-				<TestComponent keyName="foo" change={ true } />
+				<TestComponent keyName="foo" change />
 			</RegistryProvider>
 		);
 
@@ -957,7 +957,7 @@ describe( 'useSelect', () => {
 			} );
 
 			render(
-				<AsyncModeProvider value={ true }>
+				<AsyncModeProvider value>
 					<RegistryProvider value={ registry }>
 						<TestComponent />
 					</RegistryProvider>
@@ -1004,7 +1004,7 @@ describe( 'useSelect', () => {
 				</AsyncModeProvider>
 			);
 
-			const { rerender } = render( <App async={ true } /> );
+			const { rerender } = render( <App async /> );
 
 			// Ensure expected state was rendered.
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0' );
@@ -1044,7 +1044,7 @@ describe( 'useSelect', () => {
 			} );
 
 			const App = ( { variant } ) => (
-				<AsyncModeProvider value={ true }>
+				<AsyncModeProvider value>
 					<RegistryProvider value={ registry }>
 						<TestComponent variant={ variant } />
 					</RegistryProvider>
@@ -1089,7 +1089,7 @@ describe( 'useSelect', () => {
 			} );
 
 			const App = () => (
-				<AsyncModeProvider value={ true }>
+				<AsyncModeProvider value>
 					<RegistryProvider value={ registry }>
 						<TestComponent />
 					</RegistryProvider>
@@ -1134,7 +1134,7 @@ describe( 'useSelect', () => {
 			} );
 
 			const App = ( { reg } ) => (
-				<AsyncModeProvider value={ true }>
+				<AsyncModeProvider value>
 					<RegistryProvider value={ reg }>
 						<TestComponent />
 					</RegistryProvider>

--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -56,7 +56,7 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 						value={ availableView.type }
 						name="view-actions-available-view"
 						checked={ availableView.type === view.type }
-						hideOnClick={ true }
+						hideOnClick
 						onChange={ ( e ) => {
 							onChangeView( {
 								...view,

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -181,7 +181,7 @@ function HeaderToolbar( {
 			<ScrollView
 				ref={ scrollViewRef }
 				onContentSizeChange={ scrollToStart }
-				horizontal={ true }
+				horizontal
 				showsHorizontalScrollIndicator={ false }
 				keyboardShouldPersistTaps="always"
 				alwaysBounceHorizontal={ false }

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -10,19 +10,14 @@ import { PostPublishButtonOrToggle } from '../post-publish-button-or-toggle';
 
 describe( 'PostPublishButtonOrToggle should render a', () => {
 	it( 'button when the post is published (1)', () => {
-		render( <PostPublishButtonOrToggle isPublished={ true } /> );
+		render( <PostPublishButtonOrToggle isPublished /> );
 		expect(
 			screen.getByRole( 'button', { name: 'Submit for Review' } )
 		).toBeVisible();
 	} );
 
 	it( 'button when the post is scheduled (2)', () => {
-		render(
-			<PostPublishButtonOrToggle
-				isScheduled={ true }
-				isBeingScheduled={ true }
-			/>
-		);
+		render( <PostPublishButtonOrToggle isScheduled isBeingScheduled /> );
 		expect(
 			screen.getByRole( 'button', { name: 'Submit for Review' } )
 		).toBeVisible();
@@ -30,10 +25,7 @@ describe( 'PostPublishButtonOrToggle should render a', () => {
 
 	it( 'button when the post is pending and cannot be published but the viewport is >= medium (3)', () => {
 		render(
-			<PostPublishButtonOrToggle
-				isPending={ true }
-				hasPublishAction={ false }
-			/>
+			<PostPublishButtonOrToggle isPending hasPublishAction={ false } />
 		);
 
 		expect(
@@ -42,9 +34,7 @@ describe( 'PostPublishButtonOrToggle should render a', () => {
 	} );
 
 	it( 'toggle when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is enabled', () => {
-		render(
-			<PostPublishButtonOrToggle isPublishSidebarEnabled={ true } />
-		);
+		render( <PostPublishButtonOrToggle isPublishSidebarEnabled /> );
 		expect(
 			screen.getByRole( 'button', { name: 'Publish' } )
 		).toBeVisible();

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/index.js
@@ -20,7 +20,7 @@ describe( 'PluginPostPublishPanel', () => {
 				<PluginPostPublishPanel
 					className="my-plugin-post-publish-panel"
 					title="My panel title"
-					initialOpen={ true }
+					initialOpen
 				>
 					My panel content
 				</PluginPostPublishPanel>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-variant.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-variant.js
@@ -40,7 +40,7 @@ function CollectionFontVariant( {
 				<CheckboxControl
 					checked={ selected }
 					onChange={ handleToggleActivation }
-					__nextHasNoMarginBottom={ true }
+					__nextHasNoMarginBottom
 					id={ checkboxId }
 				/>
 				<label htmlFor={ checkboxId }>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/library-font-variant.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/library-font-variant.js
@@ -50,7 +50,7 @@ function LibraryFontVariant( { face, font } ) {
 				<CheckboxControl
 					checked={ isInstalled }
 					onChange={ handleToggleActivation }
-					__nextHasNoMarginBottom={ true }
+					__nextHasNoMarginBottom
 					id={ checkboxId }
 				/>
 				<label htmlFor={ checkboxId }>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -184,7 +184,7 @@ function UploadFonts() {
 						accept={ ALLOWED_FILE_EXTENSIONS.map(
 							( ext ) => `.${ ext }`
 						).join( ',' ) }
-						multiple={ true }
+						multiple
 						onChange={ onFilesUpload }
 						render={ ( { openFileDialog } ) => (
 							<Button

--- a/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
@@ -114,8 +114,8 @@ export default function GradientPalettePanel( { name } ) {
 					<Spacer margin={ 3 } />
 					<DuotonePicker
 						duotonePalette={ duotonePalette }
-						disableCustomDuotone={ true }
-						disableCustomColors={ true }
+						disableCustomDuotone
+						disableCustomColors
 						clearable={ false }
 						onChange={ noop }
 					/>

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -413,7 +413,7 @@ export default function DataviewsPatterns() {
 					isLoading={ isResolving }
 					view={ view }
 					onChangeView={ onChangeView }
-					deferredRendering={ true }
+					deferredRendering
 					supportedLayouts={ [ LAYOUT_GRID ] }
 				/>
 			</Page>

--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -66,7 +66,7 @@ function Revisions( { userConfig, blocks } ) {
 		<EditorCanvasContainer
 			title={ __( 'Revisions' ) }
 			closeButtonLabel={ __( 'Close revisions' ) }
-			enableResizing={ true }
+			enableResizing
 		>
 			<Iframe
 				className="edit-site-revisions__iframe"

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
@@ -203,7 +203,7 @@ export default function PageStatus( {
 											size="11"
 											lineHeight={ 1.4 }
 											weight={ 500 }
-											upperCase={ true }
+											upperCase
 										>
 											{ __( 'Password' ) }
 										</Text>

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -47,7 +47,7 @@ function TemplatesList( { availableTemplates, onSelect } ) {
 			blockPatterns={ availableTemplates }
 			shownPatterns={ shownTemplates }
 			onClickPattern={ onSelect }
-			showTitlesAsTooltip={ true }
+			showTitlesAsTooltip
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-modal.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 export default function RenameModal( { onClose, onConfirm } ) {
 	return (
 		<ConfirmDialog
-			isOpen={ true }
+			isOpen
 			onConfirm={ ( e ) => {
 				e.preventDefault();
 				onConfirm();

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -22,7 +22,7 @@ export default function TemplatePartNavigationMenu( { id } ) {
 			<Heading
 				className="edit-site-sidebar-navigation-screen-template-part-navigation-menu__title"
 				size="11"
-				upperCase={ true }
+				upperCase
 				weight={ 500 }
 			>
 				{ title || __( 'Navigation' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menus.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menus.js
@@ -23,7 +23,7 @@ export default function TemplatePartNavigationMenus( { menus } ) {
 			<Heading
 				className="edit-site-sidebar-navigation-screen-template-part-navigation-menu__title"
 				size="11"
-				upperCase={ true }
+				upperCase
 				weight={ 500 }
 			>
 				{ __( 'Navigation' ) }

--- a/packages/edit-site/src/components/start-template-options/index.js
+++ b/packages/edit-site/src/components/start-template-options/index.js
@@ -137,7 +137,7 @@ function StartModal( { slug, isCustom, onClose, postType } ) {
 			closeLabel={ __( 'Cancel' ) }
 			focusOnMount="firstElement"
 			onRequestClose={ onClose }
-			isFullScreen={ true }
+			isFullScreen
 		>
 			<div className="edit-site-start-template-options__modal-content">
 				<PatternSelection

--- a/packages/editor/src/components/editor-help/intro-to-blocks.native.js
+++ b/packages/editor/src/components/editor-help/intro-to-blocks.native.js
@@ -51,7 +51,7 @@ const IntroToBlocks = () => {
 					) }
 				/>
 				<HelpDetailImage
-					accessible={ true }
+					accessible
 					accessibilityLabel={ __(
 						'Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block'
 					) }

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -94,7 +94,7 @@ export default function EntityTypeList( {
 	}
 
 	return (
-		<PanelBody title={ entityLabel } initialOpen={ true }>
+		<PanelBody title={ entityLabel } initialOpen>
 			<EntityDescription record={ firstRecord } count={ count } />
 			{ list.map( ( record ) => {
 				return (

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -168,7 +168,7 @@ export default function PostLockedModal() {
 					? __( 'Someone else has taken over this post' )
 					: __( 'This post is already being edited' )
 			}
-			focusOnMount={ true }
+			focusOnMount
 			shouldCloseOnClickOutside={ false }
 			shouldCloseOnEsc={ false }
 			isDismissible={ false }

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -110,7 +110,7 @@ export class PostPublishPanel extends Component {
 						</PostPublishPanelPrepublish>
 					) }
 					{ isPostPublish && (
-						<PostPublishPanelPostpublish focusOnMount={ true }>
+						<PostPublishPanelPostpublish focusOnMount>
 							{ PostPublishExtension && <PostPublishExtension /> }
 						</PostPublishPanelPostpublish>
 					) }

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -131,7 +131,7 @@ export default function PostFormatPanel() {
 	}
 
 	return (
-		<PanelBody initialOpen={ true } title={ panelBodyTitle }>
+		<PanelBody initialOpen title={ panelBodyTitle }>
 			<p>
 				{ __(
 					'Upload external images to the Media Library. Images from different domains may load slowly, display incorrectly, or be removed unexpectedly.'

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -175,7 +175,7 @@ class PostTitle extends Component {
 					fontSize={ 24 }
 					lineHeight={ 1 }
 					fontWeight={ 'bold' }
-					deleteEnter={ true }
+					deleteEnter
 					onChange={ ( value ) => {
 						this.props.onUpdate( value );
 					} }
@@ -184,7 +184,7 @@ class PostTitle extends Component {
 					value={ title }
 					onSelectionChange={ () => {} }
 					onEnter={ this.props.onEnterPress }
-					disableEditingMenu={ true }
+					disableEditingMenu
 					__unstableIsSelected={ this.props.isSelected }
 					__unstableOnCreateUndoLevel={ () => {} }
 				/>

--- a/packages/editor/src/components/post-title/post-title-raw.js
+++ b/packages/editor/src/components/post-title/post-title-raw.js
@@ -70,7 +70,7 @@ function PostTitleRaw( _, forwardedRef ) {
 			label={ placeholder }
 			className={ className }
 			placeholder={ decodedPlaceholder }
-			hideLabelFromVision={ true }
+			hideLabelFromVision
 			autoComplete="off"
 			dir="auto"
 			rows={ 1 }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -264,7 +264,7 @@ function InlineLinkUI( {
 				createSuggestionButtonText={ createButtonText }
 				hasTextControl
 				settings={ LINK_SETTINGS }
-				showInitialSuggestions={ true }
+				showInitialSuggestions
 				suggestionsQuery={ {
 					// always show Pages as initial suggestions
 					initialSuggestionsSearchOptions: {

--- a/packages/format-library/src/text-color/test/index.native.js
+++ b/packages/format-library/src/text-color/test/index.native.js
@@ -207,7 +207,7 @@ describe( 'Text color', () => {
 			<SlotFillProvider>
 				<BlockEdit name="core/test-block" isSelected mayDisplayControls>
 					<TextColorEdit
-						isActive={ true }
+						isActive
 						activeAttributes={ {} }
 						value={ textValue }
 						onChange={ jest.fn() }

--- a/packages/format-library/src/unknown/index.js
+++ b/packages/format-library/src/unknown/index.js
@@ -35,7 +35,7 @@ export const unknown = {
 				icon={ help }
 				title={ title }
 				onClick={ onClick }
-				isActive={ true }
+				isActive
 			/>
 		);
 	},

--- a/storybook/stories/docs/inline-icon.js
+++ b/storybook/stories/docs/inline-icon.js
@@ -9,6 +9,4 @@ const StyledIcons = styled( Icons )`
 	width: 14px;
 `;
 
-export const InlineIcon = ( props ) => (
-	<StyledIcons aria-hidden={ true } { ...props } />
-);
+export const InlineIcon = ( props ) => <StyledIcons aria-hidden { ...props } />;


### PR DESCRIPTION
## What?
This PR enables the `react/jsx-boolean-value` [ESLint rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) for the Gutenberg codebase. It also fixes all violations of the rule across the codebase.

## Why?
Using the truthy shorthand is a recommendation I often encounter in PR reviews, and if we enforce it with ESLint, it will no longer be an issue. 

By using the shorthand we also keep the code more concise and short.

## How?
We're enabling the rule for the codebase. I'm intentionally not enabling it in the `@wordpress/eslint-plugin` package because it's a bit opinionated and I'm not convinced we want to apply this beyond the Gutenberg codebase. I'm happy to be convinced otherwise.

## Testing Instructions
All checks should be green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None