### PR TITLE
Navigation Block: Remove unnecessary `@param` annotation

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -544,7 +544,6 @@ class WP_Navigation_Block_Renderer {
 	 * Gets the nav element directives.
 	 *
 	 * @param bool  $is_interactive Whether the block is interactive.
-	 * @param array $attributes     The block attributes.
 	 * @return string the directives for the navigation element.
 	 */
 	private static function get_nav_element_directives( $is_interactive ) {


### PR DESCRIPTION
Found this while investigating #59516

## What?

This PR removes unnecessary annotation in the `get_nav_element_directives` method of the `WP_Navigation_Block_Renderer` class.

## Testing Instructions

No impact on the code.

P.S. Does this need to be WP6.5 backported?