### PR TITLE
Navigation Block: Fix erroneous escaping of ampersands (etc)

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1458,7 +1458,7 @@ function block_core_navigation_set_ignored_hooked_blocks_metadata( $inner_blocks
 /**
  * Updates the post meta with the list of ignored hooked blocks when the navigation is created or updated via the REST API.
  *
- * @param WP_Post $post Post object.
+ * @param stdClass $post Post object.
  */
 function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 	// We run the Block Hooks mechanism to inject the `metadata.ignoredHookedBlocks` attribute into
@@ -1480,14 +1480,8 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 		update_post_meta( $post->ID, '_wp_ignored_hooked_blocks', json_encode( $ignored_hooked_blocks ) );
 	}
 
-	$serialized_inner_blocks = block_core_navigation_remove_serialized_parent_block( $markup );
-
-	wp_update_post(
-		array(
-			'ID'           => $post->ID,
-			'post_content' => $serialized_inner_blocks,
-		)
-	);
+	$post->post_content = block_core_navigation_remove_serialized_parent_block( $markup );
+	return $post;
 }
 
 // Before adding our filter, we verify if it's already added in Core.
@@ -1497,8 +1491,15 @@ $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ig
 
 // Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
 // that are not present in Gutenberg's WP 6.5 compatibility layer.
-if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ! has_filter( 'rest_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) ) {
-	add_action( 'rest_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta', 10, 3 );
+if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) ) {
+	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta', 10, 2 );
+}
+
+// Previous versions of Gutenberg and WordPress 6.5 Betas were attaching the block_core_navigation_update_ignore_hooked_blocks_meta
+// function to the `rest_insert_wp_navigation` _action_ (rather than the `rest_pre_insert_wp_navigation` _filter_).
+// To avoid collisions, we need to remove the filter from that action if it's present.
+if ( has_filter( 'rest_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) ) {
+	remove_filter( 'rest_insert_wp_navigation', $rest_insert_wp_navigation_core_callback, 10 );
 }
 
 /**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1464,7 +1464,12 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 	// We run the Block Hooks mechanism to inject the `metadata.ignoredHookedBlocks` attribute into
 	// all anchor blocks. For the root level, we create a mock Navigation and extract them from there.
 	$blocks = parse_blocks( $post->post_content );
-	$markup = block_core_navigation_set_ignored_hooked_blocks_metadata( $blocks, $post );
+
+	// Block Hooks logic requires a `WP_Post` object (rather than the `stdClass` with the updates that
+	// we're getting from the `rest_pre_insert_wp_navigation` filter) as its second argument (to be
+	// used as context for hooked blocks insertion).
+	// We thus have to look it up from the DB,based on `$post->ID`.
+	$markup = block_core_navigation_set_ignored_hooked_blocks_metadata( $blocks, get_post( $post->ID ) );
 
 	$root_nav_block        = parse_blocks( $markup )[0];
 	$ignored_hooked_blocks = isset( $root_nav_block['attrs']['metadata']['ignoredHookedBlocks'] )

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1497,7 +1497,7 @@ $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ig
 // Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
 // that are not present in Gutenberg's WP 6.5 compatibility layer.
 if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) ) {
-	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta', 10, 2 );
+	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta', 10 );
 }
 
 // Previous versions of Gutenberg and WordPress 6.5 Betas were attaching the block_core_navigation_update_ignore_hooked_blocks_meta

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Navigation block block hooks tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Navigation block.
+ *
+ * @group blocks
+ */
+class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
+	/**
+	 * Original markup.
+	 *
+	 * @var string
+	 */
+	protected static $original_markup;
+
+	/**
+	 * Post object.
+	 *
+	 * @var object
+	 */
+	protected static $navigation_post;
+
+	/**
+	 * Setup method.
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$original_markup = '<!-- wp:navigation-link {"label":"News & About","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
+
+		self::$navigation_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_navigation',
+				'post_title'   => 'Navigation Menu',
+				'post_content' => self::$original_markup,
+			)
+		);
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( 'tests/my-block' ) ) {
+			$registry->unregister( 'tests/my-block' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
+	 */
+	public function test_block_core_navigation_update_ignore_hooked_blocks_meta() {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/navigation' => 'last_child',
+				),
+			)
+		);
+
+		$post = get_post( self::$navigation_post );
+
+		gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta( $post );
+		$this->assertSame( self::$original_markup . '<!-- wp:tests/my-block /-->', $post->post_content );
+		$this->assertSame( array( 'tests/my-block' ), get_post_meta( $post, '_wp_ignored_hooked_blocks' ) );
+	}
+}

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -58,6 +58,10 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
 	 */
 	public function test_block_core_navigation_update_ignore_hooked_blocks_meta_preserves_entities() {
+		if ( ! function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
+			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionalit.' );
+		}
+
 		register_block_type(
 			'tests/my-block',
 			array(

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -71,7 +71,10 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 
 		gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta( $post );
 
-		$this->assertSame( self::$original_markup . '<!-- wp:tests/my-block /-->', $post->post_content );
+		// We expect the '&' character to be replaced with its unicode representation.
+		$expected_markup = str_replace( '&', '\u0026amp;', self::$original_markup );
+
+		$this->assertSame( $expected_markup, $post->post_content );
 		$this->assertSame(
 			array( 'tests/my-block' ),
 			json_decode( get_post_meta( self::$navigation_post->ID, '_wp_ignored_hooked_blocks', true ), true )

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -75,6 +75,7 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 		$expected_markup = str_replace( '&', '\u0026amp;', self::$original_markup );
 
 		$this->assertSame( $expected_markup, $post->post_content );
+		$this->assertSame( $expected_markup, get_the_content( null, false, self::$navigation_post->ID ) );
 		$this->assertSame(
 			array( 'tests/my-block' ),
 			json_decode( get_post_meta( self::$navigation_post->ID, '_wp_ignored_hooked_blocks', true ), true )

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -70,7 +70,11 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 		$post = get_post( self::$navigation_post );
 
 		gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta( $post );
+
 		$this->assertSame( self::$original_markup . '<!-- wp:tests/my-block /-->', $post->post_content );
-		$this->assertSame( array( 'tests/my-block' ), get_post_meta( $post, '_wp_ignored_hooked_blocks' ) );
+		$this->assertSame(
+			array( 'tests/my-block' ),
+			json_decode( get_post_meta( self::$navigation_post->ID, '_wp_ignored_hooked_blocks', true ), true )
+		);
 	}
 }


### PR DESCRIPTION
## What?
Fix erroneous escaping of ampersands to `u0026amp;`. 

## Why?
To fix #59516. Since these "entities" are missing a leading backslash, it them to show up verbatim on the frontend!

<img width="491" alt="Screenshot 2024-03-01 at 4 38 17 PM" src="https://github.com/WordPress/gutenberg/assets/1037081/6e1b098f-4844-4537-af32-fb0853c2066f">

## How?
By using the [`rest_pre_insert_{$this->post_type}`](https://developer.wordpress.org/reference/hooks/rest_pre_insert_this-post_type/) _filter_ rather than the `rest_insert_wp_navigation` _action_. This avoids calling `wp_update_post` twice, which was the original reason of the issue, as it removed the backslash from the already-encoded entity.

(Note that the fact that encoded entities are sent over the wire in the first place is due to a quirk in the Navigation block: https://github.com/WordPress/gutenberg/pull/41063.)

## Testing Instructions
(See CI, or run `npm run test:php` locally.)

## Related

https://core.trac.wordpress.org/ticket/60671 seems to be related