### PR TITLE
(POC) Block Bindings: introduce a second state to store incoming changes

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -75,10 +75,8 @@ const BindingConnector = ( {
 	source,
 	onPropValueChange,
 } ) => {
-	const { placeholder, value: propValue } = source.useSource(
-		blockProps,
-		args
-	);
+	const { useSource } = source;
+	const { placeholder, value: propValue } = useSource( blockProps, args );
 
 	const { name: blockName } = blockProps;
 	const attrValue = blockProps.attributes[ attrName ];

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -41,4 +41,5 @@ export default {
 			updateValue: updateMetaValue,
 		};
 	},
+	lockAttributesEditing: false,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR allows editing the prop value of the external source

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This implementation lies in separating data handling depending on the propagation direction. This means that the values of the bound attributes are stored in a separate store (trunk), but the new attribute values that will be used to update the external source are stored in another one (added on this PR)

For this, it defines the setAttribute callback of the Edit component to choose when it needs updating the block attribute and when updating the local store for the incoming changes (from the block attribute to the external source)

These values are passed to the child components, which detect the changes to update the external source.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Similar to https://github.com/WordPress/gutenberg/pull/59537

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
