### PR TITLE
Ensure that errors reported from uploading font files are not duplicated

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -9,7 +9,7 @@ import {
 	useEntityRecords,
 	store as coreStore,
 } from '@wordpress/core-data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -306,29 +306,14 @@ function FontLibraryProvider( { children } ) {
 				refreshLibrary();
 			}
 
-			if ( installationErrors.length === 1 ) {
-				throw new Error(
-					sprintf(
-						/* translators: %s: Specific error message returned from server. */
-						__( 'There was an error installing fonts. %s' ),
-						installationErrors[ 0 ]
-					)
+			if ( installationErrors.length > 0 ) {
+				const installError = new Error(
+					__( 'There was an error installing fonts.' )
 				);
-			} else if ( installationErrors.length > 1 ) {
-				throw new Error(
-					sprintf(
-						/* translators: %s: Specific error messages returned from server. */
-						__( 'There were some errors installing fonts. %s' ),
-						'<ul>' +
-							installationErrors.reduce(
-								( errorMessageCollection, errorMessage ) => {
-									return `${ errorMessageCollection }<li>${ errorMessage }</li>`;
-								},
-								''
-							) +
-							'</ul>'
-					)
-				);
+
+				installError.installationErrors = installationErrors;
+
+				throw installError;
 			}
 		} finally {
 			setIsInstalling( false );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -283,6 +283,14 @@ function FontLibraryProvider( { children } ) {
 				);
 			}
 
+			installationErrors = installationErrors.reduce(
+				( unique, item ) =>
+					unique.includes( item.message )
+						? unique
+						: [ ...unique, item.message ],
+				[]
+			);
+
 			if ( fontFamiliesToActivate.length > 0 ) {
 				// Activate the font family (add the font family to the global styles).
 				activateCustomFontFamilies( fontFamiliesToActivate );
@@ -298,24 +306,27 @@ function FontLibraryProvider( { children } ) {
 				refreshLibrary();
 			}
 
-			if ( installationErrors.length > 0 ) {
+			if ( installationErrors.length === 1 ) {
 				throw new Error(
 					sprintf(
 						/* translators: %s: Specific error message returned from server. */
+						__( 'There was an error installing fonts. %s' ),
+						installationErrors[ 0 ]
+					)
+				);
+			} else if ( installationErrors.length > 1 ) {
+				throw new Error(
+					sprintf(
+						/* translators: %s: Specific error messages returned from server. */
 						__( 'There were some errors installing fonts. %s' ),
-						installationErrors.reduce(
-							( errorMessageCollection, error ) => {
-								if (
-									errorMessageCollection.indexOf(
-										error.message
-									) === -1
-								) {
-									return `${ errorMessageCollection } ${ error.message }`;
-								}
-								return errorMessageCollection;
-							},
-							''
-						)
+						'<ul>' +
+							installationErrors.reduce(
+								( errorMessageCollection, errorMessage ) => {
+									return `${ errorMessageCollection }<li>${ errorMessage }</li>`;
+								},
+								''
+							) +
+							'</ul>'
 					)
 				);
 			}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -305,7 +305,14 @@ function FontLibraryProvider( { children } ) {
 						__( 'There were some errors installing fonts. %s' ),
 						installationErrors.reduce(
 							( errorMessageCollection, error ) => {
-								return `${ errorMessageCollection } ${ error.message }`;
+								if (
+									errorMessageCollection.indexOf(
+										error.message
+									) === -1
+								) {
+									return `${ errorMessageCollection } ${ error.message }`;
+								}
+								return errorMessageCollection;
 							},
 							''
 						)

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -154,6 +154,7 @@ function UploadFonts() {
 			setNotice( {
 				type: 'error',
 				message: error.message,
+				errors: error?.installationErrors,
 			} );
 		}
 
@@ -171,6 +172,13 @@ function UploadFonts() {
 						onRemove={ () => setNotice( null ) }
 					>
 						{ notice.message }
+						{ notice.errors && (
+							<ul>
+								{ notice.errors.map( ( error, index ) => (
+									<li key={ index }>{ error }</li>
+								) ) }
+							</ul>
+						) }
 					</Notice>
 				) }
 				{ isUploading && (

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -167,7 +167,7 @@ function UploadFonts() {
 				{ notice && (
 					<Notice
 						status={ notice.type }
-						__unstableHTML={ true }
+						__unstableHTML
 						onRemove={ () => setNotice( null ) }
 					>
 						{ notice.message }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -167,6 +167,7 @@ function UploadFonts() {
 				{ notice && (
 					<Notice
 						status={ notice.type }
+						__unstableHTML={ true }
 						onRemove={ () => setNotice( null ) }
 					>
 						{ notice.message }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -225,7 +225,7 @@ export async function batchInstallFontFaces( fontFamilyId, fontFacesData ) {
 			// Handle network errors or other fetch-related errors
 			results.errors.push( {
 				data: fontFacesData[ index ],
-				message: `Fetch error: ${ result.reason.message }`,
+				message: result.reason.message,
 			} );
 		}
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Ensure that errors reported from uploading font files are not duplicated

## Why?
Fixes #59484

## How?
Only concat strings that don't exist in the error message string.

## Testing Instructions
Using the 'Upload' tab of the Font Library upload multiple fonts at once.
After the fonts are successfully uploaded upload the SAME fonts again.
Note that the message "A font face matching those settings already exists" is only shown a single time.

<img width="645" alt="image" src="https://github.com/WordPress/gutenberg/assets/146530/27fab6a0-dd3e-4148-a878-48ce7faefb2a">

NOTE: If there are multiple KINDS of messages then those are shown as a list.  (I'm... not sure how to replicate this however, in the below example I just removed the reducing logic and am showing the same message multiple times... which wouldn't actually happen now...)

<img width="643" alt="image" src="https://github.com/WordPress/gutenberg/assets/146530/a97730bc-0e4c-4de9-959a-c5918b103894">
