### PR TITLE
Remove @ajlende from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 /packages/interactivity/docs                    @juanmaguitar
 
 # Schemas
-/schemas/json                                   @ajlende
+/schemas/json
 
 # Data
 /packages/api-fetch                             @nerrad @mmtr
@@ -21,10 +21,10 @@
 /packages/block-library/src/image               @artemiomorales @michalczaplinski
 
 # Duotone
-/lib/block-supports/duotone.php                       @ajlende
-/packages/block-editor/src/components/duotone-control @ajlende
-/packages/block-editor/src/hooks/duotone.js           @ajlende
-/packages/components/src/duotone-picker               @ajlende
+/lib/block-supports/duotone.php
+/packages/block-editor/src/components/duotone-control
+/packages/block-editor/src/hooks/duotone.js
+/packages/components/src/duotone-picker
 
 # Editor
 /packages/annotations                           @atimmer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /packages/block-library/src/comment-template    @michalczaplinski
 /packages/block-library/src/comments            @michalczaplinski
 /packages/block-library/src/table-of-contents   @ZebulanStanphill
-/packages/block-library/src/image								@artemiomorales @michalczaplinski
+/packages/block-library/src/image               @artemiomorales @michalczaplinski
 
 # Duotone
 /lib/block-supports/duotone.php                       @ajlende
@@ -82,7 +82,7 @@
 /packages/scripts                               @gziolo @ntwb @nerrad @ajitbohra @ryanwelcher
 /packages/stylelint-config                      @ntwb
 /test/e2e                                       @kevin940726 @Mamaduka
-/test/php/gutenberg-coding-standards			@anton-vlasenko
+/test/php/gutenberg-coding-standards            @anton-vlasenko
 
 # UI Components
 /packages/components                            @ajitbohra


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove me from the CODOWNERS

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I feel like enough time has passed and there are enough people who have worked in the parts of the code that I was a codeowner of that things should be fine without me getting notified of every change in these parts of the codebase.

