### PR TITLE
Revert "Navigation Link UI: Focus the parent block when a block is removed."

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -173,7 +173,6 @@ export default function NavigationLinkEdit( {
 
 	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
-	const { selectBlock } = useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -193,7 +192,6 @@ export default function NavigationLinkEdit( {
 		isTopLevelLink,
 		isParentOfSelectedBlock,
 		hasChildren,
-		firstParentClientId,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -203,12 +201,7 @@ export default function NavigationLinkEdit( {
 				getBlockRootClientId,
 				hasSelectedInnerBlock,
 				getBlockParentsByBlockName,
-				getBlockParents,
-				getSelectedBlockClientId,
 			} = select( blockEditorStore );
-
-			const selectedBlockClientId = getSelectedBlockClientId();
-			const parents = getBlockParents( selectedBlockClientId );
 
 			return {
 				innerBlocks: getBlocks( clientId ),
@@ -225,7 +218,6 @@ export default function NavigationLinkEdit( {
 					true
 				),
 				hasChildren: !! getBlockCount( clientId ),
-				firstParentClientId: parents[ parents.length - 1 ],
 			};
 		},
 		[ clientId ]
@@ -575,9 +567,8 @@ export default function NavigationLinkEdit( {
 								// If there is no link then remove the auto-inserted block.
 								// This avoids empty blocks which can provided a poor UX.
 								if ( ! url ) {
+									// Need to handle refocusing the Nav block or the inserter?
 									onReplace( [] );
-									// Focus the parent block.
-									selectBlock( firstParentClientId );
 								}
 							} }
 							anchor={ popoverAnchor }


### PR DESCRIPTION
Reverts WordPress/gutenberg#59466