### PR TITLE
Remove preview from Font Family & Font Face APIs

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -655,15 +655,6 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 									'sanitize_callback' => 'sanitize_text_field',
 								),
 							),
-							'preview'               => array(
-								'description' => __( 'URL to a preview image of the font face.', 'gutenberg' ),
-								'type'        => 'string',
-								'format'      => 'uri',
-								'default'     => '',
-								'arg_options' => array(
-									'sanitize_callback' => 'sanitize_url',
-								),
-							),
 						),
 						'required'             => array( 'fontFamily', 'src' ),
 						'additionalProperties' => false,

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -341,15 +341,6 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 									'sanitize_callback' => array( 'WP_Font_Utils', 'sanitize_font_family' ),
 								),
 							),
-							'preview'    => array(
-								'description' => __( 'URL to a preview image of the font family.', 'gutenberg' ),
-								'type'        => 'string',
-								'format'      => 'uri',
-								'default'     => '',
-								'arg_options' => array(
-									'sanitize_callback' => 'sanitize_url',
-								),
-							),
 						),
 						'required'             => array( 'name', 'slug', 'fontFamily' ),
 						'additionalProperties' => false,
@@ -429,7 +420,7 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 				return array(
 					'theme_json_version'   => $properties['theme_json_version'],
 					// When creating or updating, font_family_settings is stringified JSON, to work with multipart/form-data.
-					// Font families don't currently support file uploads, but may accept preview files in the future.
+					// Font families don't currently support file uploads
 					'font_family_settings' => array(
 						'description'       => __( 'font-family declaration in theme.json format, encoded as a string.', 'gutenberg' ),
 						'type'              => 'string',
@@ -560,7 +551,6 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 				'name'       => isset( $post->post_title ) && $post->post_title ? $post->post_title : '',
 				'slug'       => isset( $post->post_name ) && $post->post_name ? $post->post_name : '',
 				'fontFamily' => isset( $settings_json['fontFamily'] ) && $settings_json['fontFamily'] ? $settings_json['fontFamily'] : '',
-				'preview'    => isset( $settings_json['preview'] ) && $settings_json['preview'] ? $settings_json['preview'] : '',
 			);
 		}
 	}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -157,6 +157,7 @@ export function makeFontFamilyFormData( fontFamily ) {
 		...familyWithValidParameters,
 		slug: kebabCase( fontFamily.slug ),
 	};
+	delete fontFamilySettings.preview;
 
 	formData.append(
 		'font_family_settings',
@@ -169,6 +170,7 @@ export function makeFontFacesFormData( font ) {
 	if ( font?.fontFace ) {
 		const fontFacesFormData = font.fontFace.map( ( item, faceIndex ) => {
 			const face = { ...item };
+			delete face.preview;
 			const formData = new FormData();
 			if ( face.file ) {
 				// Normalize to an array, since face.file may be a single file or an array of files.


### PR DESCRIPTION

## What?
Remove the preview property from the Font Face and Font Family APIs
Don't send the preview property when creating Font Face and Font Family APIs from the client

## Why?
The preview has limited value once a font is installed.  (Not NO value, but limited.  Any font INSTALLED and ACTIVATED will already have the font assets loaded in the browser and the preview isn't needed.  Only fonts INSTALLED and NOT ACTIVATED would get a SMALL benefit from using previews.). However since previews are SVG assets they aren't available to be imported into WordPress due to security concerns.

Rather than managing preview assets (at all) for fonts that have been installed instead just remove that from something that we need to be concerned with.

Previews remain unchanged for Font Faces and Font Families that are in a Font Collection.

## Testing Instructions
Using the Install Fonts tab make sure the previews are rendered with SVG files.
<img width="351" alt="image" src="https://github.com/WordPress/gutenberg/assets/146530/1dfedf05-7cef-47af-8e54-f1e6acad0e85">
Install a Font and go to the Library Tab
Ensure the font that was just installed has a preview rendered with the font resource.
<img width="289" alt="image" src="https://github.com/WordPress/gutenberg/assets/146530/58a74582-2334-4315-957c-9defcdbf1bba">

