### PR TITLE
Layout: show inherit toggle in the absence of `settings.layout` object

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -125,14 +125,13 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 	const fullLayoutType = getLayoutType( usedLayout?.type || 'default' );
 	const [ blockGapSupport ] = useSettings( 'spacing.blockGap' );
 	const hasBlockGapSupport = blockGapSupport !== null;
-	const css = fullLayoutType?.getLayoutStyle?.( {
+	return fullLayoutType?.getLayoutStyle?.( {
 		blockName,
 		selector,
 		layout,
 		style,
 		hasBlockGapSupport,
 	} );
-	return css;
 }
 
 function LayoutPanelPure( {
@@ -144,8 +143,6 @@ function LayoutPanelPure( {
 	const settings = useBlockSettings( blockName );
 	// Block settings come from theme.json under settings.[blockName].
 	const { layout: layoutSettings } = settings;
-	// Layout comes from block attributes.
-	const [ defaultThemeLayout ] = useSettings( 'layout' );
 	const { themeSupportsLayout } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return {
@@ -180,11 +177,9 @@ function LayoutPanelPure( {
 	}
 
 	// Only show the inherit toggle if it's supported,
-	// a default theme layout is set (e.g. one that provides `contentSize` and/or `wideSize` values),
 	// and either the default / flow or the constrained layout type is in use, as the toggle switches from one to the other.
 	const showInheritToggle = !! (
 		allowInheriting &&
-		!! defaultThemeLayout &&
 		( ! layout?.type ||
 			layout?.type === 'default' ||
 			layout?.type === 'constrained' ||


### PR DESCRIPTION



<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I'm not really sure if this is right, but this commit will show the layout inherit toggle regardless of whether there is a `defaultThemeLayout` value.


## Why?
Presently, an empty object will pass the test anyway, so perhaps it's okay to remove the check? 

## How?
Deleting the `defaultThemeLayout` check that's a condition for the toggle to display.

![2024-03-05 12 04 34](https://github.com/WordPress/gutenberg/assets/6458278/f3c2fc3d-e36e-4290-9ffa-51cd716e9ac3)


## Testing Instructions

In a block theme, remove the "layout" settings object:

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true
	}
}
```

Add a group block with "default" layout:

```html
<!-- wp:group {"layout":{"type":"default"}} -->
<div class="wp-block-group">
<!-- wp:paragraph -->
<p>Positive growth.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

The inherit toggle should be present.


## Screenshots or screencast <!-- if applicable -->



| Before  | After |
| ------------- | ------------- |
| <img width="400" alt="Screenshot 2024-03-05 at 12 00 15 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/3e58e4c6-cf66-45ec-8beb-e7bea01dfa62">  | <img width="400" alt="Screenshot 2024-03-05 at 12 00 30 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/91a68518-cb88-44a1-a6ad-94a25022f108">  |

