### PR TITLE
Docs: Fix typo in Tutorial

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -373,8 +373,7 @@ Save the file, and you can now move on to the Editor.
 
 Open the `edit.js` file. You will need to accomplish two tasks.
 
-Add a user interface that allows the user to enter a starting year, toggle the functionality on or off, and store these settings as attributes
-Update the block to display the correct content depending on the defined attributes
+Add a user interface that allows the user to enter a starting year, toggle the functionality on or off, and store these settings as attributes. Update the block to display the correct content depending on the defined attributes.
 
 #### Adding the user interface
 

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -373,7 +373,8 @@ Save the file, and you can now move on to the Editor.
 
 Open the `edit.js` file. You will need to accomplish two tasks.
 
-Add a user interface that allows the user to enter a starting year, toggle the functionality on or off, and store these settings as attributes. Update the block to display the correct content depending on the defined attributes.
+- Add a user interface that allows the user to enter a starting year, toggle the functionality on or off, and store these settings as attributes.
+- Update the block to display the correct content depending on the defined attributes.
 
 #### Adding the user interface
 


### PR DESCRIPTION
I fix the small mistake in [Updating edit.js](https://developer.wordpress.org/block-editor/getting-started/tutorial/#updating-edit-js-2)
