### PR TITLE
Fix issue with appender jumping when creating a new pattern.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -29,12 +29,15 @@
 	// In "constrained" layout containers, the first and last paragraphs have their margins zeroed out.
 	// In the case of this appender, it needs to apply those same rules to avoid layout shifts.
 	// Such shifts happen when the bottom margin of the Title block has been set to less than the default 1em margin of paragraphs.
-	:where(body .is-layout-constrained) & {
+	:where(body .is-layout-constrained) &,
+	:where(.wp-site-blocks) & {
 		> :first-child:first-child {
 			margin-block-start: 0;
+			margin-block-end: 0;
 		}
 
-		// Since this particular appender will only ever appear on an entirely empty document, we don't account for last-child.
+		// Since this appender will only ever appear on an entirely empty document, we don't account for last-child.
+		// This is also because it will never be the last child, the block inserter that sits in this appender is the last child.
 	}
 
 	// Dropzone.


### PR DESCRIPTION
## What?

Related to https://github.com/WordPress/gutenberg/pull/59550. Fix issue where the empty appender jumps when going from the appender button to the paragraph block.

## How?

Margin rules exist to zero out the top margin of the first paragraph block, and the bottom margin of the last. Those rules do not exist for the incarnation of the _paragraph appender_, when used in the "create new pattern" flow. This appender is a button component that exists in the canvas as a prompt to start typing, so that the document can be empty until you actually click it and a paragraph block is added.

This PR fixes it by adding the rules needed. Before, a shift:

![before](https://github.com/WordPress/gutenberg/assets/1204802/cd0919b4-6f55-40cf-a4da-8c7c0f334d1a)

After, no shift:

![after](https://github.com/WordPress/gutenberg/assets/1204802/6fddd54f-e3ce-4973-99d3-b4f1ad100780)


## Testing Instructions

Test empty documents across the editor. New pages, new posts, new patterns, anything that has the empty appender. There should be no layout shift when going from the truly empty state of the document, to the one where an empty paragraph block has been inserted.