### PR TITLE
Global Styles: Use the preivew iframe to preview typography for consistency

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/preview-styles.js
@@ -13,7 +13,7 @@ import {
  */
 import { unlock } from '../../lock-unlock';
 import { useStylesPreviewColors } from './hooks';
-import PreviewTypography from './typography-example';
+import TypographyExample from './typography-example';
 import HighlightedColors from './highlighted-colors';
 import PreviewIframe from './preview-iframe';
 
@@ -89,7 +89,7 @@ const PreviewStyles = ( { label, isFocused, withHoverView, variation } ) => {
 							overflow: 'hidden',
 						} }
 					>
-						<PreviewTypography
+						<TypographyExample
 							fontSize={ 65 * ratio }
 							variation={ variation }
 						/>

--- a/packages/edit-site/src/components/global-styles/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/preview-styles.js
@@ -13,7 +13,7 @@ import {
  */
 import { unlock } from '../../lock-unlock';
 import { useStylesPreviewColors } from './hooks';
-import PreviewTypography from './preview-typography';
+import PreviewTypography from './typography-example';
 import HighlightedColors from './highlighted-colors';
 import PreviewIframe from './preview-iframe';
 

--- a/packages/edit-site/src/components/global-styles/typography-example.js
+++ b/packages/edit-site/src/components/global-styles/typography-example.js
@@ -37,7 +37,6 @@ export default function PreviewTypography( { fontSize, variation } ) {
 
 	return (
 		<motion.div
-			className="edit-site-global-styles_preview-typography"
 			animate={ {
 				scale: 1,
 				opacity: 1,
@@ -49,6 +48,11 @@ export default function PreviewTypography( { fontSize, variation } ) {
 			transition={ {
 				delay: 0.3,
 				type: 'tween',
+			} }
+			style={ {
+				fontSize: '22px',
+				lineHeight: '44px',
+				textAlign: 'center',
 			} }
 		>
 			<span style={ headingPreviewStyle }>

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -36,9 +36,3 @@
 		outline-offset: 0;
 	}
 }
-
-.edit-site-global-styles_preview-typography {
-	font-size: 22px;
-	line-height: 44px;
-	text-align: center;
-}

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -15,7 +15,8 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { mergeBaseAndUserConfigs } from '../global-styles-provider';
 import { unlock } from '../../../lock-unlock';
 import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
-import PreviewTypography from '../preview-typography';
+import PreviewTypography from '../typography-example';
+import PreviewIframe from '../preview-iframe';
 import Subtitle from '../subtitle';
 import { getFontFamilies } from '../utils';
 import Variation from './variation';
@@ -71,10 +72,18 @@ export default function TypographyVariations() {
 				{ typographyVariations && typographyVariations.length
 					? uniqueTypographyVariations.map( ( variation, index ) => (
 							<Variation key={ index } variation={ variation }>
-								{ () => (
-									<PreviewTypography
-										variation={ variation }
-									/>
+								{ ( isFocused ) => (
+									<PreviewIframe
+										label={ variation?.title }
+										isFocused={ isFocused }
+									>
+										{ ( { key } ) => (
+											<PreviewTypography
+												key={ key }
+												variation={ variation }
+											/>
+										) }
+									</PreviewIframe>
 								) }
 							</Variation>
 					  ) )

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -15,7 +15,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { mergeBaseAndUserConfigs } from '../global-styles-provider';
 import { unlock } from '../../../lock-unlock';
 import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
-import PreviewTypography from '../typography-example';
+import TypographyExample from '../typography-example';
 import PreviewIframe from '../preview-iframe';
 import Subtitle from '../subtitle';
 import { getFontFamilies } from '../utils';
@@ -78,7 +78,7 @@ export default function TypographyVariations() {
 										isFocused={ isFocused }
 									>
 										{ ( { key } ) => (
-											<PreviewTypography
+											<TypographyExample
 												key={ key }
 												variation={ variation }
 											/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a followup to https://github.com/WordPress/gutenberg/pull/59498. It implements the Typography presets preview inside the preview iframe.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Since the other previews use the iframe, this makes the experience and code consistent across all previews. Enhancements added to one will benefit all previews.

## How?
- Wrap the typography variation previews in a `PreviewIframe` component
- Rename the PreviewTypography component to `TypographyExample`

## Testing Instructions
1. Open Global Styles
2. Open Browse Styles
3. Check you still see the Aa typography example
4. Open Typography
5. Check you still see the Aa typography example

## Screenshots or screencast <!-- if applicable -->
<img width="298" alt="Screenshot 2024-03-05 at 10 37 36" src="https://github.com/WordPress/gutenberg/assets/275961/35bf8ac7-a968-4e00-a392-1a8bc38f6f4a">

