### PR TITLE
Global Styles: Fetch the variations inside the component

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -12,7 +12,6 @@ import ScreenHeader from './header';
 import Palette from './palette';
 import { unlock } from '../../lock-unlock';
 import ColorVariations from './variations/variations-color';
-import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
 const {
 	useGlobalStyle,
@@ -31,12 +30,6 @@ function ScreenColors() {
 	const [ rawSettings ] = useGlobalSetting( '' );
 	const settings = useSettingsForBlockElement( rawSettings );
 
-	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
-		property: 'color',
-		filter: ( variation ) =>
-			variation?.settings?.color &&
-			Object.keys( variation?.settings?.color ).length,
-	} );
 	return (
 		<>
 			<ScreenHeader
@@ -47,12 +40,8 @@ function ScreenColors() {
 			/>
 			<div className="edit-site-global-styles-screen-colors">
 				<VStack spacing={ 3 }>
-					{ !! colorVariations?.length && (
-						<ColorVariations variations={ colorVariations } />
-					) }
-
+					<ColorVariations />
 					<Palette />
-
 					<StylesColorPanel
 						inheritedValue={ inheritedStyle }
 						value={ style }

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -13,7 +13,6 @@ import TypographyElements from './typography-elements';
 import TypographyVariations from './variations/variations-typography';
 import FontFamilies from './font-families';
 import ScreenHeader from './header';
-import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
 function ScreenTypography() {
 	const fontLibraryEnabled = useSelect(
@@ -21,14 +20,6 @@ function ScreenTypography() {
 			select( editorStore ).getEditorSettings().fontLibraryEnabled,
 		[]
 	);
-	const typographyVariations =
-		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			property: 'typography',
-			filter: ( variation ) =>
-				variation?.settings?.typography?.fontFamilies &&
-				Object.keys( variation?.settings?.typography?.fontFamilies )
-					.length,
-		} );
 
 	return (
 		<>
@@ -40,9 +31,7 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen-typography">
 				<VStack spacing={ 6 }>
-					{ !! typographyVariations?.length && (
-						<TypographyVariations />
-					) }
+					<TypographyVariations />
 					{ ! window.__experimentalDisableFontLibrary && (
 						<VStack spacing={ 3 }>
 							{ fontLibraryEnabled && <FontFamilies /> }

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -13,13 +13,25 @@ import { __ } from '@wordpress/i18n';
 import Subtitle from '../subtitle';
 import Variation from './variation';
 import StylesPreviewColors from '../preview-colors';
+import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
-export default function ColorVariations( { variations } ) {
+export default function ColorVariations() {
+	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
+		property: 'color',
+		filter: ( variation ) =>
+			variation?.settings?.color &&
+			Object.keys( variation?.settings?.color ).length,
+	} );
+
+	if ( ! colorVariations.length ) {
+		return null;
+	}
+
 	return (
 		<VStack spacing={ 3 }>
 			<Subtitle level={ 3 }>{ __( 'Presets' ) }</Subtitle>
 			<Grid columns={ 3 }>
-				{ variations.map( ( variation, index ) => (
+				{ colorVariations.map( ( variation, index ) => (
 					<Variation key={ index } variation={ variation }>
 						{ () => <StylesPreviewColors /> }
 					</Variation>

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -23,7 +23,7 @@ export default function ColorVariations() {
 			Object.keys( variation?.settings?.color ).length,
 	} );
 
-	if ( ! colorVariations.length ) {
+	if ( ! colorVariations?.length ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -35,6 +35,10 @@ export default function TypographyVariations() {
 
 	const { base } = useContext( GlobalStylesContext );
 
+	if ( ! typographyVariations.length ) {
+		return null;
+	}
+
 	/*
 	 * Filter duplicate variations based on the font families used in the variation.
 	 */

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -35,7 +35,7 @@ export default function TypographyVariations() {
 
 	const { base } = useContext( GlobalStylesContext );
 
-	if ( ! typographyVariations.length ) {
+	if ( ! typographyVariations?.length ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is just a simple refactor - it moves the code that fetches the variations inside the component itself.

## Why?
This makes it easier to reuse the component elsewhere as it is more self contained.

## How?
Fetch variations inside the component and return null if they can't be found.

## Testing Instructions
1. Open Global Styles > Browse styles and check you can see style previews
2. 1. Open Global Styles > Colors and check you can see color presets
3. Open Global Styles > Typography and check you can see typography presets

## Screenshots or screencast <!-- if applicable -->
N/A