### PR TITLE
Global Styles: Remove filter for same number of settings

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -16,9 +16,6 @@ import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hook
 export default function ColorVariations() {
 	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		property: 'color',
-		filter: ( variation ) =>
-			variation?.settings?.color &&
-			Object.keys( variation?.settings?.color ).length,
 	} );
 
 	if ( ! colorVariations?.length ) {

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -25,10 +25,6 @@ export default function TypographyVariations() {
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
 			property: 'typography',
-			filter: ( variation ) =>
-				variation?.settings?.typography?.fontFamilies &&
-				Object.keys( variation?.settings?.typography?.fontFamilies )
-					.length,
 		} );
 
 	const { base } = useContext( GlobalStylesContext );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When we show presets for typography and colors in Global Styles, we filter out variations where there are no color or typography changes in the settings. This removes that filter.

## Why?
I think there are legitimate reasons why a style variation wouldn't change the settings, but would still change other aspects of the styles. For example in TT3 this filter prevents and typography presets showing, because all the fonts are defined in the parent variation.

## How?
Just removes the filter.

## Testing Instructions
1. Switch to TT3
2. Open Global Styles > Typography
3. Confirm that you see Typography presets

## Screenshots or screencast <!-- if applicable -->
<img width="283" alt="Screenshot 2024-03-05 at 11 18 55" src="https://github.com/WordPress/gutenberg/assets/275961/e7c6a8cd-8674-4c21-b84d-cbda983cfc19">

