### PR TITLE
Font Library: Simplify pagination and use chevron icons on font collection page

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -29,8 +29,6 @@ import {
 import { debounce } from '@wordpress/compose';
 import { sprintf, __, _x } from '@wordpress/i18n';
 import {
-	search,
-	closeSmall,
 	moreVertical,
 	chevronLeft,
 	chevronLeftSmall,

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -34,6 +34,8 @@ import {
 	closeSmall,
 	moreVertical,
 	chevronLeft,
+	chevronLeftSmall,
+	chevronRightSmall,
 } from '@wordpress/icons';
 
 /**
@@ -432,23 +434,13 @@ function FontCollection( { slug } ) {
 					className="font-library-modal__tabpanel-layout__footer"
 				>
 					<Button
-						label={ __( 'First page' ) }
-						size="compact"
-						onClick={ () => setPage( 1 ) }
-						disabled={ page === 1 }
-						__experimentalIsFocusable
-					>
-						<span>«</span>
-					</Button>
-					<Button
 						label={ __( 'Previous page' ) }
 						size="compact"
 						onClick={ () => setPage( page - 1 ) }
 						disabled={ page === 1 }
 						__experimentalIsFocusable
-					>
-						<span>‹</span>
-					</Button>
+						icon={ chevronLeftSmall }
+					/>
 					<HStack
 						justify="flex-start"
 						expanded={ false }
@@ -492,18 +484,8 @@ function FontCollection( { slug } ) {
 						onClick={ () => setPage( page + 1 ) }
 						disabled={ page === totalPages }
 						__experimentalIsFocusable
-					>
-						<span>›</span>
-					</Button>
-					<Button
-						label={ __( 'Last page' ) }
-						size="compact"
-						onClick={ () => setPage( totalPages ) }
-						disabled={ page === totalPages }
-						__experimentalIsFocusable
-					>
-						<span>»</span>
-					</Button>
+						icon={ chevronRightSmall }
+					/>
 				</Flex>
 			) }
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This simplifies the pagination of the font collection tab by removing the first and last page arrows, and uses the WordPress chevron icons in place of the current unicode characters.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's best practice to use icons from the WordPress icons library where possible. After speaking with @jasmussen, the previous/next arrows should provide enough navigation for this component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the Font Library modal
2. Go to the Install Fonts tab
3. Make sure that the pagination still works correctly with both a keyboard and a mouse

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| ---- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/1645628/521946a0-27e2-418c-ae0a-a955cc4b4260) | ![image](https://github.com/WordPress/gutenberg/assets/1645628/e9947658-4ea0-485c-a3d9-7bc466ab661d) |
