### PR TITLE
Global Styles: Try color and typography presets in Site View

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview-iframe.js
+++ b/packages/edit-site/src/components/global-styles/preview-iframe.js
@@ -118,7 +118,6 @@ export default function PreviewIframe( {
 				<Iframe
 					className="edit-site-global-styles-preview__iframe"
 					style={ {
-						width: '100%',
 						height: normalizedHeight * ratio,
 					} }
 					onMouseEnter={ () => setIsHovered( true ) }

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -39,7 +39,7 @@ function ScreenColors() {
 				) }
 			/>
 			<div className="edit-site-global-styles-screen-colors">
-				<VStack spacing={ 3 }>
+				<VStack spacing={ 6 }>
 					<ColorVariations />
 					<Palette />
 					<StylesColorPanel

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -7,8 +7,10 @@
 }
 
 .edit-site-global-styles-preview__iframe {
-	max-width: 100%;
+	border-radius: $radius-block-ui;
 	display: block;
+	max-width: 100%;
+	width: 100%;
 }
 
 .edit-site-typography-preview {
@@ -165,3 +167,4 @@
 .edit-site-global-styles-sidebar__panel .block-editor-block-icon svg {
 	fill: currentColor;
 }
+

--- a/packages/edit-site/src/components/global-styles/typography-example.js
+++ b/packages/edit-site/src/components/global-styles/typography-example.js
@@ -50,8 +50,6 @@ export default function PreviewTypography( { fontSize, variation } ) {
 				type: 'tween',
 			} }
 			style={ {
-				fontSize: '22px',
-				lineHeight: '44px',
 				textAlign: 'center',
 			} }
 		>

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -18,6 +18,7 @@ import TypographyExample from '../typography-example';
 import PreviewIframe from '../preview-iframe';
 import { getFontFamilies } from '../utils';
 import Variation from './variation';
+import PreviewIframe from '../preview-iframe';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -1,65 +1,26 @@
 /**
  * WordPress dependencies
  */
-import { useContext } from '@wordpress/element';
 import {
 	__experimentalGrid as Grid,
 	__experimentalVStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
-import { mergeBaseAndUserConfigs } from '../global-styles-provider';
-import { unlock } from '../../../lock-unlock';
-import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { useUniqueTypographyVariations } from '../hooks';
 import TypographyExample from '../typography-example';
 import PreviewIframe from '../preview-iframe';
-import { getFontFamilies } from '../utils';
 import Variation from './variation';
 
-const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
-
 export default function TypographyVariations() {
-	const typographyVariations =
-		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			property: 'typography',
-		} );
-
-	const { base } = useContext( GlobalStylesContext );
+	const typographyVariations = useUniqueTypographyVariations();
 
 	if ( ! typographyVariations?.length ) {
 		return null;
 	}
-
-	/*
-	 * Filter duplicate variations based on the font families used in the variation.
-	 */
-	const uniqueTypographyVariations = typographyVariations?.length
-		? Object.values(
-				typographyVariations.reduce( ( acc, variation ) => {
-					const [ bodyFontFamily, headingFontFamily ] =
-						getFontFamilies(
-							mergeBaseAndUserConfigs( base, variation )
-						);
-					if (
-						headingFontFamily?.name &&
-						bodyFontFamily?.name &&
-						! acc[
-							`${ headingFontFamily?.name }:${ bodyFontFamily?.name }`
-						]
-					) {
-						acc[
-							`${ headingFontFamily?.name }:${ bodyFontFamily?.name }`
-						] = variation;
-					}
-
-					return acc;
-				}, {} )
-		  )
-		: [];
 
 	return (
 		<VStack spacing={ 3 }>
@@ -68,7 +29,7 @@ export default function TypographyVariations() {
 				className="edit-site-global-styles-style-variations-container"
 			>
 				{ typographyVariations && typographyVariations.length
-					? uniqueTypographyVariations.map( ( variation, index ) => (
+					? typographyVariations.map( ( variation, index ) => (
 							<Variation key={ index } variation={ variation }>
 								{ ( isFocused ) => (
 									<PreviewIframe

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -4,6 +4,7 @@
 import { useContext } from '@wordpress/element';
 import {
 	__experimentalGrid as Grid,
+	__experimentalVStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -18,7 +19,6 @@ import TypographyExample from '../typography-example';
 import PreviewIframe from '../preview-iframe';
 import { getFontFamilies } from '../utils';
 import Variation from './variation';
-import PreviewIframe from '../preview-iframe';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
@@ -75,11 +75,21 @@ export default function TypographyVariations() {
 										label={ variation?.title }
 										isFocused={ isFocused }
 									>
-										{ ( { key } ) => (
-											<TypographyExample
-												key={ key }
-												variation={ variation }
-											/>
+										{ ( { ratio, key } ) => (
+											<HStack
+												spacing={ 10 * ratio }
+												justify="center"
+												style={ {
+													height: '100%',
+													overflow: 'hidden',
+												} }
+											>
+												<TypographyExample
+													key={ key }
+													variation={ variation }
+													fontSize={ 85 * ratio }
+												/>
+											</HStack>
 										) }
 									</PreviewIframe>
 								) }

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -77,6 +77,7 @@ export default function TypographyVariations() {
 									>
 										{ ( { ratio, key } ) => (
 											<HStack
+												key={ key }
 												spacing={ 10 * ratio }
 												justify="center"
 												style={ {
@@ -85,7 +86,6 @@ export default function TypographyVariations() {
 												} }
 											>
 												<TypographyExample
-													key={ key }
 													variation={ variation }
 													fontSize={ 85 * ratio }
 												/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -5,7 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { edit, seen } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { __experimentalNavigatorButton as NavigatorButton } from '@wordpress/components';
+import {
+	__experimentalNavigatorButton as NavigatorButton,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { useCallback } from '@wordpress/element';
@@ -24,6 +27,8 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 import StyleBook from '../style-book';
 import useGlobalStylesRevisions from '../global-styles/screen-revisions/use-global-styles-revisions';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
+import ColorVariations from '../global-styles/variations/variations-color';
+import TypographyVariations from '../global-styles/variations/variations-typography';
 
 const noop = () => {};
 
@@ -80,7 +85,33 @@ function SidebarNavigationScreenGlobalStylesContent() {
 			onChange={ noop }
 			onInput={ noop }
 		>
-			<StyleVariationsContainer />
+			<VStack spacing={ 10 }>
+				<StyleVariationsContainer />
+				<div className="edit-site-global-styles-style-variations-container">
+					<h2
+						style={ {
+							textTransform: 'uppercase',
+							color: 'white',
+							fontWeight: '400',
+						} }
+					>
+						{ __( 'Colors' ) }
+					</h2>
+					<ColorVariations />
+				</div>
+				<div className="edit-site-global-styles-style-variations-container">
+					<h2
+						style={ {
+							textTransform: 'uppercase',
+							color: 'white',
+							fontWeight: '400',
+						} }
+					>
+						{ __( 'Typography' ) }
+					</h2>
+					<TypographyVariations />
+				</div>
+			</VStack>
 		</BlockEditorProvider>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -85,30 +85,21 @@ function SidebarNavigationScreenGlobalStylesContent() {
 			onChange={ noop }
 			onInput={ noop }
 		>
-			<VStack spacing={ 10 }>
+			<VStack
+				spacing={ 10 }
+				className="edit-site-global-styles-variation-container"
+			>
 				<StyleVariationsContainer />
-				<div className="edit-site-global-styles-style-variations-container">
-					<h2
-						style={ {
-							textTransform: 'uppercase',
-							color: 'white',
-							fontWeight: '400',
-						} }
-					>
+				<div>
+					<h3 className="edit-site-global-styles-variation-title">
 						{ __( 'Colors' ) }
-					</h2>
+					</h3>
 					<ColorVariations />
 				</div>
-				<div className="edit-site-global-styles-style-variations-container">
-					<h2
-						style={ {
-							textTransform: 'uppercase',
-							color: 'white',
-							fontWeight: '400',
-						} }
-					>
+				<div>
+					<h3 className="edit-site-global-styles-variation-title">
 						{ __( 'Typography' ) }
-					</h2>
+					</h3>
 					<TypographyVariations />
 				</div>
 			</VStack>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -77,11 +77,14 @@ function SidebarNavigationScreenGlobalStylesContent() {
 
 	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		property: 'color',
+		filter: ( variation ) => !! variation?.settings?.color,
 	} );
 
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
 			property: 'typography',
+			filter: ( variation ) =>
+				!! variation?.settings?.typography?.fontFamilies,
 		} );
 
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are
@@ -100,7 +103,7 @@ function SidebarNavigationScreenGlobalStylesContent() {
 				className="edit-site-global-styles-variation-container"
 			>
 				<StyleVariationsContainer />
-				{ colorVariations && (
+				{ colorVariations?.length && (
 					<div>
 						<h3 className="edit-site-global-styles-variation-title">
 							{ __( 'Colors' ) }
@@ -108,7 +111,7 @@ function SidebarNavigationScreenGlobalStylesContent() {
 						<ColorVariations />
 					</div>
 				) }
-				{ typographyVariations && (
+				{ typographyVariations?.length && (
 					<div>
 						<h3 className="edit-site-global-styles-variation-title">
 							{ __( 'Typography' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -29,6 +29,7 @@ import useGlobalStylesRevisions from '../global-styles/screen-revisions/use-glob
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
 import ColorVariations from '../global-styles/variations/variations-color';
 import TypographyVariations from '../global-styles/variations/variations-typography';
+import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
 const noop = () => {};
 
@@ -74,6 +75,15 @@ function SidebarNavigationScreenGlobalStylesContent() {
 		};
 	}, [] );
 
+	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
+		property: 'color',
+	} );
+
+	const typographyVariations =
+		useCurrentMergeThemeStyleVariationsWithUserConfig( {
+			property: 'typography',
+		} );
+
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are
 	// loaded. This is necessary because the Iframe component waits until
 	// the block editor store's `__internalIsInitialized` is true before
@@ -90,18 +100,22 @@ function SidebarNavigationScreenGlobalStylesContent() {
 				className="edit-site-global-styles-variation-container"
 			>
 				<StyleVariationsContainer />
-				<div>
-					<h3 className="edit-site-global-styles-variation-title">
-						{ __( 'Colors' ) }
-					</h3>
-					<ColorVariations />
-				</div>
-				<div>
-					<h3 className="edit-site-global-styles-variation-title">
-						{ __( 'Typography' ) }
-					</h3>
-					<TypographyVariations />
-				</div>
+				{ colorVariations && (
+					<div>
+						<h3 className="edit-site-global-styles-variation-title">
+							{ __( 'Colors' ) }
+						</h3>
+						<ColorVariations />
+					</div>
+				) }
+				{ typographyVariations && (
+					<div>
+						<h3 className="edit-site-global-styles-variation-title">
+							{ __( 'Typography' ) }
+						</h3>
+						<TypographyVariations />
+					</div>
+				) }
 			</VStack>
 		</BlockEditorProvider>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -30,6 +30,7 @@ import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-d
 import ColorVariations from '../global-styles/variations/variations-color';
 import TypographyVariations from '../global-styles/variations/variations-typography';
 import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { useUniqueTypographyVariations } from '../global-styles/hooks';
 
 const noop = () => {};
 
@@ -79,10 +80,7 @@ function SidebarNavigationScreenGlobalStylesContent() {
 		property: 'color',
 	} );
 
-	const typographyVariations =
-		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			property: 'typography',
-		} );
+	const typographyVariations = useUniqueTypographyVariations();
 
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are
 	// loaded. This is necessary because the Iframe component waits until

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -77,14 +77,11 @@ function SidebarNavigationScreenGlobalStylesContent() {
 
 	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		property: 'color',
-		filter: ( variation ) => !! variation?.settings?.color,
 	} );
 
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
 			property: 'typography',
-			filter: ( variation ) =>
-				!! variation?.settings?.typography?.fontFamilies,
 		} );
 
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -77,7 +77,7 @@
 	flex-shrink: 0;
 }
 
-.edit-site-sidebar-navigation-screen__content .edit-site-global-styles-style-variations-container {
+.edit-site-sidebar-navigation-screen__content .edit-site-global-styles-variation-container {
 	@include break-medium() {
 		// Safari does not currently support `scrollbar-gutter: stable`, so at
 		// particular viewport sizes it's possible for previews to render prior to a
@@ -90,7 +90,16 @@
 		// See: https://github.com/WordPress/gutenberg/issues/55112
 		max-width: 292px;
 	}
+}
 
+.edit-site-global-styles-variation-title {
+	color: $gray-300;
+	font-size: 11px;
+	text-transform: uppercase;
+	font-weight: 500;
+}
+
+.edit-site-sidebar-navigation-screen__content .edit-site-global-styles-style-variations-container {
 	.edit-site-global-styles-variations_item-preview {
 		box-shadow: 0 0 0 $border-width $gray-900;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds color and typography presets to the Site View of the Site Editor.

## Why?
These are top level settings that should be easy to change 

## How?
Just adding the components to the top level of Styles in Site View.

## Testing Instructions
1. Open the Site Editor
2. Go to Styles
3. Change the colors and typography presets
4. Check that the site updates as expected

## Screenshots or screencast
<img width="1011" alt="Screenshot 2024-03-07 at 13 37 35" src="https://github.com/WordPress/gutenberg/assets/275961/b1770ea7-7ae0-40ef-ba91-2649c2610793">



Also test the mobile view:
<img width="701" alt="Screenshot 2024-03-07 at 13 38 00" src="https://github.com/WordPress/gutenberg/assets/275961/eaa58210-59bc-42b3-a837-bf0d7a76d673">
<img width="701" alt="Screenshot 2024-03-07 at 13 37 52" src="https://github.com/WordPress/gutenberg/assets/275961/ec1069d5-b77b-47ba-a0f5-983548aa9c40">
