### PR TITLE
theme.json schema: fix `styles.background` definition

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -204,19 +204,6 @@ Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-
 ## Styles
 
 
-### background
-
-Background styles
-
-| Property  | Type   |  Props  |
-| ---       | ---    |---   |
-| backgroundImage | string, object |  |
-| backgroundPosition | string, object |  |
-| backgroundRepeat | string, object |  |
-| backgroundSize | string, object |  |
-
----
-
 ### border
 
 Border styles.

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1110,74 +1110,6 @@
 		"stylesProperties": {
 			"type": "object",
 			"properties": {
-				"background": {
-					"description": "Background styles",
-					"type": "object",
-					"properties": {
-						"backgroundImage": {
-							"description": "Sets the `background-image` CSS property.",
-							"oneOf": [
-								{
-									"description": "A valid CSS value for the background-image property.",
-									"type": "string"
-								},
-								{
-									"type": "object",
-									"properties": {
-										"source": {
-											"description": "The origin of the image. 'file' denotes that the 'url' is a path to an image or other file.",
-											"type": "string",
-											"enum": [ "file" ],
-											"default": "file"
-										},
-										"url": {
-											"description": "A URL to an image file.",
-											"type": "string"
-										}
-									},
-									"additionalProperties": false
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						},
-						"backgroundPosition": {
-							"description": "Sets the `background-position` CSS property.",
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						},
-						"backgroundRepeat": {
-							"description": "Sets the `background-repeat` CSS property.",
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						},
-						"backgroundSize": {
-							"description": "Sets the `background-size` CSS property.",
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						}
-					},
-					"additionalProperties": false
-				},
 				"border": {
 					"description": "Border styles.",
 					"type": "object",
@@ -2365,6 +2297,74 @@
 						"blocks": {
 							"description": "Styles defined on a per-block basis using the block's selector.",
 							"$ref": "#/definitions/stylesBlocksPropertiesComplete"
+						},
+						"background": {
+							"description": "Background styles.",
+							"type": "object",
+							"properties": {
+								"backgroundImage": {
+									"description": "Sets the `background-image` CSS property.",
+									"oneOf": [
+										{
+											"description": "A valid CSS value for the background-image property.",
+											"type": "string"
+										},
+										{
+											"type": "object",
+											"properties": {
+												"source": {
+													"description": "The origin of the image. 'file' denotes that the 'url' is a path to an image or other file.",
+													"type": "string",
+													"enum": [ "file" ],
+													"default": "file"
+												},
+												"url": {
+													"description": "A URL to an image file.",
+													"type": "string"
+												}
+											},
+											"additionalProperties": false
+										},
+										{
+											"$ref": "#/definitions/refComplete"
+										}
+									]
+								},
+								"backgroundPosition": {
+									"description": "Sets the `background-position` CSS property.",
+									"oneOf": [
+										{
+											"type": "string"
+										},
+										{
+											"$ref": "#/definitions/refComplete"
+										}
+									]
+								},
+								"backgroundRepeat": {
+									"description": "Sets the `background-repeat` CSS property.",
+									"oneOf": [
+										{
+											"type": "string"
+										},
+										{
+											"$ref": "#/definitions/refComplete"
+										}
+									]
+								},
+								"backgroundSize": {
+									"description": "Sets the `background-size` CSS property.",
+									"oneOf": [
+										{
+											"type": "string"
+										},
+										{
+											"$ref": "#/definitions/refComplete"
+										}
+									]
+								}
+							},
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
Follow-up #59354

## What?

This PR fixes the following two issues regarding the `background` property, which can only be defined at the top level of the `styles` property.

Considered a disallowed property:

![image](https://github.com/WordPress/gutenberg/assets/54422211/62e10e67-afb8-4076-a011-f8047552603a)

Can be unintentionally defined at block/element level:

![image](https://github.com/WordPress/gutenberg/assets/54422211/57972599-d68e-41c2-b4ea-66b767f926f5)

## Why?

The `background` property is defined as a subproperty of `stylesProperties`. However, the `stylesProperties` is also used at the block/element level.

## How?

Moved the `background` property definition directly under the `styles` property.

## Testing Instructions

Create a JSON file like the one below locally and make sure that the `background` property is only allowed at the top level.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/fix/theme-json-schema-root-background/schemas/json/theme.json",
	"version": 2,
	"styles": {
	}
}
```

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/da4ed94c-12b6-4ea5-b7f2-0f8b75aa5aab

