### PR TITLE
WP-Scripts:  Use other packagers

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+-   Add `--packager` flag to the `packages-update` command to allow specifying a custom packager when updating npm packages ([#](N/A)
 
 ## 27.3.0 (2024-02-21)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -310,6 +310,7 @@ _Example:_
 This script provides the following custom options:
 
 -   `--dist-tag` – allows specifying a custom dist-tag when updating npm packages. Defaults to `latest`. This is especially useful when using [`@wordpress/dependency-extraction-webpack-plugin`](https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin). It lets installing the npm dependencies at versions used by the given WordPress major version for local testing, etc. Example: `wp-scripts packages-update --dist-tag=wp-6.0`.
+-   `--packager` – allows specifying a custom packager when updating npm packages. Defaults to `npm`. This is especially useful when you're not using npm.
 
 #### Advanced information
 

--- a/packages/scripts/scripts/packages-update.js
+++ b/packages/scripts/scripts/packages-update.js
@@ -50,13 +50,18 @@ function getPackageVersionDiff( initialPackageJSON, finalPackageJSON ) {
 
 function updatePackagesToLatestVersion( packages ) {
 	const distTag = getArgFromCLI( '--dist-tag' ) || 'latest';
+	const packager = getArgFromCLI( '--packager' ) || 'npm';
 
 	const packagesWithLatest = packages.map(
 		( packageName ) => `${ packageName }@${ distTag }`
 	);
-	return spawn.sync( 'npm', [ 'install', ...packagesWithLatest, '--save' ], {
-		stdio: 'inherit',
-	} );
+	return spawn.sync(
+		packager,
+		[ 'install', ...packagesWithLatest, '--save' ],
+		{
+			stdio: 'inherit',
+		}
+	);
 }
 
 function outputPackageDiffReport( packageDiff ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Trying to use this script w/ a different package manager.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Virtual node_module storage is all the rage.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Going to set up a pnpm gutenberg plugin when I have a chance, add some old packages and see if this works.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Co-authored-by: margolisj <margolisj@git.wordpress.org>