### PR TITLE
Block Bindings: Fix console error when selecting a bound block

### DIFF
--- a/packages/icons/src/library/connection.js
+++ b/packages/icons/src/library/connection.js
@@ -9,7 +9,7 @@ const connection = (
 		height="24"
 		viewBox="0 0 24 24"
 		xmlns="http://www.w3.org/2000/svg"
-		fill-rule="evenodd"
+		fillRule="evenodd"
 	>
 		<Path d="M5 19L8 16L5 19Z" />
 		<Path d="M16 8L19 5L16 8Z" />


### PR DESCRIPTION
## What?
[This pull request](https://github.com/WordPress/gutenberg/pull/59185#issuecomment-1973117561) introduced a bug that throws a console error when a user select a block that is bound.

In this pull request, I'm fixing it but using the appropriate property.

## Why?
We shouldn't have errors.

## How?
Using the proper property in the React icon.

## Testing Instructions
1. Insert a bound block into a post.
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"custom_field"}}}}} -->
<p>VALUE</p>
<!-- /wp:paragraph -->
```
2. Select it and check there is no error in the console.