### PR TITLE
Fix double click to edit text of link

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -59,7 +59,10 @@ function Edit( {
 				return;
 			}
 
-			setAddingLink( true );
+			// If the link is clicked a second time the Link UI should close.
+			setAddingLink( ( currentValue ) => {
+				return ! currentValue;
+			} );
 		}
 
 		editableContentElement.addEventListener( 'click', handleClick );
@@ -127,7 +130,14 @@ function Edit( {
 	// 4. Press Escape
 	// 5. Focus should be on the Options button
 	function onFocusOutside() {
-		setAddingLink( false );
+		// If the focus outside is triggered but the link is still active,
+		// then user has clicked on the link within the rich text again.
+		// This toggle behaviour is handled in an effect above and so
+		// state is not updated here.
+		if ( ! isActive ) {
+			setAddingLink( false );
+		}
+
 		setOpenedBy( null );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/59525

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/54d99151-76cc-464f-8c33-35714a7f3b7d

