### PR TITLE
Update: Dataviews do not use strings on isCustom props passed down.

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
@@ -216,7 +216,7 @@ export default function CustomDataViewsList( { type, activeView, isCustom } ) {
 							key={ customViewRecord.id }
 							dataviewId={ customViewRecord.id }
 							isActive={
-								isCustom === 'true' &&
+								isCustom &&
 								Number( activeView ) === customViewRecord.id
 							}
 						/>

--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -38,8 +38,8 @@ export default function DataViewItem( {
 	const linkInfo = useLink( {
 		path,
 		layout,
-		activeView: isCustom === 'true' ? customViewId : slug,
-		isCustom,
+		activeView: isCustom ? customViewId : slug,
+		isCustom: isCustom ? 'true' : 'false',
 	} );
 	return (
 		<HStack

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -25,6 +25,7 @@ export default function DataViewsSidebarContent() {
 	if ( ! path || ! PATH_TO_TYPE[ path ] ) {
 		return null;
 	}
+	const isCustomBoolean = isCustom === 'true';
 	const type = PATH_TO_TYPE[ path ];
 
 	return (
@@ -39,10 +40,10 @@ export default function DataViewsSidebarContent() {
 							icon={ dataview.icon }
 							type={ dataview.view.type }
 							isActive={
-								isCustom === 'false' &&
+								! isCustomBoolean &&
 								dataview.slug === activeView
 							}
-							isCustom="false"
+							isCustom={ false }
 						/>
 					);
 				} ) }
@@ -51,7 +52,7 @@ export default function DataViewsSidebarContent() {
 				<CustomDataViewsList
 					activeView={ activeView }
 					type={ type }
-					isCustom="true"
+					isCustom
 				/>
 			) }
 		</>


### PR DESCRIPTION
Applies feedback from @mcsf at https://github.com/WordPress/gutenberg/pull/55773#pullrequestreview-1872718089. The feedback entailed ensuring that we don't pass down an 'isCustom' prop as a string. We now convert the variable to a boolean before passing it down to ensure that the type is consistent with its name.

## Testing Instructions:
I went to manage all pages and navigated between different views. I also created a new custom view and verified that everything worked as expected.
