### PR TITLE
[RNMobile] Image block: Support lightbox option in the link setting

### DIFF
--- a/packages/block-editor/src/components/image-link-destinations/index.native.js
+++ b/packages/block-editor/src/components/image-link-destinations/index.native.js
@@ -27,6 +27,7 @@ function LinkDestination( {
 	children,
 	isSelected,
 	label,
+	subLabel,
 	onPress,
 	value,
 	valueStyle,
@@ -44,6 +45,7 @@ function LinkDestination( {
 				! isSelected && styles.unselectedOptionIcon,
 			] ) }
 			label={ label }
+			subLabel={ subLabel }
 			leftAlign
 			onPress={ onPress }
 			value={ value }
@@ -64,6 +66,8 @@ function ImageLinkDestinationsScreen( props ) {
 		imageUrl,
 		attachmentPageUrl,
 		linkDestination,
+		showLightboxSetting,
+		lightboxEnabled,
 	} = route.params || {};
 
 	function goToLinkPicker() {
@@ -97,6 +101,14 @@ function ImageLinkDestinationsScreen( props ) {
 		} );
 	};
 
+	const onEnableLightbox = () => {
+		navigation.navigate( blockSettingsScreens.settings, {
+			inputValue: '',
+			text: '',
+			lightboxEnabled: true,
+		} );
+	};
+
 	return (
 		<>
 			<BottomSheet.NavBar>
@@ -107,7 +119,10 @@ function ImageLinkDestinationsScreen( props ) {
 			</BottomSheet.NavBar>
 			<PanelBody>
 				<LinkDestination
-					isSelected={ linkDestination === LINK_DESTINATION_NONE }
+					isSelected={
+						linkDestination === LINK_DESTINATION_NONE &&
+						( ! showLightboxSetting || ! lightboxEnabled )
+					}
 					label={ __( 'None' ) }
 					onPress={ setLinkDestination( LINK_DESTINATION_NONE ) }
 				/>
@@ -125,6 +140,16 @@ function ImageLinkDestinationsScreen( props ) {
 						onPress={ setLinkDestination(
 							LINK_DESTINATION_ATTACHMENT
 						) }
+					/>
+				) }
+				{ showLightboxSetting && (
+					<LinkDestination
+						isSelected={ lightboxEnabled }
+						label={ __( 'Expand on click' ) }
+						subLabel={ __(
+							'Scale the image with a lightbox effect'
+						) }
+						onPress={ onEnableLightbox }
 					/>
 				) }
 				<LinkDestination

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -12,7 +12,7 @@ import { useRoute } from '@react-navigation/native';
 /**
  * WordPress dependencies
  */
-import { Component, useEffect } from '@wordpress/element';
+import { Component, useCallback, useEffect } from '@wordpress/element';
 import {
 	requestMediaImport,
 	mediaUploadSync,
@@ -70,6 +70,7 @@ import { store as editPostStore } from '@wordpress/edit-post';
  */
 import styles from './styles.scss';
 import { getUpdatedLinkTargetSettings } from './utils';
+import { unlock } from '../lock-unlock';
 
 import {
 	LINK_DESTINATION_NONE,
@@ -91,13 +92,45 @@ function LinkSettings( {
 	image,
 	isLinkSheetVisible,
 	setMappedAttributes,
+	lightboxSetting,
 } ) {
 	const route = useRoute();
-	const { href: url, label, linkDestination, linkTarget, rel } = attributes;
+	const {
+		href: url,
+		label,
+		linkDestination,
+		linkTarget,
+		rel,
+		lightbox,
+	} = attributes;
+
+	const onSetLightbox = useCallback(
+		( enable ) => {
+			if ( enable && ! lightboxSetting?.enabled ) {
+				setMappedAttributes( {
+					lightbox: { enabled: true },
+				} );
+			} else if ( ! enable && lightboxSetting?.enabled ) {
+				setMappedAttributes( {
+					lightbox: { enabled: false },
+				} );
+			} else {
+				setMappedAttributes( {
+					lightbox: undefined,
+				} );
+			}
+		},
+		[ lightboxSetting?.enabled, setMappedAttributes ]
+	);
 
 	// Persist attributes passed from child screen.
+	// TODO: Explore a better approach to listen to navigation event.
 	useEffect( () => {
-		const { inputValue: newUrl } = route.params || {};
+		if ( ! route.params ) {
+			return;
+		}
+
+		const { inputValue: newUrl, lightboxEnabled } = route.params;
 
 		let newLinkDestination;
 		switch ( newUrl ) {
@@ -115,11 +148,19 @@ function LinkSettings( {
 				break;
 		}
 
+		onSetLightbox( lightboxEnabled );
+
 		setMappedAttributes( {
 			url: newUrl,
 			linkDestination: newLinkDestination,
 		} );
-	}, [ route.params?.inputValue ] );
+	}, [
+		attributes.url,
+		image?.link,
+		onSetLightbox,
+		route.params,
+		setMappedAttributes,
+	] );
 
 	let valueMask;
 	switch ( linkDestination ) {
@@ -135,6 +176,14 @@ function LinkSettings( {
 		default:
 			valueMask = __( 'None' );
 			break;
+	}
+
+	const showLightboxSetting =
+		!! lightbox || lightboxSetting?.allowEditing === true;
+	const lightboxEnabled =
+		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );
+	if ( showLightboxSetting && lightboxEnabled ) {
+		valueMask = __( 'Expand on click' );
 	}
 
 	const linkSettingsOptions = {
@@ -173,6 +222,8 @@ function LinkSettings( {
 							linkDestination: attributes.linkDestination,
 							imageUrl: attributes.url,
 							attachmentPageUrl: image?.link,
+							showLightboxSetting,
+							lightboxEnabled,
 						}
 					);
 				} }
@@ -670,6 +721,7 @@ export class ImageEdit extends Component {
 			featuredImageId,
 			wasBlockJustInserted,
 			shouldUseFastImage,
+			lightboxSetting,
 		} = this.props;
 		const { align, url, alt, id, sizeSlug, className } = attributes;
 		const hasImageContext = context
@@ -736,6 +788,7 @@ export class ImageEdit extends Component {
 					image={ this.props.image }
 					isLinkSheetVisible={ this.state.isLinkSheetVisible }
 					setMappedAttributes={ this.setMappedAttributes }
+					lightboxSetting={ lightboxSetting }
 				/>
 				<PanelBody
 					title={ __( 'Featured Image' ) }
@@ -924,6 +977,9 @@ export default compose( [
 				url &&
 				! hasQueryArg( url, 'w' ) );
 		const image = shouldGetMedia ? getMedia( id ) : null;
+		const [ lightboxSetting ] = unlock(
+			select( blockEditorStore )
+		).getBlockSettings( clientId, [ 'lightbox' ] );
 
 		return {
 			image,
@@ -935,6 +991,7 @@ export default compose( [
 				clientId,
 				'inserter_menu'
 			),
+			lightboxSetting,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -7,12 +7,12 @@ import {
 	TouchableWithoutFeedback,
 	View,
 } from 'react-native';
-import { useRoute } from '@react-navigation/native';
+import { useFocusEffect, useRoute } from '@react-navigation/native';
 
 /**
  * WordPress dependencies
  */
-import { Component, useCallback, useEffect } from '@wordpress/element';
+import { Component, useCallback } from '@wordpress/element';
 import {
 	requestMediaImport,
 	mediaUploadSync,
@@ -124,43 +124,44 @@ function LinkSettings( {
 	);
 
 	// Persist attributes passed from child screen.
-	// TODO: Explore a better approach to listen to navigation event.
-	useEffect( () => {
-		if ( ! route.params ) {
-			return;
-		}
+	useFocusEffect(
+		useCallback( () => {
+			if ( ! route.params ) {
+				return;
+			}
 
-		const { inputValue: newUrl, lightboxEnabled } = route.params;
+			const { inputValue: newUrl, lightboxEnabled } = route.params;
 
-		let newLinkDestination;
-		switch ( newUrl ) {
-			case attributes.url:
-				newLinkDestination = LINK_DESTINATION_MEDIA;
-				break;
-			case image?.link:
-				newLinkDestination = LINK_DESTINATION_ATTACHMENT;
-				break;
-			case '':
-				newLinkDestination = LINK_DESTINATION_NONE;
-				break;
-			default:
-				newLinkDestination = LINK_DESTINATION_CUSTOM;
-				break;
-		}
+			let newLinkDestination;
+			switch ( newUrl ) {
+				case attributes.url:
+					newLinkDestination = LINK_DESTINATION_MEDIA;
+					break;
+				case image?.link:
+					newLinkDestination = LINK_DESTINATION_ATTACHMENT;
+					break;
+				case '':
+					newLinkDestination = LINK_DESTINATION_NONE;
+					break;
+				default:
+					newLinkDestination = LINK_DESTINATION_CUSTOM;
+					break;
+			}
 
-		onSetLightbox( lightboxEnabled );
+			onSetLightbox( lightboxEnabled );
 
-		setMappedAttributes( {
-			url: newUrl,
-			linkDestination: newLinkDestination,
-		} );
-	}, [
-		attributes.url,
-		image?.link,
-		onSetLightbox,
-		route.params,
-		setMappedAttributes,
-	] );
+			setMappedAttributes( {
+				url: newUrl,
+				linkDestination: newLinkDestination,
+			} );
+		}, [
+			attributes.url,
+			image?.link,
+			onSetLightbox,
+			route.params,
+			setMappedAttributes,
+		] )
+	);
 
 	let valueMask;
 	switch ( linkDestination ) {

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -144,6 +144,61 @@ describe( 'Image Block', () => {
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
 
+	it( 'enables expand on click when lightbox setting is enabled', async () => {
+		const initialHtml = `
+		<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
+		<figure class="wp-block-image size-large is-style-default">
+			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
+		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
+		<!-- /wp:image -->`;
+		const screen = await initializeEditor( {
+			initialHtml,
+			withGlobalStyles: true,
+		} );
+		// Check that image is fetched via `getMedia`
+		expect( apiFetch ).toHaveBeenCalledWith( FETCH_MEDIA.request );
+
+		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );
+		fireEvent.press( imageBlock );
+		// Awaiting navigation event seemingly required due to React Navigation bug
+		// https://github.com/react-navigation/react-navigation/issues/9701
+		await act( () =>
+			fireEvent.press( screen.getByLabelText( 'Open Settings' ) )
+		);
+		fireEvent.press( screen.getByText( 'None' ) );
+		fireEvent.press( screen.getByText( 'Expand on click' ) );
+
+		const expectedHtml = `<!-- wp:image {"lightbox":{"enabled":true},"id":1,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
+<figure class="wp-block-image size-large is-style-default"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<!-- /wp:image -->`;
+		expect( getEditorHtml() ).toBe( expectedHtml );
+	} );
+
+	it( 'does not show the expand on click option when lightbox setting is disabled', async () => {
+		const initialHtml = `
+		<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
+		<figure class="wp-block-image size-large is-style-default">
+			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
+		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
+		<!-- /wp:image -->`;
+		const screen = await initializeEditor( {
+			initialHtml,
+			withGlobalStyles: false,
+		} );
+		// Check that image is fetched via `getMedia`
+		expect( apiFetch ).toHaveBeenCalledWith( FETCH_MEDIA.request );
+
+		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );
+		fireEvent.press( imageBlock );
+		// Awaiting navigation event seemingly required due to React Navigation bug
+		// https://github.com/react-navigation/react-navigation/issues/9701
+		await act( () =>
+			fireEvent.press( screen.getByLabelText( 'Open Settings' ) )
+		);
+		fireEvent.press( screen.getByText( 'None' ) );
+		expect( screen.queryByText( 'Expand on click' ) ).toBeNull();
+	} );
+
 	it( 'sets link to Custom URL', async () => {
 		const initialHtml = `
 		<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -138,8 +138,8 @@ export {
 	getMergedGlobalStyles,
 } from './mobile/global-styles-context';
 export {
+	getDefaultGlobalStyles,
 	getGlobalStyles,
-	getColorsAndGradients,
 	useMobileGlobalStylesColors,
 	useEditorColorScheme,
 } from './mobile/global-styles-context/utils';

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -399,7 +399,7 @@ export function useMobileGlobalStylesColors( type = 'colors' ) {
 		: defaultPalette;
 }
 
-export function getColorsAndGradients(
+export function getDefaultGlobalStyles(
 	defaultEditorColors = [],
 	defaultEditorGradients = [],
 	rawFeatures
@@ -425,6 +425,7 @@ export function getColorsAndGradients(
 				defaultPalette: defaultEditorColors?.length > 0,
 				defaultGradients: defaultEditorGradients?.length > 0,
 			},
+			blocks: features?.blocks,
 		},
 	};
 }
@@ -467,6 +468,7 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 				customLineHeight: features?.custom?.[ 'line-height' ],
 			},
 			spacing: features?.spacing,
+			blocks: features?.blocks,
 		},
 		__experimentalGlobalStylesBaseStyles: globalStyles,
 	};

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -35,7 +35,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { getGlobalStyles, getColorsAndGradients } from '@wordpress/components';
+import { getDefaultGlobalStyles, getGlobalStyles } from '@wordpress/components';
 import { NEW_BLOCK_TYPES } from '@wordpress/block-library';
 import { __ } from '@wordpress/i18n';
 
@@ -106,7 +106,7 @@ class NativeEditorProvider extends Component {
 
 		updateEditorSettings( {
 			capabilities,
-			...this.getThemeColors( this.props ),
+			...this.getThemeSettings( this.props ),
 			locale,
 			hostAppNamespace,
 		} );
@@ -171,7 +171,7 @@ class NativeEditorProvider extends Component {
 							galleryWithImageBlocks;
 					}
 					updateEditorSettings(
-						this.getThemeColors( editorSettings )
+						this.getThemeSettings( editorSettings )
 					);
 				}
 			);
@@ -262,14 +262,14 @@ class NativeEditorProvider extends Component {
 		}
 	}
 
-	getThemeColors( { rawStyles, rawFeatures } ) {
+	getThemeSettings( { rawStyles, rawFeatures } ) {
 		const { defaultEditorColors, defaultEditorGradients } = this.props;
 
 		if ( rawStyles && rawFeatures ) {
 			return getGlobalStyles( rawStyles, rawFeatures );
 		}
 
-		return getColorsAndGradients(
+		return getDefaultGlobalStyles(
 			defaultEditorColors,
 			defaultEditorGradients,
 			rawFeatures

--- a/test/native/integration-test-helpers/get-global-styles.js
+++ b/test/native/integration-test-helpers/get-global-styles.js
@@ -108,6 +108,9 @@ const GLOBAL_STYLES_RAW_FEATURES = {
 			],
 		},
 	},
+	blocks: {
+		'core/image': { lightbox: { allowEditing: true } },
+	},
 };
 
 const GLOBAL_STYLES_RAW_STYLES = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allow users to select the option "Expand on click" in the "Link to" setting of the Image block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR follows the web implementation https://github.com/WordPress/gutenberg/pull/57608 and matches the functionality provided for the [lightbox setting](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#lightbox).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

TBD

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

TBD

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
TBD