### PR TITLE
Project: Update the '.git-blame-ignore-revs' list

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ c56e8a1910ed74f405b74bbb12fe81dea974e5c3
 
 # Prettier upgrade to 3.0.3.
 0bee15148fe4330c20cf372cb46a33693e45cb5f
+
+# ESLint: Enable react/jsx-boolean-value
+9a34927870df80ac3b2da14d71f81d20ec23e2b6


### PR DESCRIPTION
## What?
PR adds merge commit for #59557 in the `.git-blame-ignore-revs` file.

## Why?
Mass refactorings by the "build tools" are tracked in the file for better `git` archeology.

## Testing Instructions
Test using the command below, and it should ignore 9the a34927870df80ac3b2da14d71f81d20ec23e2b6 commit.

```
git blame --ignore-revs-file .git-blame-ignore-revs -L 40 packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
```
