### PR TITLE
Add Box Shadow support for featured image

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -642,7 +642,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 
 -	**Name:** core/post-featured-image
 -	**Category:** theme
--	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
+-	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
 -	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -51,10 +51,6 @@ function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	if ( wp_should_skip_block_supports_serialization( $block_type, 'shadow' ) ) {
-		return array();
-	}
-
 	$shadow_block_styles = array();
 
 	$custom_shadow                 = $block_attributes['style']['shadow'] ?? null;

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -51,6 +51,10 @@ function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'shadow' ) ) {
+		return array();
+	}
+
 	$shadow_block_styles = array();
 
 	$custom_shadow                 = $block_attributes['style']['shadow'] ?? null;

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -90,7 +90,7 @@
 		}
 	},
 	"selectors": {
-		"shadow": ".wp-block-post-featured-image img, .wp-block-post-featured-image .wp-block-image__crop-area, .wp-block-post-featured-image .components-placeholder"
+		"shadow": ".wp-block-post-featured-image img, .wp-block-post-featured-image .components-placeholder"
 	},
 	"editorStyle": "wp-block-post-featured-image-editor",
 	"style": "wp-block-post-featured-image"

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -77,6 +77,9 @@
 				"width": true
 			}
 		},
+		"shadow": {
+			"__experimentalSkipSerialization": true
+		},
 		"html": false,
 		"spacing": {
 			"margin": true,
@@ -85,6 +88,9 @@
 		"interactivity": {
 			"clientNavigation": true
 		}
+	},
+	"selectors": {
+		"shadow": ".wp-block-post-featured-image img, .wp-block-post-featured-image .wp-block-image__crop-area, .wp-block-post-featured-image .components-placeholder"
 	},
 	"editorStyle": "wp-block-post-featured-image-editor",
 	"style": "wp-block-post-featured-image"

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -24,6 +24,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 	__experimentalUseBorderProps as useBorderProps,
+	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
@@ -144,6 +145,7 @@ export default function PostFeaturedImageEdit( {
 		style: { width, height, aspectRatio },
 	} );
 	const borderProps = useBorderProps( attributes );
+	const shadowProps = getShadowClassesAndStyles( attributes );
 	const blockEditingMode = useBlockEditingMode();
 
 	const placeholder = ( content ) => {
@@ -158,6 +160,7 @@ export default function PostFeaturedImageEdit( {
 					height: !! aspectRatio && '100%',
 					width: !! aspectRatio && '100%',
 					...borderProps.style,
+					...shadowProps.style,
 				} }
 			>
 				{ content }
@@ -267,6 +270,7 @@ export default function PostFeaturedImageEdit( {
 	const label = __( 'Add a featured image' );
 	const imageStyles = {
 		...borderProps.style,
+		...shadowProps.style,
 		height: aspectRatio ? '100%' : height,
 		width: !! aspectRatio && '100%',
 		objectFit: !! ( height || aspectRatio ) && scale,

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -48,8 +48,8 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! empty( $attributes['scale'] ) ) {
 		$extra_styles .= "object-fit:{$attributes['scale']};";
 	}
-	if ( ! empty(  $attributes['style']['shadow'] ) ) {
-		$shadow_styles     = wp_style_engine_get_styles( array( 'shadow' => $attributes['style']['shadow'] ) );
+	if ( ! empty( $attributes['style']['shadow'] ) ) {
+		$shadow_styles = wp_style_engine_get_styles( array( 'shadow' => $attributes['style']['shadow'] ) );
 
 		if ( ! empty( $shadow_styles['css'] ) ) {
 			$extra_styles .= $shadow_styles['css'];

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -48,6 +48,13 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! empty( $attributes['scale'] ) ) {
 		$extra_styles .= "object-fit:{$attributes['scale']};";
 	}
+	if ( ! empty(  $attributes['style']['shadow'] ) ) {
+		$shadow_styles     = wp_style_engine_get_styles( array( 'shadow' => $attributes['style']['shadow'] ) );
+
+		if ( ! empty( $shadow_styles['css'] ) ) {
+			$extra_styles .= $shadow_styles['css'];
+		}
+	}
 
 	if ( ! empty( $extra_styles ) ) {
 		$attr['style'] = empty( $attr['style'] ) ? $extra_styles : $attr['style'] . $extra_styles;


### PR DESCRIPTION
## What?
This PR adds box shadow support to the Post Featured Image Block so it has the same controls as the core Image block. 

## Why?
This PR resolves https://github.com/WordPress/gutenberg/issues/59067 and brings more parity between the Image and Post Featured Image blocks.

## How?
This PR adds block support for box shadows. The shadow style needs to be applied to the image tag inside the figure tag like the border styles. The selectors have been specified so that global styles from theme.json and elsewhere are also applied to the image rather than the figure. 

In order for this to work, the shadow.php needed to be updated to support __experimentalSkipSerialization. Without it, the box shadow style is printed to the figure.  

NOTE: This PR would potentially affect any themes that were providing a shadow style definition to the core/post-featured-image. Currently, that style is applied to the figure. With this PR it is applied to the image. This allows the box shadow to work in conjunction with a border radius.

## Testing Instructions
1. Open a post or page
2. Add a featured image
3. Add a Featured Image Block
4. Add a box shadow style. It should be visible in the editor.
5. Adjust any of the other style controls. They should all work in harmony.
6. Test the result on the front end.

### Testing Instructions for Keyboard
1. Open a post or page
2. Add a featured image
3. Add a Featured Image Block
4. Navigate to the sidebar with the keyboard
5. Navigate to the Border and & Shadow section
6. Open the kabob menu to enable the shadow with the keyboard
7. Add a box shadow style. It should be visible in the editor.
8. Adjust any of the other style controls. They should all work in harmony.
9. Test the result on the front end.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/2152870/f833d4ff-56d3-4bbe-a3de-22aeb2bae4cc
(Note that I've added a shadow to my theme.json to demonstrate that users can override global styles)
