### PR TITLE
Pattern Overrides: Display parent selector when focused on overridable block in pattern instance

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -66,6 +66,7 @@ export function PrivateBlockToolbar( {
 		shouldShowVisualToolbar,
 		showParentSelector,
 		isUsingBindings,
+		isPatternOverride,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -93,8 +94,17 @@ export function PrivateBlockToolbar( {
 		const isVisual = selectedBlockClientIds.every(
 			( id ) => getBlockMode( id ) === 'visual'
 		);
-		const _isUsingBindings = !! getBlockAttributes( selectedBlockClientId )
-			?.metadata?.bindings;
+		const bindings = getBlockAttributes( selectedBlockClientId )?.metadata
+			?.bindings;
+		const _isUsingBindings = !! bindings;
+		const _isPatternOverride = _isUsingBindings
+			? Object.keys( bindings ).some(
+					( bindingKey ) =>
+						bindings[ bindingKey ].source ===
+						'core/pattern-overrides'
+			  )
+			: false;
+
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -112,8 +122,9 @@ export function PrivateBlockToolbar( {
 					true
 				) &&
 				selectedBlockClientIds.length === 1 &&
-				_isDefaultEditingMode,
+				( _isDefaultEditingMode || _isPatternOverride ),
 			isUsingBindings: _isUsingBindings,
+			isPatternOverride: _isPatternOverride,
 		};
 	}, [] );
 
@@ -164,7 +175,9 @@ export function PrivateBlockToolbar( {
 			<div ref={ toolbarWrapperRef } className={ innerClasses }>
 				{ ! isMultiToolbar &&
 					isLargeViewport &&
-					isDefaultEditingMode && <BlockParentSelector /> }
+					( isDefaultEditingMode || isPatternOverride ) && (
+						<BlockParentSelector />
+					) }
 				{ isUsingBindings && canBindBlock( blockName ) && (
 					<BlockBindingsIndicator />
 				) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR ensures that the parent selector in the block toolbar is visible when an overridable block in a pattern instance is selected.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/WordPress/gutenberg/issues/59620
The parent selector should be visible when selecting nested blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It adds a check to see if the selected block has bindings and is a pattern override when determining whether to show the parent selector.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new synced pattern
2. Add a paragraph to the pattern
3. Enable instance overrides for the paragraph beneath 'Advanced' by giving it a name
4. Save the pattern and insert it into a post
5. Select the overridable paragrah — see that the parent selector in the toolbar is visible as expected.

<!--### Testing Instructions for Keyboard
 How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1197" alt="Screenshot 2024-03-05 at 10 01 29 PM" src="https://github.com/WordPress/gutenberg/assets/5360536/e250a2c9-fdce-4af5-bc77-ad9d3225f6b5">