### PR TITLE
Site Editor: Standardize block tools toggle button size to 32px

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -154,6 +154,7 @@ export default function HeaderEditMode() {
 										? __( 'Show block tools' )
 										: __( 'Hide block tools' )
 								}
+								size="compact"
 							/>
 						</>
 					) }


### PR DESCRIPTION
Follow-up #58532
Part of #58293

## What?

This PR changes the block toolbar toggle button size from 36px to 32px in the Site Editor.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/c1f4f433-0fe3-48ef-b33a-26552d07dd6c)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/5434b050-8906-4ec7-9787-7d12b94aa502)


## Why?

This should have been addressed in #58532, but I missed this button.

## Testing Instructions

- Access the Site Editor.
- Activate the top toolbar.
- Click on one block.
- Focus on the block toolbar toggle button and check its size.
