### PR TITLE
setTimeout to allow closing Link UI on second click

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -108,7 +108,7 @@ function Edit( {
 			if ( target ) {
 				setOpenedBy( {
 					el: target,
-					action: null,
+					action: null, // We don't need to distinguish between click or keyboard here
 				} );
 			}
 			setAddingLink( true );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
We need a second click on the same link to close the link popover

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Otherwise, you can't place the caret within the editor to edit link text. The popover will always steal focus.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a clickDelay via a 100ms setTimeout to prevent the link control ui from opening again. 

We can't toggle the `addingLink` state via the link because the `onFocusOutside` event fires to close the popover, and a the click on the inline link opens the link control again. A better fix to this issue would be to have the `onFocusOutside` event report the correct element that was clicked, and we could check the element that was clicked. Since we can't do that, the current flow looks like:

- Click a link: `setAddingLink( true )`
- Click the same link again:
  -  `onFocusOutside`: `setAddingLink( false )`
  - link click handler sets it back to true: `setAddingLink( true )`

Flow from this PR:
- Click a link: `setAddingLink( true )`
- Store the element that was clicked: `opendBy.current = event.target`
- Click the same link again:
  - `onFocusOutside`: `setAddingLink( false )`
  - Set a timeout: `clickTimeoutId.current = setTimeout( () => { clickTimeout.current = false; }, 100 );`
  - link click handler returns early if `clickTimeout.current` and `opendBy` is the same element that was clicked.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add several links to a paragraph
- Click between them 
- Double click them
- Use the toolbar to open the link control
- Use the keyboard to escape from it
- Mix all together and try to break it.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
