### PR TITLE
Code block: preserve newlines

### DIFF
--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -17,9 +17,11 @@ export default function save( { attributes } ) {
 				// prevent embedding in PHP. Ideally checks for the code block,
 				// or pre/code tags, should be made on the PHP side?
 				value={ escape(
-					attributes.content.toHTMLString( {
-						preserveWhiteSpace: true,
-					} )
+					typeof attributes.content === 'string'
+						? attributes.content
+						: attributes.content.toHTMLString( {
+								preserveWhiteSpace: true,
+						  } )
 				) }
 			/>
 		</pre>

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -16,7 +16,11 @@ export default function save( { attributes } ) {
 				// To do: `escape` encodes characters in shortcodes and URLs to
 				// prevent embedding in PHP. Ideally checks for the code block,
 				// or pre/code tags, should be made on the PHP side?
-				value={ escape( attributes.content.toString() ) }
+				value={ escape(
+					attributes.content.toHTMLString( {
+						preserveWhiteSpace: true,
+					} )
+				) }
 			/>
 		</pre>
 	);

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -432,6 +432,7 @@ _Parameters_
 
 -   _$1_ `Object`: Named argements.
 -   _$1.value_ `RichTextValue`: Rich text value.
+-   _$1.preserveWhiteSpace_ `[?boolean]`: Preserves newlines if true.
 
 _Returns_
 

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -432,7 +432,7 @@ _Parameters_
 
 -   _$1_ `Object`: Named argements.
 -   _$1.value_ `RichTextValue`: Rich text value.
--   _$1.preserveWhiteSpace_ `[?boolean]`: Preserves newlines if true.
+-   _$1.preserveWhiteSpace_ `[boolean]`: Preserves newlines if true.
 
 _Returns_
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -129,7 +129,10 @@ export function useRichText( {
 				: newRecord.formats;
 			newRecord = { ...newRecord, formats: newFormats };
 			if ( typeof value === 'string' ) {
-				_value.current = toHTMLString( { value: newRecord } );
+				_value.current = toHTMLString( {
+					value: newRecord,
+					preserveWhiteSpace,
+				} );
 			} else {
 				_value.current = new RichTextData( newRecord );
 			}

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -144,8 +144,11 @@ export class RichTextData {
 	}
 	// We could expose `toHTMLElement` at some point as well, but we'd only use
 	// it internally.
-	toHTMLString() {
-		return this.originalHTML || toHTMLString( { value: this.#value } );
+	toHTMLString( { preserveWhiteSpace } = {} ) {
+		return (
+			this.originalHTML ||
+			toHTMLString( { value: this.#value, preserveWhiteSpace } )
+		);
 	}
 	valueOf() {
 		return this.toHTMLString();

--- a/packages/rich-text/src/to-html-string.js
+++ b/packages/rich-text/src/to-html-string.js
@@ -21,7 +21,7 @@ import { toTree } from './to-tree';
  *
  * @param {Object}        $1                      Named argements.
  * @param {RichTextValue} $1.value                Rich text value.
- * @param {boolean}      [$1.preserveWhiteSpace] Preserves newlines if true.
+ * @param {boolean}       [$1.preserveWhiteSpace] Preserves newlines if true.
  *
  * @return {string} HTML string.
  */

--- a/packages/rich-text/src/to-html-string.js
+++ b/packages/rich-text/src/to-html-string.js
@@ -21,7 +21,7 @@ import { toTree } from './to-tree';
  *
  * @param {Object}        $1                      Named argements.
  * @param {RichTextValue} $1.value                Rich text value.
- * @param {?boolean}      [$1.preserveWhiteSpace] Preserves newlines if true.
+ * @param {boolean}      [$1.preserveWhiteSpace] Preserves newlines if true.
  *
  * @return {string} HTML string.
  */

--- a/packages/rich-text/src/to-html-string.js
+++ b/packages/rich-text/src/to-html-string.js
@@ -19,14 +19,16 @@ import { toTree } from './to-tree';
 /**
  * Create an HTML string from a Rich Text value.
  *
- * @param {Object}        $1       Named argements.
- * @param {RichTextValue} $1.value Rich text value.
+ * @param {Object}        $1                      Named argements.
+ * @param {RichTextValue} $1.value                Rich text value.
+ * @param {?boolean}      [$1.preserveWhiteSpace] Preserves newlines if true.
  *
  * @return {string} HTML string.
  */
-export function toHTMLString( { value } ) {
+export function toHTMLString( { value, preserveWhiteSpace } ) {
 	const tree = toTree( {
 		value,
+		preserveWhiteSpace,
 		createEmpty,
 		append,
 		getLastChild,

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -129,6 +129,7 @@ function isEqualUntil( a, b, index ) {
 
 export function toTree( {
 	value,
+	preserveWhiteSpace,
 	createEmpty,
 	append,
 	getLastChild,
@@ -267,7 +268,7 @@ export function toTree( {
 			}
 			// Ensure pointer is text node.
 			pointer = append( getParent( pointer ), '' );
-		} else if ( character === '\n' ) {
+		} else if ( ! preserveWhiteSpace && character === '\n' ) {
 			pointer = append( getParent( pointer ), {
 				type: 'br',
 				attributes: isEditableTree

--- a/test/e2e/specs/editor/blocks/__snapshots__/Code-should-paste-plain-text-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Code-should-paste-plain-text-1-chromium.txt
@@ -1,3 +1,4 @@
 <!-- wp:code -->
-<pre class="wp-block-code"><code>&lt;img /><br>	&lt;br></code></pre>
+<pre class="wp-block-code"><code>&lt;img />
+	&lt;br></code></pre>
 <!-- /wp:code -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-2-chromium.txt
@@ -7,5 +7,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:code -->
-<pre class="wp-block-code"><code>ading<br><br>Paragra</code></pre>
+<pre class="wp-block-code"><code>ading
+
+Paragra</code></pre>
 <!-- /wp:code -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR tries to fix two problems:

* The current Code block has always output HTML (can contain HTML formatting), and recently we normalised line breaks to always serialise as HTML elements (#55999). This seems to break PHP display filters that add syntax highlighting to these code blocks. Please note that they probably still breaks if you add bold or links to the Code block, but that was the case before. This PR basically reverts that change for the Code block (I left Verse and Preformatted alone). IDEALLY, these plugins should be fixed so they can handle HTML inside code blocks.
* ~~Custom code blocks that are using RichText will now also serialise line breaks as HTML elements. The ones I've checked have all formatting options disabled, so they are using RichText more as a plain text editor. In this PR, I will preserve the newlines if the attribute source type is still a string and `preserveWhiteSpace` is turned on (serialisation happens in the edit function in that case). IDEALLY, these plugins either switch to `PlainText` OR allow HTML inside their blocks.~~ Let's handle that in a follow-up.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #59548.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Create a Code block with two lines. Check the output in the code editor. They should be a newline instead of an HTML BR element.
* [Prismatic](https://wordpress.org/plugins/prismatic/) should work with the code block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
