### PR TITLE
Fix create menu after menu switch

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -154,8 +154,8 @@ function Navigation( {
 	} = useCreateNavigationMenu( clientId );
 
 	const createUntitledEmptyNavigationMenu = () => {
-		return new Promise( ( resolve ) => {
-			createNavigationMenu( '' );
+		return new Promise( async ( resolve ) => {
+			await createNavigationMenu( '' );
 			resolve();
 		} );
 	};

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -153,11 +153,8 @@ function Navigation( {
 		isError: createNavigationMenuIsError,
 	} = useCreateNavigationMenu( clientId );
 
-	const createUntitledEmptyNavigationMenu = () => {
-		return new Promise( async ( resolve ) => {
-			await createNavigationMenu( '' );
-			resolve();
-		} );
+	const createUntitledEmptyNavigationMenu = async () => {
+		await createNavigationMenu( '' );
 	};
 
 	const {
@@ -345,27 +342,21 @@ function Navigation( {
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
 	const onSelectClassicMenu = async ( classicMenu ) => {
-		return new Promise( async ( resolve ) => {
-			const navMenu = await convertClassicMenu(
-				classicMenu.id,
-				classicMenu.name,
-				'draft'
-			);
-			if ( navMenu ) {
-				handleUpdateMenu( navMenu.id, {
-					focusNavigationBlock: true,
-				} );
-			}
-			resolve();
-		} );
+		const navMenu = await convertClassicMenu(
+			classicMenu.id,
+			classicMenu.name,
+			'draft'
+		);
+		if ( navMenu ) {
+			handleUpdateMenu( navMenu.id, {
+				focusNavigationBlock: true,
+			} );
+		}
 	};
 
 	const onSelectNavigationMenu = ( menuId ) => {
-		return new Promise( ( resolve ) => {
-			handleUpdateMenu( menuId, {
-				focusNavigationBlock: true,
-			} );
-			resolve();
+		handleUpdateMenu( menuId, {
+			focusNavigationBlock: true,
 		} );
 	};
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -355,9 +355,7 @@ function Navigation( {
 	};
 
 	const onSelectNavigationMenu = ( menuId ) => {
-		handleUpdateMenu( menuId, {
-			focusNavigationBlock: true,
-		} );
+		handleUpdateMenu( menuId );
 	};
 
 	useEffect( () => {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -154,7 +154,10 @@ function Navigation( {
 	} = useCreateNavigationMenu( clientId );
 
 	const createUntitledEmptyNavigationMenu = () => {
-		createNavigationMenu( '' );
+		return new Promise( ( resolve ) => {
+			createNavigationMenu( '' );
+			resolve();
+		} );
 	};
 
 	const {
@@ -342,20 +345,28 @@ function Navigation( {
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
 	const onSelectClassicMenu = async ( classicMenu ) => {
-		const navMenu = await convertClassicMenu(
-			classicMenu.id,
-			classicMenu.name,
-			'draft'
-		);
-		if ( navMenu ) {
-			handleUpdateMenu( navMenu.id, {
-				focusNavigationBlock: true,
-			} );
-		}
+		return new Promise( async ( resolve ) => {
+			const navMenu = await convertClassicMenu(
+				classicMenu.id,
+				classicMenu.name,
+				'draft'
+			);
+			if ( navMenu ) {
+				handleUpdateMenu( navMenu.id, {
+					focusNavigationBlock: true,
+				} );
+			}
+			resolve();
+		} );
 	};
 
 	const onSelectNavigationMenu = ( menuId ) => {
-		handleUpdateMenu( menuId );
+		return new Promise( ( resolve ) => {
+			handleUpdateMenu( menuId, {
+				focusNavigationBlock: true,
+			} );
+			resolve();
+		} );
 	};
 
 	useEffect( () => {

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -82,10 +82,20 @@ function NavigationMenuSelector( {
 					value: id,
 					label,
 					ariaLabel: sprintf( actionLabel, label ),
+					disabled:
+						isUpdatingMenuRef ||
+						isResolvingNavigationMenus ||
+						! hasResolvedNavigationMenus,
 				};
 			} ) || []
 		);
-	}, [ navigationMenus, actionLabel ] );
+	}, [
+		navigationMenus,
+		actionLabel,
+		isResolvingNavigationMenus,
+		hasResolvedNavigationMenus,
+		isUpdatingMenuRef,
+	] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;
@@ -144,10 +154,6 @@ function NavigationMenuSelector( {
 									onClose();
 								} }
 								choices={ menuChoices }
-								disabled={
-									isUpdatingMenuRef ||
-									! hasResolvedNavigationMenus
-								}
 							/>
 						</MenuGroup>
 					) }
@@ -170,6 +176,7 @@ function NavigationMenuSelector( {
 										) }
 										disabled={
 											isUpdatingMenuRef ||
+											isResolvingNavigationMenus ||
 											! hasResolvedNavigationMenus
 										}
 									>
@@ -183,16 +190,17 @@ function NavigationMenuSelector( {
 					{ canUserCreateNavigationMenu && (
 						<MenuGroup label={ __( 'Tools' ) }>
 							<MenuItem
-								disabled={
-									isUpdatingMenuRef ||
-									! hasResolvedNavigationMenus
-								}
 								onClick={ async () => {
 									setIsUpdatingMenuRef( true );
 									await onCreateNew();
 									setIsUpdatingMenuRef( false );
 									onClose();
 								} }
+								disabled={
+									isUpdatingMenuRef ||
+									isResolvingNavigationMenus ||
+									! hasResolvedNavigationMenus
+								}
 							>
 								{ __( 'Create new menu' ) }
 							</MenuItem>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -144,7 +144,10 @@ function NavigationMenuSelector( {
 									onClose();
 								} }
 								choices={ menuChoices }
-								disabled={ ! hasResolvedNavigationMenus }
+								disabled={
+									isUpdatingMenuRef ||
+									! hasResolvedNavigationMenus
+								}
 							/>
 						</MenuGroup>
 					) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -140,7 +140,6 @@ function NavigationMenuSelector( {
 							<MenuItemsChoice
 								value={ currentMenuId }
 								onSelect={ ( menuId ) => {
-									setIsCreatingMenu( true );
 									onSelectNavigationMenu( menuId );
 									onClose();
 								} }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -99,7 +99,7 @@ function NavigationMenuSelector( {
 
 	let selectorLabel = '';
 
-	if ( isUpdatingMenuRef || isResolvingNavigationMenus ) {
+	if ( isResolvingNavigationMenus ) {
 		selectorLabel = __( 'Loading…' );
 	} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
 		// Note: classic Menus may be available.
@@ -149,7 +149,10 @@ function NavigationMenuSelector( {
 									);
 								} }
 								choices={ menuChoices }
-								disabled={ isUpdatingMenuRef }
+								disabled={
+									isUpdatingMenuRef ||
+									! hasResolvedNavigationMenus
+								}
 							/>
 						</MenuGroup>
 					) }
@@ -175,7 +178,10 @@ function NavigationMenuSelector( {
 											createActionLabel,
 											label
 										) }
-										disabled={ isUpdatingMenuRef }
+										disabled={
+											isUpdatingMenuRef ||
+											! hasResolvedNavigationMenus
+										}
 									>
 										{ label }
 									</MenuItem>
@@ -187,7 +193,10 @@ function NavigationMenuSelector( {
 					{ canUserCreateNavigationMenu && (
 						<MenuGroup label={ __( 'Tools' ) }>
 							<MenuItem
-								disabled={ isUpdatingMenuRef }
+								disabled={
+									isUpdatingMenuRef ||
+									! hasResolvedNavigationMenus
+								}
 								onClick={ () => {
 									setIsUpdatingMenuRef( true );
 									onCreateNew().then( () => {

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -140,16 +140,11 @@ function NavigationMenuSelector( {
 							<MenuItemsChoice
 								value={ currentMenuId }
 								onSelect={ ( menuId ) => {
-									setIsUpdatingMenuRef( true );
 									onSelectNavigationMenu( menuId );
-									setIsUpdatingMenuRef( false );
 									onClose();
 								} }
 								choices={ menuChoices }
-								disabled={
-									isUpdatingMenuRef ||
-									! hasResolvedNavigationMenus
-								}
+								disabled={ ! hasResolvedNavigationMenus }
 							/>
 						</MenuGroup>
 					) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -141,12 +141,9 @@ function NavigationMenuSelector( {
 								value={ currentMenuId }
 								onSelect={ ( menuId ) => {
 									setIsUpdatingMenuRef( true );
-									onSelectNavigationMenu( menuId ).then(
-										() => {
-											setIsUpdatingMenuRef( false );
-											onClose();
-										}
-									);
+									onSelectNavigationMenu( menuId );
+									setIsUpdatingMenuRef( false );
+									onClose();
 								} }
 								choices={ menuChoices }
 								disabled={
@@ -162,16 +159,11 @@ function NavigationMenuSelector( {
 								const label = decodeEntities( menu.name );
 								return (
 									<MenuItem
-										onClick={ () => {
+										onClick={ async () => {
 											setIsUpdatingMenuRef( true );
-											onSelectClassicMenu( menu ).then(
-												() => {
-													setIsUpdatingMenuRef(
-														false
-													);
-													onClose();
-												}
-											);
+											await onSelectClassicMenu( menu );
+											setIsUpdatingMenuRef( false );
+											onClose();
 										} }
 										key={ menu.id }
 										aria-label={ sprintf(
@@ -197,12 +189,11 @@ function NavigationMenuSelector( {
 									isUpdatingMenuRef ||
 									! hasResolvedNavigationMenus
 								}
-								onClick={ () => {
+								onClick={ async () => {
 									setIsUpdatingMenuRef( true );
-									onCreateNew().then( () => {
-										setIsUpdatingMenuRef( false );
-										onClose();
-									} );
+									await onCreateNew();
+									setIsUpdatingMenuRef( false );
+									onClose();
 								} }
 							>
 								{ __( 'Create new menu' ) }

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -13,13 +13,23 @@ import useNavigationEntities from '../../use-navigation-entities';
 
 jest.mock( '../../use-navigation-menu', () => {
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
+	const mock = jest.fn(
+		() =>
+			new Promise( ( resolve ) => {
+				resolve();
+			} )
+	);
 	return mock;
 } );
 
 jest.mock( '../../use-navigation-entities', () => {
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
+	const mock = jest.fn(
+		() =>
+			new Promise( ( resolve ) => {
+				resolve();
+			} )
+	);
 	return mock;
 } );
 
@@ -221,7 +231,12 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should call handler callback and close popover when create menu button is clicked', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn();
+				const handler = jest.fn(
+					() =>
+						new Promise( ( resolve ) => {
+							resolve();
+						} )
+				);
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
@@ -248,7 +263,12 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should handle disabled state of the create menu button during the creation process', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn();
+				const handler = jest.fn(
+					() =>
+						new Promise( ( resolve ) => {
+							resolve();
+						} )
+				);
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
@@ -425,7 +445,12 @@ describe( 'NavigationMenuSelector', () => {
 			it( 'should call the handler when the navigation menu is selected and disable all options during the import/creation process', async () => {
 				const user = userEvent.setup();
 
-				const handler = jest.fn();
+				const handler = jest.fn(
+					() =>
+						new Promise( ( resolve ) => {
+							resolve();
+						} )
+				);
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: navigationMenusFixture,
@@ -568,7 +593,12 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should call the handler when the classic menu item is selected and disable all options during the import/creation process', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn();
+				const handler = jest.fn(
+					() =>
+						new Promise( ( resolve ) => {
+							resolve();
+						} )
+				);
 
 				useNavigationMenu.mockReturnValue( {
 					canUserCreateNavigationMenu: true,

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -271,6 +271,16 @@ describe( 'NavigationMenuSelector', () => {
 					} )
 				);
 
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: [],
+					hasResolvedNavigationMenus: false,
+					isResolvingNavigationMenus: true,
+					canUserCreateNavigationMenu: true,
+					canSwitchNavigationMenu: true,
+				} );
+
+				rerender( <NavigationMenuSelector onCreateNew={ handler } /> );
+
 				// Re-open the dropdown (it's closed when the "Create menu" button is clicked).
 				await user.click( toggleButton );
 
@@ -283,6 +293,14 @@ describe( 'NavigationMenuSelector', () => {
 						name: 'Create new menu',
 					} )
 				).toBeDisabled();
+
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: [],
+					hasResolvedNavigationMenus: true,
+					isResolvingNavigationMenus: false,
+					canUserCreateNavigationMenu: true,
+					canSwitchNavigationMenu: true,
+				} );
 
 				// Simulate the menu being created and component being re-rendered.
 				rerender(
@@ -422,7 +440,7 @@ describe( 'NavigationMenuSelector', () => {
 				expect( menuItem ).toBeChecked();
 			} );
 
-			it( 'should call the handler when the navigation menu is selected and disable all options during the import/creation process', async () => {
+			it( 'should call the handler when the navigation menu is selected', async () => {
 				const user = userEvent.setup();
 
 				const handler = jest.fn();
@@ -434,7 +452,7 @@ describe( 'NavigationMenuSelector', () => {
 					canSwitchNavigationMenu: true,
 				} );
 
-				const { rerender } = render(
+				render(
 					<NavigationMenuSelector
 						onSelectNavigationMenu={ handler }
 					/>
@@ -455,42 +473,6 @@ describe( 'NavigationMenuSelector', () => {
 
 				//  Check the dropdown has been closed.
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
-
-				// Re-open the dropdown
-				await user.click( screen.getByRole( 'button' ) );
-
-				// Check the dropdown is again open and is in the "loading" state.
-				expect(
-					screen.getByRole( 'menu', {
-						name: /Loading/,
-					} )
-				).toBeInTheDocument();
-
-				// // Check all menu items are present but disabled.
-				screen.getAllByRole( 'menuitem' ).forEach( ( item ) => {
-					// // Check all menu items are present but disabled.
-					expect( item ).toBeDisabled();
-				} );
-
-				// // Simulate the menu being created and component being re-rendered.
-				rerender(
-					<NavigationMenuSelector
-						createNavigationMenuIsSuccess // classic menu import creates a Navigation menu.
-					/>
-				);
-
-				// Todo: fix bug where aria label is not updated.
-				// expect(
-				// 	screen.getByRole( 'menu', {
-				// 		name: `You are currently editing ${ navigationMenusFixture[ 0 ].title.rendered }`,
-				// 	} )
-				// ).toBeInTheDocument();
-
-				// Check all menu items are re-enabled.
-				screen.getAllByRole( 'menuitem' ).forEach( ( item ) => {
-					// // Check all menu items are present but disabled.
-					expect( item ).toBeEnabled();
-				} );
 			} );
 		} );
 
@@ -568,9 +550,13 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should call the handler when the classic menu item is selected and disable all options during the import/creation process', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn();
+				const handler = jest.fn( async () => {} );
 
 				useNavigationMenu.mockReturnValue( {
+					navigationMenus: [],
+					isResolvingNavigationMenus: false,
+					hasResolvedNavigationMenus: true,
+					canSwitchNavigationMenu: true,
 					canUserCreateNavigationMenu: true,
 				} );
 
@@ -597,6 +583,21 @@ describe( 'NavigationMenuSelector', () => {
 				// Check the dropdown has been closed.
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: [],
+					isResolvingNavigationMenus: true,
+					hasResolvedNavigationMenus: false,
+					canUserCreateNavigationMenu: true,
+				} );
+
+				useNavigationEntities.mockReturnValue( {
+					menus: classicMenusFixture,
+				} );
+
+				rerender(
+					<NavigationMenuSelector onSelectClassicMenu={ handler } />
+				);
+
 				// // Re-open the dropdown (it's closed when the "Create menu" button is clicked).
 				await user.click( screen.getByRole( 'button' ) );
 
@@ -611,6 +612,17 @@ describe( 'NavigationMenuSelector', () => {
 				screen.getAllByRole( 'menuitem' ).forEach( ( item ) => {
 					// // Check all menu items are present but disabled.
 					expect( item ).toBeDisabled();
+				} );
+
+				useNavigationMenu.mockReturnValue( {
+					navigationMenus: [],
+					isResolvingNavigationMenus: false,
+					hasResolvedNavigationMenus: true,
+					canUserCreateNavigationMenu: true,
+				} );
+
+				useNavigationEntities.mockReturnValue( {
+					menus: classicMenusFixture,
 				} );
 
 				// Simulate the menu being created and component being re-rendered.

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -13,23 +13,13 @@ import useNavigationEntities from '../../use-navigation-entities';
 
 jest.mock( '../../use-navigation-menu', () => {
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn(
-		() =>
-			new Promise( ( resolve ) => {
-				resolve();
-			} )
-	);
+	const mock = jest.fn();
 	return mock;
 } );
 
 jest.mock( '../../use-navigation-entities', () => {
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn(
-		() =>
-			new Promise( ( resolve ) => {
-				resolve();
-			} )
-	);
+	const mock = jest.fn();
 	return mock;
 } );
 
@@ -600,12 +590,14 @@ describe( 'NavigationMenuSelector', () => {
 						} )
 				);
 
-				useNavigationMenu.mockReturnValue( {
-					canUserCreateNavigationMenu: true,
-				} );
-
 				useNavigationEntities.mockReturnValue( {
 					menus: classicMenusFixture,
+				} );
+
+				useNavigationMenu.mockReturnValue( {
+					canUserCreateNavigationMenu: true,
+					isResolvingNavigationMenus: false,
+					hasResolvedNavigationMenus: true,
 				} );
 
 				const { rerender } = render(
@@ -624,6 +616,16 @@ describe( 'NavigationMenuSelector', () => {
 
 				expect( handler ).toHaveBeenCalled();
 
+				useNavigationMenu.mockReturnValue( {
+					canUserCreateNavigationMenu: true,
+					isResolvingNavigationMenus: true,
+					hasResolvedNavigationMenus: false,
+				} );
+
+				rerender(
+					<NavigationMenuSelector onSelectClassicMenu={ handler } />
+				);
+
 				// Check the dropdown has been closed.
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 
@@ -641,6 +643,11 @@ describe( 'NavigationMenuSelector', () => {
 				screen.getAllByRole( 'menuitem' ).forEach( ( item ) => {
 					// // Check all menu items are present but disabled.
 					expect( item ).toBeDisabled();
+				} );
+
+				useNavigationMenu.mockReturnValue( {
+					isResolvingNavigationMenus: false,
+					hasResolvedNavigationMenus: true,
 				} );
 
 				// Simulate the menu being created and component being re-rendered.

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -250,6 +250,7 @@ describe( 'NavigationMenuSelector', () => {
 				const user = userEvent.setup();
 				const handler = jest.fn();
 
+				// at the start we have the menus and we're not waiting on network
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
 					hasResolvedNavigationMenus: true,
@@ -271,6 +272,8 @@ describe( 'NavigationMenuSelector', () => {
 					} )
 				);
 
+				// creating a menu is a network activity
+				// so we have to wait on it
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
 					hasResolvedNavigationMenus: false,
@@ -294,6 +297,8 @@ describe( 'NavigationMenuSelector', () => {
 					} )
 				).toBeDisabled();
 
+				// once the menu is created
+				// no more network activity to wait on
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
 					hasResolvedNavigationMenus: true,
@@ -552,6 +557,7 @@ describe( 'NavigationMenuSelector', () => {
 				const user = userEvent.setup();
 				const handler = jest.fn( async () => {} );
 
+				// initially we have the menus, and we're not waiting on network
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
 					isResolvingNavigationMenus: false,
@@ -583,6 +589,8 @@ describe( 'NavigationMenuSelector', () => {
 				// Check the dropdown has been closed.
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 
+				// since we're importing we are doing network activity
+				// so we have to wait on it
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
 					isResolvingNavigationMenus: true,
@@ -614,6 +622,8 @@ describe( 'NavigationMenuSelector', () => {
 					expect( item ).toBeDisabled();
 				} );
 
+				// once the menu is imported
+				// no more network activity to wait on
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
 					isResolvingNavigationMenus: false,

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -221,12 +221,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should call handler callback and close popover when create menu button is clicked', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn(
-					() =>
-						new Promise( ( resolve ) => {
-							resolve();
-						} )
-				);
+				const handler = jest.fn();
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
@@ -253,12 +248,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should handle disabled state of the create menu button during the creation process', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn(
-					() =>
-						new Promise( ( resolve ) => {
-							resolve();
-						} )
-				);
+				const handler = jest.fn();
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
@@ -435,12 +425,7 @@ describe( 'NavigationMenuSelector', () => {
 			it( 'should call the handler when the navigation menu is selected and disable all options during the import/creation process', async () => {
 				const user = userEvent.setup();
 
-				const handler = jest.fn(
-					() =>
-						new Promise( ( resolve ) => {
-							resolve();
-						} )
-				);
+				const handler = jest.fn();
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: navigationMenusFixture,
@@ -583,21 +568,14 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should call the handler when the classic menu item is selected and disable all options during the import/creation process', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn(
-					() =>
-						new Promise( ( resolve ) => {
-							resolve();
-						} )
-				);
-
-				useNavigationEntities.mockReturnValue( {
-					menus: classicMenusFixture,
-				} );
+				const handler = jest.fn();
 
 				useNavigationMenu.mockReturnValue( {
 					canUserCreateNavigationMenu: true,
-					isResolvingNavigationMenus: false,
-					hasResolvedNavigationMenus: true,
+				} );
+
+				useNavigationEntities.mockReturnValue( {
+					menus: classicMenusFixture,
 				} );
 
 				const { rerender } = render(
@@ -616,16 +594,6 @@ describe( 'NavigationMenuSelector', () => {
 
 				expect( handler ).toHaveBeenCalled();
 
-				useNavigationMenu.mockReturnValue( {
-					canUserCreateNavigationMenu: true,
-					isResolvingNavigationMenus: true,
-					hasResolvedNavigationMenus: false,
-				} );
-
-				rerender(
-					<NavigationMenuSelector onSelectClassicMenu={ handler } />
-				);
-
 				// Check the dropdown has been closed.
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
 
@@ -643,11 +611,6 @@ describe( 'NavigationMenuSelector', () => {
 				screen.getAllByRole( 'menuitem' ).forEach( ( item ) => {
 					// // Check all menu items are present but disabled.
 					expect( item ).toBeDisabled();
-				} );
-
-				useNavigationMenu.mockReturnValue( {
-					isResolvingNavigationMenus: false,
-					hasResolvedNavigationMenus: true,
 				} );
 
 				// Simulate the menu being created and component being re-rendered.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #59604 - create menu is available as an option after menu switching.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes a seemingly useless? call to setting a state about creating a menu (`setIsCreatingMenu`) which makes no sense in the context of switching a menu.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


1. Have two menus
2. Go to the site editor
3. In a template add a navigation block
4. Open block settings
5. Above the navigation tree click the dot menu in the top right
6. Switch to another menu
7. Open the he dot menu in the top right again
8. Notice "Create new menu" option at the bottom is enabled and works

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/c8aa4142-08d9-4818-8027-df7e0e51f1d2

