### PR TITLE
Polish Google Fonts consent box.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/google-fonts-confirm-dialog.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/google-fonts-confirm-dialog.js
@@ -6,6 +6,7 @@ import {
 	Button,
 	Card,
 	CardBody,
+	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
@@ -24,7 +25,9 @@ function GoogleFontsConfirmDialog() {
 		<div className="font-library__google-fonts-confirm">
 			<Card>
 				<CardBody>
-					<Text as="h3">{ __( 'Connect to Google Fonts' ) }</Text>
+					<Heading level={ 2 }>
+						{ __( 'Connect to Google Fonts' ) }
+					</Heading>
 					<Spacer margin={ 6 } />
 					<Text as="p">
 						{ __(
@@ -38,7 +41,11 @@ function GoogleFontsConfirmDialog() {
 						) }
 					</Text>
 					<Spacer margin={ 6 } />
-					<Button variant="primary" onClick={ handleConfirm }>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						onClick={ handleConfirm }
+					>
 						{ __( 'Allow access to Google Fonts' ) }
 					</Button>
 				</CardBody>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -125,13 +125,22 @@ button.font-library-modal__upload-area {
 	align-items: center;
 	margin-top: $grid-unit-80;
 
-	h3 {
-		font-size: 1.4rem;
+	p {
+		line-height: $default-line-height;
+	}
+
+	h2 {
+		font-size: 1.2rem;
+		font-weight: 400;
 	}
 
 	.components-card {
-		width: 50%;
-		min-width: 350px;
-		max-width: 400px;
+		padding: $grid-unit-20;
+		width: 400px;
+	}
+
+	.components-button {
+		width: 100%;
+		justify-content: center;
 	}
 }


### PR DESCRIPTION
## What?

This updates the Google Fonts consent box to be closer to the initial mockups. That means a correct line height, font size, font weight, box width, and box padding.

Before:

![before](https://github.com/WordPress/gutenberg/assets/1204802/67297a33-cc82-42e2-a797-4e604d402e15)

After:

![after](https://github.com/WordPress/gutenberg/assets/1204802/2a8f0445-27a5-4b99-a2c6-2a2d60bfdfdd)

This PR also fixes what I believe was an accessibility bug; the heading level was 3, but with the modal being the preceding heading with a level of 1, I believe this level should be 2.

## Testing Instructions

* Open the fonts library, and withdraw Google Fonts consent if you've already given it (Install Fonts tab, then the ellipsis menu)
* Observe the refreshe consent box and check the heading level is correct too.