### PR TITLE
Demo: Try a story with ToggleGroupControl with PanelBody

### DIFF
--- a/packages/components/src/toggle-group-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.story.tsx
@@ -17,6 +17,7 @@ import {
 	ToggleGroupControlOption,
 	ToggleGroupControlOptionIcon,
 } from '../index';
+import { PanelBody } from '../../';
 import type {
 	ToggleGroupControlOptionProps,
 	ToggleGroupControlOptionIconProps,
@@ -139,4 +140,44 @@ export const Deselectable: StoryFn< typeof ToggleGroupControl > = Template.bind(
 Deselectable.args = {
 	...WithIcons.args,
 	isDeselectable: true,
+};
+
+export const WithVariableHeightSiblings: StoryFn<
+	typeof ToggleGroupControl
+> = ( { onChange, ...props } ) => {
+	const [ value, setValue ] =
+		useState< ToggleGroupControlProps[ 'value' ] >();
+
+	return (
+		<div style={ { overflowY: 'scroll' } }>
+			<PanelBody title="Test Panel">
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+				<br />
+			</PanelBody>
+			<PanelBody title="Another Panel">
+				<ToggleGroupControl
+					__nextHasNoMarginBottom
+					{ ...props }
+					onChange={ ( ...changeArgs ) => {
+						setValue( ...changeArgs );
+						onChange?.( ...changeArgs );
+					} }
+					value={ value }
+				/>
+			</PanelBody>
+		</div>
+	);
+};
+WithVariableHeightSiblings.args = {
+	...Default.args,
+	__nextHasNoMarginBottom: true,
+	__next40pxDefaultSize: true,
 };


### PR DESCRIPTION
## What?
This PR demonstrates a `ToggleGroupControl` inside a `PanelBody` that coexists with another sibling `PanelBody`. 

This is not intended to be merged.

## Why?
To demonstrate that a problem doesn't exist.

## How?
Just an example story.

## Testing Instructions
* Run `npm run storybook:dev`
* Go to http://localhost:50240/?path=/story/components-experimental-togglegroupcontrol--with-variable-height-siblings
* Select a control from the toggle group control.
* Verify that as you toggle the top panel, the animation works correctly and doesn't bleed up and down.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None