### PR TITLE
Fix allow mouse users to edit link text when Link UI is active

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -39,25 +39,25 @@ function Edit( {
 	contentRef,
 } ) {
 	const [ editingLink, setEditingLink ] = useState( false );
-	const [ addingNewLink, setAddingNewLink ] = useState( false );
+	const [ creatingLink, setCreatingLink ] = useState( false );
 
 	// We only need to store the button element that opened the popover. We can ignore the other states, as they will be handled by the onFocus prop to return to the rich text field.
 	const [ openedBy, setOpenedBy ] = useState( null );
 
 	const [ autoFocus, setAutoFocus ] = useState( true );
 
-	function setIsEditingExistingLink( _val, { shouldAutoFocus = true } = {} ) {
+	function setIsEditingLink( _val, { shouldAutoFocus = true } = {} ) {
 		setEditingLink( _val );
 		setAutoFocus( shouldAutoFocus );
 	}
 
-	function setIsAddingNewLink( _val ) {
+	function setIsCreatingLink( _val ) {
 		// Don't add a new link if there is already an active link.
 		// The two states are mutually exclusive.
 		if ( _val === true && isActive ) {
 			return;
 		}
-		setAddingNewLink( _val );
+		setCreatingLink( _val );
 	}
 
 	useEffect( () => {
@@ -66,7 +66,7 @@ function Edit( {
 		// becomes inactive (e.g. used arrow keys to move cursor outside of link bounds), the UI will close.
 		if ( ! isActive ) {
 			setEditingLink( false );
-			setAddingNewLink( false );
+			setCreatingLink( false );
 		}
 	}, [ isActive ] );
 
@@ -84,11 +84,11 @@ function Edit( {
 			// to be rendered in "creating" mode. We need to check isActive to see if
 			// we have an active link format.
 			if ( event.target.tagName !== 'A' || ! isActive ) {
-				setIsEditingExistingLink( false );
+				setIsEditingLink( false );
 				return;
 			}
 
-			setIsEditingExistingLink( true, { shouldAutoFocus: false } );
+			setIsEditingLink( true, { shouldAutoFocus: false } );
 		}
 
 		editableContentElement.addEventListener( 'click', handleClick );
@@ -121,9 +121,9 @@ function Edit( {
 				setOpenedBy( target );
 			}
 			if ( ! isActive ) {
-				setIsAddingNewLink( true );
+				setIsCreatingLink( true );
 			} else {
-				setIsEditingExistingLink( true );
+				setIsEditingLink( true );
 			}
 		}
 	}
@@ -143,8 +143,8 @@ function Edit( {
 		// Otherwise, we rely on the passed in onFocus to return focus to the rich text field.
 
 		// Close the popover
-		setIsEditingExistingLink( false );
-		setIsAddingNewLink( false );
+		setIsEditingLink( false );
+		setIsCreatingLink( false );
 
 		// Return focus to the toolbar button or the rich text field
 		if ( openedBy?.tagName === 'BUTTON' ) {
@@ -163,8 +163,8 @@ function Edit( {
 	// 4. Press Escape
 	// 5. Focus should be on the Options button
 	function onFocusOutside() {
-		setIsEditingExistingLink( false );
-		setIsAddingNewLink( false );
+		setIsEditingLink( false );
+		setIsCreatingLink( false );
 		setOpenedBy( null );
 	}
 
@@ -196,7 +196,7 @@ function Edit( {
 				aria-haspopup="true"
 				aria-expanded={ editingLink }
 			/>
-			{ ( isEditingActiveLink || addingNewLink ) && (
+			{ ( isEditingActiveLink || creatingLink ) && (
 				<InlineLinkUI
 					stopAddingLink={ stopAddingLink }
 					onFocusOutside={ onFocusOutside }

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -44,20 +44,21 @@ function Edit( {
 	// We only need to store the button element that opened the popover. We can ignore the other states, as they will be handled by the onFocus prop to return to the rich text field.
 	const [ openedBy, setOpenedBy ] = useState( null );
 
-	const [ autoFocus, setAutoFocus ] = useState( true );
+	// Manages whether the Link UI popover should autofocus when shown.
+	const [ shouldAutoFocus, setShouldAutoFocus ] = useState( true );
 
-	function setIsEditingLink( _val, { shouldAutoFocus = true } = {} ) {
-		setEditingLink( _val );
-		setAutoFocus( shouldAutoFocus );
+	function setIsEditingLink( isEditing, { autoFocus = true } = {} ) {
+		setEditingLink( isEditing );
+		setShouldAutoFocus( autoFocus );
 	}
 
-	function setIsCreatingLink( _val ) {
+	function setIsCreatingLink( isCreating ) {
 		// Don't add a new link if there is already an active link.
 		// The two states are mutually exclusive.
-		if ( _val === true && isActive ) {
+		if ( isCreating === true && isActive ) {
 			return;
 		}
-		setCreatingLink( _val );
+		setCreatingLink( isCreating );
 	}
 
 	useEffect( () => {
@@ -91,7 +92,7 @@ function Edit( {
 				return;
 			}
 
-			setIsEditingLink( true, { shouldAutoFocus: false } );
+			setIsEditingLink( true, { autoFocus: false } );
 		}
 
 		editableContentElement.addEventListener( 'click', handleClick );
@@ -102,7 +103,7 @@ function Edit( {
 	}, [ contentRef, isActive ] );
 
 	function addLink( target ) {
-		setAutoFocus( true );
+		setShouldAutoFocus( true );
 		const text = getTextContent( slice( value ) );
 
 		if ( ! isActive && text && isURL( text ) && isValidHref( text ) ) {
@@ -208,7 +209,7 @@ function Edit( {
 					value={ value }
 					onChange={ onChange }
 					contentRef={ contentRef }
-					focusOnMount={ autoFocus ? 'firstElement' : false }
+					focusOnMount={ shouldAutoFocus ? 'firstElement' : false }
 				/>
 			) }
 		</>

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -42,6 +42,8 @@ function Edit( {
 	// We only need to store the button element that opened the popover. We can ignore the other states, as they will be handled by the onFocus prop to return to the rich text field.
 	const [ openedBy, setOpenedBy ] = useState( null );
 
+	const [ autoFocus, setAutoFocus ] = useState( true );
+
 	useLayoutEffect( () => {
 		const editableContentElement = contentRef.current;
 		if ( ! editableContentElement ) {
@@ -56,9 +58,12 @@ function Edit( {
 			// to be rendered in "creating" mode. We need to check isActive to see if
 			// we have an active link format.
 			if ( event.target.tagName !== 'A' || ! isActive ) {
+				setAutoFocus( true );
+				setAddingLink( false );
 				return;
 			}
 
+			setAutoFocus( false );
 			setAddingLink( true );
 		}
 
@@ -90,6 +95,7 @@ function Edit( {
 			if ( target ) {
 				setOpenedBy( target );
 			}
+			setAutoFocus( true );
 			setAddingLink( true );
 		}
 	}
@@ -109,6 +115,7 @@ function Edit( {
 		// Otherwise, we rely on the passed in onFocus to return focus to the rich text field.
 
 		// Close the popover
+		setAutoFocus( true );
 		setAddingLink( false );
 		// Return focus to the toolbar button or the rich text field
 		if ( openedBy?.tagName === 'BUTTON' ) {
@@ -127,6 +134,7 @@ function Edit( {
 	// 4. Press Escape
 	// 5. Focus should be on the Options button
 	function onFocusOutside() {
+		setAutoFocus( true );
 		setAddingLink( false );
 		setOpenedBy( null );
 	}
@@ -149,6 +157,7 @@ function Edit( {
 				icon={ linkIcon }
 				title={ isActive ? __( 'Link' ) : title }
 				onClick={ ( event ) => {
+					setAutoFocus( true );
 					addLink( event.currentTarget );
 				} }
 				isActive={ isActive || addingLink }
@@ -166,6 +175,7 @@ function Edit( {
 					value={ value }
 					onChange={ onChange }
 					contentRef={ contentRef }
+					focusOnMount={ autoFocus ? 'firstElement' : false }
 				/>
 			) }
 		</>

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -38,7 +38,7 @@ function Edit( {
 	onFocus,
 	contentRef,
 } ) {
-	const [ addingLink, setAddingLink ] = useState( false );
+	const [ editingLink, setEditingLink ] = useState( false );
 	const [ addingNewLink, setAddingNewLink ] = useState( false );
 
 	// We only need to store the button element that opened the popover. We can ignore the other states, as they will be handled by the onFocus prop to return to the rich text field.
@@ -47,7 +47,7 @@ function Edit( {
 	const [ autoFocus, setAutoFocus ] = useState( true );
 
 	function setIsEditingExistingLink( _val, { shouldAutoFocus = true } = {} ) {
-		setAddingLink( _val );
+		setEditingLink( _val );
 		setAutoFocus( shouldAutoFocus );
 	}
 
@@ -61,11 +61,11 @@ function Edit( {
 	}
 
 	useEffect( () => {
-		// When the link becomes inactive (i.e. isActive is false), reset the addingLink state
+		// When the link becomes inactive (i.e. isActive is false), reset the editingLink state
 		// and the isAddingNewLink state. This means that if the Link UI is displayed and the link
 		// becomes inactive (e.g. used arrow keys to move cursor outside of link bounds), the UI will close.
 		if ( ! isActive ) {
-			setAddingLink( false );
+			setEditingLink( false );
 			setAddingNewLink( false );
 		}
 	}, [ isActive ] );
@@ -80,7 +80,7 @@ function Edit( {
 			// There is a situation whereby there is an existing link in the rich text
 			// and the user clicks on the leftmost edge of that link and fails to activate
 			// the link format, but the click event still fires on the `<a>` element.
-			// This causes the `addingLink` state to be set to `true` and the link UI
+			// This causes the `editingLink` state to be set to `true` and the link UI
 			// to be rendered in "creating" mode. We need to check isActive to see if
 			// we have an active link format.
 			if ( event.target.tagName !== 'A' || ! isActive ) {
@@ -173,6 +173,8 @@ function Edit( {
 		speak( __( 'Link removed.' ), 'assertive' );
 	}
 
+	const isEditingActiveLink = editingLink && isActive;
+
 	return (
 		<>
 			<RichTextShortcut type="primary" character="k" onUse={ addLink } />
@@ -188,13 +190,13 @@ function Edit( {
 				onClick={ ( event ) => {
 					addLink( event.currentTarget );
 				} }
-				isActive={ isActive || addingLink }
+				isActive={ isActive || editingLink }
 				shortcutType="primary"
 				shortcutCharacter="k"
 				aria-haspopup="true"
-				aria-expanded={ addingLink }
+				aria-expanded={ editingLink }
 			/>
-			{ ( ( addingLink && isActive ) || addingNewLink ) && (
+			{ ( isEditingActiveLink || addingNewLink ) && (
 				<InlineLinkUI
 					stopAddingLink={ stopAddingLink }
 					onFocusOutside={ onFocusOutside }

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -84,8 +84,7 @@ function Edit( {
 			// to be rendered in "creating" mode. We need to check isActive to see if
 			// we have an active link format.
 			if (
-				( event.target.tagName !== 'A' &&
-					event.target.parentElement.tagName !== 'A' ) || // other formats (e.g. bold) may be nested within the link.
+				! event.target.closest( '[contenteditable] a' ) || // other formats (e.g. bold) may be nested within the link.
 				! isActive
 			) {
 				setIsEditingLink( false );

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -75,6 +75,7 @@ function Edit( {
 	}, [ contentRef, isActive ] );
 
 	function addLink( target ) {
+		setAutoFocus( true );
 		const text = getTextContent( slice( value ) );
 
 		if ( ! isActive && text && isURL( text ) && isValidHref( text ) ) {
@@ -95,7 +96,6 @@ function Edit( {
 			if ( target ) {
 				setOpenedBy( target );
 			}
-			setAutoFocus( true );
 			setAddingLink( true );
 		}
 	}
@@ -157,7 +157,6 @@ function Edit( {
 				icon={ linkIcon }
 				title={ isActive ? __( 'Link' ) : title }
 				onClick={ ( event ) => {
-					setAutoFocus( true );
 					addLink( event.currentTarget );
 				} }
 				isActive={ isActive || addingLink }

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -83,7 +83,11 @@ function Edit( {
 			// This causes the `editingLink` state to be set to `true` and the link UI
 			// to be rendered in "creating" mode. We need to check isActive to see if
 			// we have an active link format.
-			if ( event.target.tagName !== 'A' || ! isActive ) {
+			if (
+				( event.target.tagName !== 'A' &&
+					event.target.parentElement.tagName !== 'A' ) || // other formats (e.g. bold) may be nested within the link.
+				! isActive
+			) {
 				setIsEditingLink( false );
 				return;
 			}

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useLayoutEffect } from '@wordpress/element';
+import { useState, useLayoutEffect, useEffect } from '@wordpress/element';
 import {
 	getTextContent,
 	applyFormat,
@@ -59,6 +59,16 @@ function Edit( {
 		}
 		setAddingNewLink( _val );
 	}
+
+	useEffect( () => {
+		// When the link becomes inactive (i.e. isActive is false), reset the addingLink state
+		// and the isAddingNewLink state. This means that if the Link UI is displayed and the link
+		// becomes inactive (e.g. used arrow keys to move cursor outside of link bounds), the UI will close.
+		if ( ! isActive ) {
+			setAddingLink( false );
+			setAddingNewLink( false );
+		}
+	}, [ isActive ] );
 
 	useLayoutEffect( () => {
 		const editableContentElement = contentRef.current;

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -63,7 +63,7 @@ function Edit( {
 
 	useEffect( () => {
 		// When the link becomes inactive (i.e. isActive is false), reset the editingLink state
-		// and the isAddingNewLink state. This means that if the Link UI is displayed and the link
+		// and the creatingLink state. This means that if the Link UI is displayed and the link
 		// becomes inactive (e.g. used arrow keys to move cursor outside of link bounds), the UI will close.
 		if ( ! isActive ) {
 			setEditingLink( false );

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -220,7 +220,6 @@ function InlineLinkUI( {
 		settings: {
 			...settings,
 			isActive,
-			__unstableActiveAttributes: activeAttributes,
 		},
 	} );
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -46,6 +46,7 @@ function InlineLinkUI( {
 	onFocusOutside,
 	stopAddingLink,
 	contentRef,
+	focusOnMount,
 } ) {
 	const richLinkTextValue = getRichTextValueFromSelection( value, isActive );
 
@@ -88,6 +89,8 @@ function InlineLinkUI( {
 		]
 	);
 
+	const hasLink = linkValue?.url;
+
 	function removeLink() {
 		const newValue = removeFormat( value, 'core/link' );
 		onChange( newValue );
@@ -96,7 +99,6 @@ function InlineLinkUI( {
 	}
 
 	function onChangeLink( nextValue ) {
-		const hasLink = linkValue?.url;
 		const isNewLink = ! hasLink;
 
 		// Merge the next value with the current link value.
@@ -245,6 +247,10 @@ function InlineLinkUI( {
 		);
 	}
 
+	if ( ! hasLink ) {
+		return null;
+	}
+
 	return (
 		<Popover
 			anchor={ popoverAnchor }
@@ -253,6 +259,7 @@ function InlineLinkUI( {
 			placement="bottom"
 			offset={ 10 }
 			shift
+			focusOnMount={ focusOnMount }
 		>
 			<LinkControl
 				value={ linkValue }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -247,10 +247,6 @@ function InlineLinkUI( {
 		);
 	}
 
-	if ( ! hasLink ) {
-		return null;
-	}
-
 	return (
 		<Popover
 			anchor={ popoverAnchor }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -256,6 +256,7 @@ function InlineLinkUI( {
 			offset={ 10 }
 			shift
 			focusOnMount={ focusOnMount }
+			constrainTabbing
 		>
 			<LinkControl
 				value={ linkValue }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -89,8 +89,6 @@ function InlineLinkUI( {
 		]
 	);
 
-	const hasLink = linkValue?.url;
-
 	function removeLink() {
 		const newValue = removeFormat( value, 'core/link' );
 		onChange( newValue );
@@ -99,6 +97,7 @@ function InlineLinkUI( {
 	}
 
 	function onChangeLink( nextValue ) {
+		const hasLink = linkValue?.url;
 		const isNewLink = ! hasLink;
 
 		// Merge the next value with the current link value.

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -218,7 +218,7 @@ function InlineLinkUI( {
 
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
-		settings: { ...settings, isActive },
+		settings: { ...settings, isActive, activeAttributes },
 	} );
 
 	async function handleCreate( pageTitle ) {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -217,7 +217,11 @@ function InlineLinkUI( {
 
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
-		settings: { ...settings, isActive, activeAttributes },
+		settings: {
+			...settings,
+			isActive,
+			__unstableActiveAttributes: activeAttributes,
+		},
 	} );
 
 	async function handleCreate( pageTitle ) {

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -177,7 +177,7 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 		wasActive,
 		// Active attributes is defaulted to a stable object to avoid re-rendering,
 		// but in specific circumstances it can be used to provide additional information
-		// about the currently active format to disambiguate the anchor from other anchors
+		// about the currently active format to disambiguate the format from other instances of the same format
 		// within the same editable content element. This is useful for `core/link` when you
 		// want to disambiguate between different links when clicking between them.
 		activeAttributes,

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -125,6 +125,8 @@ function getAnchor( editableContentElement, tagName, className ) {
 	return createVirtualAnchorElement( range, editableContentElement );
 }
 
+const STABLE_OBJECT = {};
+
 /**
  * This hook, to be used in a format type's Edit component, returns the active
  * element that is formatted, or a virtual element for the selection range if
@@ -138,7 +140,12 @@ function getAnchor( editableContentElement, tagName, className ) {
  * @return {Element|VirtualAnchorElement|undefined|null} The active element or selection range.
  */
 export function useAnchor( { editableContentElement, settings = {} } ) {
-	const { tagName, className, isActive } = settings;
+	const {
+		tagName,
+		className,
+		isActive,
+		activeAttributes = STABLE_OBJECT,
+	} = settings;
 	const [ anchor, setAnchor ] = useState( () =>
 		getAnchor( editableContentElement, tagName, className )
 	);
@@ -162,7 +169,19 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 				getAnchor( editableContentElement, tagName, className )
 			);
 		}
-	}, [ editableContentElement, tagName, className, isActive, wasActive ] );
+	}, [
+		editableContentElement,
+		tagName,
+		className,
+		isActive,
+		wasActive,
+		// Active attributes is defaulted to a stable object to avoid re-rendering,
+		// but in specific circumstances it can be used to provide additional information
+		// about the currently active format to disambiguate the anchor from other anchors
+		// within the same editable content element. This is useful for `core/link` when you
+		// want to disambiguate between different links when clicking between them.
+		activeAttributes,
+	] );
 
 	return anchor;
 }

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -7,6 +7,8 @@ import { useState, useLayoutEffect } from '@wordpress/element';
 /** @typedef {import('../register-format-type').WPFormat} WPFormat */
 /** @typedef {import('../types').RichTextValue} RichTextValue */
 
+const STABLE_OBJECT = {};
+
 /**
  * Given a range and a format tag name and class name, returns the closest
  * format element.
@@ -124,8 +126,6 @@ function getAnchor( editableContentElement, tagName, className ) {
 
 	return createVirtualAnchorElement( range, editableContentElement );
 }
-
-const STABLE_OBJECT = {};
 
 /**
  * This hook, to be used in a format type's Edit component, returns the active

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -144,7 +144,7 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 		tagName,
 		className,
 		isActive,
-		activeAttributes = STABLE_OBJECT,
+		__unstableActiveAttributes: activeAttributes = STABLE_OBJECT,
 	} = settings;
 	const [ anchor, setAnchor ] = useState( () =>
 		getAnchor( editableContentElement, tagName, className )

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -921,6 +921,51 @@ test.describe( 'Links', () => {
 	} );
 
 	test.describe( 'Editing link text', () => {
+		test( 'should allow editing text underneath popover when activated via mouse', async ( {
+			page,
+			editor,
+			LinkUtils,
+		} ) => {
+			await LinkUtils.createLink();
+
+			// Click on some other part of the text to move the caret.
+			await editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} )
+				.click();
+
+			// Click on the link to activate the Link UI.
+			const richTextLink = editor.canvas.getByRole( 'link', {
+				name: 'Gutenberg',
+			} );
+
+			await richTextLink.click();
+
+			// Check focus remains in the RichText.
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} )
+			).toBeFocused();
+
+			// Type to modify the link text.
+			await page.keyboard.type( ' is awesome' );
+
+			// expect link UI to be visible
+			const linkPopover = LinkUtils.getLinkPopover();
+
+			await expect( linkPopover ).toBeVisible();
+
+			// Press "Edit" on Link UI
+			await linkPopover.getByRole( 'button', { name: 'Edit' } ).click();
+
+			// Check that the Link Text input reflects the change to the text
+			// made in the RichText.
+			const textInput = linkPopover.getByLabel( 'Text', { exact: true } );
+			await expect( textInput ).toHaveValue( 'Gute is awesomenberg' );
+		} );
+
 		test( 'should allow for modification of link text via the Link UI', async ( {
 			page,
 			pageUtils,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows for editing a link underneath popover UI when clicking on it in Rich Text. Restores this portion of the original behaviour in WP 6.4 prior (see below) to updating the UX on the Link UI.

<details>
<summary> 📹 Screencast of behaviour in WP 6.4</summary>

https://github.com/WordPress/gutenberg/assets/444434/b4cf06ff-60de-4fbc-be0a-a14f7c732c00


</details>

Alternative to https://github.com/WordPress/gutenberg/pull/59599 and https://github.com/WordPress/gutenberg/pull/59626.

Fixes https://github.com/WordPress/gutenberg/issues/59525

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently on `trunk` if you click a link you cannot edit the text of the link except by:

- hitting escape
- using the `Text` input within the Link UI

This is a regression on WP 6.4 and so this PR tries to solve that.

This is an alternative approach to https://github.com/WordPress/gutenberg/pull/59599 and tries to better restore the previous functionality from WP 6.4 in terms of retaining the ability to edit the link text underneath the UI when it has been clicked.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In this PR I have disabled auto focus when a user _clicks_ on a link. This means the focus is not automatically transferred to the popover and remains on the rich text until the mouse user _chooses_ to select the Link UI.

This means mouse users can edit the text _underneath_ the link popover in the same way as keyboard users.

Note that users of mice should be able to perceive that a popover has appeared and thus can use the mouse pointer to choose to edit the link via the control in popover. 

The behaviour should remain the same for keyboard users. 

I also fixed a hidden bug with `useAnchor` whereby it cannot distinguish between multiple `core/link` formats within in a content editable.


### Accessibility Checks

Note that the a11y of this PR's approach was discussed during Accessibility team office hours on WP Slack. As part of this we received the [following guidance](https://wordpress.slack.com/archives/C02RP4X03/p1709741010966669):

> For now, I’d opt for:
> Not move focus into the link UI when it opens via a mouse click
> This would have to advantages:
> Mouse users can always click again inside the popover, if their intent is to edit
> or simply continue editing the text.

This suggests that this PR does meet a11y standards because the keyboard interactions are maintained as per `trunk` but mouse users get a more intuitive experience.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

For this PR please be sure to test against `trunk` (or WP 6.5 RC) to validate any "issue" isn't something already present as intended behaviour. Link UI UX has changed a lot in WP 6.5 so it's important to validate 🙏 

- New Post
- Add a paragraph block
- Add several links to the paragraph block
- Click on each link in turn and validate that the popover moves correctly between the links, shows the correct contents and anchors correctly.
- Check that when activating a link via mouse focus is _not_ transferred to the popover and remains on rich text. Check that you can make edits to the text underneath the popover (note this is as per WP 6.4).
- Check that using a keyboard to interact with links remains as per trunk.
- Check that adding other formats within a link (e.g. bold, italic .etc) does not prevent accessing the link popover by mouse or keyboard.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/914b6144-c3ce-4bab-844a-607defb207a8

Co-authored-by: getdave <get_dave@git.wordpress.org>
Co-authored-by: jeryj <jeryj@git.wordpress.org>
Co-authored-by: draganescu <andraganescu@git.wordpress.org>
Co-authored-by: scruffian <scruffian@git.wordpress.org>
Co-authored-by: bacoords <bacoords@git.wordpress.org>
Co-authored-by: annezazu <annezazu@git.wordpress.org>
Co-authored-by: youknowriad <youknowriad@git.wordpress.org>
Co-authored-by: richtabor <richtabor@git.wordpress.org>
Co-authored-by: fabiankaegy <fabiankaegy@git.wordpress.org>