### PR TITLE
docs: fix syntax in block filters example

### DIFF
--- a/docs/reference-guides/filters/block-filters.md
+++ b/docs/reference-guides/filters/block-filters.md
@@ -218,11 +218,11 @@ const withMyPluginControls = createHigherOrderComponent( ( BlockEdit ) => {
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ props.isSelected && {
+				{ props.isSelected && (
 					<InspectorControls>
 						<PanelBody>My custom control</PanelBody>
 					</InspectorControls>
-				}}
+				) }
 			</>
 		);
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the syntax in block filters example.

## Why?
Incorrect syntax used in block filters example.

## How?
Replaces incorrect curly braces with parentheses

