### PR TITLE
[Data Views] Updating keyboard navigation in list layouts

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -340,6 +340,7 @@
 
 	li {
 		margin: 0;
+		cursor: pointer;
 
 		.dataviews-view-list__item-wrapper {
 			position: relative;
@@ -355,14 +356,21 @@
 				background: $gray-100;
 				height: 1px;
 			}
+
+			> * {
+				width: 100%;
+			}
 		}
 
-		&:not(.is-selected):hover {
-			color: var(--wp-admin-theme-color);
-
-			.dataviews-view-list__primary-field,
-			.dataviews-view-list__fields {
+		&:not(.is-selected) {
+			&:hover,
+			&:focus-within {
 				color: var(--wp-admin-theme-color);
+
+				.dataviews-view-list__primary-field,
+				.dataviews-view-list__fields {
+					color: var(--wp-admin-theme-color);
+				}
 			}
 		}
 	}
@@ -388,7 +396,8 @@
 	.dataviews-view-list__item {
 		padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-30;
 		width: 100%;
-		cursor: pointer;
+		scroll-margin: $grid-unit-10 0;
+
 		&:focus {
 			&::before {
 				position: absolute;
@@ -449,7 +458,9 @@
 		line-height: $grid-unit-20;
 
 		.dataviews-view-list__field {
-			&:empty {
+			margin: 0;
+
+			&:has(.dataviews-view-list__field-value:empty) {
 				display: none;
 			}
 		}


### PR DESCRIPTION
## What?
Adds grid semantics to the list layout, and makes use of `aria-labelledby` and `aria-describedby` in list items.

## Why?
The list layout currently presents as a long list of buttons, each its own tab stop, which makes it difficult to reach the associated panel content. This is further complicated when grid items have additional detail buttons, doubling the number of tabs stops. Changing the list to a grid, and supporting <kbd>Up</kbd>/<kbd>Down</kbd> key navigation, means we can reduce the list to a single tab stop, providing easier access to the associated content.

Using `aria-labelledby` and `aria-describedby` on list items allows us to reduce the information density, such that each item only presents with the primary field as a title, with the other fields available as additional descriptive content. This means that information can be scanned much faster.

## How?
- The `Composite` component family has been used to add arrow key navigation to the list and list items.
- IDs have been added to the primary and other fields, and used on list items in `aria-labelledby` and `aria-describedby` respectively.

## Testing Instructions
List layouts should not visually be any different, and behaviour should continue as before.

### Testing Instructions for Keyboard
- Tab to list; focus should appear on first item
- Press <kbd>Tab</kbd> again; focus should move away from list to associated content
- Press <kbd>Shift</kbd>+<kbd>Tab</kbd>; focus should return to first list item
- <kbd>Up</kbd> and <kbd>Down</kbd> arrow keys should navigate through list
- <kbd>Tab</kbd>/<kbd>Shift</kbd>+<kbd>Tab</kbd> should continue to move between the associated content and the selected list item
- If a list item has an "additional details" button, <kbd>Right</kbd>/<kbd>Left</kbd> should jump between the button and the main item

## Issues
- [ ] Extra tab stop between list and content (which disappears after the first time its focused)
  - This is unrelated to this PR, and happens in trunk, but is more obvious with fewer tab stops
- [ ] Selected item isn't active when returning to view (when `postId` is given as search parameter)
  - I think this is a broader issue with data views not initialising selected data with that context in mind