### PR TITLE
Site Editor: Restore the back button when navigating to the template from the home page.

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -101,8 +101,6 @@ function useNavigateToPreviousEntityRecord() {
 			( location.params.postId &&
 				FOCUSABLE_ENTITIES.includes( location.params.postType ) );
 		const didComeFromEditorCanvas =
-			previousLocation?.params.postId &&
-			previousLocation?.params.postType &&
 			previousLocation?.params.canvas === 'edit';
 		const showBackButton = isFocusMode && didComeFromEditorCanvas;
 		return showBackButton ? () => history.back() : undefined;


### PR DESCRIPTION
I think this is a regression introduced in #58710 

## What?

When you have a static home page and you open the site editor and navigate to its template, the "back" button was not visible in trunk.

It's actually a bit tricky to get this right, we were checking that we were coming from a defined postType and postId to show the button or not, the current PR will show the button when we navigate from the editor canvas regardless of the previous thing that was rendered in the canvas.

Obviously, this is not necessarily perfect but I think it's better than what's currently in trunk but let make sure to test all kind of post types in the site editor.

## Testing Instructions

1- Have a fixed home page
2- Open the site editor
3- Go the editor
4- Click outside post blocks
5- A snackbar shows up inviting you to switch to template
6- Click edit template
7- Back button is visible in the document bar.