### PR TITLE
Add inline comment denoting version for Ruby setup

### DIFF
--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-            - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7
+            - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
               with:
                   # `.ruby-version` file location
                   working-directory: packages/react-native-editor/ios


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add version number as comment for ruby setup in `rnmobile-ios-runner.yml`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes #59624.  This PR adds a human-readable comment denoting the version number for the Ruby setup in the `rnmobile-ios-runner.yml` file. This enhances readability and helps maintain consistency with GitHub security hardening guidelines.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR adds an inline comment following the recommendation outlined in GitHub security hardening guidelines. This comment provides clarity on the version of Ruby being used in the workflow setup.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Navigate to the `rnmobile-ios-runner.yml` file.
2. Locate the Ruby setup step.
3. Verify that a comment denoting the version number is present. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/86654557/b0cf08e5-8084-4a99-9039-a6beadc2c3b4)