### PR TITLE
Components: Fix unwanted ToggleGroupControl backdrop vertical animation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `HStack`, `VStack`: Stop passing invalid props to underlying element ([#59416](https://github.com/WordPress/gutenberg/pull/59416)).
 -   `Button`: Fix focus outline in disabled primary variant ([#59391](https://github.com/WordPress/gutenberg/pull/59391)).
 -   `Button`: Place `children` before the icon when `iconPosition` is `right`  ([#59489](https://github.com/WordPress/gutenberg/pull/59489)).
+-   `ToggleGroupControl`: Fix unwanted backdrop vertical animation ([#59642](https://github.com/WordPress/gutenberg/pull/59642)).
 
 ### Internal
 

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -276,11 +276,13 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
               </svg>
             </div>
           </button>
-          <div
-            class="emotion-15"
-            role="presentation"
-            style="opacity: 1;"
-          />
+          <div>
+            <div
+              class="emotion-15"
+              role="presentation"
+              style="opacity: 1;"
+            />
+          </div>
         </div>
         <div
           class="emotion-10 emotion-11"
@@ -823,11 +825,13 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
               </svg>
             </div>
           </button>
-          <div
-            class="emotion-15"
-            role="presentation"
-            style="opacity: 1;"
-          />
+          <div>
+            <div
+              class="emotion-15"
+              role="presentation"
+              style="opacity: 1;"
+            />
+          </div>
         </div>
         <div
           class="emotion-10 emotion-11"

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -160,16 +160,18 @@ function ToggleGroupControlOptionBase(
 			</WithToolTip>
 			{ /* Animated backdrop using framer motion's shared layout animation */ }
 			{ isPressed ? (
-				<motion.div
-					className={ backdropClasses }
-					transition={
-						shouldReduceMotion
-							? REDUCED_MOTION_TRANSITION_CONFIG
-							: undefined
-					}
-					role="presentation"
-					layoutId={ LAYOUT_ID }
-				/>
+				<motion.div layout layoutRoot>
+					<motion.div
+						className={ backdropClasses }
+						transition={
+							shouldReduceMotion
+								? REDUCED_MOTION_TRANSITION_CONFIG
+								: undefined
+						}
+						role="presentation"
+						layoutId={ LAYOUT_ID }
+					/>
+				</motion.div>
 			) : null }
 		</LabelView>
 	);


### PR DESCRIPTION
## What?
This PR updates the `ToggleGroupControl` backdrop animation to be contained inside the component.

## Why?
To fix an edge case where the backdrop animation will sometimes incorrectly animate outside of the `ToggleGroupControl` component if another surrounding component changes height. I'm unable to repro this in Gutenberg, but it was easily reproducible with the [Parse.ly](https://wordpress.org/plugins/wp-parsely/) plugin.

## How?
We're utilizing `layout` and `layoutRoot` to minimize surrounding content changes impact, as [recommended by the official docs](https://www.framer.com/motion/layout-animations/###item-is-performing-unwanted-layout-animations-as-surrounding-content-changes).

## Testing Instructions
* Verify `ToggleGroupControl` still works well in Storybook and this introduces no regressions to the backdrop animation.
* Verify `ToggleGroupControl` still works well in the editor (font size picker in typography settings for example) - verify this introduces no regressions to the backdrop animation.
* All checks should be green
* With Parse.ly dev env locally, you can try it out with https://github.com/Parsely/wp-parsely/pull/2238 from the plugin sidebar - cc @acicovic @vaurdan for confirmation

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/WordPress/gutenberg/assets/8436925/02587851-3e40-4778-b579-3d16a95d084c

After:

https://github.com/WordPress/gutenberg/assets/8436925/c9617d24-96fe-4cd6-86e6-045862c8f7c9

