### PR TITLE
Patterns: Add a title to the category delete flow and increase line height

### DIFF
--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -58,7 +58,7 @@ export default Object.assign( {}, CONTROL_PROPS, TOGGLE_GROUP_CONTROL_PROPS, {
 	fontSizeMobile: '15px',
 	fontSizeSmall: 'calc(0.92 * 13px)',
 	fontSizeXSmall: 'calc(0.75 * 13px)',
-	fontLineHeightBase: '1.2',
+	fontLineHeightBase: '1.4',
 	fontWeight: 'normal',
 	fontWeightHeading: '600',
 	gridBase: '4px',

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -58,7 +58,7 @@ export default Object.assign( {}, CONTROL_PROPS, TOGGLE_GROUP_CONTROL_PROPS, {
 	fontSizeMobile: '15px',
 	fontSizeSmall: 'calc(0.92 * 13px)',
 	fontSizeXSmall: 'calc(0.75 * 13px)',
-	fontLineHeightBase: '1.4',
+	fontLineHeightBase: '1.2',
 	fontWeight: 'normal',
 	fontWeightHeading: '600',
 	gridBase: '4px',

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -90,6 +90,13 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 				onCancel={ () => setIsModalOpen( false ) }
 				confirmButtonText={ __( 'Delete' ) }
 				className="edit-site-patterns__delete-modal"
+				title={ sprintf(
+					// translators: %s: The pattern category's name.
+					__( 'Delete the category "%s"?' ),
+					decodeEntities( category.label )
+				) }
+				size="medium"
+				__experimentalHideHeader={ false }
 			>
 				{ sprintf(
 					// translators: %s: The pattern category's name.

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -92,7 +92,7 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 				className="edit-site-patterns__delete-modal"
 				title={ sprintf(
 					// translators: %s: The pattern category's name.
-					__( 'Delete the category "%s"?' ),
+					__( 'Delete "%s"?' ),
 					decodeEntities( category.label )
 				) }
 				size="medium"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Partially fixes https://github.com/WordPress/gutenberg/issues/58690 by aligning the look of the two dialogs.

## Why?
Consistency.

## How?
1. Pass a title and a size to the ConfirmDialog
2. Increase the line height for all text components

## Testing Instructions
1. Create a custom pattern category by creating a new pattern
2. Open the pattern category in the site editor
3. Find the pattern category heading
4. Click the ellipsis
5. Click delete
6. Confirm that the modal looks as in the screenshot

### Testing Instructions for Keyboard
This is a visual change

## Screenshots or screencast <!-- if applicable -->
<img width="573" alt="Screenshot 2024-03-06 at 14 16 59" src="https://github.com/WordPress/gutenberg/assets/275961/b9338c42-4c68-4538-b1b4-0e069f43b851">

