### PR TITLE
Site editor: Fix opening of save panel when using the `save` shortcut

### DIFF
--- a/packages/edit-site/src/components/keyboard-shortcuts/global.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/global.js
@@ -4,6 +4,7 @@
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -13,20 +14,25 @@ import { store as editSiteStore } from '../../store';
 function KeyboardShortcutsGlobal() {
 	const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
 		useSelect( coreStore );
+	const { hasNonPostEntityChanges } = useSelect( editorStore );
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
 
 	useShortcut( 'core/edit-site/save', ( event ) => {
 		event.preventDefault();
 
 		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-		const isDirty = !! dirtyEntityRecords.length;
+		const hasDirtyEntities = !! dirtyEntityRecords.length;
 		const isSaving = dirtyEntityRecords.some( ( record ) =>
 			isSavingEntityRecord( record.kind, record.name, record.key )
 		);
-
-		if ( ! isSaving && isDirty ) {
-			setIsSaveViewOpened( true );
+		const _hasNonPostEntityChanges = hasNonPostEntityChanges();
+		if ( ! hasDirtyEntities || ! _hasNonPostEntityChanges || isSaving ) {
+			return;
 		}
+		// At this point, we know that there are dirty entities, other than
+		// the edited post, and we're not in the process of saving, so open
+		// save view.
+		setIsSaveViewOpened( true );
 	} );
 
 	return null;

--- a/packages/edit-site/src/components/keyboard-shortcuts/global.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/global.js
@@ -10,11 +10,13 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 function KeyboardShortcutsGlobal() {
 	const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
 		useSelect( coreStore );
 	const { hasNonPostEntityChanges } = useSelect( editorStore );
+	const { getCanvasMode } = unlock( useSelect( editSiteStore ) );
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
 
 	useShortcut( 'core/edit-site/save', ( event ) => {
@@ -26,7 +28,11 @@ function KeyboardShortcutsGlobal() {
 			isSavingEntityRecord( record.kind, record.name, record.key )
 		);
 		const _hasNonPostEntityChanges = hasNonPostEntityChanges();
-		if ( ! hasDirtyEntities || ! _hasNonPostEntityChanges || isSaving ) {
+		const isViewMode = getCanvasMode() === 'view';
+		if (
+			( ! hasDirtyEntities || ! _hasNonPostEntityChanges || isSaving ) &&
+			! isViewMode
+		) {
 			return;
 		}
 		// At this point, we know that there are dirty entities, other than


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/59472

This PR adjusts the checks for when to open the save panel in site editor when using the `save` keyboard shortcut.

Right now when using the shortcut, the changes for the edited post are automatically saved by the `editor` global shortcut. So if we have changes only for the edited post there is no need to open the save panel at all.

Additionally the current logic creates another bug which is if we make changes only to the edited post and use the shortcut, if we make more changes afterwards we cannot open the save panel by clicking the `save` button because the value we keep in `edit site` store is wrong.



## Testing Instructions
1. In site editor go to a page and make some changes
2. Use the `save` shortcut
3. Observe that the save panel doesn't open
4. Make more changes and observe that you can click the `save` button
5. Start fresh and make changes to multiple entities(ex the page and a template part)
6. Use save shortcut and observe that the save panel opens. 
7. Start fresh and make changes and then go to `view` mode
8. Use save shortcut and observe that the save panel opens.

### Trunk

https://github.com/WordPress/gutenberg/assets/16275880/a04c5f27-8215-42a8-a44e-0b2ef6f1f35b



### This PR

https://github.com/WordPress/gutenberg/assets/16275880/47912782-b302-416a-ab5a-2399b87bf375

