### PR TITLE
GitHub Actions: Fix PHP file change detection logic

### DIFF
--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -21,8 +21,8 @@ jobs:
               with:
                   files: |
                       *.{php}
-                      lib/**
-                      phpunit/**
+                      lib/**/*.php
+                      phpunit/**/*.php
 
             - name: List all changed files
               if: steps.changed-files-php.outputs.any_changed == 'true'

--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -20,7 +20,7 @@ jobs:
               uses: tj-actions/changed-files@800a2825992141ddde1a8bca8ad394cec34d3188 # v42.0.5
               with:
                   files: |
-                      *.{php}
+                      **.{php}
                       lib/**/*.php
                       phpunit/**/*.php
 

--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -21,8 +21,6 @@ jobs:
               with:
                   files: |
                       **.{php}
-                      lib/**/*.php
-                      phpunit/**/*.php
 
             - name: List all changed files
               if: steps.changed-files-php.outputs.any_changed == 'true'


### PR DESCRIPTION
This issue was discovered by a bot comment below:

https://github.com/WordPress/gutenberg/pull/59531#issuecomment-1978389827

## What?

This PR fixes an issue where GitHub Actions that prompt PHP backports to core could unintentionally detect non-PHP files.

## Why?

The `lib` and `phpunit` directories contain more than just php files.

## Testing Instructions

This regular expression should be correct, but you can test it by modifying and pushing the files in the `lib`, `phpunit` directories in this PR.