### PR TITLE
Add support "HTML Element" to Site Tagline

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -847,7 +847,7 @@ Describe in a few words what the site is about. The tagline can be used in searc
 -	**Name:** core/site-tagline
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** tagName, textAlign
+-	**Attributes:** level, textAlign
 
 ## Site Title
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -847,7 +847,7 @@ Describe in a few words what the site is about. The tagline can be used in searc
 -	**Name:** core/site-tagline
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-	**Attributes:** tagName, textAlign
 
 ## Site Title
 

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -10,6 +10,10 @@
 	"attributes": {
 		"textAlign": {
 			"type": "string"
+		},
+		"tagName": {
+			"type": "string",
+			"default": "p"
 		}
 	},
 	"example": {},

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -11,9 +11,9 @@
 		"textAlign": {
 			"type": "string"
 		},
-		"tagName": {
-			"type": "string",
-			"default": "p"
+		"level": {
+			"type": "number",
+			"default": 0
 		}
 	},
 	"example": {},

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -12,17 +12,19 @@ import {
 	AlignmentControl,
 	useBlockProps,
 	BlockControls,
+	InspectorControls,
 	RichText,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { SelectControl } from '@wordpress/components';
 
 export default function SiteTaglineEdit( {
 	attributes,
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { textAlign } = attributes;
+	const { textAlign, tagName: TagName } = attributes;
 	const { canUserEdit, tagline } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -58,7 +60,7 @@ export default function SiteTaglineEdit( {
 			onChange={ setTagline }
 			aria-label={ __( 'Site tagline text' ) }
 			placeholder={ __( 'Write site tagline…' ) }
-			tagName="p"
+			tagName={ TagName }
 			value={ tagline }
 			disableLineBreaks
 			__unstableOnSplitAtEnd={ () =>
@@ -67,10 +69,30 @@ export default function SiteTaglineEdit( {
 			{ ...blockProps }
 		/>
 	) : (
-		<p { ...blockProps }>{ tagline || __( 'Site Tagline placeholder' ) }</p>
+		<TagName { ...blockProps }>
+			{ tagline || __( 'Site Tagline placeholder' ) }
+		</TagName>
 	);
 	return (
 		<>
+			<InspectorControls group="advanced">
+				<SelectControl
+					label={ __( 'HTML element' ) }
+					options={ [
+						{ label: __( 'Default (<p>)' ), value: 'p' },
+						{ label: '<h1>', value: 'h1' },
+						{ label: '<h2>', value: 'h2' },
+						{ label: '<h3>', value: 'h3' },
+						{ label: '<h4>', value: 'h4' },
+						{ label: '<h5>', value: 'h5' },
+						{ label: '<h6>', value: 'h6' },
+					] }
+					value={ TagName }
+					onChange={ ( newTagName ) =>
+						setAttributes( { tagName: newTagName } )
+					}
+				/>
+			</InspectorControls>
 			<BlockControls group="block">
 				<AlignmentControl
 					onChange={ ( newAlign ) =>

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -12,19 +12,20 @@ import {
 	AlignmentControl,
 	useBlockProps,
 	BlockControls,
-	InspectorControls,
+	HeadingLevelDropdown,
 	RichText,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
-import { SelectControl } from '@wordpress/components';
+
+const HEADING_LEVELS = [ 0, 1, 2, 3, 4, 5, 6 ];
 
 export default function SiteTaglineEdit( {
 	attributes,
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { textAlign, tagName: TagName } = attributes;
+	const { textAlign, level } = attributes;
 	const { canUserEdit, tagline } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -40,6 +41,7 @@ export default function SiteTaglineEdit( {
 		};
 	}, [] );
 
+	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const { editEntityRecord } = useDispatch( coreStore );
 
 	function setTagline( newTagline ) {
@@ -75,25 +77,14 @@ export default function SiteTaglineEdit( {
 	);
 	return (
 		<>
-			<InspectorControls group="advanced">
-				<SelectControl
-					label={ __( 'HTML element' ) }
-					options={ [
-						{ label: __( 'Default (<p>)' ), value: 'p' },
-						{ label: '<h1>', value: 'h1' },
-						{ label: '<h2>', value: 'h2' },
-						{ label: '<h3>', value: 'h3' },
-						{ label: '<h4>', value: 'h4' },
-						{ label: '<h5>', value: 'h5' },
-						{ label: '<h6>', value: 'h6' },
-					] }
-					value={ TagName }
-					onChange={ ( newTagName ) =>
-						setAttributes( { tagName: newTagName } )
+			<BlockControls group="block">
+				<HeadingLevelDropdown
+					options={ HEADING_LEVELS }
+					value={ level }
+					onChange={ ( newLevel ) =>
+						setAttributes( { level: newLevel } )
 					}
 				/>
-			</InspectorControls>
-			<BlockControls group="block">
 				<AlignmentControl
 					onChange={ ( newAlign ) =>
 						setAttributes( { textAlign: newAlign } )

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -17,9 +17,14 @@ function render_block_core_site_tagline( $attributes ) {
 	if ( ! $site_tagline ) {
 		return;
 	}
-	$tag_name           = empty( $attributes['tagName'] ) ? 'p' : $attributes['tagName'];
+
+	$tag_name           = 'p';
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+
+	if ( isset( $attributes['level'] ) ) {
+		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . (int) $attributes['level'];
+	}
 
 	return sprintf(
 		'<%1$s %2$s>%3$s</%1$s>',

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -22,8 +22,8 @@ function render_block_core_site_tagline( $attributes ) {
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 
-	if ( isset( $attributes['level'] ) ) {
-		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . (int) $attributes['level'];
+	if ( isset( $attributes['level'] ) && 0 !== $attributes['level'] ) {
+		$tag_name = 'h' . (int) $attributes['level'];
 	}
 
 	return sprintf(

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -17,11 +17,13 @@ function render_block_core_site_tagline( $attributes ) {
 	if ( ! $site_tagline ) {
 		return;
 	}
+	$tag_name           = empty( $attributes['tagName'] ) ? 'p' : $attributes['tagName'];
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 
 	return sprintf(
-		'<p %1$s>%2$s</p>',
+		'<%1$s %2$s>%3$s</%1$s>',
+		$tag_name,
 		$wrapper_attributes,
 		$site_tagline
 	);
@@ -38,4 +40,5 @@ function register_block_core_site_tagline() {
 		)
 	);
 }
+
 add_action( 'init', 'register_block_core_site_tagline' );

--- a/test/integration/fixtures/blocks/core__site-tagline.json
+++ b/test/integration/fixtures/blocks/core__site-tagline.json
@@ -2,7 +2,9 @@
 	{
 		"name": "core/site-tagline",
 		"isValid": true,
-		"attributes": {},
+		"attributes": {
+			"tagName": "p"
+		},
 		"innerBlocks": []
 	}
 ]

--- a/test/integration/fixtures/blocks/core__site-tagline.json
+++ b/test/integration/fixtures/blocks/core__site-tagline.json
@@ -3,7 +3,7 @@
 		"name": "core/site-tagline",
 		"isValid": true,
 		"attributes": {
-			"level": "0"
+			"level": 0
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__site-tagline.json
+++ b/test/integration/fixtures/blocks/core__site-tagline.json
@@ -3,7 +3,7 @@
 		"name": "core/site-tagline",
 		"isValid": true,
 		"attributes": {
-			"tagName": "p"
+			"level": "0"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add TagName attribute and control for site-tagline Block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

ref: https://github.com/WordPress/gutenberg/issues/59523

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add Inspector Controls

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1 add tagline block.
2 open Advanced Settings.
3 Change HTML element.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![スクリーンショット 2024-03-12 0 27 39](https://github.com/WordPress/gutenberg/assets/1908815/76455c65-5ed8-4f52-8ae9-1225226aed73)
