### PR TITLE
Fix typo in Dataviews and Font Collection packages

### DIFF
--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -36,11 +36,11 @@ const Pagination = memo( function Pagination( {
 					{ createInterpolateElement(
 						sprintf(
 							// translators: %s: Total number of pages.
-							_x( 'Page <CurrenPageControl /> of %s', 'paging' ),
+							_x( 'Page <CurrentPageControl /> of %s', 'paging' ),
 							totalPages
 						),
 						{
-							CurrenPageControl: (
+							CurrentPageControl: (
 								<SelectControl
 									aria-label={ __( 'Current page' ) }
 									value={ view.page }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -441,13 +441,13 @@ function FontCollection( { slug } ) {
 							sprintf(
 								// translators: %s: Total number of pages.
 								_x(
-									'Page <CurrenPageControl /> of %s',
+									'Page <CurrentPageControl /> of %s',
 									'paging'
 								),
 								totalPages
 							),
 							{
-								CurrenPageControl: (
+								CurrentPageControl: (
 									<SelectControl
 										aria-label={ __( 'Current page' ) }
 										value={ page }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the typoed component names in dataviews and font-collection.

## Why?
As reported in https://github.com/WordPress/gutenberg/issues/59652, these typos could lead to confusion for translators.

## How?
Simple typo fixes.

## Testing Instructions
There's not much to do here other than review the code and make sure nothing obvious breaks when building and testing. The experience should remain unchanged.

## Screenshots or screencast <!-- if applicable -->
