### PR TITLE
Fix site editor crashing when not fully loaded.

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -47,7 +47,7 @@ function ScreenColors() {
 			/>
 			<div className="edit-site-global-styles-screen-colors">
 				<VStack spacing={ 3 }>
-					{ !! colorVariations.length && (
+					{ !! colorVariations?.length && (
 						<ColorVariations variations={ colorVariations } />
 					) }
 

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -40,7 +40,7 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen-typography">
 				<VStack spacing={ 6 }>
-					{ !! typographyVariations.length && (
+					{ !! typographyVariations?.length && (
 						<TypographyVariations />
 					) }
 					{ ! window.__experimentalDisableFontLibrary && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixed a problem that caused the editor to crash when trying to edit typography variations or color variations when they were not loaded.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

fix: #59509

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
`typographyVariations` and `colorVariations` is nullable. So, use optional chain.

## Testing Instructions

1. Run wp-env start.
2. Go to site-editor.
3. Open Developer tools and Network tab.
4. Select "Fast 3G" or "Slow 3G" and reload browser.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
