### PR TITLE
Plugin short description less than 150 characters.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-The Gutenberg plugin brings editing, customization, and site-building to WordPress. You can test beta features before their official release.
+The Gutenberg plugin adds editing, customization, and site building to WordPress. Use it to test beta features before their official release.
 
 == Description ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-The Gutenberg plugin provides editing, customization, and site building features to WordPress. This beta plugin allows you to test bleeding-edge features before they land in future WordPress releases.
+The Gutenberg plugin brings editing, customization, and site-building to WordPress. You can test beta features before their official release.
 
 == Description ==
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Editing the short description in `readme.txt` to be less than 150 characters.

## Why?
Fix: #59494
This resolves an error seen from the plugin directory.

## How?
The short description was edited to be more concise and less than 150 characters.

## Testing Instructions
n/a — the warning is only visible to committers
