### PR TITLE
Quote: show as active when deeply nested child block is selected

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -78,11 +78,17 @@ export default function QuoteEdit( {
 
 	useMigrateOnLoad( attributes, clientId );
 
-	const hasSelection = useSelect( ( select ) => {
-		const { isBlockSelected, hasSelectedInnerBlock } =
-			select( blockEditorStore );
-		return hasSelectedInnerBlock( clientId ) || isBlockSelected( clientId );
-	}, [] );
+	const hasSelection = useSelect(
+		( select ) => {
+			const { isBlockSelected, hasSelectedInnerBlock } =
+				select( blockEditorStore );
+			return (
+				hasSelectedInnerBlock( clientId, true ) ||
+				isBlockSelected( clientId )
+			);
+		},
+		[ clientId ]
+	);
 
 	const blockProps = useBlockProps( {
 		className: classNames( className, {


### PR DESCRIPTION
When editing a quote block, and it doesn't have the `citation` attribute set, the "Add citation" UI is shown only when the quote block or an inner paragraph block is selected:

<img width="634" alt="Screenshot 2024-03-07 at 7 12 35" src="https://github.com/WordPress/gutenberg/assets/664258/dd89fb9b-8fd3-461d-a917-ccfa97bd308d">

However, this doesn't work when a _nested_ block is selected, like when editing a nested Quote -> List -> List Item:

<img width="642" alt="Screenshot 2024-03-07 at 7 12 17" src="https://github.com/WordPress/gutenberg/assets/664258/c6923b34-ab79-441d-a777-8b92a323fee4">

Here the "Add citation" UI should be also visible, but it isn't.

This PR fixes this by calling the `hasSelectedInnerBlock` with a `deep=true` parameter.

I'm also fixing a dependency array of `useSelect` call -- it should contain the `clientId` value that is used inside the callback.