### PR TITLE
Replace `isSmall` prop with `size` in `NavigationMenuSelector`

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -131,7 +131,7 @@ function NavigationMenuSelector( {
 		<DropdownMenu
 			label={ selectorLabel }
 			icon={ moreVertical }
-			toggleProps={ { isSmall: true } }
+			toggleProps={ { size: 'small' } }
 		>
 			{ ( { onClose } ) => (
 				<>

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -593,6 +593,11 @@ describe( 'Button', () => {
 			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-small' );
 		} );
 
+		it( 'should have the is-small class when small class prop is passed', () => {
+			render( <Button size="small" /> );
+			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-small' );
+		} );
+
 		it( 'should prioritize the `size` prop over `isSmall`', () => {
 			render( <Button size="compact" isSmall /> );
 			expect( screen.getByRole( 'button' ) ).not.toHaveClass(


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/53560

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Now that the `isSmall` prop is deprecated in `Button` which is used inside `DropdownMenu`, this PR replaces the `isSmall` usage in `NavigationMenuSelector` component in the block editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`isSmall` prop has been deprecated in `Button` and we should replace it with `size="small"` in all places in the code base.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It replaces the `isSmall` prop only in `NavigationMenuSelector` in the `DropdownMenu` as I ran out of time to test other components.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the Gutenberg editor by creating or editing a post in wp-admin
- Add a new block called `Navigation` --> ensure the vertical three-dot toolbar icon in the sidebar (Block > Menu) stays the same size

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

No visual changes are expected.

before | after
-- | --
<img width="1624" alt="Screenshot 2024-03-07 at 2 59 29 PM" src="https://github.com/WordPress/gutenberg/assets/1945542/9234c9c7-8bf3-4409-b83a-d88e044489f7"> | <img width="1624" alt="Screenshot 2024-03-07 at 2 59 38 PM" src="https://github.com/WordPress/gutenberg/assets/1945542/4796804f-a179-452d-8d16-59d015564dbf">
