### PR TITLE
Navigation Link: Mark the removal of the block as not persistent

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -568,6 +568,7 @@ export default function NavigationLinkEdit( {
 								// This avoids empty blocks which can provided a poor UX.
 								if ( ! url ) {
 									// Need to handle refocusing the Nav block or the inserter?
+									__unstableMarkNextChangeAsNotPersistent();
 									onReplace( [] );
 								}
 							} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #59676 by marking the removal of the empty block as not persistent

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because users won't want to undo this action.

## How?
Call __unstableMarkNextChangeAsNotPersistent before removing the block

## Testing Instructions
1. Add a navigation block
2. Use the inserter to add a new link inside
3. Focus the canvas
4. The new link should be removed
5. Use the undo action
6. The block should not be readded

