### PR TITLE
Data: deprecate the getIsResolving selector

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -51,6 +51,7 @@ describe( 'useEntityRecord', () => {
 			record: undefined,
 			save: expect.any( Function ),
 			hasResolved: false,
+			hasStarted: false,
 			isResolving: false,
 			status: 'IDLE',
 		} );
@@ -70,6 +71,7 @@ describe( 'useEntityRecord', () => {
 			record: { hello: 'world', id: 1 },
 			save: expect.any( Function ),
 			hasResolved: true,
+			hasStarted: true,
 			isResolving: false,
 			status: 'SUCCESS',
 		} );
@@ -99,6 +101,7 @@ describe( 'useEntityRecord', () => {
 				record: { hello: 'world', id: 1 },
 				save: expect.any( Function ),
 				hasResolved: true,
+				hasStarted: true,
 				isResolving: false,
 				status: 'SUCCESS',
 			} )

--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -49,6 +49,7 @@ describe( 'useEntityRecords', () => {
 		expect( data ).toEqual( {
 			records: null,
 			hasResolved: false,
+			hasStarted: false,
 			isResolving: false,
 			status: 'IDLE',
 			totalItems: null,
@@ -65,6 +66,7 @@ describe( 'useEntityRecords', () => {
 		expect( data ).toEqual( {
 			records: TEST_RECORDS,
 			hasResolved: true,
+			hasStarted: true,
 			isResolving: false,
 			status: 'SUCCESS',
 			totalItems: null,

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -116,6 +116,7 @@ describe( 'useQuerySelect', () => {
 			data: 'bar',
 			isResolving: false,
 			hasResolved: false,
+			hasStarted: false,
 			status: 'IDLE',
 		} );
 	} );
@@ -165,6 +166,7 @@ describe( 'useQuerySelect', () => {
 			data: 10,
 			isResolving: false,
 			hasResolved: false,
+			hasStarted: false,
 			status: 'IDLE',
 		} );
 
@@ -180,6 +182,7 @@ describe( 'useQuerySelect', () => {
 				data: 15,
 				isResolving: false,
 				hasResolved: true,
+				hasStarted: true,
 				status: 'SUCCESS',
 			} )
 		);

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-  Deprecate the `getIsResolved` meta-selector ([#59679](https://github.com/WordPress/gutenberg/pull/59679)).
+
 ## 9.23.0 (2024-03-06)
 
 ## 9.22.0 (2024-02-21)

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -4,6 +4,11 @@
 import createSelector from 'rememo';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import { selectorArgsToStateKey } from './utils';
@@ -34,10 +39,16 @@ export function getResolutionState( state, selectorName, args ) {
 }
 
 /**
- * Returns the raw `isResolving` value for a given selector name,
- * and arguments set. May be undefined if the selector has never been resolved
- * or not resolved for the given set of arguments, otherwise true or false for
- * resolution started and completed respectively.
+ * Returns an `isResolving`-like value for a given selector name and arguments set.
+ * Its value is either `undefined` if the selector has never been resolved or has been
+ * invalidated, or a `true`/`false` boolean value if the resolution is in progress or
+ * has finished, respectively.
+ *
+ * This is a legacy selector that was implemented when the "raw" internal data had
+ * this `undefined | boolean` format. Nowadays the internal value is an object that
+ * can be retrieved with `getResolutionState`.
+ *
+ * @deprecated
  *
  * @param {State}      state        Data state.
  * @param {string}     selectorName Selector name.
@@ -46,8 +57,13 @@ export function getResolutionState( state, selectorName, args ) {
  * @return {boolean | undefined} isResolving value.
  */
 export function getIsResolving( state, selectorName, args ) {
-	const resolutionState = getResolutionState( state, selectorName, args );
+	deprecated( 'wp.data.select( store ).getIsResolving', {
+		since: '6.6',
+		version: '6.8',
+		alternative: 'wp.data.select( store ).getResolutionState',
+	} );
 
+	const resolutionState = getResolutionState( state, selectorName, args );
 	return resolutionState && resolutionState.status === 'resolving';
 }
 

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -31,12 +31,16 @@ describe( 'getIsResolving', () => {
 		registry.registerStore( 'testStore', testStore );
 	} );
 
+	const DEPRECATION_MESSAGE =
+		'wp.data.select( store ).getIsResolving is deprecated since version 6.6 and will be removed in version 6.8. Please use wp.data.select( store ).getResolutionState instead.';
+
 	it( 'should return undefined if no state by reducerKey, selectorName', () => {
 		const result = registry
 			.select( 'testStore' )
 			.getIsResolving( 'getFoo', [] );
 
 		expect( result ).toBe( undefined );
+		expect( console ).toHaveWarnedWith( DEPRECATION_MESSAGE );
 	} );
 
 	it( 'should return undefined if state by reducerKey, selectorName, but not args', () => {

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -50,7 +50,8 @@ const templatePartToPattern = ( templatePart ) => ( {
 
 const selectTemplatePartsAsPatterns = createSelector(
 	( select, categoryId, search = '' ) => {
-		const { getEntityRecords, getIsResolving } = select( coreStore );
+		const { getEntityRecords, isResolving: isResolvingSelector } =
+			select( coreStore );
 		const { __experimentalGetDefaultTemplatePartAreas } =
 			select( editorStore );
 		const query = { per_page: -1 };
@@ -78,7 +79,7 @@ const selectTemplatePartsAsPatterns = createSelector(
 			);
 		};
 
-		const isResolving = getIsResolving( 'getEntityRecords', [
+		const isResolving = isResolvingSelector( 'getEntityRecords', [
 			'postType',
 			TEMPLATE_PART_POST_TYPE,
 			query,
@@ -99,7 +100,7 @@ const selectTemplatePartsAsPatterns = createSelector(
 				per_page: -1,
 			}
 		),
-		select( coreStore ).getIsResolving( 'getEntityRecords', [
+		select( coreStore ).isResolving( 'getEntityRecords', [
 			'postType',
 			TEMPLATE_PART_POST_TYPE,
 			{ per_page: -1 },
@@ -111,7 +112,7 @@ const selectTemplatePartsAsPatterns = createSelector(
 const selectThemePatterns = createSelector(
 	( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
-		const { getIsResolving } = select( coreStore );
+		const { isResolving: isResolvingSelector } = select( coreStore );
 		const settings = getSettings();
 		const blockPatterns =
 			settings.__experimentalAdditionalBlockPatterns ??
@@ -137,11 +138,14 @@ const selectThemePatterns = createSelector(
 					__unstableSkipMigrationLogs: true,
 				} ),
 			} ) );
-		return { patterns, isResolving: getIsResolving( 'getBlockPatterns' ) };
+		return {
+			patterns,
+			isResolving: isResolvingSelector( 'getBlockPatterns' ),
+		};
 	},
 	( select ) => [
 		select( coreStore ).getBlockPatterns(),
-		select( coreStore ).getIsResolving( 'getBlockPatterns' ),
+		select( coreStore ).isResolving( 'getBlockPatterns' ),
 		unlock( select( editSiteStore ) ).getSettings(),
 	]
 );
@@ -228,8 +232,11 @@ const convertPatternPostToItem = ( patternPost, categories ) => ( {
 
 const selectUserPatterns = createSelector(
 	( select, syncStatus, search = '' ) => {
-		const { getEntityRecords, getIsResolving, getUserPatternCategories } =
-			select( coreStore );
+		const {
+			getEntityRecords,
+			isResolving: isResolvingSelector,
+			getUserPatternCategories,
+		} = select( coreStore );
 
 		const query = { per_page: -1 };
 		const patternPosts = getEntityRecords(
@@ -248,7 +255,7 @@ const selectUserPatterns = createSelector(
 			  )
 			: EMPTY_PATTERN_LIST;
 
-		const isResolving = getIsResolving( 'getEntityRecords', [
+		const isResolving = isResolvingSelector( 'getEntityRecords', [
 			'postType',
 			PATTERN_TYPES.user,
 			query,
@@ -277,7 +284,7 @@ const selectUserPatterns = createSelector(
 		select( coreStore ).getEntityRecords( 'postType', PATTERN_TYPES.user, {
 			per_page: -1,
 		} ),
-		select( coreStore ).getIsResolving( 'getEntityRecords', [
+		select( coreStore ).isResolving( 'getEntityRecords', [
 			'postType',
 			PATTERN_TYPES.user,
 			{ per_page: -1 },

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -74,7 +74,8 @@ export default function DocumentBar() {
 			getEditorSettings,
 			__experimentalGetTemplateInfo: getTemplateInfo,
 		} = select( editorStore );
-		const { getEditedEntityRecord, getIsResolving } = select( coreStore );
+		const { getEditedEntityRecord, isResolving: isResolvingSelector } =
+			select( coreStore );
 		const _postType = getCurrentPostType();
 		const _postId = getCurrentPostId();
 		const _document = getEditedEntityRecord(
@@ -86,7 +87,7 @@ export default function DocumentBar() {
 		return {
 			postType: _postType,
 			document: _document,
-			isResolving: getIsResolving(
+			isResolving: isResolvingSelector(
 				'getEditedEntityRecord',
 				'postType',
 				_postType,


### PR DESCRIPTION
This PR is inspired in discussion in https://github.com/WordPress/gutenberg/pull/59437#issuecomment-1971174851

The `getIsResolving` meta-selector should be deprecated. It returns a weird `undefined | boolean` value and it was introduced in #6600, six years ago, when the "raw" value in the store was of this type. At that time it made sense as the "raw getter". Nowadays the raw value is a more complex object returned by `getResolutionStatus`.

Users should use the `isResolving` selector instead, which returns a clean `true`/`false` boolean.

I'm migrating all Gutenberg usages of `getIsResolving` (there are not that many) to `isResolving`.

I'm also updating how the resolution status values are computed in `enrichSelectors` used by `useQuerySelect` and `useEntityRecords`. The existing code "reverse engineers" the status value from the `isResolving` and `hasResolved` values, but it can just straightforwardly calculate it from `getResolutionStatus`, simply mapping strings to an enum.

Last, the PR is adding `hasStarted` field to the `useQuerySelect` return value. Curiously, that value is declared in the type, `QuerySelectResponse`, but not actually returned.