### PR TITLE
Replace incorrect `state` referencing with `context`

### DIFF
--- a/packages/interactivity/docs/api-reference.md
+++ b/packages/interactivity/docs/api-reference.md
@@ -759,14 +759,14 @@ If the action is async and needs to await a long delay.
 
 - The user clicks the first button.
 - The scope points to the first context, where `isOpen: true`.
-- The first access to `state.isOpen` is correct because `getContext` returns the current scope.
+- The first access to `context.isOpen` is correct because `getContext` returns the current scope.
 - The action starts awaiting a long delay.
 - Before the action resumes, the user clicks the second button.
 - The scope is changed to the second context, where `isOpen: false`.
-- The first access to `state.isOpen` is correct because `getContext` returns the current scope.
+- The first access to `context.isOpen` is correct because `getContext` returns the current scope.
 - The second action starts awaiting a long delay.
 - The first action finishes awaiting and resumes its execution.
-- The second access to `state.isOpen` of the first action is incorrect, because `getContext` now returns the wrong scope.
+- The second access to `context.isOpen` of the first action is incorrect, because `getContext` now returns the wrong scope.
 
 We need to be able to know when async actions start awaiting and resume operations, so we can restore the proper scope, and that's what generators do.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Corrects referencing of `state` to `context` in the Async actions section.

## Why?

`state` and `context` are two distinct entities in the context of interactivity API stores. This avoids confusion of interchanging these two terms.

## How?

Replaces `state` to `context`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
