### PR TITLE
Data Views: Ignore cmd-click when row not selectable

### DIFF
--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -46,9 +46,12 @@ function GridItem( {
 				'is-selected': hasBulkAction && isSelected,
 			} ) }
 			onClickCapture={ ( event ) => {
-				if ( hasBulkAction && ( event.ctrlKey || event.metaKey ) ) {
+				if ( event.ctrlKey || event.metaKey ) {
 					event.stopPropagation();
 					event.preventDefault();
+					if ( ! hasBulkAction ) {
+						return;
+					}
 					if ( ! isSelected ) {
 						onSelectionChange(
 							data.filter( ( _item ) => {

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -247,6 +247,9 @@ function TableRow( {
 				if ( event.ctrlKey || event.metaKey ) {
 					event.stopPropagation();
 					event.preventDefault();
+					if ( ! hasPossibleBulkAction ) {
+						return;
+					}
 					if ( ! isSelected ) {
 						onSelectionChange(
 							data.filter( ( _item ) => {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/59563#issuecomment-1983311550

## What?

When using <kbd>cmd + click</kbd> on an item that isn't selectable, simply ignore that event, thereby preventing the item's checkbox from flashing from checked to unchecked. This was already the case in the Grid view, and this pull request applies the same idea to Table view.

## How?

In `ViewTable`, check the value of `hasPossibleBulkAction` before proceeding with selection changes.

In `ViewGrid`, move the check for `hasBulkAction` out of the condition and into the block of the outer `if` statement. This is done so that the event mechanics remain the same whether the row is selectable or not; in particular, the statements to event stop propagation and prevent default shouldn't be predicated on that ability.

## Testing Instructions

See report in https://github.com/WordPress/gutenberg/pull/59563#issuecomment-1983311550.