### PR TITLE
Enforce @since tags in block-library/src/*/*.php files

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/archives` block on server.
  *
+ * @since 5.0.0
+ *
  * @see WP_Widget_Archives
  *
  * @param array $attributes The block attributes.
@@ -106,6 +108,8 @@ function render_block_core_archives( $attributes ) {
 
 /**
  * Register archives block.
+ *
+ * @since 5.0.0
  */
 function register_block_core_archives() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/avatar` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -99,6 +101,8 @@ function render_block_core_avatar( $attributes, $content, $block ) {
  * Generates class names and styles to apply the border support styles for
  * the Avatar block.
  *
+ * @since 6.3.0
+ *
  * @param array $attributes The block attributes.
  * @return array The border-related classnames and styles for the block.
  */
@@ -149,6 +153,8 @@ function get_block_core_avatar_border_attributes( $attributes ) {
 
 /**
  * Registers the `core/avatar` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_avatar() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/block` block on server.
  *
+ * @since 5.0.0
+ *
  * @global WP_Embed $wp_embed
  *
  * @param array $attributes The block attributes.
@@ -97,6 +99,8 @@ function render_block_core_block( $attributes ) {
 
 /**
  * Registers the `core/block` block.
+ *
+ * @since 5.3.0
  */
 function register_block_core_block() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/calendar` block on server.
  *
+ * @since 5.2.0
+ *
  * @global int $monthnum.
  * @global int $year.
  *
@@ -79,6 +81,8 @@ function render_block_core_calendar( $attributes ) {
 
 /**
  * Registers the `core/calendar` block on server.
+ *
+ * @since 5.2.0
  */
 function register_block_core_calendar() {
 	register_block_type_from_metadata(
@@ -96,6 +100,8 @@ add_action( 'init', 'register_block_core_calendar' );
  *
  * Used to hide the calendar block when there are no published posts.
  * This compensates for a known Core bug: https://core.trac.wordpress.org/ticket/12016
+ *
+ * @since 5.9.0
  *
  * @return bool Has any published posts or not.
  */
@@ -120,6 +126,8 @@ function block_core_calendar_has_published_posts() {
  * Queries the database for any published post and saves
  * a flag whether any published post exists or not.
  *
+ * @since 5.9.0
+ *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @return bool Has any published posts or not.
@@ -137,6 +145,8 @@ if ( ! is_multisite() ) {
 	/**
 	 * Handler for updating the has published posts flag when a post is deleted.
 	 *
+	 * @since 5.9.0
+	 *
 	 * @param int $post_id Deleted post ID.
 	 */
 	function block_core_calendar_update_has_published_post_on_delete( $post_id ) {
@@ -151,6 +161,8 @@ if ( ! is_multisite() ) {
 
 	/**
 	 * Handler for updating the has published posts flag when a post status changes.
+	 *
+	 * @since 5.9.0
 	 *
 	 * @param string  $new_status The status the post is changing to.
 	 * @param string  $old_status The status the post is changing from.

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/categories` block on server.
  *
+ * @since 5.0.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the categories list/dropdown markup.
@@ -63,6 +65,8 @@ function render_block_core_categories( $attributes ) {
 /**
  * Generates the inline script for a categories dropdown field.
  *
+ * @since 5.0.0
+ *
  * @param string $dropdown_id ID of the dropdown field.
  *
  * @return string Returns the dropdown onChange redirection script.
@@ -87,6 +91,8 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 
 /**
  * Registers the `core/categories` block on server.
+ *
+ * @since 5.0.0
  */
 function register_block_core_categories() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comment-author-name` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -53,6 +55,8 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 
 /**
  * Registers the `core/comment-author-name` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comment_author_name() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comment-content` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -69,6 +71,8 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/comment-content` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comment_content() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comment-date` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -46,6 +48,8 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/comment-date` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comment_date() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comment-edit-link/index.php
+++ b/packages/block-library/src/comment-edit-link/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comment-edit-link` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -48,6 +50,8 @@ function render_block_core_comment_edit_link( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/comment-edit-link` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comment_edit_link() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comment-reply-link/index.php
+++ b/packages/block-library/src/comment-reply-link/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comment-reply-link` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -70,6 +72,8 @@ function render_block_core_comment_reply_link( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/comment-reply-link` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comment_reply_link() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -92,6 +92,8 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 /**
  * Renders the `core/comment-template` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -136,6 +138,8 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/comment-template` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comment_template() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comments-pagination-next/index.php
+++ b/packages/block-library/src/comments-pagination-next/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comments-pagination-next` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -48,6 +50,8 @@ function render_block_core_comments_pagination_next( $attributes, $content, $blo
 
 /**
  * Registers the `core/comments-pagination-next` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comments_pagination_next() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comments-pagination-numbers/index.php
+++ b/packages/block-library/src/comments-pagination-numbers/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comments-pagination-numbers` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -50,6 +52,8 @@ function render_block_core_comments_pagination_numbers( $attributes, $content, $
 
 /**
  * Registers the `core/comments-pagination-numbers` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comments_pagination_numbers() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comments-pagination-previous/index.php
+++ b/packages/block-library/src/comments-pagination-previous/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comments-pagination-previous` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -40,6 +42,8 @@ function render_block_core_comments_pagination_previous( $attributes, $content, 
 
 /**
  * Registers the `core/comments-pagination-previous` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comments_pagination_previous() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comments-pagination/index.php
+++ b/packages/block-library/src/comments-pagination/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comments-pagination` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array  $attributes Block attributes.
  * @param string $content    Block default content.
  *
@@ -34,6 +36,8 @@ function render_block_core_comments_pagination( $attributes, $content ) {
 
 /**
  * Registers the `core/comments-pagination` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comments_pagination() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/comments-title` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array $attributes Block attributes.
  *
  * @return string Return the post comments title.
@@ -84,6 +86,8 @@ function render_block_core_comments_title( $attributes ) {
 
 /**
  * Registers the `core/comments-title` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_comments_title() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -124,6 +124,8 @@ add_filter( 'comment_form_defaults', 'comments_block_form_defaults' );
  * Enqueues styles from the legacy `core/post-comments` block. These styles are
  * required only by the block's fallback.
  *
+ * @since 6.1.0
+ *
  * @param string $block_name Name of the new block type.
  */
 function enqueue_legacy_post_comments_block_styles( $block_name ) {

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -16,6 +16,8 @@
  * the block is in legacy mode. If not, the HTML generated in the editor is
  * returned instead.
  *
+ * @since 6.1.0
+ *
  * @global WP_Post  $post     Global post object.
  *
  * @param array    $attributes Block attributes.
@@ -85,6 +87,8 @@ function render_block_core_comments( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/comments` block on the server.
+ *
+ * @since 6.1.0
  */
 function register_block_core_comments() {
 	register_block_type_from_metadata(
@@ -99,6 +103,8 @@ add_action( 'init', 'register_block_core_comments' );
 
 /**
  * Use the button block classes for the form-submit button.
+ *
+ * @since 6.1.0
  *
  * @param array $fields The default comment form arguments.
  *
@@ -142,6 +148,8 @@ function enqueue_legacy_post_comments_block_styles( $block_name ) {
  *
  * The same approach was followed when core/query-loop was renamed to
  * core/post-template.
+ *
+ * @since 6.1.0
  *
  * @see https://github.com/WordPress/gutenberg/pull/41807
  * @see https://github.com/WordPress/gutenberg/pull/32514

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/cover` block on server.
  *
+ * @since 6.0.0
+ *
  * @param array  $attributes The block attributes.
  * @param string $content    The block rendered content.
  *
@@ -66,6 +68,8 @@ function render_block_core_cover( $attributes, $content ) {
 
 /**
  * Registers the `core/cover` block renderer on server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_cover() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -8,6 +8,8 @@
 /**
  * When the `core/file` block is rendering, check if we need to enqueue the `wp-block-file-view` script.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes The block attributes.
  * @param string   $content    The block content.
  * @param WP_Block $block      The parsed block.
@@ -65,6 +67,8 @@ function render_block_core_file( $attributes, $content ) {
 
 /**
  * Registers the `core/file` block on server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_file() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -13,6 +13,8 @@
  * we add a custom `data-id` attribute before rendering the gallery
  * so that the Image Block can pick it up in its render_callback.
  *
+ * @since 5.9.0
+ *
  * @param array $parsed_block The block being rendered.
  * @return array The migrated block object.
  */
@@ -34,6 +36,8 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
 
 /**
  * Renders the `core/gallery` block on the server.
+ *
+ * @since 6.0.0
  *
  * @param array  $attributes Attributes of the block being rendered.
  * @param string $content Content of the block being rendered.
@@ -164,6 +168,8 @@ function block_core_gallery_render( $attributes, $content ) {
 }
 /**
  * Registers the `core/gallery` block on server.
+ *
+ * @since 5.9.0
  */
 function register_block_core_gallery() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/heading/index.php
+++ b/packages/block-library/src/heading/index.php
@@ -14,6 +14,8 @@
  * Would be transformed to:
  *  <h2 class="align-left wp-block-heading">Hello World</h2>
  *
+ * @since 6.2.0
+ *
  * @param array  $attributes Attributes of the block being rendered.
  * @param string $content Content of the block being rendered.
  *
@@ -39,6 +41,8 @@ function block_core_heading_render( $attributes, $content ) {
 
 /**
  * Registers the `core/heading` block on server.
+ *
+ * @since 6.2.0
  */
 function register_block_core_heading() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -9,6 +9,8 @@
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the home link markup in the front-end.
  *
+ * @since 6.0.0
+ *
  * @param  array $context home link block context.
  * @return array Colors CSS classes and inline styles.
  */
@@ -61,6 +63,8 @@ function block_core_home_link_build_css_colors( $context ) {
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the home link markup in the front-end.
  *
+ * @since 6.0.0
+ *
  * @param  array $context Home link block context.
  * @return array Font size CSS classes and inline styles.
  */
@@ -87,6 +91,8 @@ function block_core_home_link_build_css_font_sizes( $context ) {
 
 /**
  * Builds an array with classes and style for the li wrapper
+ *
+ * @since 6.0.0
  *
  * @param  array $context    Home link block context.
  * @return string The li wrapper attributes.
@@ -121,6 +127,8 @@ function block_core_home_link_build_li_wrapper_attributes( $context ) {
 /**
  * Renders the `core/home-link` block.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes The block attributes.
  * @param string   $content    The saved content.
  * @param WP_Block $block      The parsed block.
@@ -154,6 +162,8 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 
 /**
  * Register the home block
+ *
+ * @since 6.0.0
  *
  * @uses render_block_core_home_link()
  * @throws WP_Error An WP_Error exception parsing the block definition.

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -9,6 +9,8 @@
  * Renders the `core/image` block on the server,
  * adding a data-id attribute to the element if core/gallery has added on pre-render.
  *
+ * @since 5.9.0
+ *
  * @param array    $attributes The block attributes.
  * @param string   $content    The block content.
  * @param WP_Block $block      The block object.
@@ -85,6 +87,8 @@ function render_block_core_image( $attributes, $content, $block ) {
  *
  * This is used to determine whether the lightbox should be rendered or not.
  *
+ * @since 6.4.0
+ *
  * @param array $block Block data.
  *
  * @return array Filtered block data.
@@ -114,6 +118,8 @@ function block_core_image_get_lightbox_settings( $block ) {
 
 /**
  * Adds the directives and layout needed for the lightbox behavior.
+ *
+ * @since 6.4.0
  *
  * @param string $block_content Rendered block content.
  * @param array  $block         Block object.
@@ -219,6 +225,9 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	return $body_content;
 }
 
+/**
+ * @since 6.5.0
+ */
 function block_core_image_print_lightbox_overlay() {
 	$close_button_label = esc_attr__( 'Close' );
 
@@ -238,7 +247,7 @@ function block_core_image_print_lightbox_overlay() {
 	}
 
 	echo <<<HTML
-		<div 
+		<div
 			class="wp-lightbox-overlay zoom"
 			data-wp-interactive="core/image"
 			data-wp-context='{}'
@@ -278,6 +287,8 @@ HTML;
 
 /**
  * Registers the `core/image` block on server.
+ *
+ * @since 5.9.0
  */
 function register_block_core_image() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -147,6 +147,8 @@ function render_block_core_latest_comments( $attributes = array() ) {
 
 /**
  * Registers the `core/latest-comments` block.
+ *
+ * @since 5.3.0
  */
 function register_block_core_latest_comments() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -36,6 +36,8 @@ function wp_latest_comments_draft_or_post_title( $post = 0 ) {
 /**
  * Renders the `core/latest-comments` block on server.
  *
+ * @since 5.1.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the post content with latest comments added.

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -18,6 +18,8 @@ $block_core_latest_posts_excerpt_length = 0;
  * Callback for the excerpt_length filter used by
  * the Latest Posts block at render time.
  *
+ * @since 5.4.0
+ *
  * @return int Returns the global $block_core_latest_posts_excerpt_length variable
  *             to allow the excerpt_length filter respect the Latest Block setting.
  */
@@ -28,6 +30,8 @@ function block_core_latest_posts_get_excerpt_length() {
 
 /**
  * Renders the `core/latest-posts` block on server.
+ *
+ * @since 5.0.0
  *
  * @param array $attributes The block attributes.
  *
@@ -218,6 +222,8 @@ function render_block_core_latest_posts( $attributes ) {
 
 /**
  * Registers the `core/latest-posts` block on server.
+ *
+ * @since 5.0.0
  */
 function register_block_core_latest_posts() {
 	register_block_type_from_metadata(
@@ -240,6 +246,8 @@ add_action( 'init', 'register_block_core_latest_posts' );
  *
  * TODO: Remove when and if the bottom client-side deprecation for this block
  * is removed.
+ *
+ * @since 5.5.0
  *
  * @param array $block A single parsed block object.
  *

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -41,6 +41,8 @@ function render_block_core_loginout( $attributes ) {
 
 /**
  * Registers the `core/loginout` block on server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_loginout() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/loginout` block on server.
  *
+ * @since 5.8.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the login-out link or form.

--- a/packages/block-library/src/media-text/index.php
+++ b/packages/block-library/src/media-text/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/media-text` block on server.
  *
+ * @since 6.6.0
+ *
  * @param array  $attributes The block attributes.
  * @param string $content    The block rendered content.
  *
@@ -54,6 +56,8 @@ function render_block_core_media_text( $attributes, $content ) {
 
 /**
  * Registers the `core/media-text` block renderer on server.
+ *
+ * @since 6.6.0
  */
 function register_block_core_media_text() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -9,6 +9,8 @@
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the navigation markup in the front-end.
  *
+ * @since 5.9.0
+ *
  * @param  array $context     Navigation block context.
  * @param  array $attributes  Block attributes.
  * @param  bool  $is_sub_menu Whether the link is part of a sub-menu.
@@ -79,6 +81,8 @@ function block_core_navigation_link_build_css_colors( $context, $attributes, $is
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
  *
+ * @since 5.9.0
+ *
  * @param  array $context Navigation block context.
  * @return array Font size CSS classes and inline styles.
  */
@@ -113,6 +117,8 @@ function block_core_navigation_link_build_css_font_sizes( $context ) {
 /**
  * Returns the top-level submenu SVG chevron icon.
  *
+ * @since 5.9.0
+ *
  * @return string
  */
 function block_core_navigation_link_render_submenu_icon() {
@@ -121,6 +127,8 @@ function block_core_navigation_link_render_submenu_icon() {
 
 /**
  * Decodes a url if it's encoded, returning the same url if not.
+ *
+ * @since 6.2.0
  *
  * @param string $url The url to decode.
  *
@@ -152,6 +160,8 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 
 /**
  * Renders the `core/navigation-link` block.
+ *
+ * @since 5.9.0
  *
  * @param array    $attributes The block attributes.
  * @param string   $content    The saved content.
@@ -268,6 +278,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 /**
  * Returns a navigation link variation
+ *
+ * @since 5.9.0
  *
  * @param WP_Taxonomy|WP_Post_Type $entity post type or taxonomy entity.
  * @param string                   $kind string of value 'taxonomy' or 'post-type'.
@@ -390,6 +402,8 @@ function block_core_navigation_link_build_variations() {
 
 /**
  * Registers the navigation link block.
+ *
+ * @since 5.9.0
  *
  * @uses render_block_core_navigation_link()
  * @throws WP_Error An WP_Error exception parsing the block definition.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -9,6 +9,8 @@
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
  *
+ * @since 5.9.0
+ *
  * @param  array $context Navigation block context.
  * @return array Font size CSS classes and inline styles.
  */
@@ -43,6 +45,8 @@ function block_core_navigation_submenu_build_css_font_sizes( $context ) {
 /**
  * Returns the top-level submenu SVG chevron icon.
  *
+ * @since 5.9.0
+ *
  * @return string
  */
 function block_core_navigation_submenu_render_submenu_icon() {
@@ -51,6 +55,8 @@ function block_core_navigation_submenu_render_submenu_icon() {
 
 /**
  * Renders the `core/navigation-submenu` block.
+ *
+ * @since 5.9.0
  *
  * @param array    $attributes The block attributes.
  * @param string   $content    The saved content.
@@ -237,6 +243,8 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 /**
  * Register the navigation submenu block.
+ *
+ * @since 5.9.0
  *
  * @uses render_block_core_navigation_submenu()
  * @throws WP_Error An WP_Error exception parsing the block definition.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -963,6 +963,8 @@ function block_core_navigation_filter_out_empty_blocks( $parsed_blocks ) {
 /**
  * Returns true if the navigation block contains a nested navigation block.
  *
+ * @since 6.2.0
+ *
  * @param WP_Block_List $inner_blocks Inner block instance to be normalized.
  * @return bool true if the navigation block contains a nested navigation block.
  */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -676,6 +676,8 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 	/**
 	 * Returns the menu items for a WordPress menu location.
 	 *
+	 * @since 5.9.0
+	 *
 	 * @param string $location The menu location.
 	 * @return array Menu items for the location.
 	 */
@@ -712,6 +714,8 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 	 * Sorts a standard array of menu items into a nested structure keyed by the
 	 * id of the parent menu.
 	 *
+	 * @since 5.9.0
+	 *
 	 * @param array $menu_items Menu items to sort.
 	 * @return array An array keyed by the id of the parent menu where each element
 	 *               is an array of menu items that belong to that parent.
@@ -734,6 +738,8 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 	/**
 	 * Gets the inner blocks for the navigation block from the unstable location attribute.
 	 *
+	 * @since 6.5.0
+	 *
 	 * @param array $attributes The block attributes.
 	 * @return WP_Block_List Returns the inner blocks for the navigation block.
 	 */
@@ -752,6 +758,8 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 /**
  * Add Interactivity API directives to the navigation-submenu and page-list
  * blocks markup using the Tag Processor.
+ *
+ * @since 6.3.0
  *
  * @param WP_HTML_Tag_Processor $tags             Markup of the navigation block.
  * @param array                 $block_attributes Block attributes.
@@ -813,6 +821,8 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 /**
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the navigation markup in the front-end.
+ *
+ * @since 5.9.0
  *
  * @param array $attributes Navigation block attributes.
  *
@@ -905,6 +915,8 @@ function block_core_navigation_build_css_colors( $attributes ) {
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
  *
+ * @since 5.9.0
+ *
  * @param array $attributes Navigation block attributes.
  *
  * @return array Font size CSS classes and inline styles.
@@ -933,6 +945,8 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 /**
  * Returns the top-level submenu SVG chevron icon.
  *
+ * @since 5.9.0
+ *
  * @return string
  */
 function block_core_navigation_render_submenu_icon() {
@@ -944,6 +958,8 @@ function block_core_navigation_render_submenu_icon() {
  * 'parse_blocks' includes a null block with '\n\n' as the content when
  * it encounters whitespace. This is not a bug but rather how the parser
  * is designed.
+ *
+ * @since 5.9.0
  *
  * @param array $parsed_blocks the parsed blocks to be normalized.
  * @return array the normalized parsed blocks.
@@ -987,6 +1003,8 @@ function block_core_navigation_block_contains_core_navigation( $inner_blocks ) {
  *
  * This aims to mirror how the fallback mechanic for wp_nav_menu works.
  * See https://developer.wordpress.org/reference/functions/wp_nav_menu/#more-information.
+ *
+ * @since 5.9.0
  *
  * @return array the array of blocks to be used as a fallback.
  */
@@ -1043,6 +1061,8 @@ function block_core_navigation_get_fallback_blocks() {
 /**
  * Iterate through all inner blocks recursively and get navigation link block's post IDs.
  *
+ * @since 6.0.0
+ *
  * @param WP_Block_List $inner_blocks Block list class instance.
  *
  * @return array Array of post IDs.
@@ -1054,6 +1074,8 @@ function block_core_navigation_get_post_ids( $inner_blocks ) {
 
 /**
  * Get post IDs from a navigation link block instance.
+ *
+ * @since 6.0.0
  *
  * @param WP_Block $block Instance of a block.
  *
@@ -1078,6 +1100,8 @@ function block_core_navigation_from_block_get_post_ids( $block ) {
 /**
  * Renders the `core/navigation` block on server.
  *
+ * @since 5.9.0
+ *
  * @param array    $attributes The block attributes.
  * @param string   $content    The saved content.
  * @param WP_Block $block      The parsed block.
@@ -1090,6 +1114,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 /**
  * Register the navigation block.
+ *
+ * @since 5.9.0
  *
  * @uses render_block_core_navigation()
  * @throws WP_Error An WP_Error exception parsing the block definition.
@@ -1107,6 +1133,8 @@ add_action( 'init', 'register_block_core_navigation' );
 
 /**
  * Filter that changes the parsed attribute values of navigation blocks contain typographic presets to contain the values directly.
+ *
+ * @since 5.9.0
  *
  * @param array $parsed_block The block being rendered.
  *
@@ -1141,6 +1169,8 @@ add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_back
 
 /**
  * Turns menu item data into a nested array of parsed blocks
+ *
+ * @since 5.9.0
  *
  * @deprecated 6.3.0 Use WP_Navigation_Fallback::parse_blocks_from_menu_items() instead.
  *
@@ -1199,6 +1229,8 @@ function block_core_navigation_parse_blocks_from_menu_items( $menu_items, $menu_
 /**
  * Get the classic navigation menu to use as a fallback.
  *
+ * @since 6.2.0
+ *
  * @deprecated 6.3.0 Use WP_Navigation_Fallback::get_classic_menu_fallback() instead.
  *
  * @return object WP_Term The classic navigation.
@@ -1243,6 +1275,8 @@ function block_core_navigation_get_classic_menu_fallback() {
 /**
  * Converts a classic navigation to blocks.
  *
+ * @since 6.2.0
+ *
  * @deprecated 6.3.0 Use WP_Navigation_Fallback::get_classic_menu_fallback_blocks() instead.
  *
  * @param  object $classic_nav_menu WP_Term The classic navigation object to convert.
@@ -1284,6 +1318,8 @@ function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_me
 
 /**
  * If there's a classic menu then use it as a fallback.
+ *
+ * @since 6.2.0
  *
  * @deprecated 6.3.0 Use WP_Navigation_Fallback::create_classic_menu_fallback() instead.
  *
@@ -1330,6 +1366,8 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 /**
  * Finds the most recently published `wp_navigation` Post.
  *
+ * @since 6.1.0
+ *
  * @deprecated 6.3.0 Use WP_Navigation_Fallback::get_most_recently_published_navigation() instead.
  *
  * @return WP_Post|null the first non-empty Navigation or null.
@@ -1361,6 +1399,8 @@ function block_core_navigation_get_most_recently_published_navigation() {
 /**
  * Accepts the serialized markup of a block and its inner blocks, and returns serialized markup of the inner blocks.
  *
+ * @since 6.5.0
+ *
  * @param string $serialized_block The serialized markup of a block and its inner blocks.
  * @return string
  */
@@ -1373,6 +1413,8 @@ function block_core_navigation_remove_serialized_parent_block( $serialized_block
 /**
  * Mock a parsed block for the Navigation block given its inner blocks and the `wp_navigation` post object.
  * The `wp_navigation` post's `_wp_ignored_hooked_blocks` meta is queried to add the `metadata.ignoredHookedBlocks` attribute.
+ *
+ * @since 6.5.0
  *
  * @param array   $inner_blocks Parsed inner blocks of a Navigation block.
  * @param WP_Post $post         `wp_navigation` post object corresponding to the block.
@@ -1413,6 +1455,8 @@ function block_core_navigation_mock_parsed_block( $inner_blocks, $post ) {
  * children, the `wp_navigation` post's `_wp_ignored_hooked_blocks` meta is checked to see if any
  * of those hooked blocks should be exempted from insertion.
  *
+ * @since 6.5.0
+ *
  * @param array   $inner_blocks Parsed inner blocks of a Navigation block.
  * @param WP_Post $post         `wp_navigation` post object corresponding to the block.
  * @return string Serialized inner blocks in mock Navigation block wrapper, with hooked blocks inserted, if any.
@@ -1437,6 +1481,8 @@ function block_core_navigation_insert_hooked_blocks( $inner_blocks, $post ) {
  * Given a Navigation block's inner blocks and its corresponding `wp_navigation` post object,
  * this function inserts ignoredHookedBlocks meta into it, and returns the serialized inner blocks in a
  * mock Navigation block wrapper.
+ *
+ * @since 6.5.0
  *
  * @param array   $inner_blocks Parsed inner blocks of a Navigation block.
  * @param WP_Post $post         `wp_navigation` post object corresponding to the block.
@@ -1524,6 +1570,8 @@ if ( has_filter( 'rest_insert_wp_navigation', $rest_insert_wp_navigation_core_ca
 
 /**
  * Hooks into the REST API response for the core/navigation block and adds the first and last inner blocks.
+ *
+ * @since 6.5.0
  *
  * @param WP_REST_Response $response The response object.
  * @param WP_Post          $post     Post object.

--- a/packages/block-library/src/page-list-item/index.php
+++ b/packages/block-library/src/page-list-item/index.php
@@ -7,6 +7,8 @@
 
 /**
  * Registers the `core/page-list-item` block on server.
+ *
+ * @since 6.3.0
  */
 function register_block_core_page_list_item() {
 	register_block_type_from_metadata( __DIR__ . '/page-list-item' );

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -9,6 +9,8 @@
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the pages markup in the front-end when it is a descendant of navigation.
  *
+ * @since 5.8.0
+ *
  * @param  array $attributes Block attributes.
  * @param  array $context    Navigation block context.
  * @return array Colors CSS classes and inline styles.
@@ -101,6 +103,8 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the pages markup in the front-end when it is a descendant of navigation.
  *
+ * @since 5.8.0
+ *
  * @param  array $context Navigation block context.
  * @return array Font size CSS classes and inline styles.
  */
@@ -134,6 +138,8 @@ function block_core_page_list_build_css_font_sizes( $context ) {
 
 /**
  * Outputs Page list markup from an array of pages with nested children.
+ *
+ * @since 5.8.0
  *
  * @param boolean $open_submenus_on_click Whether to open submenus on click instead of hover.
  * @param boolean $show_submenu_icons Whether to show submenu indicator icons.
@@ -220,6 +226,8 @@ function block_core_page_list_render_nested_page_list( $open_submenus_on_click, 
 /**
  * Outputs nested array of pages
  *
+ * @since 5.8.0
+ *
  * @param array $current_level The level being iterated through.
  * @param array $children The children grouped by parent post ID.
  *
@@ -239,6 +247,8 @@ function block_core_page_list_nest_pages( $current_level, $children ) {
 
 /**
  * Renders the `core/page-list` block on server.
+ *
+ * @since 5.8.0
  *
  * @param array    $attributes The block attributes.
  * @param string   $content    The saved content.
@@ -345,6 +355,8 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/pages` block on server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_page_list() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -7,6 +7,8 @@
 
 /**
  *  Registers the `core/pattern` block on the server.
+ *
+ * @since 5.9.0
  */
 function register_block_core_pattern() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-author-biography/index.php
+++ b/packages/block-library/src/post-author-biography/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-author-biography` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param  array    $attributes Block attributes.
  * @param  string   $content    Block default content.
  * @param  WP_Block $block      Block instance.
@@ -37,6 +39,8 @@ function render_block_core_post_author_biography( $attributes, $content, $block 
 
 /**
  * Registers the `core/post-author-biography` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_post_author_biography() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-author-name/index.php
+++ b/packages/block-library/src/post-author-name/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-author-name` block on the server.
  *
+ * @since 6.2.0
+ *
  * @param  array    $attributes Block attributes.
  * @param  string   $content    Block default content.
  * @param  WP_Block $block      Block instance.
@@ -43,6 +45,8 @@ function render_block_core_post_author_name( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/post-author-name` block on the server.
+ *
+ * @since 6.2.0
  */
 function register_block_core_post_author_name() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-author` block on the server.
  *
+ * @since 5.9.0
+ *
  * @param  array    $attributes Block attributes.
  * @param  string   $content    Block default content.
  * @param  WP_Block $block      Block instance.
@@ -61,6 +63,8 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/post-author` block on the server.
+ *
+ * @since 5.9.0
  */
 function register_block_core_post_author() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-comments-form` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -54,6 +56,8 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/post-comments-form` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_post_comments_form() {
 	register_block_type_from_metadata(
@@ -67,6 +71,8 @@ add_action( 'init', 'register_block_core_post_comments_form' );
 
 /**
  * Use the button block classes for the form-submit button.
+ *
+ * @since 6.0.0
  *
  * @param array $fields The default comment form arguments.
  *

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-content` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -63,6 +65,8 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/post-content` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_post_content() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-date` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -60,6 +62,8 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/post-date` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_post_date() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-excerpt` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -66,6 +68,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/post-excerpt` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_post_excerpt() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -247,6 +247,8 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 
 /**
  * Registers the `core/post-featured-image` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_post_featured_image() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-featured-image` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -125,6 +127,8 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 /**
  * Generate markup for the HTML element that will be used for the overlay.
  *
+ * @since 6.1.0
+ *
  * @param array $attributes Block attributes.
  *
  * @return string HTML markup in string format.
@@ -190,6 +194,8 @@ function get_block_core_post_featured_image_overlay_element_markup( $attributes 
 /**
  * Generates class names and styles to apply the border support styles for
  * the Post Featured Image block.
+ *
+ * @since 6.1.0
  *
  * @param array $attributes The block attributes.
  * @return array The border-related classnames and styles for the block.

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-navigation-link` block on the server.
  *
+ * @since 5.9.0
+ *
  * @param array  $attributes Block attributes.
  * @param string $content    Block default content.
  *
@@ -123,6 +125,8 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 
 /**
  * Registers the `core/post-navigation-link` block on the server.
+ *
+ * @since 5.9.0
  */
 function register_block_core_post_navigation_link() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -8,6 +8,8 @@
 /**
  * Determines whether a block list contains a block that uses the featured image.
  *
+ * @since 6.0.0
+ *
  * @param WP_Block_List $inner_blocks Inner block instance.
  *
  * @return bool Whether the block list contains a block that uses the featured image.
@@ -145,6 +147,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/post-template` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_post_template() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-terms` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -61,6 +63,8 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 /**
  * Returns the available variations for the `core/post-terms` block.
  *
+ * @since 6.5.0
+ *
  * @return array The available variations for the block.
  */
 function block_core_post_terms_build_variations() {
@@ -110,6 +114,8 @@ function block_core_post_terms_build_variations() {
 
 /**
  * Registers the `core/post-terms` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_post_terms() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -60,6 +60,8 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/post-title` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_post_title() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/query-no-results` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -47,6 +49,8 @@ function render_block_core_query_no_results( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/query-no-results` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_query_no_results() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/query-pagination-next` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -84,6 +86,8 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 
 /**
  * Registers the `core/query-pagination-next` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_query_pagination_next() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/query-pagination-numbers` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -115,6 +117,8 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 
 /**
  * Registers the `core/query-pagination-numbers` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_query_pagination_numbers() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/query-pagination-previous` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -72,6 +74,8 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 
 /**
  * Registers the `core/query-pagination-previous` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_query_pagination_previous() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/query-pagination` block on the server.
  *
+ * @since 5.9.0
+ *
  * @param array  $attributes Block attributes.
  * @param string $content    Block default content.
  *
@@ -35,6 +37,8 @@ function render_block_core_query_pagination( $attributes, $content ) {
 
 /**
  * Registers the `core/query-pagination` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_query_pagination() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -10,6 +10,8 @@
  * For now it only supports Archive title,
  * using queried object information
  *
+ * @since 5.8.0
+ *
  * @param array $attributes Block attributes.
  *
  * @return string Returns the query title based on the queried object.
@@ -60,6 +62,8 @@ function render_block_core_query_title( $attributes ) {
 
 /**
  * Registers the `core/query-title` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_query_title() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -77,6 +77,8 @@ function render_block_core_query( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/query` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_query() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/read-more` block on the server.
  *
+ * @since 6.0.0
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.
@@ -47,6 +49,8 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/read-more` block on the server.
+ *
+ * @since 6.0.0
  */
 function register_block_core_read_more() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/rss` block on server.
  *
+ * @since 5.2.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the block content with received rss items.
@@ -107,6 +109,8 @@ function render_block_core_rss( $attributes ) {
 
 /**
  * Registers the `core/rss` block on server.
+ *
+ * @since 5.2.0
  */
 function register_block_core_rss() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -207,6 +207,8 @@ function render_block_core_search( $attributes ) {
 
 /**
  * Registers the `core/search` block on the server.
+ *
+ * @since 5.2.0
  */
 function register_block_core_search() {
 	register_block_type_from_metadata(
@@ -220,6 +222,8 @@ add_action( 'init', 'register_block_core_search' );
 
 /**
  * Builds the correct top level classnames for the 'core/search' block.
+ *
+ * @since 5.6.0
  *
  * @param array $attributes The block attributes.
  *
@@ -264,6 +268,8 @@ function classnames_for_block_core_search( $attributes ) {
  * Based on whether the Search block is configured to display the button inside
  * or not, the generated rule is injected into the appropriate collection of
  * styles for later application in the block's markup.
+ *
+ * @since 6.1.0
  *
  * @param array  $attributes     The block attributes.
  * @param string $property       Border property to generate rule for e.g. width or color.
@@ -310,6 +316,8 @@ function apply_block_core_search_border_style( $attributes, $property, $side, &$
  * injects rules into the provided wrapper, button and input style arrays for
  * uniform "flat" borders or those with individual sides configured.
  *
+ * @since 6.1.0
+ *
  * @param array  $attributes     The block attributes.
  * @param string $property       Border property to generate rule for e.g. width or color.
  * @param array  $wrapper_styles Current collection of wrapper styles.
@@ -330,6 +338,8 @@ function apply_block_core_search_border_styles( $attributes, $property, &$wrappe
  * The result will contain one entry for shared styles such as those for the
  * inner input or button and a second for the inner wrapper should the block
  * be positioning the button "inside".
+ *
+ * @since 5.8.0
  *
  * @param  array $attributes The block attributes.
  *
@@ -457,7 +467,9 @@ function styles_for_block_core_search( $attributes ) {
 }
 
 /**
- * Returns typography classnames depending on whether there are named font sizes/families .
+ * Returns typography classnames depending on whether there are named font sizes/families.
+ *
+ * @since 6.1.0
  *
  * @param array $attributes The block attributes.
  *
@@ -482,6 +494,8 @@ function get_typography_classes_for_block_core_search( $attributes ) {
 /**
  * Returns typography styles to be included in an HTML style tag.
  * This excludes text-decoration, which is applied only to the label and button elements of the search block.
+ *
+ * @since 6.1.0
  *
  * @param array $attributes The block attributes.
  *
@@ -533,6 +547,8 @@ function get_typography_styles_for_block_core_search( $attributes ) {
 /**
  * Returns border color classnames depending on whether there are named or custom border colors.
  *
+ * @since 5.9.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string The border color classnames to be applied to the block elements.
@@ -555,6 +571,8 @@ function get_border_color_classes_for_block_core_search( $attributes ) {
 
 /**
  * Returns color classnames depending on whether there are named or custom text and background colors.
+ *
+ * @since 5.9.0
  *
  * @param array $attributes The block attributes.
  *

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -8,6 +8,8 @@
 /**
  * Performs wpautop() on the shortcode block content.
  *
+ * @since 5.0.0
+ *
  * @param array  $attributes The block attributes.
  * @param string $content    The block content.
  *
@@ -19,6 +21,8 @@ function render_block_core_shortcode( $attributes, $content ) {
 
 /**
  * Registers the `core/shortcode` block on server.
+ *
+ * @since 5.0.0
  */
 function register_block_core_shortcode() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/site-logo` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string The render.
@@ -60,6 +62,8 @@ function render_block_core_site_logo( $attributes ) {
 
 /**
  * Register a core site setting for a site logo
+ *
+ * @since 5.8.0
  */
 function register_block_core_site_logo_setting() {
 	register_setting(
@@ -79,6 +83,8 @@ add_action( 'rest_api_init', 'register_block_core_site_logo_setting', 10 );
 
 /**
  * Register a core site setting for a site icon
+ *
+ * @since 5.9.0
  */
 function register_block_core_site_icon_setting() {
 	register_setting(
@@ -96,6 +102,8 @@ add_action( 'rest_api_init', 'register_block_core_site_icon_setting', 10 );
 
 /**
  * Registers the `core/site-logo` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_site_logo() {
 	register_block_type_from_metadata(
@@ -111,6 +119,8 @@ add_action( 'init', 'register_block_core_site_logo' );
 /**
  * Overrides the custom logo with a site logo, if the option is set.
  *
+ * @since 5.8.0
+ *
  * @param string $custom_logo The custom logo set by a theme.
  *
  * @return string The site logo if set.
@@ -124,6 +134,8 @@ add_filter( 'theme_mod_custom_logo', '_override_custom_logo_theme_mod' );
 
 /**
  * Updates the site_logo option when the custom_logo theme-mod gets updated.
+ *
+ * @since 5.8.0
  *
  * @param  mixed $value Attachment ID of the custom logo or an empty value.
  * @return mixed
@@ -143,6 +155,8 @@ add_filter( 'pre_set_theme_mod_custom_logo', '_sync_custom_logo_to_site_logo' );
 /**
  * Deletes the site_logo when the custom_logo theme mod is removed.
  *
+ * @since 5.8.0
+ *
  * @param array $old_value Previous theme mod settings.
  * @param array $value     Updated theme mod settings.
  */
@@ -161,6 +175,8 @@ function _delete_site_logo_on_remove_custom_logo( $old_value, $value ) {
 
 /**
  * Deletes the site logo when all theme mods are being removed.
+ *
+ * @since 5.8.0
  */
 function _delete_site_logo_on_remove_theme_mods() {
 	global $_ignore_site_logo_changes;
@@ -179,6 +195,8 @@ function _delete_site_logo_on_remove_theme_mods() {
  * Hooks `_delete_site_logo_on_remove_theme_mods` in `delete_option_theme_mods_$theme`.
  *
  * Runs on `setup_theme` to account for dynamically-switched themes in the Customizer.
+ *
+ * @since 5.8.0
  */
 function _delete_site_logo_on_remove_custom_logo_on_setup_theme() {
 	$theme = get_option( 'stylesheet' );
@@ -189,6 +207,8 @@ add_action( 'setup_theme', '_delete_site_logo_on_remove_custom_logo_on_setup_the
 
 /**
  * Removes the custom_logo theme-mod when the site_logo option gets deleted.
+ *
+ * @since 5.9.0
  */
 function _delete_custom_logo_on_remove_site_logo() {
 	global $_ignore_site_logo_changes;

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/site-tagline` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string The render.
@@ -29,6 +31,8 @@ function render_block_core_site_tagline( $attributes ) {
 
 /**
  * Registers the `core/site-tagline` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_site_tagline() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/site-title` block on the server.
  *
+ * @since 5.8.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string The render.
@@ -53,6 +55,8 @@ function render_block_core_site_title( $attributes ) {
 
 /**
  * Registers the `core/site-title` block on the server.
+ *
+ * @since 5.8.0
  */
 function register_block_core_site_title() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/social-link` block on server.
  *
+ * @since 5.4.0
+ *
  * @param Array    $attributes The block attributes.
  * @param String   $content    InnerBlocks content of the Block.
  * @param WP_Block $block      Block object.
@@ -72,6 +74,8 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 
 /**
  * Registers the `core/social-link` blocks.
+ *
+ * @since 5.4.0
  */
 function register_block_core_social_link() {
 	register_block_type_from_metadata(
@@ -86,6 +90,8 @@ add_action( 'init', 'register_block_core_social_link' );
 
 /**
  * Returns the SVG for social link.
+ *
+ * @since 5.4.0
  *
  * @param string $service The service icon.
  *
@@ -103,6 +109,8 @@ function block_core_social_link_get_icon( $service ) {
 /**
  * Returns the brand name for social link.
  *
+ * @since 5.4.0
+ *
  * @param string $service The service icon.
  *
  * @return string Brand label.
@@ -118,6 +126,8 @@ function block_core_social_link_get_name( $service ) {
 
 /**
  * Returns the SVG for social link.
+ *
+ * @since 5.4.0
  *
  * @param string $service The service slug to extract data from.
  * @param string $field The field ('name', 'icon', etc) to extract for a service.
@@ -332,6 +342,8 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 /**
  * Returns CSS styles for icon and icon background colors.
  *
+ * @since 5.7.0
+ *
  * @param array $context Block context passed to Social Link.
  *
  * @return string Inline CSS styles for link's icon and background colors.
@@ -352,6 +364,8 @@ function block_core_social_link_get_color_styles( $context ) {
 
 /**
  * Returns CSS classes for icon and icon background colors.
+ *
+ * @since 6.3.0
  *
  * @param array $context Block context passed to Social Sharing Link.
  *

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/tag-cloud` block on server.
  *
+ * @since 5.2.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the tag cloud for selected taxonomy.
@@ -42,6 +44,8 @@ function render_block_core_tag_cloud( $attributes ) {
 
 /**
  * Registers the `core/tag-cloud` block on server.
+ *
+ * @since 5.2.0
  */
 function register_block_core_tag_cloud() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/template-part` block on the server.
  *
+ * @since 5.9.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string The render.
@@ -174,6 +176,8 @@ function render_block_core_template_part( $attributes ) {
 /**
  * Returns an array of area variation objects for the template part block.
  *
+ * @since 6.1.0
+ *
  * @param array $instance_variations The variations for instances.
  *
  * @return array Array containing the block variation objects.
@@ -211,6 +215,8 @@ function build_template_part_block_area_variations( $instance_variations ) {
 
 /**
  * Returns an array of instance variation objects for the template part block
+ *
+ * @since 6.1.0
  *
  * @return array Array containing the block variation objects.
  */
@@ -266,6 +272,8 @@ function build_template_part_block_instance_variations() {
 /**
  * Returns an array of all template part block variations.
  *
+ * @since 5.9.0
+ *
  * @return array Array containing the block variation objects.
  */
 function build_template_part_block_variations() {
@@ -276,6 +284,8 @@ function build_template_part_block_variations() {
 
 /**
  * Registers the `core/template-part` block on the server.
+ *
+ * @since 5.9.0
  */
 function register_block_core_template_part() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/term-description/index.php
+++ b/packages/block-library/src/term-description/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/term-description` block on the server.
  *
+ * @since 5.9.0
+ *
  * @param array $attributes Block attributes.
  *
  * @return string Returns the description of the current taxonomy term, if available
@@ -37,6 +39,8 @@ function render_block_core_term_description( $attributes ) {
 
 /**
  * Registers the `core/term-description` block on the server.
+ *
+ * @since 5.9.0
  */
 function register_block_core_term_description() {
 	register_block_type_from_metadata(

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -173,7 +173,7 @@
 		</properties>
 	</rule>
 	<rule ref="Gutenberg.Commenting.FunctionCommentSinceTag">
-		<!-- The sniff ensures that functions have a valid @since tag but skips checking experimental packages. -->
+		<!-- The sniff ensures that functions have a valid @since tag but skips checking experimental blocks. -->
 		<include-pattern>/packages/block-library/src/.+/*\.php$</include-pattern>
 	</rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -173,6 +173,7 @@
 		</properties>
 	</rule>
 	<rule ref="Gutenberg.Commenting.FunctionCommentSinceTag">
+		<!-- The sniff ensures that functions have a valid @since tag but skips checking experimental packages. -->
 		<include-pattern>/packages/block-library/src/.+/*\.php$</include-pattern>
 	</rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -172,4 +172,7 @@
 			</property>
 		</properties>
 	</rule>
+	<rule ref="Gutenberg.Commenting.FunctionComment">
+		<include-pattern>./packages/block-library/src/*/*.php</include-pattern>
+	</rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -172,7 +172,7 @@
 			</property>
 		</properties>
 	</rule>
-	<rule ref="Gutenberg.Commenting.FunctionComment">
-		<include-pattern>./packages/block-library/src/*/*.php</include-pattern>
+	<rule ref="Gutenberg.Commenting.FunctionCommentSinceTag">
+		<include-pattern>/packages/block-library/src/.+/*\.php$</include-pattern>
 	</rule>
 </ruleset>

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Gutenberg Coding Standards.
+ *
+ * @package gutenberg/gutenberg-coding-standards
+ * @link    https://github.com/WordPress/gutenberg
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace GutenbergCS\Gutenberg\Sniffs\Commenting;
 
@@ -60,7 +67,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 		$missing_since_tag_error_message = sprintf( '@since tag is missing for the \'%s()\' function.', $function_name );
 
 		// All these tokens could be present before the docblock.
-		$tokens_before_the_docblock = [
+		$tokens_before_the_docblock = array(
 			T_PUBLIC,
 			T_PROTECTED,
 			T_PRIVATE,
@@ -68,7 +75,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 			T_FINAL,
 			T_ABSTRACT,
 			T_WHITESPACE,
-		];
+		);
 
 		$doc_block_end_token = $phpcsFile->findPrevious( $tokens_before_the_docblock, ( $stackPtr - 1 ), null, true, null, true );
 		if ( ( false === $doc_block_end_token ) || ( T_DOC_COMMENT_CLOSE_TAG !== $tokens[ $doc_block_end_token ]['code'] ) ) {
@@ -112,7 +119,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 			'InvalidSinceTagVersionValue',
 			array(
 				$function_name,
-				$version_value
+				$version_value,
 			)
 		);
 	}
@@ -120,8 +127,8 @@ class FunctionCommentSinceTagSniff implements Sniff {
 	/**
 	 * Checks if the current package is experimental.
 	 *
-	 * @param File $phpcsFile
-	 * @return bool
+	 * @param File $phpcsFile The file being scanned.
+	 * @return bool Returns true if the current package is experimental.
 	 */
 	private static function is_experimental_package( File $phpcsFile ) {
 		$block_json_filepath = dirname( $phpcsFile->getFilename() ) . DIRECTORY_SEPARATOR . 'block.json';
@@ -135,6 +142,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 			return static::$cache[ $block_json_filepath ];
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- this package doesn't depend on WordPress.
 		$block_metadata = file_get_contents( $block_json_filepath );
 		if ( false === $block_metadata ) {
 			static::$cache[ $block_json_filepath ] = false;

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
@@ -64,7 +64,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 			}
 		}
 
-		$missing_since_tag_error_message = sprintf( '@since tag is missing for the \'%s()\' function.', $function_name );
+		$missing_since_tag_error_message = sprintf( '@since tag is missing for the "%s()" function.', $function_name );
 
 		// All these tokens could be present before the docblock.
 		$tokens_before_the_docblock = array(
@@ -114,7 +114,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 		}
 
 		$phpcsFile->addError(
-			'Invalid @since version value for the `%s()` function: `%s`. Version value must be greater than or equal to 0.0.1.',
+			'Invalid @since version value for the "%s()" function: "%s". Version value must be greater than or equal to 0.0.1.',
 			$version_token,
 			'InvalidSinceTagVersionValue',
 			array(

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
@@ -15,13 +15,13 @@ use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * This sniff ensures that PHP functions have a valid `@since` tag in the docblock.
- * The sniff skips checking files in __experimental block-library packages.
+ * The sniff skips checking files in __experimental block-library blocks.
  */
 class FunctionCommentSinceTagSniff implements Sniff {
 
 	/**
 	 * This property is used to store results returned
-	 * by the static::is_experimental_package() method.
+	 * by the static::is_experimental_block() method.
 	 *
 	 * @var array
 	 */
@@ -43,7 +43,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		if ( static::is_experimental_package( $phpcsFile ) ) {
+		if ( static::is_experimental_block( $phpcsFile ) ) {
 			// This is an experimental package, so the "@since" tag is not required.
 			return;
 		}
@@ -125,12 +125,12 @@ class FunctionCommentSinceTagSniff implements Sniff {
 	}
 
 	/**
-	 * Checks if the current package is experimental.
+	 * Checks if the current block is experimental.
 	 *
 	 * @param File $phpcsFile The file being scanned.
-	 * @return bool Returns true if the current package is experimental.
+	 * @return bool Returns true if the current block is experimental.
 	 */
-	private static function is_experimental_package( File $phpcsFile ) {
+	private static function is_experimental_block( File $phpcsFile ) {
 		$block_json_filepath = dirname( $phpcsFile->getFilename() ) . DIRECTORY_SEPARATOR . 'block.json';
 
 		if ( isset( static::$cache[ $block_json_filepath ] ) ) {
@@ -142,7 +142,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 			return static::$cache[ $block_json_filepath ];
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- this package doesn't depend on WordPress.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- this Composer package doesn't depend on WordPress.
 		$block_metadata = file_get_contents( $block_json_filepath );
 		if ( false === $block_metadata ) {
 			static::$cache[ $block_json_filepath ] = false;

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
@@ -44,7 +44,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 		if ( static::is_experimental_block( $phpcsFile ) ) {
-			// This is an experimental package, so the "@since" tag is not required.
+			// The "@since" tag is not required for experimental blocks since they are not yet included in WordPress Core.
 			return;
 		}
 

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSinceTagSniff.php
@@ -83,7 +83,7 @@ class FunctionCommentSinceTagSniff implements Sniff {
 			return;
 		}
 
-		// The sniff intentionally doesn't check if the docblock has a valid start tag.
+		// The sniff intentionally doesn't check if the docblock has a valid open tag.
 		// Its only job is to make sure that the @since tag is present and has a valid version value.
 		$doc_block_start_token = $phpcsFile->findPrevious( Tokens::$commentTokens, ( $doc_block_end_token - 1 ), null, true, null, true );
 		if ( false === $doc_block_start_token ) {

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * This sniff ensures that PHP functions have docblocks defined
- * and that the `@since` tag in the docblock is present.
+ * and that the `@since` tag is present in the docblock.
  */
 class FunctionCommentSniff implements Sniff {
 	/**
@@ -80,9 +80,9 @@ class FunctionCommentSniff implements Sniff {
 		}
 
 		$phpcsFile->addError(
-			'Invalid @since tag value for the `%s()` function: `%s`. Version value must be greater than or equal to 0.0.1.',
+			'Invalid @since version value for the `%s()` function: `%s`. Version value must be greater than or equal to 0.0.1.',
 			$version_token,
-			'InvalidSinceTagValue',
+			'InvalidSinceVersionValue',
 			array(
 				$function_name,
 				$version_value

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
@@ -110,13 +110,16 @@ class FunctionCommentSniff implements Sniff {
 	 */
 	private static function is_experimental_package( File $phpcsFile ) {
 		$block_json_filepath = dirname( $phpcsFile->getFilename() ) . DIRECTORY_SEPARATOR . 'block.json';
+
 		if ( isset( static::$cache[ $block_json_filepath ] ) ) {
 			return static::$cache[ $block_json_filepath ];
 		}
+
 		if ( ! is_file( $block_json_filepath ) || ! is_readable( $block_json_filepath ) ) {
 			static::$cache[ $block_json_filepath ] = false;
 			return static::$cache[ $block_json_filepath ];
 		}
+
 		$block_metadata = file_get_contents( $block_json_filepath );
 		if ( false === $block_metadata ) {
 			static::$cache[ $block_json_filepath ] = false;
@@ -129,8 +132,8 @@ class FunctionCommentSniff implements Sniff {
 			return static::$cache[ $block_json_filepath ];
 		}
 
-		$experimental_property                 = '__experimental';
-		static::$cache[ $block_json_filepath ] = array_key_exists( $experimental_property, $block_metadata ) && ( false !== $block_metadata[ $experimental_property ] );
+		$experimental_flag                     = '__experimental';
+		static::$cache[ $block_json_filepath ] = array_key_exists( $experimental_flag, $block_metadata ) && ( false !== $block_metadata[ $experimental_flag ] );
 		return static::$cache[ $block_json_filepath ];
 	}
 }

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
@@ -26,7 +26,6 @@ class FunctionCommentSniff implements Sniff {
 	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
-		// Get the tokens of the file.
 		$tokens = $phpcsFile->getTokens();
 
 		$function_token = $phpcsFile->findNext( T_STRING, $stackPtr );
@@ -47,14 +46,12 @@ class FunctionCommentSniff implements Sniff {
 
  		$missing_since_tag_error_message = sprintf( '@since tag is missing for the `%s()` function.', $function_name );
 
-		// Get the docblock for the current function.
 		$doc_block_end_token = $phpcsFile->findPrevious( T_DOC_COMMENT_CLOSE_TAG, $stackPtr, null, false, null, true );
 		if ( false === $doc_block_end_token ) {
 			$phpcsFile->addError( $missing_since_tag_error_message, $function_token, 'MissingSinceTag' );
 			return;
 		}
 
-		// Get the docblock for the current function.
 		$doc_block_start_token = $phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, $doc_block_end_token, null, false, null, true );
 		if ( false === $doc_block_start_token ) {
 			$phpcsFile->addError( $missing_since_tag_error_message, $function_token, 'MissingSinceTag' );
@@ -76,6 +73,7 @@ class FunctionCommentSniff implements Sniff {
 		$version_value = $tokens[ $version_token ]['content'];
 
 		if ( version_compare( $version_value, '0.0.1', '>=' ) ) {
+			// Validate the version value.
 			return;
 		}
 

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
@@ -80,9 +80,9 @@ class FunctionCommentSniff implements Sniff {
 		}
 
 		$phpcsFile->addError(
-			'Invalid @since tag version value for the `%s()` function: `%s`. Version value must be greater than or equal to 0.0.1.',
+			'Invalid @since tag value for the `%s()` function: `%s`. Version value must be greater than or equal to 0.0.1.',
 			$version_token,
-			'InvalidSinceTagVersionValue',
+			'InvalidSinceTagValue',
 			array(
 				$function_name,
 				$version_value

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
@@ -5,6 +5,10 @@ namespace GutenbergCS\Gutenberg\Sniffs\Commenting;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
+/**
+ * This sniff ensures that PHP functions have docblocks defined
+ * and that the `@since` tag in the docblock is present.
+ */
 class FunctionCommentSniff implements Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -12,14 +16,14 @@ class FunctionCommentSniff implements Sniff {
 	 * @return array<int|string>
 	 */
 	public function register() {
-		return [ T_FUNCTION ];
+		return array( T_FUNCTION );
 	}
 
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
 	 * @param File $phpcsFile The file being scanned.
-	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 		// Get the tokens of the file.
@@ -47,7 +51,6 @@ class FunctionCommentSniff implements Sniff {
 		$doc_block_end_token = $phpcsFile->findPrevious( T_DOC_COMMENT_CLOSE_TAG, $stackPtr, null, false, null, true );
 		if ( false === $doc_block_end_token ) {
 			$phpcsFile->addError( $missing_since_tag_error_message, $function_token, 'MissingSinceTag' );
-
 			return;
 		}
 
@@ -55,21 +58,18 @@ class FunctionCommentSniff implements Sniff {
 		$doc_block_start_token = $phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, $doc_block_end_token, null, false, null, true );
 		if ( false === $doc_block_start_token ) {
 			$phpcsFile->addError( $missing_since_tag_error_message, $function_token, 'MissingSinceTag' );
-
 			return;
 		}
 
 		$since_tag = $phpcsFile->findNext( T_DOC_COMMENT_TAG, $doc_block_start_token, $doc_block_end_token, false, '@since', true );
 		if ( false === $since_tag ) {
 			$phpcsFile->addError( $missing_since_tag_error_message, $function_token, 'MissingSinceTag' );
-
 			return;
 		}
 
 		$version_token = $phpcsFile->findNext( T_DOC_COMMENT_WHITESPACE, $since_tag + 1, null, true, null, true );
 		if ( ( false === $version_token ) || ( T_DOC_COMMENT_STRING !== $tokens[ $version_token ]['code'] ) ) {
 			$phpcsFile->addError( $missing_since_tag_error_message, $function_token, 'MissingSinceTag' );
-
 			return;
 		}
 

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
@@ -14,6 +14,51 @@ class FunctionCommentSniff implements Sniff {
 	 */
 	public function register() {
 		return [ T_FUNCTION ];
+	}
 
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		// Get the tokens of the file.
+		$tokens = $phpcsFile->getTokens();
+
+		$function_token = $phpcsFile->findNext( T_STRING, $stackPtr );
+
+		$wrapping_tokens_to_check = array(
+			T_CLASS,
+			T_INTERFACE,
+			T_TRAIT,
+		);
+
+		foreach ( $wrapping_tokens_to_check as $wrapping_token_to_check ) {
+			if ( false !== $phpcsFile->getCondition( $function_token, $wrapping_token_to_check, false ) ) {
+				// This sniff only processes functions, not class methods.
+				return;
+			}
+		}
+
+		// Get the docblock for the current function.
+		$doc_block_end_token = $phpcsFile->findPrevious( T_DOC_COMMENT_CLOSE_TAG, $stackPtr, null, false, null, true );
+		if ( $doc_block_end_token === false ) {
+			$phpcsFile->addError( '@since tag is missing for this function', $stackPtr, 'MissingSince' );
+			return;
+		}
+
+		// Get the docblock for the current function.
+		$doc_block_start_token = $phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, $doc_block_end_token, null, false, null, true );
+		if ( $doc_block_start_token === false ) {
+			$phpcsFile->addError( '@since tag is missing for this function', $stackPtr, 'MissingSince' );
+			return;
+		}
+
+		$since_tag = $phpcsFile->findNext( T_DOC_COMMENT_TAG, $doc_block_start_token, $doc_block_end_token, false, '@since', true );
+		if ( $since_tag === false ) {
+			$phpcsFile->addError( '@since tag is missing for this function', $stackPtr, 'MissingSince' );
+			return;
+		}
 	}
 }

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GutenbergCS\Gutenberg\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+class FunctionCommentSniff implements Sniff {
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array<int|string>
+	 */
+	public function register() {
+		return [ T_FUNCTION ];
+
+	}
+}

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/Commenting/FunctionCommentSniff.php
@@ -70,7 +70,7 @@ class FunctionCommentSniff implements Sniff {
 		$all_comment_tags_but_open_comment_tag = Tokens::$commentTokens;
 		unset( $all_comment_tags_but_open_comment_tag[ T_DOC_COMMENT_OPEN_TAG ] );
 
-		$doc_block_start_token = $phpcsFile->findPrevious( $all_comment_tags_but_open_comment_tag, ( $stackPtr - 1 ), null, true, null, true );
+		$doc_block_start_token = $phpcsFile->findPrevious( $all_comment_tags_but_open_comment_tag, ( $doc_block_end_token - 1 ), null, true, null, true );
 		if ( ( false === $doc_block_start_token ) || ( T_DOC_COMMENT_OPEN_TAG !== $tokens[ $doc_block_start_token ]['code'] ) ) {
 			$phpcsFile->addError( $missing_since_tag_error_message, $function_token, 'MissingSinceTag' );
 			return;

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.inc
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.inc
@@ -11,12 +11,13 @@ function foo() {
 function bar() {
 }
 
-/**
- * @since 0.0.0
- */
-function baz() {
-}
+$result = array_map( function ( $value ) {
+	return $value * 2; // Doubling each value
+}, array( 1, 2, 3, 4, 5 ) );
 
+/**
+ * @since 0.0
+ */
 function qux() {
 }
 
@@ -28,11 +29,11 @@ class Foo {
 	}
 }
 
-interface Baz {
+interface Bar {
 	public function bar();
 }
 
-trait Spam {
+trait Baz {
 	public function bar() {
 	}
 }

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.php
@@ -13,16 +13,9 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHP_CodeSniffer\Ruleset;
 
 /**
- * Unit test class for the FunctionCommentSniff sniff.
+ * Unit test class for the FunctionCommentSinceTagSniff sniff.
  */
-final class FunctionCommentUnitTest extends AbstractSniffUnitTest {
-
-	/**
-	 * Holds the original Ruleset instance.
-	 *
-	 * @var Ruleset
-	 */
-	private static $original_ruleset;
+final class FunctionCommentSinceTagUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -32,7 +25,8 @@ final class FunctionCommentUnitTest extends AbstractSniffUnitTest {
 	public function getErrorList() {
 		return array(
 			9  => 1,
-			15  => 1,
+			19  => 1,
+			24 => 1,
 		);
 	}
 

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.php
@@ -25,7 +25,7 @@ final class FunctionCommentSinceTagUnitTest extends AbstractSniffUnitTest {
 	public function getErrorList() {
 		return array(
 			9  => 1,
-			19  => 1,
+			19 => 1,
 			24 => 1,
 		);
 	}

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.php
@@ -23,6 +23,7 @@ final class FunctionCommentSinceTagUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
+		// The sniff only supports PHP functions for now, while it ignores class, trait, and interface methods.
 		return array(
 			9  => 1,
 			19 => 1,

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentSinceTagUnitTest.php
@@ -23,7 +23,7 @@ final class FunctionCommentSinceTagUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
-		// The sniff only supports PHP functions for now, while it ignores class, trait, and interface methods.
+		// The sniff only supports PHP functions for now; it ignores class, trait, and interface methods.
 		return array(
 			9  => 1,
 			19 => 1,

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @since 1.2.3
+ */
+function foo() {
+}
+
+/**
+ * @since invalid value
+ */
+function bar() {
+}
+
+/**
+ * @since 0.0.0
+ */
+function baz() {
+}
+
+function qux() {
+}
+
+function spam() {
+}
+
+class Foo {
+	public function bar() {
+	}
+}
+
+interface Baz {
+	public function bar();
+}
+
+trait Spam {
+	public function bar() {
+	}
+}

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/Commenting/FunctionCommentUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Unit test class for Gutenberg Coding Standard.
+ *
+ * @package gutenberg-coding-standards/gbc
+ * @link    https://github.com/WordPress/gutenberg
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace GutenbergCS\Gutenberg\Tests\Commenting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Ruleset;
+
+/**
+ * Unit test class for the FunctionCommentSniff sniff.
+ */
+final class FunctionCommentUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Holds the original Ruleset instance.
+	 *
+	 * @var Ruleset
+	 */
+	private static $original_ruleset;
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			9  => 1,
+			15  => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR introduces a new sniff called `FunctionCommentSinceTagSniff` to ensure that PHP functions have a valid `@since` tag in the docblock.

The sniff skips checking files in `__experimental` block-library packages.

Fixes https://github.com/WordPress/gutenberg/issues/55777.

## Why?
`@since` tags are helpful for tracking origins and how long things have been in Core.

## How?
- [x] Defines a new sniff class `FunctionCommentSinceTagSniff` within the `GutenbergCS\Gutenberg\Sniffs\Commenting` namespace.
- [x] Adds unit tests for the `FunctionCommentSinceTagSniff` sniff.
- [x] Updates existing `block-library` functions so that they have valid `@since` tags.

## Testing Instructions
1. Try to define a PHP function somewhere in the `block-library/src/*/*.php` without a `@since` tag.
2. Make sure that CI checks fail.

### Testing Instructions for Keyboard
<!-- How can you test the changes using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or Screencast <!-- if applicable -->