### PR TITLE
Use viewScriptModule block.json field for interactivity e2e tests

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks.php
+++ b/packages/e2e-tests/plugins/interactive-blocks.php
@@ -15,26 +15,8 @@ add_action(
 			$block_json_files = glob( __DIR__ . '/interactive-blocks/**/block.json' );
 
 			// Auto register all blocks that were found.
-			foreach ( $block_json_files as $filename ) {
-				$block_folder = dirname( $filename );
-				$name         = basename( $block_folder );
-
-				$view_file = plugin_dir_url( $block_folder ) . $name . '/' . 'view.js';
-
-				wp_register_script_module(
-					$name . '-view',
-					$view_file,
-					array(
-						'@wordpress/interactivity',
-						array(
-							'id'     => '@wordpress/interactivity-router',
-							'import' => 'dynamic',
-						),
-					),
-					filemtime( $view_file )
-				);
-
-				register_block_type_from_metadata( $block_folder );
+			foreach ( $block_json_files as $block_json_file ) {
+				register_block_type( $block_json_file );
 			}
 		}
 

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-bind-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-bind-view' );
 ?>
 
 <div data-wp-interactive="directive-bind">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-class/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-class/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-class-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-class/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-class/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-class-view' );
 ?>
 
 <div data-wp-interactive='{"namespace": "directive-class"}'>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-class/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-class/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-context-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-context-view' );
 ?>
 
 <div data-wp-interactive='{"namespace": "directive-context"}'>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.asset.php
@@ -1,7 +1,9 @@
-<?php return array( 'dependencies' => array(
-	'@wordpress/interactivity',
-	array(
-		'id'     => '@wordpress/interactivity-router',
-		'import' => 'dynamic',
+<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity',
+		array(
+			'id'     => '@wordpress/interactivity-router',
+			'import' => 'dynamic',
+		),
 	),
-) );
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.asset.php
@@ -1,0 +1,7 @@
+<?php return array( 'dependencies' => array(
+	'@wordpress/interactivity',
+	array(
+		'id'     => '@wordpress/interactivity-router',
+		'import' => 'dynamic',
+	),
+) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-each-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-each-view' );
 ?>
 
 <div data-wp-interactive="directive-each">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.asset.php
@@ -1,7 +1,9 @@
-<?php return array( 'dependencies' => array(
-	'@wordpress/interactivity',
-	array(
-		'id'     => '@wordpress/interactivity-router',
-		'import' => 'dynamic',
+<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity',
+		array(
+			'id'     => '@wordpress/interactivity-router',
+			'import' => 'dynamic',
+		),
 	),
-) );
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.asset.php
@@ -1,0 +1,7 @@
+<?php return array( 'dependencies' => array(
+	'@wordpress/interactivity',
+	array(
+		'id'     => '@wordpress/interactivity-router',
+		'import' => 'dynamic',
+	),
+) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-init/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-init/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-init-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-init/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-init/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-init-view' );
 ?>
 
 <div data-wp-interactive="directive-init">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-init/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-init/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-key/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-key/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-key-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-key/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-key/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-key-view' );
 ?>
 
 <div

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-key/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-key/view.asset.php
@@ -1,7 +1,9 @@
-<?php return array( 'dependencies' => array(
-	'@wordpress/interactivity',
-	array(
-		'id'     => '@wordpress/interactivity-router',
-		'import' => 'dynamic',
+<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity',
+		array(
+			'id'     => '@wordpress/interactivity-router',
+			'import' => 'dynamic',
+		),
 	),
-) );
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-key/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-key/view.asset.php
@@ -1,0 +1,7 @@
+<?php return array( 'dependencies' => array(
+	'@wordpress/interactivity',
+	array(
+		'id'     => '@wordpress/interactivity-router',
+		'import' => 'dynamic',
+	),
+) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-on-document-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-on-document-view' );
 ?>
 
 <div data-wp-interactive="directive-on-document">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-on-window-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-on-window-view' );
 ?>
 
 <div data-wp-interactive="directive-on-window">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-on-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-on-view' );
 ?>
 
 <div data-wp-interactive="directive-on">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-priorities-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-priorities-view' );
 ?>
 
 <div data-wp-interactive="directive-priorities">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-run-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-run-view' );
 ?>
 
 <div

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.asset.php
@@ -1,7 +1,9 @@
-<?php return array( 'dependencies' => array(
-	'@wordpress/interactivity',
-	array(
-		'id'     => '@wordpress/interactivity-router',
-		'import' => 'dynamic',
+<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity',
+		array(
+			'id'     => '@wordpress/interactivity-router',
+			'import' => 'dynamic',
+		),
 	),
-) );
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.asset.php
@@ -1,0 +1,7 @@
+<?php return array( 'dependencies' => array(
+	'@wordpress/interactivity',
+	array(
+		'id'     => '@wordpress/interactivity-router',
+		'import' => 'dynamic',
+	),
+) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-style-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-style-view' );
 ?>
 
 <div data-wp-interactive="directive-style">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-text-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-text-view' );
 ?>
 
 <div data-wp-interactive="directive-context">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-watch/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-watch/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "directive-watch-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-watch/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-watch/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'directive-watch-view' );
 ?>
 
 <div data-wp-interactive="directive-watch">

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-watch/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-watch/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/negation-operator/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/negation-operator/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "negation-operator-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/negation-operator/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/negation-operator/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'negation-operator-view' );
 ?>
 
 <div data-wp-interactive="negation-operator">

--- a/packages/e2e-tests/plugins/interactive-blocks/negation-operator/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/negation-operator/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "router-navigate-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -7,8 +7,6 @@
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  */
 
-wp_enqueue_script_module( 'router-navigate-view' );
-
 if ( $attributes['disableNavigation'] ) {
 	wp_interactivity_config(
 		'core/router',

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.asset.php
@@ -1,7 +1,9 @@
-<?php return array( 'dependencies' => array(
-	'@wordpress/interactivity',
-	array(
-		'id'     => '@wordpress/interactivity-router',
-		'import' => 'dynamic',
+<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity',
+		array(
+			'id'     => '@wordpress/interactivity-router',
+			'import' => 'dynamic',
+		),
 	),
-) );
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.asset.php
@@ -1,0 +1,7 @@
+<?php return array( 'dependencies' => array(
+	'@wordpress/interactivity',
+	array(
+		'id'     => '@wordpress/interactivity-router',
+		'import' => 'dynamic',
+	),
+) );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "router-regions-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
@@ -6,8 +6,6 @@
  *
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  */
-
-wp_enqueue_script_module( 'router-regions-view' );
 ?>
 
 <section>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.asset.php
@@ -1,7 +1,9 @@
-<?php return array( 'dependencies' => array(
-	'@wordpress/interactivity',
-	array(
-		'id'     => '@wordpress/interactivity-router',
-		'import' => 'dynamic',
+<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity',
+		array(
+			'id'     => '@wordpress/interactivity-router',
+			'import' => 'dynamic',
+		),
 	),
-) );
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.asset.php
@@ -1,0 +1,7 @@
+<?php return array( 'dependencies' => array(
+	'@wordpress/interactivity',
+	array(
+		'id'     => '@wordpress/interactivity-router',
+		'import' => 'dynamic',
+	),
+) );

--- a/packages/e2e-tests/plugins/interactive-blocks/store-tag/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/store-tag/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "store-tag-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/store-tag/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/store-tag/render.php
@@ -7,8 +7,6 @@
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  */
 
-wp_enqueue_script_module( 'store-tag-view' );
-
 // These variables simulates SSR.
 $test_store_tag_counter = 'ok' === $attributes['condition'] ? 3 : 0;
 $test_store_tag_double  = $test_store_tag_counter * 2;

--- a/packages/e2e-tests/plugins/interactive-blocks/store-tag/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/store-tag/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/store/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/store/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "store-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/store/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'store-view' );
 ?>
 
 <div data-wp-interactive="test/store">

--- a/packages/e2e-tests/plugins/interactive-blocks/store/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/store/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "tovdom-islands-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'tovdom-islands-view' );
 ?>
 
 <div>

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "tovdom-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom/render.php
@@ -8,8 +8,6 @@
 $plugin_url   = plugin_dir_url( __DIR__ );
 $src_proc_ins = $plugin_url . 'tovdom/processing-instructions.js';
 $src_cdata    = $plugin_url . 'tovdom/cdata.js';
-
-wp_enqueue_script_module( 'tovdom-view' );
 ?>
 
 <div data-wp-interactive="tovdom">

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/block.json
@@ -10,6 +10,6 @@
 		"interactivity": true
 	},
 	"textdomain": "e2e-interactivity",
-	"viewScript": "with-scope-view",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/render.php
@@ -4,8 +4,6 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
-
-wp_enqueue_script_module( 'with-scope-view' );
 ?>
 
 <div data-wp-interactive="with-scope" data-wp-context='{"asyncCounter": 0, "syncCounter": 0}' data-wp-init--a='callbacks.asyncInit' data-wp-init--b='callbacks.syncInit'>

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );


### PR DESCRIPTION
## What?

Use viewScriptModule to for assets in the interactivity end-to-end test plugin.

## Why?

The interactivity end-to-end test blocks were manually registering and enqueuing view modules.
They also erroneously included (unregistered) viewScript handles.

viewScriptModule is a clean and simple way to handle registration and enqueue for these assets.

## How?

- Update block.json to change `"viewScript": "…"` to `"viewScriptModule": "file:./view.js"
- Add corresponding `view.asset.php` files.
- Remove manual enqueue from `render.php` files.

## Testing Instructions

The e2e tests should continue to pass.
