### PR TITLE
Interactivity: Restore scope when yielded promise rejects

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test/generator-scope",
+	"title": "E2E Interactivity tests - generator scope",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
@@ -11,6 +11,6 @@
 	<?php echo wp_interactivity_data_wp_context( array( 'result' => '' ) ); ?>
 >
 	<input readonly data-wp-bind--value="context.result" data-testid="result" />
-	<button type="button" data-wp-on--click='callbacks.resolve' data-testid='resolve'>Async resolve</button>
-	<button type="button" data-wp-on--click='callbacks.reject' data-testid='reject'>Async reject</button>
+	<button type="button" data-wp-on--click="callbacks.resolve" data-testid="resolve">Async resolve</button>
+	<button type="button" data-wp-on--click="callbacks.reject" data-testid="reject">Async reject</button>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * HTML for testing the directive `data-wp-bind`.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+?>
+
+<div
+	data-wp-interactive="test/generator-scope"
+	<?php echo wp_interactivity_data_wp_context( array( 'result' => '' ) ) ?>
+>
+	<input readonly data-wp-bind--value="context.result" data-testid="result" />
+	<button type="button" data-wp-on--click='callbacks.resolve' data-testid='resolve'>Async resolve</button>
+	<button type="button" data-wp-on--click='callbacks.reject' data-testid='reject'>Async reject</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * HTML for testing the directive `data-wp-bind`.
+ * HTML for testing scope restoration with generators.
  *
  * @package gutenberg-test-interactive-blocks
  */

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
@@ -8,7 +8,7 @@
 
 <div
 	data-wp-interactive="test/generator-scope"
-	<?php echo wp_interactivity_data_wp_context( array( 'result' => '' ) ) ?>
+	<?php echo wp_interactivity_data_wp_context( array( 'result' => '' ) ); ?>
 >
 	<input readonly data-wp-bind--value="context.result" data-testid="result" />
 	<button type="button" data-wp-on--click='callbacks.resolve' data-testid='resolve'>Async resolve</button>

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+store( 'test/generator-scope', {
+	callbacks: {
+		*resolve() {
+			try {
+				getContext().result = yield Promise.resolve( 'ok' );
+			} catch (err) {
+				getContext().result = err.toString()
+			}
+		},
+		*reject() {
+			try {
+				getContext().result = yield Promise.reject( new Error( '😘' ) )
+			} catch (err) {
+				getContext().result = err.toString()
+			}
+		}
+	}
+} );

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
@@ -8,16 +8,16 @@ store( 'test/generator-scope', {
 		*resolve() {
 			try {
 				getContext().result = yield Promise.resolve( 'ok' );
-			} catch (err) {
-				getContext().result = err.toString()
+			} catch ( err ) {
+				getContext().result = err.toString();
 			}
 		},
 		*reject() {
 			try {
-				getContext().result = yield Promise.reject( new Error( '😘' ) )
-			} catch (err) {
-				getContext().result = err.toString()
+				getContext().result = yield Promise.reject( new Error( '😘' ) );
+			} catch ( err ) {
+				getContext().result = err.toString();
 			}
-		}
-	}
+		},
+	},
 } );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Ensure scope is restored when catching exceptions thrown in async generator actions. ([#59708](https://github.com/WordPress/gutenberg/pull/59708))
+
 ## 5.2.0 (2024-03-06)
 
 ### Bug Fixes

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -117,8 +117,16 @@ const handlers = {
 					setScope( scope );
 					try {
 						it = gen.next( value );
+					} finally {
+						resetScope();
+						resetNamespace();
+					}
+
+					try {
 						value = await it.value;
 					} catch ( e ) {
+						setNamespace( ns );
+						setScope( scope );
 						gen.throw( e );
 					} finally {
 						resetScope();

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -109,7 +109,7 @@ const handlers = {
 				const scope = getScope();
 				const gen: Generator< any > = result( ...args );
 
-				let value: any;
+				let value: unknown;
 				let it: IteratorResult< any >;
 
 				while ( true ) {
@@ -117,15 +117,12 @@ const handlers = {
 					setScope( scope );
 					try {
 						it = gen.next( value );
-					} finally {
-						resetScope();
-						resetNamespace();
-					}
-
-					try {
 						value = await it.value;
 					} catch ( e ) {
 						gen.throw( e );
+					} finally {
+						resetScope();
+						resetNamespace();
 					}
 
 					if ( it.done ) break;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -77,7 +77,7 @@
 	<!-- Exclude PHPUnit tests from file and class name sniffs (for Core parity). -->
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
 		<exclude-pattern>/phpunit/*</exclude-pattern>
-<exclude-pattern>*\.asset\.php$</exclude-pattern>
+		<exclude-pattern>*\.asset\.php$</exclude-pattern>
 	</rule>
 	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
 		<exclude-pattern>/phpunit/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -77,7 +77,7 @@
 	<!-- Exclude PHPUnit tests from file and class name sniffs (for Core parity). -->
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
 		<exclude-pattern>/phpunit/*</exclude-pattern>
-		<exclude-pattern>*.asset.php</exclude-pattern>
+<exclude-pattern>*\.asset\.php$</exclude-pattern>
 	</rule>
 	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
 		<exclude-pattern>/phpunit/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -77,6 +77,7 @@
 	<!-- Exclude PHPUnit tests from file and class name sniffs (for Core parity). -->
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
 		<exclude-pattern>/phpunit/*</exclude-pattern>
+		<exclude-pattern>*.asset.php</exclude-pattern>
 	</rule>
 	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
 		<exclude-pattern>/phpunit/*</exclude-pattern>

--- a/test/e2e/specs/interactivity/async-actions.spec.ts
+++ b/test/e2e/specs/interactivity/async-actions.spec.ts
@@ -3,7 +3,7 @@
  */
 import { test, expect } from './fixtures';
 
-test.describe( 'generator scope', () => {
+test.describe( 'async actions', () => {
 	test.beforeAll( async ( { interactivityUtils: utils } ) => {
 		await utils.activatePlugins();
 		await utils.addPostWithBlock( 'test/generator-scope' );

--- a/test/e2e/specs/interactivity/generator-scope.spec.ts
+++ b/test/e2e/specs/interactivity/generator-scope.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'generator scope', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/generator-scope' );
+	} );
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/generator-scope' ) );
+	} );
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'Promise generator callbacks should restore scope on resolve and reject', async ( {
+		page,
+	} ) => {
+		const resultInput = page.getByTestId( 'result' );
+		await expect( resultInput ).toHaveValue( '' );
+
+		await page.getByTestId( 'resolve' ).click();
+		await expect( resultInput ).toHaveValue( 'ok' );
+
+		await page.getByTestId( 'reject' ).click();
+		await expect( resultInput ).toHaveValue( 'Error: 😘' );
+	} );
+} );


### PR DESCRIPTION
## What?

Ensure that the interactivity scope is maintained when a promise rejects.

## Why?

I expected to be able to do something like this in an interactivity callback:

```
try {
  yield Promise.reject( '💥' );
} catch ( err) {
  getContext().error = err;
}
```

But the `getContext()` in the catch block was always `undefined`.

## How?

Ensure that scope is properly set when handling rejection.

## Testing Instructions

This includes an e2e test.