### PR TITLE
Dataviews: Add: Bulk actions toolbar.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -209,6 +209,9 @@ $z-layers: (
 
 	// Ensure checkbox + actions don't overlap table header
 	".dataviews-view-table thead": 1,
+
+	// Ensure quick actions toolbar appear above pagination
+	".dataviews-bulk-actions": 2,
 );
 
 @function z-index( $key ) {

--- a/packages/dataviews/src/bulk-actions-toolbar.js
+++ b/packages/dataviews/src/bulk-actions-toolbar.js
@@ -1,0 +1,224 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	ToolbarButton,
+	Toolbar,
+	ToolbarGroup,
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+} from '@wordpress/components';
+import { useMemo, useState, useRef } from '@wordpress/element';
+import { _n, sprintf, __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
+import { useReducedMotion } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { ActionWithModal } from './item-actions';
+
+const SNACKBAR_VARIANTS = {
+	init: {
+		bottom: -48,
+	},
+	open: {
+		bottom: 24,
+		transition: {
+			bottom: { type: 'tween', duration: 0.2, ease: [ 0, 0, 0.2, 1 ] },
+		},
+	},
+	exit: {
+		opacity: 0,
+		bottom: 24,
+		transition: {
+			opacity: { type: 'tween', duration: 0.2, ease: [ 0, 0, 0.2, 1 ] },
+		},
+	},
+};
+
+function ActionTrigger( { action, onClick, items, isBusy } ) {
+	const isDisabled = useMemo( () => {
+		return isBusy || items.some( ( item ) => ! action.isEligible( item ) );
+	}, [ action, items, isBusy ] );
+	return (
+		<ToolbarButton
+			disabled={ isDisabled }
+			label={ action.label }
+			icon={ action.icon }
+			isDestructive={ action.isDestructive }
+			size="compact"
+			onClick={ onClick }
+			isBusy={ isBusy }
+			isDisabled={ isDisabled }
+		/>
+	);
+}
+
+const EMPTY_ARRAY = [];
+
+function renderToolbarContent(
+	selection,
+	actionsToShow,
+	selectedItems,
+	actionInProgress,
+	setActionInProgress,
+	setSelection
+) {
+	return (
+		<>
+			<ToolbarGroup>
+				<div className="dataviews-bulk-actions__selection-count">
+					{ selection.length === 1
+						? __( '1 item selected' )
+						: sprintf(
+								// translators: %s: Total number of selected items.
+								_n(
+									'%s item selected',
+									'%s items selected',
+									selection.length
+								),
+								selection.length
+						  ) }
+				</div>
+			</ToolbarGroup>
+			<ToolbarGroup>
+				{ actionsToShow.map( ( action ) => {
+					if ( !! action.RenderModal ) {
+						return (
+							<ActionWithModal
+								key={ action.id }
+								action={ action }
+								items={ selectedItems }
+								ActionTrigger={ ActionTrigger }
+								isBusy={ actionInProgress === action.id }
+								onActionStart={ () => {
+									setActionInProgress( action.id );
+								} }
+								onActionPerformed={ () => {
+									setActionInProgress( null );
+								} }
+							/>
+						);
+					}
+					return (
+						<ActionTrigger
+							key={ action.id }
+							action={ action }
+							items={ selectedItems }
+							onClick={ () => {
+								setActionInProgress( action.id );
+								action.callback( selectedItems, () => {
+									setActionInProgress( action.id );
+								} );
+							} }
+							isBusy={ actionInProgress === action.id }
+						/>
+					);
+				} ) }
+			</ToolbarGroup>
+			<ToolbarGroup>
+				<ToolbarButton
+					icon={ closeSmall }
+					showTooltip
+					label={ __( 'Cancel' ) }
+					isDisabled={ !! actionInProgress }
+					onClick={ () => {
+						setSelection( EMPTY_ARRAY );
+					} }
+				/>
+			</ToolbarGroup>
+		</>
+	);
+}
+
+function ToolbarContent( {
+	selection,
+	actionsToShow,
+	selectedItems,
+	setSelection,
+} ) {
+	const [ actionInProgress, setActionInProgress ] = useState( null );
+	const buttons = useRef( null );
+	if ( ! actionInProgress ) {
+		if ( buttons.current ) {
+			buttons.current = null;
+		}
+		return renderToolbarContent(
+			selection,
+			actionsToShow,
+			selectedItems,
+			actionInProgress,
+			setActionInProgress,
+			setSelection
+		);
+	} else if ( ! buttons.current ) {
+		buttons.current = renderToolbarContent(
+			selection,
+			actionsToShow,
+			selectedItems,
+			actionInProgress,
+			setActionInProgress,
+			setSelection
+		);
+	}
+	return buttons.current;
+}
+
+export default function BulkActionsToolbar( {
+	data,
+	selection,
+	actions = EMPTY_ARRAY,
+	setSelection,
+	getItemId,
+} ) {
+	const isReducedMotion = useReducedMotion();
+	const selectedItems = useMemo( () => {
+		return data.filter( ( item ) =>
+			selection.includes( getItemId( item ) )
+		);
+	}, [ selection, data, getItemId ] );
+
+	const actionsToShow = useMemo(
+		() =>
+			actions.filter( ( action ) => {
+				return (
+					action.supportsBulk &&
+					action.icon &&
+					selectedItems.some( ( item ) => action.isEligible( item ) )
+				);
+			} ),
+		[ actions, selectedItems ]
+	);
+
+	if (
+		( selection && selection.length === 0 ) ||
+		actionsToShow.length === 0
+	) {
+		return null;
+	}
+
+	return (
+		<AnimatePresence>
+			<motion.div
+				layout={ ! isReducedMotion } // See https://www.framer.com/docs/animation/#layout-animations
+				initial={ 'init' }
+				animate={ 'open' }
+				exit={ 'exit' }
+				variants={ isReducedMotion ? undefined : SNACKBAR_VARIANTS }
+				className="dataviews-bulk-actions"
+			>
+				<Toolbar label={ __( 'Bulk actions' ) }>
+					<div className="dataviews-bulk-actions-toolbar-wrapper">
+						<ToolbarContent
+							selection={ selection }
+							actionsToShow={ actionsToShow }
+							selectedItems={ selectedItems }
+							setSelection={ setSelection }
+						/>
+					</div>
+				</Toolbar>
+			</motion.div>
+		</AnimatePresence>
+	);
+}

--- a/packages/dataviews/src/bulk-actions-toolbar.js
+++ b/packages/dataviews/src/bulk-actions-toolbar.js
@@ -48,6 +48,7 @@ function ActionTrigger( { action, onClick, isBusy } ) {
 			onClick={ onClick }
 			isBusy={ isBusy }
 			isDisabled={ isBusy }
+			tooltipPosition="top"
 		/>
 	);
 }
@@ -139,6 +140,7 @@ function renderToolbarContent(
 				<ToolbarButton
 					icon={ closeSmall }
 					showTooltip
+					tooltipPosition="top"
 					label={ __( 'Cancel' ) }
 					isDisabled={ !! actionInProgress }
 					onClick={ () => {

--- a/packages/dataviews/src/bulk-actions-toolbar.js
+++ b/packages/dataviews/src/bulk-actions-toolbar.js
@@ -91,7 +91,6 @@ function renderToolbarContent(
 								action={ action }
 								items={ selectedItems }
 								ActionTrigger={ ActionTrigger }
-								isBusy={ actionInProgress === action.id }
 								onActionStart={ () => {
 									setActionInProgress( action.id );
 								} }

--- a/packages/dataviews/src/bulk-actions-toolbar.js
+++ b/packages/dataviews/src/bulk-actions-toolbar.js
@@ -39,7 +39,7 @@ const SNACKBAR_VARIANTS = {
 
 function ActionTrigger( { action, onClick, items, isBusy } ) {
 	const isDisabled = useMemo( () => {
-		return isBusy || items.some( ( item ) => ! action.isEligible( item ) );
+		return isBusy || items.every( ( item ) => ! action.isEligible( item ) );
 	}, [ action, items, isBusy ] );
 	return (
 		<ToolbarButton

--- a/packages/dataviews/src/bulk-actions-toolbar.js
+++ b/packages/dataviews/src/bulk-actions-toolbar.js
@@ -47,7 +47,7 @@ function ActionTrigger( { action, onClick, isBusy } ) {
 			size="compact"
 			onClick={ onClick }
 			isBusy={ isBusy }
-			isDisabled={ isBusy }
+			__experimentalIsFocusable
 			tooltipPosition="top"
 		/>
 	);
@@ -142,7 +142,7 @@ function renderToolbarContent(
 					showTooltip
 					tooltipPosition="top"
 					label={ __( 'Cancel' ) }
-					isDisabled={ !! actionInProgress }
+					disabled={ !! actionInProgress }
 					onClick={ () => {
 						setSelection( EMPTY_ARRAY );
 					} }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -15,6 +15,7 @@ import { LAYOUT_TABLE, LAYOUT_GRID } from './constants';
 import { VIEW_LAYOUTS } from './layouts';
 import BulkActions from './bulk-actions';
 import { normalizeFields } from './normalize-fields';
+import BulkActionsToolbar from './bulk-actions-toolbar';
 
 const defaultGetItemId = ( item ) => item.id;
 const defaultOnSelectionChange = () => {};
@@ -143,6 +144,16 @@ export default function DataViews( {
 				onChangeView={ onChangeView }
 				paginationInfo={ paginationInfo }
 			/>
+			{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
+				hasPossibleBulkAction && (
+					<BulkActionsToolbar
+						data={ data }
+						actions={ actions }
+						selection={ selection }
+						setSelection={ setSelection }
+						getItemId={ getItemId }
+					/>
+				) }
 		</div>
 	);
 }

--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -47,11 +47,22 @@ function DropdownMenuItemTrigger( { action, onClick } ) {
 	);
 }
 
-function ActionWithModal( { action, item, ActionTrigger } ) {
+export function ActionWithModal( {
+	action,
+	items,
+	ActionTrigger,
+	onActionStart,
+	onActionPerformed,
+	isBusy,
+} ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const actionTriggerProps = {
 		action,
-		onClick: () => setIsModalOpen( true ),
+		onClick: () => {
+			setIsModalOpen( true );
+		},
+		items,
+		isBusy,
 	};
 	const { RenderModal, hideModalHeader } = action;
 	return (
@@ -69,8 +80,10 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 					) }` }
 				>
 					<RenderModal
-						items={ [ item ] }
+						items={ items }
 						closeModal={ () => setIsModalOpen( false ) }
+						onActionStart={ onActionStart }
+						onActionPerformed={ onActionPerformed }
 					/>
 				</Modal>
 			) }
@@ -87,7 +100,7 @@ function ActionsDropdownMenuGroup( { actions, item } ) {
 						<ActionWithModal
 							key={ action.id }
 							action={ action }
-							item={ item }
+							items={ [ item ] }
 							ActionTrigger={ DropdownMenuItemTrigger }
 						/>
 					);
@@ -139,7 +152,7 @@ export default function ItemActions( { item, actions, isCompact } ) {
 							<ActionWithModal
 								key={ action.id }
 								action={ action }
-								item={ item }
+								items={ [ item ] }
 								ActionTrigger={ ButtonTrigger }
 							/>
 						);

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -783,3 +783,40 @@
 		}
 	}
 }
+
+
+.dataviews-bulk-actions-toolbar-wrapper {
+	display: flex;
+	flex-grow: 1;
+	width: 100%;
+}
+
+.dataviews-bulk-actions {
+	position: absolute;
+	display: flex;
+	flex-direction: column;
+	align-content: center;
+	flex-wrap: wrap;
+	width: 100%;
+	bottom: $grid-unit-30;
+
+	.components-accessible-toolbar {
+		border-color: $gray-300;
+		box-shadow: $shadow-popover;
+
+		.components-toolbar-group {
+			border-color: $gray-200;
+
+			&:last-child {
+				border: 0;
+			}
+		}
+	}
+
+	.dataviews-bulk-actions__selection-count {
+		display: flex;
+		align-items: center;
+		margin: 0 $grid-unit-10 0 $grid-unit-15;
+		color: $gray-700;
+	}
+}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -789,6 +789,14 @@
 	display: flex;
 	flex-grow: 1;
 	width: 100%;
+
+	.components-toolbar-group {
+		align-items: center;
+	}
+
+	.components-button.is-busy {
+		max-height: $button-size;
+	}
 }
 
 .dataviews-bulk-actions {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -807,6 +807,7 @@
 	flex-wrap: wrap;
 	width: 100%;
 	bottom: $grid-unit-30;
+	z-index: z-index(".dataviews-bulk-actions");
 
 	.components-accessible-toolbar {
 		border-color: $gray-300;
@@ -824,7 +825,6 @@
 	.dataviews-bulk-actions__selection-count {
 		display: flex;
 		align-items: center;
-		margin: 0 $grid-unit-10 0 $grid-unit-15;
-		color: $gray-700;
+		margin: 0 $grid-unit-10 0 $grid-unit-10;
 	}
 }

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -367,11 +367,11 @@ function useRestorePostAction() {
 					if ( promiseResult.length === 1 ) {
 						if ( promiseResult[ 0 ].reason?.message ) {
 							errorMessage = promiseResult[ 0 ].reason.message;
-					} else {
-						errorMessage = __(
-							'An error occurred while restoring the post.'
-						);
-					}
+						} else {
+							errorMessage = __(
+								'An error occurred while restoring the post.'
+							);
+						}
 						// If we were trying to move multiple posts to the trash
 					} else {
 						const errorMessages = new Set();

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -76,7 +76,8 @@ const trashPostAction = {
 					<Button
 						variant="tertiary"
 						onClick={ closeModal }
-						isDisabled={ isBusy }
+						disabled={ isBusy }
+						__experimentalIsFocusable
 					>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -179,6 +180,8 @@ const trashPostAction = {
 							closeModal();
 						} }
 						isBusy={ isBusy }
+						disabled={ isBusy }
+						__experimentalIsFocusable
 					>
 						{ __( 'Delete' ) }
 					</Button>
@@ -757,7 +760,8 @@ const resetTemplateAction = {
 					<Button
 						variant="tertiary"
 						onClick={ closeModal }
-						isDisabled={ isBusy }
+						disabled={ isBusy }
+						__experimentalIsFocusable
 					>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -774,6 +778,8 @@ const resetTemplateAction = {
 							isBusy( false );
 						} }
 						isBusy={ isBusy }
+						disabled={ isBusy }
+						__experimentalIsFocusable
 					>
 						{ __( 'Reset' ) }
 					</Button>
@@ -840,7 +846,8 @@ const deleteTemplateAction = {
 					<Button
 						variant="tertiary"
 						onClick={ closeModal }
-						isDisabled={ isBusy }
+						disabled={ isBusy }
+						__experimentalIsFocusable
 					>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -859,6 +866,8 @@ const deleteTemplateAction = {
 							closeModal();
 						} }
 						isBusy={ isBusy }
+						disabled={ isBusy }
+						__experimentalIsFocusable
 					>
 						{ __( 'Delete' ) }
 					</Button>


### PR DESCRIPTION
Implements a toolbar to make bulk actions more visible as suggested by @jameskoster in https://github.com/WordPress/gutenberg/issues/59043#issuecomment-1979230772.


## Testing
Select some items and verify a toolbar with bulk actions appears.
Apply some bulk actions and verify things work as expected.

## Screenshot
<img width="1223" alt="Screenshot 2024-03-08 at 16 11 20" src="https://github.com/WordPress/gutenberg/assets/11271197/3c8da95e-1f85-4f50-b6b4-ddcabed680dd">
