### PR TITLE
Hide save panel button isntead of removing when save panel is open

### DIFF
--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -20,6 +20,12 @@
 	padding: $grid-unit-30;
 	display: flex;
 	justify-content: center;
+
+	.is-entity-save-view-open & {
+		position: absolute;
+		right: -9999999em;
+		height: 0;
+	}
 }
 
 // Adjust the position of the notices

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -142,22 +142,20 @@ export default function SavePanel() {
 			} ) }
 			ariaLabel={ __( 'Save panel' ) }
 		>
-			{ isSaveViewOpen ? (
-				<_EntitiesSavedStates onClose={ onClose } />
-			) : (
-				<div className="edit-site-editor__toggle-save-panel">
-					<Button
-						variant="secondary"
-						className="edit-site-editor__toggle-save-panel-button"
-						onClick={ () => setIsSaveViewOpened( true ) }
-						aria-expanded={ false }
-						disabled={ disabled }
-						__experimentalIsFocusable
-					>
-						{ __( 'Open save panel' ) }
-					</Button>
-				</div>
-			) }
+			<div className="edit-site-editor__toggle-save-panel">
+				<Button
+					variant="secondary"
+					className="edit-site-editor__toggle-save-panel-button"
+					onClick={ () => setIsSaveViewOpened( true ) }
+					aria-expanded={ false }
+					disabled={ disabled }
+					aria-haspopup={ 'dialog' }
+					__experimentalIsFocusable
+				>
+					{ __( 'Open save panel' ) }
+				</Button>
+			</div>
+			{ isSaveViewOpen && <_EntitiesSavedStates onClose={ onClose } /> }
 		</NavigableRegion>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Sample code for https://github.com/WordPress/gutenberg/pull/59622

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
