### PR TITLE
Global Styles: Presets: Show the default empty variation as well as the other presets

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -110,7 +110,7 @@ export function useUniqueColorVariations() {
 		? colorVariations.filter( ( variation ) => {
 				const { settings, styles, title } = variation;
 				return (
-					title === 'Default' ||
+					title === 'Default' || // Always preseve the default variation.
 					Object.keys( settings ).length > 0 ||
 					Object.keys( styles ).length > 0
 				);

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -99,7 +99,7 @@ export function useSupportedStyles( name, element ) {
 	return supportedPanels;
 }
 
-export function useUniqueColorVariations() {
+export function useColorVariations() {
 	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		property: 'color',
 	} );
@@ -118,7 +118,7 @@ export function useUniqueColorVariations() {
 		: [];
 }
 
-export function useUniqueTypographyVariations() {
+export function useTypographyVariations() {
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
 			property: 'typography',

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -10,6 +10,7 @@ import a11yPlugin from 'colord/plugins/a11y';
 import { store as blocksStore } from '@wordpress/blocks';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useContext } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -110,7 +111,7 @@ export function useColorVariations() {
 		? colorVariations.filter( ( variation ) => {
 				const { settings, styles, title } = variation;
 				return (
-					title === 'Default' || // Always preseve the default variation.
+					title === __( 'Default' ) || // Always preseve the default variation.
 					Object.keys( settings ).length > 0 ||
 					Object.keys( styles ).length > 0
 				);

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -99,6 +99,25 @@ export function useSupportedStyles( name, element ) {
 	return supportedPanels;
 }
 
+export function useUniqueColorVariations() {
+	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
+		property: 'color',
+	} );
+	/*
+	 * Filter out variations with no settings or styles.
+	 */
+	return colorVariations?.length
+		? colorVariations.filter( ( variation ) => {
+				const { settings, styles, title } = variation;
+				return (
+					title === 'Default' ||
+					Object.keys( settings ).length > 0 ||
+					Object.keys( styles ).length > 0
+				);
+		  } )
+		: [];
+}
+
 export function useUniqueTypographyVariations() {
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
@@ -107,7 +126,8 @@ export function useUniqueTypographyVariations() {
 
 	const { base } = useContext( GlobalStylesContext );
 	/*
-	 * Filter duplicate variations based on the font families used in the variation.
+	 * Filter duplicate variations based on whether the variaitons
+	 * have different heading and body font families.
 	 */
 	return typographyVariations?.length
 		? Object.values(
@@ -116,7 +136,13 @@ export function useUniqueTypographyVariations() {
 						getFontFamilies(
 							mergeBaseAndUserConfigs( base, variation )
 						);
-					if (
+
+					// Always preseve the default variation.
+					if ( variation?.title === 'Default' ) {
+						acc[
+							`${ headingFontFamily?.name }:${ bodyFontFamily?.name }`
+						] = variation;
+					} else if (
 						headingFontFamily?.name &&
 						bodyFontFamily?.name &&
 						! acc[
@@ -127,7 +153,6 @@ export function useUniqueTypographyVariations() {
 							`${ headingFontFamily?.name }:${ bodyFontFamily?.name }`
 						] = variation;
 					}
-
 					return acc;
 				}, {} )
 		  )

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -11,10 +11,10 @@ import {
  */
 import Variation from './variation';
 import StylesPreviewColors from '../preview-colors';
-import { useUniqueColorVariations } from '../hooks';
+import { useColorVariations } from '../hooks';
 
 export default function ColorVariations() {
-	const colorVariations = useUniqueColorVariations();
+	const colorVariations = useColorVariations();
 
 	if ( ! colorVariations?.length ) {
 		return null;

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -11,12 +11,10 @@ import {
  */
 import Variation from './variation';
 import StylesPreviewColors from '../preview-colors';
-import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { useUniqueColorVariations } from '../hooks';
 
 export default function ColorVariations() {
-	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
-		property: 'color',
-	} );
+	const colorVariations = useUniqueColorVariations();
 
 	if ( ! colorVariations?.length ) {
 		return null;

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -10,13 +10,13 @@ import {
 /**
  * Internal dependencies
  */
-import { useUniqueTypographyVariations } from '../hooks';
+import { useTypographyVariations } from '../hooks';
 import TypographyExample from '../typography-example';
 import PreviewIframe from '../preview-iframe';
 import Variation from './variation';
 
 export default function TypographyVariations() {
-	const typographyVariations = useUniqueTypographyVariations();
+	const typographyVariations = useTypographyVariations();
 
 	if ( ! typographyVariations?.length ) {
 		return null;

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -28,35 +28,35 @@ export default function TypographyVariations() {
 				columns={ 3 }
 				className="edit-site-global-styles-style-variations-container"
 			>
-				{ typographyVariations &&
-					typographyVariations.length &&
-					typographyVariations.map( ( variation, index ) => (
-						<Variation key={ index } variation={ variation }>
-							{ ( isFocused ) => (
-								<PreviewIframe
-									label={ variation?.title }
-									isFocused={ isFocused }
-								>
-									{ ( { ratio, key } ) => (
-										<HStack
-											key={ key }
-											spacing={ 10 * ratio }
-											justify="center"
-											style={ {
-												height: '100%',
-												overflow: 'hidden',
-											} }
-										>
-											<TypographyExample
-												variation={ variation }
-												fontSize={ 85 * ratio }
-											/>
-										</HStack>
-									) }
-								</PreviewIframe>
-							) }
-						</Variation>
-					) ) }
+				{ typographyVariations && typographyVariations.length
+					? typographyVariations.map( ( variation, index ) => (
+							<Variation key={ index } variation={ variation }>
+								{ ( isFocused ) => (
+									<PreviewIframe
+										label={ variation?.title }
+										isFocused={ isFocused }
+									>
+										{ ( { ratio, key } ) => (
+											<HStack
+												key={ key }
+												spacing={ 10 * ratio }
+												justify="center"
+												style={ {
+													height: '100%',
+													overflow: 'hidden',
+												} }
+											>
+												<TypographyExample
+													variation={ variation }
+													fontSize={ 85 * ratio }
+												/>
+											</HStack>
+										) }
+									</PreviewIframe>
+								) }
+							</Variation>
+					  ) )
+					: null }
 			</Grid>
 		</VStack>
 	);

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -28,35 +28,35 @@ export default function TypographyVariations() {
 				columns={ 3 }
 				className="edit-site-global-styles-style-variations-container"
 			>
-				{ typographyVariations && typographyVariations.length
-					? typographyVariations.map( ( variation, index ) => (
-							<Variation key={ index } variation={ variation }>
-								{ ( isFocused ) => (
-									<PreviewIframe
-										label={ variation?.title }
-										isFocused={ isFocused }
-									>
-										{ ( { ratio, key } ) => (
-											<HStack
-												key={ key }
-												spacing={ 10 * ratio }
-												justify="center"
-												style={ {
-													height: '100%',
-													overflow: 'hidden',
-												} }
-											>
-												<TypographyExample
-													variation={ variation }
-													fontSize={ 85 * ratio }
-												/>
-											</HStack>
-										) }
-									</PreviewIframe>
-								) }
-							</Variation>
-					  ) )
-					: null }
+				{ typographyVariations &&
+					typographyVariations.length &&
+					typographyVariations.map( ( variation, index ) => (
+						<Variation key={ index } variation={ variation }>
+							{ ( isFocused ) => (
+								<PreviewIframe
+									label={ variation?.title }
+									isFocused={ isFocused }
+								>
+									{ ( { ratio, key } ) => (
+										<HStack
+											key={ key }
+											spacing={ 10 * ratio }
+											justify="center"
+											style={ {
+												height: '100%',
+												overflow: 'hidden',
+											} }
+										>
+											<TypographyExample
+												variation={ variation }
+												fontSize={ 85 * ratio }
+											/>
+										</HStack>
+									) }
+								</PreviewIframe>
+							) }
+						</Variation>
+					) ) }
 			</Grid>
 		</VStack>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -30,8 +30,8 @@ import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-d
 import ColorVariations from '../global-styles/variations/variations-color';
 import TypographyVariations from '../global-styles/variations/variations-typography';
 import {
-	useUniqueColorVariations,
-	useUniqueTypographyVariations,
+	useColorVariations,
+	useTypographyVariations,
 } from '../global-styles/hooks';
 
 const noop = () => {};
@@ -78,8 +78,8 @@ function SidebarNavigationScreenGlobalStylesContent() {
 		};
 	}, [] );
 
-	const colorVariations = useUniqueColorVariations();
-	const typographyVariations = useUniqueTypographyVariations();
+	const colorVariations = useColorVariations();
+	const typographyVariations = useTypographyVariations();
 
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are
 	// loaded. This is necessary because the Iframe component waits until

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -29,8 +29,10 @@ import useGlobalStylesRevisions from '../global-styles/screen-revisions/use-glob
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
 import ColorVariations from '../global-styles/variations/variations-color';
 import TypographyVariations from '../global-styles/variations/variations-typography';
-import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
-import { useUniqueTypographyVariations } from '../global-styles/hooks';
+import {
+	useUniqueColorVariations,
+	useUniqueTypographyVariations,
+} from '../global-styles/hooks';
 
 const noop = () => {};
 
@@ -76,10 +78,7 @@ function SidebarNavigationScreenGlobalStylesContent() {
 		};
 	}, [] );
 
-	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
-		property: 'color',
-	} );
-
+	const colorVariations = useUniqueColorVariations();
 	const typographyVariations = useUniqueTypographyVariations();
 
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -5,6 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useContext, useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -54,12 +55,28 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 	property,
 	filter,
 } ) {
-	const variations = useSelect( ( select ) => {
-		return select(
-			coreStore
-		).__experimentalGetCurrentThemeGlobalStylesVariations();
+	const { variationsFromTheme } = useSelect( ( select ) => {
+		const _variationsFromTheme =
+			select(
+				coreStore
+			).__experimentalGetCurrentThemeGlobalStylesVariations();
+
+		return {
+			variationsFromTheme: _variationsFromTheme || [],
+		};
 	}, [] );
 	const { user: baseVariation } = useContext( GlobalStylesContext );
+
+	const variations = useMemo( () => {
+		return [
+			{
+				title: __( 'Default' ),
+				settings: {},
+				styles: {},
+			},
+			...variationsFromTheme,
+		];
+	}, [ variationsFromTheme ] );
 
 	return useThemeStyleVariationsByProperty( {
 		variations,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This shows the default preset as well as the variations...

## Why?
...so that users can set them back to the original settings that came with the theme.

## How?
Add empty default variations to the ones we fetch from the store.

Fixes https://github.com/WordPress/gutenberg/issues/59574

## Testing Instructions
1. Open the Site Editor
2. Open Global Styles > Colors
3. Check that the first item is the default theme setting
2. Open Global Styles > Typography
3. Check that the first item is the default theme setting

## Screenshots or screencast <!-- if applicable -->
<img width="333" alt="Screenshot 2024-03-08 at 17 19 15" src="https://github.com/WordPress/gutenberg/assets/275961/22094d11-489b-4c45-a5e4-2e03caf24705">
<img width="319" alt="Screenshot 2024-03-08 at 17 19 08" src="https://github.com/WordPress/gutenberg/assets/275961/0789904e-0fb0-4fc7-aeed-0c55e9767268">

