### PR TITLE
Fix/issue#59698

### DIFF
--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -321,6 +321,7 @@ export const BackdropUI = styled.div< BackdropProps >`
 export const Prefix = styled.span`
 	box-sizing: border-box;
 	display: block;
+	${ fontSizeStyles }
 `;
 
 export const Suffix = styled.span`
@@ -328,4 +329,5 @@ export const Suffix = styled.span`
 	align-self: stretch;
 	box-sizing: border-box;
 	display: flex;
+	${ fontSizeStyles }
 `;

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -14,6 +14,7 @@ import { useState, forwardRef } from '@wordpress/element';
  */
 import BaseControl from '../base-control';
 import InputBase from '../input-control/input-base';
+import InputControlPrefixWrapper from '../input-control/input-prefix-wrapper';
 import { Select } from './styles/select-control-styles';
 import type { WordPressComponentProps } from '../context';
 import type { SelectControlProps } from './types';
@@ -106,7 +107,11 @@ function UnforwardedSelectControl(
 				suffix={
 					suffix || ( ! multiple && <SelectControlChevronDown /> )
 				}
-				prefix={ prefix }
+				prefix={
+					<InputControlPrefixWrapper>
+						{ prefix }
+					</InputControlPrefixWrapper>
+				}
 				labelPosition={ labelPosition }
 				__next40pxDefaultSize={ __next40pxDefaultSize }
 			>

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -20,6 +20,7 @@ import type { WordPressComponentProps } from '../context';
 import type { SelectControlProps } from './types';
 import SelectControlChevronDown from './chevron-down';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
+import InputControlSuffixWrapper from '../input-control/input-suffix-wrapper';
 
 const noop = () => {};
 
@@ -105,12 +106,19 @@ function UnforwardedSelectControl(
 				label={ label }
 				size={ size }
 				suffix={
-					suffix || ( ! multiple && <SelectControlChevronDown /> )
+					( suffix && (
+						<InputControlSuffixWrapper>
+							{ suffix }
+						</InputControlSuffixWrapper>
+					) ) ||
+					( ! multiple && <SelectControlChevronDown /> )
 				}
 				prefix={
-					<InputControlPrefixWrapper>
-						{ prefix }
-					</InputControlPrefixWrapper>
+					prefix && (
+						<InputControlPrefixWrapper>
+							{ prefix }
+						</InputControlPrefixWrapper>
+					)
 				}
 				labelPosition={ labelPosition }
 				__next40pxDefaultSize={ __next40pxDefaultSize }

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -4,7 +4,11 @@
 }
 
 @media (max-width: #{ ($break-medium) }) {
-	.components-base-control .components-base-control__field .components-select-control__input {
-		font-size: 16px;
+	.components-base-control .components-base-control__field {
+		.components-select-control__input,
+		.components-input-control__prefix,
+		.components-input-control__suffix {
+			font-size: 16px;
+		}
 	}
 }

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -2,13 +2,3 @@
 	outline: 0;
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
 }
-
-@media (max-width: #{ ($break-medium) }) {
-	.components-base-control .components-base-control__field {
-		.components-select-control__input,
-		.components-input-control__prefix,
-		.components-input-control__suffix {
-			font-size: 16px;
-		}
-	}
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adjusting the styling of the selectControl component and the inputControl component to account for situations where prefixes and suffixes are used. Also adding responsive type sizes to prefixes and suffixes. 

## Why?
This is to address issue #59698 

## How?
I added the provided wrapper components for prefixes and suffixes to the selectControl component to resolve the padding issue.
I added the responsive type styles to the prefix and suffix in the base inputControl component. Much of the styling of the selectControl seems to have been copy/pasted from inputControl but the prefix and suffix are using the base components styles. I added the responsiveness there to resolve it wherever it appears. 

## Testing Instructions
Open the selectControl and inputControl components in storybook. 
Add prefix and suffix values
In selectControl, See that there is padding added to the left and right and in both selectControl and inputControl see that the type size is using the same responsive styles as the placeholder and value text.


