### PR TITLE
Add: Support for menu group to the Dropdown

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+-	`Drowdown` : Add styling support for `MenuGroup` ([#59723](https://github.com/WordPress/gutenberg/pull/59723)).
 
 ### Enhancements
 
@@ -15,7 +16,6 @@
 -   `Button`: Fix focus outline in disabled primary variant ([#59391](https://github.com/WordPress/gutenberg/pull/59391)).
 -   `Button`: Place `children` before the icon when `iconPosition` is `right` ([#59489](https://github.com/WordPress/gutenberg/pull/59489)).
 -   `ToggleGroupControl`: Fix unwanted backdrop vertical animation ([#59642](https://github.com/WordPress/gutenberg/pull/59642)).
--	`Drowdown` : Add styling support for `MenuGroup` ([#59723](https://github.com/WordPress/gutenberg/pull/59723)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   `Button`: Fix focus outline in disabled primary variant ([#59391](https://github.com/WordPress/gutenberg/pull/59391)).
 -   `Button`: Place `children` before the icon when `iconPosition` is `right` ([#59489](https://github.com/WordPress/gutenberg/pull/59489)).
 -   `ToggleGroupControl`: Fix unwanted backdrop vertical animation ([#59642](https://github.com/WordPress/gutenberg/pull/59642)).
+-	`Drowdown` : Add styling support for `MenuGroup` ([#59723](https://github.com/WordPress/gutenberg/pull/59723)).
 
 ### Internal
 

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -60,29 +60,4 @@
 		padding-right: $grid-unit-10;
 	}
 
-	.components-menu-group {
-		padding: $grid-unit-10;
-		margin-top: 0;
-		margin-bottom: 0;
-		margin-left: -$grid-unit-10;
-		margin-right: -$grid-unit-10;
-
-		&:first-child {
-			margin-top: -$grid-unit-10;
-		}
-
-		&:last-child {
-			margin-bottom: -$grid-unit-10;
-		}
-	}
-
-	.components-menu-group + .components-menu-group {
-		margin-top: 0;
-		border-top: $border-width solid $gray-400;
-		padding: $grid-unit-10;
-
-		.is-alternate & {
-			border-color: $gray-900;
-		}
-	}
 }

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -95,7 +95,7 @@ export const WithMenuItems = Template.bind( {} );
 WithMenuItems.args = {
 	...Default.args,
 	renderContent: () => (
-		<DropdownContentWrapper>
+		<>
 			<MenuGroup label="Group 1">
 				<MenuItem>Item 1</MenuItem>
 				<MenuItem>Item 2</MenuItem>

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryFn } from '@storybook/react';
  */
 import Dropdown from '..';
 import Button from '../../button';
+import MenuGroup from '../../menu-group';
+import MenuItem from '../../menu-item';
 import { DropdownContentWrapper } from '../dropdown-content-wrapper';
 
 const meta: Meta< typeof Dropdown > = {
@@ -80,6 +82,28 @@ WithNoPadding.args = {
 	renderContent: () => (
 		<DropdownContentWrapper paddingSize="none">
 			Content wrapped with <code>{ `paddingSize="none"` }</code>.
+		</DropdownContentWrapper>
+	),
+};
+
+/**
+ * The `<DropdownContentWrapper>` convenience wrapper can also be used to remove padding entirely,
+ * with a `paddingSize` of `"none"`. This can also serve as a clean foundation to add arbitrary
+ * paddings, for example when child components already have padding on their own.
+ */
+export const WithMenuItems = Template.bind( {} );
+WithMenuItems.args = {
+	...Default.args,
+	renderContent: () => (
+		<DropdownContentWrapper>
+			<MenuGroup label="Group 1">
+				<MenuItem>Item 1</MenuItem>
+				<MenuItem>Item 2</MenuItem>
+			</MenuGroup>
+			<MenuGroup label="Group 2">
+				<MenuItem>Item 1</MenuItem>
+				<MenuItem>Item 2</MenuItem>
+			</MenuGroup>
 		</DropdownContentWrapper>
 	),
 };

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -86,11 +86,6 @@ WithNoPadding.args = {
 	),
 };
 
-/**
- * The `<DropdownContentWrapper>` convenience wrapper can also be used to remove padding entirely,
- * with a `paddingSize` of `"none"`. This can also serve as a clean foundation to add arbitrary
- * paddings, for example when child components already have padding on their own.
- */
 export const WithMenuItems = Template.bind( {} );
 WithMenuItems.args = {
 	...Default.args,

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -99,6 +99,6 @@ WithMenuItems.args = {
 				<MenuItem>Item 1</MenuItem>
 				<MenuItem>Item 2</MenuItem>
 			</MenuGroup>
-		</DropdownContentWrapper>
+		</>
 	),
 };

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -10,4 +10,26 @@
 	[role="menuitem"] {
 		white-space: nowrap;
 	}
+
+	.components-menu-group {
+		padding: $grid-unit-10;
+		margin-top: 0;
+		margin-bottom: 0;
+		margin-left: -$grid-unit-10;
+		margin-right: -$grid-unit-10;
+
+		&:first-child {
+			margin-top: -$grid-unit-10;
+		}
+
+		&:last-child {
+			margin-bottom: -$grid-unit-10;
+		}
+	}
+
+	.components-menu-group + .components-menu-group {
+		margin-top: 0;
+		border-top: $border-width solid $gray-400;
+		padding: $grid-unit-10;
+	}
 }

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -31,5 +31,9 @@
 		margin-top: 0;
 		border-top: $border-width solid $gray-400;
 		padding: $grid-unit-10;
+
+		.is-alternate & {
+			border-color: $gray-900;
+		}
 	}
 }


### PR DESCRIPTION
Before:
<img width="236" alt="Screenshot 2024-03-08 at 3 54 49 PM" src="https://github.com/WordPress/gutenberg/assets/115071/1ee730d9-9788-48d6-8112-b7538646f9fa">

After:

<img width="242" alt="Screenshot 2024-03-08 at 4 01 26 PM" src="https://github.com/WordPress/gutenberg/assets/115071/6e02e675-2b98-4432-89a0-1289ab823a30">

## What?
This PR adds nicer styling for the MenuGroup component when it is places inside the DropDown menu,

## Why?
This make the default styling of the MenuGroup much nicer when it is places inside the DropDown component. 

## How?
This PR just adds additional styles for MenuGroup to the DropDown menu.

## Testing Instructions
Start Storyboard
`npm run storybook:dev` 

Open the http://localhost:50240/?path=/story/components-dropdown--with-menu-items 

Visit 
http://localhost:50240/?path=/story/components-dropdownmenu--with-children notice that it still looks the same.

## Screenshots or screencast <!-- if applicable -->
