### PR TITLE
Added @global to PHP Docs Comments

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -13,9 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Retrieves the root plugin path.
  *
- * @return string Root path to the gutenberg plugin.
- *
  * @since 0.1.0
+ *
+ * @return string Root path to the gutenberg plugin.
  */
 function gutenberg_dir_path() {
 	return plugin_dir_path( __DIR__ );
@@ -24,11 +24,11 @@ function gutenberg_dir_path() {
 /**
  * Retrieves a URL to a file in the gutenberg plugin.
  *
+ * @since 0.1.0
+ *
  * @param  string $path Relative path of the desired file.
  *
  * @return string       Fully qualified URL pointing to the desired file.
- *
- * @since 0.1.0
  */
 function gutenberg_url( $path ) {
 	return plugins_url( $path, __DIR__ );
@@ -244,7 +244,9 @@ add_action( 'wp_default_scripts', 'gutenberg_register_packages_scripts' );
  * `build/` location.
  *
  * @since 6.7.0
-
+ *
+ * @global array $editor_styles.
+ *
  * @param WP_Styles $styles WP_Styles instance.
  */
 function gutenberg_register_packages_styles( $styles ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -245,7 +245,7 @@ add_action( 'wp_default_scripts', 'gutenberg_register_packages_scripts' );
  *
  * @since 6.7.0
  *
- * @global array $editor_styles.
+ * @global array $editor_styles
  *
  * @param WP_Styles $styles WP_Styles instance.
  */

--- a/lib/compat/wordpress-6.5/scripts-modules.php
+++ b/lib/compat/wordpress-6.5/scripts-modules.php
@@ -17,7 +17,7 @@ if ( ! function_exists( 'wp_script_modules' ) ) {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @global WP_Script_Modules $wp_script_modules.
+	 * @global WP_Script_Modules $wp_script_modules
 	 *
 	 * @return WP_Script_Modules The main WP_Script_Modules instance.
 	 */

--- a/lib/compat/wordpress-6.5/scripts-modules.php
+++ b/lib/compat/wordpress-6.5/scripts-modules.php
@@ -17,6 +17,8 @@ if ( ! function_exists( 'wp_script_modules' ) ) {
 	 *
 	 * @since 6.5.0
 	 *
+	 * @global WP_Script_Modules $wp_script_modules.
+	 *
 	 * @return WP_Script_Modules The main WP_Script_Modules instance.
 	 */
 	function wp_script_modules(): WP_Script_Modules {


### PR DESCRIPTION
- Added `@global` in php docs comments
- Added `@since` before `@param` & `@return` according to [PHP Doc Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)

**Fixes:** https://github.com/WordPress/gutenberg/issues/59724