### PR TITLE
HeadingLevelDropdown: Fix JSDoc and documentation

### DIFF
--- a/packages/block-editor/src/components/block-heading-level-dropdown/README.md
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/README.md
@@ -28,23 +28,23 @@ const MyHeadingLevelToolbar = () => (
 
 #### options
 
-The list of available HTML tags, passed from the block.
+The list of available heading levels, passed from the block.
 
 -   Type: `Object`
 -   Required: no
 
 #### value
 
-The chosen HTML tag.
+The chosen heading level.
 
--   Type: `string`
+-   Type: `number`
 -   Required: no
 
 #### onChange
 
-Callback to run when toolbar value is changed.
+Function called with the selected value changes.
 
--   Type: `string`
+-   Type: `() => number`
 -   Required: yes
 
 ## Related components

--- a/packages/block-editor/src/components/block-heading-level-dropdown/index.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/index.js
@@ -22,10 +22,10 @@ const POPOVER_PROPS = {
  *
  * @typedef WPHeadingLevelDropdownProps
  *
- * @property {number}                 value    The chosen heading level.
- * @property {number[]}               options  An array of supported heading levels.
- * @property {(newValue:number)=>any} onChange Callback to run when
- *                                             toolbar value is changed.
+ * @property {number}     value    The chosen heading level.
+ * @property {number[]}   options  An array of supported heading levels.
+ * @property {()=>number} onChange Function called with
+ *                                 the selected value changes.
  */
 
 /**
@@ -53,7 +53,7 @@ export default function HeadingLevelDropdown( {
 						targetLevel === 0
 							? __( 'Paragraph' )
 							: sprintf(
-									// translators: %s: heading level e.g: "1", "2", "3"
+									// translators: %d: heading level e.g: "1", "2", "3"
 									__( 'Heading %d' ),
 									targetLevel
 							  ),

--- a/packages/block-editor/src/components/block-heading-level-dropdown/index.native.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/index.native.js
@@ -18,9 +18,10 @@ const HEADING_LEVELS = [ 1, 2, 3, 4, 5, 6 ];
  *
  * @typedef WPHeadingLevelDropdownProps
  *
- * @property {number}                 selectedLevel The chosen heading level.
- * @property {(newValue:number)=>any} onChange      Callback to run when
- *                                                  toolbar value is changed.
+ * @property {number}     value    The chosen heading level.
+ * @property {number[]}   options  An array of supported heading levels.
+ * @property {()=>number} onChange Function called with
+ *                                 the selected value changes.
  */
 
 /**
@@ -48,7 +49,7 @@ export default function HeadingLevelDropdown( {
 					isPressed={ isActive }
 				/>
 			),
-			// translators: %s: heading level e.g: "1", "2", "3"
+			// translators: %d: heading level e.g: "1", "2", "3"
 			title: sprintf( __( 'Heading %d' ), targetLevel ),
 			isActive,
 			onClick: () => onChangeCallback( targetLevel ),


### PR DESCRIPTION
I discovered this while reviewing #59654.

## What?

This PR fixes JSDoc and the documentation in the `HeadingLevelDropdown` component.

## Why?

- This component deals with `heading level(s)` rather than `HTML tag(s)`.
- This component deals with `number`, not `string`.
- `onChange` should always return `number` type, not `any` type.
- Native component `@property` is incorrect

## Testing Instructions

CIs should be ✅.