### PR TITLE
✅ Automatically reinsert default template and focus when inner blocks are empty for the Quote Block

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -78,6 +78,32 @@ export default function QuoteEdit( {
 
 	useMigrateOnLoad( attributes, clientId );
 
+	const { hasInnerBlocks } = useSelect(
+		( select ) => {
+			const { getBlock } = select( blockEditorStore );
+			const block = getBlock( clientId );
+			return {
+				hasInnerBlocks: !! ( block && block.innerBlocks.length ),
+			};
+		},
+		[ clientId ]
+	);
+
+	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( ! hasInnerBlocks ) {
+			const blocksToInsert = TEMPLATE.map( ( [ name, attr ] ) =>
+				createBlock( name, attr )
+			);
+			replaceInnerBlocks( clientId, blocksToInsert, false );
+
+			if ( blocksToInsert.length > 0 ) {
+				selectBlock( blocksToInsert[ 0 ].clientId );
+			}
+		}
+	}, [ hasInnerBlocks, clientId, replaceInnerBlocks, selectBlock ] );
+
 	const hasSelection = useSelect(
 		( select ) => {
 			const { isBlockSelected, hasSelectedInnerBlock } =


### PR DESCRIPTION
## What?
✅ Automatically reinsert default block and focus when inner blocks are empty.

## Why?
⚠️ This PR seeks to address the following:
fix #59709

## How?
This commit enhances the QuoteEdit component by automatically reinserting a paragraph block based on the defined TEMPLATE when its inner blocks are emptied. It also ensures the cursor is set within the newly inserted block for immediate editing. This improvement streamlines the editing workflow, maintaining a consistent structure and improving user experience within the custom block.

## Testing Instructions
1. Open the block editor.
2. Insert the Quote block.
3. Insert an InnerBlock (i.e. List block)
4. Remove the InnerBlock.

### Testing Instructions for Keyboard
1. Open the block editor
2. Use `/` (forward slash) to insert the Quote block
3. Use `/` (forward slash) to insert an InnerBlock
4. Use `Backspace` to remove the InnerBlock
