### PR TITLE
Block JSON schema: Add `layout.allowCustomContentAndWideSize` field

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -477,6 +477,11 @@
 									"type": "boolean",
 									"description": "For the `flex` layout type only, determines display of the orientation control in the block toolbar.",
 									"default": true
+								},
+								"allowCustomContentAndWideSize": {
+									"type": "boolean",
+									"description": "For the `constrained` layout type only, determines display of the custom content and wide size controls in the block sidebar.",
+									"default": true
 								}
 							}
 						}


### PR DESCRIPTION
Related to #56236

## What?

This PR adds a `supports.layout.allowCustomContentAndWideSize` field to the schema of block.json.

## Why?
To enhance the developer experience. 

## Testing Instructions

Create a JSON file like the one below and open it in a code editor.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/block-schema/add-allow-custom-content-and-wide-size/schemas/json/block.json",
	"name": "test/test",
	"title": "Test",
	"supports": {
		"layout": {}
	}
}
```

You should see `allowCustomContentAndWideSize` reference.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/54422211/3adcc8e5-6e3e-437c-b79a-5e0532b2643e)
