### PR TITLE
TextareaControl: Remove extra closing curly brace in `inputStyleNeutral`

### DIFF
--- a/packages/components/src/utils/input/base.js
+++ b/packages/components/src/utils/input/base.js
@@ -14,7 +14,7 @@ export const inputStyleNeutral = css`
 	box-shadow: 0 0 0 transparent;
 	transition: box-shadow 0.1s linear;
 	border-radius: ${ CONFIG.radiusBlockUi };
-	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border } };
+	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 	${ reduceMotion( 'transition' ) }
 `;
 


### PR DESCRIPTION
# Fixed Syntax Error in CSS Component

Hello Gutenberg Contributors!

I'm excited to present my contribution to the project with this pull request. In this PR, I addressed a syntax error that was affecting the 'inputStyleNeutral' CSS component. By removing an extra curly brace, I ensured the proper functioning of this component.

## What?
The primary focus of this PR was to fix the syntax error in the 'inputStyleNeutral' CSS component.

## Why?
This fix was necessary to maintain the integrity and functionality of the CSS component within Gutenberg.

## How?
To resolve the issue, I carefully reviewed the code and removed the unnecessary curly brace in the 'inputStyleNeutral' CSS component.

## Testing Instructions
I have provided step-by-step instructions for testing this PR:
1. Open a post or page.
2. Insert a heading block.
3. Verify the behavior of the 'inputStyleNeutral' CSS component.

Additionally, for keyboard accessibility testing:
1. Navigate to a post or page.
2. Insert a heading block using keyboard navigation.
3. Confirm the functionality of the 'inputStyleNeutral' CSS component with keyboard-only interactions.

Your feedback and review of this contribution are highly appreciated. Together, we can continue to improve Gutenberg for the WordPress community!