### PR TITLE
Link dialog: Remove CSS hack.

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -93,11 +93,6 @@ $block-editor-link-control-number-of-actions: 1;
 	position: absolute;
 	right: 19px; // specific to place the button properly.
 	top: 3px;
-
-	svg {
-		position: relative;
-		top: -2px; // the icon itself is not centered within the bounds; this centers it.
-	}
 }
 
 .block-editor-link-control__search-actions {


### PR DESCRIPTION
## What?

Followup to https://github.com/WordPress/gutenberg/pull/59669#pullrequestreview-1926169900. Removes a CSS hack to correct the position of an icon.

Before it was offset:
![offset icon](https://github.com/WordPress/gutenberg/assets/1204802/936df842-f010-455f-851b-6d663c1056cd)

Now it should be right:


![correct icon](https://github.com/WordPress/gutenberg/assets/1204802/254f9786-f2fb-4c65-b085-307a929f9bef)



## Testing Instructions

Select text, add a link, observe the keyboard return icon is visually balanced.