### PR TITLE
[DataViews]: Fix item actions

### DIFF
--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -15,13 +15,13 @@ import { moreVertical } from '@wordpress/icons';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
+import { WithDropDownMenuSeparators } from './utils';
 
 const {
 	DropdownMenuV2: DropdownMenu,
 	DropdownMenuGroupV2: DropdownMenuGroup,
 	DropdownMenuItemV2: DropdownMenuItem,
 	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 	kebabCase,
 } = unlock( componentsPrivateApis );
 
@@ -137,7 +137,7 @@ export default function ItemActions( { item, actions, isCompact } ) {
 		<HStack
 			spacing={ 1 }
 			justify="flex-end"
-			className="dataviews-view-table__actions"
+			className="dataviews-item-actions"
 			style={ {
 				flexShrink: '0',
 				width: 'auto',
@@ -163,28 +163,11 @@ export default function ItemActions( { item, actions, isCompact } ) {
 						/>
 					);
 				} ) }
-			<DropdownMenu
-				trigger={
-					<Button
-						size="compact"
-						icon={ moreVertical }
-						label={ __( 'Actions' ) }
-						disabled={ ! secondaryActions.length }
-						className="dataviews-view-table__all-actions-button"
-					/>
-				}
-				placement="bottom-end"
-			>
-				<ActionsDropdownMenuGroup
-					actions={ primaryActions }
-					item={ item }
-				/>
-				<DropdownMenuSeparator />
-				<ActionsDropdownMenuGroup
-					actions={ secondaryActions }
-					item={ item }
-				/>
-			</DropdownMenu>
+			<CompactItemActions
+				item={ item }
+				primaryActions={ primaryActions }
+				secondaryActions={ secondaryActions }
+			/>
 		</HStack>
 	);
 }
@@ -200,22 +183,25 @@ function CompactItemActions( { item, primaryActions, secondaryActions } ) {
 					disabled={
 						! primaryActions.length && ! secondaryActions.length
 					}
+					className="dataviews-all-actions-button"
 				/>
 			}
 			placement="bottom-end"
 		>
-			{ !! primaryActions.length && (
-				<ActionsDropdownMenuGroup
-					actions={ primaryActions }
-					item={ item }
-				/>
-			) }
-			{ !! secondaryActions.length && (
-				<ActionsDropdownMenuGroup
-					actions={ secondaryActions }
-					item={ item }
-				/>
-			) }
+			<WithDropDownMenuSeparators>
+				{ !! primaryActions.length && (
+					<ActionsDropdownMenuGroup
+						actions={ primaryActions }
+						item={ item }
+					/>
+				) }
+				{ !! secondaryActions.length && (
+					<ActionsDropdownMenuGroup
+						actions={ secondaryActions }
+						item={ item }
+					/>
+				) }
+			</WithDropDownMenuSeparators>
 		</DropdownMenu>
 	);
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -137,14 +137,14 @@
 			}
 		}
 
-		.dataviews-view-table__actions .components-button:not(.dataviews-view-table__all-actions-button) {
+		.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
 			opacity: 0;
 		}
 
 		&:focus-within,
 		&.is-hovered {
 			.components-checkbox-control__input,
-			.dataviews-view-table__actions .components-button:not(.dataviews-view-table__all-actions-button) {
+			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
 				opacity: 1;
 			}
 		}

--- a/packages/dataviews/src/utils.js
+++ b/packages/dataviews/src/utils.js
@@ -1,7 +1,18 @@
 /**
+ * WordPress dependencies
+ */
+import { Children, Fragment } from '@wordpress/element';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { OPERATORS } from './constants';
+import { unlock } from './lock-unlock';
+
+const { DropdownMenuSeparatorV2: DropdownMenuSeparator } = unlock(
+	componentsPrivateApis
+);
 
 /**
  * Helper util to sort data by text fields, when sorting is done client side.
@@ -64,3 +75,14 @@ export const sanitizeOperators = ( field ) => {
 		Object.keys( OPERATORS ).includes( operator )
 	);
 };
+
+export function WithDropDownMenuSeparators( { children } ) {
+	return Children.toArray( children )
+		.filter( Boolean )
+		.map( ( child, i ) => (
+			<Fragment key={ i }>
+				{ i > 0 && <DropdownMenuSeparator /> }
+				{ child }
+			</Fragment>
+		) );
+}

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -22,8 +22,6 @@ import {
 	useId,
 	useRef,
 	useState,
-	Children,
-	Fragment,
 	useMemo,
 } from '@wordpress/element';
 
@@ -33,7 +31,7 @@ import {
 import SingleSelectionCheckbox from './single-selection-checkbox';
 import { unlock } from './lock-unlock';
 import ItemActions from './item-actions';
-import { sanitizeOperators } from './utils';
+import { sanitizeOperators, WithDropDownMenuSeparators } from './utils';
 import { ENUMERATION_TYPE, SORTING_DIRECTIONS } from './constants';
 import {
 	useSomeItemHasAPossibleBulkAction,
@@ -46,19 +44,7 @@ const {
 	DropdownMenuItemV2: DropdownMenuItem,
 	DropdownMenuRadioItemV2: DropdownMenuRadioItem,
 	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
-
-function WithSeparators( { children } ) {
-	return Children.toArray( children )
-		.filter( Boolean )
-		.map( ( child, i ) => (
-			<Fragment key={ i }>
-				{ i > 0 && <DropdownMenuSeparator /> }
-				{ child }
-			</Fragment>
-		) );
-}
 
 const sortArrows = { asc: '↑', desc: '↓' };
 
@@ -102,7 +88,7 @@ const HeaderMenu = forwardRef( function HeaderMenu(
 			}
 			style={ { minWidth: '240px' } }
 		>
-			<WithSeparators>
+			<WithDropDownMenuSeparators>
 				{ isSortable && (
 					<DropdownMenuGroup>
 						{ Object.entries( SORTING_DIRECTIONS ).map(
@@ -187,7 +173,7 @@ const HeaderMenu = forwardRef( function HeaderMenu(
 						</DropdownMenuItemLabel>
 					</DropdownMenuItem>
 				) }
-			</WithSeparators>
+			</WithDropDownMenuSeparators>
 		</DropdownMenu>
 	);
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/59128


In the above PR all actions(primary and secondary) are always shown in the `ellipsis` menu(aka ItemActions component). This is very similar to the `compact` view of item actions and we should reuse this and be consistent. What this means is that in this PR the only visual change is that we also add the separator between primary and secondary actions in every view(including the `grid view`).

The remaining changes are a cleanup to use generic classnames in the generic `ItemActions` component.

## Testing Instructions
1. Everything should work as before
2. In `grid` view you should see the separator too

