### PR TITLE
Add tooltip to several Back buttons.

### DIFF
--- a/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
+++ b/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
@@ -32,7 +32,7 @@ function ScreenHeader( { title } ) {
 							}
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							size="small"
-							aria-label={ __( 'Navigate to the previous view' ) }
+							label={ __( 'Back' ) }
 						/>
 						<Spacer>
 							<Heading level={ 5 }>{ title }</Heading>

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -117,7 +117,7 @@ export async function openGlobalStylesPanel( panelName ) {
  */
 export async function openPreviousGlobalStylesPanel() {
 	await page.click(
-		'div[aria-label="Editor settings"] button[aria-label="Navigate to the previous view"]'
+		'div[aria-label="Editor settings"] button[aria-label="Back"]'
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -345,7 +345,7 @@ function FontCollection( { slug } ) {
 							onClick={ () => {
 								setSelectedFont( null );
 							} }
-							aria-label={ __( 'Navigate to the previous view' ) }
+							label={ __( 'Back' ) }
 						/>
 						<Heading
 							level={ 2 }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -202,7 +202,7 @@ function InstalledFonts() {
 							onClick={ () => {
 								handleSetLibraryFontSelected( null );
 							} }
-							aria-label={ __( 'Navigate to the previous view' ) }
+							label={ __( 'Back' ) }
 						/>
 						<Heading
 							level={ 2 }

--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -26,7 +26,7 @@ function ScreenHeader( { title, description, onBack } ) {
 							}
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							size="small"
-							aria-label={ __( 'Navigate to the previous view' ) }
+							label={ __( 'Back' ) }
 							onClick={ onBack }
 						/>
 						<Spacer>

--- a/packages/preferences/src/components/preferences-modal-tabs/index.js
+++ b/packages/preferences/src/components/preferences-modal-tabs/index.js
@@ -157,9 +157,7 @@ export default function PreferencesModalTabs( { sections } ) {
 													? chevronRight
 													: chevronLeft
 											}
-											aria-label={ __(
-												'Navigate to the previous view'
-											) }
+											label={ __( 'Back' ) }
 										/>
 										<Text size="16">
 											{ section.tabLabel }

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -116,8 +116,8 @@ test.describe( 'Style Book', () => {
 			} )
 			.click();
 
-		await page.click( 'role=button[name="Navigate to the previous view"]' );
-		await page.click( 'role=button[name="Navigate to the previous view"]' );
+		await page.click( 'role=button[name="Back"]' );
+		await page.click( 'role=button[name="Back"]' );
 
 		await expect(
 			page.locator( 'role=button[name="Blocks styles"]' )
@@ -172,7 +172,7 @@ test.describe( 'Style Book', () => {
 			'style book should be visible'
 		).toBeVisible();
 
-		await page.click( 'role=button[name="Navigate to the previous view"]' );
+		await page.click( 'role=button[name="Back"]' );
 
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -79,9 +79,7 @@ test.describe( 'Global styles variations', () => {
 		await editor.canvas.locator( 'body' ).click();
 		await siteEditorStyleVariations.browseStyles();
 		await page.click( 'role=button[name="pink"i]' );
-		await page.click(
-			'role=button[name="Navigate to the previous view"i]'
-		);
+		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Colors styles"i]' );
 
 		await expect(
@@ -96,9 +94,7 @@ test.describe( 'Global styles variations', () => {
 			)
 		).toHaveCSS( 'background', /rgb\(74, 7, 74\)/ );
 
-		await page.click(
-			'role=button[name="Navigate to the previous view"i]'
-		);
+		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Typography styles"i]' );
 		await page.click( 'role=button[name="Typography Text styles"i]' );
 
@@ -120,9 +116,7 @@ test.describe( 'Global styles variations', () => {
 		await editor.canvas.locator( 'body' ).click();
 		await siteEditorStyleVariations.browseStyles();
 		await page.click( 'role=button[name="yellow"i]' );
-		await page.click(
-			'role=button[name="Navigate to the previous view"i]'
-		);
+		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Colors styles"i]' );
 
 		await expect(
@@ -137,9 +131,7 @@ test.describe( 'Global styles variations', () => {
 			)
 		).toHaveCSS( 'background', /rgb\(25, 25, 17\)/ );
 
-		await page.click(
-			'role=button[name="Navigate to the previous view"i]'
-		);
+		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Typography styles"i]' );
 		await page.click( 'role=button[name="Typography Text styles"i]' );
 
@@ -167,9 +159,7 @@ test.describe( 'Global styles variations', () => {
 		await editor.canvas.locator( 'body' ).click();
 		await siteEditorStyleVariations.browseStyles();
 		await page.click( 'role=button[name="pink"i]' );
-		await page.click(
-			'role=button[name="Navigate to the previous view"i]'
-		);
+		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Colors styles"i]' );
 		await page.click( 'role=button[name="Color palettes"i]' );
 

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -212,7 +212,7 @@ test.describe( 'Style Revisions', () => {
 			page.getByLabel( 'Global styles revisions list' )
 		).toBeVisible();
 
-		await page.click( 'role=button[name="Navigate to the previous view"]' );
+		await page.click( 'role=button[name="Back"]' );
 
 		await expect(
 			page.getByLabel( 'Global styles revisions list' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/59758

## What?
<!-- In a few words, what is the PR actually doing? -->
Many 'back' icon buttons miss a tooltip.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All icon buttons must visually expose their accessible name.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Chancs `aria-label` to `label` to make the buttons render their built-in tooltip.
- Changes the previous label `Navigate to the previous view` to a simpler `Back`:
  - The accessible name must be intuitive and be inferred from the icon appearance.
  - While adding more context to a label e.g. `Navigate to the previous view` may help screen reader users (though a little verbose), speech recognition software users wouldn't have any clue a chevron left icon button name is `Navigate to the previous view`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Test some of the following 'back' icon buttons with a left chevron. Hover or focus them and observe they do show a tooltip.

- Styles > Typograpy
- Styles > Colors
- Style Book 
- Styles Variations 
- Font library modal dialog 
- Global styles revisions§
- Preferences modal, for small screens 
- Inserter > Patterns, for small screens 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
