### PR TITLE
Refactor Link UI States

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -38,32 +38,17 @@ function Edit( {
 	onFocus,
 	contentRef,
 } ) {
-	const [ editingLink, setEditingLink ] = useState( false );
-	const [ creatingLink, setCreatingLink ] = useState( false );
+	const [ addingLink, setAddingLink ] = useState( false );
 
 	// We only need to store the button element that opened the popover. We can ignore the other states, as they will be handled by the onFocus prop to return to the rich text field.
 	const [ openedBy, setOpenedBy ] = useState( null );
-
-	function setIsEditingLink( isEditing ) {
-		setEditingLink( isEditing );
-	}
-
-	function setIsCreatingLink( isCreating ) {
-		// Don't add a new link if there is already an active link.
-		// The two states are mutually exclusive.
-		if ( isCreating === true && isActive ) {
-			return;
-		}
-		setCreatingLink( isCreating );
-	}
 
 	useEffect( () => {
 		// When the link becomes inactive (i.e. isActive is false), reset the editingLink state
 		// and the creatingLink state. This means that if the Link UI is displayed and the link
 		// becomes inactive (e.g. used arrow keys to move cursor outside of link bounds), the UI will close.
 		if ( ! isActive ) {
-			setEditingLink( false );
-			setCreatingLink( false );
+			setAddingLink( false );
 		}
 	}, [ isActive ] );
 
@@ -88,7 +73,7 @@ function Edit( {
 				return;
 			}
 
-			setIsEditingLink( true, { autoFocus: false } );
+			setAddingLink( true );
 			setOpenedBy( {
 				el: link,
 				action: 'click',
@@ -126,11 +111,7 @@ function Edit( {
 					action: null,
 				} );
 			}
-			if ( ! isActive ) {
-				setIsCreatingLink( true );
-			} else {
-				setIsEditingLink( true );
-			}
+			setAddingLink( true );
 		}
 	}
 
@@ -149,8 +130,7 @@ function Edit( {
 		// Otherwise, we rely on the passed in onFocus to return focus to the rich text field.
 
 		// Close the popover
-		setIsEditingLink( false );
-		setIsCreatingLink( false );
+		setAddingLink( false );
 
 		// Return focus to the toolbar button or the rich text field
 		if ( openedBy?.el?.tagName === 'BUTTON' ) {
@@ -169,8 +149,7 @@ function Edit( {
 	// 4. Press Escape
 	// 5. Focus should be on the Options button
 	function onFocusOutside() {
-		setIsEditingLink( false );
-		setIsCreatingLink( false );
+		setAddingLink( false );
 		setOpenedBy( null );
 	}
 
@@ -178,8 +157,6 @@ function Edit( {
 		onChange( removeFormat( value, name ) );
 		speak( __( 'Link removed.' ), 'assertive' );
 	}
-
-	const isEditingActiveLink = editingLink && isActive;
 
 	// Only autofocus if we have clicked a link within the editor
 	const shouldAutoFocus = ! (
@@ -201,13 +178,13 @@ function Edit( {
 				onClick={ ( event ) => {
 					addLink( event.currentTarget );
 				} }
-				isActive={ isActive || editingLink }
+				isActive={ isActive || addingLink }
 				shortcutType="primary"
 				shortcutCharacter="k"
 				aria-haspopup="true"
-				aria-expanded={ editingLink }
+				aria-expanded={ addingLink }
 			/>
-			{ ( isEditingActiveLink || creatingLink ) && (
+			{ addingLink && (
 				<InlineLinkUI
 					stopAddingLink={ stopAddingLink }
 					onFocusOutside={ onFocusOutside }

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -108,7 +108,7 @@ function Edit( {
 			if ( target ) {
 				setOpenedBy( {
 					el: target,
-					action: null,
+					action: null, // We don't need to distinguish between click or keyboard here
 				} );
 			}
 			setAddingLink( true );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Simplifies logic from https://github.com/WordPress/gutenberg/pull/59635 for:
- if the link ui should be showing
- if the link ui should be autofocused or not

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Code simplicity/ease of understanding.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The editing and creating states were distinctions added to decide if we should autofocus or not. There is only one instances we need to be able to autofocus: When a user clicks an existing link. This happens within a click handler, that can only exist if the user has a link to click. There is an `openBy` state we already have in use, and we can store information about this within the openBy state to determine if we should autofocus or not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
There should be no functional difference between trunk and this PR.

- New Post
- Add a paragraph block
- Add several links to the paragraph block
- Click on each link in turn and validate that the popover moves correctly between the links, shows the correct contents and anchors correctly.
- Check that when activating a link via mouse focus is _not_ transferred to the popover and remains on rich text. Check that you can make edits to the text underneath the popover (note this is as per WP 6.4).
- Check that using a keyboard to interact with links remains as per trunk.
- Check that adding other formats within a link (e.g. bold, italic .etc) does not prevent accessing the link popover by mouse or keyboard.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
