### PR TITLE
Add filter for duotone to account for gutenberg_restore_image_outer_container in classic themes

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -30,6 +30,10 @@ if ( class_exists( 'WP_Duotone' ) ) {
 	remove_filter( 'render_block', array( 'WP_Duotone', 'render_duotone_support' ) );
 }
 add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 2 );
+if ( class_exists( 'WP_Duotone' ) ) {
+	remove_filter( 'render_block_core/image', array( 'WP_Duotone', 'restore_image_outer_container' ) );
+}
+add_filter( 'render_block_core/image', array( 'WP_Duotone_Gutenberg', 'restore_image_outer_container' ), 10, 2 );
 
 // Enqueue styles.
 // Block styles (core-block-supports-inline-css) before the style engine (gutenberg_enqueue_stored_styles).

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -33,7 +33,7 @@ add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_suppo
 if ( class_exists( 'WP_Duotone' ) ) {
 	remove_filter( 'render_block_core/image', array( 'WP_Duotone', 'restore_image_outer_container' ) );
 }
-add_filter( 'render_block_core/image', array( 'WP_Duotone_Gutenberg', 'restore_image_outer_container' ), 10, 2 );
+add_filter( 'render_block_core/image', array( 'WP_Duotone_Gutenberg', 'restore_image_outer_container' ), 10, 1 );
 
 // Enqueue styles.
 // Block styles (core-block-supports-inline-css) before the style engine (gutenberg_enqueue_stored_styles).

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -28,11 +28,9 @@ if ( function_exists( 'wp_render_duotone_support' ) ) {
 }
 if ( class_exists( 'WP_Duotone' ) ) {
 	remove_filter( 'render_block', array( 'WP_Duotone', 'render_duotone_support' ) );
-}
-add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 2 );
-if ( class_exists( 'WP_Duotone' ) ) {
 	remove_filter( 'render_block_core/image', array( 'WP_Duotone', 'restore_image_outer_container' ) );
 }
+add_filter( 'render_block', array( 'WP_Duotone_Gutenberg', 'render_duotone_support' ), 10, 2 );
 add_filter( 'render_block_core/image', array( 'WP_Duotone_Gutenberg', 'restore_image_outer_container' ), 10, 1 );
 
 // Enqueue styles.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -913,7 +913,7 @@ class WP_Duotone_Gutenberg {
 		$tags          = new WP_HTML_Tag_Processor( $block_content );
 		$wrapper_query = array(
 			'tag_name'   => 'div',
-			'class_name' => 'wp-block-image'
+			'class_name' => 'wp-block-image',
 		);
 		if ( ! $tags->next_tag( $wrapper_query ) ) {
 			return $block_content;

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -897,6 +897,36 @@ class WP_Duotone_Gutenberg {
 	}
 
 	/**
+	 * Fixes the issue with our generated class name not being added to the block's outer container
+	 * in classic themes due to gutenberg_restore_image_outer_container from layout block supports.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param  string $block_content Rendered block content.
+	 * @param  array  $block         Block object.
+	 * @return string                Filtered block content.
+	 */
+	public static function restore_image_outer_container( $block_content, $block ) {
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+		if ( $tags->next_tag( array( 'tag_name' => 'div', 'class_name' => 'wp-block-image' ) ) ) {
+			$tags->set_bookmark( 'wrapper-div' );
+			$tags->next_tag();
+			$inner_classnames = explode( ' ', $tags->get_attribute( 'class' ) );
+			foreach ( $inner_classnames as $classname ) {
+				if ( 0 === strpos( $classname, 'wp-duotone' ) ) {
+					$tags->remove_class( $classname );
+					$tags->seek( 'wrapper-div' );
+					$tags->add_class( $classname );
+					break;
+				}
+			}
+			return $tags->get_updated_html();
+		}
+
+		return $block_content;
+	}
+
+	/**
 	 * Appends the used block duotone filter declarations to the inline block supports CSS.
 	 *
 	 * @since 6.3.0

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -907,23 +907,29 @@ class WP_Duotone_Gutenberg {
 	 * @return string                Filtered block content.
 	 */
 	public static function restore_image_outer_container( $block_content, $block ) {
-		$tags = new WP_HTML_Tag_Processor( $block_content );
-		if ( $tags->next_tag( array( 'tag_name' => 'div', 'class_name' => 'wp-block-image' ) ) ) {
-			$tags->set_bookmark( 'wrapper-div' );
-			$tags->next_tag();
-			$inner_classnames = explode( ' ', $tags->get_attribute( 'class' ) );
-			foreach ( $inner_classnames as $classname ) {
-				if ( 0 === strpos( $classname, 'wp-duotone' ) ) {
-					$tags->remove_class( $classname );
-					$tags->seek( 'wrapper-div' );
-					$tags->add_class( $classname );
-					break;
-				}
-			}
-			return $tags->get_updated_html();
+		if ( wp_theme_has_theme_json() ) {
+			return $block_content;
 		}
 
-		return $block_content;
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+		if ( ! $tags->next_tag( array( 'tag_name' => 'div', 'class_name' => 'wp-block-image' ) ) ) {
+			return $block_content;
+		}
+
+		$tags->set_bookmark( 'wrapper-div' );
+		$tags->next_tag();
+
+		$inner_classnames = explode( ' ', $tags->get_attribute( 'class' ) );
+		foreach ( $inner_classnames as $classname ) {
+			if ( 0 === strpos( $classname, 'wp-duotone' ) ) {
+				$tags->remove_class( $classname );
+				$tags->seek( 'wrapper-div' );
+				$tags->add_class( $classname );
+				break;
+			}
+		}
+
+		return $tags->get_updated_html();
 	}
 
 	/**

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -903,16 +903,19 @@ class WP_Duotone_Gutenberg {
 	 * @since 6.5.0
 	 *
 	 * @param  string $block_content Rendered block content.
-	 * @param  array  $block         Block object.
 	 * @return string                Filtered block content.
 	 */
-	public static function restore_image_outer_container( $block_content, $block ) {
+	public static function restore_image_outer_container( $block_content ) {
 		if ( wp_theme_has_theme_json() ) {
 			return $block_content;
 		}
 
 		$tags = new WP_HTML_Tag_Processor( $block_content );
-		if ( ! $tags->next_tag( array( 'tag_name' => 'div', 'class_name' => 'wp-block-image' ) ) ) {
+		$wrapper_query=  array(
+			'tag_name'   => 'div',
+			'class_name' => 'wp-block-image'
+		);
+		if ( ! $tags->next_tag( $wrapper_query ) ) {
 			return $block_content;
 		}
 

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -910,8 +910,8 @@ class WP_Duotone_Gutenberg {
 			return $block_content;
 		}
 
-		$tags = new WP_HTML_Tag_Processor( $block_content );
-		$wrapper_query=  array(
+		$tags          = new WP_HTML_Tag_Processor( $block_content );
+		$wrapper_query = array(
 			'tag_name'   => 'div',
 			'class_name' => 'wp-block-image'
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue with duotone filters not working in aligned images in classic themes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #54121

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a filter to restore the generated duotone class name for blocks that get a wrapping `div` due to `gutenberg_restore_image_outer_container`.

It isn't the most elegant solution, but it works. I'm open to other suggestions.

Unfortunately we can't just change the priority on the layout core/image filter since the block filters run after all the general filters where duotone is added.

And I didn't see a filter to update the block metadata at render time.

So I ended up with a filter that moves the class after the fact.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Switch to a classic theme such as Twenty Twenty.
2. Add images with combinations of duotone and alignments.
3. In the rendered page, see that the duotone filters work.

Here's the example HTML post content from the screenshots using Twenty Twenty.

```html
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"33.34%"} -->
<div class="wp-block-column" style="flex-basis:33.34%"><!-- wp:image {"width":"100px","sizeSlug":"large","linkDestination":"none","align":"left","style":{"color":{"duotone":"var:preset|duotone|purple-green"}}} -->
<figure class="wp-block-image alignleft size-large is-resized"><img src="https://upload.wikimedia.org/wikipedia/commons/5/57/Aristotle_transparent.png" alt="" style="width:100px"/></figure>
<!-- /wp:image --></div>
<!-- /wp:column -->

<!-- wp:column {"width":"33.34%"} -->
<div class="wp-block-column" style="flex-basis:33.34%"><!-- wp:image {"width":"100px","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000000","#cb2954"]}}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://upload.wikimedia.org/wikipedia/commons/5/57/Aristotle_transparent.png" alt="" style="width:100px"/></figure>
<!-- /wp:image --></div>
<!-- /wp:column -->

<!-- wp:column {"width":"33.33%"} -->
<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image {"width":"100px","sizeSlug":"large","linkDestination":"none","align":"left","style":{"color":{"duotone":["#cd2653","#f5efe0"]}},"className":"is-resized"} -->
<figure class="wp-block-image alignleft size-large is-resized"><img src="https://upload.wikimedia.org/wikipedia/commons/5/57/Aristotle_transparent.png" alt="" style="width:100px"/></figure>
<!-- /wp:image --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:image {"width":"100px","sizeSlug":"large","linkDestination":"none","align":"left","style":{"color":{"duotone":"var:preset|duotone|blue-orange"}},"className":"is-resized"} -->
<figure class="wp-block-image alignleft size-large is-resized"><img src="https://upload.wikimedia.org/wikipedia/commons/5/57/Aristotle_transparent.png" alt="" style="width:100px"/></figure>
<!-- /wp:image -->

<!-- wp:image {"width":"100px","sizeSlug":"large","linkDestination":"none","align":"right","style":{"color":{"duotone":["#000000","#dcd7ca"]}},"className":"is-resized"} -->
<figure class="wp-block-image alignright size-large is-resized"><img src="https://upload.wikimedia.org/wikipedia/commons/5/57/Aristotle_transparent.png" alt="" style="width:100px"/></figure>
<!-- /wp:image -->

<!-- wp:image {"width":"100px","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#858585","#f5efe0"]}},"className":"is-resized"} -->
<figure class="wp-block-image size-large is-resized"><img src="https://upload.wikimedia.org/wikipedia/commons/5/57/Aristotle_transparent.png" alt="" style="width:100px"/></figure>
<!-- /wp:image -->
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

Showing images with duotone in multiple contexts in Twenty Twenty. As you can see, before the aligned images didn't get the duotone filters while the unaligned ones did.

### Before

![before](https://github.com/WordPress/gutenberg/assets/5129775/c5246e28-e2ee-4f7c-baed-6e176b115446)

```html
<div class="wp-block-image">
<figure class="wp-duotone-purple-green alignleft size-large is-resized"><img decoding="async" src="https://upload.wikimedia.org/wikipedia/commons/5/57/Aristotle_transparent.png" alt="" style="width:100px"></figure></div>
```

### After
 
![after](https://github.com/WordPress/gutenberg/assets/5129775/3bfe2d8f-146e-4a66-a836-703c8ae37143)

```html
<div class="wp-block-image wp-duotone-purple-green">
<figure class="alignleft size-large is-resized"><img decoding="async" src="https://upload.wikimedia.org/wikipedia/commons/5/57/Aristotle_transparent.png" alt="" style="width:100px"></figure></div>
```