### PR TITLE
Backport r57804 from wp-dev.

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -876,17 +876,16 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 
 			$overrides = array(
 				'upload_error_handler' => array( $this, 'handle_font_file_upload_error' ),
-				// Arbitrary string to avoid the is_uploaded_file() check applied
-				// when using 'wp_handle_upload'.
-				'action'               => 'wp_handle_font_upload',
 				// Not testing a form submission.
 				'test_form'            => false,
-				// Seems mime type for files that are not images cannot be tested.
-				// See wp_check_filetype_and_ext().
-				'test_type'            => true,
 				// Only allow uploading font files for this request.
 				'mimes'                => WP_Font_Utils::get_allowed_font_mime_types(),
 			);
+
+			// Bypasses is_uploaded_file() when running unit tests.
+			if ( defined( 'DIR_TESTDATA' ) && DIR_TESTDATA ) {
+				$overrides['action'] = 'wp_handle_mock_upload';
+			}
 
 			$uploaded_file = wp_handle_upload( $file, $overrides );
 			remove_filter( 'upload_dir', $set_upload_dir );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Backport [r57804](https://core.trac.wordpress.org/changeset/57804) from wp-dev. 

Fixes #59766
See https://core.trac.wordpress.org/ticket/60741
Backports https://github.com/WordPress/wordpress-develop/pull/6242

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

* Applies consistency with the wp-dev endpoint
* Hardens the endpoint and removes unneeded overrides from the endpoint. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Copy and paste of the changes. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open Font Library upload model
2. Ensure uploading a font from your local computer succeeds 
3. Ensure installing a font from Google succeeds.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
