### PR TITLE
Site Editor: Fix selected featured image when opening media library

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -224,7 +224,6 @@ function PostFeaturedImage( {
 							</div>
 						) }
 						value={ featuredImageId }
-						postId={ currentPostId }
 					/>
 				</MediaUploadCheck>
 			</div>

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -224,6 +224,7 @@ function PostFeaturedImage( {
 							</div>
 						) }
 						value={ featuredImageId }
+						postId={ currentPostId }
 					/>
 				</MediaUploadCheck>
 			</div>

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -300,12 +300,7 @@ class MediaUpload extends Component {
 	 */
 	buildAndSetFeatureImageFrame() {
 		const { wp } = window;
-		const {
-			value: featuredImageId,
-			postId,
-			multiple,
-			allowedTypes,
-		} = this.props;
+		const { value: featuredImageId, multiple, allowedTypes } = this.props;
 		const featuredImageFrame = getFeaturedImageMediaFrame();
 		const attachments = getAttachmentsCollection( featuredImageId );
 		const selection = new wp.media.model.Selection( attachments.models, {
@@ -325,7 +320,6 @@ class MediaUpload extends Component {
 		// not for site editor.
 		wp.media.view.settings.post = {
 			...wp.media.view.settings.post,
-			id: postId,
 			featuredImageId: featuredImageId || -1,
 		};
 	}

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -300,19 +300,34 @@ class MediaUpload extends Component {
 	 */
 	buildAndSetFeatureImageFrame() {
 		const { wp } = window;
+		const {
+			value: featuredImageId,
+			postId,
+			multiple,
+			allowedTypes,
+		} = this.props;
 		const featuredImageFrame = getFeaturedImageMediaFrame();
-		const attachments = getAttachmentsCollection( this.props.value );
+		const attachments = getAttachmentsCollection( featuredImageId );
 		const selection = new wp.media.model.Selection( attachments.models, {
 			props: attachments.props.toJSON(),
 		} );
 		this.frame = new featuredImageFrame( {
-			mimeType: this.props.allowedTypes,
+			mimeType: allowedTypes,
 			state: 'featured-image',
-			multiple: this.props.multiple,
+			multiple,
 			selection,
-			editing: this.props.value ? true : false,
+			editing: featuredImageId,
 		} );
 		wp.media.frame = this.frame;
+		// In order to select the current featured image when opening
+		// the media library we have to set the appropriate settings.
+		// Currently they are set in php for the post editor, but
+		// not for site editor.
+		wp.media.view.settings.post = {
+			...wp.media.view.settings.post,
+			id: postId,
+			featuredImageId: featuredImageId || -1,
+		};
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/59768

With our unification efforts for site and post editor the featured image panel is reused now in both editors. The featured image panel in site editor results in showing an extra empty thumbnail when opening the media library.

It turns out it all starts with `wp_enqueue_media` where in post editor we pass the proper post id, which is responsible for many many things, [including setting options](https://github.com/ntsekouras/wordpress-develop/blob/trunk/src/wp-includes/media.php#L4763) for the [proper selection too](https://github.com/ntsekouras/wordpress-develop/blob/trunk/src/js/media/controllers/featured-image.js#L107). I don't think that would be the way for site editor as the script loads once and in site editor we update the `postId` without reloading.


In my approach I update the needed settings when we open the media library modal client side.


## Testing Instructions
1. In a page in site editor verify that the featured image flow works as expected(proper selection, update, removal)
2. Observe that in post editor everything keeps working as expected.

### Before

https://github.com/WordPress/gutenberg/assets/16275880/22529c4c-dba1-46ac-b2fc-5d952a838d97



### After


https://github.com/WordPress/gutenberg/assets/16275880/90227fd2-251c-4cb8-9b35-7d2423da2f7c



