### PR TITLE
Media & Text: Remove the duplicate Media width control.

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -346,16 +346,6 @@ function MediaTextEdit( {
 					) }
 				/>
 			) }
-			{ ( mediaUrl || featuredImageURL ) && (
-				<RangeControl
-					__nextHasNoMarginBottom
-					label={ __( 'Media width' ) }
-					value={ temporaryMediaWidth || mediaWidth }
-					onChange={ commitWidthChange }
-					min={ WIDTH_CONSTRAINT_PERCENTAGE }
-					max={ 100 - WIDTH_CONSTRAINT_PERCENTAGE }
-				/>
-			) }
 		</PanelBody>
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes the duplicate Media width control from the Media & text block.
Closes https://github.com/WordPress/gutenberg/issues/59772

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The duplication of the control was a mistake.

## Testing Instructions
Add a Media & text block with video, image, and feature image.
Confirm the block settings panel only show one Media width setting (the range slider).
Confirm that there are no other unexpected problems with any settings, and that the block is still correct on the front.
