### PR TITLE
RNMobile: Remove workaround to a now-resolved dictation bug

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -346,24 +346,7 @@ class RCTAztecView: Aztec.TextView {
 
         super.deleteBackward()
         updatePlaceholderVisibility()
-    }
-
-    // MARK: - Dictation
-    
-    func removeUnicodeAndRestoreCursor(from textView: UITextView) {
-        // Capture current cursor position
-        let originalPosition = textView.offset(from: textView.beginningOfDocument, to: textView.selectedTextRange?.start ?? textView.beginningOfDocument)
-                
-        // Replace occurrences of the obj symbol ("\u{FFFC}")
-        textView.text = textView.text?.replacingOccurrences(of: "\u{FFFC}", with: "")
-        
-        // Detect if cursor is off-by-one and correct, if so
-        let newPositionOffset = originalPosition > 0 ? originalPosition - 1 : originalPosition
-        if let newPosition = textView.position(from: textView.beginningOfDocument, offset: newPositionOffset) {
-            // Move the cursor to the correct, new position following dictation
-            textView.selectedTextRange = textView.textRange(from: newPosition, to: newPosition)
-        }
-    }
+    }    
 
     // MARK: - Custom Edit Intercepts
 
@@ -784,13 +767,6 @@ extension RCTAztecView: UITextViewDelegate {
     }
 
     func textViewDidChange(_ textView: UITextView) {
-        // Workaround for RN dictation bug that adds obj symbol.
-        // Ref: https://github.com/facebook/react-native/issues/36521
-        // TODO: Remove workaround when RN issue is fixed
-        if textView.text?.contains("\u{FFFC}") == true {
-            removeUnicodeAndRestoreCursor(from: textView)
-        }
-
         propagateContentChanges()
         updatePlaceholderVisibility()
         //Necessary to send height information to JS after pasting text.


### PR DESCRIPTION
## Related PRs

* `Gutenberg Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6720
* `iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/22820

## What?

Reverts a hack that was introduced in https://github.com/WordPress/gutenberg/pull/49452. The hack involved manually checking for and removing an `obj` symbol that was added during dictation due to a React Native bug.

## Why?

The React Native bug behind the issue was fixed in https://github.com/facebook/react-native/pull/37188. As Gutenberg Mobile is now on React Native 0.73, we benefit from that fix. The workaround for the bug is therefore no longer necessary.

## How?

The workaround was removed in https://github.com/WordPress/gutenberg/pull/59779/commits/ecbb195f3c9f89cddda771162975ce03f9aa94ed.

## Testing Instructions

An installable build is available at https://github.com/wordpress-mobile/WordPress-iOS/pull/22820 for testing on a physical device.

We need to verify that dictation works as expected on iOS, and that no `obj` symbol is added. The following example tests cover that, plus some other issues that came up previously:

<details>
 <summary>Test 1: Verify dictation works as expected, with no content loss ⤵️</summary>

1. Navigate to My Site → Posts and create a new post.
2. Activate the iOS dictation feature and dictate some text.
3. Notice the text added to the editor.
4. If the keyboard remains visible while dictating, tap another block on the editor or begin typing onto the keyboard. Alternatively, if the keyboard is not visible while dictating, tap the language pop up.
5. Verify that taking an action while dictation is still running doesn't lead to content loss
</details>

<details>
 <summary>Test 2: Verify no obj symbol is added after dictation ⤵️</summary>

1. Navigate to My Site → Posts and create a new post.
2. Tap on the Post Title.
3. Start dictating with voice.
4. When finished, press Enter.
5. Confirm that there is no visible `obj` symbol appended to the post title.
6. Exit the post editor and verify that no `obj` symbol is visible from the post list.
</details>

<details>
 <summary>Test 3: Verify block expands with content ⤵️</summary>

1. Navigate to My Site → Posts and create a new post.
2. Tap on "Start writing..." to focus the default paragraph block.
3. Say "I am writing a new block with my voice"
4. Switch to keyboard input and type some text
5. Confirm that the paragraph box expands to a second line
</details>

<details>
 <summary>Test 4: Verify text position is retained after dictating in middle of paragraph ⤵️</summary>

1. Navigate to My Site → Posts and create a new post.
2. Tap on "Start writing..." to focus the default paragraph block.
3. Activate the iOS dictation feature and dictate "Mary had a little lamb its fleece was white as snow"
4. Place the cursor after "little" then deactivate iOS dictation
5. Activate the iOS dictation feature and dictate "Old MacDonald had a Farm"
7. Tap below the block to start a new paragraph
8. Confirm that the ordering of the words is "Mary had a little old MacDonald had a Farm lamb it's fleece was white as snow" _not_ "Mary had a little lamb it's fleece was white as snow old MacDonald had a Farm"
</details>

In addition, verify that there are no failed tests across the Gutenberg, Gutenberg Mobile, and WordPress iOS PRs signalling unwanted side effects.