### PR TITLE
Enable PHP change detection even from forked repositories

### DIFF
--- a/.github/workflows/php-changes-detection.yml
+++ b/.github/workflows/php-changes-detection.yml
@@ -1,7 +1,7 @@
 name: OPTIONAL - Confirm if PHP changes require backporting to WordPress Core
 
 on:
-    pull_request:
+    pull_request_target:
         types: [opened, synchronize]
 jobs:
     detect_php_changes:


### PR DESCRIPTION
Fixes #59441

## What?

This PR will detect changes in PHP files and leave comments even when a PR is submitted from a forked repository.

## Why?

GitHub Actions shows an error like below.

```
Run peter-evans/create-or-update-comment@v4
/home/runner/work/_actions/peter-evans/create-or-update-comment/v4/dist/index.js:4695
      const error = new requestError.RequestError(toErrorMessage(data), status, {
                    ^

RequestError [HttpError]: Resource not accessible by integration
```

I think this issue is similar to #52981. If the PR is from a forked repository, I would expect GitHub Actions to fail because contributors don't have write permission.

## How?

I changed the trigger from `pull_request` to `pull_request_target`.  This GitHub Actions uses [peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment), which is also mentioned in that repository's README as follows:

> Note: In public repositories this action does not work in pull_request workflows when triggered by forks. Any attempt will be met with the error, Resource not accessible by integration. This is due to token restrictions put in place by GitHub Actions. Private repositories can be configured to [enable workflows](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#enabling-workflows-for-forks-of-private-repositories) from forks to run without restriction. See [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks) for further explanation. Alternatively, use the [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event to comment on pull requests.

## Testing Instructions

I believe this PR makes sense, but I don't know how to test that this PR is correct 😅

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
