### PR TITLE
Block Post Terms: Fix PHP fatal when get_the_term_list returns a WP_Error object

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -49,13 +49,17 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . '</span>' . $suffix;
 	}
 
-	return get_the_term_list(
+	$term_list = get_the_term_list(
 		$block->context['postId'],
 		$attributes['term'],
 		wp_kses_post( $prefix ),
 		'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
 		wp_kses_post( $suffix )
 	);
+	if ( false === $term_list || is_wp_error( $term_list ) ) {
+		return '';
+	}
+	return $term_list;
 }
 
 /**

--- a/phpunit/blocks/render-block-post-terms-test.php
+++ b/phpunit/blocks/render-block-post-terms-test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * File block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Post Terms block.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Post_Terms extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::render_block_core_post_terms
+	 */
+	public function test_render_block_core_post_terms_works_with_invalid_post_terms() {
+		global $post;
+
+		$global_post = $post;
+		$post        = $this->factory->post->create_and_get();
+
+		wp_set_post_tags( $post->ID, array( 'foo', 'bar' ) );
+
+		add_filter( 'get_the_terms', array( $this, 'add_invalid_post_term' ) );
+		$post_content = '<!-- wp:paragraph --><p><!-- wp:post-terms {"term":"post_tag"} --></p><!-- /wp:paragraph -->';
+		$new_content  = apply_filters( 'the_content', $post_content );
+		$this->assertStringContainsString( '<p>', $new_content );
+		$post = $global_post;
+		remove_filter( 'get_the_terms', array( $this, 'filter_post_terms' ) );
+	}
+
+	public function add_invalid_post_term( $terms ) {
+		$terms[0] = null;
+		return $terms;
+	}
+}

--- a/phpunit/blocks/render-block-post-terms-test.php
+++ b/phpunit/blocks/render-block-post-terms-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File block rendering tests.
+ * Post Terms block rendering tests.
  *
  * @package WordPress
  * @subpackage Blocks


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
If `get_the_term_list()` returns for some reason a `WP_Error` object for a given post (we noticed this as a result of a cache invalidation bug), the affected request will result in the following PHP fatal. While the problem is not really on the post terms block, I think it should handle such cases gracefully.

```
Error: Object of class WP_Error could not be converted to string

/var/www/html/wp-includes/class-wp-block.php:463
/var/www/html/wp-includes/class-wp-block.php:443
/var/www/html/wp-includes/blocks.php:1705
/var/www/html/wp-includes/blocks.php:1743
/var/www/html/wp-includes/class-wp-hook.php:324
/var/www/html/wp-includes/plugin.php:205
/var/www/html/wp-content/plugins/gutenberg/phpunit/blocks/render-block-post-terms-test.php:29
```
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It checks the return value of `get_the_term_list()` to make sure we are always returning a `string` on the block render callback.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See the unit test

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
