### PR TITLE
fix custom-select-control dropdown border color

### DIFF
--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -21,7 +21,7 @@
 	}
 
 	// Block UI appearance.
-	border: $border-width solid $gray-900;
+	border: $border-width solid $gray-200;
 	background-color: $white;
 	border-radius: $radius-block-ui;
 	outline: none;


### PR DESCRIPTION
In this PR fix the custom-select-control dropdown border-color

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
fix custom-select-control dropdown border-color

## Why?
Changes this border color   custom-select-control dropdown looks good

## How?
When edit heading blocks then I see this issue

## Testing Instructions
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3.  Then go to heading blocks typography and set appearance and font weight you can see the dropdown border. -->

### Testing Instructions for Keyboard


## Screenshots or screencast  https://prnt.sc/ux98V_GjxrnI
