### PR TITLE
Data views: Ensure the 'select all' checkbox appears on hover

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -142,7 +142,8 @@
 		}
 
 		&:focus-within,
-		&.is-hovered {
+		&.is-hovered,
+		&:hover {
 			.components-checkbox-control__input,
 			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
 				opacity: 1;


### PR DESCRIPTION
## What?
Fix an issue where the 'select all' checkbox in the table header wasn't appearing on hover.

## Why?
Seems there was a regression where it would only appear on `tr:focus-within`


## Testing Instructions
1. Open a data view like Manage all templates
2. Mouse over the table header
3. Notice the 'select all' checkbox appears


https://github.com/WordPress/gutenberg/assets/846565/35fa6692-642c-40ee-ba41-5ac9d6e127c3


