### PR TITLE
Handle when attributes param passed into hasStickyOrFixedPositionValue is nullish

### DIFF
--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -152,7 +152,7 @@ export function hasPositionValue( props ) {
  * @return {boolean} Whether or not the block is set to a sticky or fixed position.
  */
 export function hasStickyOrFixedPositionValue( attributes ) {
-	const positionType = attributes.style?.position?.type;
+	const positionType = attributes?.style?.position?.type;
 	return positionType === 'sticky' || positionType === 'fixed';
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR updates `hasStickyOrFixedPositionValue()` to handle when the passed in `attributes` param is nullish.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without this fix, `hasStickeyOrFixedPositionValue()` crashes with the following unhandled error if passed in a nullish value for `attributes`:

```
Uncaught TypeError: Cannot read properties of null (reading 'style')
``` 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This is fixed by making sure `attributes` is not nullish before attempting to access properties on it.

## Testing Instructions

I have only reproduced this in the new product editor in WooCommerce (see https://github.com/woocommerce/woocommerce/issues/45522)...

With WooCommerce 8.7.0-rc.1 or later (or `trunk`) with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
1. Click on summary field to focus it.
2. Click on margin of editor.
3. Verify the editor crashes and is blank.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Screenshot of crash in WooCommerce...

https://github.com/WordPress/gutenberg/assets/2098816/c5613432-ad8a-4c38-b09a-d96025d8e1d6

