### PR TITLE
Global styles utils: remove unused vars

### DIFF
--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -10,25 +10,7 @@ import { getTypographyFontSizeValue } from './typography-utils';
 import { getValueFromObjectPath } from '../../utils/object';
 
 /* Supporting data. */
-export const ROOT_BLOCK_NAME = 'root';
 export const ROOT_BLOCK_SELECTOR = 'body';
-export const ROOT_BLOCK_SUPPORTS = [
-	'background',
-	'backgroundColor',
-	'color',
-	'linkColor',
-	'captionColor',
-	'buttonColor',
-	'headingColor',
-	'fontFamily',
-	'fontSize',
-	'fontStyle',
-	'fontWeight',
-	'lineHeight',
-	'textDecoration',
-	'textTransform',
-	'padding',
-];
 
 export const PRESET_METADATA = [
 	{


### PR DESCRIPTION


## What?
Just removing two unused vars

## How?
![image](https://github.com/WordPress/gutenberg/assets/6458278/fcbc098e-8393-4d97-916e-291c462b2649)


## Testing Instructions
Tests and build should pass
