### PR TITLE
Site editor: find font families for typography presets crashes editor

### DIFF
--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -12,14 +12,14 @@ export function getVariationClassName( variation ) {
 }
 
 function getFontFamilyFromSetting( fontFamilies, setting ) {
-	if ( ! setting ) {
+	if ( ! Array.isArray( fontFamilies ) || ! setting ) {
 		return null;
 	}
 
 	const fontFamilyVariable = setting.replace( 'var(', '' ).replace( ')', '' );
 	const fontFamilySlug = fontFamilyVariable?.split( '--' ).slice( -1 )[ 0 ];
 
-	return fontFamilies?.find(
+	return fontFamilies.find(
 		( fontFamily ) => fontFamily.slug === fontFamilySlug
 	);
 }

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -19,7 +19,7 @@ function getFontFamilyFromSetting( fontFamilies, setting ) {
 	const fontFamilyVariable = setting.replace( 'var(', '' ).replace( ')', '' );
 	const fontFamilySlug = fontFamilyVariable?.split( '--' ).slice( -1 )[ 0 ];
 
-	return fontFamilies.find(
+	return fontFamilies?.find(
 		( fontFamily ) => fontFamily.slug === fontFamilySlug
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`fontFamilies` can be `undefined`, so, when trying to match with a [body style](https://github.com/WordPress/gutenberg/blob/99efe850ee908f75bfe3f263b98d4b0b839a0d72/packages/edit-site/src/components/global-styles/utils.js#L29-L29) the `Array.find` will fail.

~~Add optional chaining~~ Check that `fontFamilies` is an array, so the editor doesn't crash.

## Why?

https://github.com/WordPress/gutenberg/assets/6458278/8db531e6-a84b-4863-b5e0-d889af3134d8



## Testing Instructions
Using a theme with no font family presets, e.g., emptytheme, but with some body typography font family styles:

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
	},
	"styles": {
		"typography": {
			"fontFamily": "Arial, sans-serif"
		}
	}
}
```


Open the site editor, then open global styles sidebar.

The editor shouldn't crash.
