### PR TITLE
Fix media replace url which overlaps edit icon

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -39,7 +39,7 @@
 			max-width: 200px;
 			white-space: nowrap;
 			text-overflow: ellipsis;
-    		overflow: hidden;
+			overflow: hidden;
 		}
 
 		.block-editor-link-control__tools {

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -38,6 +38,8 @@
 		.block-editor-link-control__search-item-info {
 			max-width: 200px;
 			white-space: nowrap;
+			text-overflow: ellipsis;
+    		overflow: hidden;
 		}
 
 		.block-editor-link-control__tools {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fix the media url which overlaps edit icon when the url is too long which makes it hard to click.  

![image](https://github.com/WordPress/gutenberg/assets/6544224/65f470f2-e5e3-4dba-92aa-8330a3612aa3)


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix this issue: https://github.com/WordPress/gutenberg/issues/59807

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By setting a text overflow ellipsis on this url to prevent the issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go in the editor (in any context: page edition, template edition...)
2. Add any media block _(ex: image, video...)_
3. Click on the media block
4. Click on "**Insert a url**" inside this block
5. Add a long url and save
6. Click on the video block and click on "**Replace**" in the toolbar
7. See the result

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
### Before
![image](https://github.com/WordPress/gutenberg/assets/6544224/5bf69b4b-e09a-4788-83af-2b0f6ff4a80f)

### After
![image](https://github.com/WordPress/gutenberg/assets/6544224/208896ff-664d-468e-bcc8-05a35e5cc3d8)
