### PR TITLE
DataViews: Add default getValue for fields

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -71,13 +71,11 @@ const fields = [
 	{
 		id: 'title',
 		header: 'Title',
-		getValue: ({ item }) => item.title,
 		enableHiding: false,
 	},
 	{
 		id: 'date',
 		header: 'Date',
-		getValue: ( { item } ) => item.date,
 		render: ( { item } ) => {
 			return (
 				<time>{ getFormattedDate( item.date ) }</time>
@@ -87,7 +85,6 @@ const fields = [
 	{
 		id: 'author',
 		header: __( 'Author' ),
-		getValue: ( { item } ) => item.author,
 		render: ( { item } ) => {
 			return (
 				<a href="...">{ item.author }</a>
@@ -123,7 +120,7 @@ Each field is an object with the following properties:
 
 -   `id`: identifier for the field. Unique.
 -   `header`: the field's name to be shown in the UI.
--   `getValue`: function that returns the value of the field.
+-   `getValue`: function that returns the value of the field, defaults to `field[id]`.
 -   `render`: function that renders the field. Optional, `getValue` will be used if `render` is not defined.
 -   `elements`: the set of valid values for the field's value.
 -   `type`: the type of the field. Used to generate the proper filters. Only `enumeration` available at the moment. See "Field types".

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -77,10 +77,16 @@ export default function DataViews( {
 		( v ) => v.type === view.type
 	).component;
 	const _fields = useMemo( () => {
-		return fields.map( ( field ) => ( {
-			...field,
-			render: field.render || field.getValue,
-		} ) );
+		return fields.map( ( field ) => {
+			const getValue =
+				field.getValue || ( ( { item } ) => item[ field.id ] );
+
+			return {
+				...field,
+				getValue,
+				render: field.render || getValue,
+			};
+		} );
 	}, [ fields ] );
 
 	const hasPossibleBulkAction = useSomeItemHasAPossibleBulkAction(

--- a/packages/dataviews/src/stories/index.story.js
+++ b/packages/dataviews/src/stories/index.story.js
@@ -50,14 +50,12 @@ const fields = [
 	{
 		header: 'Title',
 		id: 'title',
-		getValue: ( { item } ) => item.title,
 		maxWidth: 400,
 		enableHiding: false,
 	},
 	{
 		header: 'Type',
 		id: 'type',
-		getValue: ( { item } ) => item.type,
 		maxWidth: 400,
 		enableHiding: false,
 		type: 'enumeration',
@@ -71,7 +69,6 @@ const fields = [
 	{
 		header: 'Description',
 		id: 'description',
-		getValue: ( { item } ) => item.description,
 		maxWidth: 200,
 		enableSorting: false,
 	},

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -337,7 +337,6 @@ export default function PagePages() {
 			{
 				header: __( 'Date' ),
 				id: 'date',
-				getValue: ( { item } ) => item.date,
 				render: ( { item } ) => {
 					const formattedDate = dateI18n(
 						getSettings().formats.datetimeAbbreviated,

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -296,7 +296,6 @@ export default function DataviewsPatterns() {
 			{
 				header: __( 'Title' ),
 				id: 'title',
-				getValue: ( { item } ) => item.title,
 				render: ( { item } ) => (
 					<Title item={ item } categoryId={ categoryId } />
 				),

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -309,7 +309,6 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 			_fields.push( {
 				header: __( 'Description' ),
 				id: 'description',
-				getValue: ( { item } ) => item.description,
 				render: ( { item } ) => {
 					return item.description ? (
 						<span className="page-templates-description">


### PR DESCRIPTION
## What?

A small quality of life improvement to the DataViews fields API. This API makes `getValue` optional by relying on the `id` of the field as a fallback, which should probably be common.

## Why?

Improve DevX a bit, the API need to be optimized for the common cases and allow customization for advanced ones.

## Testing Instructions

- You can check that filtering still works in the dataviews story. 