### PR TITLE
Global Styles: Fix retrieval of referenced preset values in editor

### DIFF
--- a/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
@@ -968,6 +968,37 @@ describe( 'global styles renderer', () => {
 				'font-size: 15px',
 			] );
 		} );
+
+		it( 'should correctly resolve referenced values', () => {
+			const stylesWithRef = {
+				typography: {
+					fontSize: {
+						ref: 'styles.elements.h1.typography.fontSize',
+					},
+					letterSpacing: {
+						ref: 'styles.elements.h1.typography.letterSpacing',
+					},
+				},
+			};
+			const tree = {
+				styles: {
+					elements: {
+						h1: {
+							typography: {
+								fontSize: 'var:preset|font-size|xx-large',
+								letterSpacing: '2px',
+							},
+						},
+					},
+				},
+			};
+			expect(
+				getStylesDeclarations( stylesWithRef, '.wp-block', false, tree )
+			).toEqual( [
+				'font-size: var(--wp--preset--font-size--xx-large)',
+				'letter-spacing: 2px',
+			] );
+		} );
 	} );
 
 	describe( 'processCSSNesting', () => {

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -409,7 +409,9 @@ export function getStylesDeclarations(
 		let ruleValue = rule.value;
 		if ( typeof ruleValue !== 'string' && ruleValue?.ref ) {
 			const refPath = ruleValue.ref.split( '.' );
-			ruleValue = getValueFromObjectPath( tree, refPath );
+			ruleValue = compileStyleValue(
+				getValueFromObjectPath( tree, refPath )
+			);
 			// Presence of another ref indicates a reference to another dynamic value.
 			// Pointing to another dynamic value is not supported.
 			if ( ! ruleValue || ruleValue?.ref ) {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/59585

## What?

Updates the retrieval of values for styles set using `ref` within theme.json to resolve the `var:preset|<type>|<value>` preset strings into `var(--wp--preset--type--value)` CSS values.

## Why?

Without this fix, invalid CSS is generated within the editor for styles that `ref` another preset value within global styles.

## How?

Pass the referenced value through `compileStyleValue` as happens with non-referenced values.

## Testing Instructions

Ensure new unit test passes: `npm run test:unit packages/block-editor/src/components/global-styles/test/use-global-styles-output.js`

The easiest means of testing this manually is via the contrived scenario below:

1. In your theme's theme.json file:
   - update the `core/heading` block's styles to use a `ref` value for its `fontSize` (see snippet below)
2. In the Site Editor:
   - Navigate to Global Styles > Typography > Headings > H1 and change its font size to one of the preset values
   - Inspect the `core/heading` block again and confirm its font size rule has a valid CSS value e.g. `var(--wp--preset--font-size--xx-large)` 


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="340" alt="Screenshot 2024-03-13 at 2 41 09 PM" src="https://github.com/WordPress/gutenberg/assets/60436221/f3ebeff9-a7d5-4314-b3d8-2c79c0f7141c"> | <img width="341" alt="Screenshot 2024-03-13 at 2 56 11 PM" src="https://github.com/WordPress/gutenberg/assets/60436221/065f228b-4c44-46e1-b1cd-ee4b180d8997"> |

