### PR TITLE
Ensure consistent return type in `WP_Navigation_Block_Renderer::get_markup_for_inner_block()`

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -136,8 +136,9 @@ class WP_Navigation_Block_Renderer {
 				return '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
 			}
 
-			return $inner_block_content;
 		}
+		
+		return $inner_block_content;
 	}
 
 	/**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -135,9 +135,8 @@ class WP_Navigation_Block_Renderer {
 			if ( static::does_block_need_a_list_item_wrapper( $inner_block ) ) {
 				return '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
 			}
-
 		}
-		
+
 		return $inner_block_content;
 	}
 


### PR DESCRIPTION
Fixes get_markup_for_inner_block()

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
moves return outside of conditional so method can return `''` instead of `null`.

## Why?
Fixes #59814 and https://core.trac.wordpress.org/ticket/60762

## How?
move return outside of conditional

## Testing Instructions
An empty inner_block on a site triggers this error

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
