### PR TITLE
[Data Views]: Remove separator in item actions

### DIFF
--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -33,7 +33,7 @@ export default function DataViews( {
 	fields,
 	search = true,
 	searchLabel = undefined,
-	actions,
+	actions = [],
 	data,
 	getItemId = defaultGetItemId,
 	isLoading = false,

--- a/packages/dataviews/src/utils.js
+++ b/packages/dataviews/src/utils.js
@@ -1,10 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { Children, Fragment } from '@wordpress/element';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,11 +8,6 @@ import {
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
 } from './constants';
-import { unlock } from './lock-unlock';
-
-const { DropdownMenuSeparatorV2: DropdownMenuSeparator } = unlock(
-	componentsPrivateApis
-);
 
 /**
  * Helper util to sort data by text fields, when sorting is done client side.
@@ -109,14 +98,3 @@ export const sanitizeOperators = ( field ) => {
 
 	return operators;
 };
-
-export function WithDropDownMenuSeparators( { children } ) {
-	return Children.toArray( children )
-		.filter( Boolean )
-		.map( ( child, i ) => (
-			<Fragment key={ i }>
-				{ i > 0 && <DropdownMenuSeparator /> }
-				{ child }
-			</Fragment>
-		) );
-}

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -23,6 +23,8 @@ import {
 	useRef,
 	useState,
 	useMemo,
+	Children,
+	Fragment,
 } from '@wordpress/element';
 
 /**
@@ -31,7 +33,7 @@ import {
 import SingleSelectionCheckbox from './single-selection-checkbox';
 import { unlock } from './lock-unlock';
 import ItemActions from './item-actions';
-import { sanitizeOperators, WithDropDownMenuSeparators } from './utils';
+import { sanitizeOperators } from './utils';
 import { ENUMERATION_TYPE, SORTING_DIRECTIONS } from './constants';
 import {
 	useSomeItemHasAPossibleBulkAction,
@@ -44,7 +46,19 @@ const {
 	DropdownMenuItemV2: DropdownMenuItem,
 	DropdownMenuRadioItemV2: DropdownMenuRadioItem,
 	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
+	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
+
+function WithDropDownMenuSeparators( { children } ) {
+	return Children.toArray( children )
+		.filter( Boolean )
+		.map( ( child, i ) => (
+			<Fragment key={ i }>
+				{ i > 0 && <DropdownMenuSeparator /> }
+				{ child }
+			</Fragment>
+		) );
+}
 
 const sortArrows = { asc: '↑', desc: '↓' };
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -355,11 +355,11 @@ export default function PagePages() {
 	const actions = useMemo(
 		() => [
 			viewPostAction,
-			trashPostAction,
 			restorePostAction,
 			permanentlyDeletePostAction,
 			editPostAction,
 			postRevisionsAction,
+			trashPostAction,
 		],
 		[ permanentlyDeletePostAction, restorePostAction, editPostAction ]
 	);

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -415,9 +415,9 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 	const actions = useMemo(
 		() => [
 			resetTemplateAction,
-			deleteTemplateAction,
 			renameTemplateAction,
 			postRevisionsAction,
+			deleteTemplateAction,
 		],
 		[ resetTemplateAction ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR removes the separator in item actions dialog and since we show both primary and secondary actions there, we can refactor the code a bit.

Additionally, the `delete` is now rendered at the bottom of the dialog to reduce its prominence. In the future we'll probably need some grouping of actions in a contextual way, but not for now.

## Testing Instructions
1. Item actions in all views should work as before
2. The separator is gone
3. `Delete` action is at the bottom of the dialog
