### PR TITLE
[RNMobile] Improve UI of error boundary component

### DIFF
--- a/packages/editor/src/components/error-boundary/style.native.scss
+++ b/packages/editor/src/components/error-boundary/style.native.scss
@@ -1,39 +1,115 @@
-.error-boundary__container {
+.error-boundary__scroll {
+	height: 100%;
+	width: 100%;
+}
+
+.error-boundary__scroll-container {
 	flex-grow: 1;
-	justify-content: flex-start;
-}
-
-.error-boundary__message {
-	font-size: 16;
-}
-
-.error-boundary__actions-container {
-	margin-top: 16px;
+	max-height: 580px;
+	align-items: center;
 	justify-content: center;
-	flex-direction: row;
 }
 
-.copy-button__container {
-	background-color: $light-primary;
-	border-radius: 3px;
-	padding: $grid-unit $grid-unit-20;
-	margin-top: 8px;
-	margin-left: 8px;
-	margin-right: 8px;
+
+.error-boundary__container {
+	width: 100%;
+	max-width: 600px;
+	justify-content: center;
+	align-items: center;
+	padding: 0 24px;
 }
 
-.copy-button__container--dark {
-	color: $background-dark-secondary;
+.error-boundary__icon-container {
+	$size: 40px;
+
+	width: $size;
+	height: $size;
+	align-items: center;
+	justify-content: center;
+	margin-bottom: 8px;
+	background-color: rgba(60, 60, 67, 0.3);
+	border-radius: $size/2;
+}
+
+.error-boundary__icon-container--dark {
 	background-color: $gray-20;
 }
 
+.error-boundary__icon {
+	width: 24px;
+	height: 24px;
+	fill: $white;
+}
+
+.error-boundary__title {
+	font-size: 20px;
+	font-weight: 600;
+	line-height: 25px;
+	color: $black;
+	text-align: center;
+	margin-bottom: 8px;
+}
+
+.error-boundary__title--dark {
+	color: $white;
+}
+
+.error-boundary__message {
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 21px;
+	color: rgba(60, 60, 67, 0.6);
+	text-align: center;
+	margin-bottom: 16px;
+}
+
+.error-boundary__message--dark {
+	color: $white;
+}
+
+.error-boundary__actions-container {
+	width: 100%;
+	max-width: 400px;
+	justify-content: center;
+	gap: 12px;
+	padding-top: 16px;
+}
+
+.copy-button__container {
+	border-radius: 5px;
+	padding: $grid-unit $grid-unit-20;
+	background-color: $light-primary;
+}
+
+.copy-button__container--dark {
+	background-color: $gray-20;
+}
+
+.copy-button__container--secondary {
+	border: 1px #c6c6c8;
+	background-color: $white;
+}
+
+.copy-button__container--secondary-dark {
+	background-color: $black;
+}
+
 .copy-button__text {
+	font-size: 17px;
+	font-weight: 400;
+	line-height: 22px;
 	text-align: center;
 	color: $white;
-	font-size: 16;
-	font-weight: 400;
 }
 
 .copy-button__text--dark {
+	color: $background-dark-secondary;
+}
+
+.copy-button__text--secondary {
 	color: $black;
+}
+
+.copy-button__text--secondary-dark {
+	color: $white;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

**This PR is a follow-up of https://github.com/WordPress/gutenberg/pull/59221.** Update the UI of the Error Boundary component that is displayed in editor-level exceptions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This enhancement will provide a better experience when the user encounters editor-level exceptions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update styles and rendering logic of the `ErrorBoundary` component, located in the editor package.
* Remove usage of `Warning` component as the design of the `ErrorBoundary` component is now custom. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Apply the following patch file to show the Error boundary component:
```patch
diff --git forkSrcPrefix/packages/editor/src/components/error-boundary/index.native.js forkDstPrefix/packages/editor/src/components/error-boundary/index.native.js
index 6f76a4fbdccfe58b388206e750b2dd30e64cc0fd..532d8988b728ff237c62bbe837069f7eff2be726 100644
--- forkSrcPrefix/packages/editor/src/components/error-boundary/index.native.js
+++ forkDstPrefix/packages/editor/src/components/error-boundary/index.native.js
@@ -89,7 +89,7 @@ class ErrorBoundary extends Component {
 		super( ...arguments );
 
 		this.state = {
-			error: null,
+			error: Error( 'test' ),
 		};
 	}
 

```
2. Rotate the device, use different device sizes, and switch between light/dark modes.
3. Observe that the UI is rendered properly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

**iPhone:**
| Light | Dark |
|--------|--------|
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/2f8552d9-6e52-4171-b0e6-6e2314bc0d31> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/3ace9803-63e9-4a8f-9138-48e138a6166b> |
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/91f13549-2cf7-477e-8d10-f281b639c357> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/ffbe2e51-745a-49d6-b6fb-faf64b25a8d3> | 

**iPad:**
| Light | Dark |
|--------|--------|
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/8450a6e8-557a-4324-81c8-d7d254a0620b> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/d21cf79f-64fc-4966-991d-caad55185a26> |
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/e31c1bb0-955c-4127-b2fe-5d5272537d75> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/4173ada6-7acd-40bf-921f-fd45d02b761e> | 

**Android:**
| Light | Dark |
|--------|--------|
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/6b93b072-d6c4-436f-bc36-0af6af1f52f7> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/99edca6d-1310-4996-8755-5613102bcb16> |
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/ce90e865-9b21-4c12-903f-44054bcffa7e> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/4df85647-57ed-43ad-934e-55d2e2c175f9> | 