### PR TITLE
Make the delete navigation menu confirm dialogs consistent

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -39,7 +39,7 @@ import {
 	Spinner,
 	Notice,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { close, Icon } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
@@ -841,15 +841,11 @@ function Navigation( {
 						{ hasResolvedCanUserDeleteNavigationMenu &&
 							canUserDeleteNavigationMenu && (
 								<NavigationMenuDeleteControl
-									onDelete={ ( deletedMenuTitle = '' ) => {
+									onDelete={ () => {
 										replaceInnerBlocks( clientId, [] );
 										showNavigationMenuStatusNotice(
-											sprintf(
-												// translators: %s: the name of a menu (e.g. Header navigation).
-												__(
-													'Navigation menu %s successfully deleted.'
-												),
-												deletedMenuTitle
+											__(
+												'Navigation menu successfully deleted.'
 											)
 										);
 									} }

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -5,11 +5,7 @@ import {
 	Button,
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
-import {
-	store as coreStore,
-	useEntityId,
-	useEntityProp,
-} from '@wordpress/core-data';
+import { store as coreStore, useEntityId } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -18,7 +14,6 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 	const [ isConfirmDialogVisible, setIsConfirmDialogVisible ] =
 		useState( false );
 	const id = useEntityId( 'postType', 'wp_navigation' );
-	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
 	const { deleteEntityRecord } = useDispatch( coreStore );
 
 	return (
@@ -40,7 +35,7 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 						deleteEntityRecord( 'postType', 'wp_navigation', id, {
 							force: true,
 						} );
-						onDelete( title );
+						onDelete();
 					} }
 					onCancel={ () => {
 						setIsConfirmDialogVisible( false );

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -3,8 +3,7 @@
  */
 import {
 	Button,
-	Modal,
-	__experimentalHStack as HStack,
+	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import {
 	store as coreStore,
@@ -13,10 +12,10 @@ import {
 } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 export default function NavigationMenuDeleteControl( { onDelete } ) {
-	const [ isConfirmModalVisible, setIsConfirmModalVisible ] =
+	const [ isConfirmDialogVisible, setIsConfirmDialogVisible ] =
 		useState( false );
 	const id = useEntityId( 'postType', 'wp_navigation' );
 	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
@@ -29,50 +28,29 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 				variant="secondary"
 				isDestructive
 				onClick={ () => {
-					setIsConfirmModalVisible( true );
+					setIsConfirmDialogVisible( true );
 				} }
 			>
 				{ __( 'Delete menu' ) }
 			</Button>
-			{ isConfirmModalVisible && (
-				<Modal
-					title={ sprintf(
-						/* translators: %s: the name of a menu to delete */
-						__( 'Delete %s' ),
-						title
-					) }
-					onRequestClose={ () => setIsConfirmModalVisible( false ) }
+			{ isConfirmDialogVisible && (
+				<ConfirmDialog
+					isOpen
+					onConfirm={ () => {
+						deleteEntityRecord( 'postType', 'wp_navigation', id, {
+							force: true,
+						} );
+						onDelete( title );
+					} }
+					onCancel={ () => {
+						setIsConfirmDialogVisible( false );
+					} }
+					confirmButtonText={ __( 'Delete' ) }
 				>
-					<p>
-						{ __(
-							'Are you sure you want to delete this navigation menu?'
-						) }
-					</p>
-					<HStack justify="right">
-						<Button
-							variant="tertiary"
-							onClick={ () => {
-								setIsConfirmModalVisible( false );
-							} }
-						>
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button
-							variant="primary"
-							onClick={ () => {
-								deleteEntityRecord(
-									'postType',
-									'wp_navigation',
-									id,
-									{ force: true }
-								);
-								onDelete( title );
-							} }
-						>
-							{ __( 'Confirm' ) }
-						</Button>
-					</HStack>
-				</Modal>
+					{ __(
+						'Are you sure you want to delete this Navigation menu?'
+					) }
+				</ConfirmDialog>
 			) }
 		</>
 	);

--- a/packages/components/src/confirm-dialog/README.md
+++ b/packages/components/src/confirm-dialog/README.md
@@ -138,3 +138,10 @@ The optional custom text to display as the confirmation button's label
 -   Default: "Cancel"
 
 The optional custom text to display as the cancellation button's label
+
+## Best practices
+
+The ConfirmDialog component should:
+
+-   Be used only for short confirmation messages where a cancel and confirm actions are provided.
+-   Use a descriptive text for the _confirm_ button. Default is "OK".

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-confirm-dialog.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-confirm-dialog.js
@@ -4,12 +4,11 @@
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function RenameModal( { onClose, onConfirm } ) {
+export default function DeleteConfirmDialog( { onClose, onConfirm } ) {
 	return (
 		<ConfirmDialog
 			isOpen
-			onConfirm={ ( e ) => {
-				e.preventDefault();
+			onConfirm={ () => {
 				onConfirm();
 
 				// Immediate close avoids ability to hit delete multiple times.

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -10,7 +10,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import RenameModal from './rename-modal';
-import DeleteModal from './delete-modal';
+import DeleteConfirmDialog from './delete-confirm-dialog';
 
 const POPOVER_PROPS = {
 	position: 'bottom right',
@@ -20,14 +20,15 @@ export default function ScreenNavigationMoreMenu( props ) {
 	const { onDelete, onSave, onDuplicate, menuTitle } = props;
 
 	const [ renameModalOpen, setRenameModalOpen ] = useState( false );
-	const [ deleteModalOpen, setDeleteModalOpen ] = useState( false );
+	const [ deleteConfirmDialogOpen, setDeleteConfirmDialogOpen ] =
+		useState( false );
 
 	const closeModals = () => {
 		setRenameModalOpen( false );
-		setDeleteModalOpen( false );
+		setDeleteConfirmDialogOpen( false );
 	};
 	const openRenameModal = () => setRenameModalOpen( true );
-	const openDeleteModal = () => setDeleteModalOpen( true );
+	const openDeleteConfirmDialog = () => setDeleteConfirmDialogOpen( true );
 
 	return (
 		<>
@@ -60,7 +61,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 							<MenuItem
 								isDestructive
 								onClick={ () => {
-									openDeleteModal();
+									openDeleteConfirmDialog();
 
 									// Close the dropdown after opening the modal.
 									onClose();
@@ -72,11 +73,12 @@ export default function ScreenNavigationMoreMenu( props ) {
 					</div>
 				) }
 			</DropdownMenu>
-
-			{ deleteModalOpen && (
-				<DeleteModal onClose={ closeModals } onConfirm={ onDelete } />
+			{ deleteConfirmDialogOpen && (
+				<DeleteConfirmDialog
+					onClose={ closeModals }
+					onConfirm={ onDelete }
+				/>
 			) }
-
 			{ renameModalOpen && (
 				<RenameModal
 					onClose={ closeModals }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -35,9 +35,12 @@ function useDeleteNavigationMenu() {
 					throwOnError: true,
 				}
 			);
-			createSuccessNotice( __( 'Deleted Navigation menu' ), {
-				type: 'snackbar',
-			} );
+			createSuccessNotice(
+				__( 'Navigation menu successfully deleted.' ),
+				{
+					type: 'snackbar',
+				}
+			);
 			goTo( '/navigation' );
 		} catch ( error ) {
 			createErrorNotice(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/59788

## What?
<!-- In a few words, what is the PR actually doing? -->
Navigation menus can be deleted from the editor navigation panel and from the navigation block inspector. For consistency, the user flow should be as similar as possible however the confirmation dialogs are different.
The Snackboar notices after successful deletion should look similar as well.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Consistency is key. Making the two confirmation dialogs look the same and work the same helps usability and reduces cognitive load. Also, reduces code.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use a `ConfirmDialog` component instead of a custom Modal.
Simplifies and makes consistent the Snackbar notices text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Make sure you have at least two navigation menus.
- Go to the site editor, view mode.
- In the navigation panel, click Design > Navigation > {menu name} > Actions ellipsis button > Delete
- Observe the confirmation dialog and keep it open.
- Open a new browser tab.
- Go to the site editor, edit mode.
- In the editor canvas, select a Navigation block that does have another menu.
- In the Navigation block inspector panel, go to the Settings tab, scroll down to 'Advanced', expand it and click 'Delete menu'.
- Observe the confirmation dialog and keep it open.
- Compare the two confirmation dialog in your browser tabs and observe they look identical.
- Test the 'Cancel' action on both confirmation dialogs and observe the dialogs close and focus is moved back to the most appropriate place.
- Reopen both confirmation dialogs.
- Test the 'Delete' action on both confirmation dialogs and observe the deletion works as expected.
- Observe the Snackbar notices and check they use the same text.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/WordPress/gutenberg/assets/1682452/1bca0c6a-d9fd-4679-9aed-7f32b3482087)

After:

![after](https://github.com/WordPress/gutenberg/assets/1682452/fa513fab-d31c-46bf-b6cf-5e41e23dcfbe)
