### PR TITLE
Heading Block: Show default block name in list view when content is empty

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { heading as icon } from '@wordpress/icons';
-import { toHTMLString } from '@wordpress/rich-text';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -31,21 +30,16 @@ export const settings = {
 		const { content, level } = attributes;
 
 		const customName = attributes?.metadata?.name;
-		const contentHTML =
-			typeof content === 'string'
-				? content
-				: toHTMLString( {
-						value: content,
-				  } );
+		const hasContent = content?.length > 0;
 
 		// In the list view, use the block's content as the label.
 		// If the content is empty, fall back to the default label.
-		if ( context === 'list-view' && ( customName || contentHTML ) ) {
-			return customName || contentHTML;
+		if ( context === 'list-view' && ( customName || hasContent ) ) {
+			return customName || content;
 		}
 
 		if ( context === 'accessibility' ) {
-			return ! contentHTML || contentHTML.length === 0
+			return ! hasContent
 				? sprintf(
 						/* translators: accessibility text. %s: heading level. */
 						__( 'Level %s. Empty.' ),
@@ -55,7 +49,7 @@ export const settings = {
 						/* translators: accessibility text. 1: heading level. 2: heading content. */
 						__( 'Level %1$s. %2$s' ),
 						level,
-						contentHTML
+						content
 				  );
 		}
 	},

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { heading as icon } from '@wordpress/icons';
+import { toHTMLString } from '@wordpress/rich-text';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -30,15 +31,16 @@ export const settings = {
 		const { content, level } = attributes;
 
 		const customName = attributes?.metadata?.name;
+		const contentHTML = toHTMLString( { value: content } );
 
 		// In the list view, use the block's content as the label.
 		// If the content is empty, fall back to the default label.
-		if ( context === 'list-view' && ( customName || content ) ) {
-			return attributes?.metadata?.name || content;
+		if ( context === 'list-view' && ( customName || contentHTML ) ) {
+			return customName || contentHTML;
 		}
 
 		if ( context === 'accessibility' ) {
-			return ! content || content.length === 0
+			return ! contentHTML || contentHTML.length === 0
 				? sprintf(
 						/* translators: accessibility text. %s: heading level. */
 						__( 'Level %s. Empty.' ),
@@ -48,7 +50,7 @@ export const settings = {
 						/* translators: accessibility text. 1: heading level. 2: heading content. */
 						__( 'Level %1$s. %2$s' ),
 						level,
-						content
+						contentHTML
 				  );
 		}
 	},

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -31,7 +31,12 @@ export const settings = {
 		const { content, level } = attributes;
 
 		const customName = attributes?.metadata?.name;
-		const contentHTML = toHTMLString( { value: content } );
+		const contentHTML =
+			typeof content === 'string'
+				? content
+				: toHTMLString( {
+						value: content,
+				  } );
 
 		// In the list view, use the block's content as the label.
 		// If the content is empty, fall back to the default label.

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -292,6 +292,53 @@ test.describe( 'Heading', () => {
 		] );
 	} );
 
+	test( 'Should have proper label in the list view', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/heading' } );
+
+		await page
+			.getByRole( 'toolbar', { name: 'Document tools' } )
+			.getByRole( 'button', { name: 'Document Overview' } )
+			.click();
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect(
+			listView.getByRole( 'link' ),
+			'should show default block name if the content is empty'
+		).toHaveText( 'Heading' );
+
+		await editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Heading',
+			} )
+			.fill( 'Heading content' );
+
+		await expect(
+			listView.getByRole( 'link' ),
+			'should show content'
+		).toHaveText( 'Heading content' );
+
+		await editor.openDocumentSettingsSidebar();
+
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+
+		await page
+			.getByRole( 'textbox', {
+				name: 'Block name',
+			} )
+			.fill( 'My new name' );
+
+		await expect(
+			listView.getByRole( 'link' ),
+			'should show custom name'
+		).toHaveText( 'My new name' );
+	} );
+
 	test.describe( 'Block transforms', () => {
 		test.describe( 'FROM paragraph', () => {
 			test( 'should preserve the content', async ( { editor } ) => {

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -298,6 +298,9 @@ test.describe( 'Heading', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/heading' } );
 
+		await editor.publishPost();
+		await page.reload();
+
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Document Overview' } )


### PR DESCRIPTION
Probably caused regression by #43204

## What?

This PR displays the default block name in list view when the Heading block content is "empty".

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/ad61c85a-1b79-41a4-8e93-ce6f8e587412)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/53e3d953-c870-45f7-a9f4-0c2fc8ff1e99)

## Why?

My understanding is that #43204 changed the content type of the Heading block from `string` to `rich-text`. As a result, the `content` passed to the `__experimentalLabel` prop will be an object like the one below, even if the content is empty.

![rich-text-data](https://github.com/WordPress/gutenberg/assets/54422211/24a1e196-08be-4565-bdd0-791231ad3902)

As a result, the content will be considered "not empty" and will not be displayed in the list view.

## How?

Use `toHTMLString()` to convert the content to an HTML string beforehand. Additionally, I added e2e tests to prevent regressions.

## Testing Instructions

### List View

- Insert an "empty" Heading block.
- **Save the post and reload the browser.**
- Open the list view.
  - trunk: No label will be displayed. 
  - This PR: The default block name "Heading" should be displayed.
- Fill in the content of the Heading block.
- You should now see that content in the list view.
- Enter a custom name.
- You should now see the custom name in the list view.

### Accesibility

This label is also used when the context is `accesibility`. There seems to be no regression in this regard, but please switch to select mode and check that the `aria-label` is displayed correctly in the developer tools.

![accesibility-context](https://github.com/WordPress/gutenberg/assets/54422211/a8a724a3-821c-4873-b443-d601e128c624)

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/5dfc8e7f-ffc5-498d-ba0f-00f39f680af3