### PR TITLE
Re-introduce `data_wp_context()` with `_deprecated_function()` call

### DIFF
--- a/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
@@ -178,3 +178,23 @@ if ( ! function_exists( 'wp_interactivity_data_wp_context' ) ) {
 		'\'';
 	}
 }
+
+if ( ! function_exists( 'data_wp_context' ) ) {
+	/**
+	 * `data_wp_context()` was renamed to follow WordPress Core naming schemes.
+	 *
+	 * @link https://github.com/WordPress/gutenberg/pull/59465/
+	 * @link https://core.trac.wordpress.org/ticket/60575
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param array  $context         The array of context data to encode.
+	 * @param string $store_namespace Optional. The unique store namespace identifier.
+	 * @return string A complete `data-wp-context` directive with a JSON encoded value representing the context array and
+	 *                the store namespace if specified.
+	 */
+	function data_wp_context( array $context, string $store_namespace = '' ): string {
+		_deprecated_function( __FUNCTION__, '5.6.0', 'wp_interactivity_data_wp_context()' );
+		return wp_interactivity_data_wp_context( $context, $store_namespace );
+	}
+}

--- a/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
@@ -194,7 +194,7 @@ if ( ! function_exists( 'data_wp_context' ) ) {
 	 *                the store namespace if specified.
 	 */
 	function data_wp_context( array $context, string $store_namespace = '' ): string {
-		_deprecated_function( __FUNCTION__, '5.6.0', 'wp_interactivity_data_wp_context()' );
+		_deprecated_function( __FUNCTION__, '6.5', 'wp_interactivity_data_wp_context()' );
 		return wp_interactivity_data_wp_context( $context, $store_namespace );
 	}
 }

--- a/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/interactivity-api.php
@@ -187,6 +187,7 @@ if ( ! function_exists( 'data_wp_context' ) ) {
 	 * @link https://core.trac.wordpress.org/ticket/60575
 	 *
 	 * @since 6.5.0
+	 * @deprecated 6.5.0
 	 *
 	 * @param array  $context         The array of context data to encode.
 	 * @param string $store_namespace Optional. The unique store namespace identifier.


### PR DESCRIPTION
## What?

Following its removal in https://github.com/WordPress/gutenberg/pull/59465 and release in Gutenberg 17.9, this can potentially result in fatal errors on sites where plugins or themes are calling `data_wp_context()` instead of the newer function name.

This should backfill it in, and provide a reminder to update to the newer function.

## Why?

Avoids fatal errors where third-party code was using the old function name.

## How?

Mapping the old function to the new function with a `_deprecated_function()` invocation to remind the user.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
