### PR TITLE
Close navigation link ui on escape

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -570,6 +570,7 @@ export default function NavigationLinkEdit( {
 									// Need to handle refocusing the Nav block or the inserter?
 									onReplace( [] );
 								}
+								setIsLinkOpen( false );
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/59847
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allows closing the navigation link ui on Escape keypress

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Call `setIsLinkOpen( false );` within the `onClose` event (What gets called when escape is pressed)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Select a navigation link block
- Press the link edit button in the block toolbar
- Focus should be within the link ui
- Press Escape
- Focus should be on the block toolbar edit link button

