### PR TITLE
Issue 59778/font family control error

### DIFF
--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -17,7 +17,12 @@ export default function FontFamilyControl( {
 } ) {
 	const [ blockLevelFontFamilies ] = useSettings( 'typography.fontFamilies' );
 	if ( ! fontFamilies ) {
-		fontFamilies = blockLevelFontFamilies;
+		const { theme, custom } = blockLevelFontFamilies;
+		fontFamilies = theme !== undefined ? theme : [];
+		if ( custom !== undefined ) {
+			fontFamilies = [ ...fontFamilies, ...custom ];
+		}
+
 	}
 
 	if ( ! fontFamilies || fontFamilies.length === 0 ) {

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -22,7 +22,6 @@ export default function FontFamilyControl( {
 		if ( custom !== undefined ) {
 			fontFamilies = [ ...fontFamilies, ...custom ];
 		}
-
 	}
 
 	if ( ! fontFamilies || fontFamilies.length === 0 ) {

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -16,7 +16,7 @@ export default function FontFamilyControl( {
 	...props
 } ) {
 	const [ blockLevelFontFamilies ] = useSettings( 'typography.fontFamilies' );
-	if ( ! fontFamilies ) {
+	if ( ! fontFamilies && blockLevelFontFamilies !== undefined ) {
 		const { theme, custom } = blockLevelFontFamilies;
 		fontFamilies = theme !== undefined ? theme : [];
 		if ( custom !== undefined ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes error that breaks the block where the FontFamilyControl is used without fontFamilies specified. It now returns an array with ``custom`` and ``theme`` font families if present. 

## Why?
A Font Family selector without specifying fonts was a working feature and has been broken recently with the changes in the value of the fontFamily setting.  - [Issue 59778](https://github.com/WordPress/gutenberg/issues/59778) 


## How?
It just need an adjustment to merge ``custom`` fonts and ``theme`` fonts when selecting the setting.

## Testing Instructions
1. Use a block that makes use of FontFamilyControl without specifying fontFamily, such as ``LanguageSwitcher`` from [WPML](https://wpml.org), to take advantage of theme and custom fonts.
2. Add the block, click on "Font Family" control in the sidebar Block section.
3. Notice the block displays the current ``theme`` preconfigured fonts.
4. Add a custom font into the theme (Site Editor > Styles > Typography > Install Font).
5. Go to the block editor, check the new font is available.
6. Choose an old theme, like twenty-nineteen. 
7. Go to block, notice the section is empty, but block is not broken as before.


### Testing Instructions for Keyboard
-no ui changes-


