### PR TITLE
E2E theme switch: match incoming theme slug, then optional folder

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
@@ -13,11 +13,24 @@ async function activateTheme(
 	let response = await this.request.get( THEMES_URL );
 	const html = await response.text();
 	const optionalFolder = '([a-z0-9-]+%2F)?';
-	const matchGroup = html.match(
-		`action=activate&amp;stylesheet=${ optionalFolder }${ encodeURIComponent(
+
+	// The `optionalFolder` regex part matches paths with a folder,
+	// so it will return the first match, which might contain a folder.
+	// First try to honor the including theme slug, that is, without a folder.
+	let matchGroup = html.match(
+		`action=activate&amp;stylesheet=${ encodeURIComponent(
 			themeSlug
 		) }&amp;_wpnonce=[a-z0-9]+`
 	);
+
+	// If the theme is not found, try to match the theme slug with a folder.
+	if ( ! matchGroup ) {
+		matchGroup = html.match(
+			`action=activate&amp;stylesheet=${ optionalFolder }${ encodeURIComponent(
+				themeSlug
+			) }&amp;_wpnonce=[a-z0-9]+`
+		);
+	}
 
 	if ( ! matchGroup ) {
 		if ( html.includes( `data-slug="${ themeSlug }"` ) ) {

--- a/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
@@ -16,7 +16,7 @@ async function activateTheme(
 
 	// The `optionalFolder` regex part matches paths with a folder,
 	// so it will return the first match, which might contain a folder.
-	// First try to honor the including theme slug, that is, without a folder.
+	// First try to honor the included theme slug, that is, without a folder.
 	let matchGroup = html.match(
 		`action=activate&amp;stylesheet=${ encodeURIComponent(
 			themeSlug


### PR DESCRIPTION
## What?

I don't know if this PR is good or not, but throwing it out there.

When switching themes in E2E tests, `optionalFolder` regex part matches paths with a folder, so it will return the first match, which might contain a folder. 

The consequence is that the regex will match `somefolder/twentytwentyfour` given a theme slug of `twentytwentyfour`, and therefore tests that wish to test against `twentytwentyfour` won't be able to because `somefolder/twentytwentyfour` will be activated instead.

## Why?
Context: https://github.com/WordPress/gutenberg/pull/59792#issuecomment-1995998089

## How?

Test for incoming theme slug first.

First try to honor the including theme slug, that is, without a folder, the look for the optional folder path, if any.

## Testing Instructions
All E2E tests should pass.
