### PR TITLE
Allow blocks to be grouped as a Grid

### DIFF
--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -4,7 +4,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { group, row, stack } from '@wordpress/icons';
+import { group, row, stack, grid } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -17,6 +17,7 @@ const layouts = {
 	group: { type: 'constrained' },
 	row: { type: 'flex', flexWrap: 'nowrap' },
 	stack: { type: 'flex', orientation: 'vertical' },
+	grid: { type: 'grid' },
 };
 
 function BlockGroupToolbar() {
@@ -60,6 +61,7 @@ function BlockGroupToolbar() {
 
 	const onConvertToRow = () => onConvertToGroup( 'row' );
 	const onConvertToStack = () => onConvertToGroup( 'stack' );
+	const onConvertToGrid = () => onConvertToGroup( 'grid' );
 
 	// Don't render the button if the current selection cannot be grouped.
 	// A good example is selecting multiple button blocks within a Buttons block:
@@ -74,6 +76,9 @@ function BlockGroupToolbar() {
 	);
 	const canInsertStack = !! variations.find(
 		( { name } ) => name === 'group-stack'
+	);
+	const canInsertGrid = !! variations.find(
+		( { name } ) => name === 'group-grid'
 	);
 
 	return (
@@ -95,6 +100,13 @@ function BlockGroupToolbar() {
 					icon={ stack }
 					label={ _x( 'Stack', 'verb' ) }
 					onClick={ onConvertToStack }
+				/>
+			) }
+			{ canInsertGrid && (
+				<ToolbarButton
+					icon={ grid }
+					label={ _x( 'Grid', 'verb' ) }
+					onClick={ onConvertToGrid }
 				/>
 			) }
 		</ToolbarGroup>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Another step towards #57478.

Allows a selection of multiple blocks to be grouped as a Grid.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add several blocks to a post or template.
2. Select two or more blocks, and check that a "Grid" option appears in the block toolbar.
3. Clicking on "Grid" should group the selected blocks inside a Grid block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/8096000/cd3d9a22-cef3-4274-aae6-7c83c9559908

