### PR TITLE
Fix overlay issue when empty featured image is used in Cover Block

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -489,6 +489,9 @@ function CoverEdit( {
 		getPositionClassName( contentPosition )
 	);
 
+	const showOverlay =
+		url || ! useFeaturedImage || ( useFeaturedImage && ! url );
+
 	return (
 		<>
 			{ blockControls }
@@ -500,9 +503,7 @@ function CoverEdit( {
 				data-url={ url }
 			>
 				{ resizeListener }
-				{ ( ( ! url && useFeaturedImage ) ||
-					! useFeaturedImage ||
-					url ) && (
+				{ showOverlay && (
 					<span
 						aria-hidden="true"
 						className={ classnames(

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -500,7 +500,9 @@ function CoverEdit( {
 				data-url={ url }
 			>
 				{ resizeListener }
-				{ ( ! useFeaturedImage || url ) && (
+				{ ( ( ! url && useFeaturedImage ) ||
+					! useFeaturedImage ||
+					url ) && (
 					<span
 						aria-hidden="true"
 						className={ classnames(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/57887

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Overlay doesn't show when empty featured image is used in cover block.
  
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Add cover block
2. Select featured image option as cover background, Keeping featured image blank.
3. Notice overlay
 
## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-03-14 at 11 00 46@2x](https://github.com/WordPress/gutenberg/assets/61308756/fb90adeb-0efe-4edd-b316-bf771b44e4bc)
