### PR TITLE
Fix image layout shift from placeholder to selected placeholder

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -2,11 +2,6 @@
 // @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-image.wp-block-image {
 
-	&:not(.is-selected) .components-placeholder__fieldset {
-		// Show only is selected.
-		display: none;
-	}
-
 	// Show Placeholder style on-select.
 	&.is-selected .components-placeholder {
 		// Block UI appearance.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,7 +1,8 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
--	`Drowdown` : Add styling support for `MenuGroup` ([#59723](https://github.com/WordPress/gutenberg/pull/59723)).
+-	`Dropdown` : Add styling support for `MenuGroup` ([#59723](https://github.com/WordPress/gutenberg/pull/59723)).
+-	`Placeholder` : Allow overflow but only when placeholder is selected, to fix a layout shift. `MenuGroup` ([#59857](https://github.com/WordPress/gutenberg/pull/59857)).
 
 ### Enhancements
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -212,7 +212,7 @@
 
 	// By painting the borders here, we enable them to be replaced by the Border control.
 	@include placeholder-style();
-	overflow: auto;
+	overflow: hidden;
 }
 
 // Position the spinner.

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -212,7 +212,11 @@
 
 	// By painting the borders here, we enable them to be replaced by the Border control.
 	@include placeholder-style();
+
 	overflow: hidden;
+	.is-selected & {
+		overflow: auto;
+	}
 }
 
 // Position the spinner.


### PR DESCRIPTION
## What?

Alternative to #59305. Still fixes #59226. 

The original fix caused the unselected image block placeholder to collapse in height, so there's a layout shift between selected and unselected states:

![after](https://github.com/WordPress/gutenberg/assets/1204802/96a79227-8635-4f27-b0a4-b813d9cabad2)

For reference, before it would look like this, without the layout shift:

![before](https://github.com/WordPress/gutenberg/assets/1204802/8e37aa23-85bd-4a9b-b868-21e807121097)

This was caused by hiding the fieldset when the block was unselected. This PR hides overflow instead. First, removing the original fix restored the scrollbars:

![sans the original fix](https://github.com/WordPress/gutenberg/assets/1204802/f2dc6938-1fdf-4791-979c-81d8d45ec82c)

The overflow rule hides them again:

![new fix](https://github.com/WordPress/gutenberg/assets/1204802/ae5d22d3-f034-472d-8ac6-4875259b4df2)

## Why?

Selecting and deselecting blocks should not cause layout shifts.

## Testing Instructions

* Insert an image block, empty.
* Select it and deselect it, the height of both states should be the same.
* Insert the "Team members" pattern.
* If you're on the mac, make sure you have scrollbars set to always show.
* Resize the viewport, no scrollbars should appear in the unselected image placeholder.