### PR TITLE
DataViews: make list layout stable

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -45,12 +45,7 @@ export default function useLayoutAreas() {
 		};
 	}
 
-	// List layout is still experimental.
-	// Extracted it here out of the conditionals so it doesn't unintentionally becomes stable.
-	const isListLayout =
-		isCustom !== 'true' &&
-		layout === 'list' &&
-		window?.__experimentalAdminViews;
+	const isListLayout = isCustom !== 'true' && layout === 'list';
 
 	if ( path === '/pages' ) {
 		return {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -49,9 +49,6 @@ import { unlock } from '../../lock-unlock';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
-const SUPPORTED_LAYOUTS = window?.__experimentalAdminViews
-	? [ LAYOUT_GRID, LAYOUT_TABLE, LAYOUT_LIST ]
-	: [ LAYOUT_GRID, LAYOUT_TABLE ];
 
 function useView( postType ) {
 	const { params } = useLocation();
@@ -429,7 +426,6 @@ export default function PagePages() {
 				view={ view }
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
-				supportedLayouts={ SUPPORTED_LAYOUTS }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -63,10 +63,6 @@ const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
 
-const SUPPORTED_LAYOUTS = window?.__experimentalAdminViews
-	? [ LAYOUT_TABLE, LAYOUT_GRID, LAYOUT_LIST ]
-	: [ LAYOUT_TABLE, LAYOUT_GRID ];
-
 const defaultConfigPerViewType = {
 	[ LAYOUT_TABLE ]: {
 		primaryField: 'title',
@@ -473,7 +469,6 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
 				deferredRendering={ ! view.hiddenFields?.includes( 'preview' ) }
-				supportedLayouts={ SUPPORTED_LAYOUTS }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -205,9 +205,7 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 	const { params } = useLocation();
 	const { activeView = 'all', layout } = params;
 	const defaultView = useMemo( () => {
-		const usedType = window?.__experimentalAdminViews
-			? layout ?? DEFAULT_VIEW.type
-			: DEFAULT_VIEW.type;
+		const usedType = layout ?? DEFAULT_VIEW.type;
 		return {
 			...DEFAULT_VIEW,
 			type: usedType,

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -102,27 +102,11 @@ export default function useSyncPathWithURL() {
 					path: navigatorLocation.path,
 				} );
 			} else if (
-				navigatorLocation.path === '/wp_template/all' &&
-				! window?.__experimentalAdminViews
-			) {
-				// When the experiment is disabled, we only support table layout.
-				// Clear it out from the URL, so layouts other than table cannot be accessed.
-				updateUrlParams( {
-					postType: undefined,
-					categoryType: undefined,
-					categoryId: undefined,
-					path: navigatorLocation.path,
-					layout: undefined,
-				} );
-			} else if (
 				// These sidebar paths are special in the sense that the url in these pages may or may not have a postId and we need to retain it if it has.
 				// The "type" property should be kept as well.
-				( navigatorLocation.path === '/pages' &&
-					window?.__experimentalAdminViews ) ||
-				( navigatorLocation.path === '/wp_template/all' &&
-					window?.__experimentalAdminViews ) ||
-				( navigatorLocation.path === '/wp_template_part/all' &&
-					window?.__experimentalAdminViews )
+				navigatorLocation.path === '/pages' ||
+				navigatorLocation.path === '/wp_template/all' ||
+				navigatorLocation.path === '/wp_template_part/all'
 			) {
 				updateUrlParams( {
 					postType: undefined,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/59659

## What?

Makes the `list` layout stable, so it is available without the "admin views" experiment enabled.

## Why?

It is to be used as the index for some of the types (pages). While there's still issues to iron out, it's quite solid.

## How?

- Pages: https://github.com/WordPress/gutenberg/pull/59858/commits/16b9ae2d9d98effc50aac7f70507535726b3ab3d
- Templates&parts: https://github.com/WordPress/gutenberg/pull/59858/commits/bf69ef58c2da9dec6039e324f284d52c71f8fe76
- Layout parameter: https://github.com/WordPress/gutenberg/pull/59858/commits/7639e6cc1719cb7ec44ca8283369a4034ed49259

## Testing Instructions

Disable the "admin views" experiment and verify that the `list` layout is available for Pages, Templates, and Parts. It should work in all the flows.

## Notes

Note: the commit https://github.com/WordPress/gutenberg/pull/59858/commits/d7bddee395640d79c30d0df674954caf519e39ae represents the https://github.com/WordPress/gutenberg/pull/59792 but squashed. Trying to assess whether the performance test failure that happens over there is real.
