### PR TITLE
[RNMobile] Update UI of error boundary component

### DIFF
--- a/packages/editor/src/components/error-boundary/index.native.js
+++ b/packages/editor/src/components/error-boundary/index.native.js
@@ -147,7 +147,7 @@ class ErrorBoundary extends Component {
 						</View>
 						<Text style={ titleStyle }>
 							{ __(
-								'The editor has encountered an unexpected error.'
+								'The editor has encountered an unexpected error'
 							) }
 						</Text>
 						<Text style={ messageStyle }>

--- a/packages/editor/src/components/error-boundary/style.native.scss
+++ b/packages/editor/src/components/error-boundary/style.native.scss
@@ -32,7 +32,7 @@
 }
 
 .error-boundary__icon-container--dark {
-	background-color: $gray-20;
+	background-color: rgba(235, 235, 245, 0.3);
 }
 
 .error-boundary__icon {
@@ -64,7 +64,7 @@
 }
 
 .error-boundary__message--dark {
-	color: $white;
+	color: rgba(235, 235, 245, 0.6);
 }
 
 .error-boundary__actions-container {
@@ -82,7 +82,7 @@
 }
 
 .copy-button__container--dark {
-	background-color: $gray-20;
+	background-color: $white;
 }
 
 .copy-button__container--secondary {
@@ -91,6 +91,7 @@
 }
 
 .copy-button__container--secondary-dark {
+	border-color: rgba(255, 255, 255, 0.3);
 	background-color: $black;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

**This PR follows up https://github.com/WordPress/gutenberg/pull/59823.**

Update the UI of the error boundary component, specifically, to improve styling when using dark mode.

> [!NOTE]
> **For Copy Review:**
> The texts were introduced in https://github.com/WordPress/gutenberg/pull/59823. We are seeking for review in the following elements:
> * **Title:** The editor has encountered an unexpected error
> * **Message:** You can copy your post text in case your content is impacted. Copy error details to debug and share with support.
> * **Copy button 1:** Copy post text
> * **Copy button 2:** Copy error details
>
> Thanks 🙇 !

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is an enhancement based on design feedback.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update dark mode colors used in the different elements of the error boundary component.
* Remove period from title.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Apply the following patch file to show the Error boundary component:
```patch
diff --git forkSrcPrefix/packages/editor/src/components/error-boundary/index.native.js forkDstPrefix/packages/editor/src/components/error-boundary/index.native.js
index 6f76a4fbdccfe58b388206e750b2dd30e64cc0fd..532d8988b728ff237c62bbe837069f7eff2be726 100644
--- forkSrcPrefix/packages/editor/src/components/error-boundary/index.native.js
+++ forkDstPrefix/packages/editor/src/components/error-boundary/index.native.js
@@ -89,7 +89,7 @@ class ErrorBoundary extends Component {
 		super( ...arguments );
 
 		this.state = {
-			error: null,
+			error: Error( 'test' ),
 		};
 	}
 

```
2. Rotate the device, use different device sizes, and switch between light/dark modes.
3. Observe that the UI is rendered properly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

**iPhone:**

| Light | Dark |
|--------|--------|
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/81de3bde-715a-4c60-9c8e-b535b131af75> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/1a951407-148f-41b0-be85-3d330478410f> |

**iPad:**

| Light | Dark |
|--------|--------|
| <img src=https://github.com/WordPress/gutenberg/assets/14905380/7938d582-3526-44c7-9e7f-6cc67a980102> | <img src=https://github.com/WordPress/gutenberg/assets/14905380/86965382-a95e-4d96-a679-7df154b3370a> | 