### PR TITLE
Add $schema to tsconfig files

### DIFF
--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"module": "commonjs",

--- a/packages/a11y/tsconfig.json
+++ b/packages/a11y/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/autop/tsconfig.json
+++ b/packages/autop/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/blob/tsconfig.json
+++ b/packages/blob/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/block-library/tsconfig.json
+++ b/packages/block-library/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/block-serialization-default-parser/tsconfig.json
+++ b/packages/block-serialization-default-parser/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/core-data/tsconfig.json
+++ b/packages/core-data/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/data-controls/tsconfig.json
+++ b/packages/data-controls/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/date/tsconfig.json
+++ b/packages/date/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/deprecated/tsconfig.json
+++ b/packages/deprecated/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/docgen/tsconfig.json
+++ b/packages/docgen/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "lib",

--- a/packages/dom-ready/tsconfig.json
+++ b/packages/dom-ready/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/dom/tsconfig.json
+++ b/packages/dom/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/e2e-test-utils-playwright/tsconfig.json
+++ b/packages/e2e-test-utils-playwright/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"incremental": false,

--- a/packages/element/tsconfig.json
+++ b/packages/element/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/escape-html/tsconfig.json
+++ b/packages/escape-html/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"module": "CommonJS",

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/html-entities/tsconfig.json
+++ b/packages/html-entities/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/interactivity-router/tsconfig.json
+++ b/packages/interactivity-router/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/interactivity/tsconfig.json
+++ b/packages/interactivity/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/is-shallow-equal/tsconfig.json
+++ b/packages/is-shallow-equal/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/keycodes/tsconfig.json
+++ b/packages/keycodes/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/lazy-import/tsconfig.json
+++ b/packages/lazy-import/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "lib",

--- a/packages/notices/tsconfig.json
+++ b/packages/notices/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/prettier-config/tsconfig.json
+++ b/packages/prettier-config/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "lib",

--- a/packages/primitives/tsconfig.json
+++ b/packages/primitives/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/priority-queue/tsconfig.json
+++ b/packages/priority-queue/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/private-apis/tsconfig.json
+++ b/packages/private-apis/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/project-management-automation/tsconfig.json
+++ b/packages/project-management-automation/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "lib",

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/redux-routine/tsconfig.json
+++ b/packages/redux-routine/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/report-flaky-tests/tsconfig.json
+++ b/packages/report-flaky-tests/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"module": "CommonJS",

--- a/packages/rich-text/tsconfig.json
+++ b/packages/rich-text/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/style-engine/tsconfig.json
+++ b/packages/style-engine/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/token-list/tsconfig.json
+++ b/packages/token-list/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/undo-manager/tsconfig.json
+++ b/packages/undo-manager/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/url/tsconfig.json
+++ b/packages/url/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/warning/tsconfig.json
+++ b/packages/warning/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/packages/wordcount/tsconfig.json
+++ b/packages/wordcount/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"noEmit": true,

--- a/test/performance/tsconfig.json
+++ b/test/performance/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"noEmit": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"schema": "https://json.schemastore.org/tsconfig.json",
+	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"references": [
 		{ "path": "bin" },
 		{ "path": "packages/a11y" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"schema": "https://json.schemastore.org/tsconfig.json",
 	"references": [
 		{ "path": "bin" },
 		{ "path": "packages/a11y" },


### PR DESCRIPTION


## What?

Add `$schema` to tsconfig files.

## Why?

The `$schema` field provides information about the JSON file that editor integrations can leverage to support developers.
It can also be used for validation, but that's not the goal of this PR.