### PR TITLE
[RNMobile] Improve File block UI

### DIFF
--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -411,6 +411,11 @@ export class FileEdit extends Component {
 				? ''
 				: __( 'Add text…' );
 
+		const viewContainerStyle = this.props.getStylesFromColorScheme(
+			styles.viewContainer,
+			styles.viewContainerDark
+		);
+
 		return (
 			<MediaUploadProgress
 				mediaId={ id }
@@ -446,6 +451,7 @@ export class FileEdit extends Component {
 							<View
 								onLayout={ this.onLayout }
 								testID="file-edit-container"
+								style={ viewContainerStyle }
 							>
 								{ this.getPlaceholderWidth( placeholderText ) }
 								{ isUploadInProgress ||

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -1,3 +1,11 @@
+.viewContainer {
+	background-color: $light-ultra-dim;
+}
+
+.viewContainerDark {
+	background-color: $dark-ultra-dim;
+}
+
 .container {
 	margin-top: 2px;
 	padding: $grid-unit-20;

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -1,11 +1,12 @@
 .container {
 	margin-top: 2px;
+	padding: $grid-unit-20;
 }
 
 .defaultButton {
 	border-radius: $border-width * 4;
 	padding: $grid-unit-10;
-	margin-top: $grid-unit-20;
+	margin: $grid-unit-20;
 	background-color: $button-fallback-bg;
 }
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -15,6 +15,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [**] [internal] Upgrade React Native to version 0.73.3 [#58475]
 -   [**] Add error boundary components and exception logging [#59221]
 -   [**] Fix crash occurring when the URL associated with a Video block is changed too quickly [#59841]
+-   [**] Improve File block UI [#59863]
 
 ## 1.114.1
 -   [**] Fix a crash produced when the content of a synced pattern is updated [#59632]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Improves UI of the File block on mobile. 

Fixes:

* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6725


## Why?
The appearance of the File block could be improved. When a file is uploaded, the filename and download button text are flush with the block border, and generally looks disorganised.


## How?
Updates the mobile File block to add spacing between the block outline and content, and adds light/dark mode backgrounds to make the File block appear more inline with other media block styles. 


## Testing Instructions
1) Open a Post and add a File block
2) Note that the content is not flush with the block outline (border) and the content has a background color

## Screenshots or screencast <!-- if applicable -->

<details>
<summary>Before</summary>
File block on the bottom, Audio block on top for comparison:

<img src="https://github.com/WordPress/gutenberg/assets/643285/8599881d-a032-4a89-8930-702831199584" width="50%" />

</details>


<details>
<summary>After </summary>
File block on top, Audio block on bottom for comparison:

Light Mode | Dark Mode
-|-
<img src="https://github.com/WordPress/gutenberg/assets/643285/a464f6c2-c24a-4e19-9fd7-4750b91d8cda"  /> | <img src="https://github.com/WordPress/gutenberg/assets/643285/080bb105-84cb-45cd-869f-107348784a40" />

</details>