### PR TITLE
Add "Dry run" mode to Cherry Picking script

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -6,14 +6,15 @@ import readline from 'readline';
 
 import { spawnSync } from 'node:child_process';
 
-const LABEL = process.argv[ 2 ] || 'Backport to WP Beta/RC';
+const DRY_RUN = process.argv.includes( '--dry-run' );
+const LABEL =
+	process.argv.filter( ( arg ) => arg !== '--dry-run' )[ 2 ] ||
+	'Backport to WP Beta/RC';
 const BACKPORT_COMPLETED_LABEL = 'Backported to WP Core';
 const BRANCH = getCurrentBranch();
 const GITHUB_CLI_AVAILABLE = spawnSync( 'gh', [ 'auth', 'status' ] )
 	?.stdout?.toString()
 	.includes( '✓ Logged in to github.com' );
-
-const DRY_RUN = !! process.argv.includes( '--dry-run' );
 
 const autoPropagateResultsToGithub = GITHUB_CLI_AVAILABLE && ! DRY_RUN;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds ability to run the Cherry Picking script in a "dry run" mode.

Part of https://github.com/WordPress/gutenberg/issues/59399 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's all too easy to run the Cherry Picking script and have the results propagate to Github. With this flag you can run the script and be sure results will never get propagated. 

This is useful when testing locally and for folks getting familiar with the workflow/tooling around releases.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Adds `--dry-run` flag
- Conditionalise behaviour to not propagate results if flag is provided
- Update comments output to reflect flag.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In a terminal run:

```
npm run other:cherry-pick -- --dry-run
```

- See that script will output necessary warnings
- Check the default `Backport to WP RC/Beta` is used as the "label" to search for and it doesn't accidentally use "--dry-run" as the label if no custom label is provided.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
