### PR TITLE
Improve likelihood of Cherry Picking script including all PRs

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -113,15 +113,18 @@ function cli( command, args, pipe = false ) {
  */
 async function fetchPRs() {
 	const { items } = await GitHubFetch(
-		`/search/issues?q=is:pr state:closed sort:updated label:"${ LABEL }" repo:WordPress/gutenberg`
+		`/search/issues?per_page=100&q=is:pr state:closed sort:updated label:"${ LABEL }" repo:WordPress/gutenberg`
 	);
 	const PRs = items
-		.map( ( { id, number, title, pull_request, closed_at } ) => ( {
+		// eslint-disable-next-line camelcase
+		.map( ( { id, number, title, pull_request } ) => ( {
 			id,
 			number,
 			title,
+			// eslint-disable-next-line camelcase
 			pull_request,
 		} ) )
+		// eslint-disable-next-line camelcase
 		.filter( ( { pull_request } ) => !! pull_request?.merged_at )
 		.sort(
 			( a, b ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improves the liklihood that the Cherry Picking script will fetch all the PRs that need to be cherry picked.

Closes https://github.com/WordPress/gutenberg/issues/59210

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Github API paginates it's results with a default of 30. It is possible that for a given release there will be more than 30 PRs that need to be picked into the relevant release branch. 

This needs fixing so that future release leads don't end up missing PRs. I already updated the release docs with this extra warning but it makes sense to also improve the tooling.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds the `per_page` param to the request and sets it to `100`. 

I see this as a "good enough" fix. If there are more than 100 PRs in a given release we have a bigger problem 😆 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- We can run the script passing a label we know will have _a lot_ of PRs. This is to simulate testing for a release where lots of PRs are labeled with the default label.
- **Do not propagate the results to Github** - you can say "no" when prompted to avoid this.
- Run `npm run other:cherry-pick -- "[Type] Bug"`. 
- Check that more than 30 PRs are found.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
