### PR TITLE
Plugin: Remove unnecessary 'IS_GUTENBERG_PLUGIN' check in 'load.php'

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -124,10 +124,8 @@ require __DIR__ . '/compat/wordpress-6.5/block-bindings/block-bindings.php';
 require __DIR__ . '/compat/wordpress-6.5/block-bindings/post-meta.php';
 require __DIR__ . '/compat/wordpress-6.5/script-loader.php';
 
-// Not to be included in WordPress 6.5.
-if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-	require __DIR__ . '/compat/wordpress-6.6/block-bindings/pattern-overrides.php';
-}
+// WordPress 6.6 compat.
+require __DIR__ . '/compat/wordpress-6.6/block-bindings/pattern-overrides.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';


### PR DESCRIPTION
## What?
This is a follow-up to #59702.

PR unnecessary `IS_GUTENBERG_PLUGIN` check in 'load.php' for loading pattern overrides code.

## Why?
The `load.php` is the Gutenberg plugin-specific file; it doesn't get synced with Core and `IS_GUTENBERG_PLUGIN` is always true for it.

## Testing Instructions
CI checks should be green.
