### PR TITLE
Block Hooks: Return early from saving meta data for the navigation without a $post->ID

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1512,8 +1512,10 @@ function block_core_navigation_set_ignored_hooked_blocks_metadata( $inner_blocks
  * @return stdClass The updated post object.
  */
 function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
-	// In this scenario the user has likely tried to create a navigation via the REST API.
-	// In which case we won't have a post ID to work with and store meta against.
+	/*
+	* In this scenario the user has likely tried to create a navigation via the REST API.
+	* In which case we won't have a post ID to work with and store meta against.
+	*/
 	if ( ! isset( $post->ID ) ) {
 		return $post;
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1513,9 +1513,9 @@ function block_core_navigation_set_ignored_hooked_blocks_metadata( $inner_blocks
  */
 function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 	/*
-	* In this scenario the user has likely tried to create a navigation via the REST API.
-	* In which case we won't have a post ID to work with and store meta against.
-	*/
+	 * In this scenario the user has likely tried to create a navigation via the REST API.
+	 * In which case we won't have a post ID to work with and store meta against.
+	 */
 	if ( ! isset( $post->ID ) ) {
 		return $post;
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1516,7 +1516,7 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 	 * In this scenario the user has likely tried to create a navigation via the REST API.
 	 * In which case we won't have a post ID to work with and store meta against.
 	 */
-	if ( ! isset( $post->ID ) ) {
+	if ( empty( $post->ID ) ) {
 		return $post;
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1512,6 +1512,12 @@ function block_core_navigation_set_ignored_hooked_blocks_metadata( $inner_blocks
  * @return stdClass The updated post object.
  */
 function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
+	// In this scenario the user has likely tried to create a navigation via the REST API.
+	// In which case we won't have a post ID to work with and store meta against.
+	if ( ! isset( $post->ID ) ) {
+		return $post;
+	}
+
 	/*
 	 * We run the Block Hooks mechanism to inject the `metadata.ignoredHookedBlocks` attribute into
 	 * all anchor blocks. For the root level, we create a mock Navigation and extract them from there.

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -13,6 +13,11 @@
  */
 class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	/**
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
 	 * Original markup.
 	 *
 	 * @var string
@@ -28,8 +33,16 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 
 	/**
 	 * Setup method.
+	 *
+	 * * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
-	public static function wpSetUpBeforeClass() {
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
 		//self::$original_markup = '<!-- wp:navigation-link {"label":"News & About","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
 
 		self::$navigation_post = self::factory()->post->create_and_get(
@@ -39,6 +52,13 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 				'post_content' => 'Original content',
 			)
 		);
+	}
+
+	/**
+	 *
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
 	}
 
 	/**
@@ -97,7 +117,7 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
 	 */
 	public function test_block_core_navigation_rest_creation() {
-		wp_set_current_user( 1 );
+		wp_set_current_user( self::$admin_id );
 
 		$post_type_object = get_post_type_object( 'wp_navigation' );
 		$request          = new WP_REST_Request( 'POST', '/wp/v2/' . $post_type_object->rest_base );

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -101,10 +101,13 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 
 		$post_type_object = get_post_type_object( 'wp_navigation' );
 		$request          = new WP_REST_Request( 'POST', '/wp/v2/' . $post_type_object->rest_base );
-		$request->set_param( 'title', 'Title ' . $post_type_object->label );
-		$request->set_param( 'content', $post_type_object->label );
-		$request->set_param( '_locale', 'user' );
-
+		$request->set_body_params(
+			array(
+				'title'   => 'Title ' . $post_type_object->label,
+				'content' => $post_type_object->label,
+				'_locale' => 'user',
+			)
+		);
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertNotEmpty( $response->get_status() );

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -13,11 +13,6 @@
  */
 class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	/**
-	 * @var int
-	 */
-	protected static $admin_id;
-
-	/**
 	 * Original markup.
 	 *
 	 * @var string
@@ -33,16 +28,8 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 
 	/**
 	 * Setup method.
-	 *
-	 * * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
-	public static function wpSetUpBeforeClass( $factory ) {
-		self::$admin_id = $factory->user->create(
-			array(
-				'role' => 'administrator',
-			)
-		);
-
+	public static function wpSetUpBeforeClass() {
 		//self::$original_markup = '<!-- wp:navigation-link {"label":"News & About","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
 
 		self::$navigation_post = self::factory()->post->create_and_get(
@@ -52,13 +39,6 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 				'post_content' => 'Original content',
 			)
 		);
-	}
-
-	/**
-	 *
-	 */
-	public static function wpTearDownAfterClass() {
-		self::delete_user( self::$admin_id );
 	}
 
 	/**

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -105,7 +105,7 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 		$request->set_param( 'content', $post_type_object->label );
 		$request->set_param( '_locale', 'user' );
 
-		$response = rest_get_server()->dispatch( $request ); // Triggers the error.
+		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertNotEmpty( $response->get_status() );
 		$this->assertSame( 201, $response->get_status() );

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -92,4 +92,22 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 			'Block was not added to ignored hooked blocks metadata.'
 		);
 	}
+
+	/**
+	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta being called via the REST API.
+	 */
+	public function test_block_core_navigation_rest_creation() {
+		wp_set_current_user( 1 );
+
+		$post_type_object = get_post_type_object( 'wp_navigation' );
+		$request          = new WP_REST_Request( 'POST', '/wp/v2/' . $post_type_object->rest_base );
+		$request->set_param( 'title', 'Title ' . $post_type_object->label );
+		$request->set_param( 'content', $post_type_object->label );
+		$request->set_param( '_locale', 'user' );
+
+		$response = rest_get_server()->dispatch( $request ); // Triggers the error.
+
+		$this->assertNotEmpty( $response->get_status() );
+		$this->assertSame( 201, $response->get_status() );
+	}
 }

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -117,6 +117,10 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
 	 */
 	public function test_block_core_navigation_rest_creation() {
+		if ( ! function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
+			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionalit.' );
+		}
+
 		wp_set_current_user( self::$admin_id );
 
 		$post_type_object = get_post_type_object( 'wp_navigation' );

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -94,7 +94,7 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta being called via the REST API.
+	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
 	 */
 	public function test_block_core_navigation_rest_creation() {
 		wp_set_current_user( 1 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
If the user is creating a navigation menu via a `POST` request to the REST API then we need to return early since we won't have a `$post->ID` to store the ignored hooked blocks meta against.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There are a number of reasons for this change but primarily because it returns an error since it incorrectly assumes there's a `$post->ID` in a scenario when there's not.

Another reason is because if the user is creating the navigation via the REST API they likely haven't got any hooked blocks in their content since we insert these [when the response is being prepared](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/navigation/index.php#L1604-L1609) for the site editor.

The only other way a user can create a new navigation is by duplicating an existing one. In which case the hooked blocks markup and meta data will be duplicated along with it and will retain the intended behaviour.

A known side effect of this means that the next time this navigation is loaded (if the user is creating it via the REST API outside of the site editor), if it has any anchor blocks it will proceed to insert the hooked blocks since we won't have run the ignored hooked blocks logic for reasons mentioned above. Whether this is a 'bug' or not I think is still a bit of a grey area but given that I believe this is an edge case I think its acceptable until we decide a better course of action.

Fixes https://github.com/WordPress/gutenberg/issues/59867

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check for the existence of a `$post->ID` and if not found, return `$post` early.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Regression test the navigation if we feel its required.
2. Create a navigation via the REST API similar to how is done in accompanying tests and ensure you get a successful response.
