### PR TITLE
Core Data: Update method generating plural names

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -39,6 +39,7 @@ export const rootEntitiesConfig = [
 				'url',
 			].join( ',' ),
 		},
+		plural: '__unstableBases',
 		syncConfig: {
 			fetch: async () => {
 				return apiFetch( { path: '/' } );
@@ -63,6 +64,7 @@ export const rootEntitiesConfig = [
 		name: 'site',
 		kind: 'root',
 		baseURL: '/wp/v2/settings',
+		plural: 'sites',
 		getTitle: ( record ) => {
 			return record?.title ?? __( 'Site Title' );
 		},
@@ -92,6 +94,7 @@ export const rootEntitiesConfig = [
 		key: 'slug',
 		baseURL: '/wp/v2/types',
 		baseURLParams: { context: 'edit' },
+		plural: 'postTypes',
 		syncConfig: {
 			fetch: async ( id ) => {
 				return apiFetch( {
@@ -220,6 +223,7 @@ export const rootEntitiesConfig = [
 		kind: 'root',
 		baseURL: '/wp/v2/themes',
 		baseURLParams: { context: 'edit' },
+		plural: 'themes',
 		key: 'stylesheet',
 	},
 	{
@@ -228,6 +232,7 @@ export const rootEntitiesConfig = [
 		kind: 'root',
 		baseURL: '/wp/v2/plugins',
 		baseURLParams: { context: 'edit' },
+		plural: 'plugins',
 		key: 'plugin',
 	},
 	{
@@ -408,32 +413,20 @@ async function loadTaxonomyEntities() {
  * const nameSingular = getMethodName( 'root', 'theme', 'get' );
  * // nameSingular is getRootTheme
  *
- * const namePlural = getMethodName( 'root', 'theme', 'set' );
+ * const namePlural = getMethodName( 'root', 'theme', 'set', 'themes' );
  * // namePlural is setRootThemes
  * ```
  *
- * @param {string}  kind      Entity kind.
- * @param {string}  name      Entity name.
- * @param {string}  prefix    Function prefix.
- * @param {boolean} usePlural Whether to use the plural form or not.
+ * @param {string} kind   Entity kind.
+ * @param {string} name   Entity name.
+ * @param {string} prefix Function prefix.
+ * @param {string} plural Plural for of the name.
  *
  * @return {string} Method name
  */
-export const getMethodName = (
-	kind,
-	name,
-	prefix = 'get',
-	usePlural = false
-) => {
-	const entityConfig = rootEntitiesConfig.find(
-		( config ) => config.kind === kind && config.name === name
-	);
+export const getMethodName = ( kind, name, prefix = 'get', plural ) => {
 	const kindPrefix = kind === 'root' ? '' : pascalCase( kind );
-	const nameSuffix = pascalCase( name ) + ( usePlural ? 's' : '' );
-	const suffix =
-		usePlural && 'plural' in entityConfig && entityConfig?.plural
-			? pascalCase( entityConfig.plural )
-			: nameSuffix;
+	const suffix = plural ? pascalCase( plural ) : pascalCase( name );
 	return `${ prefix }${ kindPrefix }${ suffix }`;
 };
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -413,20 +413,19 @@ async function loadTaxonomyEntities() {
  * const nameSingular = getMethodName( 'root', 'theme', 'get' );
  * // nameSingular is getRootTheme
  *
- * const namePlural = getMethodName( 'root', 'theme', 'set', 'themes' );
+ * const namePlural = getMethodName( 'root', 'themes', 'set' );
  * // namePlural is setRootThemes
  * ```
  *
  * @param {string} kind   Entity kind.
  * @param {string} name   Entity name.
  * @param {string} prefix Function prefix.
- * @param {string} plural Plural for of the name.
  *
  * @return {string} Method name
  */
-export const getMethodName = ( kind, name, prefix = 'get', plural ) => {
+export const getMethodName = ( kind, name, prefix = 'get' ) => {
 	const kindPrefix = kind === 'root' ? '' : pascalCase( kind );
-	const suffix = plural ? pascalCase( plural ) : pascalCase( name );
+	const suffix = pascalCase( name );
 	return `${ prefix }${ kindPrefix }${ suffix }`;
 };
 

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -22,23 +22,31 @@ import { unlock } from './private-apis';
 // The "kind" and the "name" of the entity are combined to generate these shortcuts.
 
 const entitySelectors = rootEntitiesConfig.reduce( ( result, entity ) => {
-	const { kind, name } = entity;
+	const { kind, name, plural } = entity;
 	result[ getMethodName( kind, name ) ] = ( state, key, query ) =>
 		selectors.getEntityRecord( state, kind, name, key, query );
-	result[ getMethodName( kind, name, 'get', true ) ] = ( state, query ) =>
-		selectors.getEntityRecords( state, kind, name, query );
+
+	if ( plural ) {
+		result[ getMethodName( kind, name, 'get', plural ) ] = (
+			state,
+			query
+		) => selectors.getEntityRecords( state, kind, name, query );
+	}
 	return result;
 }, {} );
 
 const entityResolvers = rootEntitiesConfig.reduce( ( result, entity ) => {
-	const { kind, name } = entity;
+	const { kind, name, plural } = entity;
 	result[ getMethodName( kind, name ) ] = ( key, query ) =>
 		resolvers.getEntityRecord( kind, name, key, query );
-	const pluralMethodName = getMethodName( kind, name, 'get', true );
-	result[ pluralMethodName ] = ( ...args ) =>
-		resolvers.getEntityRecords( kind, name, ...args );
-	result[ pluralMethodName ].shouldInvalidate = ( action ) =>
-		resolvers.getEntityRecords.shouldInvalidate( action, kind, name );
+
+	if ( plural ) {
+		const pluralMethodName = getMethodName( kind, name, 'get', plural );
+		result[ pluralMethodName ] = ( ...args ) =>
+			resolvers.getEntityRecords( kind, name, ...args );
+		result[ pluralMethodName ].shouldInvalidate = ( action ) =>
+			resolvers.getEntityRecords.shouldInvalidate( action, kind, name );
+	}
 	return result;
 }, {} );
 

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -27,10 +27,8 @@ const entitySelectors = rootEntitiesConfig.reduce( ( result, entity ) => {
 		selectors.getEntityRecord( state, kind, name, key, query );
 
 	if ( plural ) {
-		result[ getMethodName( kind, name, 'get', plural ) ] = (
-			state,
-			query
-		) => selectors.getEntityRecords( state, kind, name, query );
+		result[ getMethodName( kind, plural, 'get' ) ] = ( state, query ) =>
+			selectors.getEntityRecords( state, kind, name, query );
 	}
 	return result;
 }, {} );
@@ -41,7 +39,7 @@ const entityResolvers = rootEntitiesConfig.reduce( ( result, entity ) => {
 		resolvers.getEntityRecord( kind, name, key, query );
 
 	if ( plural ) {
-		const pluralMethodName = getMethodName( kind, name, 'get', plural );
+		const pluralMethodName = getMethodName( kind, plural, 'get' );
 		result[ pluralMethodName ] = ( ...args ) =>
 			resolvers.getEntityRecords( kind, name, ...args );
 		result[ pluralMethodName ].shouldInvalidate = ( action ) =>

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -28,13 +28,23 @@ describe( 'getMethodName', () => {
 	} );
 
 	it( 'should use the plural form', () => {
-		const methodName = getMethodName( 'root', 'postType', 'get', true );
+		const methodName = getMethodName(
+			'root',
+			'postType',
+			'get',
+			'postTypes'
+		);
 
 		expect( methodName ).toEqual( 'getPostTypes' );
 	} );
 
 	it( 'should use the given plural form', () => {
-		const methodName = getMethodName( 'root', 'taxonomy', 'get', true );
+		const methodName = getMethodName(
+			'root',
+			'taxonomy',
+			'get',
+			'taxonomies'
+		);
 
 		expect( methodName ).toEqual( 'getTaxonomies' );
 	} );

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -27,24 +27,8 @@ describe( 'getMethodName', () => {
 		expect( methodName ).toEqual( 'setPostType' );
 	} );
 
-	it( 'should use the plural form', () => {
-		const methodName = getMethodName(
-			'root',
-			'postType',
-			'get',
-			'postTypes'
-		);
-
-		expect( methodName ).toEqual( 'getPostTypes' );
-	} );
-
 	it( 'should use the given plural form', () => {
-		const methodName = getMethodName(
-			'root',
-			'taxonomy',
-			'get',
-			'taxonomies'
-		);
+		const methodName = getMethodName( 'root', 'taxonomies', 'get' );
 
 		expect( methodName ).toEqual( 'getTaxonomies' );
 	} );


### PR DESCRIPTION
## What?
PR updates the internal `getMethodName` helper and makes it "pure" by removing the reliance on `rootEntitiesConfig`. The entity's `plural` name needs to be explicitly passed to the method.

I've also updated shortcut generation logic to generate plural selectors only when the entity config specifies its existence by defining a `plural` property. All existing configurations have also been updated.

## Why?
This will allow the method to be used for entities defined outside of the `rootEntitiesConfig` list. See #59243.

Not every entity supports fetching the list of items (via `getEntityRecords`). Good examples are the `site` and `__unstableBase` entities. They represent a single item with multiple properties. Running the `getSites()` selector does nothing. Updated logic allows configs to opt-out from generating plural shortcuts when the REST API schema doesn't support them.

Note: We have to keep `getSites` and `getUnstableBases` around for backward compatibility.

## Testing Instructions
CI checks should be passing.

Inspect shortcuts by running `wp.data.select( 'core' )` in the DevTools console. Returned selectors should match the trunk.
