### PR TITLE
Only check for 'other' block control slot in useHasAnyBlockControls

### DIFF
--- a/packages/block-editor/src/components/block-controls/use-has-block-controls.js
+++ b/packages/block-editor/src/components/block-controls/use-has-block-controls.js
@@ -2,34 +2,27 @@
  * WordPress dependencies
  */
 import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
-import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
  */
 import groups from './groups';
 
+/**
+ * We only care about the "other" slot here.
+ * This check is specifically for allowing the Replace
+ * <MediaReplaceFlow /> on featured images and images
+ * within content locked areas.
+ * https://github.com/WordPress/gutenberg/pull/53410
+ *
+ * TODO: Remove this hook, as having a toolbar with only a Replace button is a
+ * misuse of the toolbar.
+ */
 export function useHasAnyBlockControls() {
-	let hasAnyBlockControls = false;
-	for ( const group in groups ) {
-		// It is safe to violate the rules of hooks here as the `groups` object
-		// is static and will not change length between renders. Do not return
-		// early as that will cause the hook to be called a different number of
-		// times between renders.
-		// eslint-disable-next-line react-hooks/rules-of-hooks
-		if ( useHasBlockControls( group ) ) {
-			hasAnyBlockControls = true;
-		}
-	}
-	return hasAnyBlockControls;
-}
-
-export function useHasBlockControls( group = 'default' ) {
-	const Slot = groups[ group ]?.Slot;
+	const Slot = groups.other?.Slot;
 	const fills = useSlotFills( Slot?.__unstableName );
 	if ( ! Slot ) {
-		warning( `Unknown BlockControls group "${ group }" provided.` );
-		return null;
+		return false;
 	}
 	return !! fills?.length;
 }

--- a/packages/block-editor/src/components/block-controls/use-has-block-controls.js
+++ b/packages/block-editor/src/components/block-controls/use-has-block-controls.js
@@ -18,7 +18,7 @@ import groups from './groups';
  * TODO: Remove this hook, as having a toolbar with only a Replace button is a
  * misuse of the toolbar.
  */
-export function useHasAnyBlockControls() {
+export function useHasOtherBlockControls() {
 	const Slot = groups.other?.Slot;
 	const fills = useSlotFills( Slot?.__unstableName );
 	if ( ! Slot ) {

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -130,11 +130,6 @@ export function PrivateBlockToolbar( {
 
 	const isLargeViewport = ! useViewportMatch( 'medium', '<' );
 
-	const hasBlockToolbar = useHasBlockToolbar();
-	if ( ! hasBlockToolbar ) {
-		return null;
-	}
-
 	const isMultiToolbar = blockClientIds.length > 1;
 	const isSynced =
 		isReusableBlock( blockType ) || isTemplatePart( blockType );
@@ -242,6 +237,11 @@ export function PrivateBlockToolbar( {
  * @param {string}  props.variant        Style variant of the toolbar, also passed to the Dropdowns rendered from Block Toolbar Buttons.
  */
 export default function BlockToolbar( { hideDragHandle, variant } ) {
+	const hasBlockToolbar = useHasBlockToolbar();
+	if ( ! hasBlockToolbar ) {
+		return null;
+	}
+
 	return (
 		<PrivateBlockToolbar
 			hideDragHandle={ hideDragHandle }

--- a/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
+++ b/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
@@ -7,7 +7,7 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { useHasAnyBlockControls } from '../block-controls/use-has-block-controls';
+import { useHasOtherBlockControls } from '../block-controls/use-has-block-controls';
 
 /**
  * Returns true if the block toolbar should be shown.
@@ -15,7 +15,7 @@ import { useHasAnyBlockControls } from '../block-controls/use-has-block-controls
  * @return {boolean} Whether the block toolbar component will be rendered.
  */
 export function useHasBlockToolbar() {
-	const hasAnyBlockControls = useHasAnyBlockControls();
+	const hasAnyBlockControls = useHasOtherBlockControls();
 	return useSelect(
 		( select ) => {
 			const {

--- a/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
+++ b/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
@@ -7,7 +7,6 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { useHasOtherBlockControls } from '../block-controls/use-has-block-controls';
 
 /**
  * Returns true if the block toolbar should be shown.
@@ -15,35 +14,19 @@ import { useHasOtherBlockControls } from '../block-controls/use-has-block-contro
  * @return {boolean} Whether the block toolbar component will be rendered.
  */
 export function useHasBlockToolbar() {
-	const hasAnyBlockControls = useHasOtherBlockControls();
-	return useSelect(
-		( select ) => {
-			const {
-				getBlockEditingMode,
-				getBlockName,
-				getSelectedBlockClientIds,
-			} = select( blockEditorStore );
+	return useSelect( ( select ) => {
+		const { getBlockName, getSelectedBlockClientIds } =
+			select( blockEditorStore );
 
-			const selectedBlockClientIds = getSelectedBlockClientIds();
-			const selectedBlockClientId = selectedBlockClientIds[ 0 ];
-			const isDefaultEditingMode =
-				getBlockEditingMode( selectedBlockClientId ) === 'default';
-			const blockType =
-				selectedBlockClientId &&
-				getBlockType( getBlockName( selectedBlockClientId ) );
-			const isToolbarEnabled =
-				blockType &&
-				hasBlockSupport( blockType, '__experimentalToolbar', true );
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
+		const blockType =
+			selectedBlockClientId &&
+			getBlockType( getBlockName( selectedBlockClientId ) );
+		const isToolbarEnabled =
+			blockType &&
+			hasBlockSupport( blockType, '__experimentalToolbar', true );
 
-			if (
-				! isToolbarEnabled ||
-				( ! isDefaultEditingMode && ! hasAnyBlockControls )
-			) {
-				return false;
-			}
-
-			return true;
-		},
-		[ hasAnyBlockControls ]
-	);
+		return isToolbarEnabled;
+	}, [] );
 }


### PR DESCRIPTION
The useHasAnyBlockControls hook is a hefty way of checking if we are in `contentOnly` mode for the image and featured image blocks. This reduces the performance impact from https://github.com/WordPress/gutenberg/pull/58979 while we figure out what to do in a more permanent way.

Other ideas:
**1. Have a non-block toolbar popover for content-only items in image/featured image**: It _only_ uses a Replace button, and it's quite weird when Top Toolbar mode is on. For example, the Replace button is in the top toolbar here without any image block icon or other toolbar items. What am I replacing? I think this should _only_ be a floating button in a popover, not something that relies on the block toolbar. There are now [more tools being added to Pattern overrides](https://github.com/WordPress/gutenberg/pull/58998), so maybe this should be its own section within the block toolbar, or a separate block toolbar? 

<img width="988" alt="Site editor with top toolbar mode on with Replace button is in the top toolbar with no context." src="https://github.com/WordPress/gutenberg/assets/967608/2b2694d1-a991-4be7-a132-ace2c3018223">

**2. Write specific overrides into the block toolbar to account for contentOnly toolbar items** Is this a misuse of the toolbar? It seems intended to not render in contentOnly mode (as no other toolbar items show), so if we do want to use it, maybe we should specifically write in these instances rather than allow for an empty-looking toolbar?

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improve the performance of Selecting blocks.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Performance improvement.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The `<MediaReplaceFlow />` used by the image and featured image are in the "other" slot. Let's not check for all slots when we can do the check once. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
