### PR TITLE
Shadow support enable skip serialization for dynamic blocks

### DIFF
--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -47,11 +47,10 @@ function gutenberg_register_shadow_support( $block_type ) {
 function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 	$has_shadow_support = block_has_support( $block_type, array( 'shadow' ), false );
 
-	if ( ! $has_shadow_support ) {
-		return array();
-	}
-
-	if ( wp_should_skip_block_supports_serialization( $block_type, 'shadow' ) ) {
+	if (
+		! $has_shadow_support ||
+		wp_should_skip_block_supports_serialization( $block_type, 'shadow' )
+	) {
 		return array();
 	}
 

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -51,6 +51,10 @@ function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'shadow' ) ) {
+		return array();
+	}
+
 	$shadow_block_styles = array();
 
 	$custom_shadow                 = $block_attributes['style']['shadow'] ?? null;


### PR DESCRIPTION
## What?
When a dynamic block defines __experimentalSkipSerialization in its block.supports.shadow the styles continue to be printed to the block wrapper element. This PR corrects that behavior so that shadow behaves like border, color, and others.

## Why?
This provides the expected behavior for dynamic blocks that need to opt out of having the shadow styles printed to the block wrapper.

## How?
Added a check at the start of the render function to return an empty array of the block has set __experimentalSkipSerialization

## Testing Instructions
1. Choose a core dynamic block such as core/post-featured-image or create a dynamic block for testing
2. Add shadow to the block supports in block.json
3. Build the block
4. Add the block in a post and verify that the shadow styles are printed on the block wrapper
5. Update shadow to include "__experimentalSkipSerialization": true
6. Rebuild the block
7. Update the post and verify that the shadow styles are not printed on the block wrapper

There is a risk of a deprecation/regression so also check the core blocks that already support shadow
1. core/button
2. core/column
3. core/columns
4. core/image
Core/image uses __experimentalSkipSerialization so verify that there is no change in the editor or front end with this PR.
These are not dynamic blocks so should be unaffected by this change.

