### PR TITLE
Grid layout: Set default number of columns in manual mode to 4

### DIFF
--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -62,6 +62,9 @@ const units = [
 	{ value: 'em', label: 'em', default: 0 },
 ];
 
+// Default number of columns when in "manual" mode.
+const DEFAULT_NUM_COLUMNS = 4;
+
 export default {
 	name: 'grid',
 	label: __( 'Grid' ),
@@ -286,7 +289,7 @@ function GridLayoutTypeControl( { layout, onChange } ) {
 	 * previous type so we can switch back without loss.
 	 */
 	const [ tempColumnCount, setTempColumnCount ] = useState(
-		columnCount || 3
+		columnCount || DEFAULT_NUM_COLUMNS
 	);
 	const [ tempMinimumColumnWidth, setTempMinimumColumnWidth ] = useState(
 		minimumColumnWidth || '12rem'
@@ -298,7 +301,7 @@ function GridLayoutTypeControl( { layout, onChange } ) {
 		if ( value === 'manual' ) {
 			setTempMinimumColumnWidth( minimumColumnWidth || '12rem' );
 		} else {
-			setTempColumnCount( columnCount || 3 );
+			setTempColumnCount( columnCount || DEFAULT_NUM_COLUMNS );
 		}
 		onChange( {
 			...layout,


### PR DESCRIPTION
Increases the default number of columns when a Grid layout is in "manual" mode to 4. (It was 3.)

<img width="298" alt="Screenshot 2024-03-15 at 10 47 45" src="https://github.com/WordPress/gutenberg/assets/612155/2ab18d94-b5d1-474d-a1b0-2a42855f4ba7">
