### PR TITLE
Fix lightbox UI disallow editing

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -241,7 +241,10 @@ const ImageURLInputUI = ( {
 	);
 
 	const linkEditorValue = urlInput !== null ? urlInput : url;
-	const showLinkEditor = ( ! linkEditorValue && ! lightboxEnabled ) === true;
+	const showLinkEditor =
+		( ! linkEditorValue &&
+			( ! lightboxEnabled ||
+				( lightboxEnabled && ! showLightboxSetting ) ) ) === true;
 
 	const urlLabel = (
 		getLinkDestinations().find(
@@ -258,7 +261,9 @@ const ImageURLInputUI = ( {
 				aria-expanded={ isOpen }
 				onClick={ openLinkUI }
 				ref={ setPopoverAnchor }
-				isActive={ !! url || lightboxEnabled }
+				isActive={
+					!! url || ( lightboxEnabled && showLightboxSetting )
+				}
 			/>
 			{ isOpen && (
 				<URLPopover
@@ -267,7 +272,10 @@ const ImageURLInputUI = ( {
 					onFocusOutside={ onFocusOutside() }
 					onClose={ closeLinkUI }
 					renderSettings={
-						! lightboxEnabled ? () => advancedOptions : null
+						! lightboxEnabled ||
+						( lightboxEnabled && ! showLightboxSetting )
+							? () => advancedOptions
+							: null
 					}
 					additionalControls={
 						showLinkEditor && (
@@ -314,54 +322,62 @@ const ImageURLInputUI = ( {
 					}
 					offset={ 13 }
 				>
-					{ ( ! url || isEditingLink ) && ! lightboxEnabled && (
-						<>
-							<URLPopover.LinkEditor
-								className="block-editor-format-toolbar__link-container-content"
-								value={ linkEditorValue }
-								onChangeInputValue={ setUrlInput }
-								onSubmit={ onSubmitLinkChange() }
-								autocompleteRef={ autocompleteRef }
-							/>
-						</>
-					) }
-					{ url && ! isEditingLink && ! lightboxEnabled && (
-						<>
-							<URLPopover.LinkViewer
-								className="block-editor-format-toolbar__link-container-content"
-								url={ url }
-								onEditLinkClick={ startEditLink }
-								urlLabel={ urlLabel }
-							/>
-							<Button
-								icon={ linkOff }
-								label={ __( 'Remove link' ) }
-								onClick={ onLinkRemove }
-								size="compact"
-							/>
-						</>
-					) }
-					{ ! url && ! isEditingLink && lightboxEnabled && (
-						<div className="block-editor-url-popover__expand-on-click">
-							<Icon icon={ fullscreen } />
-							<div className="text">
-								<p>{ __( 'Expand on click' ) }</p>
-								<p className="description">
-									{ __(
-										'Scales the image with a lightbox effect'
-									) }
-								</p>
+					{ ( ! url || isEditingLink ) &&
+						( ! lightboxEnabled ||
+							( lightboxEnabled && ! showLightboxSetting ) ) && (
+							<>
+								<URLPopover.LinkEditor
+									className="block-editor-format-toolbar__link-container-content"
+									value={ linkEditorValue }
+									onChangeInputValue={ setUrlInput }
+									onSubmit={ onSubmitLinkChange() }
+									autocompleteRef={ autocompleteRef }
+								/>
+							</>
+						) }
+					{ url &&
+						! isEditingLink &&
+						( ! lightboxEnabled ||
+							( lightboxEnabled && ! showLightboxSetting ) ) && (
+							<>
+								<URLPopover.LinkViewer
+									className="block-editor-format-toolbar__link-container-content"
+									url={ url }
+									onEditLinkClick={ startEditLink }
+									urlLabel={ urlLabel }
+								/>
+								<Button
+									icon={ linkOff }
+									label={ __( 'Remove link' ) }
+									onClick={ onLinkRemove }
+									size="compact"
+								/>
+							</>
+						) }
+					{ ! url &&
+						! isEditingLink &&
+						lightboxEnabled &&
+						showLightboxSetting && (
+							<div className="block-editor-url-popover__expand-on-click">
+								<Icon icon={ fullscreen } />
+								<div className="text">
+									<p>{ __( 'Expand on click' ) }</p>
+									<p className="description">
+										{ __(
+											'Scales the image with a lightbox effect'
+										) }
+									</p>
+								</div>
+								<Button
+									icon={ linkOff }
+									label={ __( 'Disable expand on click' ) }
+									onClick={ () => {
+										onSetLightbox( false );
+									} }
+									size="compact"
+								/>
 							</div>
-							<Button
-								icon={ linkOff }
-								label={ __( 'Disable expand on click' ) }
-								onClick={ () => {
-									onSetLightbox( false );
-								} }
-								size="compact"
-							/>
-						</div>
-					) }
+						) }
 				</URLPopover>
 			) }
 		</>

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -251,6 +251,62 @@ const ImageURLInputUI = ( {
 		) || {}
 	).title;
 
+	const PopoverChildren = () => {
+		if (
+			lightboxEnabled &&
+			showLightboxSetting &&
+			! url &&
+			! isEditingLink
+		) {
+			return (
+				<div className="block-editor-url-popover__expand-on-click">
+					<Icon icon={ fullscreen } />
+					<div className="text">
+						<p>{ __( 'Expand on click' ) }</p>
+						<p className="description">
+							{ __( 'Scales the image with a lightbox effect' ) }
+						</p>
+					</div>
+					<Button
+						icon={ linkOff }
+						label={ __( 'Disable expand on click' ) }
+						onClick={ () => {
+							onSetLightbox( false );
+						} }
+						size="compact"
+					/>
+				</div>
+			);
+		} else if ( ! url || isEditingLink ) {
+			return (
+				<URLPopover.LinkEditor
+					className="block-editor-format-toolbar__link-container-content"
+					value={ linkEditorValue }
+					onChangeInputValue={ setUrlInput }
+					onSubmit={ onSubmitLinkChange() }
+					autocompleteRef={ autocompleteRef }
+				/>
+			);
+		} else if ( url && ! isEditingLink ) {
+			return (
+				<>
+					<URLPopover.LinkViewer
+						className="block-editor-format-toolbar__link-container-content"
+						url={ url }
+						onEditLinkClick={ startEditLink }
+						urlLabel={ urlLabel }
+					/>
+					<Button
+						icon={ linkOff }
+						label={ __( 'Remove link' ) }
+						onClick={ onLinkRemove }
+						size="compact"
+					/>
+				</>
+			);
+		}
+	};
+
 	return (
 		<>
 			<ToolbarButton
@@ -318,57 +374,7 @@ const ImageURLInputUI = ( {
 					}
 					offset={ 13 }
 				>
-					{ ( ! url || isEditingLink ) && hideLightboxPanel && (
-						<>
-							<URLPopover.LinkEditor
-								className="block-editor-format-toolbar__link-container-content"
-								value={ linkEditorValue }
-								onChangeInputValue={ setUrlInput }
-								onSubmit={ onSubmitLinkChange() }
-								autocompleteRef={ autocompleteRef }
-							/>
-						</>
-					) }
-					{ url && ! isEditingLink && hideLightboxPanel && (
-						<>
-							<URLPopover.LinkViewer
-								className="block-editor-format-toolbar__link-container-content"
-								url={ url }
-								onEditLinkClick={ startEditLink }
-								urlLabel={ urlLabel }
-							/>
-							<Button
-								icon={ linkOff }
-								label={ __( 'Remove link' ) }
-								onClick={ onLinkRemove }
-								size="compact"
-							/>
-						</>
-					) }
-					{ ! url &&
-						! isEditingLink &&
-						lightboxEnabled &&
-						showLightboxSetting && (
-							<div className="block-editor-url-popover__expand-on-click">
-								<Icon icon={ fullscreen } />
-								<div className="text">
-									<p>{ __( 'Expand on click' ) }</p>
-									<p className="description">
-										{ __(
-											'Scales the image with a lightbox effect'
-										) }
-									</p>
-								</div>
-								<Button
-									icon={ linkOff }
-									label={ __( 'Disable expand on click' ) }
-									onClick={ () => {
-										onSetLightbox( false );
-									} }
-									size="compact"
-								/>
-							</div>
-						) }
+					<PopoverChildren />
 				</URLPopover>
 			) }
 		</>

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -241,10 +241,9 @@ const ImageURLInputUI = ( {
 	);
 
 	const linkEditorValue = urlInput !== null ? urlInput : url;
-	const showLinkEditor =
-		( ! linkEditorValue &&
-			( ! lightboxEnabled ||
-				( lightboxEnabled && ! showLightboxSetting ) ) ) === true;
+	const hideLightboxPanel =
+		! lightboxEnabled || ( lightboxEnabled && ! showLightboxSetting );
+	const showLinkEditor = ! linkEditorValue && hideLightboxPanel;
 
 	const urlLabel = (
 		getLinkDestinations().find(
@@ -272,10 +271,7 @@ const ImageURLInputUI = ( {
 					onFocusOutside={ onFocusOutside() }
 					onClose={ closeLinkUI }
 					renderSettings={
-						! lightboxEnabled ||
-						( lightboxEnabled && ! showLightboxSetting )
-							? () => advancedOptions
-							: null
+						hideLightboxPanel ? () => advancedOptions : null
 					}
 					additionalControls={
 						showLinkEditor && (
@@ -322,38 +318,33 @@ const ImageURLInputUI = ( {
 					}
 					offset={ 13 }
 				>
-					{ ( ! url || isEditingLink ) &&
-						( ! lightboxEnabled ||
-							( lightboxEnabled && ! showLightboxSetting ) ) && (
-							<>
-								<URLPopover.LinkEditor
-									className="block-editor-format-toolbar__link-container-content"
-									value={ linkEditorValue }
-									onChangeInputValue={ setUrlInput }
-									onSubmit={ onSubmitLinkChange() }
-									autocompleteRef={ autocompleteRef }
-								/>
-							</>
-						) }
-					{ url &&
-						! isEditingLink &&
-						( ! lightboxEnabled ||
-							( lightboxEnabled && ! showLightboxSetting ) ) && (
-							<>
-								<URLPopover.LinkViewer
-									className="block-editor-format-toolbar__link-container-content"
-									url={ url }
-									onEditLinkClick={ startEditLink }
-									urlLabel={ urlLabel }
-								/>
-								<Button
-									icon={ linkOff }
-									label={ __( 'Remove link' ) }
-									onClick={ onLinkRemove }
-									size="compact"
-								/>
-							</>
-						) }
+					{ ( ! url || isEditingLink ) && hideLightboxPanel && (
+						<>
+							<URLPopover.LinkEditor
+								className="block-editor-format-toolbar__link-container-content"
+								value={ linkEditorValue }
+								onChangeInputValue={ setUrlInput }
+								onSubmit={ onSubmitLinkChange() }
+								autocompleteRef={ autocompleteRef }
+							/>
+						</>
+					) }
+					{ url && ! isEditingLink && hideLightboxPanel && (
+						<>
+							<URLPopover.LinkViewer
+								className="block-editor-format-toolbar__link-container-content"
+								url={ url }
+								onEditLinkClick={ startEditLink }
+								urlLabel={ urlLabel }
+							/>
+							<Button
+								icon={ linkOff }
+								label={ __( 'Remove link' ) }
+								onClick={ onLinkRemove }
+								size="compact"
+							/>
+						</>
+					) }
 					{ ! url &&
 						! isEditingLink &&
 						lightboxEnabled &&

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -46,6 +46,7 @@ const ImageURLInputUI = ( {
 	showLightboxSetting,
 	lightboxEnabled,
 	onSetLightbox,
+	resetLightbox,
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	// Use internal state instead of a ref to make sure that the component
@@ -299,7 +300,10 @@ const ImageURLInputUI = ( {
 					<Button
 						icon={ linkOff }
 						label={ __( 'Remove link' ) }
-						onClick={ onLinkRemove }
+						onClick={ () => {
+							onLinkRemove();
+							resetLightbox();
+						} }
 						size="compact"
 					/>
 				</>

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -378,7 +378,7 @@ const ImageURLInputUI = ( {
 					}
 					offset={ 13 }
 				>
-					<PopoverChildren />
+					{ PopoverChildren() }
 				</URLPopover>
 			) }
 		</>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -347,8 +347,7 @@ export default function Image( {
 
 	const [ lightboxSetting ] = useSettings( 'lightbox' );
 
-	const showLightboxSetting =
-		!! lightbox || lightboxSetting?.allowEditing === true;
+	const showLightboxSetting = lightboxSetting?.allowEditing === true;
 
 	const lightboxChecked =
 		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -268,14 +268,25 @@ export default function Image( {
 				lightbox: { enabled: false },
 			} );
 		} else {
-			resetLightbox();
+			setAttributes( {
+				lightbox: undefined,
+			} );
 		}
 	}
 
 	function resetLightbox() {
-		setAttributes( {
-			lightbox: undefined,
-		} );
+		// When deleting a link from an image while lightbox settings
+		// are enabled by default, we should disable the lightbox,
+		// otherwise the resulting UX looks like a mistake.
+		if ( lightboxSetting?.enabled && lightboxSetting?.allowEditing ) {
+			setAttributes( {
+				lightbox: { enabled: false },
+			} );
+		} else {
+			setAttributes( {
+				lightbox: undefined,
+			} );
+		}
 	}
 
 	function onSetTitle( value ) {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -268,10 +268,14 @@ export default function Image( {
 				lightbox: { enabled: false },
 			} );
 		} else {
-			setAttributes( {
-				lightbox: undefined,
-			} );
+			resetLightbox();
 		}
+	}
+
+	function resetLightbox() {
+		setAttributes( {
+			lightbox: undefined,
+		} );
 	}
 
 	function onSetTitle( value ) {
@@ -497,6 +501,7 @@ export default function Image( {
 							showLightboxSetting={ showLightboxSetting }
 							lightboxEnabled={ lightboxChecked }
 							onSetLightbox={ onSetLightbox }
+							resetLightbox={ resetLightbox }
 						/>
 					) }
 				{ allowCrop && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -278,6 +278,7 @@ export default function Image( {
 		// When deleting a link from an image while lightbox settings
 		// are enabled by default, we should disable the lightbox,
 		// otherwise the resulting UX looks like a mistake.
+		// See https://github.com/WordPress/gutenberg/pull/59890/files#r1532286123.
 		if ( lightboxSetting?.enabled && lightboxSetting?.allowEditing ) {
 			setAttributes( {
 				lightbox: { enabled: false },

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -351,7 +351,11 @@ export default function Image( {
 
 	const [ lightboxSetting ] = useSettings( 'lightbox' );
 
-	const showLightboxSetting = lightboxSetting?.allowEditing === true;
+	const showLightboxSetting =
+		// If a block-level override is set, we should give users the option to
+		// remove that override, even if the lightbox UI is disabled in the settings.
+		( !! lightbox && lightbox?.enabled !== lightboxSetting?.enabled ) ||
+		lightboxSetting?.allowEditing;
 
 	const lightboxChecked =
 		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );


### PR DESCRIPTION
## What?
This PR fixes an issue wherein the `allowEditing` value of the lightbox was not resulting in a consistent UX. It also addresses other related edge cases.

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/59837
Fixes https://github.com/WordPress/gutenberg/issues/59797

When one disables editing of the lightbox, the expectation is that the UI related to the lightbox config should be seamlessly removed from the editor.

## How?
It adds logic to handle the case wherein the lightbox animation is enabled by default but editing of the lightbox is not.
It also covers various edge cases regarding how the block-level settings interact with the `theme.json` settings.

## Testing Instructions
To make sure this is working properly, We need to test various scenarios and edge cases.
In particular, we need to test the UI in the following scenarios:

1. Image block DOES NOT have a link configured, and...
- DOES NOT have a lightbox override
- DOES have a lightbox override of ENABLED set to TRUE
- DOES have a lightbox override of ENABLED set to FALSE
2. Image block DOES have a link configured, and...
- DOES NOT have a lightbox override
- DOES have a lightbox override of ENABLED set to TRUE
- DOES have a lightbox override of ENABLED set to FALSE

In addition, each one of the scenarios above needs to be tested with the following `theme.json` configurations:

**allowEditing _false_, enabled _false_**
```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"blocks": {
			"core/image": {
				"lightbox": {
					"allowEditing": false,
					"enabled": false
				}
			}
		}
	}
}
```

**allowEditing _true_, enabled _false_**
```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"blocks": {
			"core/image": {
				"lightbox": {
					"allowEditing": true,
					"enabled": false
				}
			}
		}
	}
}
```

**allowEditing _false_, enabled _true_**
```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"blocks": {
			"core/image": {
				"lightbox": {
					"allowEditing": false,
					"enabled": true
				}
			}
		}
	}
}
```

**allowEditing _true_, enabled _true_**
```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"blocks": {
			"core/image": {
				"lightbox": {
					"allowEditing": true,
					"enabled": true
				}
			}
		}
	}
}
```

To test:
1. Add the image blocks detailed above to a new post
2. Click on each image, and verify that the UI appears (or is hidden) as expected for each scenario
3. Do this with each specified variation of the `theme.json`

### Testing overview

https://github.com/WordPress/gutenberg/assets/5360536/2dbf9a42-86f4-42a0-9827-9cfa7db1df19

### Test cases walkthrough

#### Part 1
*I mispeak early in this video — in the first scenario, the lightbox UI should be disabled.*

https://github.com/WordPress/gutenberg/assets/5360536/984d907f-7aff-4e20-8066-c2e2b1d4ced9

#### Part 2
https://github.com/WordPress/gutenberg/assets/5360536/09d70ca7-14b5-4237-9d29-a4cdbc4bb7bf