### PR TITLE
List Item: Add color support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -426,7 +426,7 @@ Create a list item. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/
 -	**Category:** text
 -	**Parent:** core/list
 -	**Allowed Blocks:** core/list
--	**Supports:** interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
+-	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** content, placeholder
 
 ## Login/out

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -21,8 +21,15 @@
 	},
 	"supports": {
 		"className": false,
-		"__experimentalSelector": ".wp-block-list > li",
 		"splitting": true,
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
 		"spacing": {
 			"margin": true,
 			"padding": true,
@@ -47,5 +54,8 @@
 		"interactivity": {
 			"clientNavigation": true
 		}
+	},
+	"selectors": {
+		"root": ".wp-block-list > li"
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/59854

## What?

Adds color block support to the List Item block to match the parent List block.

## Why?

The List Item block allows customizing typographic styles. This PR provides consistency for color styling and greater control for users.

## How?

- Opts into color block support
- Only makes text and background color controls display by default to match List block's configuration
- Updates the deprecated use of `__experimentalSelector` to use the [selectors API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-selectors/).

## Testing Instructions

1. Edit a post and add a list block with several items, some including links
2. Select individual list item blocks and confirm you can customize colors appropriately
3. Save and ensure the colors are correct on the frontend
4. Switch to the Site Editor and navigate to Global Styles > Blocks > List Item
5. Set some global colors for List Item blocks
6. Save and switch back to the post editor
7. Confirm the global styles are applied correctly and are overridden by the individual styles added earlier
8. Double check colors again on the frontend

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/0298aec8-1b48-468c-a669-6903f2aa07e1

