### PR TITLE
Editor: Fix loading templates using a top level pattern block that includes a template part.

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -232,7 +232,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			setRenderingMode( settings.defaultRenderingMode ?? 'post-only' );
 		}, [ settings.defaultRenderingMode, setRenderingMode ] );
 
-		useHideBlocksFromInserter( post.type );
+		useHideBlocksFromInserter( post.type, mode );
 
 		// Register the editor commands.
 		useCommands();

--- a/packages/editor/src/components/provider/use-hide-blocks-from-inserter.js
+++ b/packages/editor/src/components/provider/use-hide-blocks-from-inserter.js
@@ -18,8 +18,9 @@ const POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART = [
  * the template part and post content blocks need to be hidden.
  *
  * @param {string} postType Post Type
+ * @param {string} mode     Rendering mode
  */
-export function useHideBlocksFromInserter( postType ) {
+export function useHideBlocksFromInserter( postType, mode ) {
 	useEffect( () => {
 		/*
 		 * Prevent adding template part in the editor.
@@ -32,7 +33,8 @@ export function useHideBlocksFromInserter( postType ) {
 					! POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART.includes(
 						postType
 					) &&
-					blockType.name === 'core/template-part'
+					blockType.name === 'core/template-part' &&
+					mode === 'post-only'
 				) {
 					return false;
 				}
@@ -77,5 +79,5 @@ export function useHideBlocksFromInserter( postType ) {
 				'removePostContentFromInserter'
 			);
 		};
-	}, [ postType ] );
+	}, [ postType, mode ] );
 }


### PR DESCRIPTION
closes #59634
Regression introduced in #58928

## What?

This bug actually existed in the post editor before but was hidden (only visible in template preview mode) so when unifying this logic (hiding template parts) with the site editor, it became more visible.

Basically this PR limits the removal of the "template part" from the allowed blocks in "post-only" mode, in other words templates surrounding the pages/posts being rendered may use template parts.

1- Install [bedrock](https://wordpress.com/theme/bedrock) theme 
2- Set a static page as home page
3- Open the site editor, the page and template should load (and not be empty)