### PR TITLE
Avoid auto-removing font families without font faces

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -274,8 +274,22 @@ function FontLibraryProvider( { children } ) {
 						...alreadyInstalledFontFaces,
 					];
 					fontFamiliesToActivate.push( fontFamilyToInstall );
-				} else if ( isANewFontFamily ) {
-					// If the font family is new, delete it to avoid having font families without font faces.
+				}
+
+				// If it's a system font but was installed successfully, activate it.
+				if (
+					installedFontFamily &&
+					! fontFamilyToInstall?.fontFace?.length
+				) {
+					fontFamiliesToActivate.push( installedFontFamily );
+				}
+
+				// If the font family is new and is not a system font, delete it to avoid having font families without font faces.
+				if (
+					isANewFontFamily &&
+					fontFamilyToInstall?.fontFace?.length > 0 &&
+					sucessfullyInstalledFontFaces?.length === 0
+				) {
 					await fetchUninstallFontFamily( installedFontFamily.id );
 				}
 


### PR DESCRIPTION
## What?
Avoid auto-removing font families without font faces.

## Why?
There's a bug in the auto-removal of the installed font families without font faces.

## How?
Improve the checkings to fire and remove a font family.

## Testing Instructions
1. Install font families with many font faces and check they work OK.
2. Install system fonts and check they work OK.
3. Disable writing permissions in your font dir.
4. Install font families with font faces and check they are not added in the list of installed fonts.
5. Install system fonts and check (using [this plugin](https://github.com/matiasbenedetto/modern-fonts-stacks-for-wp-font-library) as an example) they continue working as expected.

