### PR TITLE
Button: Keep deprecated props in type definitions

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 -   `TextControl`: Add typings for `date`, `time` and `datetime-local` ([#59666](https://github.com/WordPress/gutenberg/pull/59666)).
 
+### Internal
+
+-   `Button`: Keep deprecated props in type definitions ([#59913](https://github.com/WordPress/gutenberg/pull/59913)).
+
 ## 27.1.0 (2024-03-06)
 
 ### Bug Fix

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -68,7 +68,6 @@ function useDeprecatedProps( {
 		deprecated( 'Button isDefault prop', {
 			since: '5.4',
 			alternative: 'variant="secondary"',
-			version: '6.2',
 		} );
 
 		computedVariant ??= 'secondary';

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -87,7 +87,7 @@ function useDeprecatedProps( {
 }
 
 export function UnforwardedButton(
-	props: ButtonProps,
+	props: ButtonProps & DeprecatedButtonProps,
 	ref: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -65,7 +65,7 @@ function useDeprecatedProps( {
 	}
 
 	if ( isDefault ) {
-		deprecated( 'Button isDefault prop', {
+		deprecated( 'wp.components.Button `isDefault` prop', {
 			since: '5.4',
 			alternative: 'variant="secondary"',
 		} );

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -554,13 +554,11 @@ describe( 'Button', () => {
 
 	describe( 'deprecated props', () => {
 		it( 'should not break when the legacy isPrimary prop is passed', () => {
-			// @ts-expect-error
 			render( <Button isPrimary /> );
 			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-primary' );
 		} );
 
 		it( 'should not break when the legacy isSecondary prop is passed', () => {
-			// @ts-expect-error
 			render( <Button isSecondary /> );
 			expect( screen.getByRole( 'button' ) ).toHaveClass(
 				'is-secondary'
@@ -568,19 +566,16 @@ describe( 'Button', () => {
 		} );
 
 		it( 'should not break when the legacy isTertiary prop is passed', () => {
-			// @ts-expect-error
 			render( <Button isTertiary /> );
 			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-tertiary' );
 		} );
 
 		it( 'should not break when the legacy isLink prop is passed', () => {
-			// @ts-expect-error
 			render( <Button isLink /> );
 			expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-link' );
 		} );
 
 		it( 'should warn when the isDefault prop is passed', () => {
-			// @ts-expect-error
 			render( <Button isDefault /> );
 			expect( screen.getByRole( 'button' ) ).toHaveClass(
 				'is-secondary'

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -149,10 +149,40 @@ type AnchorProps = {
 };
 
 export type DeprecatedButtonProps = {
+	/**
+	 * Gives the button a default style.
+	 *
+	 * @deprecated Use the `'secondary'` value on the `variant` prop instead.
+	 * @ignore
+	 */
 	isDefault?: boolean;
+	/**
+	 * Gives the button a link style.
+	 *
+	 * @deprecated Use the `'link'` value on the `variant` prop instead.
+	 * @ignore
+	 */
 	isLink?: boolean;
+	/**
+	 * Gives the button a primary style.
+	 *
+	 * @deprecated Use the `'primary'` value on the `variant` prop instead.
+	 * @ignore
+	 */
 	isPrimary?: boolean;
+	/**
+	 * Gives the button a default style.
+	 *
+	 * @deprecated Use the `'secondary'` value on the `variant` prop instead.
+	 * @ignore
+	 */
 	isSecondary?: boolean;
+	/**
+	 * Gives the button a text-based style.
+	 *
+	 * @deprecated Use the `'tertiary'` value on the `variant` prop instead.
+	 * @ignore
+	 */
 	isTertiary?: boolean;
 };
 


### PR DESCRIPTION
In preparation for #59733
Informed by feedback in #55401

## What?

Tweaks how the deprecated props on `Button` are managed so that they are more permissive:

- Keep deprecated props in the TypeScript type definitions, so that they will be flagged as deprecated but not block TS compilation.
- Remove the hard deprecation version for the `isDefault` prop, since this is a very low maintenance back compat layer and we can pretty much keep it around indefinitely.

## Why?

It's already been a while since these props have been deprecated, but I still think it's worthwhile to set some good patterns here before adding new deprecations like in #59734.

The main back compat considerations I think we should uphold are:

- Keep deprecated props in the type definitions so compilation does not fail, and to prevent future prop name collisions.
- Hard deprecations don't necessarily need to happen if the maintenance cost of the back compat layer is negligible.

## Testing Instructions

- Type checks still pass
- Using one of the deprecated Button props should not throw a TS error
- The deprecated props should still be hidden from the Storybook props table (The JSDoc `@ignore` tag does this)
