### PR TITLE
Fix the block variations transforms labeling and improve UI clarity

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -60,7 +60,6 @@ function VariationsDropdown( {
 	return (
 		<DropdownMenu
 			className={ className }
-			label={ __( 'Transform to variation' ) }
 			text={ __( 'Transform to variation' ) }
 			popoverProps={ {
 				position: 'bottom center',

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -29,22 +29,26 @@ function VariationsButtons( {
 	variations,
 } ) {
 	return (
-		<fieldset className={ className }>
-			<legend>
-				<BaseControl.VisualLabel>
-					{ __( 'Transform to variation' ) }
-				</BaseControl.VisualLabel>
-			</legend>
-			{ variations.map( ( variation ) => (
-				<Button
-					key={ variation.name }
-					icon={ <BlockIcon icon={ variation.icon } showColors /> }
-					isPressed={ selectedValue === variation.name }
-					label={ variation.title }
-					onClick={ () => onSelectVariation( variation.name ) }
-				/>
-			) ) }
-		</fieldset>
+		<div className={ className }>
+			<fieldset>
+				<legend>
+					<BaseControl.VisualLabel>
+						{ __( 'Transform to variation' ) }
+					</BaseControl.VisualLabel>
+				</legend>
+				{ variations.map( ( variation ) => (
+					<Button
+						key={ variation.name }
+						icon={
+							<BlockIcon icon={ variation.icon } showColors />
+						}
+						isPressed={ selectedValue === variation.name }
+						label={ variation.title }
+						onClick={ () => onSelectVariation( variation.name ) }
+					/>
+				) ) }
+			</fieldset>
+		</div>
 	);
 }
 
@@ -63,28 +67,29 @@ function VariationsDropdown( {
 	);
 
 	return (
-		<DropdownMenu
-			className={ className }
-			text={ __( 'Transform to variation' ) }
-			popoverProps={ {
-				position: 'bottom center',
-				className: `${ className }__popover`,
-			} }
-			icon={ chevronDown }
-			toggleProps={ { iconPosition: 'right' } }
-		>
-			{ () => (
-				<div className={ `${ className }__container` }>
-					<MenuGroup>
-						<MenuItemsChoice
-							choices={ selectOptions }
-							value={ selectedValue }
-							onSelect={ onSelectVariation }
-						/>
-					</MenuGroup>
-				</div>
-			) }
-		</DropdownMenu>
+		<div className={ className }>
+			<DropdownMenu
+				text={ __( 'Transform to variation' ) }
+				popoverProps={ {
+					position: 'bottom center',
+					className: `${ className }__popover`,
+				} }
+				icon={ chevronDown }
+				toggleProps={ { iconPosition: 'right' } }
+			>
+				{ () => (
+					<div className={ `${ className }__container` }>
+						<MenuGroup>
+							<MenuItemsChoice
+								choices={ selectOptions }
+								value={ selectedValue }
+								onSelect={ onSelectVariation }
+							/>
+						</MenuGroup>
+					</div>
+				) }
+			</DropdownMenu>
+		</div>
 	);
 }
 
@@ -168,8 +173,8 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 
 	const baseClass = 'block-editor-block-variation-transforms';
 
-	// Show buttons if there are more than 5 variations because the ToggleGroupControl does not wrap
-	const showButtons = variations.length > 5;
+	// Show buttons if there are more than 6 variations because the ToggleGroupControl does not wrap
+	const showButtons = variations.length > 6;
 
 	const ButtonComponent = showButtons
 		? VariationsButtons

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -108,7 +108,6 @@ function VariationsToggleGroupControl( {
 			<ToggleGroupControl
 				label={ __( 'Transform to variation' ) }
 				value={ selectedValue }
-				hideLabelFromVision
 				onChange={ onSelectVariation }
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
@@ -120,15 +119,7 @@ function VariationsToggleGroupControl( {
 							<BlockIcon icon={ variation.icon } showColors />
 						}
 						value={ variation.name }
-						label={
-							selectedValue === variation.name
-								? variation.title
-								: sprintf(
-										/* translators: %s: Name of the block variation */
-										__( 'Transform to %s' ),
-										variation.title
-								  )
-						}
+						label={ variation.title }
 					/>
 				) ) }
 			</ToggleGroupControl>

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -10,6 +10,7 @@ import {
 	MenuItemsChoice,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+	BaseControl,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -29,7 +30,11 @@ function VariationsButtons( {
 } ) {
 	return (
 		<fieldset className={ className }>
-			<legend>{ __( 'Transform to variation' ) }</legend>
+			<legend>
+				<BaseControl.VisualLabel>
+					{ __( 'Transform to variation' ) }
+				</BaseControl.VisualLabel>
+			</legend>
 			{ variations.map( ( variation ) => (
 				<Button
 					key={ variation.name }

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	DropdownMenu,
@@ -10,7 +10,6 @@ import {
 	MenuItemsChoice,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
-	VisuallyHidden,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -30,26 +29,14 @@ function VariationsButtons( {
 } ) {
 	return (
 		<fieldset className={ className }>
-			<VisuallyHidden as="legend">
-				{ __( 'Transform to variation' ) }
-			</VisuallyHidden>
+			<legend>{ __( 'Transform to variation' ) }</legend>
 			{ variations.map( ( variation ) => (
 				<Button
 					key={ variation.name }
 					icon={ <BlockIcon icon={ variation.icon } showColors /> }
 					isPressed={ selectedValue === variation.name }
-					label={
-						selectedValue === variation.name
-							? variation.title
-							: sprintf(
-									/* translators: %s: Name of the block variation */
-									__( 'Transform to %s' ),
-									variation.title
-							  )
-					}
+					label={ variation.title }
 					onClick={ () => onSelectVariation( variation.name ) }
-					aria-label={ variation.title }
-					showTooltip
 				/>
 			) ) }
 		</fieldset>

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -2,6 +2,12 @@
 	padding: 0 $grid-unit-20 $grid-unit-20 52px;
 	width: 100%;
 
+	legend {
+		padding: 0;
+		// Makes the inline label be the correct height, equivalent to setting line-height: 0
+		display: flex;
+	}
+
 	.components-dropdown-menu__toggle {
 		border: 1px solid $gray-700;
 		border-radius: $radius-block-ui;

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -1,11 +1,15 @@
 .block-editor-block-variation-transforms {
-	padding: 0 $grid-unit-20 $grid-unit-20 52px;
-	width: 100%;
+	padding: $grid-unit-20;
+	border-top: $border-width solid $gray-200;
 
 	legend {
 		padding: 0;
 		// Makes the inline label be the correct height, equivalent to setting line-height: 0
 		display: flex;
+	}
+
+	.components-dropdown-menu {
+		width: 100%;
 	}
 
 	.components-dropdown-menu__toggle {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/59898

## What?
<!-- In a few words, what is the PR actually doing? -->
The block variations in the block inspector may use 3 different components based on some conditions. All three components use less than ideal labeling. Also, the UI doesn't really make clear what the icon buttons are about.
Minor: when rendered as a dropdown button, the gap between the toggle button and the dropdwon menu is too large.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- All settings sections in the inspector should be clearly identified by some visible text that clearly explains what that UI is about. Depending on the cases, these visible text can be a visual label, or a fieldseet legend, or a toggle button text (for the menu).
- The variation labels must not change dynamically. The also need to match the tooltips text.
- A dropdown menu must be 'visually connected' to its toggle button, the current gap is too large.
- I'm not sure why the variations are visually placed within the block 'card'. The block card is meant to contain the block name and descriptions. The variations are a separate concept. As such, they should be visually separated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Makes the radiogroup 'visual label' visible. The group itself is labeled via an `aria-label` that uses the same text of the visual label. This hasn't changed, it's how the component works.
- Avoids to dynamically change the button labels. The accessible name of a control should rarely change.
- Makes the tooltips text match the accessible name.
- Reduces the gap between the menu toggle and the menu by making sure all three components the variations can be rendered with use the same wrapper, with the same padding.
- Visually separates the variations UI from the block card.
- There's now more horizontal room so the default radiogroup now shows up to _six_ variations instead of five. When more than 6, the component switches to a group of buttons that can wrap to multiple lines, as it is on trunk.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the site editor and select a Group block.
- Observe the variations in the block inspector.
- Observe the variations are now left aligned and have a visible title 'Transform to variation'.
- Hover or focus each button and activate them. Observe the tooltiip text is always the same and doesn't change dynamically.
- Alter the [Group block variations](https://github.com/WordPress/gutenberg/blob/b6c37f383070d35af77d1aab9b9ef01df33c6d9d/packages/block-library/src/group/variations.js) and add a few more variations so that they are more than 6. Build and refresh the editor.
- Observe the variations are now normal icon buttons.
- Obseerve the variations have a visible title 'Transform to variation'.
- Hover or focus each button and observe their tooltip text matches the aria-label value.
- Alter again the variations and make at least two of them use the same icon. Build and refresh the editor.
- Observe the variations are now a dropdown menu.
- Observe the menu toggle text is still 'Transform to variation', this hasn't changed.
- Hover or focus the menu toggle and observe there's no tooltip any longer (the tooltip was redundant as it just repeated the visible text).
- Open the menu and observe the gap between the menu toggle and the menu is now the expected one and consistent with all the other dropdown menus.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/WordPress/gutenberg/assets/1682452/0307e2b1-3eeb-47ab-97d7-5581f8d5fe4c)

After:

![after](https://github.com/WordPress/gutenberg/assets/1682452/aa5ecfa4-f625-4b3a-ad64-324dd7caef97)
