### PR TITLE
Typography Presets: Use && rather to avoid a messy nested conditional

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -28,35 +28,35 @@ export default function TypographyVariations() {
 				columns={ 3 }
 				className="edit-site-global-styles-style-variations-container"
 			>
-				{ typographyVariations && typographyVariations.length
-					? typographyVariations.map( ( variation, index ) => (
-							<Variation key={ index } variation={ variation }>
-								{ ( isFocused ) => (
-									<PreviewIframe
-										label={ variation?.title }
-										isFocused={ isFocused }
-									>
-										{ ( { ratio, key } ) => (
-											<HStack
-												key={ key }
-												spacing={ 10 * ratio }
-												justify="center"
-												style={ {
-													height: '100%',
-													overflow: 'hidden',
-												} }
-											>
-												<TypographyExample
-													variation={ variation }
-													fontSize={ 85 * ratio }
-												/>
-											</HStack>
-										) }
-									</PreviewIframe>
-								) }
-							</Variation>
-					  ) )
-					: null }
+				{ typographyVariations &&
+					typographyVariations.length &&
+					typographyVariations.map( ( variation, index ) => (
+						<Variation key={ index } variation={ variation }>
+							{ ( isFocused ) => (
+								<PreviewIframe
+									label={ variation?.title }
+									isFocused={ isFocused }
+								>
+									{ ( { ratio, key } ) => (
+										<HStack
+											key={ key }
+											spacing={ 10 * ratio }
+											justify="center"
+											style={ {
+												height: '100%',
+												overflow: 'hidden',
+											} }
+										>
+											<TypographyExample
+												variation={ variation }
+												fontSize={ 85 * ratio }
+											/>
+										</HStack>
+									) }
+								</PreviewIframe>
+							) }
+						</Variation>
+					) ) }
 			</Grid>
 		</VStack>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a small refactor...

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
...to make the code easier to read.

## How?
Replace a `? ... : ` with a '&&'

## Testing Instructions
1. Open the Site Editor
2. Open Global Styles
3. Open Typography and check that presets load (using TT4)
4. Open Colors and check that presets load (using TT4)