### PR TITLE
Avoid override certain paths on theme variation switch

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -25,6 +25,7 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 
 const PATHS_TO_AVOID_OVERWRITING = [
 	[ 'settings', 'typography', 'fontFamilies', 'custom' ],
+	[ 'settings', 'color', 'palette', 'custom' ],
 ];
 
 export default function Variation( { variation, children } ) {

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -15,11 +15,17 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { mergeBaseAndUserConfigs } from '../global-styles-provider';
+import getValueFromObjectPath from '../../../utils/get-value-from-object-path';
+import setNestedValue from '../../../utils/set-nested-value';
 import { unlock } from '../../../lock-unlock';
 
 const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
+
+const PATHS_TO_AVOID_OVERWRITING = [
+	[ 'settings', 'typography', 'fontFamilies', 'custom' ],
+];
 
 export default function Variation( { variation, children } ) {
 	const [ isFocused, setIsFocused ] = useState( false );
@@ -38,10 +44,20 @@ export default function Variation( { variation, children } ) {
 	);
 
 	const selectVariation = () => {
-		setUserConfig( () => ( {
-			settings: variation.settings,
-			styles: variation.styles,
-		} ) );
+		setUserConfig( ( currentConfig ) => {
+			// Avoids overwriting certain paths when applying a theme variation.
+			for ( const path of PATHS_TO_AVOID_OVERWRITING ) {
+				// Gets the value from the current config.
+				const value = getValueFromObjectPath( currentConfig, path );
+				// Sets the value in the applied variation.
+				setNestedValue( variation, path, value );
+			}
+
+			return {
+				settings: variation.settings,
+				styles: variation.styles,
+			};
+		} );
 	};
 
 	const selectOnEnter = ( event ) => {

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -27,6 +27,8 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSupportedStyles } from '../../components/global-styles/hooks';
 import { unlock } from '../../lock-unlock';
 import cloneDeep from '../../utils/clone-deep';
+import getValueFromObjectPath from '../../utils/get-value-from-object-path';
+import setNestedValue from '../../utils/set-nested-value';
 
 const { cleanEmptyObject, GlobalStylesContext } = unlock(
 	blockEditorPrivateApis
@@ -104,14 +106,6 @@ const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
 };
 
 const SUPPORTED_STYLES = [ 'border', 'color', 'spacing', 'typography' ];
-
-const getValueFromObjectPath = ( object, path ) => {
-	let value = object;
-	path.forEach( ( fieldName ) => {
-		value = value?.[ fieldName ];
-	} );
-	return value;
-};
 
 const flatBorderProperties = [ 'borderColor', 'borderWidth', 'borderStyle' ];
 const sides = [ 'top', 'right', 'bottom', 'left' ];
@@ -234,46 +228,6 @@ function useChangesToPush( name, attributes, userConfig ) {
 
 		return changes;
 	}, [ supports, attributes, blockUserConfig ] );
-}
-
-/**
- * Sets the value at path of object.
- * If a portion of path doesn’t exist, it’s created.
- * Arrays are created for missing index properties while objects are created
- * for all other missing properties.
- *
- * This function intentionally mutates the input object.
- *
- * Inspired by _.set().
- *
- * @see https://lodash.com/docs/4.17.15#set
- *
- * @todo Needs to be deduplicated with its copy in `@wordpress/core-data`.
- *
- * @param {Object} object Object to modify
- * @param {Array}  path   Path of the property to set.
- * @param {*}      value  Value to set.
- */
-function setNestedValue( object, path, value ) {
-	if ( ! object || typeof object !== 'object' ) {
-		return object;
-	}
-
-	path.reduce( ( acc, key, idx ) => {
-		if ( acc[ key ] === undefined ) {
-			if ( Number.isInteger( path[ idx + 1 ] ) ) {
-				acc[ key ] = [];
-			} else {
-				acc[ key ] = {};
-			}
-		}
-		if ( idx === path.length - 1 ) {
-			acc[ key ] = value;
-		}
-		return acc[ key ];
-	}, object );
-
-	return object;
 }
 
 function PushChangesToGlobalStylesControl( {

--- a/packages/edit-site/src/utils/get-value-from-object-path.js
+++ b/packages/edit-site/src/utils/get-value-from-object-path.js
@@ -1,0 +1,7 @@
+export default function getValueFromObjectPath( object, path ) {
+	let value = object;
+	path.forEach( ( fieldName ) => {
+		value = value?.[ fieldName ];
+	} );
+	return value;
+}

--- a/packages/edit-site/src/utils/set-nested-value.js
+++ b/packages/edit-site/src/utils/set-nested-value.js
@@ -1,0 +1,39 @@
+/**
+ * Sets the value at path of object.
+ * If a portion of path doesn’t exist, it’s created.
+ * Arrays are created for missing index properties while objects are created
+ * for all other missing properties.
+ *
+ * This function intentionally mutates the input object.
+ *
+ * Inspired by _.set().
+ *
+ * @see https://lodash.com/docs/4.17.15#set
+ *
+ * @todo Needs to be deduplicated with its copy in `@wordpress/core-data`.
+ *
+ * @param {Object} object Object to modify
+ * @param {Array}  path   Path of the property to set.
+ * @param {*}      value  Value to set.
+ */
+export default function setNestedValue( object, path, value ) {
+	if ( ! object || typeof object !== 'object' ) {
+		return object;
+	}
+
+	path.reduce( ( acc, key, idx ) => {
+		if ( acc[ key ] === undefined ) {
+			if ( Number.isInteger( path[ idx + 1 ] ) ) {
+				acc[ key ] = [];
+			} else {
+				acc[ key ] = {};
+			}
+		}
+		if ( idx === path.length - 1 ) {
+			acc[ key ] = value;
+		}
+		return acc[ key ];
+	}, object );
+
+	return object;
+}


### PR DESCRIPTION
## What?
Avoid overriding certain paths on the theme variation switch.

## Why?
Theme variation switching overrides certain `theme.json` data paths that are not supposed to override.
A theme variation is data intended to change the `theme` level data and not the `custom` data and it should only affect settings/styles defined by themes and not the custom styles defined by users.

This change is added to fix part of this issue https://github.com/WordPress/gutenberg/issues/59818


## How?
Add an array of `theme.json` paths that the theme variation should not overwrite. 

## Testing Instructions
1. Activate a theme that includes variations in their `settings.typography.fontFamilies` theme.json data (for example TwentyTwentyFour).
2. Install a few fonts using the Font Library.
3. Go to the style variations panel and switch the variation.
4. Check that the fonts installed using the font library are still listed as installed and active.

--- 

## Use cases

## Custom colors

Let's say the user want to add 2 colors to create a notice paragraph on their posts. This is how it would work: 

#### Trunk
https://github.com/WordPress/gutenberg/assets/1310626/805c722c-2da4-4fa9-9c90-f404a6dab8f4

#### This PR
https://github.com/WordPress/gutenberg/assets/1310626/626127cd-e482-4d57-9a66-f6094d2dfd88

---

### Using custom fonts in posts

In this example, I'm installing a custom font and using it in a post. On Trunk, after applying a style variation, the custom font selected by the user previously is not rendered. Running this PR it is.

#### Trunk:

https://github.com/WordPress/gutenberg/assets/1310626/64eb609e-55e1-4974-bd43-32dbb293166d

#### This PR:

https://github.com/WordPress/gutenberg/assets/1310626/68041f45-1b03-4f96-b69f-6b6ca48f7c0c




---

### Active fonts

In the _trunk_ one the active fonts installed using the font library are lost of theme variation switch and in the _this PR_ the font families remain active. It means that the active fonts used in posts or blocks will continue working as expected.

#### Trunk

https://github.com/WordPress/gutenberg/assets/1310626/44d7f516-8b6b-4998-a14f-977b821e753a


#### This PR
https://github.com/WordPress/gutenberg/assets/1310626/42fbe195-771c-470e-a605-807d7bbdc6f0

