### PR TITLE
Fix navigation link ui close focus management

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -172,6 +172,7 @@ export default function NavigationLinkEdit( {
 		replaceBlock,
 		__unstableMarkNextChangeAsNotPersistent,
 		selectPreviousBlock,
+		selectBlock,
 	} = useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
@@ -525,6 +526,12 @@ export default function NavigationLinkEdit( {
 												'core/image',
 												'core/strikethrough',
 											] }
+											onClick={ () => {
+												if ( ! url ) {
+													setIsLinkOpen( true );
+													setOpenedBy( ref.current );
+												}
+											} }
 										/>
 										{ description && (
 											<span className="wp-block-navigation-item__description">
@@ -580,6 +587,9 @@ export default function NavigationLinkEdit( {
 								if ( openedBy ) {
 									openedBy.focus();
 									setOpenedBy( null );
+								} else {
+									// select the block if no ref, such as when adding a new link
+									selectBlock( clientId );
 								}
 							} }
 							anchor={ popoverAnchor }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -281,10 +281,6 @@ export default function NavigationLinkEdit( {
 				selectLabelText();
 			}
 		}
-		// Reset openedBy to null if the linkUI is closed
-		else if ( ! isLinkOpen ) {
-			setOpenedBy( null );
-		}
 	}, [ url, isLinkOpen, label ] );
 
 	/**
@@ -583,6 +579,7 @@ export default function NavigationLinkEdit( {
 								setIsLinkOpen( false );
 								if ( openedBy ) {
 									openedBy.focus();
+									setOpenedBy( null );
 								}
 							} }
 							anchor={ popoverAnchor }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -172,7 +172,6 @@ export default function NavigationLinkEdit( {
 		replaceBlock,
 		__unstableMarkNextChangeAsNotPersistent,
 		selectPreviousBlock,
-		selectBlock,
 	} = useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
@@ -587,9 +586,12 @@ export default function NavigationLinkEdit( {
 								if ( openedBy ) {
 									openedBy.focus();
 									setOpenedBy( null );
+								} else if ( ref.current ) {
+									// select the ref when adding a new link
+									ref.current.focus();
 								} else {
-									// select the block if no ref, such as when adding a new link
-									selectBlock( clientId );
+									// Fallback
+									selectPreviousBlock( clientId, true );
 								}
 							} }
 							anchor={ popoverAnchor }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -333,6 +333,8 @@ export default function NavigationLinkEdit( {
 			// as it shares the CMD+K shortcut.
 			// See https://github.com/WordPress/gutenberg/pull/59845.
 			event.preventDefault();
+			// If this link is a child of a parent submenu item, the parent submenu item event will also open, closing this popover
+			event.stopPropagation();
 			setIsLinkOpen( true );
 			setOpenedBy( ref.current );
 		}
@@ -525,12 +527,6 @@ export default function NavigationLinkEdit( {
 												'core/image',
 												'core/strikethrough',
 											] }
-											onClick={ () => {
-												if ( ! url ) {
-													setIsLinkOpen( true );
-													setOpenedBy( ref.current );
-												}
-											} }
 										/>
 										{ description && (
 											<span className="wp-block-navigation-item__description">

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -33,7 +33,7 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { decodeEntities } from '@wordpress/html-entities';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -183,6 +183,7 @@ export default function NavigationLinkEdit( {
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
 	const itemLabelPlaceholder = __( 'Add label…' );
 	const ref = useRef();
+	const prevUrl = usePrevious( url );
 
 	// Change the label using inspector causes rich text to change focus on firefox.
 	// This is a workaround to keep the focus on the label field when label filed is focused we don't render the rich text.
@@ -271,17 +272,18 @@ export default function NavigationLinkEdit( {
 
 	// If the LinkControl popover is open and the URL has changed, close the LinkControl and focus the label text.
 	useEffect( () => {
-		if ( isLinkOpen && url ) {
-			// Does this look like a URL and have something TLD-ish?
-			if (
-				isURL( prependHTTP( label ) ) &&
-				/^.+\.[a-z]+/.test( label )
-			) {
-				// Focus and select the label text.
-				selectLabelText();
-			}
+		// We only want to do this when the URL has gone from nothing to a new URL AND the label looks like a URL
+		if (
+			! prevUrl &&
+			url &&
+			isLinkOpen &&
+			isURL( prependHTTP( label ) ) &&
+			/^.+\.[a-z]+/.test( label )
+		) {
+			// Focus and select the label text.
+			selectLabelText();
 		}
-	}, [ url, isLinkOpen, label ] );
+	}, [ prevUrl, url, isLinkOpen, label ] );
 
 	/**
 	 * Focus the Link label text and select it.

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -138,8 +138,11 @@ export default function NavigationSubmenuEdit( {
 
 	const { showSubmenuIcon, maxNestingLevel, openSubmenusOnClick } = context;
 
-	const { __unstableMarkNextChangeAsNotPersistent, replaceBlock } =
-		useDispatch( blockEditorStore );
+	const {
+		__unstableMarkNextChangeAsNotPersistent,
+		replaceBlock,
+		selectBlock,
+	} = useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
 	const [ openedBy, setOpenedBy ] = useState( null );
@@ -475,6 +478,7 @@ export default function NavigationSubmenuEdit( {
 							onClick={ () => {
 								if ( ! openSubmenusOnClick && ! url ) {
 									setIsLinkOpen( true );
+									setOpenedBy( ref.current );
 								}
 							} }
 						/>
@@ -488,6 +492,8 @@ export default function NavigationSubmenuEdit( {
 								if ( openedBy ) {
 									openedBy.focus();
 									setOpenedBy( null );
+								} else {
+									selectBlock( clientId );
 								}
 							} }
 							anchor={ popoverAnchor }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -333,21 +333,15 @@ test.describe( 'Navigation block', () => {
 		const navBlock = navigation.getNavBlock();
 
 		const navBlockInserter = navigation.getNavBlockInserter();
-		// Wait until the nav block inserter is visible before we move on to using it
+		// Wait until the nav block inserter is visible before we continue. Otherwise the navigation block may not have finished being created.
 		await expect( navBlockInserter ).toBeVisible();
 
 		/**
-		 * Test: Exiting the appender from the link control returns focus to the navigation block
-		 *
-		 * 1. Use arrow keys to reach Appender
-		 * 2. Enter to open link control
-		 * 3. Escape to exit
-		 * 4. Focus should be within the Navigation Block, ideally on the appender that opened it
+		 * Test: We don't lose focus when using the navigation link appender
 		 */
 		await pageUtils.pressKeys( 'ArrowDown' );
 		await navigation.useBlockInserter();
 		await navigation.addLinkClose();
-
 		/**
 		 * TODO: This is not desired behavior. Ideally the
 		 * Appender should be focused again since it opened
@@ -360,18 +354,15 @@ test.describe( 'Navigation block', () => {
 
 		/**
 		 * Test: Creating a link sends focus to the newly created navigation link item
-		 *
-		 * 1. Use arrow keys to reach Appender
-		 * 2. Enter to open link control
-		 * 3. Arrow down to the suggested pages
-		 * 4. Enter
-		 * 5. Focus should be on the newly created navigation item
 		 */
-
 		await pageUtils.pressKeys( 'ArrowDown' );
 
 		await navigation.useBlockInserter();
 		await navigation.addPage( 'Cat' );
+		/**
+		 * Test: We can open and close the preview with the keyboard and escape
+		 *       buttons from a top-level nav item using both the shortcut and toolbar
+		 */
 		await navigation.previewOpenClose( {
 			label: 'Cat',
 			activator: 'shortcut',
@@ -384,14 +375,7 @@ test.describe( 'Navigation block', () => {
 		/**
 		 * Test: Creating a link from a url-string (https://www.example.com) returns
 		 *       focus to the newly created link with the text selected
-		 *
-		 * 1. Use arrow keys to reach Appender
-		 * 2. Enter to open link control
-		 * 3. Type https://www.example.com
-		 * 4. Enter
-		 * 5. Focus should be on the newly created navigation item with text selected
 		 */
-
 		// Move focus to the Add Block Appender.
 		await page.keyboard.press( 'Escape' );
 		await pageUtils.pressKeys( 'ArrowDown' );
@@ -402,36 +386,22 @@ test.describe( 'Navigation block', () => {
 		await navigation.expectToHaveTextSelected( 'example.com' );
 
 		/**
-		 * Test: Exiting the link control from the toolbar link button returns
-		 *       focus to the toolbar
-		 *
-		 * 1. Go to toolbar link button
-		 * 2. Enter
-		 * 3. Focus is within the link control
-		 * 4. Escape to exit
-		 * 5. Focus should be on the toolbar link button
+		 * Test: We can open and close the preview with the keyboard and escape
+		 *       buttons from a top-level nav link with a url-like label using
+		 *       both the shortcut and toolbar
 		 */
-		// Move caret to beginning of nav item label
 		await pageUtils.pressKeys( 'ArrowLeft' );
 		await navigation.previewOpenClose( {
 			label: 'example.com',
-			linkName: 'Example Domain',
 			activator: 'shortcut',
 		} );
 		await navigation.previewOpenClose( {
 			label: 'example.com',
-			linkName: 'Example Domain',
 			activator: 'toolbar',
 		} );
 
 		/**
 		 * Test: Can add submenu item using the keyboard
-		 *
-		 * 1. Go to toolbar add submenu button
-		 * 2. Enter
-		 * 3. Focus is within the link control
-		 * 4. Escape to exit
-		 * 5. Focus should be on the toolbar link button
 		 */
 		navigation.useToolbarButton( 'Add submenu' );
 
@@ -442,10 +412,15 @@ test.describe( 'Navigation block', () => {
 
 		await pageUtils.pressKeys( 'ArrowDown' );
 		// There is a bug that won't allow us to press Enter to add the link: https://github.com/WordPress/gutenberg/issues/60051
-		// Use Enter after that bug is resolved
+		// TODO: Use Enter after that bug is resolved
 		await navigation.useLinkShortcut();
 
 		await navigation.addPage( 'Dog' );
+
+		/**
+		 * Test: We can open and close the preview with the keyboard and escape
+		 *       buttons from a submenu nav item using both the shortcut and toolbar
+		 */
 		await navigation.previewOpenClose( {
 			label: 'Dog',
 			activator: 'shortcut',
@@ -460,6 +435,55 @@ test.describe( 'Navigation block', () => {
 
 		// We should be at the first position on the label
 		await navigation.checkLabelFocus( 'Dog' );
+
+		/**
+		 * Test: We don't lose focus when closing the submenu appender
+		 */
+		// Move focus to the submenu navigation appender
+
+		/**
+		 * Test: We can open and close the preview with the keyboard and escape
+		 *       buttons from a submenu parent item using both the shortcut and toolbar
+		 */
+
+		// TODO: Update _how_ we reach the block appender. This is annoying to use.
+		await page.keyboard.press( 'End' );
+		await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+		await navigation.useBlockInserter();
+		await navigation.addLinkClose();
+		/**
+		 * TODO: This is not desired behavior. Ideally the
+		 * Appender should be focused again since it opened
+		 * the link control.
+		 * IMPORTANT: This check is not to enforce this behavior,
+		 * but to make sure focus is kept nearby until we are able
+		 * to send focus to the appender. It is falling back to the previous sibling.
+		 */
+		await navigation.checkLabelFocus( 'Dog' );
+
+		/**
+		 * Test: Use the submenu nav item appender to add a custom link
+		 */
+		await page.keyboard.press( 'End' );
+		await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+		await navigation.useBlockInserter();
+		await navigation.addCustomURL( 'https://wordpress.org' );
+		await navigation.expectToHaveTextSelected( 'wordpress.org' );
+
+		/**
+		 * Test: We can open and close the preview with the keyboard and escape
+		 *       buttons from a top-level nav link with a url-like label using
+		 *       both the shortcut and toolbar
+		 */
+		await pageUtils.pressKeys( 'ArrowLeft' );
+		await navigation.previewOpenClose( {
+			label: 'wordpress.org',
+			activator: 'shortcut',
+		} );
+		await navigation.previewOpenClose( {
+			label: 'wordpress.org',
+			activator: 'toolbar',
+		} );
 	} );
 
 	test( 'Adding new links to a navigation block with existing inner blocks triggers creation of a single Navigation Menu', async ( {
@@ -694,7 +718,7 @@ class Navigation {
 	 * @param {Object} options
 	 */
 	async previewOpenClose( options = {} ) {
-		const { label, linkName = '', activator } = options;
+		const { label, activator } = options;
 		if ( activator === 'shortcut' ) {
 			await this.useLinkShortcut();
 		} else if ( activator === 'toolbar' ) {
@@ -704,17 +728,22 @@ class Navigation {
 			return;
 		}
 
-		const linkControlLink = this.getLinkControlLink(
-			linkName !== '' ? linkName : label
-		);
-		const navLink = this.getNavLink( label );
-		await expect( navLink ).toBeVisible();
-
-		await expect( linkControlLink ).toBeFocused();
+		const linkPopover = this.getLinkPopover();
+		await expect( linkPopover ).toBeVisible();
+		// Expect focus to be within the link control. We could be more exact here, but it would be more brittle that way. We really care if focus is within it or not.
+		expect(
+			await this.page.evaluate( () => {
+				const { activeElement } =
+					document.activeElement?.contentDocument ?? document;
+				return !! activeElement.closest(
+					'.components-popover__content .block-editor-link-control'
+				);
+			} )
+		).toBe( true );
 
 		await this.page.keyboard.press( 'Escape' );
 
-		await expect( linkControlLink ).toBeHidden();
+		await expect( linkPopover ).toBeHidden();
 
 		if ( activator === 'shortcut' ) {
 			await this.checkLabelFocus( label );
@@ -736,5 +765,19 @@ class Navigation {
 				return;
 			}
 		}
+	}
+
+	/**
+	 * This method is used as a temporary workaround for retriveing the
+	 * LinkControl component. This is because it currently does not expose
+	 * any accessible attributes. In general we should avoid using this method
+	 * and instead rely on locating the sub elements of the component directly.
+	 * Remove / update method once the following PR has landed:
+	 * https://github.com/WordPress/gutenberg/pull/54063.
+	 */
+	getLinkPopover() {
+		return this.page.locator(
+			'.components-popover__content .block-editor-link-control'
+		);
 	}
 }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -313,7 +313,7 @@ test.describe( 'Navigation block', () => {
 		await expect( warningMessage ).toBeVisible();
 	} );
 
-	test( 'creating navigation menus via keyboard without losing focus', async ( {
+	test( 'navigation manages focus for creating, editing, and deleting items', async ( {
 		admin,
 		page,
 		pageUtils,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -430,14 +430,8 @@ test.describe( 'Navigation block', () => {
 		/**
 		 * Test: We don't lose focus when closing the submenu appender
 		 */
+
 		// Move focus to the submenu navigation appender
-
-		/**
-		 * Test: We can open and close the preview with the keyboard and escape
-		 *       buttons from a submenu parent item using both the shortcut and toolbar
-		 */
-
-		// TODO: Update _how_ we reach the block appender. This is annoying to use.
 		await page.keyboard.press( 'End' );
 		await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 		await navigation.useBlockInserter();
@@ -463,7 +457,6 @@ test.describe( 'Navigation block', () => {
 
 		/**
 		 * Test: We can open and close the preview with the keyboard and escape
-		 *       buttons from a top-level nav link with a url-like label using
 		 *       both the shortcut and toolbar
 		 */
 		await pageUtils.pressKeys( 'ArrowLeft' );
@@ -474,8 +467,8 @@ test.describe( 'Navigation block', () => {
 
 		/**
 		 * Test: We can open and close the preview from a submenu navigation block (the top-level parent of a submenu)
+		 * using both the shortcut and toolbar
 		 */
-		// Navigate to our navigation submenu block
 		// Exit the toolbar
 		await page.keyboard.press( 'Escape' );
 		// Move to the submenu item
@@ -484,9 +477,11 @@ test.describe( 'Navigation block', () => {
 
 		// Check we're on our submenu link
 		await navigation.checkLabelFocus( 'example.com' );
+		// Test the shortcut
 		await navigation.useLinkShortcut();
 		await navigation.previewIsOpenAndCloses();
 		await navigation.checkLabelFocus( 'example.com' );
+		// Test the toolbar
 		await navigation.canUseToolbarLink();
 		await page.keyboard.press( 'Escape' );
 		await navigation.checkLabelFocus( 'example.com' );
@@ -606,10 +601,6 @@ class Navigation {
 		} );
 	}
 
-	getNavLink( label ) {
-		return this.editor.canvas.locator( 'a' ).filter( { hasText: label } );
-	}
-
 	getNavBlock() {
 		return this.editor.canvas.getByRole( 'document', {
 			name: 'Block: Navigation',
@@ -648,6 +639,11 @@ class Navigation {
 		await this.pageUtils.pressKeys( 'primary+k' );
 	}
 
+	/**
+	 * Moves focus to the toolbar and arrows to the button and activates it.
+	 *
+	 * @param {string} name the name of the toolbar button
+	 */
 	async useToolbarButton( name ) {
 		await this.pageUtils.pressKeys( 'alt+F10' );
 		await this.arrowToLabel( name );
@@ -665,6 +661,7 @@ class Navigation {
 	 * Adds a page via the link control and closes it.
 	 * Usage:
 	 * - Open the new link control however you'd like (block appender, command+k on Add link label...)
+	 *
 	 * @param {string} label Text of page you want added. Must be a part of the pages added in the beforeAll in this test suite.
 	 */
 	async addPage( label ) {
@@ -695,6 +692,7 @@ class Navigation {
 	 * Usage:
 	 * - Open the new link control however you'd like (block appender, command+k on Add link label...)
 	 * - Expect focus to return to the canvas with the url label highlighted
+	 *
 	 * @param {string} url URL you want added to the navigation
 	 */
 	async addCustomURL( url ) {
@@ -706,6 +704,7 @@ class Navigation {
 
 	/**
 	 * Checks if the passed string matches the current editor selection
+	 *
 	 * @param {string} text Text you want to see if it's selected
 	 */
 	async expectToHaveTextSelected( text ) {
@@ -717,10 +716,7 @@ class Navigation {
 	}
 
 	/**
-	 * Usage: Move focus to the nav block inserter. This will open and close it, and check the states.
-	 * Your code will need to:
-	 * 1. Place focus on the nav block appender
-	 * 2. Check that focus is back where you want it.
+	 * Closes the new link popover when used from the block appender
 	 */
 	async addLinkClose() {
 		const linkControlSearch = this.getLinkControlSearch();
@@ -733,8 +729,9 @@ class Navigation {
 	}
 
 	/**
-	 * Checks that a label has the correct text selected
-	 * Usage: Caret must be placed at the beginning of the nav label
+	 * Checks that we are focused on a specific navigation item.
+	 * It will return the caret to the beginning of the item.
+	 *
 	 * @param {string} label Nav label text
 	 */
 	async checkLabelFocus( label ) {
@@ -751,6 +748,7 @@ class Navigation {
 	 * - the preview is open
 	 * - has focus within it
 	 * - closes with Escape
+	 * - The popover is now hidden
 	 */
 	async previewIsOpenAndCloses() {
 		const linkPopover = this.getLinkPopover();


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/58820
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Focus when closing the link ui has not been managed. This PR fixes focus loss from:
- New link (+ appender) -> Escape (doesn't create link) -> Focuses closest sibling (adjacent or parent or navigation block)
- New link (+ appender) -> Create link -> Focuses the newly created navigation item
- Edit link ( primary + k) -> Escape -> Focuses navigation link item 
- Editing link from toolbar -> Focus sent back to link toolbar item
- Empty link click or primary + k -> Focuses navigation link item 
- All the same scenarios for submenus as well
- Bonus: Fixes an issue where having a url-like menu item will always be selected when the popover closes, instead of only on create

It also adds an extensive e2e test that checks for focus management and being able to create, use the link control, and delete navigation items and submenu items.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Accessibility, focus management. There were severe focus loss issues across the navigation block, especially when using the link control popover.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds openedBy state to navigation-link and submenu components and handles the various situations.

## Testing Instructions for Keyboard
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check for focus loss when interacting with the navigation block link ui only using your keyboard
- New link (+ appender) -> Escape (doesn't create link) -> Focuses closest sibling (adjacent or parent or navigation block)
- New link (+ appender) -> Create link -> Focuses the newly created navigation item
- Edit link ( primary + k) -> Escape -> Focuses navigation link item 
- Editing link from toolbar -> Focus sent back to link toolbar item
- Empty link click (Add label) or primary + k -> Focuses navigation link item 
- All the same scenarios for submenu items as well as submenu parents

For the navigation label selection issue:
- Create a link like "https//example.com"
- example.com label should be selected when closing the popover using Escape
- deselect the text
- Open the link popover again 
- Escape to close it
- example.com should not be selected

## Screenshots or screencast <!-- if applicable -->
This video shows all the steps in the "navigation manages focus for creating, editing, and deleting items" test in slowMo mode:

https://github.com/WordPress/gutenberg/assets/967608/ec52f469-1f23-4a7e-8535-e7dcb026eee7

