### PR TITLE
Fix: Invalid links to getting started with JavaScript.

### DIFF
--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -10,7 +10,7 @@ In WordPress lingo, a _format_ is a [HTML tag with text-level semantics](https:/
 
 ## Before you start
 
-This guide assumes you are already familiar with WordPress plugins and loading JavaScript with them, see the [Plugin Handbook](https://developer.wordpress.org/plugins/) or [JavaScript Tutorial](/docs/how-to-guides/javascript/README.md) to brush up.
+This guide assumes you are already familiar with WordPress plugins and loading JavaScript with them, see the [Plugin Handbook](https://developer.wordpress.org/plugins/) or [JavaScript Tutorial](/docs/getting-started/fundamentals/javascript-in-the-block-editor.md) to brush up.
 
 You will need:
 

--- a/docs/how-to-guides/metabox.md
+++ b/docs/how-to-guides/metabox.md
@@ -16,7 +16,7 @@ This guide shows how to create a block that prompts a user for a single value, a
 
 ## Before you start
 
-This guide assumes you are already familiar with WordPress plugins, post meta, and basic JavaScript. Review the [Getting started with JavaScript tutorial](/docs/how-to-guides/javascript/README.md) for an introduction.
+This guide assumes you are already familiar with WordPress plugins, post meta, and basic JavaScript. Review the [Getting started with JavaScript tutorial](/docs/getting-started/fundamentals/javascript-in-the-block-editor.md) for an introduction.
 
 The guide will walk through creating a basic block, but recommended to go through the [Create Block tutorial](/docs/getting-started/devenv/get-started-with-create-block.md) for a deeper understanding of creating custom blocks.
 

--- a/docs/how-to-guides/plugin-sidebar-0.md
+++ b/docs/how-to-guides/plugin-sidebar-0.md
@@ -10,7 +10,7 @@ _Note: this tutorial covers a custom sidebar, if you are looking to add controls
 
 ## Before you start
 
-The tutorial assumes you have an existing plugin setup and are ready to add PHP and JavaScript code. Please, refer to [Getting started with JavaScript](/docs/how-to-guides/javascript/README.md) tutorial for an introduction to WordPress plugins and how to use JavaScript to extend the block editor.
+The tutorial assumes you have an existing plugin setup and are ready to add PHP and JavaScript code. Please, refer to [Getting started with JavaScript](/docs/getting-started/fundamentals/javascript-in-the-block-editor.md) tutorial for an introduction to WordPress plugins and how to use JavaScript to extend the block editor.
 
 ## Step-by-step guide
 


### PR DESCRIPTION
The links to /docs/how-to-guides/javascript/README.md return a 404 e.g https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/javascript/README.md is invalid while /docs/getting-started/fundamentals/javascript-in-the-block-editor.md e.g: https://github.com/WordPress/gutenberg/blob/trunk/docs/getting-started/fundamentals/javascript-in-the-block-editor.md works as expected.


## Testing Instructions
Verified the changed links work as expected.
