### PR TITLE
Add php @global docs

### DIFF
--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -10,7 +10,7 @@
  *
  * @since 6.0.0
  *
- * @global WP_Query $wp_query              WordPress Query object.
+ * @global WP_Query $wp_query WordPress Query object.
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.

--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -10,6 +10,8 @@
  *
  * @since 6.0.0
  *
+ * @global WP_Query $wp_query              WordPress Query object.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -10,7 +10,7 @@
  *
  * @since 5.8.0
  *
- * @global WP_Query $wp_query              WordPress Query object.
+ * @global WP_Query $wp_query WordPress Query object.
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -10,6 +10,8 @@
  *
  * @since 5.8.0
  *
+ * @global WP_Query $wp_query              WordPress Query object.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -10,7 +10,7 @@
  *
  * @since 5.8.0
  *
- * @global WP_Query $wp_query              WordPress Query object.
+ * @global WP_Query $wp_query WordPress Query object.
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -10,6 +10,8 @@
  *
  * @since 5.8.0
  *
+ * @global WP_Query $wp_query              WordPress Query object.
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -10,7 +10,7 @@
  *
  * @since 5.9.0
  *
- * @global WP_Embed $wp_embed
+ * @global WP_Embed $wp_embed WordPress Embed object.
  *
  * @param array $attributes The block attributes.
  *

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -10,6 +10,8 @@
  *
  * @since 5.9.0
  *
+ * @global WP_Embed $wp_embed
+ *
  * @param array $attributes The block attributes.
  *
  * @return string The render.

--- a/packages/widgets/src/blocks/widget-group/index.php
+++ b/packages/widgets/src/blocks/widget-group/index.php
@@ -8,6 +8,9 @@
 /**
  * Renders the 'core/widget-group' block.
  *
+ * @global array $wp_registered_sidebars
+ * @global array $_sidebar_being_rendered
+ *
  * @param array    $attributes The block attributes.
  * @param string   $content The block content.
  * @param WP_Block $block The block.
@@ -59,6 +62,8 @@ add_action( 'init', 'register_block_core_widget_group' );
  * it. This lets us get to the current sidebar in
  * render_block_core_widget_group().
  *
+ * @global array $_sidebar_being_rendered
+ *
  * @param int|string $index       Index, name, or ID of the dynamic sidebar.
  */
 function note_sidebar_being_rendered( $index ) {
@@ -70,6 +75,8 @@ add_action( 'dynamic_sidebar_before', 'note_sidebar_being_rendered' );
 /**
  * Clear whatever we set in note_sidebar_being_rendered() after WordPress
  * finishes rendering a sidebar.
+ *
+ * @global array $_sidebar_being_rendered
  */
 function discard_sidebar_being_rendered() {
 	global $_sidebar_being_rendered;

--- a/packages/widgets/src/blocks/widget-group/index.php
+++ b/packages/widgets/src/blocks/widget-group/index.php
@@ -76,7 +76,7 @@ add_action( 'dynamic_sidebar_before', 'note_sidebar_being_rendered' );
  * Clear whatever we set in note_sidebar_being_rendered() after WordPress
  * finishes rendering a sidebar.
  *
- * @global array $_sidebar_being_rendered
+ * @global int|string $_sidebar_being_rendered
  */
 function discard_sidebar_being_rendered() {
 	global $_sidebar_being_rendered;

--- a/packages/widgets/src/blocks/widget-group/index.php
+++ b/packages/widgets/src/blocks/widget-group/index.php
@@ -76,7 +76,7 @@ add_action( 'dynamic_sidebar_before', 'note_sidebar_being_rendered' );
  * Clear whatever we set in note_sidebar_being_rendered() after WordPress
  * finishes rendering a sidebar.
  *
- * @global int|string $_sidebar_being_rendered 
+ * @global int|string $_sidebar_being_rendered
  */
 function discard_sidebar_being_rendered() {
 	global $_sidebar_being_rendered;

--- a/packages/widgets/src/blocks/widget-group/index.php
+++ b/packages/widgets/src/blocks/widget-group/index.php
@@ -8,8 +8,8 @@
 /**
  * Renders the 'core/widget-group' block.
  *
- * @global array $wp_registered_sidebars
- * @global array $_sidebar_being_rendered
+ * @global array      $wp_registered_sidebars
+ * @global int|string $_sidebar_being_rendered
  *
  * @param array    $attributes The block attributes.
  * @param string   $content The block content.
@@ -62,7 +62,7 @@ add_action( 'init', 'register_block_core_widget_group' );
  * it. This lets us get to the current sidebar in
  * render_block_core_widget_group().
  *
- * @global array $_sidebar_being_rendered
+ * @global int|string $_sidebar_being_rendered
  *
  * @param int|string $index       Index, name, or ID of the dynamic sidebar.
  */

--- a/packages/widgets/src/blocks/widget-group/index.php
+++ b/packages/widgets/src/blocks/widget-group/index.php
@@ -76,7 +76,7 @@ add_action( 'dynamic_sidebar_before', 'note_sidebar_being_rendered' );
  * Clear whatever we set in note_sidebar_being_rendered() after WordPress
  * finishes rendering a sidebar.
  *
- * @global int|string $_sidebar_being_rendered
+ * @global int|string $_sidebar_being_rendered 
  */
 function discard_sidebar_being_rendered() {
 	global $_sidebar_being_rendered;


### PR DESCRIPTION
Added `@global` documentation according to [PHP Doc Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) in below files:

1.  packages/block-library/src/query-no-results/index.php
2.  packages/block-library/src/query-pagination-next/index.php
3.  packages/block-library/src/query-pagination-numbers/index.php
4.  packages/block-library/src/template-part/index.php
5.  packages/widgets/src/blocks/widget-group/index.php


**Fixes:** https://github.com/WordPress/gutenberg/issues/59930