### PR TITLE
Font Library: fix JS errors when activating or deactivating system fonts

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -425,15 +425,15 @@ function FontLibraryProvider( { children } ) {
 
 		const isFaceActivated = isFontActivated(
 			font.slug,
-			face.fontStyle,
-			face.fontWeight,
+			face?.fontStyle,
+			face?.fontWeight,
 			font.source
 		);
 
 		if ( isFaceActivated ) {
 			loadFontFaceInBrowser(
 				face,
-				getDisplaySrcFromFontFace( face.src ),
+				getDisplaySrcFromFontFace( face?.src ),
 				'all'
 			);
 		} else {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -134,9 +134,9 @@ export function unloadFontFaceInBrowser( fontFace, removeFrom = 'all' ) {
 	const unloadFontFace = ( fonts ) => {
 		fonts.forEach( ( f ) => {
 			if (
-				f.family === formatFontFaceName( fontFace.fontFamily ) &&
-				f.weight === fontFace.fontWeight &&
-				f.style === fontFace.fontStyle
+				f.family === formatFontFaceName( fontFace?.fontFamily ) &&
+				f.weight === fontFace?.fontWeight &&
+				f.style === fontFace?.fontStyle
 			) {
 				fonts.delete( f );
 			}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -87,6 +87,10 @@ export function formatFontFamily( input ) {
  * formatFontFaceName(", 'Open Sans', 'Helvetica Neue', sans-serif") => "Open Sans"
  */
 export function formatFontFaceName( input ) {
+	if ( ! input ) {
+		return '';
+	}
+
 	let output = input.trim();
 	if ( output.includes( ',' ) ) {
 		output = output


### PR DESCRIPTION
## What?

Fix JS errors in the Font Library when activating or deactivating a system font (font family without font faces)

Found while reviewing https://github.com/WordPress/gutenberg/pull/59910

## How?

- Adding optional chaining checks (e.g. `face?.fontStyle`) when displaying font faces
- Checking for empty input in `formatFontFaceName` (matching the similar server-side function, `WP_Font_Utils::sanitize_font_family`)

## Testing Instructions

- Install and activating the ["Modern Font Stacks" plugin](https://github.com/matiasbenedetto/modern-fonts-stacks-for-wp-font-library), or register your own system fonts collection
- Install one of the system fonts
- Go to the newly installed font in the font library, and uncheck/check the font to deactivate and reactivate it
- Without this PR, you will see JS console errors, such as `Uncaught TypeError: can't access property "fontStyle", t is undefined`
- With this PR, you should not see any errors