### PR TITLE
BlockSettingsDropdown: No need to cast 'clientIds' to an array

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -98,16 +98,10 @@ export default function BlockActions( {
 			return removeBlocks( clientIds, updateSelection );
 		},
 		onInsertBefore() {
-			const clientId = Array.isArray( clientIds )
-				? clientIds[ 0 ]
-				: clientId;
-			insertBeforeBlock( clientId );
+			insertBeforeBlock( clientIds[ 0 ] );
 		},
 		onInsertAfter() {
-			const clientId = Array.isArray( clientIds )
-				? clientIds[ clientIds.length - 1 ]
-				: clientId;
-			insertAfterBlock( clientId );
+			insertAfterBlock( clientIds[ clientIds.length - 1 ] );
 		},
 		onMoveTo() {
 			setNavigationMode( true );

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -46,18 +46,15 @@ function CopyMenuItem( { clientIds, onCopy, label } ) {
 export function BlockSettingsDropdown( {
 	block,
 	clientIds,
-	__experimentalSelectBlock,
 	children,
+	__experimentalSelectBlock,
 	__unstableDisplayLocation,
 	...props
 } ) {
 	// Get the client id of the current block for this menu, if one is set.
 	const currentClientId = block?.clientId;
-	const blockClientIds = Array.isArray( clientIds )
-		? clientIds
-		: [ clientIds ];
-	const count = blockClientIds.length;
-	const firstBlockClientId = blockClientIds[ 0 ];
+	const count = clientIds.length;
+	const firstBlockClientId = clientIds[ 0 ];
 	const {
 		firstParentClientId,
 		onlyBlock,


### PR DESCRIPTION
## What?
PR removes unnecessary casting to an array of `clientIds` for the `BlockSettingsDropdown` and fixes leftover logic in `BlockActions` component.

## Why?
The parent `BlockSettingsMenu` component always receives `clientIds` as an array.

* [Block Toolbar](https://github.com/WordPress/gutenberg/blob/72b9ffa48a265bdd3c7963862863f61a24e87cad/packages/block-editor/src/components/block-toolbar/index.js#L225) - IDs come from the `getSelectedBlockClientIds` selector, which always returns an array.
* List View - consumer here [ensures](https://github.com/WordPress/gutenberg/blob/72b9ffa48a265bdd3c7963862863f61a24e87cad/packages/block-editor/src/components/list-view/block.js#L304-L306) to pass an array as required.

## Testing Instructions
1. Open a post or page.
2. Insert blocks.
3. Open the block settings dropdown. Test list view as well.
4. Action should produce any errors.
5. Try inserting a block before and after.
6. The action should work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-03-18 at 08 54 21](https://github.com/WordPress/gutenberg/assets/240569/1dde93a3-24a3-4ed5-83ad-9cee7cab600a)
