### PR TITLE
BlockSettingsMenuControls: Remove '__unstableDisplayLocation' prop

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/README.md
+++ b/packages/block-editor/src/components/block-settings-menu-controls/README.md
@@ -16,12 +16,3 @@ function ReusableBlocksMenuItems() {
 	);
 }
 ```
-
-## Props
-
-### `__unstableDisplayLocation`
-
--   **Type:** `String`
--   **Default:** `undefined`
-
-A string representing the location where the component is being displayed within the UI. This can be used to conditionalize certain behaviors including the display of associated components. This behaviour will likely be refactored to a React.Context implementation.

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -26,11 +26,7 @@ import { BlockRenameControl, useBlockRename } from '../block-rename';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
-const BlockSettingsMenuControlsSlot = ( {
-	fillProps,
-	clientIds = null,
-	__unstableDisplayLocation,
-} ) => {
+const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 	const { selectedBlocks, selectedClientIds } = useSelect(
 		( select ) => {
 			const { getBlockNamesByClientId, getSelectedBlockClientIds } =
@@ -61,7 +57,6 @@ const BlockSettingsMenuControlsSlot = ( {
 		<Slot
 			fillProps={ {
 				...fillProps,
-				__unstableDisplayLocation,
 				selectedBlocks,
 				selectedClientIds,
 			} }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -48,7 +48,6 @@ export function BlockSettingsDropdown( {
 	clientIds,
 	children,
 	__experimentalSelectBlock,
-	__unstableDisplayLocation,
 	...props
 } ) {
 	// Get the client id of the current block for this menu, if one is set.
@@ -338,9 +337,6 @@ export function BlockSettingsDropdown( {
 									firstBlockClientId,
 								} }
 								clientIds={ clientIds }
-								__unstableDisplayLocation={
-									__unstableDisplayLocation
-								}
 							/>
 							{ typeof children === 'function'
 								? children( { onClose } )


### PR DESCRIPTION
## What?
PR removes unused `__unstableDisplayLocation` prop introduced in #43987.

## Why?
It's not used by Core, and all the PRs cited in the original #43987 have been closed.

## Testing Instructions
1. Open a post or page.
2. Instert a block.
3. Confirm that the block settings dropdown works as before.

### Testing Instructions for Keyboard
Same.
