### PR TITLE
FlatTermSelector: Invalidate optimistic update if term creation fails

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -40,10 +40,13 @@ const isSameTermName = ( termA, termB ) =>
 	unescapeString( termB ).toLowerCase();
 
 const termNamesToIds = ( names, terms ) => {
-	return names.map(
-		( termName ) =>
-			terms.find( ( term ) => isSameTermName( term.name, termName ) ).id
-	);
+	return names
+		.map(
+			( termName ) =>
+				terms.find( ( term ) => isSameTermName( term.name, termName ) )
+					?.id
+		)
+		.filter( ( id ) => id !== undefined );
 };
 
 export function FlatTermSelector( { slug } ) {
@@ -193,9 +196,8 @@ export function FlatTermSelector( { slug } ) {
 		setValues( uniqueTerms );
 
 		if ( newTermNames.length === 0 ) {
-			return onUpdateTerms(
-				termNamesToIds( uniqueTerms, availableTerms )
-			);
+			onUpdateTerms( termNamesToIds( uniqueTerms, availableTerms ) );
+			return;
 		}
 
 		if ( ! hasCreateAction ) {
@@ -209,7 +211,7 @@ export function FlatTermSelector( { slug } ) {
 		)
 			.then( ( newTerms ) => {
 				const newAvailableTerms = availableTerms.concat( newTerms );
-				return onUpdateTerms(
+				onUpdateTerms(
 					termNamesToIds( uniqueTerms, newAvailableTerms )
 				);
 			} )
@@ -217,6 +219,9 @@ export function FlatTermSelector( { slug } ) {
 				createErrorNotice( error.message, {
 					type: 'snackbar',
 				} );
+				// In case of a failure, try assigning available terms.
+				// This will invalidate the optimistic update.
+				onUpdateTerms( termNamesToIds( uniqueTerms, availableTerms ) );
 			} );
 	}
 


### PR DESCRIPTION
## What?
Fixes #39130.

PR fixes and improves error handling for the `FlatTermSelector`. This prevents optimistic update artifacts from being displayed if the creation of a new term fails.

## Why?
The `FlatTermSelector` uses an internal state to handle optimistic updates and provide better UX. The state should be invalidated when WP data selectors fetch new values, but the invalidation logic didn't account for term creation errors.

P.S. The component had no error handling until #53369.

## How?
Add a call to `onUpdateTerms` when there's an error during the term creation.

## Testing Instructions
1. Open a post.
2. Add a few tags to it.
3. Emulate term creation error using the test snippet.
4. Try creating a new tag by typing a unique name and pressing the <kbd>Enter</kbd> key.
5. Confirm that the error notice is displayed.
6. Confirm that the new tag is removed from the token list


### Test snippet
```php
add_filter('pre_insert_term', function ($term, $taxonomy) {
    return new \WP_Error('test_fail', 'Test fail!', [
        'status' => 400,
    ]);
}, 10, 2);
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/6de69c47-8cc5-4d7d-a5a3-c136dd0b01db

