### PR TITLE
Cherry Pick changes for WordPress 6.5 RC3

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -30,15 +30,16 @@ export const settings = {
 		const { content, level } = attributes;
 
 		const customName = attributes?.metadata?.name;
+		const hasContent = content?.length > 0;
 
 		// In the list view, use the block's content as the label.
 		// If the content is empty, fall back to the default label.
-		if ( context === 'list-view' && ( customName || content ) ) {
-			return attributes?.metadata?.name || content;
+		if ( context === 'list-view' && ( customName || hasContent ) ) {
+			return customName || content;
 		}
 
 		if ( context === 'accessibility' ) {
-			return ! content || content.length === 0
+			return ! hasContent
 				? sprintf(
 						/* translators: accessibility text. %s: heading level. */
 						__( 'Level %s. Empty.' ),

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -333,6 +333,7 @@ export default function NavigationLinkEdit( {
 			isKeyboardEvent.primary( event, 'k' ) ||
 			( ( ! url || isDraft || isInvalid ) && event.keyCode === ENTER )
 		) {
+			event.preventDefault();
 			setIsLinkOpen( true );
 		}
 	}

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -279,6 +279,7 @@ export default function NavigationSubmenuEdit( {
 
 	function onKeyDown( event ) {
 		if ( isKeyboardEvent.primary( event, 'k' ) ) {
+			event.preventDefault();
 			setIsLinkOpen( true );
 		}
 	}

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -342,16 +342,7 @@ function Navigation( {
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
 	const onSelectClassicMenu = async ( classicMenu ) => {
-		const navMenu = await convertClassicMenu(
-			classicMenu.id,
-			classicMenu.name,
-			'draft'
-		);
-		if ( navMenu ) {
-			handleUpdateMenu( navMenu.id, {
-				focusNavigationBlock: true,
-			} );
-		}
+		return convertClassicMenu( classicMenu.id, classicMenu.name, 'draft' );
 	};
 
 	const onSelectNavigationMenu = ( menuId ) => {
@@ -402,6 +393,9 @@ function Navigation( {
 			showClassicMenuConversionNotice(
 				__( 'Classic menu imported successfully.' )
 			);
+			handleUpdateMenu( createNavigationMenuPost?.id, {
+				focusNavigationBlock: true,
+			} );
 		}
 
 		if ( classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_ERROR ) {
@@ -414,6 +408,8 @@ function Navigation( {
 		classicMenuConversionError,
 		hideClassicMenuConversionNotice,
 		showClassicMenuConversionNotice,
+		createNavigationMenuPost?.id,
+		handleUpdateMenu,
 	] );
 
 	useEffect( () => {
@@ -866,50 +862,52 @@ function Navigation( {
 					</InspectorControls>
 				) }
 
-				{ isLoading && (
-					<TagName { ...blockProps }>
+				<TagName
+					{ ...blockProps }
+					aria-describedby={
+						! isPlaceholder && ! isLoading
+							? accessibleDescriptionId
+							: undefined
+					}
+				>
+					{ isLoading && (
 						<div className="wp-block-navigation__loading-indicator-container">
 							<Spinner className="wp-block-navigation__loading-indicator" />
 						</div>
-					</TagName>
-				) }
+					) }
 
-				{ ! isLoading && (
-					<TagName
-						{ ...blockProps }
-						aria-describedby={
-							! isPlaceholder
-								? accessibleDescriptionId
-								: undefined
-						}
-					>
-						<AccessibleMenuDescription
-							id={ accessibleDescriptionId }
-						/>
-						<ResponsiveWrapper
-							id={ clientId }
-							onToggle={ setResponsiveMenuVisibility }
-							hasIcon={ hasIcon }
-							icon={ icon }
-							isOpen={ isResponsiveMenuOpen }
-							isResponsive={ isResponsive }
-							isHiddenByDefault={ 'always' === overlayMenu }
-							overlayBackgroundColor={ overlayBackgroundColor }
-							overlayTextColor={ overlayTextColor }
-						>
-							{ isEntityAvailable && (
-								<NavigationInnerBlocks
-									clientId={ clientId }
-									hasCustomPlaceholder={
-										!! CustomPlaceholder
-									}
-									templateLock={ templateLock }
-									orientation={ orientation }
-								/>
-							) }
-						</ResponsiveWrapper>
-					</TagName>
-				) }
+					{ ! isLoading && (
+						<>
+							<AccessibleMenuDescription
+								id={ accessibleDescriptionId }
+							/>
+							<ResponsiveWrapper
+								id={ clientId }
+								onToggle={ setResponsiveMenuVisibility }
+								hasIcon={ hasIcon }
+								icon={ icon }
+								isOpen={ isResponsiveMenuOpen }
+								isResponsive={ isResponsive }
+								isHiddenByDefault={ 'always' === overlayMenu }
+								overlayBackgroundColor={
+									overlayBackgroundColor
+								}
+								overlayTextColor={ overlayTextColor }
+							>
+								{ isEntityAvailable && (
+									<NavigationInnerBlocks
+										clientId={ clientId }
+										hasCustomPlaceholder={
+											!! CustomPlaceholder
+										}
+										templateLock={ templateLock }
+										orientation={ orientation }
+									/>
+								) }
+							</ResponsiveWrapper>
+						</>
+					) }
+				</TagName>
 			</RecursionProvider>
 		</EntityProvider>
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1465,6 +1465,14 @@ function block_core_navigation_set_ignored_hooked_blocks_metadata( $inner_blocks
  */
 function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 	/*
+	 * In this scenario the user has likely tried to create a navigation via the REST API.
+	 * In which case we won't have a post ID to work with and store meta against.
+	 */
+	if ( empty( $post->ID ) ) {
+		return $post;
+	}
+
+	/*
 	 * We run the Block Hooks mechanism to inject the `metadata.ignoredHookedBlocks` attribute into
 	 * all anchor blocks. For the root level, we create a mock Navigation and extract them from there.
 	 */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -135,9 +135,9 @@ class WP_Navigation_Block_Renderer {
 			if ( static::does_block_need_a_list_item_wrapper( $inner_block ) ) {
 				return '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
 			}
-
-			return $inner_block_content;
 		}
+
+		return $inner_block_content;
 	}
 
 	/**

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test/deferred-store",
+	"title": "E2E Interactivity tests - deferred store",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * HTML for testing scope restoration with generators.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+?>
+
+<div
+	data-wp-interactive="test/deferred-store"
+	<?php echo wp_interactivity_data_wp_context( array( 'text' => '!dlrow ,olleH' ) ); ?>
+>
+	<span data-wp-text="state.reversedText" data-testid="result"></span>
+	<span data-wp-text="state.reversedTextGetter" data-testid="result-getter"></span>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	setTimeout( () => {
+		store( 'test/deferred-store', {
+			state: {
+				reversedText() {
+					return [ ...getContext().text ].reverse().join( '' );
+				},
+
+				get reversedTextGetter() {
+					return [ ...getContext().text ].reverse().join( '' );
+				},
+			},
+		} );
+	}, 50 );
+} );

--- a/packages/e2e-tests/plugins/interactive-blocks/store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/store/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * HTML for testing the directive `data-wp-bind`.
+ * HTML for testing the `store` function.
  *
  * @package gutenberg-test-interactive-blocks
  */
@@ -9,6 +9,7 @@ wp_enqueue_script_module( 'store-view' );
 ?>
 
 <div data-wp-interactive="test/store">
+	<div data-wp-text="state.0" data-testid="state-0"></div>
 	<div
 		data-testid="non-plain object"
 		data-wp-text="state.isNotProxified"

--- a/packages/e2e-tests/plugins/interactive-blocks/store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/store/view.js
@@ -3,18 +3,21 @@
  */
 import { store, getElement } from '@wordpress/interactivity';
 
+// A non-object state should never be allowed.
+store( 'test/store', { state: [ 'wrong' ] } );
 
 const { state } = store( 'test/store', {
 	state: {
+		0: 'right',
 		get isNotProxified() {
 			const { ref } = getElement();
 			return state.elementRef === ref;
-		}
+		},
 	},
 	callbacks: {
 		init() {
 			const { ref } = getElement();
 			state.elementRef = ref; // HTMLElement
-		}
-	}
-} )
+		},
+	},
+} );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -425,15 +425,15 @@ function FontLibraryProvider( { children } ) {
 
 		const isFaceActivated = isFontActivated(
 			font.slug,
-			face.fontStyle,
-			face.fontWeight,
+			face?.fontStyle,
+			face?.fontWeight,
 			font.source
 		);
 
 		if ( isFaceActivated ) {
 			loadFontFaceInBrowser(
 				face,
-				getDisplaySrcFromFontFace( face.src ),
+				getDisplaySrcFromFontFace( face?.src ),
 				'all'
 			);
 		} else {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -274,8 +274,22 @@ function FontLibraryProvider( { children } ) {
 						...alreadyInstalledFontFaces,
 					];
 					fontFamiliesToActivate.push( fontFamilyToInstall );
-				} else if ( isANewFontFamily ) {
-					// If the font family is new, delete it to avoid having font families without font faces.
+				}
+
+				// If it's a system font but was installed successfully, activate it.
+				if (
+					installedFontFamily &&
+					! fontFamilyToInstall?.fontFace?.length
+				) {
+					fontFamiliesToActivate.push( installedFontFamily );
+				}
+
+				// If the font family is new and is not a system font, delete it to avoid having font families without font faces.
+				if (
+					isANewFontFamily &&
+					fontFamilyToInstall?.fontFace?.length > 0 &&
+					sucessfullyInstalledFontFaces?.length === 0
+				) {
 					await fetchUninstallFontFamily( installedFontFamily.id );
 				}
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -134,9 +134,9 @@ export function unloadFontFaceInBrowser( fontFace, removeFrom = 'all' ) {
 	const unloadFontFace = ( fonts ) => {
 		fonts.forEach( ( f ) => {
 			if (
-				f.family === formatFontFaceName( fontFace.fontFamily ) &&
-				f.weight === fontFace.fontWeight &&
-				f.style === fontFace.fontStyle
+				f.family === formatFontFaceName( fontFace?.fontFamily ) &&
+				f.weight === fontFace?.fontWeight &&
+				f.style === fontFace?.fontStyle
 			) {
 				fonts.delete( f );
 			}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -87,6 +87,10 @@ export function formatFontFamily( input ) {
  * formatFontFaceName(", 'Open Sans', 'Helvetica Neue', sans-serif") => "Open Sans"
  */
 export function formatFontFaceName( input ) {
+	if ( ! input ) {
+		return '';
+	}
+
 	let output = input.trim();
 	if ( output.includes( ',' ) ) {
 		output = output

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Ensure that stores are available for subscription before hydration. ([#59842](https://github.com/WordPress/gutenberg/pull/59842))
 -   Ensure scope is restored when catching exceptions thrown in async generator actions. ([#59708](https://github.com/WordPress/gutenberg/pull/59708))
 
 ## 5.2.0 (2024-03-06)

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Prevent non-objects from being set in store state. ([#59886](https://github.com/WordPress/gutenberg/pull/59886))
 -   Ensure that stores are available for subscription before hydration. ([#59842](https://github.com/WordPress/gutenberg/pull/59842))
 -   Ensure scope is restored when catching exceptions thrown in async generator actions. ([#59708](https://github.com/WordPress/gutenberg/pull/59708))
 

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -15,7 +15,7 @@ import type { VNode, Context, RefObject } from 'preact';
 /**
  * Internal dependencies
  */
-import { stores } from './store';
+import { store, stores, universalUnlock } from './store';
 interface DirectiveEntry {
 	value: string | Object;
 	namespace: string;
@@ -259,8 +259,14 @@ export const directive = (
 
 // Resolve the path to some property of the store object.
 const resolve = ( path, namespace ) => {
+	let resolvedStore = stores.get( namespace );
+	if ( typeof resolvedStore === 'undefined' ) {
+		resolvedStore = store( namespace, undefined, {
+			lock: universalUnlock,
+		} );
+	}
 	let current = {
-		...stores.get( namespace ),
+		...resolvedStore,
 		context: getScope().context[ namespace ],
 	};
 	path.split( '.' ).forEach( ( p ) => ( current = current[ p ] ) );

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -202,7 +202,7 @@ interface StoreOptions {
 	lock?: boolean | string;
 }
 
-const universalUnlock =
+export const universalUnlock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
 /**

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -274,7 +274,10 @@ export function store(
 		if ( lock !== universalUnlock ) {
 			storeLocks.set( namespace, lock );
 		}
-		const rawStore = { state: deepSignal( state ), ...block };
+		const rawStore = {
+			state: deepSignal( isObject( state ) ? state : {} ),
+			...block,
+		};
 		const proxiedStore = new Proxy( rawStore, handlers );
 		rawStores.set( namespace, rawStore );
 		stores.set( namespace, proxiedStore );

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -59,7 +59,7 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	 */
 	public function test_block_core_navigation_update_ignore_hooked_blocks_meta_preserves_entities() {
 		if ( ! function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
-			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionalit.' );
+			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionality.' );
 		}
 
 		register_block_type(
@@ -90,6 +90,36 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 			array( 'tests/my-block' ),
 			json_decode( get_post_meta( self::$navigation_post->ID, '_wp_ignored_hooked_blocks', true ), true ),
 			'Block was not added to ignored hooked blocks metadata.'
+		);
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
+	 */
+	public function test_block_core_navigation_dont_modify_no_post_id() {
+		if ( ! function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
+			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionality.' );
+		}
+
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/navigation' => 'last_child',
+				),
+			)
+		);
+
+		$original_markup    = '<!-- wp:navigation-link {"label":"News","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
+		$post               = new stdClass();
+		$post->post_content = $original_markup;
+
+		$post = gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta( $post );
+
+		$this->assertSame(
+			$original_markup,
+			$post->post_content,
+			'Post content did not match the original markup.'
 		);
 	}
 }

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -292,6 +292,56 @@ test.describe( 'Heading', () => {
 		] );
 	} );
 
+	test( 'Should have proper label in the list view', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/heading' } );
+
+		await editor.publishPost();
+		await page.reload();
+
+		await page
+			.getByRole( 'toolbar', { name: 'Document tools' } )
+			.getByRole( 'button', { name: 'Document Overview' } )
+			.click();
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect(
+			listView.getByRole( 'link' ),
+			'should show default block name if the content is empty'
+		).toHaveText( 'Heading' );
+
+		await editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Heading',
+			} )
+			.fill( 'Heading content' );
+
+		await expect(
+			listView.getByRole( 'link' ),
+			'should show content'
+		).toHaveText( 'Heading content' );
+
+		await editor.openDocumentSettingsSidebar();
+
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+
+		await page
+			.getByRole( 'textbox', {
+				name: 'Block name',
+			} )
+			.fill( 'My new name' );
+
+		await expect(
+			listView.getByRole( 'link' ),
+			'should show custom name'
+		).toHaveText( 'My new name' );
+	} );
+
 	test.describe( 'Block transforms', () => {
 		test.describe( 'FROM paragraph', () => {
 			test( 'should preserve the content', async ( { editor } ) => {

--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -543,6 +543,48 @@ test.describe( 'Navigation block - List view editing', () => {
 		// we have unmounted the list view and then remounted it).
 		await expect( linkControl.getSearchInput() ).toBeHidden();
 	} );
+
+	test( `can create a new menu without losing focus`, async ( {
+		page,
+		editor,
+		requestUtils,
+	} ) => {
+		await requestUtils.createNavigationMenu( navMenuBlocksFixture );
+
+		await editor.insertBlock( { name: 'core/navigation' } );
+
+		await editor.openDocumentSettingsSidebar();
+
+		await page.getByLabel( 'Test Menu' ).click();
+
+		await page.keyboard.press( 'ArrowUp' );
+
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Create new menu' } )
+		).toBeFocused();
+
+		await page.keyboard.press( 'Enter' );
+
+		// Check that the menu was created
+		await expect(
+			page
+				.getByTestId( 'snackbar' )
+				.getByText( 'Navigation Menu successfully created.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'This navigation menu is empty.' )
+		).toBeVisible();
+
+		// Move focus to the appender
+		await page.keyboard.press( 'ArrowDown' );
+		await expect(
+			editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Navigation',
+				} )
+				.getByLabel( 'Add block' )
+		).toBeFocused();
+	} );
 } );
 
 class LinkControl {

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'deferred store', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/deferred-store' );
+	} );
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/deferred-store' ) );
+	} );
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'Ensure that a store can be subscribed to before it is initialized', async ( {
+		page,
+	} ) => {
+		const resultInput = page.getByTestId( 'result' );
+		await expect( resultInput ).toHaveText( '' );
+		await expect( resultInput ).toHaveText( 'Hello, world!' );
+	} );
+
+	// There is a known issue for deferred getters right now.
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'Ensure that a state getter can be subscribed to before it is initialized', async ( {
+		page,
+	} ) => {
+		const resultInput = page.getByTestId( 'result-getter' );
+		await expect( resultInput ).toHaveText( '' );
+		await expect( resultInput ).toHaveText( 'Hello, world!' );
+	} );
+} );

--- a/test/e2e/specs/interactivity/store.spec.ts
+++ b/test/e2e/specs/interactivity/store.spec.ts
@@ -3,7 +3,7 @@
  */
 import { test, expect } from './fixtures';
 
-test.describe( 'data-wp-bind', () => {
+test.describe( 'store', () => {
 	test.beforeAll( async ( { interactivityUtils: utils } ) => {
 		await utils.activatePlugins();
 		await utils.addPostWithBlock( 'test/store' );
@@ -21,5 +21,12 @@ test.describe( 'data-wp-bind', () => {
 	test( 'non-plain objects are not proxified', async ( { page } ) => {
 		const el = page.getByTestId( 'non-plain object' );
 		await expect( el ).toHaveText( 'true' );
+	} );
+
+	test( 'Ensures that state cannot be set to a non-object', async ( {
+		page,
+	} ) => {
+		const element = page.getByTestId( 'state-0' );
+		await expect( element ).toHaveText( 'right' );
 	} );
 } );


### PR DESCRIPTION
It includes the following fixes:

   #59845 – Prevent default on primary+k to prevent command center from opening on navigation link
   #59820 – Ensure consistent return type in `WP_Navigation_Block_Renderer::get_markup_for_inner_block()`
   #59801 – Do not focus new navigation block menu until loading is finished
   #59842 – Interactivity: Ensure stores are initialized on client
   #59875 – Block Hooks: Return early from saving meta data for the navigation without a $post->ID
   #59886 – Interactivity API: Prevent non-object state from being added
   #59910 – Avoid auto-removing font families without font faces
   #59827 – Heading Block: Show default block name in list view when content is empty
   #59935 – Font Library: fix JS errors when activating or deactivating system fonts