### PR TITLE
DataViews: add AND logic operators to filters

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancement
 
+- Two new operators have been added: `isAll` and `isNotAll`. These are meant to represent `AND` operations. For example, `Category is all: Book, Review, Science Fiction` would represent all items that have all three categories selected.
 - DataViews now supports multi-selection. A new set of filter operators has been introduced: `is`, `isNot`, `isAny`, `isNone`. Single-selection operators are `is` and `isNot`, and multi-selection operators are `isAny` and `isNone`. If no operators are declared for a filter, it will support multi-selection. Additionally, the old filter operators `in` and `notIn` operators have been deprecated and will work as `is` and `isNot` respectively. Please, migrate to the new operators as they'll be removed soon.
 
 ## 0.7.0 (2024-03-06)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -305,12 +305,16 @@ Callback that signals the user triggered the details for one of more items, and 
 
 Allowed operators for fields of type `enumeration`:
 
-- `is`: whether the item is equal to a single value.
-- `isNot`: whether the item is not equal to a single value.
-- `isAny`: whether the item is present in a list of values.
-- `isNone`: whether the item is not present in a list of values.
+| Operator | Selection | Description | Example |
+| --- | ---  | --- | --- |
+| `is` | Single item | `EQUAL TO`. The item's field is equal to a single value. | Author is Admin |
+| `isNot` | Single item | `NOT EQUAL TO`. The item's field is not equal to a single value. | Author is not Admin |
+| `isAny` | Multiple items | `OR`. The item's field is present in a list of values. | Author is any: Admin, Editor |
+| `isNone` | Multiple items | `NOT OR`. The item's field is not present in a list of values. | Author is none: Admin, Editor |
+| `isAll` | Multiple items | `AND`. The item's field has all of the values in the list. | Category is all: Book, Review, Science Fiction |
+| `isNotAll` | Multiple items | `NOT AND`. The item's field doesn't have all of the values in the list. | Category is not all: Book, Review, Science Fiction |
 
-`is` and `isNot` are single-selection operators, while `isAny` and `isNone` are multi-selection. By default, a filter with no operators declared will support multi-selection. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded and the filter won't allow selecting more than one item.
+`is` and `isNot` are single-selection operators, while `isAny`, `isNone`, `isAll`, and `isNotALl` are multi-selection. By default, a filter with no operators declared will support the `isAny` and `isNone` multi-selection operators. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded and the filter won't allow selecting more than one item.
 
 > The legacy operators `in` and `notIn` have been deprecated and will be removed soon. In the meantime, they work as `is` and `isNot` operators, respectively.
 

--- a/packages/dataviews/src/constants.js
+++ b/packages/dataviews/src/constants.js
@@ -24,11 +24,16 @@ export const OPERATOR_IS = 'is';
 export const OPERATOR_IS_NOT = 'isNot';
 export const OPERATOR_IS_ANY = 'isAny';
 export const OPERATOR_IS_NONE = 'isNone';
+export const OPERATOR_IS_ALL = 'isAll';
+export const OPERATOR_IS_NOT_ALL = 'isNotAll';
+
 export const ALL_OPERATORS = [
 	OPERATOR_IS,
 	OPERATOR_IS_NOT,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
+	OPERATOR_IS_ALL,
+	OPERATOR_IS_NOT_ALL,
 ];
 export const OPERATORS = {
 	[ OPERATOR_IS ]: {
@@ -46,6 +51,14 @@ export const OPERATORS = {
 	[ OPERATOR_IS_NONE ]: {
 		key: 'is-none-filter',
 		label: __( 'Is none' ),
+	},
+	[ OPERATOR_IS_ALL ]: {
+		key: 'is-all-filter',
+		label: __( 'Is all' ),
+	},
+	[ OPERATOR_IS_NOT_ALL ]: {
+		key: 'is-not-all-filter',
+		label: __( 'Is not all' ),
 	},
 };
 

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -30,6 +30,8 @@ import {
 	OPERATOR_IS_NOT,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
+	OPERATOR_IS_ALL,
+	OPERATOR_IS_NOT_ALL,
 } from './constants';
 
 const FilterText = ( { activeElements, filterInView, filter } ) => {
@@ -59,6 +61,30 @@ const FilterText = ( { activeElements, filterInView, filter } ) => {
 			sprintf(
 				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is none: Admin, Editor". */
 				__( '<Name>%1$s is none: </Name><Value>%2$s</Value>' ),
+				filter.name,
+				activeElements.map( ( element ) => element.label ).join( ', ' )
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_IS_ALL ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is all: Admin, Editor". */
+				__( '<Name>%1$s is all: </Name><Value>%2$s</Value>' ),
+				filter.name,
+				activeElements.map( ( element ) => element.label ).join( ', ' )
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_IS_NOT_ALL ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is not all: Admin, Editor". */
+				__( '<Name>%1$s is not all: </Name><Value>%2$s</Value>' ),
 				filter.name,
 				activeElements.map( ( element ) => element.label ).join( ', ' )
 			),


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/55100
Follow-up to https://github.com/WordPress/gutenberg/pull/59610

## What?

Adds two new operators `isAll` and `isNotAll` that filters can use. They are not in use by default, as none of the current use cases (pages, patterns, templates, parts) needs it.

## Why?

We want to support this operation for future use cases (posts, media).

## How?

- c3c2b0d25cf3fed01d8d82221d3dcc6e7d44b6ea Declare the new constant.
- 1158623bcc3d67b64f1f5b3c828c5e399212f531 Implement summary display.
- e3e64dd0179209597efd4c2c6b4765e1ae51f39c Add docs & changelog.

## Testing Instructions

- Go to one of the pages, for example, `Templates` & `Parts` at `packages/edit-site/src/components/page-templates-template-parts/index.js`, and declare these filters as supported for the `Author` field:

```js
filterBy: {
    operators: [ `isAny`, `isNone`, `isAll`, `isNotAll` ]
}
```

- Verify the operator is displayed in the filters widget:

<img width="313" alt="Captura de ecrã 2024-03-18, às 14 37 43" src="https://github.com/WordPress/gutenberg/assets/583546/94df435e-a462-4d77-840a-37c95cdb5311">

- Select one of the operators and verify that the filter summary is updated: 

<img width="397" alt="Captura de ecrã 2024-03-18, às 14 41 55" src="https://github.com/WordPress/gutenberg/assets/583546/6f95c80b-a215-4ffe-a388-516eb9ddbd80">

And that the filter's operator [at this point](https://github.com/WordPress/gutenberg/blob/add/is-all-operator-dataviews/packages/edit-site/src/components/page-templates-template-parts/index.js#L373) is correct.

