### PR TITLE
Update api-reference - data-bind--hidden is an incorrrect attribute - should be data-wp-bind--hidden

### DIFF
--- a/packages/interactivity/docs/api-reference.md
+++ b/packages/interactivity/docs/api-reference.md
@@ -33,7 +33,7 @@ Interactivity API directives use the `data-` prefix. Here's an example of direct
     Toggle
   </button>
 
-  <p id="p-1" data-bind--hidden="!context.isOpen">
+  <p id="p-1" data-wp-bind--hidden="!context.isOpen">
     This element is now visible!
   </p>
 </div>
@@ -652,10 +652,10 @@ const { state } = store( "myPlugin", {
 } );
 ```
 
-And then, the string value `"state.isPlaying"` is used to assign the result of this selector to `data-bind--hidden`.
+And then, the string value `"state.isPlaying"` is used to assign the result of this selector to `data-wp-bind--hidden`.
 
 ```html
-<div data-bind--hidden="!state.isPlaying" ... >
+<div data-wp-bind--hidden="!state.isPlaying" ... >
   <iframe ...></iframe>
 </div>
 ```
@@ -668,7 +668,7 @@ The example below is getting `state.isPlaying` from `otherPlugin` instead of `my
 
 ```html
 <div data-wp-interactive="myPlugin">
-  <div data-bind--hidden="otherPlugin::!state.isPlaying" ... >
+  <div data-wp-bind--hidden="otherPlugin::!state.isPlaying" ... >
 		<iframe ...></iframe>
 	</div>
 </div>


### PR DESCRIPTION
The examples have an error. 

data-bind--hidden should be data-wp-bind--hidden

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixing a code error in a code example in the Interactivity API

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
