### PR TITLE
Fix Navigation block e2e focus test by avoiding reliance on invalid locator

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -565,12 +565,6 @@ test.describe( 'Navigation block - List view editing', () => {
 
 		await page.keyboard.press( 'Enter' );
 
-		// Check that the menu was created
-		await expect(
-			page
-				.getByTestId( 'snackbar' )
-				.getByText( 'Navigation Menu successfully created.' )
-		).toBeVisible();
 		await expect(
 			page.getByText( 'This navigation menu is empty.' )
 		).toBeVisible();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the e2e tests for the Nav block which are flaky because they rely on invalid locator.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should avoid `getByTestId` because it isn't present in certain environments.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes line. It's not needed to verify the focus behaviour accordingly to @jeryj who is the author. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

```
npm run test:e2e:playwright --  -g "can create a new menu without losing focus"
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
