### PR TITLE
Fix list of base theme fonts when a theme variation is applied. 

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -119,7 +119,7 @@ function FontLibraryProvider( { children } ) {
 	 *
 	 * Uses the fonts from global styles + the ones from the theme.json file that hasn't repeated slugs.
 	 * Avoids incosistencies with the fonts listed in the font library modal as base (unactivated).
-	 * These inconsistencies can happen when the active theme fonts in global styles aren't defined in theme.json file as when a theme style variantion is applied.
+	 * These inconsistencies can happen when the active theme fonts in global styles aren't defined in theme.json file as when a theme style variation is applied.
 	 */
 	const baseThemeFonts = baseFontFamilies?.theme
 		? themeFonts.concat(

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -117,9 +117,9 @@ function FontLibraryProvider( { children } ) {
 	/*
 	 * Base Theme Fonts are the fonts defined in the theme.json *file*.
 	 *
-	 * Use the fonts from global styles + the ones from the theme.json file that hasn't repeated slugs.
+	 * Uses the fonts from global styles + the ones from the theme.json file that hasn't repeated slugs.
 	 * Avoids incosistencies with the fonts listed in the font library modal as base (unactivated).
-	 * These inconsistencies can happen when the active theme fonts in global styles aren't defined in theme.json file as when a theme variant is applied.
+	 * These inconsistencies can happen when the active theme fonts in global styles aren't defined in theme.json file as when a theme style variantion is applied.
 	 */
 	const baseThemeFonts = baseFontFamilies?.theme
 		? themeFonts.concat(

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -105,6 +105,7 @@ function FontLibraryProvider( { children } ) {
 	const [ modalTabOpen, setModalTabOpen ] = useState( false );
 	const [ libraryFontSelected, setLibraryFontSelected ] = useState( null );
 
+	// Themes Fonts are the fonts defined in the global styles (database persisted theme.json data).
 	const themeFonts = fontFamilies?.theme
 		? fontFamilies.theme
 				.map( ( f ) => setUIValuesNeeded( f, { source: 'theme' } ) )
@@ -113,6 +114,13 @@ function FontLibraryProvider( { children } ) {
 
 	const themeFontsSlugs = new Set( themeFonts.map( ( f ) => f.slug ) );
 
+	/*
+	 * Base Theme Fonts are the fonts defined in the theme.json *file*.
+	 *
+	 * Use the fonts from global styles + the ones from the theme.json file that hasn't repeated slugs.
+	 * Avoids incosistencies with the fonts listed in the font library modal as base (unactivated).
+	 * These inconsistencies can happen when the active theme fonts in global styles aren't defined in theme.json file as when a theme variant is applied.
+	 */
 	const baseThemeFonts = baseFontFamilies?.theme
 		? themeFonts.concat(
 				baseFontFamilies.theme

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -105,16 +105,21 @@ function FontLibraryProvider( { children } ) {
 	const [ modalTabOpen, setModalTabOpen ] = useState( false );
 	const [ libraryFontSelected, setLibraryFontSelected ] = useState( null );
 
-	const baseThemeFonts = baseFontFamilies?.theme
-		? baseFontFamilies.theme
-				.map( ( f ) => setUIValuesNeeded( f, { source: 'theme' } ) )
-				.sort( ( a, b ) => a.name.localeCompare( b.name ) )
-		: [];
-
 	const themeFonts = fontFamilies?.theme
 		? fontFamilies.theme
 				.map( ( f ) => setUIValuesNeeded( f, { source: 'theme' } ) )
 				.sort( ( a, b ) => a.name.localeCompare( b.name ) )
+		: [];
+
+	const themeFontsSlugs = new Set( themeFonts.map( ( f ) => f.slug ) );
+
+	const baseThemeFonts = baseFontFamilies?.theme
+		? themeFonts.concat(
+				baseFontFamilies.theme
+					.filter( ( f ) => ! themeFontsSlugs.has( f.slug ) )
+					.map( ( f ) => setUIValuesNeeded( f, { source: 'theme' } ) )
+					.sort( ( a, b ) => a.name.localeCompare( b.name ) )
+		  )
 		: [];
 
 	const customFonts = fontFamilies?.custom
@@ -144,8 +149,7 @@ function FontLibraryProvider( { children } ) {
 			return;
 		}
 
-		const fonts =
-			font.source === 'theme' ? baseThemeFonts : baseCustomFonts;
+		const fonts = font.source === 'theme' ? themeFonts : baseCustomFonts;
 
 		// Tries to find the font in the installed fonts
 		const fontSelected = fonts.find( ( f ) => f.slug === font.slug );


### PR DESCRIPTION
## What?
- Improve the list of base theme fonts in the font library modal.
- This fixes the issue of opening a different font than the one selected when a theme variation with repeated font slugs is applied.

## Why?
Fixes part of: https://github.com/WordPress/gutenberg/issues/59818
Fixes part of: https://github.com/WordPress/gutenberg/issues/59574


## How?
Using as a base theme fonts the list of fonts composed by the de-duplicated list of: 
 - the theme fonts in global styles (database)
 - the `theme.json` file font families

## Testing Instructions
1. activate a theme with theme style variations (example TT4 and TT3)
2. Switch the style variation.
3. Tap on the font family names from the sidebar.
4. Check that the font listed is the correct one.

## Screenshots or screencast <!-- if applicable -->

### Before
Notice that the font selected in the sidebar is not the one displayed in the modal.


https://github.com/WordPress/gutenberg/assets/1310626/fc67bfaf-a46d-4c30-885d-6106071f7bbc




### After

https://github.com/WordPress/gutenberg/assets/1310626/7145d796-b4ff-46dd-ac48-a9b9a9e4a17a

