### PR TITLE
Update GitHub edit URL in docusaurus.config.js

### DIFF
--- a/platform-docs/docusaurus.config.js
+++ b/platform-docs/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
 				docs: {
 					sidebarPath: require.resolve( './sidebars.js' ),
 					editUrl:
-						'https://github.com/WordPress/gutenberg/tree/main/platform-docs/',
+						'https://github.com/WordPress/gutenberg/tree/trunk/platform-docs/',
 				},
 				theme: {
 					customCss: require.resolve( './src/css/custom.css' ),


### PR DESCRIPTION
Updated the `editUrl` property in the `docusaurus.config.js` so that the "Edit this page" links work correctly.