### PR TITLE
Set post terms priority to 11

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -126,4 +126,4 @@ function register_block_core_post_terms() {
 		)
 	);
 }
-add_action( 'init', 'register_block_core_post_terms' );
+add_action( 'init', 'register_block_core_post_terms', 11 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix the issue mentionned at  #59971 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This fix avoid to not have a Categories block variation for your custom taxonomies, because when using the `register_taxonomy()` function without priority, it is set to 10 by default, which is the same priority than [post terms variations](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/post-terms/index.php#L110)

Also this fix avoid to get 'Invalid taxonomy' when using `get_terms()` function for a custom taxonomy without a priority set.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a custom taxonomy with `register_taxonomy( 'custom_taxonomy', ['cpt_slug'])`
2. Add action without priority `add_action( 'init', 'ltrihan_register_custom_taxonomy');`
3. Try to search your block variation, or use the `get_terms('custom_taxonomy')` function.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
