### PR TITLE
Update dependency-extraction-webpack-plugin docs

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -317,7 +317,7 @@ function requestToHandle( request ) {
 }
 
 module.exports = {
-	plugins: [ new DependencyExtractionWebpackPlugin( { requestToExternal } ) ],
+	plugins: [ new DependencyExtractionWebpackPlugin( { requestToHandle } ) ],
 };
 ```
 


### PR DESCRIPTION
requestToHandle is example is wrong. It shows requestToExternal being passed into the plugin, but function name is different.

## What?
Fixes an example code for requestToHandle

![image](https://github.com/WordPress/gutenberg/assets/2080743/b35e8ceb-00aa-4504-b5a9-877f86561074)
