### PR TITLE
File: Add center alignment editor class for classic themes

### DIFF
--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -4,6 +4,9 @@
 		// Stop file block from collapsing when floated.
 		height: auto;
 	}
+	.wp-block[data-align="center"] > & {
+		text-align: center;
+	}
 
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
## What?
Fixes #59968.

PR adds a center alignment class to the File block. This is used in the editor by classic themes.

## Why?
See #59968.

## Testing Instructions
1. Activate Twenty Seventeen (or any earlier default theme).
2. Create a new post.
3. Add a File block and select file.
4. Set block alignment to "Center"
5. Confirm the block is correctly aligned in the editor.
6. Preview the post and verify alignment matches on the front end

### Testing Instructions for Keyboard
Same.
