### PR TITLE
Font Library: Reset notices when navigating away from the collection

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -344,6 +344,7 @@ function FontCollection( { slug } ) {
 							size="small"
 							onClick={ () => {
 								setSelectedFont( null );
+								setNotice( null );
 							} }
 							label={ __( 'Back' ) }
 						/>


### PR DESCRIPTION
## What?
Fixes #59947.

PR updated the Font Library to remove notices when navigating away from the collections. There's already a similar handle for switching tabs. See #58180.

## Why?
Previous behavior was a bug. See #59947.

## Testing Instructions
1. Open the Site Editor.
2. Install a font and wait for the success message.
3. Navigate to a different collection.
4. Confirm that the success message isn't displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/1562ebdb-dd75-49a9-9985-3b7de1cd0c04

