### PR TITLE
Fix `getEntityRecordsTotalPages` when `per_page` is not provided

### DIFF
--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -126,3 +126,9 @@ export function getQueriedTotalItems( state, query = {} ) {
 
 	return state.queries?.[ context ]?.[ stableKey ]?.meta?.totalItems ?? null;
 }
+
+export function getQueriedTotalPages( state, query = {} ) {
+	const { stableKey, context } = getQueryParts( query );
+
+	return state.queries?.[ context ]?.[ stableKey ]?.meta?.totalPages ?? null;
+}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -238,6 +238,9 @@ export const getEntityRecords =
 					totalItems: parseInt(
 						response.headers.get( 'X-WP-Total' )
 					),
+					totalPages: parseInt(
+						response.headers.get( 'X-WP-TotalPages' )
+					),
 				};
 			} else {
 				records = Object.values( await apiFetch( { path } ) );

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -14,7 +14,11 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import { STORE_NAME } from './name';
-import { getQueriedItems, getQueriedTotalItems } from './queried-data';
+import {
+	getQueriedItems,
+	getQueriedTotalItems,
+	getQueriedTotalPages,
+} from './queried-data';
 import { DEFAULT_ENTITY_KEY } from './entities';
 import {
 	getNormalizedCommaSeparable,
@@ -623,6 +627,11 @@ export const getEntityRecordsTotalPages = (
 	if ( query.per_page === -1 ) return 1;
 	const totalItems = getQueriedTotalItems( queriedState, query );
 	if ( ! totalItems ) return totalItems;
+	// If `per_page` is not set and the query relies on the defaults of the
+	// REST endpoint, get the info from query's meta.
+	if ( ! query.per_page ) {
+		return getQueriedTotalPages( queriedState, query );
+	}
 	return Math.ceil( totalItems / query.per_page );
 };
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

There is a [bug reported ](https://github.com/WordPress/gutenberg/pull/55316#discussion_r1529860713)by @Mamaduka where `getEntityRecordsTotalPages` can return `NaN` if the query  doesn't provide `per_page` relies on the defaults from REST API.




## How?
If the `per_page` argument is not provided, we can fallback to the header of the response, since it should update properly with other changes of the query. We should still derive the result if the `per_page` is provided, because it's not part of the stable key, where we keep the information in state.

## Testing Instructions
1. Everything should work as before when the `per_page` argument is provided. You can test this easily in pages list(DataViews) and update the `rows per page`.
2. Test with a query that doesn't set the `per_page` and observe that `getEntityRecordsTotalPages` returns the proper result.
