### PR TITLE
Fix inner block block crash when rendering Template Part "Replace" UI during click-through

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -214,8 +214,9 @@ function Iframe( {
 			);
 		};
 		node.ownerDocument.defaultView.addEventListener( 'resize', onResize );
+
 		return () => {
-			node.ownerDocument.defaultView.removeEventListener(
+			node.ownerDocument.defaultView?.removeEventListener(
 				'resize',
 				onResize
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a block crash in the Template Part blocks that can be "Replaced".

by accounting for possible `null` value of `document.defaultView` when cleaning up event listeners. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To avoid block crash when "clicking-through" these blocks to inner blocks that are commonly inside them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Some Template Parts are "replaceable" with other patterns. Users are shown a list of possible pattern options under the `Replace` panel in the block sidebar.

These patterns use the `BlockPreview` component. Ultimately this ends up in the `Iframe` component. 

https://github.com/WordPress/gutenberg/blob/dbfed70b2301f1f8b7296545354f3d62ada4d47b/packages/block-editor/src/components/iframe/index.js#L103

Each iframe has it's own `document.defaultView` which [according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView)...

> returns the [window](https://developer.mozilla.org/en-US/docs/Web/API/Window) object associated with [a document](https://developer.mozilla.org/en-US/docs/Glossary/Browsing_context), or null if none is available.

Currently we have event listener cleanup that _always_ expects `defaultView` _not_ to be `null`. Unfortunately when "clicking through" the Template Part, it seems that the previews get briefly rendered and then quickly _removed_ when the user ends up selecting an inner block of the template part.

From testing, I can see that it is possible for `defaultView` to be `null` and thus attempting `removeEventListener` on it will throw an error.

This PR fixes that by conditionalising the `removeEventListener` here...

https://github.com/WordPress/gutenberg/blob/dbfed70b2301f1f8b7296545354f3d62ada4d47b/packages/block-editor/src/components/iframe/index.js#L218-L221



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### On Trunk

- Active TT4
- Open Editor
- Click on Navigation block. You will have to "click through" the `Header` Template Part to do this.
- Notice that the block crashes.

### On this PR

- Active TT4
- Open Editor
- Click on Navigation block. You will have to "click through" the `Header` Template Part to do this.
- Notice that the block does not crash.




### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


### Before (On Trunk)

https://github.com/WordPress/gutenberg/assets/444434/f728ce07-b3ff-4696-acd9-21a3962dfe1e

### After (this PR)


https://github.com/WordPress/gutenberg/assets/444434/f118b728-5b0e-4438-aa31-ba81fa156f6f

