### PR TITLE
DateTimePicker: Change day button size back from 32px to 28px

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,8 +18,7 @@
 
 ### Bug Fix
 -   `PaletteEdit`: Fix number incrementing of default names for new colors added in non-en-US locales ([#52212](https://github.com/WordPress/gutenberg/pull/52212)).
-
-
+-   `DateTimePicker`: Change day button size back from 32px to 28px ([#59990](https://github.com/WordPress/gutenberg/pull/59990)).
 
 ## 27.1.0 (2024-03-06)
 

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -84,8 +84,8 @@ export const DayButton = styled( Button, {
 
 	&&& {
 		border-radius: 100%;
-		height: ${ space( 8 ) };
-		width: ${ space( 8 ) };
+		height: ${ space( 7 ) };
+		width: ${ space( 7 ) };
 
 		${ ( props ) =>
 			props.isSelected &&


### PR DESCRIPTION
Fixes #59966
Revert part of #55502

## What?

This PR reverts the date button size of the `DataTimePicker` component as changed by #55502.

This will prevent unintentional horizontal scroll bars from appearing in the panel when publishing the post.

The images below are for Windows OS and Chrome browser.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/1b78677a-fb27-41fd-99db-e4f886186072)| ![image](https://github.com/WordPress/gutenberg/assets/54422211/180c3d1d-f31c-4376-a478-dd05bb2fd850)| 

## Why?

This issue is not an issue with the component itself. #55502 changed the date button size from 28px to 32px. This caused the width of the entire calendar to exceed the width of the publish sidebar.

## How?

Changed button size back to 28px. As a result, the horizontal scrollbar will not be displayed. But since the content is originally overflowing from the grid layout, I think we need a more ideal solution in the future.

![image](https://github.com/WordPress/gutenberg/assets/54422211/4f8710a3-0a86-4d70-b182-948523d35360)

## Testing Instructions

- Create a new post.
- Enter the content and press the "Publish" button.
- Open the "Publish: Immediately" panel.
- A horizontal scrollbar should not appear in the public sidebar.