### PR TITLE
Block Editor: fix crash when unmounting an editor iframe

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -208,17 +208,14 @@ function Iframe( {
 	}, [] );
 
 	const windowResizeRef = useRefEffect( ( node ) => {
+		const nodeWindow = node.ownerDocument.defaultView;
+
 		const onResize = () => {
-			setIframeWindowInnerHeight(
-				node.ownerDocument.defaultView.innerHeight
-			);
+			setIframeWindowInnerHeight( nodeWindow.innerHeight );
 		};
-		node.ownerDocument.defaultView.addEventListener( 'resize', onResize );
+		nodeWindow.addEventListener( 'resize', onResize );
 		return () => {
-			node.ownerDocument.defaultView.removeEventListener(
-				'resize',
-				onResize
-			);
+			nodeWindow.removeEventListener( 'resize', onResize );
 		};
 	}, [] );
 


### PR DESCRIPTION
Fixes a crash that is reproducible like this:

Open Site Editor, and select a Header area:

<img width="1035" alt="Screenshot 2024-03-19 at 14 08 32" src="https://github.com/WordPress/gutenberg/assets/664258/c0c4e857-448a-4e96-a9c9-70f197877011">

The sidebar shows several preview iframes in the "Replace" area.

Now switch from the "Block" tab to the "Template" tab. That unmounts these preview iframes, but also leads to a crash!

<img width="847" alt="Screenshot 2024-03-19 at 14 09 17" src="https://github.com/WordPress/gutenberg/assets/664258/e69523cb-1be0-490e-9422-b397386a62a7">

This is because the cleanup of the offending `useRefEffect` runs when the iframe element is already removed from DOM. And at that time its `contentWindow` is `null`.

The solution is to "hold on" to a reference to the window in a local `nodeWindow` variable. That solves the crash.

In theory, the `contentWindow` of an iframe can change when the iframe navigates to a different URL, but the existing code doesn't account for that anyway -- it would be removing a listener from a window different from the one it added the listener to.