### PR TITLE
Interactive template: Use wp_interactivity_data_wp_context function

### DIFF
--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Update the template to use `wp_interactivity_data_wp_context` for the context attribute ([#57712](https://github.com/WordPress/gutenberg/pull/57712)).
+
 ## 1.16.0 (2024-03-06)
 
 ## 1.15.0 (2024-02-21)

--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancement
 
--   Update the template to use `wp_interactivity_data_wp_context` for the context attribute ([#57712](https://github.com/WordPress/gutenberg/pull/57712)).
+-   Update the template to use `wp_interactivity_data_wp_context` for the context attribute ([#59995](https://github.com/WordPress/gutenberg/pull/59995)).
 
 ## 1.16.0 (2024-03-06)
 

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -18,7 +18,7 @@ $unique_id = wp_unique_id( 'p-' );
 <div
 	<?php echo get_block_wrapper_attributes(); ?>
 	data-wp-interactive="{{namespace}}"
-	data-wp-context='{ "isOpen": false }'
+	<?php echo wp_interactivity_data_wp_context( array( "isOpen" => false  ) ); ?>
 	data-wp-watch="callbacks.logIsOpen"
 >
 	<button

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -18,7 +18,7 @@ $unique_id = wp_unique_id( 'p-' );
 <div
 	<?php echo get_block_wrapper_attributes(); ?>
 	data-wp-interactive="{{namespace}}"
-	<?php echo wp_interactivity_data_wp_context( array( "isOpen" => false  ) ); ?>
+	<?php echo wp_interactivity_data_wp_context( array( 'isOpen' => false  ) ); ?>
 	data-wp-watch="callbacks.logIsOpen"
 >
 	<button

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -18,7 +18,7 @@ $unique_id = wp_unique_id( 'p-' );
 <div
 	<?php echo get_block_wrapper_attributes(); ?>
 	data-wp-interactive="{{namespace}}"
-	<?php echo wp_interactivity_data_wp_context( array( 'isOpen' => false  ) ); ?>
+	<?php echo wp_interactivity_data_wp_context( array( 'isOpen' => false ) ); ?>
 	data-wp-watch="callbacks.logIsOpen"
 >
 	<button


### PR DESCRIPTION
## What?

Use `wp_interactivity_data_wp_context` in the interactive create-block template.

## Why?

[This functions exists to do this](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-interactivity/packages-interactivity-api-reference/#wp_interactivity_data_wp_context), it helps prevent mistakes and problems with escaping. It should be used in the example code.

## Testing Instructions

This can be tested by building it locally (npm run build) and using it:

```sh
path/to/gutenberg/packages/create-block/index.js --template path/to/gutenberg/packages/create-block-interactive-template
```

Then in the generated plugin, run `npm run build` and try out the plugin on a WordPress installation.
