### PR TITLE
Update 'sidebar card' appearance

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/index.js
@@ -22,7 +22,7 @@ export default function SidebarCard( {
 } ) {
 	return (
 		<div className={ classnames( 'edit-site-sidebar-card', className ) }>
-			<HStack spacing={ 3 } className="edit-site-sidebar-card__header">
+			<HStack spacing={ 2 } className="edit-site-sidebar-card__header">
 				<Icon className="edit-site-sidebar-card__icon" icon={ icon } />
 				<h2 className="edit-site-sidebar-card__title">{ title }</h2>
 				{ actions }

--- a/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/index.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import {
 	Icon,
+	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -22,9 +23,21 @@ export default function SidebarCard( {
 } ) {
 	return (
 		<div className={ classnames( 'edit-site-sidebar-card', className ) }>
-			<HStack spacing={ 2 } className="edit-site-sidebar-card__header">
+			<HStack
+				spacing={ 2 }
+				className="edit-site-sidebar-card__header"
+				align="flex-start"
+			>
 				<Icon className="edit-site-sidebar-card__icon" icon={ icon } />
-				<h2 className="edit-site-sidebar-card__title">{ title }</h2>
+				<Text
+					numberOfLines={ 2 }
+					truncate
+					className="edit-site-sidebar-card__title"
+					weight={ 500 }
+					as="h2"
+				>
+					{ title }
+				</Text>
 				{ actions }
 			</HStack>
 			<VStack className="edit-site-sidebar-card__content">

--- a/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/style.scss
@@ -4,8 +4,6 @@
 	}
 
 	&__title {
-		font-weight: 500;
-		flex-grow: 1;
 		&.edit-site-sidebar-card__title {
 			font-size: 16px;
 			line-height: $icon-size;
@@ -28,5 +26,9 @@
 		display: flex;
 		justify-content: space-between;
 		margin: 0 0 $grid-unit-15;
+	}
+
+	.edit-site-template-card__actions {
+		flex-shrink: 0;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/style.scss
@@ -5,18 +5,17 @@
 
 	&__title {
 		font-weight: 500;
-		line-height: $icon-size;
 		flex-grow: 1;
 		&.edit-site-sidebar-card__title {
-			font-size: $default-font-size;
-			line-height: $default-line-height;
+			font-size: 16px;
+			line-height: $icon-size;
 			margin: 0;
-			padding: 3px 0; // This makes the title as high as the icon.
 		}
 	}
 
 	&__description {
 		font-size: $default-font-size;
+		color: $gray-700;
 	}
 
 	&__icon {
@@ -28,6 +27,6 @@
 	&__header {
 		display: flex;
 		justify-content: space-between;
-		margin: 0 0 $grid-unit-05;
+		margin: 0 0 $grid-unit-15;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/style.scss
@@ -4,6 +4,8 @@
 	}
 
 	&__title {
+		width: 100%;
+
 		&.edit-site-sidebar-card__title {
 			font-size: 16px;
 			line-height: $icon-size;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/59783. 

## What?
Update the appearance of the 'sidebar card' element.

## Why?
To match the designs in https://github.com/WordPress/gutenberg/issues/59689. Specifically to further establish the hierarchy of information.

## How?
1. Decrease the space between icon / title
2. Increase title size and line-height
3. Adjust description color

## Screenshots

| Before | After |
| --- | --- |
| <img width="279" alt="Screenshot 2024-03-19 at 15 13 15" src="https://github.com/WordPress/gutenberg/assets/846565/20ced02d-aff2-4e3e-b8df-fc438cccbb12"> | <img width="279" alt="Screenshot 2024-03-19 at 15 25 42" src="https://github.com/WordPress/gutenberg/assets/846565/40e68511-8648-4b1c-a851-091923391813"> |

Additionally long titles are now truncated to two lines like so:

<img width="279" alt="Screenshot 2024-03-19 at 15 45 44" src="https://github.com/WordPress/gutenberg/assets/846565/90a1f61c-47db-45a4-974f-780bb065a1c7">
