### PR TITLE
Adjust the List View close icon to resemble the Inspector close icon

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -212,7 +212,7 @@
 		align-items: center;
 		width: 100%;
 		height: auto;
-		padding: ($grid-unit-15 * 0.5) $grid-unit-05 ($grid-unit-15 * 0.5) 0;
+		padding: ($grid-unit-15 * 0.5) ($grid-unit-15 * 0.5) ($grid-unit-15 * 0.5) 0;
 		text-align: left;
 		border-radius: $radius-block-ui;
 		position: relative;
@@ -309,14 +309,14 @@
 
 		&,
 		.components-button.has-icon {
-			width: 24px;
-			min-width: 24px;
+			width: $button-size-small;
+			min-width: $button-size-small;
 			padding: 0;
 		}
 	}
 
 	.block-editor-list-view-block__menu-cell {
-		padding-right: $grid-unit-05;
+		padding-right: calc(#{$grid-unit-05} * 1.5); // 6px.
 
 		.components-button.has-icon {
 			height: 24px;
@@ -406,7 +406,7 @@
 		transform: translateY(-50%);
 		background: rgba($black, 0.1);
 		border-radius: $radius-block-ui;
-		padding: 2px 6px;
+		padding: 1px 6px;
 		max-width: 100%;
 		box-sizing: border-box;
 	}

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -316,7 +316,7 @@
 	}
 
 	.block-editor-list-view-block__menu-cell {
-		padding-right: calc(#{$grid-unit-05} * 1.5); // 6px.
+		padding-right: $grid-unit-15 * 0.5; // 6px.
 
 		.components-button.has-icon {
 			height: 24px;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -406,7 +406,7 @@
 		transform: translateY(-50%);
 		background: rgba($black, 0.1);
 		border-radius: $radius-block-ui;
-		padding: 1px 6px;
+		padding: 2px 6px;
 		max-width: 100%;
 		box-sizing: border-box;
 	}

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -135,6 +135,7 @@ export default function ListViewSidebar() {
 						icon={ closeSmall }
 						label={ __( 'Close' ) }
 						onClick={ closeListView }
+						size="compact"
 					/>
 					<Tabs.TabList
 						className="editor-list-view-sidebar__tabs-tablist"

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -135,7 +135,7 @@ export default function ListViewSidebar() {
 						icon={ closeSmall }
 						label={ __( 'Close' ) }
 						onClick={ closeListView }
-						size="compact"
+						size="small"
 					/>
 					<Tabs.TabList
 						className="editor-list-view-sidebar__tabs-tablist"

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -16,7 +16,7 @@
 		background: $white;
 		order: 1;
 		align-self: center;
-		margin-right: $grid-unit-10;
+		margin-right: $grid-unit-15;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A quick fix to make the close icon of the List View sidebar the same metrics and size as the close icon within the Inspector. Also aligns the icon with each block's more menu icon in List View. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Add a few blocks.
3. Open List View.
4. Compare List View with the Inspector; both close icons should have the same metrics and treatments.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-03-19 at 13 44 49](https://github.com/WordPress/gutenberg/assets/1813435/40b675f0-937f-42d7-a2be-942688fd9e67)
