### PR TITLE
Revert shadow.defaultPresets default to true

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -73,7 +73,7 @@ Settings related to shadows.
 
 | Property  | Type   | Default | Props  |
 | ---       | ---    | ---    |---   |
-| defaultPresets | boolean | false |  |
+| defaultPresets | boolean | true |  |
 | presets | array |  | name, shadow, slug |
 
 ---

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -38,7 +38,6 @@ Setting that enables the following UI tools:
 - position: sticky
 - spacing: blockGap, margin, padding
 - typography: lineHeight
-- shadow: defaultPresets
 
 
 ---

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -682,7 +682,6 @@ class WP_Theme_JSON_Gutenberg {
 		array( 'spacing', 'margin' ),
 		array( 'spacing', 'padding' ),
 		array( 'typography', 'lineHeight' ),
-		array( 'shadow', 'defaultPresets' ),
 	);
 
 	/**

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -319,6 +319,19 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			}
 			$theme_support_data['settings']['color']['defaultGradients'] = $default_gradients;
 
+			if ( ! isset( $theme_support_data['settings']['shadow'] ) ) {
+				$theme_support_data['settings']['shadow'] = array();
+			}
+			$default_shadows = false;
+			if ( current_theme_supports( 'default-shadow-presets' ) ) {
+				$default_shadows = true;
+			}
+			if ( ! isset( $theme_support_data['settings']['shadow']['presets'] ) ) {
+				// If the theme does not have any shadows, we still want to show the core ones.
+				$default_shadows = true;
+			}
+			$theme_support_data['settings']['shadow']['defaultPresets'] = $default_shadows;
+
 			// Allow themes to enable all border settings via theme_support.
 			if ( current_theme_supports( 'border' ) ) {
 				$theme_support_data['settings']['border']['color']  = true;

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -191,7 +191,7 @@
 			"text": true
 		},
 		"shadow": {
-			"defaultPresets": false,
+			"defaultPresets": true,
 			"presets": [
 				{
 					"name": "Natural",

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -289,9 +289,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'typography' => array(
 				'lineHeight' => true,
 			),
-			'shadow'     => array(
-				'defaultPresets' => true,
-			),
 			'blocks'     => array(
 				'core/paragraph' => array(
 					'typography' => array(
@@ -330,9 +327,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 					'typography' => array(
 						'lineHeight' => false,
-					),
-					'shadow'     => array(
-						'defaultPresets' => true,
 					),
 				),
 			),

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -20,7 +20,7 @@
 			"type": "object",
 			"properties": {
 				"appearanceTools": {
-					"description": "Setting that enables the following UI tools:\n\n- background: backgroundImage, backgroundSize\n- border: color, radius, style, width\n- color: link, heading, button, caption\n- dimensions: aspectRatio, minHeight\n- position: sticky\n- spacing: blockGap, margin, padding\n- typography: lineHeight\n- shadow: defaultPresets",
+					"description": "Setting that enables the following UI tools:\n\n- background: backgroundImage, backgroundSize\n- border: color, radius, style, width\n- color: link, heading, button, caption\n- dimensions: aspectRatio, minHeight\n- position: sticky\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
 					"type": "boolean",
 					"default": false
 				}
@@ -77,7 +77,7 @@
 						"defaultPresets": {
 							"description": "Allow users to choose shadows from the default shadow presets.",
 							"type": "boolean",
-							"default": false
+							"default": true
 						},
 						"presets": {
 							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60815
WP Dev PR: https://github.com/WordPress/wordpress-develop/pull/6295

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Reverts the core `settings.shadow.defaultPresets` back to `true`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #59989

Themes should not change appearance with just a WP update. We have a migration mechanism for theme.json to allow for theme authors to change default values that should be used if we want to change a default.

All of the `default*` settings have been `true` by default as they've been added, so this brings consistency to that again as well.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Changes the `settings.shadow.defaultPresets` to `true` in lib/theme.json.
- Removes `array( 'shadow', 'defaultPresets' )` from `APPEARANCE_TOOLS_OPT_INS` as it is no longer needed when we have `true` by default.
- Adds `editor-shadow-presets` and `default-shadow-presets` theme supports for classic themes to match how colors/gradients presets work.
- Updates related docs/tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Block themes

Here is an example theme.json for testing that would override the default `natural` shadow with a red shadow to make the difference obvious.

```jsonc
// theme.json
{
	"$schema": "https://schemas.wp.org/wp/6.4/theme.json",
	"version": 2,
	"settings": {
		"shadow": {
			"presets": [
				{
					"name": "Natural",
					"slug": "natural",
					"shadow": "6px 6px 9px #F00"
				}
			]
		},
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/button": {
				"shadow": "var(--wp--preset--shadow--natural)"
			}
		}
	}
}
```

1. Use the above theme.json as an example theme.
2. Insert a button in a post.
3. Preview the post in `wp/6.4`
4. Preview the post in `trunk`
5. Preview the post in this PR
6. See that `wp/6.4` and this PR match.

### Classic themes

TODO: Finish writing testing scenarios.

- Test disabling shadow presets.
  ```php
  add_theme_support( 'editor-shadow-presets', array() );
  ```

- Test custom shadow presets.
  ```php
  add_theme_support( 'editor-shadow-presets', array(
    array(
      "name"   => "Custom Shadow",
      "slug"   => "custom-shadow",
      "shadow" => "10px 10px 0px 0px #F0F"
    )
  ) );
  ``` 

- Test disabling default shadow presets.
  ```php
  add_theme_support( 'default-shadow-presets', false );
  ```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

### Block themes

#### WP 6.4

![Screen Shot 2024-03-19 at 12 56 11](https://github.com/WordPress/gutenberg/assets/5129775/7c4250f0-65e5-40b9-a064-3be87e2fea81)

#### Current 6.5 (`"defaultPresets": false`)

![Screen Shot 2024-03-19 at 12 55 36](https://github.com/WordPress/gutenberg/assets/5129775/061263ba-53aa-4812-85ab-0e48ebde35fd)

#### This PR (`"defaultPresets": true`)

![Screen Shot 2024-03-19 at 12 55 24](https://github.com/WordPress/gutenberg/assets/5129775/a85552b2-5b65-401b-8284-7e4f9bb06a4c)

### Classic themes

TODO: Screenshots of UI for classic themes in each of the testing scenarios.