### PR TITLE
Developer Documentation  fixed the markup for the link of theme.json on key-concepts.md

### DIFF
--- a/docs/explanations/architecture/key-concepts.md
+++ b/docs/explanations/architecture/key-concepts.md
@@ -65,6 +65,6 @@ More on [Site editing templates](/docs/explanations/architecture/full-site-editi
 
 ## Styles
 
-Styles, formerly known as Global Styles and as such referenced in the code, is both an interface that users access through the editor and a configuration system done through [a `theme.json` file](/docs/how-to-guides/themes/global-settings-and-styles.md). This file absorbs most of the configuration aspects usually scattered through various `add_theme_support` calls to simplify communicating with the editor. It thus aims to improve declaring what settings should be enabled, what specific tools a theme offers (like a custom color palette), the available design tools present, and an infrastructure that allows to coordinate the styles coming from WordPress, the active theme, and the user.
+Styles, formerly known as Global Styles and as such referenced in the code, is both an interface that users access through the editor and a configuration system done through a [theme.json](/docs/how-to-guides/themes/global-settings-and-styles.md) file. This file absorbs most of the configuration aspects usually scattered through various `add_theme_support` calls to simplify communicating with the editor. It thus aims to improve declaring what settings should be enabled, what specific tools a theme offers (like a custom color palette), the available design tools present, and an infrastructure that allows to coordinate the styles coming from WordPress, the active theme, and the user.
 
 Learn more about [Global Styles](/docs/explanations/architecture/styles.md#global-styles).


### PR DESCRIPTION
fixed the markup for the link of theme.json  on the Styles paragraph

.... through a theme.json file. ....

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixing the markup link 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
So the link is consistent. The actual link , links the whole "a theme.json file" rather than just "theme.json"

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Moving out the "a" and "file" from the markup

