### PR TITLE
RadioControl: Update deprecated suggestion in readme

### DIFF
--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -119,4 +119,4 @@ The value property of the currently selected option.
 
 -   To select one or more items from a set, use the `CheckboxControl` component.
 -   To toggle a single setting on or off, use the `ToggleControl` component.
--   To format as a button group, use the `RadioGroup` component.
+-   To format as a segmented button group, use the `ToggleGroupControl` component.


### PR DESCRIPTION
Removes the suggestion to use the deprecated `RadioGroup` component, and replaces it with `ToggleGroupControl`.
