### PR TITLE
Components: Hide private READMEs from handbook

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -738,12 +738,6 @@
 		"parent": "components"
 	},
 	{
-		"title": "CustomSelectControlV2",
-		"slug": "custom-select-control-v2",
-		"markdown_source": "../packages/components/src/custom-select-control-v2/README.md",
-		"parent": "components"
-	},
-	{
 		"title": "CustomSelectControl",
 		"slug": "custom-select-control",
 		"markdown_source": "../packages/components/src/custom-select-control/README.md",
@@ -1197,12 +1191,6 @@
 		"title": "TabPanel",
 		"slug": "tab-panel",
 		"markdown_source": "../packages/components/src/tab-panel/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Tabs",
-		"slug": "tabs",
-		"markdown_source": "../packages/components/src/tabs/README.md",
 		"parent": "components"
 	},
 	{

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -8,13 +8,15 @@ const { join } = require( 'path' );
 
 const baseRepoUrl = '..';
 const componentPaths = glob( 'packages/components/src/*/**/README.md', {
-	// Don't expose documentation for mobile only and G2 components just yet.
+	// Don't expose documentation for mobile only and private components just yet.
 	ignore: [
 		'**/src/mobile/**/README.md',
 		'packages/components/src/theme/README.md',
 		'packages/components/src/view/README.md',
 		'packages/components/src/dropdown-menu-v2/README.md',
 		'packages/components/src/progress-bar/README.md',
+		'packages/components/src/tabs/README.md',
+		'packages/components/src/custom-select-control-v2/README.md',
 	],
 } );
 const packagePaths = glob( 'packages/*/package.json' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Removes private component docs that were unintentionally leaking into the public Block Editor Handbook:

- [CustomSelectControlV2](https://developer.wordpress.org/block-editor/reference-guides/components/custom-select-control-v2/)
- [Tabs](https://developer.wordpress.org/block-editor/reference-guides/components/tabs/)

## Why?

It is unnecessary and confusing to list still-private components in the handbook, since they are not publicly available yet.

## Testing Instructions

This can only be tested by deploying.

### Related

For some reason, we can see some published component READMEs that are not in the manifest.json:

- [DropdownMenuV2Ariakit](https://developer.wordpress.org/block-editor/reference-guides/components/dropdown-menu-v2-ariakit/) (Why?!)
- [Theme](https://developer.wordpress.org/block-editor/reference-guides/components/theme/)

I'm guessing this is some kind of caching issue? I don't see anything suspicious in the [code responsible](https://github.com/WordPress/wporg-developer/blob/trunk/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php) for handling the manifest.json, but we may have to escalate this issue if it doesn't resolve in the next deploy.