### PR TITLE
Update the query block to permit non-core interactive blocks

### DIFF
--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -43,7 +43,7 @@ export default function EnhancedPaginationModal( {
 	if ( hasBlocksFromPlugins ) {
 		notice =
 			__(
-				'Currently, avoiding full page reloads is not possible when blocks from plugins are present inside the Query block.'
+				'Currently, avoiding full page reloads is not possible when non-interactive blocks from plugins are present inside the Query block.'
 			) +
 			' ' +
 			notice;

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -43,7 +43,7 @@ export default function EnhancedPaginationModal( {
 	if ( hasBlocksFromPlugins ) {
 		notice =
 			__(
-				'Currently, avoiding full page reloads is not possible when non-interactive blocks from plugins are present inside the Query block.'
+				'Currently, avoiding full page reloads is not possible when non-interactive or non-clientNavigation compatible blocks from plugins are present inside the Query block.'
 			) +
 			' ' +
 			notice;

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -384,18 +384,17 @@ export const useUnsupportedBlocks = ( clientId ) => {
 					 *  - supports.interactivity = true;
 					 *  - supports.interactivity.clientNavigation = true;
 					 */
-					const blockInteractivityBool =
-						getBlockSupport( blockName, 'interactivity' ) === true;
+					const blockInteractivityBool = Object.is(
+						getBlockSupport( blockName, 'interactivity' ),
+						true
+					);
 					const blockClientNavigation = getBlockSupport(
 						blockName,
 						'interactivity.clientNavigation'
 					);
 					const blockInteractivity =
 						blockInteractivityBool || blockClientNavigation;
-					if (
-						! blockName.startsWith( 'core/' ) &&
-						! blockInteractivity
-					) {
+					if ( ! blockInteractivity ) {
 						blocks.hasBlocksFromPlugins = true;
 					} else if ( blockName === 'core/post-content' ) {
 						blocks.hasPostContentBlock = true;

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -384,7 +384,7 @@ export const useUnsupportedBlocks = ( clientId ) => {
 					 *  - supports.interactivity = true;
 					 *  - supports.interactivity.clientNavigation = true;
 					 */
-					const blockSupportsInteractivityBool = Object.is(
+					const blockSupportsInteractivity = Object.is(
 						getBlockSupport( blockName, 'interactivity' ),
 						true
 					);
@@ -394,7 +394,7 @@ export const useUnsupportedBlocks = ( clientId ) => {
 							'interactivity.clientNavigation'
 						);
 					const blockInteractivity =
-						blockSupportsInteractivityBool ||
+						blockSupportsInteractivity ||
 						blockSupportsInteractivityClientNavigation;
 					if ( ! blockInteractivity ) {
 						blocks.hasBlocksFromPlugins = true;

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -6,7 +6,11 @@ import { useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
-import { cloneBlock, store as blocksStore } from '@wordpress/blocks';
+import {
+	cloneBlock,
+	getBlockSupport,
+	store as blocksStore,
+} from '@wordpress/blocks';
 
 /** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
 
@@ -375,7 +379,14 @@ export const useUnsupportedBlocks = ( clientId ) => {
 			getClientIdsOfDescendants( clientId ).forEach(
 				( descendantClientId ) => {
 					const blockName = getBlockName( descendantClientId );
-					if ( ! blockName.startsWith( 'core/' ) ) {
+					const blockInteractivity = getBlockSupport(
+						blockName,
+						'interactivity'
+					);
+					if (
+						! blockName.startsWith( 'core/' ) &&
+						! blockInteractivity
+					) {
 						blocks.hasBlocksFromPlugins = true;
 					} else if ( blockName === 'core/post-content' ) {
 						blocks.hasPostContentBlock = true;

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -384,16 +384,18 @@ export const useUnsupportedBlocks = ( clientId ) => {
 					 *  - supports.interactivity = true;
 					 *  - supports.interactivity.clientNavigation = true;
 					 */
-					const blockInteractivityBool = Object.is(
+					const blockSupportsInteractivityBool = Object.is(
 						getBlockSupport( blockName, 'interactivity' ),
 						true
 					);
-					const blockClientNavigation = getBlockSupport(
-						blockName,
-						'interactivity.clientNavigation'
-					);
+					const blockSupportsInteractivityClientNavigation =
+						getBlockSupport(
+							blockName,
+							'interactivity.clientNavigation'
+						);
 					const blockInteractivity =
-						blockInteractivityBool || blockClientNavigation;
+						blockSupportsInteractivityBool ||
+						blockSupportsInteractivityClientNavigation;
 					if ( ! blockInteractivity ) {
 						blocks.hasBlocksFromPlugins = true;
 					} else if ( blockName === 'core/post-content' ) {

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -379,10 +379,19 @@ export const useUnsupportedBlocks = ( clientId ) => {
 			getClientIdsOfDescendants( clientId ).forEach(
 				( descendantClientId ) => {
 					const blockName = getBlockName( descendantClientId );
-					const blockInteractivity = getBlockSupport(
+					/*
+					 * Client side navigation can be true in two states:
+					 *  - supports.interactivity = true;
+					 *  - supports.interactivity.clientNavigation = true;
+					 */
+					const blockInteractivityBool =
+						getBlockSupport( blockName, 'interactivity' ) === true;
+					const blockClientNavigation = getBlockSupport(
 						blockName,
-						'interactivity'
+						'interactivity.clientNavigation'
 					);
+					const blockInteractivity =
+						blockInteractivityBool || blockClientNavigation;
 					if (
 						! blockName.startsWith( 'core/' ) &&
 						! blockInteractivity


### PR DESCRIPTION
## What?
Allow non-core interactive blocks to be placed inside the core/query block

Fixes #59752

## Why?
With the introduction of the interactivity API, extenders are eager to use the API with the core/query block to enhance WordPress sites. This adjustment allows them to be used.

## How?
Adds a check to ensure that any non-core blocks inside the core/query block have their block.supports.interactivity property set to true.

## Testing Instructions
1. Create a new page/post with query with a post template and pagination within it. 
2. Set the query's "Force page reload" to false
3. Add a non-core block inside the query.
4. Verify that you get the modal alerting you that non-interactive plugin blocks are not allowed. "Force page reload" is enabled.
5. Add a non-core block that has block.supports.interactivity inside the query
6. Verify you can enable/disable the "Force page reload"
7. On the front end verify that the advanced pagination works as expected.

Here's a non-core block with block.supports.interactivity you can use to test this: [test static block](https://github.com/colinduwe/test-block-static/blob/main/test-block-static.zip)

https://github.com/WordPress/gutenberg/assets/2152870/180c1e79-5071-4f15-b16d-d013b5309db8



