### PR TITLE
Background block supports: move size defaults to hooks and block.json

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -103,6 +103,46 @@ export function hasBackgroundSupport( blockName, feature = 'any' ) {
 	return !! support?.[ feature ];
 }
 
+function useBlockProps( { name, style } ) {
+	if (
+		! hasBackgroundSupport( name ) ||
+		! style?.background?.backgroundImage
+	) {
+		return;
+	}
+
+	const backgroundImage = style?.background?.backgroundImage;
+	let props;
+
+	// Set block background defaults.
+	if ( backgroundImage?.source === 'file' && !! backgroundImage?.url ) {
+		if ( ! style?.background?.backgroundSize ) {
+			props = {
+				style: {
+					backgroundSize: 'cover',
+				},
+			};
+		}
+
+		if (
+			'contain' === style?.background?.backgroundSize &&
+			! style?.background?.backgroundPosition
+		) {
+			props = {
+				style: {
+					backgroundPosition: 'center',
+				},
+			};
+		}
+	}
+
+	if ( ! props ) {
+		return;
+	}
+
+	return props;
+}
+
 /**
  * Resets the background image block support attributes. This can be used when disabling
  * the background image controls for a block via a `ToolsPanel`.
@@ -425,11 +465,10 @@ function BackgroundSizePanelItem( {
 	// If the current value is `cover` and the repeat value is `undefined`, then
 	// the toggle should be unchecked as the default state. Otherwise, the toggle
 	// should reflect the current repeat value.
-	const repeatCheckedValue =
+	const repeatCheckedValue = ! (
 		repeatValue === 'no-repeat' ||
 		( currentValueForToggle === 'cover' && repeatValue === undefined )
-			? false
-			: true;
+	);
 
 	const hasValue = hasBackgroundSizeValue( style );
 
@@ -602,3 +641,9 @@ export function BackgroundImagePanel( props ) {
 		</InspectorControls>
 	);
 }
+
+export default {
+	useBlockProps,
+	attributeKeys: [ 'style' ],
+	hasSupport: hasBackgroundSupport,
+};

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -8,6 +8,7 @@ import {
 } from './utils';
 import './compat';
 import align from './align';
+import background from './background';
 import './lock';
 import anchor from './anchor';
 import ariaLabel from './aria-label';
@@ -47,6 +48,7 @@ createBlockEditFilter(
 );
 createBlockListBlockFilter( [
 	align,
+	background,
 	style,
 	color,
 	dimensions,

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -430,35 +430,6 @@ describe( 'getCSSRules', () => {
 		] );
 	} );
 
-	it( 'should output fallback cover background size when no size is provided', () => {
-		expect(
-			getCSSRules(
-				{
-					background: {
-						backgroundImage: {
-							source: 'file',
-							url: 'https://example.com/image.jpg',
-						},
-					},
-				},
-				{
-					selector: '.some-selector',
-				}
-			)
-		).toEqual( [
-			{
-				selector: '.some-selector',
-				key: 'backgroundImage',
-				value: "url( 'https://example.com/image.jpg' )",
-			},
-			{
-				selector: '.some-selector',
-				key: 'backgroundSize',
-				value: 'cover',
-			},
-		] );
-	} );
-
 	it( 'should output background image value when that value is a string', () => {
 		expect(
 			getCSSRules(
@@ -477,46 +448,6 @@ describe( 'getCSSRules', () => {
 				selector: '.some-selector',
 				key: 'backgroundImage',
 				value: "linear-gradient(to bottom,rgb(255 255 0 / 50%),rgb(0 0 255 / 50%), url('https://example.com/image.jpg')",
-			},
-			{
-				selector: '.some-selector',
-				key: 'backgroundSize',
-				value: 'cover',
-			},
-		] );
-	} );
-
-	it( 'should output fallback center position for contain background size', () => {
-		expect(
-			getCSSRules(
-				{
-					background: {
-						backgroundImage: {
-							source: 'file',
-							url: 'https://example.com/image.jpg',
-						},
-						backgroundSize: 'contain',
-					},
-				},
-				{
-					selector: '.some-selector',
-				}
-			)
-		).toEqual( [
-			{
-				selector: '.some-selector',
-				key: 'backgroundImage',
-				value: "url( 'https://example.com/image.jpg' )",
-			},
-			{
-				selector: '.some-selector',
-				key: 'backgroundSize',
-				value: 'contain',
-			},
-			{
-				selector: '.some-selector',
-				key: 'backgroundPosition',
-				value: 'center',
 			},
 		] );
 	} );


### PR DESCRIPTION

## What? Why? How? 

Split from https://github.com/WordPress/gutenberg/pull/59889

This commit moves the logic that sets the default background CSS property values from the style engine to a `useBlockProps` hook.

The style engine can now generate "pure" styles, with output values reflecting input values, and not be opinionated or return feature-specific mutations. This might be handy for global styles, where background defaults aren't required for body tag background images.

> [!IMPORTANT]
> Because it's removing the style engine logic, this PR also affects the default behaviour of theme.json site-wide background images. It won't fill in defaults. Given that https://github.com/WordPress/gutenberg/pull/59889 is removing these defaults anyway, then it's a known and expected outcome.



## Testing Instructions

There should be no regressions in the way background images work in the editor.

When adding a background image to a group block, the default background size should be "cover". Example HTML:

```html
<!-- wp:group {"style":{"dimensions":{"minHeight":"517px"},"background":{"backgroundImage":{"url":"https://animaldiversity.org/collections/contributors/phil_myers/Myliobatidae/Aetobatus2326/large.jpg","source":"file","title":"Myliobatidae"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="min-height:517px"></div>
<!-- /wp:group -->
```

When the background size is set to "contain", the default background position should be "center":

```html
<!-- wp:group {"style":{"dimensions":{"minHeight":"517px"},"background":{"backgroundImage":{"url":"https://animaldiversity.org/collections/contributors/phil_myers/Myliobatidae/Aetobatus2326/large.jpg","source":"file","title":"Myliobatidae"},"backgroundSize":"contain"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="min-height:517px"></div>
<!-- /wp:group -->
```


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/6458278/087ae753-5649-43df-9645-b947e5cf8746


