### PR TITLE
Uses the proper function to output interactivity context

### DIFF
--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -13,12 +13,15 @@
 
 // Generate unique id for aria-controls.
 $unique_id = wp_unique_id( 'p-' );
+$my_context = array(
+	'isOpen' : false,
+);
 ?>
 
 <div
 	<?php echo get_block_wrapper_attributes(); ?>
 	data-wp-interactive="{{namespace}}"
-	data-wp-context='{ "isOpen": false }'
+	<?php echo wp_interactivity_data_wp_context( $my_context ); ?>
 	data-wp-watch="callbacks.logIsOpen"
 >
 	<button


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the current Interactivity API create block scaffold, the block's context is output manually in the attribute, but a better example of the best practice would be using `wp_interactivity_data_wp_context( $my_context );` per the [API Reference](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-interactivity/packages-interactivity-api-reference/#wp_interactivity_data_wp_context)
