### PR TITLE
Pattern Explorer: Pass 'rootClientId' to the pattern list

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
@@ -41,6 +41,7 @@ function PatternsExplorer( { initialCategory, rootClientId } ) {
 				selectedCategory={ selectedCategory }
 				patternCategories={ patternCategories }
 				patternSourceFilter={ patternSourceFilter }
+				rootClientId={ rootClientId }
 			/>
 		</div>
 	);

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
@@ -47,10 +47,16 @@ function PatternsListHeader( { filterValue, filteredBlockPatternsLength } ) {
 	);
 }
 
-function PatternList( { searchValue, selectedCategory, patternCategories } ) {
+function PatternList( {
+	searchValue,
+	selectedCategory,
+	patternCategories,
+	rootClientId,
+} ) {
 	const container = useRef();
 	const debouncedSpeak = useDebounce( speak, 500 );
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
+		rootClientId,
 		shouldFocusBlock: true,
 	} );
 	const [ patterns, , onClickPattern ] = usePatternsState(


### PR DESCRIPTION
## What?
Fixes #59984.

PR fixes the Pattern Explorer modal not loading patterns in the Site Editor when viewing pages.

## Why?
The destination `rootClientId` has [special handling](https://github.com/WordPress/gutenberg/blob/f98609b7f12a69535e77ce7a4c32bd5363d04b75/packages/editor/src/store/private-selectors.js#L31-L43) when the editor's rendering mode is locked. In those cases, the `__experimentalGetAllowedPatterns` call with the default root client (`' '` - empty string) will return no results.

## How?
Pass the `rootClientId` to the `PatternList` component. The value was already available in its parent component.

## Testing Instructions
1. Open the Site Editor.
2. Navigate to Design -> Pages and open any page.
3. Open the Inserter > Patterns -> Explora all Patterns modal.
4. Confirm that the patterns are loaded correctly.
5. Smoke test the same modal when viewing the template and in the post editor. It should work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/d6d684d7-4ec5-42be-a06d-25bebee2d22a

