### PR TITLE
Editor: Memoize 'getInsertionPoint' selector

### DIFF
--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import createSelector from 'rememo';
+
+/**
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -22,28 +27,41 @@ const EMPTY_INSERTION_POINT = {
  *
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
-export const getInsertionPoint = createRegistrySelector(
-	( select ) => ( state ) => {
-		if ( typeof state.blockInserterPanel === 'object' ) {
-			return state.blockInserterPanel;
-		}
+export const getInsertionPoint = createRegistrySelector( ( select ) =>
+	createSelector(
+		( state ) => {
+			if ( typeof state.blockInserterPanel === 'object' ) {
+				return state.blockInserterPanel;
+			}
 
-		if ( getRenderingMode( state ) === 'template-locked' ) {
+			if ( getRenderingMode( state ) === 'template-locked' ) {
+				const [ postContentClientId ] =
+					select( blockEditorStore ).getBlocksByName(
+						'core/post-content'
+					);
+				if ( postContentClientId ) {
+					return {
+						rootClientId: postContentClientId,
+						insertionIndex: undefined,
+						filterValue: undefined,
+					};
+				}
+			}
+
+			return EMPTY_INSERTION_POINT;
+		},
+		( state ) => {
 			const [ postContentClientId ] =
 				select( blockEditorStore ).getBlocksByName(
 					'core/post-content'
 				);
-			if ( postContentClientId ) {
-				return {
-					rootClientId: postContentClientId,
-					insertionIndex: undefined,
-					filterValue: undefined,
-				};
-			}
+			return [
+				state.blockInserterPanel,
+				getRenderingMode( state ),
+				postContentClientId,
+			];
 		}
-
-		return EMPTY_INSERTION_POINT;
-	}
+	)
 );
 
 export function getListViewToggleRef( state ) {


### PR DESCRIPTION
## What?
PR memoized editor's `getInsertionPoint` registry selector. Which is now possible thanks to the #57888.

## Why?
This prevents the selector from returning different values when called with the same state.

## Testing Instructions
1. Open the Site Editor.
2. Navigate to the any page.
3. Open the inserter.
4. Confirm that the `useSelect` doesn't log warnings.
5. Confirm block/pattern insertion works as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-03-20 at 08 20 38](https://github.com/WordPress/gutenberg/assets/240569/67b1fbc5-8cf8-4063-b374-23b661d23365)
