### PR TITLE
theme.json schema: Add settings.color.caption definition

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -98,6 +98,7 @@ Settings related to colors.
 | text | boolean | true |  |
 | heading | boolean | true |  |
 | button | boolean | true |  |
+| caption | boolean | true |  |
 
 ---
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -241,6 +241,11 @@
 							"description": "Allow users to set button colors in a block.",
 							"type": "boolean",
 							"default": true
+						},
+						"caption": {
+							"description": "Allow users to set caption colors in a block.",
+							"type": "boolean",
+							"default": true
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds the missing `settings.color.caption` definition in the theme.json schema. This should also eliminate the warning that is occurring in ~~TT4's~~ the default theme.json.

![tt4_theme_json](https://github.com/WordPress/gutenberg/assets/54422211/69667902-0d80-4ee3-86ea-0601605cc254)

## Testing Instructions

Create a JSON file like the one below locally and make sure the `settings.color.caption` property is allowed.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/fix/theme-json-schema-caption/schemas/json/theme.json",
	"version": 2,
	"settings": {
		"color": {
		}
	}
}
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/9988866b-8fc2-40c6-bca4-ff72c06db33d)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/3cb327cd-f28a-413c-aa63-f6f2ec43c2f1)
