### PR TITLE
Pattern Explorer: Remove leftover source filter state handlers

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
@@ -14,16 +14,11 @@ import { usePatternCategories } from '../block-patterns-tab/use-pattern-categori
 
 function PatternsExplorer( { initialCategory, rootClientId } ) {
 	const [ searchValue, setSearchValue ] = useState( '' );
-	const [ patternSourceFilter, setPatternSourceFilter ] = useState( 'all' );
-
 	const [ selectedCategory, setSelectedCategory ] = useState(
 		initialCategory?.name
 	);
 
-	const patternCategories = usePatternCategories(
-		rootClientId,
-		patternSourceFilter
-	);
+	const patternCategories = usePatternCategories( rootClientId );
 
 	return (
 		<div className="block-editor-block-patterns-explorer">
@@ -33,14 +28,11 @@ function PatternsExplorer( { initialCategory, rootClientId } ) {
 				onClickCategory={ setSelectedCategory }
 				searchValue={ searchValue }
 				setSearchValue={ setSearchValue }
-				patternSourceFilter={ patternSourceFilter }
-				setPatternSourceFilter={ setPatternSourceFilter }
 			/>
 			<PatternList
 				searchValue={ searchValue }
 				selectedCategory={ selectedCategory }
 				patternCategories={ patternCategories }
-				patternSourceFilter={ patternSourceFilter }
 				rootClientId={ rootClientId }
 			/>
 		</div>


### PR DESCRIPTION
## What?
PR removes pattern source filtering logic leftovers from the Pattern Explorer. These handlers are no longer needed after refactoring in #54681.

## Testing Instructions
1. Open a post or page.
2. Open Inserter > Patterns.
3. Confirm category source filtering works as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/f25721e6-330a-486f-b7b0-9311067fb111

