### PR TITLE
Docs: Remove alert callout on block selectors page

### DIFF
--- a/docs/reference-guides/block-api/block-selectors.md
+++ b/docs/reference-guides/block-api/block-selectors.md
@@ -1,11 +1,5 @@
 # Selectors
 
-<div class="callout callout-alert">
-	This API was stabilized in Gutenberg 15.5 and is planned for core release
-	in WordPress 6.3. To use this prior to WordPress 6.3, you will need to
-	install and activate Gutenberg >= 15.5.
-</div>
-
 Block Selectors is the API that allows blocks to customize the CSS selector used
 when their styles are generated.
 


### PR DESCRIPTION
## What?
PR removes alert callout from the Block Selectors documentation page. The API was stabilized almost two releases ago.

Here's the dev note: https://make.wordpress.org/core/2023/07/17/introducing-the-block-selectors-api/

## Testing Instructions
None.

## Sceenshot
![CleanShot 2024-03-20 at 09 35 03](https://github.com/WordPress/gutenberg/assets/240569/c7014a75-b312-4f6f-b1f8-48688e650872)
