### PR TITLE
Replace screenshots of Radio Control

### DIFF
--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -20,12 +20,12 @@ If you have a list of available options that can be collapsed, consider using a 
 
 #### Do
 
-![](https://raw.githubusercontent.com/krokodok/gutenberg/b3bfe9b6ce458de792595f863df1412975d1c714/do.png)
+![Right: A screenshot showing two radio buttons for "Author" and "Editor", one checked](https://github.com/WordPress/gutenberg/assets/10128264/77da4e95-b038-43e7-bd29-11282cc2bac7)
 Use radio buttons when only one item can be selected from a list.
 
 #### Don’t
 
-![](https://raw.githubusercontent.com/krokodok/gutenberg/b3bfe9b6ce458de792595f863df1412975d1c714/dont.png)
+![Wrong: A screenshot showing two checkboxes for "Author" and "Editor", one checked](https://github.com/WordPress/gutenberg/assets/10128264/214f37a8-2080-4c10-a4b5-b011e0875f18)
 Don’t use checkboxes when only one item can be selected from a list. Use radio buttons instead.
 
 #### Defaults

--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -20,12 +20,12 @@ If you have a list of available options that can be collapsed, consider using a 
 
 #### Do
 
-![](https://make.wordpress.org/design/files/2018/11/radio-usage-do.png)
+![](https://raw.githubusercontent.com/krokodok/gutenberg/b3bfe9b6ce458de792595f863df1412975d1c714/do.png)
 Use radio buttons when only one item can be selected from a list.
 
 #### Don’t
 
-![](https://make.wordpress.org/design/files/2018/11/radio-usage-dont.png)
+![](https://raw.githubusercontent.com/krokodok/gutenberg/b3bfe9b6ce458de792595f863df1412975d1c714/dont.png)
 Don’t use checkboxes when only one item can be selected from a list. Use radio buttons instead.
 
 #### Defaults


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Replacing screenshots showing a wrong component with the right one, as discussed in https://github.com/WordPress/gutenberg/issues/28763.

### Please help
Could someone take my two files 

- https://raw.githubusercontent.com/krokodok/gutenberg/b3bfe9b6ce458de792595f863df1412975d1c714/do.png
- https://raw.githubusercontent.com/krokodok/gutenberg/b3bfe9b6ce458de792595f863df1412975d1c714/dont.png

and upload them to the make.wordpress.org server and then change the URLs in the README file? I looked through the repository into other README documents, and there do not seem to be other cases of GitHub hosted images.

Also, since [the last time I commented](https://github.com/WordPress/gutenberg/issues/28763#issuecomment-1490429398) on the original issue with screenshots, GitHub [changed the visibility](https://github.com/orgs/community/discussions/54551) of GitHub hosted images. Because I created new screenshots today, that contain the big, coloured "Right" and "Wrong" indicators, I can't "host" them on GitHub via a comment on the issue, as previously. The files now live inside a branch in my fork, which is not optimal, since this could be deleted some day!

## Why?
The old screenshot was not showing the RadioControl component but a custom one instead.

## How?
The screenshots are replaced.

## Testing Instructions
n/a

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast <!-- if applicable -->
### Old
<img width="1047" alt="grafik" src="https://github.com/WordPress/gutenberg/assets/10128264/db59f974-f0e7-446b-bbec-17508e9e6300">

### New
<img width="1057" alt="grafik" src="https://github.com/WordPress/gutenberg/assets/10128264/0a102482-079a-425c-ba0e-cc2f0314d02f">
