### PR TITLE
Update the line height for components

### DIFF
--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -58,7 +58,7 @@ export default Object.assign( {}, CONTROL_PROPS, TOGGLE_GROUP_CONTROL_PROPS, {
 	fontSizeMobile: '15px',
 	fontSizeSmall: 'calc(0.92 * 13px)',
 	fontSizeXSmall: 'calc(0.75 * 13px)',
-	fontLineHeightBase: '1.2',
+	fontLineHeightBase: '1.4',
 	fontWeight: 'normal',
 	fontWeightHeading: '600',
 	gridBase: '4px',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? / Why?
In https://github.com/WordPress/gutenberg/pull/59645 we discovered that we are using the wrong line height for components. The CSS declares `$default-line-height: 1.4;` so we should update the JS settings to match.

## How?
Update the JS config.

## Testing Instructions
1. Look at the line height in ConfirmDialog component and see that it is 1.4 (see https://github.com/WordPress/gutenberg/pull/60004)

## Screenshots or screencast <!-- if applicable -->
<img width="493" alt="Screenshot 2024-03-20 at 11 38 28" src="https://github.com/WordPress/gutenberg/assets/275961/548d034e-0fb9-4fdb-b200-34dd95dadc18">

cc @jasmussen 

