### PR TITLE
Media & Text: Make the alt text editable when featured images are used

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -14,9 +14,6 @@
 		},
 		"mediaAlt": {
 			"type": "string",
-			"source": "attribute",
-			"selector": "figure img",
-			"attribute": "alt",
 			"default": "",
 			"__experimentalRole": "content"
 		},

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -171,9 +171,6 @@ function MediaTextEdit( {
 	const featuredImageURL = useFeaturedImage
 		? featuredImageMedia?.source_url
 		: '';
-	const featuredImageAlt = useFeaturedImage
-		? featuredImageMedia?.alt_text
-		: '';
 
 	const toggleUseFeaturedImage = () => {
 		setAttributes( {
@@ -181,7 +178,7 @@ function MediaTextEdit( {
 			mediaType: 'image',
 			mediaId: undefined,
 			mediaUrl: undefined,
-			mediaAlt: undefined,
+			mediaAlt: '',
 			useFeaturedImage: ! useFeaturedImage,
 		} );
 	};
@@ -322,7 +319,7 @@ function MediaTextEdit( {
 				<TextareaControl
 					__nextHasNoMarginBottom
 					label={ __( 'Alternative text' ) }
-					value={ mediaAlt || featuredImageAlt }
+					value={ mediaAlt }
 					onChange={ onMediaAltChange }
 					help={
 						<>
@@ -431,7 +428,6 @@ function MediaTextEdit( {
 						mediaWidth,
 						useFeaturedImage,
 						featuredImageURL,
-						featuredImageAlt,
 					} }
 				/>
 				{ mediaPosition !== 'right' && <div { ...innerBlocksProps } /> }

--- a/packages/block-library/src/media-text/index.php
+++ b/packages/block-library/src/media-text/index.php
@@ -49,6 +49,9 @@ function render_block_core_media_text( $attributes, $content ) {
 	$processor->set_attribute( 'src', esc_url( $current_featured_image ) );
 	$processor->set_attribute( 'class', 'wp-image-' . get_post_thumbnail_id() . ' size-' . $media_size_slug );
 
+	// Ensure that an alt attribute is always present, even if it is empty.
+	$processor->set_attribute( 'alt', isset( $attributes['mediaAlt'] ) ? $attributes['mediaAlt'] : '' );
+
 	$content = $processor->get_updated_html();
 
 	return $content;

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -132,7 +132,6 @@ function MediaContainer( props, ref ) {
 		toggleUseFeaturedImage,
 		useFeaturedImage,
 		featuredImageURL,
-		featuredImageAlt,
 	} = props;
 
 	const isTemporaryMedia = ! mediaId && isBlobURL( mediaUrl );
@@ -163,7 +162,7 @@ function MediaContainer( props, ref ) {
 		const mediaTypeRenderers = {
 			image: () =>
 				useFeaturedImage && featuredImageURL ? (
-					<img src={ featuredImageURL } alt={ featuredImageAlt } />
+					<img src={ featuredImageURL } alt={ mediaAlt } />
 				) : (
 					mediaUrl && <img src={ mediaUrl } alt={ mediaAlt } />
 				),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What & How?
<!-- In a few words, what is the PR actually doing? -->

For https://github.com/WordPress/gutenberg/issues/60023
When the Media & text block uses a featured image, the alt text is not editable. If the image has an alt text in the media library, it shows in the alt text option in the block settings panel, but it can't be replaced or removed.
No alt text is output on the front.

The PR removes the `featuredImageAlt` constant from the Media & text block and only uses the `mediaAlt` constant for the alternative text.
When the setting "Use featured image" is toggled, it resets the `mediaAlt` attribute to an empty string.
If the alt text is changed through the option in the block settings panel, the `mediaAlt` attribute is updated.
The changes to index.php ensures that:
- The img tag always has an alt attribute, even if the alt attribute is empty.
- When there is a custom alt text saved to the attribute, it is used.

The changes to block.json ensures that the block does not try to populate the `mediaAlt` attribute with an empty string from the markup when the featured image is used. Or at least that is what I think it does- this is one point I would need help with.

- The upside is that with the PR, the alt text is editable and is used on the front.
- The downside about this change is that the alt text that is set for the featured image in the media library is never used in the Media & text block.

## Testing Instructions
Add a Media & text block with a featured image, and change the alt text.
Also test for any other regressions with the alt text for standard images.
