### PR TITLE
Remove CSS order property from social icons placeholder UI.

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -67,7 +67,6 @@
 .wp-block-social-links .wp-block-social-links__social-prompt {
 	min-height: $button-size-small;
 	list-style: none;
-	order: 2; // Move after the appender button. Because this element is non-interactive, it does not affect tab order.
 
 	// Show as block UI.
 	font-family: $default-font;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58938

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of an effort to remove all the CSS order properties from the codebase. Additionally, in this specific caces this `order` property doesn't do anything after the design has changed. See details in the issue https://github.com/WordPress/gutenberg/issues/58938

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `order` CSS property must not be used when changing the order of elements impacts the reading order or the focus order.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the CSS `order` property.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Create a post and add a Social Icons block.
- Observe the block placeholder shows some text 'Click plus to add' followed by a pluc icon button labeled 'Add block'.
- Observe the visual order of the text and the plus icon button is the same as on trunk.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
