### PR TITLE
Time picker: Provide property for show/hide date part

### DIFF
--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -85,6 +85,7 @@ function buildPadInputStateReducer( pad: number ) {
  *     <TimePicker
  *       currentTime={ date }
  *       onChange={ ( newTime ) => setTime( newTime ) }
+ *       showDatePicker={ true }
  *       is12Hour
  *     />
  *   );
@@ -94,6 +95,7 @@ function buildPadInputStateReducer( pad: number ) {
 export function TimePicker( {
 	is12Hour,
 	currentTime,
+	showDatePicker = true,
 	onChange,
 }: TimePickerProps ) {
 	const [ date, setDate ] = useState( () =>
@@ -323,48 +325,52 @@ export function TimePicker( {
 					<TimeZone />
 				</HStack>
 			</Fieldset>
-			<Fieldset>
-				<BaseControl.VisualLabel
-					as="legend"
-					className="components-datetime__time-legend" // Unused, for backwards compatibility.
-				>
-					{ __( 'Date' ) }
-				</BaseControl.VisualLabel>
-				<HStack
-					className="components-datetime__time-wrapper" // Unused, for backwards compatibility.
-				>
-					{ is12Hour ? (
-						<>
-							{ monthField }
-							{ dayField }
-						</>
-					) : (
-						<>
-							{ dayField }
-							{ monthField }
-						</>
-					) }
-					<YearInput
-						className="components-datetime__time-field components-datetime__time-field-year" // Unused, for backwards compatibility.
-						label={ __( 'Year' ) }
-						hideLabelFromVision
-						__next40pxDefaultSize
-						value={ year }
-						step={ 1 }
-						min={ 1 }
-						max={ 9999 }
-						required
-						spinControls="none"
-						isPressEnterToChange
-						isDragEnabled={ false }
-						isShiftStepEnabled={ false }
-						onChange={ buildNumberControlChangeCallback( 'year' ) }
-						__unstableStateReducer={ buildPadInputStateReducer(
-							4
+			{ showDatePicker && (
+				<Fieldset>
+					<BaseControl.VisualLabel
+						as="legend"
+						className="components-datetime__time-legend" // Unused, for backwards compatibility.
+					>
+						{ __( 'Date' ) }
+					</BaseControl.VisualLabel>
+					<HStack
+						className="components-datetime__time-wrapper" // Unused, for backwards compatibility.
+					>
+						{ is12Hour ? (
+							<>
+								{ monthField }
+								{ dayField }
+							</>
+						) : (
+							<>
+								{ dayField }
+								{ monthField }
+							</>
 						) }
-					/>
-				</HStack>
-			</Fieldset>
+						<YearInput
+							className="components-datetime__time-field components-datetime__time-field-year" // Unused, for backwards compatibility.
+							label={ __( 'Year' ) }
+							hideLabelFromVision
+							__next40pxDefaultSize
+							value={ year }
+							step={ 1 }
+							min={ 1 }
+							max={ 9999 }
+							required
+							spinControls="none"
+							isPressEnterToChange
+							isDragEnabled={ false }
+							isShiftStepEnabled={ false }
+							onChange={ buildNumberControlChangeCallback(
+								'year'
+							) }
+							__unstableStateReducer={ buildPadInputStateReducer(
+								4
+							) }
+						/>
+					</HStack>
+				</Fieldset>
+			) }
 		</Wrapper>
 	);
 }

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -12,6 +12,11 @@ export type TimePickerProps = {
 	is12Hour?: boolean;
 
 	/**
+	 * Whether to show the date picker.
+	 */
+	showDatePicker?: boolean;
+
+	/**
 	 * The function called when a new time has been selected. It is passed the
 	 * time as an argument.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related to: https://github.com/WordPress/gutenberg/issues/52734

## What?
<!-- In a few words, what is the PR actually doing? -->
Added an option to show/hide date part of the time picker component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
With this PR, we are supporting a case when there is a need to show only a time picker without a date component.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Provide the `showDatePicker`  property for the show/hide date part of the time picker component

## Testing Instructions
- Open storybook
- Toggle `showDatePicker` property
- Check the component changes
- Check if everything works as before the change

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![Screen Capture on 2024-03-20 at 14-45-21](https://github.com/WordPress/gutenberg/assets/1241413/bd82a469-ad94-4df7-bb24-a91b4b7407a1)
