### PR TITLE
RichText: document the identifier prop

### DIFF
--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -12,6 +12,10 @@ _Required._ HTML string to make editable. The HTML should be valid, and valid in
 
 _Required._ Called when the value changes.
 
+### `identifier: String`
+
+_Optional._ If the editable field is bound to a block attribute (through the `value` and `onChange` props) then this prop should specify the attribute name. The field will use this value to set the block editor selection correctly, specifying in which attribute and at what offset does the selection start or end.
+
 ### `tagName: String`
 
 _Default: `div`._ The [tag name](https://www.w3.org/TR/html51/syntax.html#tag-name) of the editable element.
@@ -50,6 +54,7 @@ _Optional._ By default, all registered formats are allowed. This setting can be 
 ```js
 <RichText
 	tagName="h2"
+	identifier="content"
 	value={ attributes.content }
 	allowedFormats={ [ 'core/bold', 'core/italic' ] } // Allow the content to be made bold or italic, but do not allow othe formatting options
 	onChange={ ( content ) => setAttributes( { content } ) }
@@ -99,6 +104,7 @@ registerBlockType( /* ... */, {
 			<RichText
 				tagName="h2"
 				className={ className }
+				identifier="content"
 				value={ attributes.content }
 				onChange={ ( content ) => setAttributes( { content } ) }
 			/>


### PR DESCRIPTION
The `RichText` component, when used in a block edit function, should have an `identifier` prop that's identical to the name of the block attribute that it's bound to. The `identifier` is then used as the `attributeKey` value in selection, and is also used when splitting or merging blocks.

This PRs fixes this for many core blocks.

Before this PR, you would see an auto-generated `attributeKey` on selection when editing, e.g., the Categories block:

<img width="707" alt="Screenshot 2024-03-20 at 14 14 29" src="https://github.com/WordPress/gutenberg/assets/664258/48f1c8ad-cf31-4c41-8e7e-7fa48b427bad">

After this PR, the selection very nicely references the `prefix` attribute that's being edited:

<img width="617" alt="Screenshot 2024-03-20 at 14 17 06" src="https://github.com/WordPress/gutenberg/assets/664258/658bda2d-3c54-4685-a709-cd35d1f156f6">
