### PR TITLE
Tests: Shard JS unit tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
-                shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
+                shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
-                shard: ['1/3', '2/3', '3/3']
+                shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
-                shard: ['1/4', '2/4', '3/4', '4/4']
+                shard: ['1/1']
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
-                shard: [1, 2, 3, 4]
+                shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -50,12 +50,12 @@ jobs:
               # build tasks, however. These must be run.
               run: npx lerna run build
 
-            - name: Running the tests ${{ matrix.shard }}/${{ strategy.job-total }}
+            - name: Running the tests ${{ matrix.shard }}
               run: |
                   npm run test:unit -- \
                     --ci \
                     --maxWorkers="${{ steps.cpu-cores.outputs.count }}" \
-                    --shard="${{ matrix.shard }}/${{ strategy.job-total }}" \
+                    --shard="${{ matrix.shard }}" \
                     --cacheDirectory="$HOME/.jest-cache"
 
     unit-js-date:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
-                shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
+                shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,7 +31,8 @@ jobs:
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
-            - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+            - name: Checkout repository
+              uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
               with:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
@@ -68,7 +69,8 @@ jobs:
                 node: ['20', '21']
 
         steps:
-            - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+            - name: Checkout repository
+              uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
               with:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
@@ -169,7 +171,8 @@ jobs:
             WP_ENV_CORE: ${{ matrix.wordpress == '' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wordpress ) }}
 
         steps:
-            - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+            - name: Checkout repository
+              uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
               with:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
@@ -349,7 +352,8 @@ jobs:
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
 
         steps:
-            - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+            - name: Checkout repository
+              uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
               with:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
     unit-js:
-        name: JavaScript (Node.js ${{ matrix.node }})
+        name: JavaScript (Node.js ${{ matrix.node }}) ${{ matrix.shard }}
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
@@ -50,7 +50,7 @@ jobs:
               # build tasks, however. These must be run.
               run: npx lerna run build
 
-            - name: Running the tests ${{ matrix.shard }}
+            - name: Running the tests
               run: |
                   npm run test:unit -- \
                     --ci \

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -77,17 +77,17 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
 
-            - name: Get number of CPU cores
+            - name: Determine the number of CPU cores
               uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
               id: cpu-cores
 
-            - name: npm build
+            - name: Run build scripts
               # It's not necessary to run the full build, since Jest can interpret
               # source files with `babel-jest`. Some packages have their own custom
               # build tasks, however. These must be run.
               run: npx lerna run build
 
-            - name: Running the date tests
+            - name: Run the date tests
               run: npm run test:unit:date -- --ci --maxWorkers=${{ steps.cpu-cores.outputs.count }} --cacheDirectory="$HOME/.jest-cache"
 
     compute-previous-wordpress-version:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,6 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
+                shard: [1, 2, 3, 4]
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -49,8 +50,13 @@ jobs:
               # build tasks, however. These must be run.
               run: npx lerna run build
 
-            - name: Running the tests
-              run: npm run test:unit -- --ci --maxWorkers=${{ steps.cpu-cores.outputs.count }} --cacheDirectory="$HOME/.jest-cache"
+            - name: Running the tests ${{ matrix.shard }}/${{ strategy.job-total }}
+              run: |
+                  npm run test:unit -- \
+                    --ci \
+                    --maxWorkers="${{ steps.cpu-cores.outputs.count }}" \
+                    --shard="${{ matrix.shard }}/${{ strategy.job-total }}" \
+                    --cacheDirectory="$HOME/.jest-cache"
 
     unit-js-date:
         name: JavaScript Date Tests (Node.js ${{ matrix.node }})

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
-                shard: ['1/4', '2/4', '3/4', '4/4']
+                shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
-                shard: ['1/1']
+                shard: ['1/2', '2/2']
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -44,7 +44,7 @@ jobs:
               uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
               id: cpu-cores
 
-            - name: npm build
+            - name: Run build scripts
               # It's not necessary to run the full build, since Jest can interpret
               # source files with `babel-jest`. Some packages have their own custom
               # build tasks, however. These must be run.
@@ -360,7 +360,7 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
 
-            - name: Npm build
+            - name: Run build scripts
               # It's not necessary to run the full build, since Jest can interpret
               # source files with `babel-jest`. Some packages have their own custom
               # build tasks, however. These must be run.

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -41,7 +41,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
 
-            - name: Get number of CPU cores
+            - name: Determine the number of CPU cores
               uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
               id: cpu-cores
 
@@ -357,7 +357,7 @@ jobs:
               with:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-            - name: Get number of CPU cores
+            - name: Determine the number of CPU cores
               uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
               id: cpu-cores
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -52,6 +52,35 @@ jobs:
             - name: Running the tests
               run: npm run test:unit -- --ci --maxWorkers=${{ steps.cpu-cores.outputs.count }} --cacheDirectory="$HOME/.jest-cache"
 
+    unit-js-date:
+        name: JavaScript Date Tests (Node.js ${{ matrix.node }})
+        runs-on: ubuntu-latest
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        strategy:
+            fail-fast: false
+            matrix:
+                node: ['20', '21']
+
+        steps:
+            - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+              with:
+                  node-version: ${{ matrix.node }}
+
+            - name: Get number of CPU cores
+              uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
+              id: cpu-cores
+
+            - name: npm build
+              # It's not necessary to run the full build, since Jest can interpret
+              # source files with `babel-jest`. Some packages have their own custom
+              # build tasks, however. These must be run.
+              run: npx lerna run build
+
             - name: Running the date tests
               run: npm run test:unit:date -- --ci --maxWorkers=${{ steps.cpu-cores.outputs.count }} --cacheDirectory="$HOME/.jest-cache"
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '21']
-                shard: ['1/2', '2/2']
+                shard: ['1/3', '2/3', '3/3']
 
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2


### PR DESCRIPTION
## What?

- Split out JS date unit tests
- [Shard](https://jestjs.io/docs/cli#--shard) main JS unit tests into 4 shards.

[See this comment for findings on different numbers of shards.](https://github.com/WordPress/gutenberg/pull/60045#issuecomment-2034529737)

Anecdotally, the JavaScript unit tests run in ~2 minutes (parallelized on 4 workers * 2 node versions) instead of ~3:45 currently on trunk.

Follow up to #59904.

## Why?

We can speed up the JS unit tests by sharding them — they're split up and different tests are run in parallel on different workers.

