### PR TITLE
Make sure Social icons links aren't empty and improve UI clarity

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -860,7 +860,7 @@ Displays the name of this site. Update the block, and the changes apply everywhe
 
 ## Social Icon
 
-Display an icon linking to a social media profile or site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/social-link))
+Display an icon linking to a social profile or site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/social-link))
 
 -	**Name:** core/social-link
 -	**Category:** widgets
@@ -870,7 +870,7 @@ Display an icon linking to a social media profile or site. ([Source](https://git
 
 ## Social Icons
 
-Display icons linking to your social media profiles or sites. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/social-links))
+Display icons linking to your social profiles or sites. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/social-links))
 
 -	**Name:** core/social-links
 -	**Category:** widgets

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -5,7 +5,7 @@
 	"title": "Social Icon",
 	"category": "widgets",
 	"parent": [ "core/social-links" ],
-	"description": "Display an icon linking to a social media profile or site.",
+	"description": "Display an icon linking to a social profile or site.",
 	"textdomain": "default",
 	"attributes": {
 		"url": {

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -144,7 +144,7 @@ const SocialLinkEdit = ( {
 							) }
 							value={ socialLinkLabel }
 							onChange={ ( value ) =>
-								setAttributes( { label: value || undefined } )
+								setAttributes( { label: value } )
 							}
 						/>
 					</PanelRow>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -114,7 +114,7 @@ const SocialLinkEdit = ( {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 
 	const IconComponent = getIconBySite( service );
-	const socialLinkLabel = label ? label : getNameBySite( service );
+	const socialLinkText = label ? label : getNameBySite( service );
 	const blockProps = useBlockProps( {
 		className: classes,
 		style: {
@@ -134,7 +134,7 @@ const SocialLinkEdit = ( {
 							help={ __(
 								'The link text is visible when enabled from the parent Social Icons block.'
 							) }
-							value={ socialLinkLabel }
+							value={ socialLinkText }
 							onChange={ ( value ) =>
 								setAttributes( { label: value } )
 							}
@@ -162,7 +162,7 @@ const SocialLinkEdit = ( {
 							'screen-reader-text': ! showLabels,
 						} ) }
 					>
-						{ socialLinkLabel }
+						{ socialLinkText }
 					</span>
 				</Button>
 				{ isSelected && showURLPopover && (

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -23,7 +23,7 @@ import {
 	PanelRow,
 	TextControl,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { keyboardReturn } from '@wordpress/icons';
 
 /**
@@ -114,8 +114,7 @@ const SocialLinkEdit = ( {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 
 	const IconComponent = getIconBySite( service );
-	const socialLinkName = getNameBySite( service );
-	const socialLinkLabel = label ? label : socialLinkName;
+	const socialLinkLabel = label ? label : getNameBySite( service );
 	const blockProps = useBlockProps( {
 		className: classes,
 		style: {
@@ -127,13 +126,7 @@ const SocialLinkEdit = ( {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody
-					title={ sprintf(
-						/* translators: %s: name of the social service. */
-						__( '%s link text' ),
-						socialLinkName
-					) }
-				>
+				<PanelBody title={ __( 'Settings' ) }>
 					<PanelRow>
 						<TextControl
 							__nextHasNoMarginBottom

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -132,7 +132,7 @@ const SocialLinkEdit = ( {
 							__nextHasNoMarginBottom
 							label={ __( 'Link text' ) }
 							help={ __(
-								'The link text is only visible when Show links text is enabled.'
+								'The link text is visible when enabled from the parent Social Icons block.'
 							) }
 							value={ socialLinkLabel }
 							onChange={ ( value ) =>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -93,7 +93,7 @@ const SocialLinkEdit = ( {
 	setAttributes,
 	clientId,
 } ) => {
-	const { url, service, label, rel } = attributes;
+	const { url, service, label = '', rel } = attributes;
 	const {
 		showLabels,
 		iconColor,
@@ -114,7 +114,13 @@ const SocialLinkEdit = ( {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 
 	const IconComponent = getIconBySite( service );
-	const socialLinkText = label ? label : getNameBySite( service );
+	const socialLinkName = getNameBySite( service );
+	// The initial label (ie. the link text) is an empty string.
+	// We want to prevent empty links so that the link text always fallbacks to
+	// the social name, even when users enter and save an empty string or only
+	// spaces. The PHP render callback fallbacks to the social name as well.
+	const socialLinkText = label.trim() === '' ? socialLinkName : label;
+
 	const blockProps = useBlockProps( {
 		className: classes,
 		style: {
@@ -134,10 +140,11 @@ const SocialLinkEdit = ( {
 							help={ __(
 								'The link text is visible when enabled from the parent Social Icons block.'
 							) }
-							value={ socialLinkText }
+							value={ label }
 							onChange={ ( value ) =>
 								setAttributes( { label: value } )
 							}
+							placeholder={ socialLinkName }
 						/>
 					</PanelRow>
 				</PanelBody>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -58,7 +58,9 @@ const SocialLinkURLPopover = ( {
 						onChange={ ( nextURL ) =>
 							setAttributes( { url: nextURL } )
 						}
-						placeholder={ __( 'Enter address' ) }
+						placeholder={ __( 'Enter social media link' ) }
+						label={ __( 'Enter social media link' ) }
+						hideLabelFromVision
 						disableSuggestions
 						onKeyDown={ ( event ) => {
 							if (
@@ -128,7 +130,7 @@ const SocialLinkEdit = ( {
 				<PanelBody
 					title={ sprintf(
 						/* translators: %s: name of the social service. */
-						__( '%s label' ),
+						__( '%s link text' ),
 						socialLinkName
 					) }
 					initialOpen={ false }
@@ -136,9 +138,9 @@ const SocialLinkEdit = ( {
 					<PanelRow>
 						<TextControl
 							__nextHasNoMarginBottom
-							label={ __( 'Link label' ) }
+							label={ __( 'Link text' ) }
 							help={ __(
-								'Briefly describe the link to help screen reader users.'
+								'The link text is only visible when Show links text is enabled.'
 							) }
 							value={ socialLinkLabel }
 							onChange={ ( value ) =>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -172,16 +172,16 @@ const SocialLinkEdit = ( {
 					>
 						{ socialLinkLabel }
 					</span>
-					{ isSelected && showURLPopover && (
-						<SocialLinkURLPopover
-							url={ url }
-							setAttributes={ setAttributes }
-							setPopover={ setPopover }
-							popoverAnchor={ popoverAnchor }
-							clientId={ clientId }
-						/>
-					) }
 				</Button>
+				{ isSelected && showURLPopover && (
+					<SocialLinkURLPopover
+						url={ url }
+						setAttributes={ setAttributes }
+						setPopover={ setPopover }
+						popoverAnchor={ popoverAnchor }
+						clientId={ clientId }
+					/>
+				) }
 			</li>
 		</>
 	);

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -58,8 +58,8 @@ const SocialLinkURLPopover = ( {
 						onChange={ ( nextURL ) =>
 							setAttributes( { url: nextURL } )
 						}
-						placeholder={ __( 'Enter social media link' ) }
-						label={ __( 'Enter social media link' ) }
+						placeholder={ __( 'Enter social link' ) }
+						label={ __( 'Enter social link' ) }
 						hideLabelFromVision
 						disableSuggestions
 						onKeyDown={ ( event ) => {

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -133,7 +133,6 @@ const SocialLinkEdit = ( {
 						__( '%s link text' ),
 						socialLinkName
 					) }
-					initialOpen={ false }
 				>
 					<PanelRow>
 						<TextControl

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -113,7 +113,7 @@ const SocialLinkEdit = ( {
 
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
-	const socialLinkLabel = label ?? socialLinkName;
+	const socialLinkLabel = label ? label : socialLinkName;
 	const blockProps = useBlockProps( {
 		className: classes,
 		style: {
@@ -140,7 +140,7 @@ const SocialLinkEdit = ( {
 							help={ __(
 								'Briefly describe the link to help screen reader users.'
 							) }
-							value={ label || '' }
+							value={ socialLinkLabel }
 							onChange={ ( value ) =>
 								setAttributes( { label: value || undefined } )
 							}

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -19,9 +19,11 @@
 function render_block_core_social_link( $attributes, $content, $block ) {
 	$open_in_new_tab = isset( $block->context['openInNewTab'] ) ? $block->context['openInNewTab'] : false;
 
+	$text = ! empty( $attributes['label'] ) ? trim( $attributes['label'] ) : '';
+
 	$service     = isset( $attributes['service'] ) ? $attributes['service'] : 'Icon';
 	$url         = isset( $attributes['url'] ) ? $attributes['url'] : false;
-	$label       = ! empty( $attributes['label'] ) ? $attributes['label'] : block_core_social_link_get_name( $service );
+	$text        = $text ? $text : block_core_social_link_get_name( $service );
 	$rel         = isset( $attributes['rel'] ) ? $attributes['rel'] : '';
 	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
 
@@ -57,7 +59,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$link  = '<li ' . $wrapper_attributes . '>';
 	$link .= '<a href="' . esc_url( $url ) . '" class="wp-block-social-link-anchor">';
 	$link .= $icon;
-	$link .= '<span class="wp-block-social-link-label' . ( $show_labels ? '' : ' screen-reader-text' ) . '">' . esc_html( $label ) . '</span>';
+	$link .= '<span class="wp-block-social-link-label' . ( $show_labels ? '' : ' screen-reader-text' ) . '">' . esc_html( $text ) . '</span>';
 	$link .= '</a></li>';
 
 	$processor = new WP_HTML_Tag_Processor( $link );

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -5,7 +5,7 @@
 	"title": "Social Icons",
 	"category": "widgets",
 	"allowedBlocks": [ "core/social-link" ],
-	"description": "Display icons linking to your social media profiles or sites.",
+	"description": "Display icons linking to your social profiles or sites.",
 	"keywords": [ "links" ],
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -203,7 +203,7 @@ export function SocialLinksEdit( props ) {
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __( 'Show links text' ) }
+						label={ __( 'Show text' ) }
 						checked={ showLabels }
 						onChange={ () =>
 							setAttributes( { showLabels: ! showLabels } )

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -203,7 +203,7 @@ export function SocialLinksEdit( props ) {
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __( 'Show labels' ) }
+						label={ __( 'Show links text' ) }
 						checked={ showLabels }
 						onChange={ () =>
 							setAttributes( { showLabels: ! showLabels } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60044

## What?
<!-- In a few words, what is the PR actually doing? -->
Social links can be empty when users save the link text input field with an empty value or only spaces.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Empty links are far from ideal for semantics. SEO, and accessibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Makes sure the social link text isn't empty by implementing a fallback to the social name.
- The fallback is transparently shown in the editing UI: Users can still empty the link text input field or save only spaces but the UI will show the social name fallback.
- Terminology: changes 'social media' to 'social' 
- The popover input field placeholder changes from 'Enter address' to 'Enter social link'
- Changes labeling of the input field from default 'URL' to 'Enter social link' so that it matches the visibile placeholder 
- Simplifies the settings panel title to 'Settings'
- Changes the label of the input field from 'Link label' to 'Link text'
- Changes the input description to 'The link text is visible when enabled from the parent Social Icons block.'
- Adds a placeholder to the input field with the social name, as that's the default value 
- Moves the `SocialLinkURLPopover` outside of the social link `Button` so that the tooltip of the button within the popover works.
- In the parent Social Links block, changes the label 'Show labels' to 'Show text'.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a Social Icons block.
- To better test, enable 'Show labels' in the block settings panel.
- Add a Social link.
- Observe the social link shows the social name.
- Click the social link to open the popover and apply a social link URL.
- Hover or focus the 'Apply' button in the popover and observe it shows a tooltip.
- In the block settings inspector, observe the Link Text input field is empty and shows a placeholder with the social name instead of being entirely empty.
- Publish the post.
- Go to the front end and observe the social link does have a link text (the social name).
- In the editor, change the link text to some custom value and save.
- Observe that both the editor and the front end show the new link text.
- In the editor, change the link text to only spaces and save.
- Observe that both the editor and the front end show the social name as the link text.
- In the editor, empty the link text and save.
- Observe that both the editor and the front end show the social name as the link text.
- Check all the new labels and descriptions listed in the 'How' section.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
