### PR TITLE
Prevent reordering of header and footer template parts when zoomed out

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -65,6 +65,7 @@ const BlockMoverButton = forwardRef(
 			? clientIds
 			: [ clientIds ];
 		const blocksCount = normalizedClientIds.length;
+		const { disabled } = props;
 
 		const {
 			blockType,
@@ -98,7 +99,9 @@ const BlockMoverButton = forwardRef(
 
 				return {
 					blockType: block ? getBlockType( block.name ) : null,
-					isDisabled: direction === 'up' ? isFirstBlock : isLastBlock,
+					isDisabled:
+						disabled ||
+						( direction === 'up' ? isFirstBlock : isLastBlock ),
 					rootClientId: blockRootClientId,
 					firstIndex: firstBlockIndex,
 					isFirst: isFirstBlock,

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -19,7 +19,12 @@ import BlockDraggable from '../block-draggable';
 import { BlockMoverUpButton, BlockMoverDownButton } from './button';
 import { store as blockEditorStore } from '../../store';
 
-function BlockMover( { clientIds, hideDragHandle } ) {
+function BlockMover( {
+	clientIds,
+	hideDragHandle,
+	isPrevBlockTemplatePart,
+	isNextBlockTemplatePart,
+} ) {
 	const { canMove, rootClientId, isFirst, isLast, orientation } = useSelect(
 		( select ) => {
 			const {
@@ -80,22 +85,26 @@ function BlockMover( { clientIds, hideDragHandle } ) {
 				</BlockDraggable>
 			) }
 			<div className="block-editor-block-mover__move-button-container">
-				<ToolbarItem>
-					{ ( itemProps ) => (
-						<BlockMoverUpButton
-							clientIds={ clientIds }
-							{ ...itemProps }
-						/>
-					) }
-				</ToolbarItem>
-				<ToolbarItem>
-					{ ( itemProps ) => (
-						<BlockMoverDownButton
-							clientIds={ clientIds }
-							{ ...itemProps }
-						/>
-					) }
-				</ToolbarItem>
+				{ ! isPrevBlockTemplatePart && (
+					<ToolbarItem>
+						{ ( itemProps ) => (
+							<BlockMoverUpButton
+								clientIds={ clientIds }
+								{ ...itemProps }
+							/>
+						) }
+					</ToolbarItem>
+				) }
+				{ ! isNextBlockTemplatePart && (
+					<ToolbarItem>
+						{ ( itemProps ) => (
+							<BlockMoverDownButton
+								clientIds={ clientIds }
+								{ ...itemProps }
+							/>
+						) }
+					</ToolbarItem>
+				) }
 			</div>
 		</ToolbarGroup>
 	);

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -85,26 +85,24 @@ function BlockMover( {
 				</BlockDraggable>
 			) }
 			<div className="block-editor-block-mover__move-button-container">
-				{ ! isPrevBlockTemplatePart && (
-					<ToolbarItem>
-						{ ( itemProps ) => (
-							<BlockMoverUpButton
-								clientIds={ clientIds }
-								{ ...itemProps }
-							/>
-						) }
-					</ToolbarItem>
-				) }
-				{ ! isNextBlockTemplatePart && (
-					<ToolbarItem>
-						{ ( itemProps ) => (
-							<BlockMoverDownButton
-								clientIds={ clientIds }
-								{ ...itemProps }
-							/>
-						) }
-					</ToolbarItem>
-				) }
+				<ToolbarItem>
+					{ ( itemProps ) => (
+						<BlockMoverUpButton
+							disabled={ isPrevBlockTemplatePart }
+							clientIds={ clientIds }
+							{ ...itemProps }
+						/>
+					) }
+				</ToolbarItem>
+				<ToolbarItem>
+					{ ( itemProps ) => (
+						<BlockMoverDownButton
+							disabled={ isNextBlockTemplatePart }
+							clientIds={ clientIds }
+							{ ...itemProps }
+						/>
+					) }
+				</ToolbarItem>
 			</div>
 		</ToolbarGroup>
 	);

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -22,8 +22,8 @@ import { store as blockEditorStore } from '../../store';
 function BlockMover( {
 	clientIds,
 	hideDragHandle,
-	isPrevBlockTemplatePart,
-	isNextBlockTemplatePart,
+	isBlockMoverUpButtonDisabled,
+	isBlockMoverDownButtonDisabled,
 } ) {
 	const { canMove, rootClientId, isFirst, isLast, orientation } = useSelect(
 		( select ) => {
@@ -88,7 +88,7 @@ function BlockMover( {
 				<ToolbarItem>
 					{ ( itemProps ) => (
 						<BlockMoverUpButton
-							disabled={ isPrevBlockTemplatePart }
+							disabled={ isBlockMoverUpButtonDisabled }
 							clientIds={ clientIds }
 							{ ...itemProps }
 						/>
@@ -97,7 +97,7 @@ function BlockMover( {
 				<ToolbarItem>
 					{ ( itemProps ) => (
 						<BlockMoverDownButton
-							disabled={ isNextBlockTemplatePart }
+							disabled={ isBlockMoverDownButtonDisabled }
 							clientIds={ clientIds }
 							{ ...itemProps }
 						/>

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -61,6 +61,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				getBlockListSettings,
 				__unstableGetEditorMode,
 				getNextBlockClientId,
+				getPreviousBlockClientId,
 			} = select( blockEditorStore );
 			const { getActiveBlockVariation, getBlockType } =
 				select( blocksStore );
@@ -74,7 +75,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				blockType?.name === 'core/template-part';
 
 			let isNextBlockTemplatePart = false;
-			const nextClientId = getNextBlockClientId( clientId );
+			const nextClientId = getNextBlockClientId();
 			if ( nextClientId ) {
 				const { name: nextName } = getBlock( nextClientId );
 				const nextBlockType = getBlockType( nextName );
@@ -83,7 +84,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 			}
 
 			let isPrevBlockTemplatePart = false;
-			const prevClientId = getNextBlockClientId( clientId );
+			const prevClientId = getPreviousBlockClientId();
 			if ( prevClientId ) {
 				const { name: prevName } = getBlock( prevClientId );
 				const prevBlockType = getBlockType( prevName );

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -289,8 +289,12 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 						<BlockMover
 							clientIds={ [ clientId ] }
 							hideDragHandle
-							isPrevBlockTemplatePart={ isPrevBlockTemplatePart }
-							isNextBlockTemplatePart={ isNextBlockTemplatePart }
+							isBlockMoverUpButtonDisabled={
+								isPrevBlockTemplatePart
+							}
+							isBlockMoverDownButtonDisabled={
+								isNextBlockTemplatePart
+							}
 						/>
 					) }
 					{ editorMode === 'navigation' && (

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -60,6 +60,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				hasBlockMovingClientId,
 				getBlockListSettings,
 				__unstableGetEditorMode,
+				getNextBlockClientId,
 			} = select( blockEditorStore );
 			const { getActiveBlockVariation, getBlockType } =
 				select( blocksStore );
@@ -69,6 +70,26 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 			const orientation =
 				getBlockListSettings( rootClientId )?.orientation;
 			const match = getActiveBlockVariation( name, attributes );
+			const isBlockTemplatePart =
+				blockType?.name === 'core/template-part';
+
+			let isNextBlockTemplatePart = false;
+			const nextClientId = getNextBlockClientId( clientId );
+			if ( nextClientId ) {
+				const { name: nextName } = getBlock( nextClientId );
+				const nextBlockType = getBlockType( nextName );
+				isNextBlockTemplatePart =
+					nextBlockType?.name === 'core/template-part';
+			}
+
+			let isPrevBlockTemplatePart = false;
+			const prevClientId = getNextBlockClientId( clientId );
+			if ( prevClientId ) {
+				const { name: prevName } = getBlock( prevClientId );
+				const prevBlockType = getBlockType( prevName );
+				isPrevBlockTemplatePart =
+					prevBlockType?.name === 'core/template-part';
+			}
 
 			return {
 				blockMovingMode: hasBlockMovingClientId(),
@@ -80,11 +101,22 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 					index + 1,
 					orientation
 				),
+				isBlockTemplatePart,
+				isNextBlockTemplatePart,
+				isPrevBlockTemplatePart,
 			};
 		},
 		[ clientId, rootClientId ]
 	);
-	const { label, icon, blockMovingMode, editorMode } = selected;
+	const {
+		label,
+		icon,
+		blockMovingMode,
+		editorMode,
+		isBlockTemplatePart,
+		isNextBlockTemplatePart,
+		isPrevBlockTemplatePart,
+	} = selected;
 	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
 
@@ -252,8 +284,13 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 					<BlockIcon icon={ icon } showColors />
 				</FlexItem>
 				<FlexItem>
-					{ editorMode === 'zoom-out' && (
-						<BlockMover clientIds={ [ clientId ] } hideDragHandle />
+					{ editorMode === 'zoom-out' && ! isBlockTemplatePart && (
+						<BlockMover
+							clientIds={ [ clientId ] }
+							hideDragHandle
+							isPrevBlockTemplatePart={ isPrevBlockTemplatePart }
+							isNextBlockTemplatePart={ isNextBlockTemplatePart }
+						/>
 					) }
 					{ editorMode === 'navigation' && (
 						<BlockDraggable clientIds={ [ clientId ] }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Advances #50739

- [x] Disable moving control for header and footer (and any template part) in zoom out mode.
- [x]  Disable moving control for sections before header or after footer.
- [ ] Do the above for the ListView?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve the experience of assembling pages and templates using patterns.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check block type and disable block mover for the block toolbar that appears in zoom out mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

0. Enable the zoom out mode experiment
1. Go to the site editor
2. Create a new template
3. Make sure to have a header and a footer
4. Add some patterns
5. Enable zoom out mode
6. _Notice header and footer can't be moved_
7. _Notice the patterns can't be moved before header or after footer_

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/cbe2191f-b1be-496c-82df-3de3b7ef5aea


