### PR TITLE
Interactivity API: Variable name correction in the documentation

### DIFF
--- a/packages/interactivity/docs/api-reference.md
+++ b/packages/interactivity/docs/api-reference.md
@@ -1107,7 +1107,7 @@ This code
 
 ```php
 wp_interactivity_state( 'myPlugin', array( 'greeting' => 'Hello, World!' ) );
-$html = '<div data-wp-text="myPlugin::state.greeting"></div>';
+$html_content = '<div data-wp-text="myPlugin::state.greeting"></div>';
 $processed_html = wp_interactivity_process_directives( $html_content );
 echo $processed_html;
 ```


### PR DESCRIPTION
## What?
Minor correction to a variable name referenced in a code snippet on the interactivity api documentation

## Why?
The current code snippet in the documentation is incorrect. `wp_interactivity_process_directives()` is being passed an undefined value

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
N/A

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="948" alt="Screenshot 2024-03-20 at 5 06 24 PM" src="https://github.com/WordPress/gutenberg/assets/1923932/d218a274-116f-4c91-995c-15c409ad7565">
