### PR TITLE
Social icons: only render label container when there's a label

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -142,7 +142,7 @@ const SocialLinkEdit = ( {
 							) }
 							value={ label || '' }
 							onChange={ ( value ) =>
-								setAttributes( { label: value } )
+								setAttributes( { label: value || undefined } )
 							}
 						/>
 					</PanelRow>

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -19,10 +19,10 @@
 function render_block_core_social_link( $attributes, $content, $block ) {
 	$open_in_new_tab = isset( $block->context['openInNewTab'] ) ? $block->context['openInNewTab'] : false;
 
-	$service     = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
-	$url         = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label       = ( ! empty( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
-	$rel         = ( isset( $attributes['rel'] ) ) ? $attributes['rel'] : '';
+	$service     = isset( $attributes['service'] ) ? $attributes['service'] : 'Icon';
+	$url         = isset( $attributes['url'] ) ? $attributes['url'] : false;
+	$label       = ! empty( $attributes['label'] ) ? $attributes['label'] : block_core_social_link_get_name( $service );
+	$rel         = isset( $attributes['rel'] ) ? $attributes['rel'] : '';
 	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
 
 	// Don't render a link if there is no URL set.

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -21,7 +21,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 
 	$service     = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url         = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label       = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
+	$label       = ( ! empty( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
 	$rel         = ( isset( $attributes['rel'] ) ) ? $attributes['rel'] : '';
 	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
 
@@ -57,9 +57,8 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$link  = '<li ' . $wrapper_attributes . '>';
 	$link .= '<a href="' . esc_url( $url ) . '" class="wp-block-social-link-anchor">';
 	$link .= $icon;
-	$link .= '<span class="wp-block-social-link-label' . ( $show_labels ? '' : ' screen-reader-text' ) . '">';
-	$link .= esc_html( $label );
-	$link .= '</span></a></li>';
+	$link .= '<span class="wp-block-social-link-label' . ( $show_labels ? '' : ' screen-reader-text' ) . '">' . esc_html( $label ) . '</span>';
+	$link .= '</a></li>';
 
 	$processor = new WP_HTML_Tag_Processor( $link );
 	$processor->next_tag( 'a' );


### PR DESCRIPTION
## What? How?
Checks for label content before rendering a `wp-block-social-link-label` span using `! empty( $attributes['label'] )`.

Also as a double precaution, setting the label attribute to `undefined` instead of `''`.

If there's no label, render the default in the frontend.

## Why?
To avoid rendering an empty `wp-block-social-link-label` span on the frontend.

> Also as a double precaution, setting the label attribute to `undefined` instead of `''`.

Empty strings will pass PHP's `isset` check. 


## Testing Instructions

1. Insert social icons into post and publish.
2. Observe that a default label is rendered, e.g., `<span class="wp-block-social-link-label screen-reader-text">Mail</span>`
3. In the editor, edit the icons' label. Save the post. Check that the labels have been updated on the frontend.
4. Now remove the same labels in the editor.
5. Now the `<span class="wp-block-social-link-label screen-reader-text"/>` should contain the default label from the [$services_data](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/social-link/index.php#L137-L138) array

Test HTML

```html
<!-- wp:social-links {"openInNewTab":true} -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"http://wordpress.org","service":"wordpress","label":"WordPress"} /-->

<!-- wp:social-link {"url":"mailto:example@example.org","service":"mail"} /-->

<!-- wp:social-link {"service":"fivehundredpx"} /-->

<!-- wp:social-link {"url":"http://wordpress.org","service":"chain","label":""} /--></ul>
<!-- /wp:social-links -->
```
