### PR TITLE
Deprecations: Update versions supposed to be removed in WordPress 6.2

### DIFF
--- a/packages/components/src/button/deprecated.tsx
+++ b/packages/components/src/button/deprecated.tsx
@@ -29,7 +29,6 @@ function UnforwardedIconButton(
 	deprecated( 'wp.components.IconButton', {
 		since: '5.4',
 		alternative: 'wp.components.Button',
-		version: '6.2',
 	} );
 
 	return (

--- a/packages/editor/src/components/deprecated.js
+++ b/packages/editor/src/components/deprecated.js
@@ -66,7 +66,7 @@ function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
 		deprecated( 'wp.editor.' + name, {
 			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
-			version: '6.2',
+			version: '6.8',
 		} );
 
 		return <Wrapped ref={ ref } { ...props } />;
@@ -87,7 +87,7 @@ function deprecateFunction( name, func ) {
 		deprecated( 'wp.editor.' + name, {
 			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
-			version: '6.2',
+			version: '6.8',
 		} );
 
 		return func( ...args );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -832,7 +832,7 @@ const getBlockEditorAction =
 			since: '5.3',
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
-			version: '6.2',
+			version: '6.8',
 		} );
 		registry.dispatch( blockEditorStore )[ name ]( ...args );
 	};

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1362,7 +1362,7 @@ function getBlockEditorSelector( name ) {
 		deprecated( "`wp.data.select( 'core/editor' )." + name + '`', {
 			since: '5.3',
 			alternative: "`wp.data.select( 'core/block-editor' )." + name + '`',
-			version: '6.2',
+			version: '6.8',
 		} );
 
 		return select( blockEditorStore )[ name ]( ...args );

--- a/packages/nux/src/index.js
+++ b/packages/nux/src/index.js
@@ -9,5 +9,5 @@ export { default as DotTip } from './components/dot-tip';
 deprecated( 'wp.nux', {
 	since: '5.4',
 	hint: 'wp.components.Guide can be used to show a user guide.',
-	version: '6.2',
+	version: '6.8',
 } );


### PR DESCRIPTION
## What?

WordPress 6.5 is going to be released next week and we still have some deprecations in our code base saying that the APIs will be removed in 6.2. That's obviously a bad signal to send.

I'm going to try to do a review of these APIs (version per version) to see which ones should be delayed, remove the version entirely or remove the API.

No real impact here but I expect that we'd need to discuss some of these.