### PR TITLE
Shadow: add unit tests for shadow support

### DIFF
--- a/backport-changelog/6279.md
+++ b/backport-changelog/6279.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6279
+
+* https://github.com/WordPress/gutenberg/pull/60063

--- a/phpunit/block-supports/shadow-test.php
+++ b/phpunit/block-supports/shadow-test.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Test the shadow block supports.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_Supports_Shadow_Test extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	public function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a new block for testing shadow support.
+	 *
+	 * @param string $block_name Name for the test block.
+	 * @param array  $supports   Array defining block support configuration.
+	 *
+	 * @return WP_Block_Type The block type for the newly registered test block.
+	 */
+	private function register_shadow_block_with_support( $block_name, $supports = array() ) {
+		$this->test_block_name = $block_name;
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => $supports,
+			)
+		);
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		return $registry->get_registered( $this->test_block_name );
+	}
+
+	public function test_shadow_object_with_no_styles() {
+		$block_type  = self::register_shadow_block_with_support(
+			'test/shadow-object-with-no-styles',
+			array(
+				'shadow' => true,
+			)
+		);
+		$block_attrs = array( 'style' => array( 'shadow' => '' ) );
+		$actual      = gutenberg_apply_shadow_support( $block_type, $block_attrs );
+		$expected    = array();
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_shadow_without_support() {
+		$block_type = self::register_shadow_block_with_support(
+			'test/shadow-without-support',
+			array(
+				'shadow' => false,
+			)
+		);
+		$block_atts = array(
+			'style' => array(
+				'shadow' => '1px 1px 1px #000',
+			),
+		);
+
+		$actual   = gutenberg_apply_shadow_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_shadow_with_single_shadow() {
+		$block_type = self::register_shadow_block_with_support(
+			'test/shadow-with-single-shadow',
+			array(
+				'shadow' => true,
+			)
+		);
+		$block_atts = array(
+			'style' => array(
+				'shadow' => '1px 1px 1px #000',
+			),
+		);
+
+		$actual   = gutenberg_apply_shadow_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'box-shadow:1px 1px 1px #000;',
+		);
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_shadow_with_comma_separated_shadows() {
+		$block_type = self::register_shadow_block_with_support(
+			'test/shadow-with-comma-separated-shadows',
+			array(
+				'shadow' => true,
+			)
+		);
+		$block_atts = array(
+			'style' => array(
+				'shadow' => '1px 1px 1px #000, 2px 2px 2px #fff',
+			),
+		);
+
+		$actual   = gutenberg_apply_shadow_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'box-shadow:1px 1px 1px #000, 2px 2px 2px #fff;',
+		);
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_shadow_with_named_shadow() {
+		$block_type  = self::register_shadow_block_with_support(
+			'test/shadow-with-named-shadow',
+			array(
+				'shadow' => true,
+			)
+		);
+		$block_attrs = array(
+			'style' => array(
+				'shadow' => 'var:preset|shadow|natural',
+			),
+		);
+		$actual      = gutenberg_apply_shadow_support( $block_type, $block_attrs );
+		$expected    = array(
+			'style' => 'box-shadow:var(--wp--preset--shadow--natural);',
+		);
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_shadow_with_skipped_serialization() {
+		$block_type = self::register_shadow_block_with_support(
+			'test/shadow-with-skipped-serialization',
+			array(
+				'shadow' => array(
+					'__experimentalSkipSerialization' => true,
+				),
+			)
+		);
+		$block_atts = array(
+			'style' => array(
+				'shadow' => '1px 1px 1px #000',
+			),
+		);
+
+		$actual   = gutenberg_apply_shadow_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/phpunit/block-supports/shadow-test.php
+++ b/phpunit/block-supports/shadow-test.php
@@ -50,119 +50,58 @@ class WP_Block_Supports_Shadow_Test extends WP_UnitTestCase {
 		return $registry->get_registered( $this->test_block_name );
 	}
 
-	public function test_shadow_object_with_no_styles() {
+	/**
+	 * Tests the generation of shadow block support styles.
+	 *
+	 * @dataProvider data_generate_shadow_fixtures
+	 *
+	 * @param boolean|array $support Shadow block support configuration.
+	 * @param string        $value   Shadow style value for style attribute object.
+	 * @param array         $expected       Expected shadow block support styles.
+	 */
+	public function test_gutenberg_apply_shadow_support( $support, $value, $expected ) {
 		$block_type  = self::register_shadow_block_with_support(
-			'test/shadow-object-with-no-styles',
-			array(
-				'shadow' => true,
-			)
+			'test/shadow-block',
+			array( 'shadow' => $support )
 		);
-		$block_attrs = array( 'style' => array( 'shadow' => '' ) );
+		$block_attrs = array( 'style' => array( 'shadow' => $value ) );
 		$actual      = gutenberg_apply_shadow_support( $block_type, $block_attrs );
-		$expected    = array();
 
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function test_shadow_without_support() {
-		$block_type = self::register_shadow_block_with_support(
-			'test/shadow-without-support',
-			array(
-				'shadow' => false,
-			)
-		);
-		$block_atts = array(
-			'style' => array(
-				'shadow' => '1px 1px 1px #000',
+	public function data_generate_shadow_fixtures() {
+		return array(
+			'with no styles'               => array(
+				'support'  => true,
+				'value'    => '',
+				'expected' => array(),
+			),
+			'without support'              => array(
+				'support'  => false,
+				'value'    => '1px 1px 1px #000',
+				'expected' => array(),
+			),
+			'with single shadow'           => array(
+				'support'  => true,
+				'value'    => '1px 1px 1px #000',
+				'expected' => array( 'style' => 'box-shadow:1px 1px 1px #000;' ),
+			),
+			'with comma separated shadows' => array(
+				'support'  => true,
+				'value'    => '1px 1px 1px #000, 2px 2px 2px #fff',
+				'expected' => array( 'style' => 'box-shadow:1px 1px 1px #000, 2px 2px 2px #fff;' ),
+			),
+			'with preset shadow'           => array(
+				'support'  => true,
+				'value'    => 'var:preset|shadow|natural',
+				'expected' => array( 'style' => 'box-shadow:var(--wp--preset--shadow--natural);' ),
+			),
+			'with serialization skipped'   => array(
+				'support'  => array( '__experimentalSkipSerialization' => true ),
+				'value'    => '1px 1px 1px #000',
+				'expected' => array(),
 			),
 		);
-
-		$actual   = gutenberg_apply_shadow_support( $block_type, $block_atts );
-		$expected = array();
-
-		$this->assertSame( $expected, $actual );
-	}
-
-	public function test_shadow_with_single_shadow() {
-		$block_type = self::register_shadow_block_with_support(
-			'test/shadow-with-single-shadow',
-			array(
-				'shadow' => true,
-			)
-		);
-		$block_atts = array(
-			'style' => array(
-				'shadow' => '1px 1px 1px #000',
-			),
-		);
-
-		$actual   = gutenberg_apply_shadow_support( $block_type, $block_atts );
-		$expected = array(
-			'style' => 'box-shadow:1px 1px 1px #000;',
-		);
-
-		$this->assertSame( $expected, $actual );
-	}
-
-	public function test_shadow_with_comma_separated_shadows() {
-		$block_type = self::register_shadow_block_with_support(
-			'test/shadow-with-comma-separated-shadows',
-			array(
-				'shadow' => true,
-			)
-		);
-		$block_atts = array(
-			'style' => array(
-				'shadow' => '1px 1px 1px #000, 2px 2px 2px #fff',
-			),
-		);
-
-		$actual   = gutenberg_apply_shadow_support( $block_type, $block_atts );
-		$expected = array(
-			'style' => 'box-shadow:1px 1px 1px #000, 2px 2px 2px #fff;',
-		);
-
-		$this->assertSame( $expected, $actual );
-	}
-
-	public function test_shadow_with_named_shadow() {
-		$block_type  = self::register_shadow_block_with_support(
-			'test/shadow-with-named-shadow',
-			array(
-				'shadow' => true,
-			)
-		);
-		$block_attrs = array(
-			'style' => array(
-				'shadow' => 'var:preset|shadow|natural',
-			),
-		);
-		$actual      = gutenberg_apply_shadow_support( $block_type, $block_attrs );
-		$expected    = array(
-			'style' => 'box-shadow:var(--wp--preset--shadow--natural);',
-		);
-
-		$this->assertSame( $expected, $actual );
-	}
-
-	public function test_shadow_with_skipped_serialization() {
-		$block_type = self::register_shadow_block_with_support(
-			'test/shadow-with-skipped-serialization',
-			array(
-				'shadow' => array(
-					'__experimentalSkipSerialization' => true,
-				),
-			)
-		);
-		$block_atts = array(
-			'style' => array(
-				'shadow' => '1px 1px 1px #000',
-			),
-		);
-
-		$actual   = gutenberg_apply_shadow_support( $block_type, $block_atts );
-		$expected = array();
-
-		$this->assertSame( $expected, $actual );
 	}
 }

--- a/phpunit/block-supports/shadow-test.php
+++ b/phpunit/block-supports/shadow-test.php
@@ -70,6 +70,11 @@ class WP_Block_Supports_Shadow_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function data_generate_shadow_fixtures() {
 		return array(
 			'with no styles'               => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds missing PHP unit tests for Shadow support.

It tests 
* shadow support enabled/disabled, and 
* serialization is skipped/not skipped.

```
if (
    ! $has_shadow_support ||
    wp_should_skip_block_supports_serialization( $block_type, 'shadow' )
) {
    return array();
}
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Not applicable.

Related fix: #59887
