### PR TITLE
Block Editor: Fix ESLint warning in BlockListBlock component

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -112,7 +112,10 @@ function BlockListBlock( {
 		...context
 	} = useContext( PrivateBlockContext );
 	const { removeBlock } = useDispatch( blockEditorStore );
-	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
+	const onRemove = useCallback(
+		() => removeBlock( clientId ),
+		[ clientId, removeBlock ]
+	);
 
 	const parentLayout = useLayout() || {};
 


### PR DESCRIPTION
## What?
PR fixes the ESLint warning in the `BlockListBlock` component. The `removeBlock` action has a stable reference and is safe to pass as a dependency.

```
warning  React Hook useCallback has a missing dependency: 'removeBlock'. Either include it or remove the dependency array
```

## Why?
Ideally, the codebase should be warning-free.

## Testing Instructions
CI checks are green.