### PR TITLE
Allow opt-out of pattern overrides

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -29,6 +29,7 @@ import { useFlashEditableBlocks } from './components/use-flash-editable-blocks';
 import { selectBlockPatternsKey } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
 import { PrivateRichText } from './components/rich-text/';
+import { BlockRenameModal } from './components/block-rename';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -62,4 +63,5 @@ lock( privateApis, {
 	selectBlockPatternsKey,
 	requiresWrapperOnCopy,
 	PrivateRichText,
+	BlockRenameModal,
 } );

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -1,0 +1,93 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import {
+	InspectorControls,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { addBindings } from './use-set-pattern-bindings';
+import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
+import { unlock } from '../lock-unlock';
+
+const { BlockRenameModal } = unlock( blockEditorPrivateApis );
+
+function PatternOverridesControls( { attributes, name, setAttributes } ) {
+	const [ showBlockNameModal, setShowBlockNameModal ] = useState( false );
+
+	const syncedAttributes = PARTIAL_SYNCING_SUPPORTED_BLOCKS[ name ];
+	const attributeSources = syncedAttributes.map(
+		( attributeName ) =>
+			attributes.metadata?.bindings?.[ attributeName ]?.source
+	);
+	const isConnectedToOtherSources = attributeSources.every(
+		( source ) => source && source !== 'core/pattern-overrides'
+	);
+
+	function updateBindings( isChecked, customName ) {
+		if ( isChecked && ! attributes.metadata?.name && ! customName ) {
+			setShowBlockNameModal( true );
+			return;
+		}
+
+		const prevBindings = attributes?.metadata?.bindings;
+		const updatedBindings = isChecked
+			? addBindings( prevBindings, syncedAttributes )
+			: // Explicitly set to false to disable pattern overrides.
+			  false;
+
+		const updatedMetadata = {
+			...attributes.metadata,
+			bindings: updatedBindings,
+		};
+
+		if ( customName ) {
+			updatedMetadata.name = customName;
+		}
+
+		setAttributes( {
+			metadata: updatedMetadata,
+		} );
+	}
+
+	// Avoid overwriting other (e.g. meta) bindings.
+	if ( isConnectedToOtherSources ) return null;
+
+	return (
+		<>
+			<InspectorControls group="advanced">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Allow pattern overrides' ) }
+					checked={ attributeSources.some(
+						( source ) => source === 'core/pattern-overrides'
+					) }
+					help={ __(
+						'Allow attributes within this block to be overridden by pattern instances.'
+					) }
+					onChange={ ( isChecked ) => {
+						updateBindings( isChecked );
+					} }
+				/>
+			</InspectorControls>
+
+			{ showBlockNameModal && (
+				<BlockRenameModal
+					blockName={ attributes.metadata?.name || '' }
+					onClose={ () => setShowBlockNameModal( false ) }
+					onSave={ ( newName ) => {
+						updateBindings( true, newName );
+					} }
+				/>
+			) }
+		</>
+	);
+}
+
+export default PatternOverridesControls;

--- a/packages/patterns/src/components/use-set-pattern-bindings.js
+++ b/packages/patterns/src/components/use-set-pattern-bindings.js
@@ -30,7 +30,7 @@ function removeBindings( bindings, syncedAttributes ) {
 	return updatedBindings;
 }
 
-function addBindings( bindings, syncedAttributes ) {
+export function addBindings( bindings, syncedAttributes ) {
 	const updatedBindings = { ...bindings };
 	for ( const attributeName of syncedAttributes ) {
 		if ( ! bindings?.[ attributeName ] ) {
@@ -64,7 +64,9 @@ export default function useSetPatternBindings(
 		if (
 			! hasPatternOverridesSource ||
 			currentPostType !== 'wp_block' ||
-			metadataName === prevMetadataName
+			metadataName === prevMetadataName ||
+			// Don't update the bindings if it's explicitly set to false.
+			bindings === false
 		) {
 			return;
 		}

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -14,6 +14,7 @@ import RenamePatternModal from './components/rename-pattern-modal';
 import PatternsMenuItems from './components';
 import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
 import useSetPatternBindings from './components/use-set-pattern-bindings';
+import PatternOverridesControls from './components/pattern-overrides-controls';
 import ResetOverridesControl from './components/reset-overrides-control';
 import { useAddPatternCategory } from './private-hooks';
 import {
@@ -35,6 +36,7 @@ lock( privateApis, {
 	PatternsMenuItems,
 	RenamePatternCategoryModal,
 	useSetPatternBindings,
+	PatternOverridesControls,
 	ResetOverridesControl,
 	useAddPatternCategory,
 	PATTERN_TYPES,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Supersedes #59583. Attempts to close #59812.

Add an opt-out toggle for pattern overrides.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The current implementation of pattern overrides relies on the block's name (Block Renaming API) to enable the feature, but it lacks an opt-out mechanism to just name the block without enabling the feature.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR adds a toggle box next to the block name control, which defaults to true, and disables the feature when it's toggled off.

The design is similar to what @SaxonF shared in https://github.com/WordPress/gutenberg/issues/59813#issuecomment-2003044111 (the last one).

Technically, we set the `bindings` to `false` to disable the feature. This is not "officially supported" but it seems to work 🤷.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a synced pattern.
2. Add some supported blocks (`heading`, `paragraph`, `image`, and `button`) to the patterns and give them block names (in the editor settings -> Advanced panel)
3. Once they have block names, the "pattern overrides" toggle box should be automatically turned on.
4. Otherwise, if the block doesn't have a name, turning on the toggle box should prompt a block renaming modal.
5. Turning off the toggle box with the name still present should set the `bindings` attribute to `false`.
6. Insert the pattern in a post and edit those blocks. Blocks that have names but don't have the toggle turned on should not be editable.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/546470f0-5c0b-4346-89d3-eda6b8a46248

