### PR TITLE
Remove @kevin940726 and @Mamaduka from e2e test codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,7 +81,6 @@
 /packages/prettier-config                       @ntwb @gziolo
 /packages/scripts                               @gziolo @ntwb @nerrad @ajitbohra @ryanwelcher
 /packages/stylelint-config                      @ntwb
-/test/e2e                                       @Mamaduka
 /test/php/gutenberg-coding-standards            @anton-vlasenko
 
 # UI Components

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,7 +81,7 @@
 /packages/prettier-config                       @ntwb @gziolo
 /packages/scripts                               @gziolo @ntwb @nerrad @ajitbohra @ryanwelcher
 /packages/stylelint-config                      @ntwb
-/test/e2e                                       @kevin940726 @Mamaduka
+/test/e2e                                       @Mamaduka
 /test/php/gutenberg-coding-standards            @anton-vlasenko
 
 # UI Components


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Remove @kevin940726 from e2e test codeowners.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Now that the migration is (nearly) done, and most of the contributors are more familiar with writing playwright tests, I don't think I need to be pinged on every PR that touches tests anymore. Also, It's kind of overwhelming and I have less time to help on tests now 😅.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Edit `CODEOWNERS`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Nothing to test.

## Screenshots or screencast <!-- if applicable -->
N/A
