### PR TITLE
Add filter to allow extending the list of post content blocks

### DIFF
--- a/docs/reference-guides/filters/block-filters.md
+++ b/docs/reference-guides/filters/block-filters.md
@@ -283,6 +283,24 @@ wp.hooks.addFilter(
 ```
 
 
+### `editor.postContentBlockTypes`
+
+Used to modify the list of blocks that should be enabled even when used inside a locked template. Any block that saves data to a post should be added here. Examples of this are the post featured image block. Which often gets used in templates but should still allow selecting the image even when the template is locked.
+
+_Example:_
+
+```js
+const addExampleBlockToPostContentBlockTypes = ( blockTypes ) => {
+	return [ ...blockTypes, 'namespace/example' ];
+};
+
+wp.hooks.addFilter(
+	'editor.postContentBlockTypes',
+	'my-plugin/post-content-block-types',
+	addExampleBlockToPostContentBlockTypes
+);
+```
+
 ## Removing Blocks
 
 ### Using a deny list

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -4,13 +4,14 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
-const CONTENT_ONLY_BLOCKS = [
-	'core/post-content',
-	'core/post-featured-image',
+const CONTENT_ONLY_BLOCKS = applyFilters( 'editor.postContentBlockTypes', [
 	'core/post-title',
+	'core/post-featured-image',
+	'core/post-content',
 	'core/template-part',
-];
+] );
 
 /**
  * Component that when rendered, makes it so that the site editor allows only


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a filter to allow extending the hardcoded list of post content blocks. 

Closing: #59290

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This list is used to determine which blocks should allow editing their content even when displayed in a locked template. an example of this is the post featured image block. When building custom blocks that save to a custom meta field for example is is crucial to also allow this kind of experience where the field can be edited even when the block is used outside of the post content in the template. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding a filter that allows you to change the list of block names that should be enabled. 
