### PR TITLE
Index view for Templates & Parts: use `grid` layout as default

### DIFF
--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -76,7 +76,7 @@ const defaultConfigPerViewType = {
 };
 
 const DEFAULT_VIEW = {
-	type: LAYOUT_TABLE,
+	type: LAYOUT_GRID,
 	search: '',
 	page: 1,
 	perPage: 20,
@@ -87,7 +87,7 @@ const DEFAULT_VIEW = {
 	// All fields are visible by default, so it's
 	// better to keep track of the hidden ones.
 	hiddenFields: [ 'preview' ],
-	layout: defaultConfigPerViewType[ LAYOUT_TABLE ],
+	layout: defaultConfigPerViewType[ LAYOUT_GRID ],
 	filters: [],
 };
 

--- a/test/e2e/specs/site-editor/hybrid-theme.spec.js
+++ b/test/e2e/specs/site-editor/hybrid-theme.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Hybrid theme', () => {
 		);
 
 		await expect(
-			page.getByRole( 'table' ).getByRole( 'link', { name: 'header' } )
+			page.getByRole( 'link', { name: 'header' } )
 		).toBeVisible();
 	} );
 
@@ -29,9 +29,7 @@ test.describe( 'Hybrid theme', () => {
 			'postType=wp_template_part&path=/wp_template_part/all'
 		);
 
-		const templatePart = page
-			.getByRole( 'table' )
-			.getByRole( 'link', { name: 'header' } );
+		const templatePart = page.getByRole( 'link', { name: 'header' } );
 
 		await expect( templatePart ).toBeVisible();
 		await templatePart.click();

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -10,23 +10,23 @@ test.describe( 'Templates', () => {
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 		] );
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
+
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 	} );
+
 	test( 'Sorting', async ( { admin, page } ) => {
 		await admin.visitSiteEditor( { path: '/wp_template' } );
+
 		// Descending by title.
-		await page
-			.getByRole( 'button', { name: 'Template', exact: true } )
-			.click();
-		await page
-			.getByRole( 'menuitemradio', {
-				name: 'Sort descending',
-			} )
-			.click();
+		await page.getByRole( 'button', { name: 'View options' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Sort by' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Template' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'descending' } ).click();
 		const firstTitle = page
 			.getByRole( 'region', {
 				name: 'Template',
@@ -35,12 +35,12 @@ test.describe( 'Templates', () => {
 			.getByRole( 'link', { includeHidden: true } )
 			.first();
 		await expect( firstTitle ).toHaveText( 'Tag Archives' );
+
 		// Ascending by title.
-		await page
-			.getByRole( 'menuitemradio', { name: 'Sort ascending' } )
-			.click();
+		await page.getByRole( 'menuitemradio', { name: 'ascending' } ).click();
 		await expect( firstTitle ).toHaveText( 'Category Archives' );
 	} );
+
 	test( 'Filtering', async ( { requestUtils, admin, page } ) => {
 		await requestUtils.createTemplate( 'wp_template', {
 			slug: 'date',
@@ -82,10 +82,17 @@ test.describe( 'Templates', () => {
 		await page.keyboard.press( 'Escape' ); // close the menu.
 		await expect( titles ).toHaveCount( 2 );
 	} );
+
 	test( 'Field visibility', async ( { admin, page } ) => {
 		await admin.visitSiteEditor( { path: '/wp_template' } );
+
+		await page.getByRole( 'button', { name: 'View options' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Layout' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+
 		await page.getByRole( 'button', { name: 'Description' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Hide' } ).click();
+
 		await expect(
 			page.getByRole( 'button', { name: 'Description' } )
 		).toBeHidden();


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/59659
Follow-up to https://github.com/WordPress/gutenberg/pull/59792

## What?

Sets the `grid` layout as the default for the templates & parts index views:

| Templates | Parts |
| --- | --- |
| <img width="1511" alt="Captura de ecrã 2024-03-21, às 11 25 40" src="https://github.com/WordPress/gutenberg/assets/583546/9d7564a9-2891-415d-b133-1c7779ef2c0c"> | <img width="967" alt="Captura de ecrã 2024-03-21, às 11 39 04" src="https://github.com/WordPress/gutenberg/assets/583546/1610d32c-ac17-4d06-a64d-8143cbf9360f"> |

## How?

- 97f8d6cf6bcb18059ad82109d39eae56b5931c55 Set `grid` as default.

## Testing Instructions

Navigate to "Site Editor > Templates" and verify the `grid` layout is used as default.
