### PR TITLE
Pattern Shuffling: Don't assume that patterns have categories

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -56,7 +56,7 @@ export default function Shuffle( { clientId, as = Container } ) {
 				// Check if the pattern has only one top level block,
 				// otherwise we may shuffle to pattern that will not allow to continue shuffling.
 				pattern.blocks.length === 1 &&
-				pattern.categories.some( ( category ) => {
+				pattern.categories?.some( ( category ) => {
 					return categories.includes( category );
 				} )
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In https://github.com/WordPress/gutenberg/pull/59251 we introduced pattern shuffling, but we assumed that patterns have categories, when in reality they don't always have to.

## Why?
This fixes an error in the editor.

## How?
Check that patterns have a category before we iterate over them.

## Testing Instructions
1. Switch to a theme with patterns that don't have a category (e.g. Overlaid)
2. Try inserting a pattern. In trunk the editor will crash. In this branch the pattern will be inserted.

