### PR TITLE
Navigation: Avoid content loss when only specific entity fields are edited

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1520,6 +1520,14 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 		return $post;
 	}
 
+	/**
+	 * Skip meta generation when consumers intentionally update specific Navigation fields
+	 * and omit the content update.
+	 */
+	if ( ! isset( $post->post_content ) ) {
+		return $post;
+	}
+
 	/*
 	 * We run the Block Hooks mechanism to inject the `metadata.ignoredHookedBlocks` attribute into
 	 * all anchor blocks. For the root level, we create a mock Navigation and extract them from there.


### PR DESCRIPTION
## What?
Fixes #59991.

PR fixes the Navigation block content loss when renaming them in the Site Editor. It also fixes PHP warnings when post content isn't set.

```
PHP Warning: Undefined property: stdClass::$post_content in ~/gutenberg/wp-content/plugins/gutenberg/build/block-library/blocks/navigation.php on line 1527

PHP Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in ~/gutenberg/wp-includes/class-wp-block-parser.php on line 252

PHP Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in ~/gutenberg/wp-includes/class-wp-block-parser.php on line 324
```

## Why?
The entities can choose to update only specific fields (See `__experimentalSaveSpecifiedEntityEdits`) via REST API, and the prepared entity update will only contain those properties.

## How?
Bail early when post content isn't set for the prepared update.

## Testing Instructions
1. Open the Site Editor.
2. Navigate to Design > Navigation.
3. Pick any navigation.
4. Click on "Actions" and rename it.
5. Confirm that navigation block content stays intact after renaming.

### Testing Instructions for Keyboard
Same.
