### PR TITLE
Data views: Update template actions

### DIFF
--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { external, trash, backup } from '@wordpress/icons';
+import { external, trash, backup, edit } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -372,6 +372,8 @@ export function useEditPostAction() {
 		() => ( {
 			id: 'edit-post',
 			label: __( 'Edit' ),
+			isPrimary: true,
+			icon: edit,
 			isEligible( { status } ) {
 				return status !== 'trash';
 			},

--- a/packages/edit-site/src/components/page-templates-template-parts/actions.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/actions.js
@@ -32,7 +32,7 @@ export function useResetTemplateAction() {
 	return useMemo(
 		() => ( {
 			id: 'reset-template',
-			label: __( 'Reset' ),
+			label: __( 'Clear customizations' ),
 			isEligible: isTemplateRevertable,
 			supportsBulk: true,
 			async callback( templates ) {

--- a/packages/edit-site/src/components/page-templates-template-parts/actions.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/actions.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { backup, trash } from '@wordpress/icons';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { useMemo, useState } from '@wordpress/element';
@@ -34,8 +33,6 @@ export function useResetTemplateAction() {
 		() => ( {
 			id: 'reset-template',
 			label: __( 'Reset' ),
-			isPrimary: true,
-			icon: backup,
 			isEligible: isTemplateRevertable,
 			supportsBulk: true,
 			async callback( templates ) {
@@ -112,8 +109,6 @@ export function useResetTemplateAction() {
 export const deleteTemplateAction = {
 	id: 'delete-template',
 	label: __( 'Delete' ),
-	isPrimary: true,
-	icon: trash,
 	isEligible: isTemplateRemovable,
 	supportsBulk: true,
 	hideModalHeader: true,

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -51,7 +51,7 @@ import {
 	deleteTemplateAction,
 	renameTemplateAction,
 } from './actions';
-import { postRevisionsAction } from '../actions';
+import { postRevisionsAction, useEditPostAction } from '../actions';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 import AddNewTemplatePart from './add-new-template-part';
@@ -406,8 +406,10 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 	}, [ records, view, fields ] );
 
 	const resetTemplateAction = useResetTemplateAction();
+	const editTemplateAction = useEditPostAction();
 	const actions = useMemo(
 		() => [
+			editTemplateAction,
 			resetTemplateAction,
 			renameTemplateAction,
 			postRevisionsAction,


### PR DESCRIPTION
## What?

Follows up #59551 and implements some changes discussed in https://github.com/WordPress/gutenberg/issues/56603:

* De-emphasises destructive actions 'Delete' and 'Reset'
* Updates 'Reset' label to 'Clear customizations' to match elsewhere. Ii may be time to use the simpler 'Reset' label but that should be applied across the board.
* Add an 'Edit' quick-action to match the pages data view.

## Testing Instructions
1. Open the templates data view
2. Observe the new 'Edit' quick action when hovering a table row
3. Observe that 'Delete' and 'Clear customizations' actions now live in the ellipsis menu.


## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="281" alt="Screenshot 2024-03-21 at 13 31 22" src="https://github.com/WordPress/gutenberg/assets/846565/6a6092af-6981-48ed-906b-151762018ab7"> | <img width="332" alt="Screenshot 2024-03-21 at 13 25 00" src="https://github.com/WordPress/gutenberg/assets/846565/cfad78ae-63bd-42a5-9f61-ba88bc48140b"> |

For reference, here's the actions for pages:

<img width="230" alt="Screenshot 2024-03-21 at 13 32 21" src="https://github.com/WordPress/gutenberg/assets/846565/673cd06e-f24b-4d84-8f08-a445d6b150b7">


