### PR TITLE
Update google fonts font collection data url to the latest version available

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -170,7 +170,7 @@ function gutenberg_register_font_collections() {
 		array(
 			'name'          => _x( 'Google Fonts', 'font collection name', 'gutenberg' ),
 			'description'   => __( 'Install from Google Fonts. Fonts are copied to and served from your site.', 'gutenberg' ),
-			'font_families' => 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json',
+			'font_families' => 'https://s.w.org/images/fonts/wp-6.5/collections/google-fonts-with-preview.json',
 			'categories'    => array(
 				array(
 					'name' => _x( 'Sans Serif', 'font category', 'gutenberg' ),


### PR DESCRIPTION
## What?
 Update the Google Fonts JSON data URL to the latest deployed version in the WordPress.org CDN.


## Why?
Reference:
https://meta.trac.wordpress.org/ticket/7522
https://github.com/WordPress/google-fonts-to-wordpress-collection/pull/21
