### PR TITLE
Inserter: Cache search normalization results

### DIFF
--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -13,8 +13,8 @@ const defaultGetCategory = ( item ) => item.category;
 const defaultGetCollection = () => null;
 
 // Normalization cache
-const extractedWords = {};
-const normalizedSearch = {};
+const extractedWords = new Map();
+const normalizedSearch = new Map();
 
 /**
  * Extracts words from an input string.
@@ -24,11 +24,11 @@ const normalizedSearch = {};
  * @return {Array} Words, extracted from the input string.
  */
 function extractWords( input = '' ) {
-	if ( typeof extractedWords[ input ] !== 'undefined' ) {
-		return extractedWords[ input ];
+	if ( extractedWords.has( input ) ) {
+		return extractedWords.get( input );
 	}
 
-	extractedWords[ input ] = noCase( input, {
+	const result = noCase( input, {
 		splitRegexp: [
 			/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
 			/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
@@ -38,7 +38,9 @@ function extractWords( input = '' ) {
 		.split( ' ' )
 		.filter( Boolean );
 
-	return extractedWords[ input ];
+	extractedWords.set( input, result );
+
+	return result;
 }
 
 /**
@@ -49,23 +51,25 @@ function extractWords( input = '' ) {
  * @return {string} The normalized search input.
  */
 function normalizeSearchInput( input = '' ) {
-	if ( typeof normalizedSearch[ input ] !== 'undefined' ) {
-		return normalizedSearch[ input ];
+	if ( normalizedSearch.has( input ) ) {
+		return normalizedSearch.get( input );
 	}
 
 	// Disregard diacritics.
 	//  Input: "média"
-	input = removeAccents( input );
+	let result = removeAccents( input );
 
 	// Accommodate leading slash, matching autocomplete expectations.
 	//  Input: "/media"
-	input = input.replace( /^\//, '' );
+	result = result.replace( /^\//, '' );
 
 	// Lowercase.
 	//  Input: "MEDIA"
-	normalizedSearch[ input ] = input.toLowerCase();
+	result = result.toLowerCase();
 
-	return normalizedSearch[ input ];
+	normalizedSearch.set( input, result );
+
+	return result;
 }
 
 /**

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -21,7 +21,7 @@ const stripRegexp = /(\p{C}|\p{P}|\p{S})+/giu; // Anything that's not a punctuat
 
 // Normalization cache
 const extractedWords = new Map();
-const normalizedSearch = new Map();
+const normalizedStrings = new Map();
 
 /**
  * Extracts words from an input string.
@@ -54,9 +54,9 @@ function extractWords( input = '' ) {
  *
  * @return {string} The normalized search input.
  */
-function normalizeSearchInput( input = '' ) {
-	if ( normalizedSearch.has( input ) ) {
-		return normalizedSearch.get( input );
+function normalizeString( input = '' ) {
+	if ( normalizedStrings.has( input ) ) {
+		return normalizedStrings.get( input );
 	}
 
 	// Disregard diacritics.
@@ -71,7 +71,7 @@ function normalizeSearchInput( input = '' ) {
 	//  Input: "MEDIA"
 	result = result.toLowerCase();
 
-	normalizedSearch.set( input, result );
+	normalizedStrings.set( input, result );
 
 	return result;
 }
@@ -84,7 +84,7 @@ function normalizeSearchInput( input = '' ) {
  * @return {string[]} The normalized list of search terms.
  */
 export const getNormalizedSearchTerms = ( input = '' ) => {
-	return extractWords( normalizeSearchInput( input ) );
+	return extractWords( normalizeString( input ) );
 };
 
 const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
@@ -170,8 +170,8 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 	const category = getCategory( item );
 	const collection = getCollection( item );
 
-	const normalizedSearchInput = normalizeSearchInput( searchTerm );
-	const normalizedTitle = normalizeSearchInput( title );
+	const normalizedSearchInput = normalizeString( searchTerm );
+	const normalizedTitle = normalizeString( title );
 
 	let rank = 0;
 

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -12,6 +12,10 @@ const defaultGetKeywords = ( item ) => item.keywords || [];
 const defaultGetCategory = ( item ) => item.category;
 const defaultGetCollection = () => null;
 
+// Normalization cache
+const extractedWords = {};
+const normalizedSearch = {};
+
 /**
  * Extracts words from an input string.
  *
@@ -20,11 +24,11 @@ const defaultGetCollection = () => null;
  * @return {Array} Words, extracted from the input string.
  */
 function extractWords( input = '' ) {
-	if ( typeof extractWords[ input ] !== 'undefined' ) {
-		return extractWords[ input ];
+	if ( typeof extractedWords[ input ] !== 'undefined' ) {
+		return extractedWords[ input ];
 	}
 
-	extractWords[ input ] = noCase( input, {
+	extractedWords[ input ] = noCase( input, {
 		splitRegexp: [
 			/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
 			/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
@@ -34,7 +38,7 @@ function extractWords( input = '' ) {
 		.split( ' ' )
 		.filter( Boolean );
 
-	return extractWords[ input ];
+	return extractedWords[ input ];
 }
 
 /**
@@ -45,8 +49,8 @@ function extractWords( input = '' ) {
  * @return {string} The normalized search input.
  */
 function normalizeSearchInput( input = '' ) {
-	if ( typeof normalizeSearchInput[ input ] !== 'undefined' ) {
-		return normalizeSearchInput[ input ];
+	if ( typeof normalizedSearch[ input ] !== 'undefined' ) {
+		return normalizedSearch[ input ];
 	}
 
 	// Disregard diacritics.
@@ -59,9 +63,9 @@ function normalizeSearchInput( input = '' ) {
 
 	// Lowercase.
 	//  Input: "MEDIA"
-	normalizeSearchInput[ input ] = input.toLowerCase();
+	normalizedSearch[ input ] = input.toLowerCase();
 
-	return normalizeSearchInput[ input ];
+	return normalizedSearch[ input ];
 }
 
 /**

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -12,6 +12,13 @@ const defaultGetKeywords = ( item ) => item.keywords || [];
 const defaultGetCategory = ( item ) => item.category;
 const defaultGetCollection = () => null;
 
+// Normalization regexes
+const splitRegexp = [
+	/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
+	/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
+];
+const stripRegexp = /(\p{C}|\p{P}|\p{S})+/giu; // Anything that's not a punctuation, symbol or control/format character.
+
 // Normalization cache
 const extractedWords = new Map();
 const normalizedSearch = new Map();
@@ -29,11 +36,8 @@ function extractWords( input = '' ) {
 	}
 
 	const result = noCase( input, {
-		splitRegexp: [
-			/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
-			/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
-		],
-		stripRegexp: /(\p{C}|\p{P}|\p{S})+/giu, // Anything that's not a punctuation, symbol or control/format character.
+		splitRegexp,
+		stripRegexp,
 	} )
 		.split( ' ' )
 		.filter( Boolean );

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -20,7 +20,11 @@ const defaultGetCollection = () => null;
  * @return {Array} Words, extracted from the input string.
  */
 function extractWords( input = '' ) {
-	return noCase( input, {
+	if ( typeof extractWords[ input ] !== 'undefined' ) {
+		return extractWords[ input ];
+	}
+
+	extractWords[ input ] = noCase( input, {
 		splitRegexp: [
 			/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
 			/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
@@ -29,6 +33,8 @@ function extractWords( input = '' ) {
 	} )
 		.split( ' ' )
 		.filter( Boolean );
+
+	return extractWords[ input ];
 }
 
 /**
@@ -39,6 +45,10 @@ function extractWords( input = '' ) {
  * @return {string} The normalized search input.
  */
 function normalizeSearchInput( input = '' ) {
+	if ( typeof normalizeSearchInput[ input ] !== 'undefined' ) {
+		return normalizeSearchInput[ input ];
+	}
+
 	// Disregard diacritics.
 	//  Input: "média"
 	input = removeAccents( input );
@@ -49,9 +59,9 @@ function normalizeSearchInput( input = '' ) {
 
 	// Lowercase.
 	//  Input: "MEDIA"
-	input = input.toLowerCase();
+	normalizeSearchInput[ input ] = input.toLowerCase();
 
-	return input;
+	return normalizeSearchInput[ input ];
 }
 
 /**


### PR DESCRIPTION
## What?
We're adding some internal cache to the internal inserter search input normalization functions.

## Why?
During a single search, we'll call each of these functions hundreds of times, with the same input and the same output. 

Internally, both of them will do some string manipulation, including regex search and replace, and there's no need to run it every time when we can only run it once per session. 

Although I don't aim for any visible performance improvements, in my local testing, this saves a few ms (5ms on average) for every inserter search. Even if it saves 1 ms, that would still be an improvement of over 10% for each inserter search, so it's worth trying out.

Performance tests seem to indicate a very slight improvement to the inserter search metrics:

```
┌──────────────────────┬──────────────────────────────────────────┬──────────────┐
│ (index)              │ 76335edcaf762f27c1db6c062df1f60643a5311c │ trunk        │
├──────────────────────┼──────────────────────────────────────────┼──────────────┤
│ inserterSearch       │ '5.99 ms'                                │ '6.12 ms'    │
│ minInserterSearch    │ '5.63 ms'                                │ '5.7 ms'     │
│ maxInserterSearch    │ '6.68 ms'                                │ '7.09 ms'    │
```

however, I usually don't trust them that much, as the demonstrated difference is within the expected noise levels.

## How?
We're targeting `extractWords` and `normalizeSearchInput` since they're both internal, private functions. 

~For both of them, we're caching the normalization / extraction results in the function object itself, since that way, we don't need to create an extra object for the cache. ~

IMHO that's fine to do since those functions are private for the inserter search items module.

## Testing Instructions
* Verify inserter search still works well.
* Verify all checks are green.


### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None