### PR TITLE
Update field display in grid layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -327,7 +327,24 @@
 		}
 
 		.dataviews-view-grid__field {
-			.dataviews-view-grid__field-value {
+			align-items: flex-start;
+
+			&:not(.is-column) {
+				align-items: center;
+
+				.dataviews-view-grid__field-name {
+					width: 35%;
+				}
+
+				.dataviews-view-grid__field-value {
+					width: 65%;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+				}
+			}
+
+			.dataviews-view-grid__field-name {
 				color: $gray-700;
 			}
 		}

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -111,16 +111,18 @@ function GridItem( {
 						<Flex
 							className={ classnames(
 								'dataviews-view-grid__field',
-								field.gridDisplayDirection &&
-									'is-' + field.gridDisplayDirection
+								field.gridDisplayDirection === 'column'
+									? 'is-column'
+									: 'is-row'
 							) }
 							key={ field.id }
 							gap={ 1 }
 							justify="flex-start"
 							expanded
+							style={ { height: 'auto' } }
 							direction={
-								field.gridDisplayDirection
-									? field.gridDisplayDirection
+								field.gridDisplayDirection === 'column'
+									? 'column'
 									: 'row'
 							}
 						>

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -35,6 +35,7 @@ function GridItem( {
 	mediaField,
 	primaryField,
 	visibleFields,
+	displayAsColumnFields,
 } ) {
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
@@ -111,7 +112,7 @@ function GridItem( {
 						<Flex
 							className={ classnames(
 								'dataviews-view-grid__field',
-								field.gridDisplayDirection === 'column'
+								displayAsColumnFields?.includes( field.id )
 									? 'is-column'
 									: 'is-row'
 							) }
@@ -121,7 +122,7 @@ function GridItem( {
 							expanded
 							style={ { height: 'auto' } }
 							direction={
-								field.gridDisplayDirection === 'column'
+								displayAsColumnFields?.includes( field.id )
 									? 'column'
 									: 'row'
 							}
@@ -193,6 +194,9 @@ export default function ViewGrid( {
 								mediaField={ mediaField }
 								primaryField={ primaryField }
 								visibleFields={ visibleFields }
+								displayAsColumnFields={
+									view.layout.displayAsColumnFields
+								}
 							/>
 						);
 					} ) }

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -10,8 +10,9 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	Tooltip,
 	Spinner,
+	Flex,
+	FlexItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
@@ -107,17 +108,32 @@ function GridItem( {
 						return null;
 					}
 					return (
-						<VStack
-							className="dataviews-view-grid__field"
+						<Flex
+							className={ classnames(
+								'dataviews-view-grid__field',
+								field.gridDisplayDirection &&
+									'is-' + field.gridDisplayDirection
+							) }
 							key={ field.id }
-							spacing={ 1 }
+							gap={ 1 }
+							justify="flex-start"
+							expanded
+							direction={
+								field.gridDisplayDirection
+									? field.gridDisplayDirection
+									: 'row'
+							}
 						>
-							<Tooltip text={ field.header } placement="left">
-								<div className="dataviews-view-grid__field-value">
-									{ renderedValue }
-								</div>
-							</Tooltip>
-						</VStack>
+							<FlexItem className="dataviews-view-grid__field-name">
+								{ field.header }
+							</FlexItem>
+							<FlexItem
+								className="dataviews-view-grid__field-value"
+								style={ { maxHeight: 'none' } }
+							>
+								{ renderedValue }
+							</FlexItem>
+						</Flex>
 					);
 				} ) }
 			</VStack>

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -70,6 +70,7 @@ const defaultConfigPerViewType = {
 	[ LAYOUT_GRID ]: {
 		mediaField: 'preview',
 		primaryField: 'title',
+		displayAsColumnFields: [ 'description' ],
 	},
 	[ LAYOUT_LIST ]: {
 		primaryField: 'title',
@@ -303,7 +304,6 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 			_fields.push( {
 				header: __( 'Description' ),
 				id: 'description',
-				gridDisplayDirection: 'column',
 				render: ( { item } ) => {
 					return item.description ? (
 						<span className="page-templates-description">

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -148,7 +148,7 @@ function AuthorField( { item, viewType } ) {
 					<Icon icon={ icon } />
 				</div>
 			) }
-			<span>{ text }</span>
+			<span className="page-templates-author-field__name">{ text }</span>
 		</HStack>
 	);
 }
@@ -303,6 +303,7 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 			_fields.push( {
 				header: __( 'Description' ),
 				id: 'description',
+				gridDisplayDirection: 'column',
 				render: ( { item } ) => {
 					return item.description ? (
 						<span className="page-templates-description">

--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -92,6 +92,10 @@
 	}
 }
 
+.dataviews-view-grid-field__template-description {
+	flex-direction: column;
+}
+
 .page-templates-author-field__icon {
 	display: flex;
 	flex-shrink: 0;
@@ -101,6 +105,11 @@
 	svg {
 		fill: currentColor;
 	}
+}
+
+.page-templates-author-field__name {
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 .edit-site-list__rename-modal {

--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -92,10 +92,6 @@
 	}
 }
 
-.dataviews-view-grid-field__template-description {
-	flex-direction: column;
-}
-
 .page-templates-author-field__icon {
 	display: flex;
 	flex-shrink: 0;


### PR DESCRIPTION
## What?
This PR attempts to update the display of fields in data views Grid layout, including an option for consumers to specify the orientation of appearance; column or row. 

## Why?
Currently only the field values are visible. A tooltip reveals the field name on hover, but this isn't the most accessible approach. Additionally, this pattern means you cannot always tell which field a value refers to at a glance. For instance a timestamp could be interpreted several ways. 

By arranging the field name and value in a row we can display the necessary information without consuming additional space. An option to arrange in a column means fields with much longer values (e.g. template description) can be displayed in a readable manner.

This change also moves us closer to the arrangement of data we find in the 'Details panel' and latest [Inspector designs](https://github.com/WordPress/gutenberg/issues/59689).

In the graphic below see before/after examples for templates, pages, and patterns.

<img width="1510" alt="fields" src="https://github.com/WordPress/gutenberg/assets/846565/6de1ab2a-f886-453b-8d1b-2c68ddf52e3a">


## How?
In `packages/dataviews/src/view-grid.js` the the `Flex` component that displays the field will switch between `row` (default) and `column` arrangements based on whether the the consumer configures a `gridDisplayDirection` property on the field. 

To ensure rows take up minimal space the value will truncate accordingly. Consumers can use the `column` orientation when more space is required.

## Testing Instructions
1. Open the templates data view, switch to grid layout and toggle on all fields
2. Notice the description is arranged as a column, and author is arranged as a row
3. When fields are displayed as a row check the value truncates correctly (you may need to manually insert a longer value via the browser inspector)

## Notes
As a follow-up it might be nice to allow consumers to say that certain field name are omitted from display. This can be useful when the name can be inferred from the value, e.g. the template description.