### PR TITLE
DataViews: remove the `enumeration` type as redundant

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+- The `enumeration` type has been removed and we'll introduce new field types soon. The existing filters will still work as before given they checked for field.elements, which is still a condition filters should have.
+
 ## 0.8.0 (2024-03-21)
 
 ### Enhancement

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -90,7 +90,6 @@ const fields = [
 				<a href="...">{ item.author }</a>
 			);
 		},
-		type: 'enumeration',
 		elements: [
 			{ value: 1, label: 'Admin' }
 			{ value: 2, label: 'User' }
@@ -106,7 +105,6 @@ const fields = [
 		getValue: ( { item } ) =>
 			STATUSES.find( ( { value } ) => value === item.status )
 				?.label ?? item.status,
-		type: 'enumeration',
 		elements: STATUSES,
 		filterBy: {
 			operators: [ 'isAny' ],
@@ -123,7 +121,7 @@ Each field is an object with the following properties:
 -   `getValue`: function that returns the value of the field, defaults to `field[id]`.
 -   `render`: function that renders the field. Optional, `getValue` will be used if `render` is not defined.
 -   `elements`: the set of valid values for the field's value.
--   `type`: the type of the field. Used to generate the proper filters. Only `enumeration` available at the moment. See "Field types".
+-   `type`: the type of the field. See "Field types".
 -   `enableSorting`: whether the data can be sorted by the given field. True by default.
 -   `enableHiding`: whether the field can be hidden. True by default.
 -   `filterBy`: configuration for the filters.
@@ -299,11 +297,11 @@ Callback that signals the user triggered the details for one of more items, and 
 
 ### Fields
 
-- `enumeration`: the field value should be taken and can be filtered from a closed list of elements.
+> The `enumeration` type was removed as it was deemed redundant with the field.elements metadata. New types will be introduced soon.
 
 ### Operators
 
-Allowed operators for fields of type `enumeration`:
+Allowed operators:
 
 | Operator | Selection | Description | Example |
 | --- | ---  | --- | --- |

--- a/packages/dataviews/src/constants.js
+++ b/packages/dataviews/src/constants.js
@@ -16,9 +16,6 @@ import ViewTable from './view-table';
 import ViewGrid from './view-grid';
 import ViewList from './view-list';
 
-// Field types.
-export const ENUMERATION_TYPE = 'enumeration';
-
 // Filter operators.
 export const OPERATOR_IS = 'is';
 export const OPERATOR_IS_NOT = 'isNot';

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -10,12 +10,7 @@ import FilterSummary from './filter-summary';
 import AddFilter from './add-filter';
 import ResetFilters from './reset-filters';
 import { sanitizeOperators } from './utils';
-import {
-	ENUMERATION_TYPE,
-	ALL_OPERATORS,
-	OPERATOR_IS,
-	OPERATOR_IS_NOT,
-} from './constants';
+import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from './constants';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 
 const Filters = memo( function Filters( {
@@ -28,7 +23,7 @@ const Filters = memo( function Filters( {
 	const addFilterRef = useRef();
 	const filters = [];
 	fields.forEach( ( field ) => {
-		if ( ! field.type ) {
+		if ( ! field.elements?.length ) {
 			return;
 		}
 
@@ -37,31 +32,24 @@ const Filters = memo( function Filters( {
 			return;
 		}
 
-		switch ( field.type ) {
-			case ENUMERATION_TYPE:
-				if ( ! field.elements?.length ) {
-					return;
-				}
-
-				const isPrimary = !! field.filterBy?.isPrimary;
-				filters.push( {
-					field: field.id,
-					name: field.header,
-					elements: field.elements,
-					singleSelection: operators.some( ( op ) =>
-						[ OPERATOR_IS, OPERATOR_IS_NOT ].includes( op )
-					),
-					operators,
-					isVisible:
-						isPrimary ||
-						view.filters.some(
-							( f ) =>
-								f.field === field.id &&
-								ALL_OPERATORS.includes( f.operator )
-						),
-					isPrimary,
-				} );
-		}
+		const isPrimary = !! field.filterBy?.isPrimary;
+		filters.push( {
+			field: field.id,
+			name: field.header,
+			elements: field.elements,
+			singleSelection: operators.some( ( op ) =>
+				[ OPERATOR_IS, OPERATOR_IS_NOT ].includes( op )
+			),
+			operators,
+			isVisible:
+				isPrimary ||
+				view.filters.some(
+					( f ) =>
+						f.field === field.id &&
+						ALL_OPERATORS.includes( f.operator )
+				),
+			isPrimary,
+		} );
 	} );
 	// Sort filters by primary property. We need the primary filters to be first.
 	// Then we sort by name.

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -34,7 +34,7 @@ import SingleSelectionCheckbox from './single-selection-checkbox';
 import { unlock } from './lock-unlock';
 import ItemActions from './item-actions';
 import { sanitizeOperators } from './utils';
-import { ENUMERATION_TYPE, SORTING_DIRECTIONS } from './constants';
+import { SORTING_DIRECTIONS } from './constants';
 import {
 	useSomeItemHasAPossibleBulkAction,
 	useHasAPossibleBulkAction,
@@ -76,7 +76,7 @@ const HeaderMenu = forwardRef( function HeaderMenu(
 	// 3. If it's not primary. If it is, it should be already visible.
 	const canAddFilter =
 		! view.filters?.some( ( _filter ) => field.id === _filter.field ) &&
-		field.type === ENUMERATION_TYPE &&
+		!! field.elements?.length &&
 		!! operators.length &&
 		! field.filterBy?.isPrimary;
 	if ( ! isSortable && ! isHidable && ! canAddFilter ) {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/55100

## What?

Removes the `enumeration` field type.

## Why?

The `enumeration` type is too coarse for what we want to achieve with field types. We haven't ran into issues yet because we haven't implemented other features (editing).

Two concrete examples were we could use a more fine-grained type system are:

- In [this PR](https://github.com/WordPress/gutenberg/pull/59897#discussion_r1533471737), the field type could be string or array. While the filter could be the same (enumeration), we should check for the field value differently.
- The current `type: enumeration` fields are actually different things. For example, [status is a string](https://github.com/WordPress/gutenberg/blob/remove/enumeration-type-dataviews/packages/edit-site/src/components/page-pages/index.js#L328) but author is a [number](https://github.com/WordPress/gutenberg/blob/remove/enumeration-type-dataviews/packages/edit-site/src/components/page-pages/index.js#L314).

I plan to introduce other types soon to support other kind of filters as [this one](https://github.com/WordPress/gutenberg/issues/55100#issuecomment-1991837749).

## How?

- b0abc16c58328e14eece170d44160f4b84b24423 Checking for field.elements instead of field.type has proven enough.

## Testing Instructions

Go to any of the dataviews-powered pages (Site Editor > Pages > Manage all pages, Site editor > Patterns, Site Editor > Patterns > Manage template parts, Site Editor > Templates) and verify filters still work as expected.
