### PR TITLE
Pattern Shuffling: Only use the category that the user selected to shuffle patterns

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -163,7 +163,9 @@ export function PatternCategoryPreviews( {
 					ref={ scrollContainerRef }
 					shownPatterns={ pagingProps.categoryPatternsAsyncList }
 					blockPatterns={ pagingProps.categoryPatterns }
-					onClickPattern={ onClickPattern }
+					onClickPattern={ ( pattern, blocks ) =>
+						onClickPattern( pattern, blocks, category )
+					}
 					onHover={ onHover }
 					label={ category.label }
 					orientation="vertical"

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -56,7 +56,7 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const onClickPattern = useCallback(
-		( pattern, blocks ) => {
+		( pattern, blocks, category ) => {
 			const patternBlocks =
 				pattern.type === INSERTER_PATTERN_TYPES.user &&
 				pattern.syncStatus !== 'unsynced'
@@ -64,7 +64,8 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 					: blocks;
 			onInsert(
 				( patternBlocks ?? [] ).map( ( block ) => cloneBlock( block ) ),
-				pattern.name
+				pattern.name,
+				category
 			);
 			createSuccessNotice(
 				sprintf(

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -90,8 +90,11 @@ function InserterMenu(
 	);
 
 	const onInsertPattern = useCallback(
-		( blocks, patternName ) => {
-			onInsertBlocks( blocks, { patternName } );
+		( blocks, patternName, category ) => {
+			onInsertBlocks( blocks, {
+				patternName,
+				category,
+			} );
 			onSelect();
 		},
 		[ onInsertBlocks, onSelect ]

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -759,7 +759,14 @@ function cloneDeep( object ) {
 	return ! object ? {} : JSON.parse( JSON.stringify( object ) );
 }
 
-const addPatternCategoryToMetadata = ( reducer ) => ( state, action ) => {
+/**
+ * Higher-order reducer which adds the selected pattern category to the outer block.
+ *
+ * @param {Function} reducer Original reducer function.
+ *
+ * @return {Function} Enhanced reducer function.
+ */
+const withPatternCategory = ( reducer ) => ( state, action ) => {
 	if ( action.type === 'INSERT_BLOCKS' ) {
 		const { blocks, meta } = action;
 		const nextState = reducer( state, action );
@@ -798,7 +805,7 @@ export const blocks = pipe(
 	withPersistentBlockChange,
 	withIgnoredBlockChange,
 	withResetControlledBlocks,
-	addPatternCategoryToMetadata
+	withPatternCategory
 )( {
 	// The state is using a Map instead of a plain object for performance reasons.
 	// You can run the "./test/performance.js" unit test to check the impact
@@ -878,9 +885,7 @@ export const blocks = pipe(
 						newState.set( key, value );
 					}
 				);
-
-				// Add pattern category to metadata if available.
-				return newState; //addPatternCategoryToMetadata( newState, action );
+				return newState;
 			}
 
 			case 'UPDATE_BLOCK': {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -755,10 +755,6 @@ const withResetControlledBlocks = ( reducer ) => ( state, action ) => {
 	return reducer( state, action );
 };
 
-function cloneDeep( object ) {
-	return ! object ? {} : JSON.parse( JSON.stringify( object ) );
-}
-
 /**
  * Higher-order reducer which adds the selected pattern category to the outer block.
  *
@@ -769,19 +765,18 @@ function cloneDeep( object ) {
 const withPatternCategory = ( reducer ) => ( state, action ) => {
 	if ( action.type === 'INSERT_BLOCKS' ) {
 		const { blocks, meta } = action;
-		const nextState = reducer( state, action );
-		const firstBlockClientId = blocks[ 0 ].clientId;
-		const firstBlockAttributes = cloneDeep( blocks[ 0 ].attributes );
 		if ( meta?.category && blocks.length === 1 ) {
-			nextState.attributes.set( firstBlockClientId, {
-				...firstBlockAttributes,
+			const newState = { ...state };
+			newState.attributes = new Map( state.attributes );
+			newState.attributes.set( blocks[ 0 ].clientId, {
+				...blocks[ 0 ].attributes,
 				metadata: {
-					...( firstBlockAttributes.metadata || {} ),
+					...( blocks[ 0 ].attributes.metadata || {} ),
 					categories: [ meta.category.name ],
 				},
 			} );
+			return reducer( newState, action );
 		}
-		return nextState;
 	}
 
 	return reducer( state, action );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This uses the category the user selected as the basis for pattern shuffling - so if a pattern has more than one category, we only use the one that the user selected the category from instead of all the categories that the pattern is in.

## Why?
It can be confusing when a category is in multiple categories, so this helps to keep the shuffling contained to the one category the user selected.

## How?
We pass the category name into the reducer and add it to the block metadata.

## Testing Instructions
1. Switch to TT4
2. Create a new post
3. Open the inserter and switch the patterns tab
4. Open the "Team" category
5. Insert the pattern into the post
6. Open the code view in the editor
7. Check that the post contains only the `team` category, not the `about` category.

## Screenshots or screencast <!-- if applicable -->
<img width="1737" alt="Screenshot 2024-03-21 at 17 43 36" src="https://github.com/WordPress/gutenberg/assets/275961/299a53fc-1c60-4061-bf0b-4c5616ed950c">
