### PR TITLE
InputControl: Ignore IME events when `isPressEnterToChange`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `InputControl`: Ignore IME events when `isPressEnterToChange` is enabled ([#60090](https://github.com/WordPress/gutenberg/pull/60090)).
+
 ## 27.2.0 (2024-03-21)
 
 -   `Dropdown` : Add styling support for `MenuGroup` ([#59723](https://github.com/WordPress/gutenberg/pull/59723)).

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -24,6 +24,7 @@ import { useDragCursor } from './utils';
 import { Input } from './styles/input-control-styles';
 import { useInputControlStateReducer } from './reducer/reducer';
 import type { InputFieldProps } from './types';
+import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 
 const noop = () => {};
 
@@ -222,7 +223,7 @@ function InputField(
 			onBlur={ handleOnBlur }
 			onChange={ handleOnChange }
 			onFocus={ handleOnFocus }
-			onKeyDown={ handleOnKeyDown }
+			onKeyDown={ withIgnoreIMEEvents( handleOnKeyDown ) }
 			onMouseDown={ handleOnMouseDown }
 			ref={ ref }
 			inputSize={ size }


### PR DESCRIPTION
Follow-up to #59081
Part of #45605

## What?

Ignore <kbd>Enter</kbd> and <kbd>Esc</kbd> keydowns emitted during IME composition when the `isPressEnterToChange` prop is enabled.

When this prop is enabled:

- <kbd>Enter</kbd> will need to be hit before an `onChange` event is fired. <kbd>Enter</kbd> keys pressed during IME composition are not intended to commit the change in the entire input field, so they should be ignored.
- <kbd>Esc</kbd> will clear the input field when there are "uncommitted" changes (i.e. changes that have not been committed with <kbd>Enter</kbd> yet). <kbd>Esc</kbd> keys pressed during IME composition are not intended to clear the entire input field, so they should be ignored.

## Why?

This was found during an audit of the components package to see if there is any keydown handling logic that doesn't ignore IME events properly. This was the only violation that I found. (There _is_ unfiltered keydown handling logic in other components too, but they are unlikely to involve IME events.)

## Testing Instructions

1. On the "Default" story for InputControl in the Storybook, enable the `isPressEnterToChange` prop and reload.
2. Type with your IME in the input field. <kbd>Enter</kbd> keypresses during composition should not log an `onChange` event in the Actions panel.
3. Reload. Add some text to the input field, but without hitting <kbd>Enter</kbd> to commit the changes to the InputControl. Type some more text using your IME and <kbd>Esc</kbd> before completing the composition. The existing text in the input field should remain, and only the uncompleted composition should be canceled.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/555336/309f721b-4e12-4eb4-93a1-f7189d5e70c9

### After

https://github.com/WordPress/gutenberg/assets/555336/8d823015-2726-4da9-83a5-84abaddf8bfa

