### PR TITLE
Update: Move post actions to the editor package.

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -15,6 +15,7 @@ import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -34,18 +35,12 @@ import {
 	OPERATOR_IS_NONE,
 } from '../../utils/constants';
 
-import {
-	renamePostAction,
-	trashPostAction,
-	usePermanentlyDeletePostAction,
-	useRestorePostAction,
-	postRevisionsAction,
-	viewPostAction,
-	useEditPostAction,
-} from '../actions';
 import AddNewPageModal from '../add-new-page';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
+
+const { postManagementActions } = unlock( editorPrivateApis );
+const { usePostActions } = postManagementActions;
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
@@ -346,22 +341,20 @@ export default function PagePages() {
 		],
 		[ authors, view.type ]
 	);
-
-	const permanentlyDeletePostAction = usePermanentlyDeletePostAction();
-	const restorePostAction = useRestorePostAction();
-	const editPostAction = useEditPostAction();
-	const actions = useMemo(
-		() => [
-			editPostAction,
-			viewPostAction,
-			restorePostAction,
-			permanentlyDeletePostAction,
-			postRevisionsAction,
-			renamePostAction,
-			trashPostAction,
-		],
-		[ permanentlyDeletePostAction, restorePostAction, editPostAction ]
+	const onActionPerformed = useCallback(
+		( actionId, items ) => {
+			if ( actionId === 'edit-post' ) {
+				const post = items[ 0 ];
+				history.push( {
+					postId: post.id,
+					postType: post.type,
+					canvas: 'edit',
+				} );
+			}
+		},
+		[ history ]
 	);
+	const actions = usePostActions( { onActionPerformed } );
 	const onChangeView = useCallback(
 		( newView ) => {
 			if ( newView.type !== view.type ) {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -354,7 +354,7 @@ export default function PagePages() {
 		},
 		[ history ]
 	);
-	const actions = usePostActions( { onActionPerformed } );
+	const actions = usePostActions( onActionPerformed );
 	const onChangeView = useCallback(
 		( newView ) => {
 			if ( newView.type !== view.type ) {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -39,8 +39,7 @@ import AddNewPageModal from '../add-new-page';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
 
-const { postManagementActions } = unlock( editorPrivateApis );
-const { usePostActions } = postManagementActions;
+const { usePostActions } = unlock( editorPrivateApis );
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -23,6 +23,7 @@ import {
 } from '@wordpress/block-editor';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -45,10 +46,12 @@ import {
 	deleteTemplateAction,
 	renameTemplateAction,
 } from './actions';
-import { postRevisionsAction, useEditPostAction } from '../actions';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 import AddNewTemplatePart from './add-new-template-part';
+
+const { postManagementActions } = unlock( editorPrivateApis );
+const { useEditPostAction, postRevisionsAction } = postManagementActions;
 
 const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -355,7 +355,7 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 		},
 		[ history ]
 	);
-	const postActions = usePostActions( { onActionPerformed } );
+	const postActions = usePostActions( onActionPerformed );
 	const actions = useMemo(
 		() => [
 			postActions.find( ( action ) => action.id === 'edit-post' ),

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -50,8 +50,7 @@ import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 import AddNewTemplatePart from './add-new-template-part';
 
-const { postManagementActions } = unlock( editorPrivateApis );
-const { usePostActions } = postManagementActions;
+const { usePostActions } = unlock( editorPrivateApis );
 
 const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -354,18 +354,19 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 		},
 		[ history ]
 	);
-	const postActions = usePostActions( onActionPerformed );
+	const [ editAction, viewRevisionsAction ] = usePostActions(
+		onActionPerformed,
+		[ 'edit-post', 'view-post-revisions' ]
+	);
 	const actions = useMemo(
 		() => [
-			postActions.find( ( action ) => action.id === 'edit-post' ),
+			editAction,
 			resetTemplateAction,
 			renameTemplateAction,
-			postActions.find(
-				( action ) => action.id === 'view-post-revisions'
-			),
+			viewRevisionsAction,
 			deleteTemplateAction,
 		],
-		[ postActions ]
+		[ editAction, viewRevisionsAction ]
 	);
 
 	const onChangeView = useCallback(

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -51,7 +51,7 @@ import { unlock } from '../../lock-unlock';
 import AddNewTemplatePart from './add-new-template-part';
 
 const { postManagementActions } = unlock( editorPrivateApis );
-const { useEditPostAction, postRevisionsAction } = postManagementActions;
+const { usePostActions } = postManagementActions;
 
 const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis
@@ -342,16 +342,31 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 		return filterSortAndPaginate( records, view, fields );
 	}, [ records, view, fields ] );
 
-	const editTemplateAction = useEditPostAction();
+	const onActionPerformed = useCallback(
+		( actionId, items ) => {
+			if ( actionId === 'edit-post' ) {
+				const post = items[ 0 ];
+				history.push( {
+					postId: post.id,
+					postType: post.type,
+					canvas: 'edit',
+				} );
+			}
+		},
+		[ history ]
+	);
+	const postActions = usePostActions( { onActionPerformed } );
 	const actions = useMemo(
 		() => [
-			editTemplateAction,
+			postActions.find( ( action ) => action.id === 'edit-post' ),
 			resetTemplateAction,
 			renameTemplateAction,
-			postRevisionsAction,
+			postActions.find(
+				( action ) => action.id === 'view-post-revisions'
+			),
 			deleteTemplateAction,
 		],
-		[ editTemplateAction ]
+		[ postActions ]
 	);
 
 	const onChangeView = useCallback(

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -416,71 +416,88 @@ export const postRevisionsAction = {
 export function usePostActions( onActionPerformed, actionIds = null ) {
 	const permanentlyDeletePostAction = usePermanentlyDeletePostAction();
 	const restorePostAction = useRestorePostAction();
-	return useMemo( () => {
-		// By default, return all actions...
-		const defaultActions = [
-			editPostAction,
-			viewPostAction,
-			restorePostAction,
-			permanentlyDeletePostAction,
-			postRevisionsAction,
-			trashPostAction,
-		];
+	return useMemo(
+		() => {
+			// By default, return all actions...
+			const defaultActions = [
+				editPostAction,
+				viewPostAction,
+				restorePostAction,
+				permanentlyDeletePostAction,
+				postRevisionsAction,
+				trashPostAction,
+			];
 
-		// ... unless `actionIds` was specified, in which case we find the
-		// actions matching the given IDs.
-		const actions = actionIds
-			? actionIds.map( ( actionId ) =>
-					defaultActions.find( ( { id } ) => actionId === id )
-			  )
-			: defaultActions;
+			// ... unless `actionIds` was specified, in which case we find the
+			// actions matching the given IDs.
+			const actions = actionIds
+				? actionIds.map( ( actionId ) =>
+						defaultActions.find( ( { id } ) => actionId === id )
+				  )
+				: defaultActions;
 
-		if ( onActionPerformed ) {
-			for ( let i = 0; i < actions.length; ++i ) {
-				if ( actions[ i ].callback ) {
-					const existingCallback = actions[ i ].callback;
-					actions[ i ] = {
-						...actions[ i ],
-						callback: ( items, _onActionPerformed ) => {
-							existingCallback( items, ( _items ) => {
-								if ( _onActionPerformed ) {
-									_onActionPerformed( _items );
-								}
-								onActionPerformed( actions[ i ].id, _items );
-							} );
-						},
-					};
-				}
-				if ( actions[ i ].RenderModal ) {
-					const ExistingRenderModal = actions[ i ].RenderModal;
-					actions[ i ] = {
-						...actions[ i ],
-						RenderModal: ( props ) => {
-							return (
-								<ExistingRenderModal
-									items={ props.items }
-									closeModal={ props.closeModal }
-									onActionPerformed={ ( _items ) => {
-										if ( props.onActionPerformed ) {
-											props.onActionPerformed( _items );
-										}
-										onActionPerformed(
-											actions[ i ].id,
-											_items
-										);
-									} }
-								/>
-							);
-						},
-					};
+			if ( onActionPerformed ) {
+				for ( let i = 0; i < actions.length; ++i ) {
+					if ( actions[ i ].callback ) {
+						const existingCallback = actions[ i ].callback;
+						actions[ i ] = {
+							...actions[ i ],
+							callback: ( items, _onActionPerformed ) => {
+								existingCallback( items, ( _items ) => {
+									if ( _onActionPerformed ) {
+										_onActionPerformed( _items );
+									}
+									onActionPerformed(
+										actions[ i ].id,
+										_items
+									);
+								} );
+							},
+						};
+					}
+					if ( actions[ i ].RenderModal ) {
+						const ExistingRenderModal = actions[ i ].RenderModal;
+						actions[ i ] = {
+							...actions[ i ],
+							RenderModal: ( props ) => {
+								return (
+									<ExistingRenderModal
+										items={ props.items }
+										closeModal={ props.closeModal }
+										onActionPerformed={ ( _items ) => {
+											if ( props.onActionPerformed ) {
+												props.onActionPerformed(
+													_items
+												);
+											}
+											onActionPerformed(
+												actions[ i ].id,
+												_items
+											);
+										} }
+									/>
+								);
+							},
+						};
+					}
 				}
 			}
-		}
-		return actions;
-	}, [
-		actionIds,
-		permanentlyDeletePostAction,
-		restorePostAction,
-		onActionPerformed,
-	] );
+			return actions;
+		},
+
+		// Disable reason: if provided, `actionIds` is a shallow array of
+		// strings, and the strings themselves should be part of the useMemo
+		// dependencies. Two different disable statements are needed, as the
+		// first flags what it thinks are missing dependencies, and the second
+		// flags the array spread operation.
+		//
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+			...( actionIds || [] ),
+			permanentlyDeletePostAction,
+			restorePostAction,
+			onActionPerformed,
+		]
+	);
 }

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -413,7 +413,7 @@ export const postRevisionsAction = {
 	},
 };
 
-export function usePostActions( { onActionPerformed } ) {
+export function usePostActions( onActionPerformed ) {
 	const permanentlyDeletePostAction = usePermanentlyDeletePostAction();
 	const restorePostAction = useRestorePostAction();
 	return useMemo( () => {

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -374,18 +374,18 @@ export const viewPostAction = {
 };
 
 export const editPostAction = {
-			id: 'edit-post',
-			label: __( 'Edit' ),
-			isPrimary: true,
-			icon: edit,
-			isEligible( { status } ) {
-				return status !== 'trash';
-			},
+	id: 'edit-post',
+	label: __( 'Edit' ),
+	isPrimary: true,
+	icon: edit,
+	isEligible( { status } ) {
+		return status !== 'trash';
+	},
 	callback( posts, onActionPerformed ) {
 		if ( onActionPerformed ) {
 			onActionPerformed( posts );
 		}
-			},
+	},
 };
 export const postRevisionsAction = {
 	id: 'view-post-revisions',

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -413,11 +413,12 @@ export const postRevisionsAction = {
 	},
 };
 
-export function usePostActions( onActionPerformed ) {
+export function usePostActions( onActionPerformed, actionIds = null ) {
 	const permanentlyDeletePostAction = usePermanentlyDeletePostAction();
 	const restorePostAction = useRestorePostAction();
 	return useMemo( () => {
-		const actions = [
+		// By default, return all actions...
+		const defaultActions = [
 			editPostAction,
 			viewPostAction,
 			restorePostAction,
@@ -425,6 +426,15 @@ export function usePostActions( onActionPerformed ) {
 			postRevisionsAction,
 			trashPostAction,
 		];
+
+		// ... unless `actionIds` was specified, in which case we find the
+		// actions matching the given IDs.
+		const actions = actionIds
+			? actionIds.map( ( actionId ) =>
+					defaultActions.find( ( { id } ) => actionId === id )
+			  )
+			: defaultActions;
+
 		if ( onActionPerformed ) {
 			for ( let i = 0; i < actions.length; ++i ) {
 				if ( actions[ i ].callback ) {
@@ -467,5 +477,10 @@ export function usePostActions( onActionPerformed ) {
 			}
 		}
 		return actions;
-	}, [ permanentlyDeletePostAction, restorePostAction, onActionPerformed ] );
+	}, [
+		actionIds,
+		permanentlyDeletePostAction,
+		restorePostAction,
+		onActionPerformed,
+	] );
 }

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -8,10 +8,11 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 
 import {
 	Button,
+	TextControl,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -413,6 +414,83 @@ export const postRevisionsAction = {
 	},
 };
 
+export const renamePostAction = {
+	id: 'rename-post',
+	label: __( 'Rename' ),
+	isEligible( post ) {
+		return post.status !== 'trash';
+	},
+	RenderModal: ( { items, closeModal } ) => {
+		const [ item ] = items;
+		const originalTitle = decodeEntities(
+			typeof item.title === 'string' ? item.title : item.title.rendered
+		);
+		const [ title, setTitle ] = useState( () => originalTitle );
+		const { editEntityRecord, saveEditedEntityRecord } =
+			useDispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			useDispatch( noticesStore );
+
+		async function onRename( event ) {
+			event.preventDefault();
+			try {
+				await editEntityRecord( 'postType', item.type, item.id, {
+					title,
+				} );
+				// Update state before saving rerenders the list.
+				setTitle( '' );
+				closeModal();
+				// Persist edited entity.
+				await saveEditedEntityRecord( 'postType', item.type, item.id, {
+					throwOnError: true,
+				} );
+				createSuccessNotice( __( 'Name updated' ), {
+					type: 'snackbar',
+				} );
+			} catch ( error ) {
+				const errorMessage =
+					error.message && error.code !== 'unknown_error'
+						? error.message
+						: __( 'An error occurred while updating the name' );
+				createErrorNotice( errorMessage, { type: 'snackbar' } );
+			}
+		}
+
+		return (
+			<form onSubmit={ onRename }>
+				<VStack spacing="5">
+					<TextControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+						required
+					/>
+					<HStack justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ () => {
+								closeModal();
+							} }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							type="submit"
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		);
+	},
+};
+
 export function usePostActions( onActionPerformed, actionIds = null ) {
 	const permanentlyDeletePostAction = usePermanentlyDeletePostAction();
 	const restorePostAction = useRestorePostAction();
@@ -425,6 +503,7 @@ export function usePostActions( onActionPerformed, actionIds = null ) {
 				restorePostAction,
 				permanentlyDeletePostAction,
 				postRevisionsAction,
+				renamePostAction,
 				trashPostAction,
 			];
 

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -15,6 +15,7 @@ import PostPanelRow from './components/post-panel-row';
 import PostViewLink from './components/post-view-link';
 import PreviewDropdown from './components/preview-dropdown';
 import PreferencesModal from './components/preferences-modal';
+import * as postManagementActions from './components/post-actions/actions';
 import PostCardPanel from './components/post-card-panel';
 
 export const privateApis = {};
@@ -31,6 +32,7 @@ lock( privateApis, {
 	PostViewLink,
 	PreviewDropdown,
 	PreferencesModal,
+	postManagementActions,
 	PostCardPanel,
 
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -15,7 +15,7 @@ import PostPanelRow from './components/post-panel-row';
 import PostViewLink from './components/post-view-link';
 import PreviewDropdown from './components/preview-dropdown';
 import PreferencesModal from './components/preferences-modal';
-import * as postManagementActions from './components/post-actions/actions';
+import { usePostActions } from './components/post-actions/actions';
 import PostCardPanel from './components/post-card-panel';
 
 export const privateApis = {};
@@ -32,7 +32,7 @@ lock( privateApis, {
 	PostViewLink,
 	PreviewDropdown,
 	PreferencesModal,
-	postManagementActions,
+	usePostActions,
 	PostCardPanel,
 
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/pull/59849.

This PR moves the post actions to the editor package. And introduces a new usePostActions with a global onActionPerformed function as discussed https://github.com/WordPress/gutenberg/pull/59849#pullrequestreview-1936097226.
For now, the actions are not used in new places we just use them on data views as before.
After this PR and https://github.com/WordPress/gutenberg/pull/59870 are merged we are going to unify post actions across dataviews, post details panel, and post inspector panel.

## Testing
- Open the data views for pages (wp-admin/site-editor.php?path=%2Fpage&layout=table) and verify things work as before. 