### PR TITLE
Activate the fonts coming from the backend and not the data from the frontend

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -281,6 +281,8 @@ function FontLibraryProvider( { children } ) {
 					sucessfullyInstalledFontFaces?.length > 0 ||
 					alreadyInstalledFontFaces?.length > 0
 				) {
+					// Use font data from REST API not from client to ensure
+					// correct font information is used.
 					installedFontFamily.fontFace = [
 						...sucessfullyInstalledFontFaces,
 					];

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -281,11 +281,11 @@ function FontLibraryProvider( { children } ) {
 					sucessfullyInstalledFontFaces?.length > 0 ||
 					alreadyInstalledFontFaces?.length > 0
 				) {
-					fontFamilyToInstall.fontFace = [
+					installedFontFamily.fontFace = [
 						...sucessfullyInstalledFontFaces,
-						...alreadyInstalledFontFaces,
 					];
-					fontFamiliesToActivate.push( fontFamilyToInstall );
+
+					fontFamiliesToActivate.push( installedFontFamily );
 				}
 
 				// If it's a system font but was installed successfully, activate it.
@@ -402,14 +402,29 @@ function FontLibraryProvider( { children } ) {
 	};
 
 	const activateCustomFontFamilies = ( fontsToAdd ) => {
-		// Merge the existing custom fonts with the new fonts.
+		// Removes the id from the families and faces to avoid saving that to global styles post content.
+		const fontsToActivate = fontsToAdd.map(
+			( { id: _familyDbId, fontFace, ...font } ) => ( {
+				...font,
+				...( fontFace && fontFace.length > 0
+					? {
+							fontFace: fontFace.map(
+								( { id: _faceDbId, ...face } ) => face
+							),
+					  }
+					: {} ),
+			} )
+		);
+
 		// Activate the fonts by set the new custom fonts array.
 		setFontFamilies( {
 			...fontFamilies,
-			custom: mergeFontFamilies( fontFamilies?.custom, fontsToAdd ),
+			// Merge the existing custom fonts with the new fonts.
+			custom: mergeFontFamilies( fontFamilies?.custom, fontsToActivate ),
 		} );
+
 		// Add custom fonts to the browser.
-		fontsToAdd.forEach( ( font ) => {
+		fontsToActivate.forEach( ( font ) => {
 			if ( font.fontFace ) {
 				font.fontFace.forEach( ( face ) => {
 					// Load font faces just in the iframe because they already are in the document.


### PR DESCRIPTION
## What?
Activate the fonts coming from the backend and not the data from the frontend

## Why?
In some cases, as in https://github.com/WordPress/gutenberg/issues/60040, the data coming from the frontend can have non-properly formatted the `font-family` property. In the case of the issue linked `Heineken Serif 18` instead of `"Heineken Serif 18"`.

Fixes: https://github.com/WordPress/gutenberg/issues/60040

## How?
In this PR we use the font family and font face data coming from the API to activate the fonts (add to the Global Styles).

## Testing Instructions
1. Follow the instructions from https://github.com/WordPress/gutenberg/issues/60040
2. Use the rest of the font library and check that the other install methods work as expected.


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1310626/aebc01b8-1f76-492c-94c7-8f2f94a80d0a

