### PR TITLE
Fix missing class for Global Styles > Colors

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -51,7 +51,7 @@
 	justify-content: center;
 }
 
-.edit-site-global-styles-screen-colors .color-block-support-panel {
+.edit-site-global-styles-screen .color-block-support-panel {
 	padding-left: 0;
 	padding-right: 0;
 	padding-top: 0;


### PR DESCRIPTION
A small class fix that was omitted accidentally for https://github.com/WordPress/gutenberg/pull/60031.  

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. See the Global Styles > Colors view.
3. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-03-21 at 16 17 01](https://github.com/WordPress/gutenberg/assets/1813435/c0d355a0-9ad0-490d-b858-953845ef1c57)|![CleanShot 2024-03-21 at 16 16 30](https://github.com/WordPress/gutenberg/assets/1813435/c90b1944-3faf-403d-b73b-32617140aaa7)|

