### PR TITLE
[Create Block] Update external template docs to include variants.

### DIFF
--- a/packages/create-block/docs/external-template.md
+++ b/packages/create-block/docs/external-template.md
@@ -126,7 +126,7 @@ module.exports = {
 };
 ```
 
-Variants are accessed using the `--variant` flag i.e`--variant secondary`.
+Variants are accessed using the `--variant` flag, i.e`--variant secondary`.
 
 If no variant is provided, the first variant is used if any are defined.
 

--- a/packages/create-block/docs/external-template.md
+++ b/packages/create-block/docs/external-template.md
@@ -107,7 +107,7 @@ The following configurable variables are used with the template files. Template 
 
 ### `variants`
 
-Variants are used to create variations for a template. Variants can override any `defaultValues` by provided their own.
+Variants are used to create variations for a template. Variants can override any `defaultValues` by providing their own.
 
 ```js
 module.exports = {

--- a/packages/create-block/docs/external-template.md
+++ b/packages/create-block/docs/external-template.md
@@ -104,3 +104,41 @@ The following configurable variables are used with the template files. Template 
 -   `style` (default: `'file:./style-index.css'`) – a frontend and editor style definition.
 -   `render` (no default) – a path to the PHP file used when rendering the block type on the server before presenting on the front end.
 -   `customBlockJSON` (no default) - allows definition of additional properties for the generated block.json file.
+
+### `variants`
+
+Variants are used to create variations for a template. Variants can override any `defaultValues` by provided their own.
+
+```js
+module.exports = {
+	defaultValues: {
+		slug: 'my-fantastic-block',
+		title: 'My fantastic block',
+		dashicon: 'palmtree',
+		version: '1.2.3',
+	},
+	variants: {
+		primary: {},
+		secondary: {
+			title: 'My fantastic block - secondary variant',
+		},
+	},
+};
+```
+
+Variants are accessed using the `--variant` flag i.e`--variant secondary`.
+
+If no variant is provided, the first variant is used if any are defined.
+
+Mustache variables are created for variants that can be used to conditionally output content in files. The format is `{{isVARIANT_NAMEVariant}}`.
+
+```mustache
+{{#isPrimaryVariant}}
+This content is only rendered if `--variant primary` is passed.
+{{/isPrimaryVariant}}
+
+{{#isSecondaryVariant}}
+This content is only rendered if `--variant secondary` is passed.
+{{/isSecondaryVariant}}
+
+```


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds missing documentation for the `variants` property in external project templates for the create-block package,

## Why?
This is a powerful feature that needs explaining.

