### PR TITLE
Style engine: allow classname slugs to use incoming style value

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -274,7 +274,7 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 					'path'          => array( 'typography', 'textAlign' ),
 					'classnames'    => array(
 						'has-text-align-$slug' => array(
-							'regex' => '#^[a-z-]+$#',
+							'use_value' => true,
 						),
 					),
 				),
@@ -461,8 +461,8 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 					$slug = null;
 
 					if ( is_string( $style_value ) ) {
-						if ( ! empty( $property_key['regex'] ) && preg_match( $property_key['regex'], $style_value, $matches ) ) {
-							$slug = _wp_to_kebab_case( $matches[0] );
+						if ( ! empty( $property_key['use_value'] ) && true === $property_key['use_value'] ) {
+							$slug = _wp_to_kebab_case( $style_value );
 						} else {
 							$slug = static::get_slug_from_preset_value( $style_value, $property_key );
 						}

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -267,6 +267,17 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 					),
 					'path'          => array( 'typography', 'lineHeight' ),
 				),
+				'textAlign'      => array(
+					'property_keys' => array(
+						'default' => 'text-align',
+					),
+					'path'          => array( 'typography', 'textAlign' ),
+					'classnames'    => array(
+						'has-text-align-$slug' => array(
+							'regex' => '#^[a-z-]+$#',
+						),
+					),
+				),
 				'textColumns'    => array(
 					'property_keys' => array(
 						'default' => 'column-count',
@@ -444,9 +455,18 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 				foreach ( $style_definition['classnames'] as $classname => $property_key ) {
 					if ( true === $property_key ) {
 						$classnames[] = $classname;
+						continue;
 					}
 
-					$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+					$slug = null;
+
+					if ( is_string( $style_value ) ) {
+						if ( ! empty( $property_key['regex'] ) && preg_match( $property_key['regex'], $style_value, $matches ) ) {
+							$slug = _wp_to_kebab_case( $matches[0] );
+						} else {
+							$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+						}
+					}
 
 					if ( $slug ) {
 						/*

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -324,6 +324,52 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
+			'valid_classnames_with_value_regex'            => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'textAlign' => 'left',
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'text-align:left;',
+					'declarations' => array(
+						'text-align' => 'left',
+					),
+					'classnames'   => 'has-text-align-left',
+				),
+			),
+
+			'no_classnames_with_invalid_value_regex'       => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'textAlign' => '12px',
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'text-align:12px;',
+					'declarations' => array(
+						'text-align' => '12px',
+					),
+				),
+			),
+
+			'no_classnames_with_invalid_type_regex'        => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'textAlign' => 10,
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'text-align:10;',
+					'declarations' => array(
+						'text-align' => 10,
+					),
+				),
+			),
+
 			'invalid_classnames_preset_value'              => array(
 				'block_styles'    => array(
 					'color'   => array(

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -324,7 +324,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'valid_classnames_with_value_regex'            => array(
+			'valid_classnames_with_value'            => array(
 				'block_styles'    => array(
 					'typography' => array(
 						'textAlign' => 'left',
@@ -340,18 +340,19 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'no_classnames_with_invalid_value_regex'       => array(
+			'valid_classnames_with_hyphenated_value'       => array(
 				'block_styles'    => array(
 					'typography' => array(
-						'textAlign' => '12px',
+						'textAlign' => 'justify-all',
 					),
 				),
 				'options'         => array(),
 				'expected_output' => array(
-					'css'          => 'text-align:12px;',
+					'css'          => 'text-align:justify-all;',
 					'declarations' => array(
-						'text-align' => '12px',
+						'text-align' => 'justify-all',
 					),
+					'classnames'   => 'has-text-align-justify-all',
 				),
 			),
 

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -324,7 +324,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'valid_classnames_with_value'            => array(
+			'valid_classnames_with_value'                  => array(
 				'block_styles'    => array(
 					'typography' => array(
 						'textAlign' => 'left',


### PR DESCRIPTION
## What?

This is an experimental PR to test how the style engine can build classnames using incoming style values.

The idea arose here: https://github.com/WordPress/gutenberg/pull/59531#issuecomment-2011214152

For supported block styles, the style engine can already generate classnames based on preset values, however it looks for the slug in the following string formats: `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`.

What could be useful is to be able generate classnames based on CSS properties and/or values.

For example:

```css

.has-text-align-left {
   text-align: left;
}

.has-writing-mode-horizontal-tb {
     writing-mode: horizontal-tb;
}
```

## Why?

Aside from the use case in https://github.com/WordPress/gutenberg/pull/59531#issuecomment-2011214152, I was also imagining how the style engine could generate semantic class names.


## How?

The first commit tested using a stored regex to parse style values. I thought this may have been useful to customize the classnames for individual CSS properties, or remove CSS units etc. 

```php
$style_value = 'center';

'textAlign'      => array(
    'property_keys' => array(
        'default' => 'text-align',
    ),
    'path'          => array( 'typography', 'textAlign' ),
        'classnames'    => array(
            'has-text-align-$slug' => array(
                'regex' => '/^[a-z-]+$/', 
        ),
    ),
),

/*
`$slug` in `has-text-align-$slug` will be replaced with `$matches[0]` from `preg_match( $property_key['regex'], $style_value, $matches )`;
*/
```

The motive to use regexes was aspirational, but not currently pragmatic: string values for most CSS properties that we're interesting in are good enough.

So now it's just a flag to say: "hey, use the style value to replace `$slug`"

```php
'has-text-align-$slug' => array(
    'use_value' => true,
),
```

Furthermore, if the value of `'has-text-align-$slug'` is `array()`, then we could add 'regex' properties later if required.

## Testing Instructions

`npm run test:unit:php:base -- --filter WP_Style_Engine_Test`

Try out some other values for text align:

```php
gutenberg_style_engine_get_styles(
    array( 'typography' => array( 'textAlign' => 'start' ) )
)

/*

Output: see the classname `has-text-align-start`

array(
    'css'                => 'text-align:start;',
    'declarations' => array( 'text-align' => 'start' ),
    'classnames'   => 'has-text-align-start,
)

*/
```
