### PR TITLE
Fix enqueuing block theme styles when separate asset loading is enabled.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -269,8 +269,10 @@ function gutenberg_register_core_block_assets( $block_name ) {
 		wp_register_style( "wp-block-{$block_name}", false, array() );
 	}
 
-	// If the current theme supports wp-block-styles, dequeue the full stylesheet
-	// and instead attach each block's theme-styles to their block styles stylesheet.
+	/*
+	 * If the current theme supports wp-block-styles, dequeue the core styles
+	 * and enqueue the plugin ones instead.
+	 */
 	if ( current_theme_supports( 'wp-block-styles' ) ) {
 
 		// Get the path to the block's stylesheet.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -290,7 +290,6 @@ function gutenberg_register_core_block_assets( $block_name ) {
 				$default_version
 			);
 			wp_style_add_data( "wp-block-{$block_name}-theme", 'path', gutenberg_dir_path() . $theme_style_path );
-			
 		}
 	}
 
@@ -308,8 +307,6 @@ function gutenberg_register_core_block_assets( $block_name ) {
 		wp_register_style( "wp-block-{$block_name}-editor", false );
 	}
 }
-
-// add_filter( 'should_load_separate_core_block_assets', '__return_false', 11 );
 
 /**
  * Complements the implementation of block type `core/social-icon`, whether it

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -273,19 +273,6 @@ function gutenberg_register_core_block_assets( $block_name ) {
 	// and instead attach each block's theme-styles to their block styles stylesheet.
 	if ( current_theme_supports( 'wp-block-styles' ) ) {
 
-		// Dequeue the full stylesheet.
-		// Make sure this only runs once, it doesn't need to run for every block.
-		static $stylesheet_removed;
-		if ( ! $stylesheet_removed ) {
-			add_action(
-				'wp_enqueue_scripts',
-				static function () {
-					wp_dequeue_style( 'wp-block-library-theme' );
-				}
-			);
-			$stylesheet_removed = true;
-		}
-
 		// Get the path to the block's stylesheet.
 		$theme_style_path = is_rtl()
 			? "build/block-library/blocks/$block_name/theme-rtl.css"
@@ -293,23 +280,15 @@ function gutenberg_register_core_block_assets( $block_name ) {
 
 		// If the file exists, enqueue it.
 		if ( file_exists( gutenberg_dir_path() . $theme_style_path ) ) {
-
-			if ( file_exists( $stylesheet_path ) ) {
-				// If there is a main stylesheet for this block, append the theme styles to main styles.
-				wp_add_inline_style(
-					"wp-block-{$block_name}",
-					file_get_contents( gutenberg_dir_path() . $theme_style_path )
-				);
-			} else {
-				// If there is no main stylesheet for this block, register theme style.
-				wp_register_style(
-					"wp-block-{$block_name}",
-					gutenberg_url( $theme_style_path ),
-					array(),
-					$default_version
-				);
-				wp_style_add_data( "wp-block-{$block_name}", 'path', gutenberg_dir_path() . $theme_style_path );
-			}
+			wp_deregister_style( "wp-block-{$block_name}-theme" );
+			wp_register_style(
+				"wp-block-{$block_name}-theme",
+				gutenberg_url( $theme_style_path ),
+				array(),
+				$default_version
+			);
+			wp_style_add_data( "wp-block-{$block_name}-theme", 'path', gutenberg_dir_path() . $theme_style_path );
+			
 		}
 	}
 
@@ -327,6 +306,8 @@ function gutenberg_register_core_block_assets( $block_name ) {
 		wp_register_style( "wp-block-{$block_name}-editor", false );
 	}
 }
+
+// add_filter( 'should_load_separate_core_block_assets', '__return_false', 11 );
 
 /**
  * Complements the implementation of block type `core/social-icon`, whether it


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes [this issue](https://github.com/WordPress/gutenberg/pull/59457#pullrequestreview-1948039576) encountered in testing #59457.

When `wp_should_load_separate_core_block_assets()` is true, full block library stylesheets are dequeued in favour of loading only the styles for blocks present on the page, each in its own `<style>` tag. If the theme has support for `wp-block-styles` and the block has a `theme.scss` stylesheet, that also gets enqueued in its own style tag. 

The bug in Gutenberg is that the styles coming from `theme.scss` were being appended to the tag containing the main block styles, so they're being duplicated (because core is still enqueuing the theme styles in their own tag).

This PR changes the logic so that the `theme.scss` styles get enqueued in their own tag, with the core ones being dequeued first.

I also removed a redundant bit of logic to de-register the main stylesheet, because that already gets removed on the core side when `wp_should_load_separate_core_block_assets()` is true.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Activate Twenty Twenty Two theme;
2. Add an Audio block to a post and inspect its styles on the front end;
3. On trunk, verify that the styles inside `wp-block-audio-theme-inline-css` are duplicated in `wp-block-audio-inline-css` and changes made to the Audio block `theme.scss` file end up inside `wp-block-audio-inline-css`;
4. On this branch, verify that there is no duplication of styles in these two tags and changes made to the Audio block `theme.scss` file are shown in `wp-block-audio-theme-inline-css`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Trunk:
<img width="414" alt="Screenshot 2024-03-22 at 12 03 06 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/ca30ce9f-3474-4d4e-aabe-0f5500a44dda">

This PR:
<img width="406" alt="Screenshot 2024-03-22 at 12 06 43 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/ae57e6a0-f0d9-4a5f-be42-5491edbf9df4">

