### PR TITLE
DataViews: Fix react warning error in list layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -458,8 +458,6 @@
 		line-height: $grid-unit-20;
 
 		.dataviews-view-list__field {
-			margin: 0;
-
 			&:has(.dataviews-view-list__field-value:empty) {
 				display: none;
 			}

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -98,7 +98,7 @@ function ListItem( {
 									id={ descriptionId }
 								>
 									{ visibleFields.map( ( field ) => (
-										<p
+										<div
 											key={ field.id }
 											className="dataviews-view-list__field"
 										>
@@ -111,7 +111,7 @@ function ListItem( {
 											<span className="dataviews-view-list__field-value">
 												{ field.render( { item } ) }
 											</span>
-										</p>
+										</div>
 									) ) }
 								</div>
 							</VStack>


### PR DESCRIPTION
Related to #59637

## What?

This PR changes the field's HTML element from `p` to `div` to prevent browser warning errors in the dataview list layouts.

![image](https://github.com/WordPress/gutenberg/assets/54422211/45bc2614-30c8-4474-bafc-92a8d53ae0d3)

## Why?

Since [only flow content is allowed](https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element) as the content of the `p` element, it is not possible to include a `div` element. I don't think it's possible to wrap this field in a `p` element because any child could be rendered.

## How?

I changed the `p` element to a `div` element and removed the margin that was no longer needed as a result. As the screenshot below shows, this PR changes the font size from **13px** to **12px**. I think this is the expected font size behavior in the list view, what do you think? I'm also a little concerned that there might be accessibility issues.

## Testing Instructions

- Access any data view and change to the list layout.
- There should be no errors displayed in the browser console.

## Screenshots or screencast <!-- if applicable -->

### Before

The author field has a font size of 13px, which is a default paragraph style by WP Core.

![before](https://github.com/WordPress/gutenberg/assets/54422211/2a2c4f8f-3acd-4ee2-a156-b00b303d5d38)

### After

The author field has a font size of 12px defined by the data view component.

![after](https://github.com/WordPress/gutenberg/assets/54422211/780e192b-cbac-4c18-96ab-9e7a5e9ce9ae)