### PR TITLE
DataViews: Don't memoize every callback 'PagePages' component

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -377,27 +377,17 @@ export default function PagePages() {
 	);
 
 	const [ showAddPageModal, setShowAddPageModal ] = useState( false );
-	const openModal = useCallback( () => {
-		if ( ! showAddPageModal ) {
-			setShowAddPageModal( true );
-		}
-	}, [ showAddPageModal ] );
-	const closeModal = useCallback( () => {
-		if ( showAddPageModal ) {
-			setShowAddPageModal( false );
-		}
-	}, [ showAddPageModal ] );
-	const handleNewPage = useCallback(
-		( { type, id } ) => {
-			history.push( {
-				postId: id,
-				postType: type,
-				canvas: 'edit',
-			} );
-			closeModal();
-		},
-		[ history ]
-	);
+
+	const openModal = () => setShowAddPageModal( true );
+	const closeModal = () => setShowAddPageModal( false );
+	const handleNewPage = ( { type, id } ) => {
+		history.push( {
+			postId: id,
+			postType: type,
+			canvas: 'edit',
+		} );
+		closeModal();
+	};
 
 	// TODO: we need to handle properly `data={ data || EMPTY_ARRAY }` for when `isLoading`.
 	return (


### PR DESCRIPTION
## What?
A small follow-up to #57685.

PR removes unnecessary callback memoization in the `PagePages` component.

## Why?
These callbacks aren't passed as effect dependencies or memoized component props. There's no need to ensure their stable reference.

## Testing Instructions
1. Open the Site Editor.
2. Navigate to Design > Page.
3. Add a new page.
4. The flow should work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-03-22 at 09 06 12](https://github.com/WordPress/gutenberg/assets/240569/9e0fc502-d6ab-43bf-976f-5f0f95817ce8)

