### PR TITLE
Zoom-out view: disable canvas resizing

### DIFF
--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  */
 import { useSelect } from '@wordpress/data';
 import { useViewportMatch, useResizeObserver } from '@wordpress/compose';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -28,22 +29,21 @@ const { useLocation } = unlock( routerPrivateApis );
 
 export default function SiteEditorCanvas( { onClick } ) {
 	const location = useLocation();
-	const { templateType, isFocusableEntity, isViewMode } = useSelect(
-		( select ) => {
+	const { templateType, isFocusableEntity, isViewMode, isZoomOutMode } =
+		useSelect( ( select ) => {
 			const { getEditedPostType, getCanvasMode } = unlock(
 				select( editSiteStore )
 			);
-
+			const { __unstableGetEditorMode } = select( blockEditorStore );
 			const _templateType = getEditedPostType();
 
 			return {
 				templateType: _templateType,
 				isFocusableEntity: FOCUSABLE_ENTITIES.includes( _templateType ),
 				isViewMode: getCanvasMode() === 'view',
+				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
 			};
-		},
-		[]
-	);
+		}, [] );
 	const isFocusMode = location.params.focusMode || isFocusableEntity;
 	const [ resizeObserver, sizes ] = useResizeObserver();
 
@@ -55,6 +55,8 @@ export default function SiteEditorCanvas( { onClick } ) {
 		! isViewMode &&
 		// Disable resizing in mobile viewport.
 		! isMobileViewport &&
+		// Dsiable resizing in zoomed-out mode.
+		! isZoomOutMode &&
 		// Disable resizing when editing a template in focus mode.
 		templateType !== TEMPLATE_POST_TYPE;
 


### PR DESCRIPTION
Fixes #59389

## What?

This PR prevents canvas resizing when in zoomed out view.

## Why?

In a zoom-out view, canvas resizing should not be an expected feature. As reported in #59389, this causes unintended behavior.

## How?

Check editor mode and disable resizing when in zoom out mode.

## Testing Instructions

- Enable "Zoomed out view" setting in the Experimental Settings page.
- Open pattern, template part, navigation etc. in the Site Editor.
- Click the zoom-out view button.
- The resize handle should disappear.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/c9ced6e8-a944-4255-97c2-61f555eeeec2