### PR TITLE
[Mobile] Fixes Aztec IndexOutOfBoundsException

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         espressoVersion = '3.0.1'
 
         // libs
-        aztecVersion = 'v2.1.0'
+        aztecVersion = 'v2.1.1'
         wordpressUtilsVersion = '3.3.0'
 
         // main


### PR DESCRIPTION
[DO NOT MERGE]

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/20481

**Related PRs:**
- https://github.com/wordpress-mobile/AztecEditor-Android/pull/1078
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6765
- https://github.com/wordpress-mobile/WordPress-Android/pull/20518

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds exception handling in the Aztec Android editor for an edge case

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This bug resulted in a crash on some occasions

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
See https://github.com/wordpress-mobile/AztecEditor-Android/pull/1078

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
The PR is mobile only and does not affect the UI

## Screenshots or screencast <!-- if applicable -->
See https://github.com/wordpress-mobile/AztecEditor-Android/pull/1078