### PR TITLE
Fix flaky Site Editor pages e2e test

### DIFF
--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -97,14 +97,14 @@ test.describe( 'Pages', () => {
 		// Set up
 		await draftNewPage( page );
 		await addPageContent( editor, page );
-
-		/*
-		 * Test create page.Test creating a new page and editing the template.
-		 */
-		// Switch to template editing focus.
 		await editor.openDocumentSettingsSidebar();
-		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
+
+		// Switch to template editing focus.
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await editorSettings.getByRole( 'tab', { name: 'Page' } ).click();
+		await editorSettings
 			.getByRole( 'button', { name: 'Template options' } )
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();


### PR DESCRIPTION
## What?
Fixes #60102.

PR fixes `create a new page, edit template and toggle page template preview` e2e test, which became flaky after merging #60010.

## How?
Intentionally switch to the "Page" tab in the document settings.

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/site-editor/pages.spec.js
```
