### PR TITLE
Summary: Polish featured image

### DIFF
--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -31,7 +31,7 @@
 	box-shadow: 0 0 0 0 var(--wp-admin-theme-color);
 	overflow: hidden; // Ensure the focus style properly encapsulates the image.
 	outline-offset: -#{$border-width};
-	min-height: $grid-unit-70;
+	min-height: $grid-unit-50 * 2;
 	margin-bottom: $grid-unit-20;
 
 	display: flex;

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -12,7 +12,6 @@
 
 .editor-post-featured-image__container {
 	position: relative;
-	aspect-ratio: 2/1;
 
 	&:hover,
 	&:focus,
@@ -31,8 +30,9 @@
 	@include reduce-motion("transition");
 	box-shadow: 0 0 0 0 var(--wp-admin-theme-color);
 	overflow: hidden; // Ensure the focus style properly encapsulates the image.
-	outline: $border-width solid rgba(0, 0, 0, 0.1);
 	outline-offset: -#{$border-width};
+	min-height: $grid-unit-50 * 2;
+	margin-bottom: $grid-unit-10;
 
 	display: flex;
 	justify-content: center;

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -31,8 +31,8 @@
 	box-shadow: 0 0 0 0 var(--wp-admin-theme-color);
 	overflow: hidden; // Ensure the focus style properly encapsulates the image.
 	outline-offset: -#{$border-width};
-	min-height: $grid-unit-50 * 2;
-	margin-bottom: $grid-unit-10;
+	min-height: $grid-unit-70;
+	margin-bottom: $grid-unit-20;
 
 	display: flex;
 	justify-content: center;
@@ -40,6 +40,7 @@
 
 .editor-post-featured-image__preview {
 	height: auto;
+	outline: $border-width solid rgba($black, 0.1);
 
 	.editor-post-featured-image__preview-image {
 		object-fit: cover;


### PR DESCRIPTION
## What?

Polishes the featured image component of the new summary panel, and makes it less prominent when unset. Here's a screenshot of the component in trunk:

![featured image in trunk](https://github.com/WordPress/gutenberg/assets/1204802/e2d20ffb-833b-4dea-a48a-6dbff3531d18)

Featured images are nice, but many posts and pages are not going to have them, or even need them. So for the unset state, it should not be quite as prominent as here. In fact, we probably want to go even smaller than what this PR does. 

For now, I've pulled this down to be smaller, about the size it was before:

![no featured image](https://github.com/WordPress/gutenberg/assets/1204802/bd8b9d34-3ce9-4eae-aaaa-c19400af2d48)

It still grows to a 2:1 aspect ratio when a featured image is set:
![featured image](https://github.com/WordPress/gutenberg/assets/1204802/651a5898-b956-4225-9a97-badf632808e5)

I also removed the border. It wasn't there before, and in general this "dropzone" component we use elsewhere, borderless, such as in the font library, so it's probably best to not diverge:

![previously](https://github.com/WordPress/gutenberg/assets/1204802/99c44797-7992-418a-a7ba-f39a589602b1)

So this PR:

* Removes the border
* Removes the 2:1 aspect ratio for the unset feature image and replaces it with a min-height (which should likely be even smaller still)
* Adds a bottom margin to harmoniously space it with the items below.

## Testing Instructions

Obsere the post or page summary panel, and observe changes to the featured image as unset.