### PR TITLE
History: simplify the push and replace methods

### DIFF
--- a/packages/router/src/history.js
+++ b/packages/router/src/history.js
@@ -6,31 +6,26 @@ import { createBrowserHistory } from 'history';
 /**
  * WordPress dependencies
  */
-import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { buildQueryString } from '@wordpress/url';
 
 const history = createBrowserHistory();
 
 const originalHistoryPush = history.push;
 const originalHistoryReplace = history.replace;
 
+function buildSearch( params ) {
+	const queryString = buildQueryString( params );
+	return queryString.length > 0 ? '?' + queryString : queryString;
+}
+
 function push( params, state ) {
-	const currentArgs = getQueryArgs( window.location.href );
-	const currentUrlWithoutArgs = removeQueryArgs(
-		window.location.href,
-		...Object.keys( currentArgs )
-	);
-	const newUrl = addQueryArgs( currentUrlWithoutArgs, params );
-	return originalHistoryPush.call( history, newUrl, state );
+	const search = buildSearch( params );
+	return originalHistoryPush.call( history, { search }, state );
 }
 
 function replace( params, state ) {
-	const currentArgs = getQueryArgs( window.location.href );
-	const currentUrlWithoutArgs = removeQueryArgs(
-		window.location.href,
-		...Object.keys( currentArgs )
-	);
-	const newUrl = addQueryArgs( currentUrlWithoutArgs, params );
-	return originalHistoryReplace.call( history, newUrl, state );
+	const search = buildSearch( params );
+	return originalHistoryReplace.call( history, { search }, state );
 }
 
 history.push = push;


### PR DESCRIPTION
The `history.push` and `history.replace` methods replace the query string (aka `search`) part of the URL and leave the rest of the URL as is. That can be achieved by simply passing a `{ search }` object to the `history` package and it will do it for us. We don't need to read the URL, remove query args and then add the new ones.

**How to test:** Verify that navigation around Site Editor still works as before.