### PR TITLE
Editor: Update hover color of editor document title

### DIFF
--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -18,9 +18,10 @@
 
 	.components-button {
 		border-radius: $grid-unit-05;
+		transition: all 0.1s ease-out;
+		@include reduce-motion("transition");
 
 		&:hover {
-			color: var(--wp-block-synced-color);
 			background: $gray-200;
 		}
 	}
@@ -39,7 +40,7 @@
 .editor-document-bar__title {
 	flex-grow: 1;
 	overflow: hidden;
-	color: $gray-800;
+	color: $gray-900;
 	gap: $grid-unit-05;
 	display: flex;
 	justify-content: center;
@@ -48,10 +49,6 @@
 	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
 	@include break-small() {
 		padding-left: $grid-unit-40;
-	}
-
-	&:hover {
-		color: var(--wp-admin-theme-color);
 	}
 
 	.editor-document-bar.is-global & {

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -51,7 +51,7 @@
 	}
 
 	&:hover {
-		color: var(--wp-block-synced-color);
+		color: var(--wp-admin-theme-color);
 	}
 
 	.editor-document-bar.is-global & {

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -88,7 +88,7 @@
 	position: absolute;
 
 	&:hover {
-		color: var(--wp-block-synced-color);
+		color: $gray-900;
 		background-color: transparent;
 	}
 }


### PR DESCRIPTION
# What?
Follow up to: 
- https://github.com/WordPress/gutenberg/issues/60059

https://github.com/nirav7707/gutenberg/assets/56816580/fcb57e33-7e90-40d6-ac2b-c09176712a79
# Why?
- differentiate from synced assets