### PR TITLE
[Mobile] Fixes Aztec IndexOutOfBoundsException

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         espressoVersion = '3.0.1'
 
         // libs
-        aztecVersion = 'v2.1.0'
+        aztecVersion = 'v2.1.1'
         wordpressUtilsVersion = '3.3.0'
 
         // main


### PR DESCRIPTION
This PR brings changes from https://github.com/WordPress/gutenberg/pull/60107 which is currently blocked by a CI check.

## What?
Check the original PR for more information but it just updates the Aztec version to `2.1.1`

## Why?
To avoid a crash in the mobile editor.

## How?
By addressing the issue in the Aztec code.

## Testing Instructions
Check https://github.com/WordPress/gutenberg/pull/60107 for instructions.