### PR TITLE
Add __next40pxDefaultSize to Image block Title Attribute

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -692,6 +692,7 @@ export default function Image( {
 			<InspectorControls group="advanced">
 				<TextControl
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'Title attribute' ) }
 					value={ title || '' }
 					onChange={ onSetTitle }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Tiny fix in support of https://github.com/WordPress/gutenberg/issues/46734 to use the next default field size for the "Title Attribute" field in the Advanced settings of the Image block.

## Why?
Consistency.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert an image block.
3. Add an image.
4. Open the block inspector.
5. Open the "Advanced" panel.
6. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-03-22 at 10 18 10](https://github.com/WordPress/gutenberg/assets/1813435/fa400dd1-917c-4780-87ab-cb3f14f17fda)| ![CleanShot 2024-03-22 at 10 18 59](https://github.com/WordPress/gutenberg/assets/1813435/964b43e1-1dca-4324-b56c-cf08a2143f23)|