### PR TITLE
Global Styles: Make strings translatable

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-color-palette.js
+++ b/packages/edit-site/src/components/global-styles/screen-color-palette.js
@@ -25,8 +25,8 @@ function ScreenColorPalette( { name } ) {
 			/>
 			<Tabs>
 				<Tabs.TabList>
-					<Tabs.Tab tabId="solid">Solid</Tabs.Tab>
-					<Tabs.Tab tabId="gradient">Gradient</Tabs.Tab>
+					<Tabs.Tab tabId="solid">{ __( 'Solid' ) }</Tabs.Tab>
+					<Tabs.Tab tabId="gradient">{ __( 'Gradient' ) }</Tabs.Tab>
 				</Tabs.TabList>
 				<Tabs.TabPanel tabId="solid" focusable={ false }>
 					<ColorPalettePanel name={ name } />


### PR DESCRIPTION
Make 'Solid' and 'Gradient' labels translatable in the global styles color palette settings.

## What?
Add missing gettext to translation strings

## Why?
To allow translation of labels

## How?
Wrap with `__()`

## Testing Instructions
1. Open a post or page in a translated WordPress.
2. Go to Styles > Colors
3. Open color schene
4. See the 'Solid' and 'Grandient' untranslated

## Screenshots or screencast
![imagem](https://github.com/WordPress/gutenberg/assets/7371591/a0c74f4c-5855-4e47-96b1-028ee2a29580)

Fixes #60142 