### PR TITLE
Update: Use getPostIcon selector on document bar.

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -15,13 +15,7 @@ import {
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
-import {
-	chevronLeftSmall,
-	chevronRightSmall,
-	page as pageIcon,
-	navigation as navigationIcon,
-	symbol,
-} from '@wordpress/icons';
+import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as commandsStore } from '@wordpress/commands';
@@ -32,6 +26,7 @@ import { useReducedMotion } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const TYPE_LABELS = {
 	// translators: 1: Pattern title.
@@ -42,11 +37,6 @@ const TYPE_LABELS = {
 	wp_template: __( 'Editing template: %s' ),
 	// translators: 1: Template part title.
 	wp_template_part: __( 'Editing template part: %s' ),
-};
-
-const ICONS = {
-	wp_block: symbol,
-	wp_navigation: navigationIcon,
 };
 
 const TEMPLATE_POST_TYPES = [ 'wp_template', 'wp_template_part' ];
@@ -93,7 +83,12 @@ export default function DocumentBar() {
 				_postType,
 				_postId
 			),
-			templateIcon: _templateInfo.icon,
+			templateIcon: unlock( select( editorStore ) ).getPostIcon(
+				_postType,
+				{
+					area: _document?.area,
+				}
+			),
 			templateTitle: _templateInfo.title,
 			onNavigateToPreviousEntityRecord:
 				getEditorSettings().onNavigateToPreviousEntityRecord,
@@ -104,7 +99,6 @@ export default function DocumentBar() {
 	const isReducedMotion = useReducedMotion();
 
 	const isNotFound = ! document && ! isResolving;
-	const icon = ICONS[ postType ] ?? pageIcon;
 	const isTemplate = TEMPLATE_POST_TYPES.includes( postType );
 	const isGlobalEntity = GLOBAL_POST_TYPES.includes( postType );
 	const hasBackButton = !! onNavigateToPreviousEntityRecord;
@@ -177,7 +171,7 @@ export default function DocumentBar() {
 							isReducedMotion ? { duration: 0 } : undefined
 						}
 					>
-						<BlockIcon icon={ isTemplate ? templateIcon : icon } />
+						<BlockIcon icon={ templateIcon } />
 						<Text
 							size="body"
 							as="h1"


### PR DESCRIPTION
Update the DocumentBar component to use the new getPostIcon selector removing duplicate logic.

## Testing

Verify the document bar works as expected on pages, templates, template parts, and patterns.
