### PR TITLE
Fix self closing navigation overlay

### DIFF
--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -66,7 +66,14 @@ const { state, actions } = store(
 					actions.openMenu( 'hover' );
 			},
 			closeMenuOnHover() {
-				actions.closeMenu( 'hover' );
+				const { type, overlayOpenedBy } = getContext();
+				if (
+					type === 'submenu' &&
+					// Only open on hover if the overlay is closed.
+					Object.values( overlayOpenedBy || {} ).filter( Boolean )
+						.length === 0
+				)
+					actions.closeMenu( 'hover' );
 			},
 			openMenuOnClick() {
 				const ctx = getContext();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #60048

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's a bug

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Copy the closing conditions from the opening conditions on the `closeMenuOnHover` action in navigation block's view script.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Navigation Block with the following structure:
Menu Item
SubMenu
** Submenu item
** Submenu item
Menu item with a post/page saved as a draft
2. Set the Navigation to display as an overlay
3. Check the frontend and hover over the submenu

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/a50b4dff-2db6-4a9a-889c-ed50ab4bd743


