### PR TITLE
Polish Autocomplete popover

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 -   `TextControl`: Add typings for `date`, `time` and `datetime-local` ([#59666](https://github.com/WordPress/gutenberg/pull/59666)).
 -   `Text`, `Heading`, `ItemGroup` : Update the line height from 1.2 to 1.4 ([#60041](https://github.com/WordPress/gutenberg/pull/60041)).
+-   `Autocomplete` : match the autocomplete styling to that of List View and Command Palette([#60131](https://github.com/WordPress/gutenberg/pull/60131)).
 
 ### Deprecation
 

--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -1,6 +1,6 @@
 .components-autocomplete__popover .components-popover__content {
-	padding: $grid-unit-20;
-	min-width: 220px;
+	padding: $grid-unit-10;
+	min-width: 200px;
 }
 
 .components-autocomplete__result.components-button {
@@ -11,6 +11,7 @@
 	width: 100%;
 
 	&.is-selected {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+		background: $components-color-accent;
+		color: $white;
 	}
 }

--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -10,7 +10,12 @@
 	text-align: left;
 	width: 100%;
 
-	&.is-selected {
+	&:focus:not(:disabled) {
+		@include block-toolbar-button-style__focus();
+	}
+
+	&.is-selected,
+	&:not(:disabled,[aria-disabled="true"]):active {
 		background: $components-color-accent;
 		color: $white;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A quick exploration to match the autocomplete styling to that of List View and Command Palette. Also tweaks the size and padding a bit to generally map to existing popovers. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Use the `/` shortcut to add blocks.
3. See changes.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1813435/cf16f817-d974-489e-8764-f559e18ad531

The Command Palette: 
![CleanShot 2024-03-22 at 14 29 00](https://github.com/WordPress/gutenberg/assets/1813435/ba7ef732-071c-4e46-a612-8fccf8d33d8a)
