### PR TITLE
Add ToggleControl for "Open in new tab" in Settings.

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -12,6 +12,7 @@ import {
 	PanelBody,
 	TextControl,
 	TextareaControl,
+	ToggleControl,
 	ToolbarButton,
 	Tooltip,
 	ToolbarGroup,
@@ -166,7 +167,17 @@ export default function NavigationLinkEdit( {
 	context,
 	clientId,
 } ) {
-	const { id, label, type, url, description, rel, title, kind } = attributes;
+	const {
+		id,
+		label,
+		type,
+		url,
+		description,
+		rel,
+		title,
+		kind,
+		opensInNewTab,
+	} = attributes;
 
 	const [ isInvalid, isDraft ] = useIsInvalidLink( kind, type, id );
 	const { maxNestingLevel } = context;
@@ -476,6 +487,16 @@ export default function NavigationLinkEdit( {
 						help={ __(
 							'The relationship of the linked URL as space-separated link types.'
 						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Open in new tab' ) }
+						onChange={ ( value ) =>
+							setAttributes( {
+								opensInNewTab: value,
+							} )
+						}
+						checked={ opensInNewTab }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -11,6 +11,7 @@ import {
 	PanelBody,
 	TextControl,
 	TextareaControl,
+	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
@@ -135,7 +136,8 @@ export default function NavigationSubmenuEdit( {
 	context,
 	clientId,
 } ) {
-	const { label, type, url, description, rel, title } = attributes;
+	const { label, type, url, description, rel, title, opensInNewTab } =
+		attributes;
 
 	const { showSubmenuIcon, maxNestingLevel, openSubmenusOnClick } = context;
 
@@ -445,6 +447,16 @@ export default function NavigationSubmenuEdit( {
 						help={ __(
 							'The relationship of the linked URL as space-separated link types.'
 						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Open in new tab' ) }
+						onChange={ ( value ) =>
+							setAttributes( {
+								opensInNewTab: value,
+							} )
+						}
+						checked={ opensInNewTab }
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add "Open new tab" ToggleControl to the `core/navigation-link` and `core/navigation-submenu` block inspectors.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
fix: #59994

## How?
ToggleControl was used as in core/post-title.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Edit navigation.
2. Add page link / custom link.
3. Check block inspector and toggle "Open new tab".

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1908815/8b3eacb6-f73a-4cc3-9841-1867dd2ceb8e




