### PR TITLE
Update "Actions" string to "Options" in List View

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -396,7 +396,7 @@ function ListViewBlock( {
 							clientIds={ dropdownClientIds }
 							block={ block }
 							icon={ moreVertical }
-							label={ __( 'Actions' ) }
+							label={ __( 'Options' ) }
 							popoverProps={ {
 								anchor: settingsPopoverAnchor, // Used to position the settings at the cursor on right-click.
 							} }

--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -266,21 +266,21 @@ test.describe( 'Navigation block - List view editing', () => {
 				hasText: 'Block 2 of 2, Level 1.', // proxy for filtering by description.
 			} );
 
-		// The actions menu button is a sibling of the menu item gridcell.
+		// The options menu button is a sibling of the menu item gridcell.
 		const subMenuItemActions = subMenuItem
 			.locator( '..' ) // parent selector.
 			.getByRole( 'button', {
-				name: 'Actions',
+				name: 'Options',
 			} );
 
 		// Open the actions menu.
 		await subMenuItemActions.click();
 
-		// usage of `page` is required because the actions menu is rendered into a slot
+		// usage of `page` is required because the options menu is rendered into a slot
 		// outside of the treegrid.
 		const removeBlockAction = page
 			.getByRole( 'menu', {
-				name: 'Actions',
+				name: 'Options',
 			} )
 			.getByRole( 'menuitem', {
 				name: 'Remove Top Level Item 2',
@@ -401,7 +401,7 @@ test.describe( 'Navigation block - List view editing', () => {
 			description: 'Structure for navigation menu: Test Menu',
 		} );
 
-		// click on actions menu for the first menu item and select remove.
+		// click on options menu for the first menu item and select remove.
 		const firstMenuItem = listView
 			.getByRole( 'gridcell', {
 				name: 'Top Level Item 1',
@@ -410,22 +410,22 @@ test.describe( 'Navigation block - List view editing', () => {
 				hasText: 'Block 1 of 2, Level 1.', // proxy for filtering by description.
 			} );
 
-		// The actions menu button is a sibling of the menu item gridcell.
+		// The options menu button is a sibling of the menu item gridcell.
 		const firstItemActions = firstMenuItem
 			.locator( '..' ) // parent selector.
 			.getByRole( 'button', {
-				name: 'Actions',
+				name: 'Options',
 			} );
 
 		// Open the actions menu.
 		await firstItemActions.click();
 
 		// Add the submenu.
-		// usage of `page` is required because the actions menu is rendered into a slot
+		// usage of `page` is required because the options menu is rendered into a slot
 		// outside of the treegrid.
 		const addSubmenuAction = page
 			.getByRole( 'menu', {
-				name: 'Actions',
+				name: 'Options',
 			} )
 			.getByRole( 'menuitem', {
 				name: 'Add submenu',

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -179,14 +179,14 @@ test.describe( 'Block Renaming', () => {
 			await pageUtils.pressKeys( 'primary+a' );
 
 			const blockActionsTrigger = listView.getByRole( 'button', {
-				name: 'Actions',
+				name: 'Options',
 			} );
 
 			await blockActionsTrigger.click();
 
 			const renameMenuItem = page
 				.getByRole( 'menu', {
-					name: 'Actions',
+					name: 'Options',
 				} )
 				.getByRole( 'menuitem', {
 					name: 'Rename',
@@ -227,20 +227,20 @@ test.describe( 'Block Renaming', () => {
 				name: 'Heading',
 			} );
 
-			// The actions menu button is a sibling of the menu item gridcell.
+			// The options menu button is a sibling of the menu item gridcell.
 			const headingItemActions = headingItem
 				.locator( '..' ) // parent selector.
 				.getByRole( 'button', {
-					name: 'Actions',
+					name: 'Options',
 				} );
 
 			await headingItemActions.click();
 
-			// usage of `page` is required because the actions menu is rendered
+			// usage of `page` is required because the options menu is rendered
 			// into a slot outside of the treegrid.
 			const renameMenuItem = page
 				.getByRole( 'menu', {
-					name: 'Actions',
+					name: 'Options',
 				} )
 				.getByRole( 'menuitem', {
 					name: 'Rename',

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -280,7 +280,7 @@ test.describe( 'List View', () => {
 			imageItem
 				.locator( '..' ) // parent selector.
 				.getByRole( 'button', {
-					name: 'Actions',
+					name: 'Options',
 				} )
 		).toBeFocused();
 
@@ -295,7 +295,7 @@ test.describe( 'List View', () => {
 			groupItem
 				.locator( '..' ) // parent selector.
 				.getByRole( 'button', {
-					name: 'Actions',
+					name: 'Options',
 				} )
 		).toBeFocused();
 	} );
@@ -936,12 +936,12 @@ test.describe( 'List View', () => {
 		const listView = await listViewUtils.openListView();
 
 		await listView
-			.getByRole( 'button', { name: 'Actions' } )
+			.getByRole( 'button', { name: 'Options' } )
 			.first()
 			.click();
 
 		await page
-			.getByRole( 'menu', { name: 'Actions' } )
+			.getByRole( 'menu', { name: 'Options' } )
 			.getByRole( 'menuitem', { name: 'Duplicate' } )
 			.click();
 		await expect
@@ -957,11 +957,11 @@ test.describe( 'List View', () => {
 
 		await page.keyboard.press( 'Shift+ArrowUp' );
 		await listView
-			.getByRole( 'button', { name: 'Actions' } )
+			.getByRole( 'button', { name: 'Options' } )
 			.first()
 			.click();
 		await page
-			.getByRole( 'menu', { name: 'Actions' } )
+			.getByRole( 'menu', { name: 'Options' } )
 			.getByRole( 'menuitem', { name: 'Delete' } )
 			.click();
 		await expect
@@ -979,9 +979,9 @@ test.describe( 'List View', () => {
 			.filter( {
 				has: page.getByRole( 'gridcell', { name: 'File' } ),
 			} )
-			.getByRole( 'button', { name: 'Actions' } );
+			.getByRole( 'button', { name: 'Options' } );
 		const optionsForFileMenu = page.getByRole( 'menu', {
-			name: 'Actions',
+			name: 'Options',
 		} );
 		await expect(
 			optionsForFileToggle,

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -68,12 +68,12 @@ test.describe( 'Editing Navigation Menus', () => {
 				listView.locator( `id=${ navBlockNodeDescriptionId }` )
 			).toHaveText( /This block is locked./ );
 
-			// The block should have no actions menu.
+			// The block should have no options menu.
 			await expect(
 				navBlockNode
 					.locator( '..' ) // parent selector.
 					.getByRole( 'button', {
-						name: 'Actions',
+						name: 'Options',
 					} )
 			).toBeHidden();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to https://github.com/WordPress/gutenberg/pull/59370#discussion_r1532990060, updating "Actions" to "Options" for the List View items. 

We should use the same strings for the same control. The block toolbar uses "Options" as the label for this control, the same should be used in List View. 

I originally inquired about adapting the two to be the same per https://github.com/WordPress/gutenberg/issues/57078. 

## Why?
It's confusing naming the same control differently. 

## How?
String change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a block.
3. Open List View.
4. Select the vertical ellipsis icon. 
5. See changes in tooltip value. 

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-03-22 at 16 15 23](https://github.com/WordPress/gutenberg/assets/1813435/c0649a41-34d6-4d25-bb3d-e4798aaef5e2)
![CleanShot 2024-03-22 at 16 15 38](https://github.com/WordPress/gutenberg/assets/1813435/065a5f9b-e1fd-4a5e-8d55-43971d90f12a)


