### PR TITLE
Add sizeSlug to the image inserted from Inserter.

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -127,7 +127,6 @@ export function MediaPreview( { media, onClick, category } ) {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isInserting, setIsInserting ] = useState( false );
 	const { getSettings, getBlock } = useSelect( blockEditorStore );
-	const { imageDefaultSize } = getSettings();
 	const [ block, preview ] = useMemo(
 		() => getBlockAndPreviewFromMedia( media, category.mediaType ),
 		[ media, category.mediaType ]
@@ -189,11 +188,13 @@ export function MediaPreview( { media, onClick, category } ) {
 									img.media_type === 'image'
 								) {
 									const sizeSlug =
-										img.sizes?.[ imageDefaultSize ] ||
+										img.sizes?.[
+											settings.imageDefaultSize
+										] ||
 										img.media_details?.sizes?.[
-											imageDefaultSize
+											settings.imageDefaultSize
 										]
-											? imageDefaultSize
+											? settings.imageDefaultSize
 											: 'full';
 									onClick( {
 										...clonedBlock,
@@ -252,7 +253,6 @@ export function MediaPreview( { media, onClick, category } ) {
 			updateBlockAttributes,
 			createErrorNotice,
 			getBlock,
-			imageDefaultSize,
 		]
 	);
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -129,13 +129,8 @@ export function MediaPreview( { media, onClick, category } ) {
 	const { getSettings, getBlock } = useSelect( blockEditorStore );
 	const { imageDefaultSize } = getSettings();
 	const [ block, preview ] = useMemo(
-		() =>
-			getBlockAndPreviewFromMedia(
-				media,
-				category.mediaType,
-				imageDefaultSize
-			),
-		[ media, category.mediaType, imageDefaultSize ]
+		() => getBlockAndPreviewFromMedia( media, category.mediaType ),
+		[ media, category.mediaType ]
 	);
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
@@ -187,7 +182,7 @@ export function MediaPreview( { media, onClick, category } ) {
 								return;
 							}
 
-if ( ! getBlock( clonedBlock.clientId ) ) {
+							if ( ! getBlock( clonedBlock.clientId ) ) {
 								// Ensure the block is only inserted once.
 								if (
 									clonedBlock.name === 'core/image' &&
@@ -256,7 +251,6 @@ if ( ! getBlock( clonedBlock.clientId ) ) {
 			createSuccessNotice,
 			updateBlockAttributes,
 			createErrorNotice,
-<<<<<<< HEAD
 			getBlock,
 			imageDefaultSize,
 		]

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -126,7 +126,7 @@ export function MediaPreview( { media, onClick, category } ) {
 		useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isInserting, setIsInserting ] = useState( false );
-	const { getSettings } = useSelect( blockEditorStore );
+	const { getSettings, getBlock } = useSelect( blockEditorStore );
 	const { imageDefaultSize } = getSettings();
 	const [ block, preview ] = useMemo(
 		() =>
@@ -139,7 +139,6 @@ export function MediaPreview( { media, onClick, category } ) {
 	);
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
-	const { getSettings, getBlock } = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const onMediaInsert = useCallback(
@@ -188,16 +187,38 @@ export function MediaPreview( { media, onClick, category } ) {
 								return;
 							}
 
-							if ( ! getBlock( clonedBlock.clientId ) ) {
+if ( ! getBlock( clonedBlock.clientId ) ) {
 								// Ensure the block is only inserted once.
-								onClick( {
-									...clonedBlock,
-									attributes: {
-										...clonedBlock.attributes,
-										id: img.id,
-										url: img.url,
-									},
-								} );
+								if (
+									clonedBlock.name === 'core/image' &&
+									img.media_type === 'image'
+								) {
+									const sizeSlug =
+										img.sizes?.[ imageDefaultSize ] ||
+										img.media_details?.sizes?.[
+											imageDefaultSize
+										]
+											? imageDefaultSize
+											: 'full';
+									onClick( {
+										...clonedBlock,
+										attributes: {
+											...clonedBlock.attributes,
+											id: img.id,
+											url: img.url,
+											sizeSlug,
+										},
+									} );
+								} else {
+									onClick( {
+										...clonedBlock,
+										attributes: {
+											...clonedBlock.attributes,
+											id: img.id,
+											url: img.url,
+										},
+									} );
+								}
 
 								createSuccessNotice(
 									__( 'Image uploaded and inserted.' ),
@@ -211,7 +232,6 @@ export function MediaPreview( { media, onClick, category } ) {
 									url: img.url,
 								} );
 							}
-
 							setIsInserting( false );
 						},
 						allowedTypes: ALLOWED_MEDIA_TYPES,
@@ -236,7 +256,9 @@ export function MediaPreview( { media, onClick, category } ) {
 			createSuccessNotice,
 			updateBlockAttributes,
 			createErrorNotice,
+<<<<<<< HEAD
 			getBlock,
+			imageDefaultSize,
 		]
 	);
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -126,9 +126,16 @@ export function MediaPreview( { media, onClick, category } ) {
 		useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isInserting, setIsInserting ] = useState( false );
+	const { getSettings } = useSelect( blockEditorStore );
+	const { imageDefaultSize } = getSettings();
 	const [ block, preview ] = useMemo(
-		() => getBlockAndPreviewFromMedia( media, category.mediaType ),
-		[ media, category.mediaType ]
+		() =>
+			getBlockAndPreviewFromMedia(
+				media,
+				category.mediaType,
+				imageDefaultSize
+			),
+		[ media, category.mediaType, imageDefaultSize ]
 	);
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -2,11 +2,11 @@
  * WordPress dependencies
  */
 import { __, isRTL } from '@wordpress/i18n';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useViewportMatch } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -20,6 +20,7 @@ import MobileTabNavigation from '../mobile-tab-navigation';
 
 import CategoryTabs from '../category-tabs';
 import InserterNoResults from '../no-results';
+import { store as blockEditorStore } from '../../../store';
 
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video', 'audio' ];
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -1,10 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useViewportMatch } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,6 +17,7 @@ import MediaUpload from '../../media-upload';
 import { useMediaCategories } from './hooks';
 import { getBlockAndPreviewFromMedia } from './utils';
 import MobileTabNavigation from '../mobile-tab-navigation';
+
 import CategoryTabs from '../category-tabs';
 import InserterNoResults from '../no-results';
 
@@ -30,6 +33,8 @@ function MediaTab( {
 	const mediaCategories = useMediaCategories( rootClientId );
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const baseCssClass = 'block-editor-inserter__media-tabs';
+	const { getSettings } = useSelect( blockEditorStore );
+	const { imageDefaultSize } = getSettings();
 	const onSelectMedia = useCallback(
 		( media ) => {
 			if ( ! media?.url ) {
@@ -41,10 +46,14 @@ function MediaTab( {
 				window.__experimentalDataViewsMediaModal && media.mime_type
 					? media.mime_type.split( '/' )[ 0 ]
 					: media.type;
-			const [ block ] = getBlockAndPreviewFromMedia( media, mediaType );
+			const [ block ] = getBlockAndPreviewFromMedia(
+				media,
+				mediaType,
+				imageDefaultSize
+			);
 			onInsert( block );
 		},
-		[ onInsert ]
+		[ onInsert, imageDefaultSize ]
 	);
 	const categories = useMemo(
 		() =>

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -1,12 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -35,7 +34,6 @@ function MediaTab( {
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const baseCssClass = 'block-editor-inserter__media-tabs';
 	const { getSettings } = useSelect( blockEditorStore );
-	const { imageDefaultSize } = getSettings();
 	const onSelectMedia = useCallback(
 		( media ) => {
 			if ( ! media?.url ) {
@@ -47,6 +45,8 @@ function MediaTab( {
 				window.__experimentalDataViewsMediaModal && media.mime_type
 					? media.mime_type.split( '/' )[ 0 ]
 					: media.type;
+
+			const { imageDefaultSize } = getSettings();
 			const [ block ] = getBlockAndPreviewFromMedia(
 				media,
 				mediaType,
@@ -54,7 +54,7 @@ function MediaTab( {
 			);
 			onInsert( block );
 		},
-		[ onInsert, imageDefaultSize ]
+		[ onInsert, getSettings ]
 	);
 	const categories = useMemo(
 		() =>

--- a/packages/block-editor/src/components/inserter/media-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/media-tab/utils.js
@@ -10,15 +10,15 @@ const mediaTypeTag = { image: 'img', video: 'video', audio: 'audio' };
 /**
  * Creates a block and a preview element from a media object.
  *
- * @param {InserterMediaItem}         media           The media object to create the block from.
- * @param {('image'|'audio'|'video')} mediaType       The media type to create the block for.
- * @param {string}                    defaultSizeSlug The default size slug to use for the image block.
+ * @param {InserterMediaItem}         media     The media object to create the block from.
+ * @param {('image'|'audio'|'video')} mediaType The media type to create the block for.
+ * @param {string}                    sizeSlug  The size slug to use for the images.
  * @return {[WPBlock, JSX.Element]} An array containing the block and the preview element.
  */
 export function getBlockAndPreviewFromMedia(
 	media,
 	mediaType,
-	defaultSizeSlug = 'full'
+	sizeSlug = 'full'
 ) {
 	// Add the common attributes between the different media types.
 	const attributes = {
@@ -30,7 +30,12 @@ export function getBlockAndPreviewFromMedia(
 	if ( mediaType === 'image' ) {
 		attributes.url = mediaSrc;
 		attributes.alt = alt;
-		attributes.sizeSlug = defaultSizeSlug;
+		attributes.sizeSlug =
+			// Try `sizeSlug` and fall back to 'full'.
+			media.sizes?.[ sizeSlug ] ||
+			media.media_details?.sizes?.[ sizeSlug ]
+				? sizeSlug
+				: 'full';
 	} else if ( [ 'video', 'audio' ].includes( mediaType ) ) {
 		attributes.src = mediaSrc;
 	}

--- a/packages/block-editor/src/components/inserter/media-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/media-tab/utils.js
@@ -10,11 +10,16 @@ const mediaTypeTag = { image: 'img', video: 'video', audio: 'audio' };
 /**
  * Creates a block and a preview element from a media object.
  *
- * @param {InserterMediaItem}         media     The media object to create the block from.
- * @param {('image'|'audio'|'video')} mediaType The media type to create the block for.
+ * @param {InserterMediaItem}         media           The media object to create the block from.
+ * @param {('image'|'audio'|'video')} mediaType       The media type to create the block for.
+ * @param {string}                    defaultSizeSlug The default size slug to use for the image block.
  * @return {[WPBlock, JSX.Element]} An array containing the block and the preview element.
  */
-export function getBlockAndPreviewFromMedia( media, mediaType ) {
+export function getBlockAndPreviewFromMedia(
+	media,
+	mediaType,
+	defaultSizeSlug = 'full'
+) {
 	// Add the common attributes between the different media types.
 	const attributes = {
 		id: media.id || undefined,
@@ -25,7 +30,7 @@ export function getBlockAndPreviewFromMedia( media, mediaType ) {
 	if ( mediaType === 'image' ) {
 		attributes.url = mediaSrc;
 		attributes.alt = alt;
-		attributes.sizeSlug = 'full';
+		attributes.sizeSlug = defaultSizeSlug;
 	} else if ( [ 'video', 'audio' ].includes( mediaType ) ) {
 		attributes.src = mediaSrc;
 	}

--- a/packages/block-editor/src/components/inserter/media-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/media-tab/utils.js
@@ -25,6 +25,7 @@ export function getBlockAndPreviewFromMedia( media, mediaType ) {
 	if ( mediaType === 'image' ) {
 		attributes.url = mediaSrc;
 		attributes.alt = alt;
+		attributes.sizeSlug = 'full';
 	} else if ( [ 'video', 'audio' ].includes( mediaType ) ) {
 		attributes.src = mediaSrc;
 	}

--- a/packages/block-editor/src/components/inserter/media-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/media-tab/utils.js
@@ -12,14 +12,9 @@ const mediaTypeTag = { image: 'img', video: 'video', audio: 'audio' };
  *
  * @param {InserterMediaItem}         media     The media object to create the block from.
  * @param {('image'|'audio'|'video')} mediaType The media type to create the block for.
- * @param {string}                    sizeSlug  The size slug to use for the images.
  * @return {[WPBlock, JSX.Element]} An array containing the block and the preview element.
  */
-export function getBlockAndPreviewFromMedia(
-	media,
-	mediaType,
-	sizeSlug = 'full'
-) {
+export function getBlockAndPreviewFromMedia( media, mediaType ) {
 	// Add the common attributes between the different media types.
 	const attributes = {
 		id: media.id || undefined,
@@ -30,12 +25,6 @@ export function getBlockAndPreviewFromMedia(
 	if ( mediaType === 'image' ) {
 		attributes.url = mediaSrc;
 		attributes.alt = alt;
-		attributes.sizeSlug =
-			// Try `sizeSlug` and fall back to 'full'.
-			media.sizes?.[ sizeSlug ] ||
-			media.media_details?.sizes?.[ sizeSlug ]
-				? sizeSlug
-				: 'full';
 	} else if ( [ 'video', 'audio' ].includes( mediaType ) ) {
 		attributes.src = mediaSrc;
 	}

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -754,8 +754,8 @@ test.describe( 'insert media from inserter', () => {
 		await page.getByRole( 'tab', { name: 'Images' } ).click();
 		await page.getByLabel( uploadedMedia.title.raw ).click();
 		await expect.poll( editor.getEditedPostContent ).toBe(
-			`<!-- wp:image {"id":${ uploadedMedia.id }} -->
-<figure class="wp-block-image"><img src="${ uploadedMedia.source_url }" alt="${ uploadedMedia.alt_text }" class="wp-image-${ uploadedMedia.id }"/></figure>
+			`<!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full"} -->
+<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="${ uploadedMedia.alt_text }" class="wp-image-${ uploadedMedia.id }"/></figure>
 <!-- /wp:image -->`
 		);
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The image inserted from the block inserter is full size, so add `"sizeSlug": "full"` to the image block to be created.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
fix: #55027

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add sizeSlug to the attributes of the block created by `getBlockAndPreviewFromMedia`.

## Testing Instructions
1. Add image to Media Library
2. Edit a page/post
3. Block Inserter => Image block => add image from Media Library
4. Block Inserter => Media => Images / Media Library => add same image
5. Compare declared image resolutions in sidebar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/1908815/34c2aad9-8273-4d87-ad08-27332bc16943

