### PR TITLE
Adds readme for block editor component tool-selector

### DIFF
--- a/packages/block-editor/src/components/tool-selector/README.md
+++ b/packages/block-editor/src/components/tool-selector/README.md
@@ -1,0 +1,82 @@
+# ToolSelector
+
+The `ToolSelector` component provides a dropdown menu for selecting between different editing modes in the WordPress block editor.
+
+## Usage
+
+```jsx
+/**
+ * WordPress dependencies
+ */
+import { ToolSelector } from '@wordpress/block-editor';
+
+const MyEditor = () => {
+    return (
+        <div>
+            <ToolSelector />
+            {/* Other editor content */}
+        </div>
+    );
+}
+
+export default MyEditor;
+```
+
+## Props
+
+- **ref**: A reference to the component instance. Useful for accessing the DOM node or component instance.
+  - *Type*: React.ref
+  - *Required*: No
+
+### Other Props
+
+Additionally, the `ToolSelector` component accepts all props supported by the `Button` component from `@wordpress/components`.
+
+## Components Used
+
+The `ToolSelector` component internally uses the following WordPress components:
+
+- `Button`: For rendering the toggle button.
+- `Dropdown`: For managing the dropdown menu.
+- `MenuItemsChoice`: For rendering the choices within the dropdown menu.
+- `NavigableMenu`: For rendering a navigable menu within the dropdown.
+
+## Internal Dependencies
+
+The `ToolSelector` component relies on the following internal WordPress dependencies:
+
+- `store`: The block editor's data store for managing editor state.
+
+## Icon Usage
+
+The `ToolSelector` component utilizes icons from `@wordpress/icons` for rendering mode selection icons.
+
+## Editor Modes
+
+The `ToolSelector` component allows switching between the following editor modes:
+
+- **Edit Mode**: Enables editing blocks.
+- **Navigation Mode**: Enables selecting blocks.
+
+## Accessibility
+
+The `ToolSelector` component ensures accessibility by providing appropriate ARIA attributes and keyboard navigation support.
+
+### Accessibility in Edit Mode
+
+In edit mode, the `ToolSelector` ensures that:
+
+- The toggle button has an appropriate label for screen readers.
+- Keyboard navigation is supported for opening and closing the dropdown menu.
+
+### Accessibility in Navigation Mode
+
+In navigation mode, the `ToolSelector` ensures that:
+
+- The toggle button has an appropriate label for screen readers.
+- Keyboard navigation is supported for opening and closing the dropdown menu.
+
+## Contributing
+
+Feel free to contribute to this component by submitting pull requests, reporting issues, or suggesting improvements.
+


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds missing readme for block editor component tool-selector

## Why?
The tool-selector component was missing the necessary readme. 

## How?
This PR is addressing the issue https://github.com/WordPress/gutenberg/issues/22891

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
