### PR TITLE
Documentation: Fix @todo tags to follow standards in WordPress comments.

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -135,7 +135,7 @@ async function runNpmReleaseBranchSyncStep( pluginReleaseBranch, config ) {
 		/*
 		 * Replace content from remote branch.
 		 *
-		 * @TODO: What is our goal here? Could `git reset --hard origin/${pluginReleaseBranch}` work?
+		 * @todo What is our goal here? Could `git reset --hard origin/${pluginReleaseBranch}` work?
 		 *        Why are we manually removing and then adding files back in?
 		 */
 		await repo

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -858,7 +858,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 * are still present in the wrapper as they are in this example. Frequently, additional classes
 	 * will also be present; rarely should classes be removed.
 	 *
-	 * @TODO: Find a better way to match the first inner block. If it's possible to identify where the
+	 * @todo Find a better way to match the first inner block. If it's possible to identify where the
 	 *        first inner block starts, then it will be possible to find the last tag before it starts
 	 *        and then that tag, if an opening tag, can be solidly identified as a wrapping element.
 	 *        Can some unique value or class or ID be added to the inner blocks when they process

--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-active-formatting-elements.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-active-formatting-elements.php
@@ -107,7 +107,7 @@ if ( ! class_exists( 'WP_HTML_Active_Formatting_Elements' ) ) {
 			* > paired such that the two attributes in each pair have identical names, namespaces, and values
 			* > (the order of the attributes does not matter).
 			*
-			* @TODO: Implement the "Noah's Ark clause" to only add up to three of any given kind of formatting elements to the stack.
+			* @todo Implement the "Noah's Ark clause" to only add up to three of any given kind of formatting elements to the stack.
 			*/
 			// > Add element to the list of active formatting elements.
 			$this->stack[] = $token;

--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-processor.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-processor.php
@@ -254,7 +254,7 @@ if ( ! class_exists( 'WP_HTML_Processor' ) ) {
 			$p->state->context_node   = array( 'BODY', array() );
 			$p->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_BODY;
 
-			// @TODO: Create "fake" bookmarks for non-existent but implied nodes.
+			// @todo Create "fake" bookmarks for non-existent but implied nodes.
 			$p->bookmarks['root-node']    = new WP_HTML_Span( 0, 0 );
 			$p->bookmarks['context-node'] = new WP_HTML_Span( 0, 0 );
 
@@ -508,7 +508,7 @@ if ( ! class_exists( 'WP_HTML_Processor' ) ) {
 				* When moving on to the next node, therefore, if the bottom-most element
 				* on the stack is a void element, it must be closed.
 				*
-				* @TODO: Once self-closing foreign elements and BGSOUND are supported,
+				* @todo Once self-closing foreign elements and BGSOUND are supported,
 				*        they must also be implicitly closed here too. BGSOUND is
 				*        special since it's only self-closing if the self-closing flag
 				*        is provided in the opening tag, otherwise it expects a tag closer.
@@ -610,7 +610,7 @@ if ( ! class_exists( 'WP_HTML_Processor' ) ) {
 				*/
 				case '+BUTTON':
 					if ( $this->state->stack_of_open_elements->has_element_in_scope( 'BUTTON' ) ) {
-						// @TODO: Indicate a parse error once it's possible. This error does not impact the logic here.
+						// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 						$this->generate_implied_end_tags();
 						$this->state->stack_of_open_elements->pop_until( 'BUTTON' );
 					}
@@ -687,14 +687,14 @@ if ( ! class_exists( 'WP_HTML_Processor' ) ) {
 				case '-SECTION':
 				case '-SUMMARY':
 					if ( ! $this->state->stack_of_open_elements->has_element_in_scope( $tag_name ) ) {
-						// @TODO: Report parse error.
+						// @todo Report parse error.
 						// Ignore the token.
 						return $this->step();
 					}
 
 					$this->generate_implied_end_tags();
 					if ( $this->state->stack_of_open_elements->current_node()->node_name !== $tag_name ) {
-						// @TODO: Record parse error: this error doesn't impact parsing.
+						// @todo Record parse error: this error doesn't impact parsing.
 					}
 					$this->state->stack_of_open_elements->pop_until( $tag_name );
 					return true;

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -144,7 +144,7 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 			$slug       = $request->get_param( 'slug' );
 			$collection = WP_Font_Library::get_instance()->get_font_collection( $slug );
 
-			// @TODO: remove `is_wp_error` check once WP trunk is updated to return null when a collection is not found.
+			// @todo remove `is_wp_error` check once WP trunk is updated to return null when a collection is not found.
 			if ( ! $collection || is_wp_error( $collection ) ) {
 				return new WP_Error( 'rest_font_collection_not_found', __( 'Font collection not found.' ), array( 'status' => 404 ) );
 			}

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -1,7 +1,7 @@
 .block-editor-block-switcher {
 	position: relative;
 
-	// @todo: override toolbar group inherited paddings from components/block-tools/style.scss.
+	// @todo override toolbar group inherited paddings from components/block-tools/style.scss.
 	// This is best fixed by making the mover control area a proper single toolbar group.
 	// It needs specificity due to style inherited from .components-accessible-toolbar .components-button.has-icon.has-icon.
 	.components-button.components-dropdown-menu__toggle.has-icon.has-icon {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -133,7 +133,7 @@
 		}
 	}
 
-	// @todo: override toolbar group inherited paddings from components/block-tools/style.scss.
+	// @todo override toolbar group inherited paddings from components/block-tools/style.scss.
 	// This is best fixed by making the mover control area a proper single toolbar group.
 	.components-toolbar-group {
 		padding: 0;

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -101,7 +101,7 @@
 		height: $button-size-small;
 	}
 
-	// @todo: these are currently two separate components. Since we're now
+	// @todo these are currently two separate components. Since we're now
 	// treating them the same, one or both can be retired.
 	.block-editor-inserter__toggle.components-button.has-icon,
 	.block-list-appender__toggle {
@@ -134,7 +134,7 @@
 
 	// These could be avoided by employing a :not(:only-child) on the parent,
 	// but this should be more performant.
-	// @todo: These styles can almost certainly be refactored away we refactor
+	// @todo These styles can almost certainly be refactored away we refactor
 	// the markup and classes of the component itself. The rules provide some
 	// baseline styles for when the block is the only one inside.
 	&:only-child {

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -2,7 +2,7 @@
 	fill: currentColor;
 }
 
-// @todo: Ideally, popover, swatch size, and gap values should be CSS variables
+// @todo Ideally, popover, swatch size, and gap values should be CSS variables
 // to apply precise grid layouts.
 // https://github.com/WordPress/gutenberg/blob/954ecae571abbddc113d3a4bd8e1a72230180554/packages/block-editor/src/components/duotone-control/style.scss#L3-L9
 .block-editor-global-styles__shadow-popover-container {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -27,7 +27,7 @@ figure.wp-block-gallery {
 		}
 	}
 
-	// @todo: this deserves a refactor, by being moved to the toolbar.
+	// @todo this deserves a refactor, by being moved to the toolbar.
 	.block-editor-media-placeholder.is-appender {
 		.components-placeholder__label {
 			display: none;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -131,7 +131,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	 * the `$parsed_block['innerBlocks']` via the `render_block_data` hook.
 	 * However, this hook doesn't apply inner block updates when blocks are
 	 * nested.
-	 * @todo: In the future, if this hook supports updating innerBlocks in
+	 * @todo In the future, if this hook supports updating innerBlocks in
 	 * nested blocks, it should be refactored.
 	 *
 	 * @see: https://github.com/WordPress/gutenberg/pull/58733

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,5 +1,5 @@
 // Provide special styling for the placeholder.
-// @todo: this particular minimal style of placeholder could be componentized further.
+// @todo this particular minimal style of placeholder could be componentized further.
 .wp-block-image.wp-block-image {
 
 	// Show Placeholder style on-select.
@@ -13,7 +13,7 @@
 		// Disable any duotone filter applied in the selected state.
 		filter: none !important;
 
-		// @todo: this should eventually be overridden by a custom border-radius set in the inspector.
+		// @todo this should eventually be overridden by a custom border-radius set in the inspector.
 		border-radius: $radius-block-ui;
 
 		> svg {

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -1,5 +1,5 @@
 // Provide special styling for the placeholder.
-// @todo: this particular minimal style of placeholder could be componentized further.
+// @todo this particular minimal style of placeholder could be componentized further.
 .wp-block-post-featured-image {
 	.block-editor-media-placeholder {
 		z-index: 1; // Need to put it above the overlay so the upload button works.

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -31,7 +31,7 @@
 }
 
 // Provide special styling for the placeholder.
-// @todo: this particular minimal style of placeholder could be componentized further.
+// @todo this particular minimal style of placeholder could be componentized further.
 .wp-block-site-logo.wp-block-site-logo {
 
 	&.is-default-size .components-placeholder {
@@ -54,7 +54,7 @@
 		border-radius: inherit;
 
 		// Provide a minimum size for the placeholder, for when the logo is resized.
-		// @todo: resizing is currently only possible by adding an image, resizing,
+		// @todo resizing is currently only possible by adding an image, resizing,
 		// and then removing the image again. We might want to enable resizing on the
 		// placeholder itself.
 		min-height: $grid-unit-60;

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -86,7 +86,7 @@
 }
 
 // Improve the preview, ensure buttons are fully opaque despite being disabled.
-// @todo: Look at improving the preview component to make this unnecessary.
+// @todo Look at improving the preview component to make this unnecessary.
 .block-editor-block-preview__content .components-button:disabled {
 	opacity: 1;
 }

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -1,5 +1,5 @@
 // Provide special styling for the placeholder.
-// @todo: this particular minimal style of placeholder could be componentized further.
+// @todo this particular minimal style of placeholder could be componentized further.
 .wp-block-video.wp-block-video {
 	// Show Placeholder style on-select.
 	&.is-selected .components-placeholder {
@@ -9,7 +9,7 @@
 		box-shadow: inset 0 0 0 $border-width $gray-900;
 		border: none;
 
-		// @todo: this should eventually be overridden by a custom border-radius set in the inspector.
+		// @todo this should eventually be overridden by a custom border-radius set in the inspector.
 		border-radius: $radius-block-ui;
 
 		> svg {

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -44,7 +44,7 @@ function useDeprecatedProps( {
 	let computedVariant = variant;
 
 	const newProps: { 'aria-pressed'?: boolean } = {
-		// @TODO Mark `isPressed` as deprecated
+		// @todo Mark `isPressed` as deprecated
 		'aria-pressed': isPressed,
 	};
 

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -300,7 +300,7 @@ export const Tooltip = styled.span< TooltipProps >`
 	) }
 `;
 
-// @todo: Refactor RangeControl with latest HStack configuration
+// @todo Refactor RangeControl with latest HStack configuration
 // @see: packages/components/src/h-stack
 export const InputNumber = styled( NumberControl )`
 	display: inline-block;

--- a/packages/components/src/toolbar/toolbar/style.scss
+++ b/packages/components/src/toolbar/toolbar/style.scss
@@ -89,7 +89,7 @@
 			min-width: $block-toolbar-height;
 		}
 
-		// @todo: We should extract the tabs styles to the tabs component itself
+		// @todo We should extract the tabs styles to the tabs component itself
 		&.components-tab-button {
 			font-weight: 500;
 

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -143,7 +143,7 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		// @todo, Should we allow this behaviour? Side-effects
+		// @todo Should we allow this behaviour? Side-effects
 		// on mount are discouraged in React (breaks Suspense and React Async Mode)
 		// leaving in place for now under the assumption there's current usage
 		// of withSelect in GB that expects support.

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -88,7 +88,7 @@
 
 	// Until checkboxes WordPress-wide are updated to match the new style,
 	// checkboxes used in metaboxes have to be slightly unstyled here.
-	// @todo: remove this entire rule once checkboxes are the same everywhere.
+	// @todo remove this entire rule once checkboxes are the same everywhere.
 	// See: https://github.com/WordPress/gutenberg/issues/18053
 	.metabox-location-side .postbox input[type="checkbox"] {
 		border: $border-width solid $gray-700;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -1,5 +1,5 @@
 .font-library-modal {
-	// @todo: If a new prop is added to the Modal component that constrains
+	// @todo If a new prop is added to the Modal component that constrains
 	// the content width, we should use that prop instead of this style.
 	// see https://github.com/WordPress/gutenberg/issues/54471.
 	&.font-library-modal {

--- a/packages/editor/src/components/document-tools/style.scss
+++ b/packages/editor/src/components/document-tools/style.scss
@@ -40,7 +40,7 @@
 	// here to the original button styles
 	.editor-document-tools__left > .components-button.has-icon,
 	.editor-document-tools__left > .components-dropdown > .components-button.has-icon {
-		// @todo: override toolbar group inherited paddings from components/block-tools/style.scss.
+		// @todo override toolbar group inherited paddings from components/block-tools/style.scss.
 		// This is best fixed by making the mover control area a proper single toolbar group.
 		// It needs specificity due to style inherited from .components-accessible-toolbar .components-button.has-icon.has-icon.
 		height: $button-size-compact;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Ensure proper case for "@todo" tags in phpdocs.
Fixes #59539 

## Why?
There was invalid @todo tags (invalid: @todo: @todo @todo:)

## How?
I've changed the @todo tags found in files to follow guidelines in https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#phpdoc-tags

PR done in WordCamp Torrelodones 2024 Core contributor table.
