### PR TITLE
Background image: move controls into a popover

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -65,8 +65,10 @@ $z-layers: (
 	// Needs to be below media library that has a z-index of 160000.
 	"{core/video track editor popover}": 160000 - 10,
 
-	// Needs to be below media library that has a z-index of 160000.
+	// Needs to be below media library (.media-model) that has a z-index of 160000.
 	".block-editor-format-toolbar__image-popover": 160000 - 10,
+	// Below the media library backdrop (.media-modal-backdrop), which has a z-index of 159900.
+	".block-editor-global-styles-background-panel__popover": 159900 - 10,
 
 	// Small screen inner blocks overlay must be displayed above drop zone,
 	// settings menu, and movers.

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -57,6 +57,7 @@ const BACKGROUND_POPOVER_PROPS = {
 	placement: 'left-start',
 	offset: 36,
 	shift: true,
+	className: 'block-editor-global-styles-background-panel__popover',
 };
 const noop = () => {};
 

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -57,7 +57,6 @@ const BACKGROUND_POPOVER_PROPS = {
 	offset: 36,
 	shift: true,
 	className: 'block-editor-global-styles-background-panel__popover',
-	expandOnMobile: true,
 };
 const noop = () => {};
 
@@ -546,7 +545,6 @@ function BackgroundSizeControls( {
 	return (
 		<VStack spacing={ 3 } className="single-column">
 			<FocalPointPicker
-				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				label={ __( 'Position' ) }
 				url={ getResolvedThemeFilePath( imageValue, themeFileURIs ) }
@@ -554,7 +552,6 @@ function BackgroundSizeControls( {
 				onChange={ updateBackgroundPosition }
 			/>
 			<ToggleGroupControl
-				size="__unstable-large"
 				label={ __( 'Size' ) }
 				value={ currentValueForToggle }
 				onChange={ updateBackgroundSize }
@@ -589,26 +586,24 @@ function BackgroundSizeControls( {
 				/>
 			</ToggleGroupControl>
 			<HStack justify="flex-start" spacing={ 2 } as="span">
-				{ currentValueForToggle !== undefined &&
-				currentValueForToggle !== 'cover' &&
-				currentValueForToggle !== 'contain' ? (
-					<UnitControl
-						aria-label={ __( 'Background image width' ) }
-						onChange={ updateBackgroundSize }
-						value={ sizeValue }
-						size="__unstable-large"
-						__unstableInputWidth="100px"
-						min={ 0 }
-						placeholder={ __( 'Auto' ) }
-					/>
-				) : null }
-				{ currentValueForToggle !== 'cover' && (
-					<ToggleControl
-						label={ __( 'Repeat' ) }
-						checked={ repeatCheckedValue }
-						onChange={ toggleIsRepeated }
-					/>
-				) }
+				<UnitControl
+					aria-label={ __( 'Background image width' ) }
+					onChange={ updateBackgroundSize }
+					value={ sizeValue }
+					__unstableInputWidth="100px"
+					min={ 0 }
+					placeholder={ __( 'Auto' ) }
+					disabled={
+						currentValueForToggle !== 'auto' ||
+						currentValueForToggle === undefined
+					}
+				/>
+				<ToggleControl
+					label={ __( 'Repeat' ) }
+					checked={ repeatCheckedValue }
+					onChange={ toggleIsRepeated }
+					disabled={ currentValueForToggle === 'cover' }
+				/>
 			</HStack>
 		</VStack>
 	);

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -264,7 +264,13 @@ function BackgroundControlsPanel( {
 	);
 }
 
-function BackgroundImageControls( { onChange, style, inheritedValue } ) {
+function BackgroundImageControls( {
+	onChange,
+	style,
+	inheritedValue,
+	onRemoveImage = noop,
+	displayInPanel,
+} ) {
 	const mediaUpload = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
 		[]
@@ -378,6 +384,12 @@ function BackgroundImageControls( { onChange, style, inheritedValue } ) {
 				allowedTypes={ [ IMAGE_BACKGROUND_TYPE ] }
 				accept="image/*"
 				onSelect={ onSelectMedia }
+				popoverProps={ {
+					className: clsx( {
+						'block-editor-global-styles-background-panel__media-replace-popover':
+							displayInPanel,
+					} ),
+				} }
 				name={
 					<InspectorImagePreviewItem
 						className="block-editor-global-styles-background-panel__image-preview"
@@ -403,6 +415,7 @@ function BackgroundImageControls( { onChange, style, inheritedValue } ) {
 						onClick={ () => {
 							closeAndFocus();
 							resetBackgroundImage();
+							onRemoveImage();
 						} }
 					>
 						{ __( 'Reset ' ) }
@@ -712,6 +725,10 @@ export default function BackgroundPanel( {
 								onChange={ onChange }
 								style={ value }
 								inheritedValue={ inheritedValue }
+								displayInPanel
+								onRemoveImage={ () =>
+									setIsDropDownOpen( false )
+								}
 							/>
 							<BackgroundSizeControls
 								onChange={ onChange }

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -51,13 +51,13 @@ import { getResolvedThemeFilePath } from './theme-file-uri-utils';
 const IMAGE_BACKGROUND_TYPE = 'image';
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
-	backgroundSize: true,
 };
 const BACKGROUND_POPOVER_PROPS = {
 	placement: 'left-start',
 	offset: 36,
 	shift: true,
 	className: 'block-editor-global-styles-background-panel__popover',
+	expandOnMobile: true,
 };
 const noop = () => {};
 
@@ -414,7 +414,6 @@ function BackgroundImageControls( {
 					<MenuItem
 						onClick={ () => {
 							closeAndFocus();
-							resetBackgroundImage();
 							onRemoveImage();
 						} }
 					>
@@ -661,6 +660,10 @@ export default function BackgroundPanel( {
 			background: {},
 		};
 	}, [] );
+
+	const resetBackground = () =>
+		onChange( setImmutably( value, [ 'background' ], {} ) );
+
 	const { title, url } = value?.background?.backgroundImage || {
 		...inheritedValue?.background?.backgroundImage,
 	};
@@ -668,32 +671,12 @@ export default function BackgroundPanel( {
 		hasBackgroundImageValue( value ) ||
 		hasBackgroundImageValue( inheritedValue );
 
-	const hasSizeValue =
-		hasBackgroundSizeValue( value ) ||
-		hasBackgroundSizeValue( inheritedValue );
-
 	const shouldShowBackgroundImageControls =
 		hasImageValue &&
 		( settings?.background?.backgroundSize ||
 			settings?.background?.backgroundPosition ||
 			settings?.background?.backgroundRepeat );
-	const resetBackgroundSize = () =>
-		onChange(
-			setImmutably( value, [ 'background' ], {
-				...value?.background,
-				backgroundPosition: undefined,
-				backgroundRepeat: undefined,
-				backgroundSize: undefined,
-			} )
-		);
-	const resetBackgroundImage = () =>
-		onChange(
-			setImmutably(
-				value,
-				[ 'background', 'backgroundImage' ],
-				undefined
-			)
-		);
+
 	const [ isDropDownOpen, setIsDropDownOpen ] = useState( false );
 
 	return (
@@ -726,16 +709,14 @@ export default function BackgroundPanel( {
 								style={ value }
 								inheritedValue={ inheritedValue }
 								displayInPanel
-								onRemoveImage={ () =>
-									setIsDropDownOpen( false )
-								}
+								onRemoveImage={ () => {
+									setIsDropDownOpen( false );
+									resetBackground();
+								} }
 							/>
 							<BackgroundSizeControls
 								onChange={ onChange }
 								panelId={ panelId }
-								isShownByDefault={
-									defaultControls.backgroundImage
-								}
 								style={ value }
 								defaultValues={ defaultValues }
 								inheritedValue={ inheritedValue }
@@ -756,15 +737,7 @@ export default function BackgroundPanel( {
 			<ToolsPanelItem
 				hasValue={ () => hasImageValue }
 				label={ __( 'Image' ) }
-				onDeselect={ resetBackgroundImage }
-				isShownByDefault={ defaultControls.backgroundImage }
-				panelId={ panelId }
-				className="block-editor-global-styles-background-panel__hidden-tools-panel-item"
-			/>
-			<ToolsPanelItem
-				hasValue={ () => hasSizeValue }
-				label={ __( 'Size' ) }
-				onDeselect={ resetBackgroundSize }
+				onDeselect={ resetBackground }
 				isShownByDefault={ defaultControls.backgroundImage }
 				panelId={ panelId }
 				className="block-editor-global-styles-background-panel__hidden-tools-panel-item"

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -545,6 +545,7 @@ function BackgroundSizeControls( {
 	return (
 		<VStack spacing={ 3 } className="single-column">
 			<FocalPointPicker
+				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				label={ __( 'Position' ) }
 				url={ getResolvedThemeFilePath( imageValue, themeFileURIs ) }
@@ -552,6 +553,7 @@ function BackgroundSizeControls( {
 				onChange={ updateBackgroundPosition }
 			/>
 			<ToggleGroupControl
+				size="__unstable-large"
 				label={ __( 'Size' ) }
 				value={ currentValueForToggle }
 				onChange={ updateBackgroundSize }
@@ -590,6 +592,7 @@ function BackgroundSizeControls( {
 					aria-label={ __( 'Background image width' ) }
 					onChange={ updateBackgroundSize }
 					value={ sizeValue }
+					size="__unstable-large"
 					__unstableInputWidth="100px"
 					min={ 0 }
 					placeholder={ __( 'Auto' ) }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -90,6 +90,7 @@
 
 	.block-editor-global-styles-background-panel__inspector-preview-inner {
 		height: 100%;
+
 	}
 
 	.block-editor-global-styles-background-panel__image-tools-panel-item {
@@ -158,6 +159,7 @@
 .block-editor-global-styles-background-panel__inspector-image-indicator-wrapper {
 	width: 20px;
 	height: 20px;
+	margin-right: $grid-unit-10;
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator {
@@ -195,4 +197,13 @@
 	height: 0;
 	width: 0;
 	position: absolute;
+}
+
+.block-editor-global-styles-background-panel__tab-panel {
+	padding: $grid-unit-20;
+	width: 260px;
+}
+
+.block-editor-global-styles-background-panel__size-controls .components-base-control {
+	width: 100%;
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -71,64 +71,56 @@
 	direction: ltr;
 }
 
+
 .block-editor-global-styles-background-panel__inspector-media-replace-container {
-	position: relative;
+	//position: relative;
 	border: 1px solid $gray-300;
 	border-radius: 2px;
-	justify-content: center;
-	align-items: stretch;
+	//justify-content: center;
+	//align-items: stretch;
 	// Full width. ToolsPanel lays out children in a grid.
 	grid-column: 1 / -1;
-
-	&.has-image {
-		display: flex;
-	}
 
 	&.is-open {
 		background-color: $gray-100;
 	}
 
-	.block-editor-global-styles-background-panel__inspector-preview-inner {
-		height: 100%;
-
-	}
-
 	.block-editor-global-styles-background-panel__image-tools-panel-item {
-		&.is-wide {
-			width: 100%;
-			.block-editor-global-styles-background-panel__inspector-preview-inner {
-				justify-content: center;
-			}
+		flex-grow: 1;
+		border: 0;
+		.components-dropdown {
+			display: block;
 		}
 	}
 
-	.block-editor-global-styles-background-panel__image-preview,
-	.block-editor-global-styles-background-panel__inspector-media-replace {
-		flex-grow: 1;
-	}
-
-	.block-editor-global-styles-background-panel__image-preview-content,
-	.block-editor-global-styles-background-panel__dropdown-toggle {
+	.block-editor-global-styles-background-panel__inspector-preview-inner {
 		height: 100%;
-		width: 100%;
-		padding-left: $grid-unit-15;
 	}
 
-	.block-editor-global-styles-background-panel__dropdown-toggle {
-		cursor: pointer;
-		background: transparent;
-		border: none;
+	.components-dropdown {
+		display: block;
+		height: 36px;
 	}
+}
 
+.block-editor-global-styles-background-panel__image-tools-panel-item {
+	border: 1px solid $gray-300;
+	border-radius: 2px;
+	// Full width. ToolsPanel lays out children in a grid.
+	grid-column: 1 / -1;
 	// Since there is no option to skip rendering the drag'n'drop icon in drop
 	// zone, we hide it for now.
 	.components-drop-zone__content-icon {
 		display: none;
 	}
 
+	.components-dropdown {
+		display: block;
+		height: 36px;
+	}
+
 	button.components-button {
 		color: $gray-900;
-		//box-shadow: inset 0 0 0 $border-width $gray-400;
 		width: 100%;
 		display: block;
 
@@ -140,20 +132,29 @@
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
+}
 
-	.block-editor-global-styles-background-panel__inspector-media-replace-title {
-		word-break: break-all;
-		// The Button component is white-space: nowrap, and that won't work with line-clamp.
-		white-space: normal;
+.block-editor-global-styles-background-panel__image-preview-content,
+.block-editor-global-styles-background-panel__dropdown-toggle {
+	height: 100%;
+	width: 100%;
+	padding-left: $grid-unit-15;
+}
 
-		// Without this, the ellipsis can sometimes be partially hidden by the Button padding.
-		text-align: start;
-		text-align-last: center;
-	}
+.block-editor-global-styles-background-panel__dropdown-toggle {
+	cursor: pointer;
+	background: transparent;
+	border: none;
+}
 
-	.components-dropdown {
-		display: block;
-	}
+.block-editor-global-styles-background-panel__inspector-media-replace-title {
+	word-break: break-all;
+	// The Button component is white-space: nowrap, and that won't work with line-clamp.
+	white-space: normal;
+
+	// Without this, the ellipsis can sometimes be partially hidden by the Button padding.
+	text-align: start;
+	text-align-last: center;
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator-wrapper {
@@ -197,13 +198,4 @@
 	height: 0;
 	width: 0;
 	position: absolute;
-}
-
-.block-editor-global-styles-background-panel__tab-panel {
-	padding: $grid-unit-20;
-	width: 260px;
-}
-
-.block-editor-global-styles-background-panel__size-controls .components-base-control {
-	width: 100%;
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -200,8 +200,7 @@
 	position: absolute;
 }
 
-// Hack to push into background when the media modal is open.
-// @TODO how to target the background panel specifically?
-.modal-open .components-dropdown__content {
-	z-index: 100000;
+// Push control panel into the background when the media modal is open.
+.modal-open .block-editor-global-styles-background-panel__popover {
+	z-index: z-index(".block-editor-global-styles-background-panel__popover");
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -199,3 +199,9 @@
 	width: 0;
 	position: absolute;
 }
+
+// Hack to push into background when the media modal is open.
+// @TODO how to target the background panel specifically?
+.modal-open .components-dropdown__content {
+	z-index: 100000;
+}

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -73,6 +73,40 @@
 
 .block-editor-global-styles-background-panel__inspector-media-replace-container {
 	position: relative;
+	border: 1px solid $gray-300;
+	border-radius: 2px;
+	display: flex;
+	justify-content: center;
+	align-items: stretch;
+	// Full width. ToolsPanel lays out children in a grid.
+	grid-column: 1 / -1;
+
+	&.is-open {
+		background-color: $gray-100;
+	}
+
+	.block-editor-global-styles-background-panel__inspector-preview-inner {
+		height: 100%;
+	}
+
+	.block-editor-global-styles-background-panel__image-preview,
+	.block-editor-global-styles-background-panel__inspector-media-replace {
+		flex-grow: 1;
+	}
+
+	.block-editor-global-styles-background-panel__image-preview-content,
+	.block-editor-global-styles-background-panel__dropdown-toggle {
+		height: 100%;
+		width: 100%;
+		padding-left: $grid-unit-15;
+	}
+
+	.block-editor-global-styles-background-panel__dropdown-toggle {
+		cursor: pointer;
+		background: transparent;
+		border: none;
+	}
+
 	// Since there is no option to skip rendering the drag'n'drop icon in drop
 	// zone, we hide it for now.
 	.components-drop-zone__content-icon {
@@ -84,7 +118,6 @@
 		box-shadow: inset 0 0 0 $border-width $gray-400;
 		width: 100%;
 		display: block;
-		height: $grid-unit-50;
 
 		&:hover {
 			color: var(--wp-admin-theme-color);
@@ -111,11 +144,8 @@
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator-wrapper {
-	display: block;
 	width: 20px;
 	height: 20px;
-	flex: none;
-	background: #fff;
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator {
@@ -141,3 +171,16 @@
 	box-sizing: inherit;
 }
 
+.block-editor-global-styles-background-panel__dropdown-content-wrapper {
+	min-width: 260px;
+	.components-base-control__help,
+	.components-toggle-control {
+		margin-bottom: 0;
+	}
+}
+
+.block-editor-global-styles-background-panel__hidden-tools-panel-item {
+	height: 0px;
+	position: absolute;
+	width: 0px;
+}

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -75,11 +75,14 @@
 	position: relative;
 	border: 1px solid $gray-300;
 	border-radius: 2px;
-	display: flex;
 	justify-content: center;
 	align-items: stretch;
 	// Full width. ToolsPanel lays out children in a grid.
 	grid-column: 1 / -1;
+
+	&.has-image {
+		display: flex;
+	}
 
 	&.is-open {
 		background-color: $gray-100;
@@ -87,6 +90,15 @@
 
 	.block-editor-global-styles-background-panel__inspector-preview-inner {
 		height: 100%;
+	}
+
+	.block-editor-global-styles-background-panel__image-tools-panel-item {
+		&.is-wide {
+			width: 100%;
+			.block-editor-global-styles-background-panel__inspector-preview-inner {
+				justify-content: center;
+			}
+		}
 	}
 
 	.block-editor-global-styles-background-panel__image-preview,
@@ -115,7 +127,7 @@
 
 	button.components-button {
 		color: $gray-900;
-		box-shadow: inset 0 0 0 $border-width $gray-400;
+		//box-shadow: inset 0 0 0 $border-width $gray-400;
 		width: 100%;
 		display: block;
 
@@ -180,7 +192,7 @@
 }
 
 .block-editor-global-styles-background-panel__hidden-tools-panel-item {
-	height: 0px;
+	height: 0;
+	width: 0;
 	position: absolute;
-	width: 0px;
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -189,6 +189,9 @@
 	.components-toggle-control {
 		margin-bottom: 0;
 	}
+	.components-focal-point-picker__media--image {
+		max-height: 100px;
+	}
 }
 
 .block-editor-global-styles-background-panel__hidden-tools-panel-item {

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -73,11 +73,8 @@
 
 
 .block-editor-global-styles-background-panel__inspector-media-replace-container {
-	//position: relative;
 	border: 1px solid $gray-300;
 	border-radius: 2px;
-	//justify-content: center;
-	//align-items: stretch;
 	// Full width. ToolsPanel lays out children in a grid.
 	grid-column: 1 / -1;
 
@@ -160,7 +157,6 @@
 .block-editor-global-styles-background-panel__inspector-image-indicator-wrapper {
 	width: 20px;
 	height: 20px;
-	margin-right: $grid-unit-10;
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator {
@@ -203,4 +199,17 @@
 // Push control panel into the background when the media modal is open.
 .modal-open .block-editor-global-styles-background-panel__popover {
 	z-index: z-index(".block-editor-global-styles-background-panel__popover");
+}
+
+.block-editor-global-styles-background-panel__media-replace-popover {
+	.components-popover__content {
+		// width of block-editor-global-styles-background-panel__dropdown-content-wrapper minus padding.
+		width: 226px;
+	}
+	.components-button {
+		padding: 0 $grid-unit-10;
+	}
+	.components-button .components-menu-items__item-icon.has-icon-right {
+		margin-left: $grid-unit-30 - $grid-unit-10;
+	}
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -184,6 +184,7 @@
 
 .block-editor-global-styles-background-panel__dropdown-content-wrapper {
 	min-width: 260px;
+	overflow-x: hidden;
 	.components-base-control__help,
 	.components-toggle-control {
 		margin-bottom: 0;

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -154,9 +154,12 @@
 	text-align-last: center;
 }
 
-.block-editor-global-styles-background-panel__inspector-image-indicator-wrapper {
-	width: 20px;
-	height: 20px;
+.block-editor-global-styles-background-panel__inspector-preview-inner {
+	.block-editor-global-styles-background-panel__inspector-image-indicator-wrapper {
+		width: 20px;
+		height: 20px;
+		min-width: auto;
+	}
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator {
@@ -190,7 +193,7 @@
 		margin-bottom: 0;
 	}
 	.components-focal-point-picker__media--image {
-		max-height: 100px;
+		max-height: clamp(120px, 9vh, 280px);
 	}
 }
 

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -147,10 +147,12 @@ export function BackgroundImagePanel( {
 		return null;
 	}
 
+	/*
 	const defaultControls = getBlockSupport( name, [
 		BACKGROUND_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );
+*/
 
 	const onChange = ( newStyle ) => {
 		setAttributes( {
@@ -172,7 +174,9 @@ export function BackgroundImagePanel( {
 		<StylesBackgroundPanel
 			as={ BackgroundInspectorControl }
 			panelId={ clientId }
+			/*
 			defaultControls={ defaultControls }
+			*/
 			defaultValues={ BACKGROUND_DEFAULT_VALUES }
 			settings={ updatedSettings }
 			onChange={ onChange }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -147,13 +147,6 @@ export function BackgroundImagePanel( {
 		return null;
 	}
 
-	/*
-	const defaultControls = getBlockSupport( name, [
-		BACKGROUND_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
-*/
-
 	const onChange = ( newStyle ) => {
 		setAttributes( {
 			style: cleanEmptyObject( newStyle ),

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -174,9 +174,6 @@ export function BackgroundImagePanel( {
 		<StylesBackgroundPanel
 			as={ BackgroundInspectorControl }
 			panelId={ clientId }
-			/*
-			defaultControls={ defaultControls }
-			*/
 			defaultValues={ BACKGROUND_DEFAULT_VALUES }
 			settings={ updatedSettings }
 			onChange={ onChange }

--- a/packages/edit-site/src/components/global-styles/background-panel.js
+++ b/packages/edit-site/src/components/global-styles/background-panel.js
@@ -45,13 +45,6 @@ export default function BackgroundPanel() {
 	const _links = useGlobalStyleLinks();
 	const [ settings ] = useGlobalSetting( '' );
 
-	const defaultControls = {
-		backgroundImage: true,
-		backgroundSize:
-			hasBackgroundImageValue( style ) ||
-			hasBackgroundImageValue( inheritedStyle ),
-	};
-
 	return (
 		<StylesBackgroundPanel
 			inheritedValue={ inheritedStyle }
@@ -59,7 +52,6 @@ export default function BackgroundPanel() {
 			onChange={ setStyle }
 			settings={ settings }
 			defaultValues={ BACKGROUND_DEFAULT_VALUES }
-			defaultControls={ defaultControls }
 			themeFileURIs={ _links?.[ 'wp:theme-file' ] }
 		/>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR:

1. moves the background controls into a flyout panel
2. consolidates properties in the tool panel beneath the "background image" property, which means that resetting an image will reset all associated properties

See: 
- https://github.com/WordPress/gutenberg/pull/57005#issuecomment-1866076523
- https://github.com/WordPress/gutenberg/pull/60100#issuecomment-2178866354

Doing this with a view to consolidate colors and fill. See: https://github.com/WordPress/gutenberg/pull/60100#issuecomment-2160054475

Also take into account:

- https://github.com/WordPress/gutenberg/pull/59454#issuecomment-2020150910
- https://github.com/WordPress/gutenberg/pull/59454#issuecomment-2021680599



### TODO

- [x] Refactor main components in packages/block-editor/src/components/global-styles/background-panel.js
- [x] Condense and consolidate controls in the popover
- [x] Mobile view - ensure it works as expected. 
- [x] Test keyboard interaction
- [ ] ~Wire in tools panel reset for individual properties? E.g., position and repeat?~

## Why?

To win back space in the sidebar controls.

## How?

Moving background image controls into a flyout popover. This includes, where an image exists, the media select control.

To get the Tools Panel controls to work, I've created an invisible `ToolsPanelItem` components for each control set - this registers reset callbacks and so on in the Tools Panel.

## Testing Instructions

The flyout appears in the Global styles (Layout > Background Image) and at the block level for Group, Quote, Post Content blocks. For both:

1. Check that you add/upload/reset background images from the sidebar panel.
3. When a background image is selected, the sidebar control activates the flyout.
4. The controls the flyout should update the background image properties as expected
5. Ensure the Tools Panel controls works, that is, everything should open, close and reset.
6. In mobile view (< 782px) check that the flyout appears in the viewport width. 
7. Resetting the image should also reset size, position, and repeat.

### Testing Instructions for Keyboard

Check:

1. You can tab through the sidebar controls, and add a background image
2. . Where a background image exists, check you can tab to the background image control and hit Enter to open and focus the new flyout.
3. . Tab through the flyout and change the background image properties


## Screenshots or screencast <!-- if applicable -->

| Global styles  | Blocks |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-06-27 at 11 47 29 AM" src="https://github.com/WordPress/gutenberg/assets/6458278/ab08002d-e7a4-419e-afb4-3f8cc59481af">  | <img width="300" alt="Screenshot 2024-06-27 at 11 48 01 AM" src="https://github.com/WordPress/gutenberg/assets/6458278/b115bb43-d7a3-48af-9d30-e5f8c61c9ea8"> |

Resetting background properties:


https://github.com/WordPress/gutenberg/assets/6458278/13137e1a-893e-44a4-bc1d-af7d9a9742bf



## Related

- https://core.trac.wordpress.org/ticket/22058
