### PR TITLE
Style Engine: continue get_classnames loop after adding the default classname

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -444,6 +444,7 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 				foreach ( $style_definition['classnames'] as $classname => $property_key ) {
 					if ( true === $property_key ) {
 						$classnames[] = $classname;
+						continue;
 					}
 
 					$slug = static::get_slug_from_preset_value( $style_value, $property_key );


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Quick janitorial PR that continues the `get_classnames` loop after adding the default classname.



## Why?

Because we've added the classname by virtue of testing for `true`, and besides, `get_slug_from_preset_value` only works on a string, not a boolean.

## How?
`continue;`


## Testing

There are no material changes.

CI should pass.