### PR TITLE
Fix horizontal flex layout in classic themes.

### DIFF
--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -2,7 +2,7 @@
 // Specificity is kept at this level as many classic themes output
 // rules like figure { margin: 0; } which would break centering.
 // These rules should also not apply to direct children of flex layout blocks.
-:where(.editor-styles-wrapper) :where(:not(.is-layout-flex)) > .wp-block {
+:where(.editor-styles-wrapper) :where(:not(.is-layout-flex, .is-layout-grid)) > .wp-block {
 	margin-left: auto;
 	margin-right: auto;
 }

--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -1,7 +1,8 @@
 // Provide baseline auto margin for centering blocks.
 // Specificity is kept at this level as many classic themes output
 // rules like figure { margin: 0; } which would break centering.
-.editor-styles-wrapper .wp-block {
+// These rules should also not apply to direct children of flex layout blocks.
+:where(.editor-styles-wrapper) :where(:not(.is-layout-flex)) > .wp-block {
 	margin-left: auto;
 	margin-right: auto;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #60078.

The selector adding auto margins to all blocks in the classic stylesheet (only enqueued for classic themes) is overly specific and targets blocks too broadly. This PR reduces the selector specificity and changes it to not apply to direct children of flex blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With a classic theme active, add a Row block to a post;
2. Change the justification in the Layout sidebar panel;
3. Check that the new justification applies correctly in the editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1084" alt="Screenshot 2024-03-25 at 4 49 56 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/e17893dd-e4de-4658-868d-9580f5a110a2">


