### PR TITLE
Template Parts: Update the 'Replace' label to 'Design'

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -301,7 +301,7 @@ export default function TemplatePartEdit( {
 					( partsAsPatterns.length > 0 ||
 						blockPatterns.length > 0 ) && (
 						<InspectorControls>
-							<PanelBody title={ __( 'Replace' ) }>
+							<PanelBody title={ __( 'Design' ) }>
 								<TemplatesList
 									availableTemplates={ partsAsPatterns }
 									onSelect={ ( pattern ) => {


### PR DESCRIPTION
## What?
Updates the "Replace" label to "Design". Suggested in https://github.com/WordPress/gutenberg/pull/59883

## Why?
The designs in https://github.com/WordPress/gutenberg/issues/59689 suggest a "Design" panel for this purpose, which would contain sections where you can change the design/layout, style variation, etc. We might begin to install that here:

## How?
Text change

## Testing Instructions
1. Open the Site Editor
2. Select a template part block
3. Open the block inspector
4. Check that the label for the panel is "Design"

## Screenshots or screencast <!-- if applicable -->
<img width="469" alt="Screenshot 2024-03-25 at 09 36 25" src="https://github.com/WordPress/gutenberg/assets/275961/7a82412b-bd49-4c49-bf3b-7671db116771">
