### PR TITLE
date-fns: bump to v3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25368,21 +25368,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/date-fns": {
-			"version": "2.30.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-			"dependencies": {
-				"@babel/runtime": "^7.21.0"
-			},
-			"engines": {
-				"node": ">=0.11"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/date-fns"
-			}
-		},
 		"node_modules/dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -51931,19 +51916,6 @@
 				"react": ">=16.8"
 			}
 		},
-		"node_modules/use-lilius": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.1.tgz",
-			"integrity": "sha512-Dque7ax/91znesQWz2wM95O5iTHWzAsKQa2e7qvyPhXev/UAfgQIiXSqiB96tfiwQ+8+371FDK7oftuzw0Awhg==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"date-fns": "^2.28.0"
-			},
-			"peerDependencies": {
-				"react": "*",
-				"react-dom": "*"
-			}
-		},
 		"node_modules/use-memo-one": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
@@ -55152,7 +55124,7 @@
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
 				"remove-accents": "^0.5.0",
-				"use-lilius": "^2.0.1",
+				"use-lilius": "^2.0.4",
 				"uuid": "^9.0.1",
 				"valtio": "1.7.0"
 			},
@@ -55205,6 +55177,18 @@
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
 			"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+		},
+		"packages/components/node_modules/use-lilius": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.4.tgz",
+			"integrity": "sha512-5y4yKCDivylrUOB5V19BKLWFVyjInC/nkOHjiy4M5qjZzRR0HJQtNKVOZ+o5SMW+mOj1wIg65qXZ0uJF40Iv4w==",
+			"dependencies": {
+				"date-fns": "^3.0.0"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
 		},
 		"packages/components/node_modules/uuid": {
 			"version": "8.3.2",
@@ -71121,7 +71105,7 @@
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
 				"remove-accents": "^0.5.0",
-				"use-lilius": "^2.0.1",
+				"use-lilius": "^2.0.4",
 				"uuid": "^9.0.1",
 				"valtio": "1.7.0"
 			},
@@ -71156,6 +71140,14 @@
 					"version": "6.2.1",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
 					"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+				},
+				"use-lilius": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.4.tgz",
+					"integrity": "sha512-5y4yKCDivylrUOB5V19BKLWFVyjInC/nkOHjiy4M5qjZzRR0HJQtNKVOZ+o5SMW+mOj1wIg65qXZ0uJF40Iv4w==",
+					"requires": {
+						"date-fns": "^3.0.0"
+					}
 				},
 				"uuid": {
 					"version": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -77121,14 +77113,6 @@
 						"webidl-conversions": "^7.0.0"
 					}
 				}
-			}
-		},
-		"date-fns": {
-			"version": "2.30.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-			"requires": {
-				"@babel/runtime": "^7.21.0"
 			}
 		},
 		"dateformat": {
@@ -97364,14 +97348,6 @@
 			"version": "0.1.9",
 			"resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.9.tgz",
 			"integrity": "sha512-CL/29uS74AwreI/f2oz2hLTW7ZqVeV5+gxFeGudzQrgkCytrHw33G4KbnQOrRlAEzzAFXi7dDLMC9zhWcVpzmw=="
-		},
-		"use-lilius": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.1.tgz",
-			"integrity": "sha512-Dque7ax/91znesQWz2wM95O5iTHWzAsKQa2e7qvyPhXev/UAfgQIiXSqiB96tfiwQ+8+371FDK7oftuzw0Awhg==",
-			"requires": {
-				"date-fns": "^2.28.0"
-			}
 		},
 		"use-memo-one": {
 			"version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25368,6 +25368,15 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"node_modules/dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -51916,6 +51925,18 @@
 				"react": ">=16.8"
 			}
 		},
+		"node_modules/use-lilius": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.5.tgz",
+			"integrity": "sha512-IbPjJe4T6B0zQV6ahftVtHvCAxi6RAuDpEcO8TmnHh4nBtx7JbGdpbgXWOUj/9YjrzEbdT/lW7JWcBVbX3MbrA==",
+			"dependencies": {
+				"date-fns": "^3.6.0"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
 		"node_modules/use-memo-one": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
@@ -55124,7 +55145,7 @@
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
 				"remove-accents": "^0.5.0",
-				"use-lilius": "^2.0.4",
+				"use-lilius": "^2.0.5",
 				"uuid": "^9.0.1",
 				"valtio": "1.7.0"
 			},
@@ -55153,15 +55174,6 @@
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
 		},
-		"packages/components/node_modules/date-fns": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"packages/components/node_modules/framer-motion": {
 			"version": "10.13.0",
 			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.13.0.tgz",
@@ -55177,18 +55189,6 @@
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
 			"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
-		},
-		"packages/components/node_modules/use-lilius": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.4.tgz",
-			"integrity": "sha512-5y4yKCDivylrUOB5V19BKLWFVyjInC/nkOHjiy4M5qjZzRR0HJQtNKVOZ+o5SMW+mOj1wIg65qXZ0uJF40Iv4w==",
-			"dependencies": {
-				"date-fns": "^3.0.0"
-			},
-			"peerDependencies": {
-				"react": "*",
-				"react-dom": "*"
-			}
 		},
 		"packages/components/node_modules/uuid": {
 			"version": "8.3.2",
@@ -55854,15 +55854,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/editor/node_modules/date-fns": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"packages/element": {
@@ -71105,7 +71096,7 @@
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
 				"remove-accents": "^0.5.0",
-				"use-lilius": "^2.0.4",
+				"use-lilius": "^2.0.5",
 				"uuid": "^9.0.1",
 				"valtio": "1.7.0"
 			},
@@ -71122,11 +71113,6 @@
 					"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 					"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
 				},
-				"date-fns": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-					"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
-				},
 				"framer-motion": {
 					"version": "10.13.0",
 					"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.13.0.tgz",
@@ -71140,14 +71126,6 @@
 					"version": "6.2.1",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
 					"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
-				},
-				"use-lilius": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.4.tgz",
-					"integrity": "sha512-5y4yKCDivylrUOB5V19BKLWFVyjInC/nkOHjiy4M5qjZzRR0HJQtNKVOZ+o5SMW+mOj1wIg65qXZ0uJF40Iv4w==",
-					"requires": {
-						"date-fns": "^3.0.0"
-					}
 				},
 				"uuid": {
 					"version": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -71624,13 +71602,6 @@
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
 				"remove-accents": "^0.5.0"
-			},
-			"dependencies": {
-				"date-fns": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-					"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
-				}
 			}
 		},
 		"@wordpress/element": {
@@ -77114,6 +77085,11 @@
 					}
 				}
 			}
+		},
+		"date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
 		},
 		"dateformat": {
 			"version": "3.0.3",
@@ -97348,6 +97324,14 @@
 			"version": "0.1.9",
 			"resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.9.tgz",
 			"integrity": "sha512-CL/29uS74AwreI/f2oz2hLTW7ZqVeV5+gxFeGudzQrgkCytrHw33G4KbnQOrRlAEzzAFXi7dDLMC9zhWcVpzmw=="
+		},
+		"use-lilius": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.5.tgz",
+			"integrity": "sha512-IbPjJe4T6B0zQV6ahftVtHvCAxi6RAuDpEcO8TmnHh4nBtx7JbGdpbgXWOUj/9YjrzEbdT/lW7JWcBVbX3MbrA==",
+			"requires": {
+				"date-fns": "^3.6.0"
+			}
 		},
 		"use-memo-one": {
 			"version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55139,7 +55139,7 @@
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
-				"date-fns": "^2.28.0",
+				"date-fns": "^3.6.0",
 				"deepmerge": "^4.3.0",
 				"downshift": "^6.0.15",
 				"fast-deep-equal": "^3.1.3",
@@ -55180,6 +55180,15 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
+		},
+		"packages/components/node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
 		},
 		"packages/components/node_modules/framer-motion": {
 			"version": "10.13.0",
@@ -55849,7 +55858,7 @@
 				"@wordpress/warning": "file:../warning",
 				"@wordpress/wordcount": "file:../wordcount",
 				"classnames": "^2.3.1",
-				"date-fns": "^2.28.0",
+				"date-fns": "^3.6.0",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
@@ -55861,6 +55870,15 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/editor/node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"packages/element": {
@@ -71090,7 +71108,7 @@
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
-				"date-fns": "^2.28.0",
+				"date-fns": "^3.6.0",
 				"deepmerge": "^4.3.0",
 				"downshift": "^6.0.15",
 				"fast-deep-equal": "^3.1.3",
@@ -71119,6 +71137,11 @@
 					"version": "0.1.3",
 					"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 					"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
+				},
+				"date-fns": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+					"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
 				},
 				"framer-motion": {
 					"version": "10.13.0",
@@ -71604,11 +71627,18 @@
 				"@wordpress/warning": "file:../warning",
 				"@wordpress/wordcount": "file:../wordcount",
 				"classnames": "^2.3.1",
-				"date-fns": "^2.28.0",
+				"date-fns": "^3.6.0",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.2",
 				"remove-accents": "^0.5.0"
+			},
+			"dependencies": {
+				"date-fns": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+					"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
+				}
 			}
 		},
 		"@wordpress/element": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,8 @@
 -   `Popover`, `ColorPicker`: Obviate pointer event trap #59449 ([#59449](https://github.com/WordPress/gutenberg/pull/59449)).
 -   `Popover`, `ToggleGroupControl`: Use `useReducedMotion()` ([#60168](https://github.com/WordPress/gutenberg/pull/60168)).
 -   `NavigatorProvider`: Simplify the router state logic ([#60190](https://github.com/WordPress/gutenberg/pull/60190)).
+-   Update `date-fns` to version `3.6.0` ([#60163](https://github.com/WordPress/gutenberg/pull/60163)).
+-   Update `use-lilius` to version `2.0.5` ([#60163](https://github.com/WordPress/gutenberg/pull/60163)).
 
 ### Experimental
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,7 +75,7 @@
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.3.1",
 		"remove-accents": "^0.5.0",
-		"use-lilius": "^2.0.4",
+		"use-lilius": "^2.0.5",
 		"uuid": "^9.0.1",
 		"valtio": "1.7.0"
 	},

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,7 +75,7 @@
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.3.1",
 		"remove-accents": "^0.5.0",
-		"use-lilius": "^2.0.1",
+		"use-lilius": "^2.0.4",
 		"uuid": "^9.0.1",
 		"valtio": "1.7.0"
 	},

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -62,7 +62,7 @@
 		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
-		"date-fns": "^2.28.0",
+		"date-fns": "^3.6.0",
 		"deepmerge": "^4.3.0",
 		"downshift": "^6.0.15",
 		"fast-deep-equal": "^3.1.3",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -64,7 +64,7 @@
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.3.1",
-		"date-fns": "^2.28.0",
+		"date-fns": "^3.6.0",
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^4.0.2",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR bumps `date-fns` to the latest `v3.6.0`. Also bumps `use-lilius` to the latest version (`v2.0.5`) which also updated `date-fns` to v3.6. 

## Why?
There are [a bunch of fixes](https://date-fns.org/v3.6.0/docs/Change-Log) in it, plus some potential bundle size improvements.

## How?
Just bumping some dependency versions of `date-fns`.

~We're suggesting a bump to the latest version at https://github.com/its-danny/use-lilius/pull/499. We might need to wait until that lands and a new version is released in order to ensure we don't use multiple `date-fns` versions under the hood.~ `use-lilius@v2.0.5` was released with `date-fns@3.6.0` as a dependency yesterday, so we're using that as well to match the underlying `date-fns` dependency version.

## Testing Instructions
* Test scheduling of posts in the post editor:
  * Calendar with scheduled posts still works with dots where there are scheduled posts.
  * Navigating between months should still work
  * Selecting a different time and date should still work
* Verify the `DateTimePicker`, `DatePicker` and `TimePicker` components in Storybook still work well.
* All checks should still be green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None