### PR TITLE
Text: Add text-wrap: pretty

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 -   `ExternalLink`: Use unicode arrow instead of svg icon ([#60255](https://github.com/WordPress/gutenberg/pull/60255)).
 -   `ProgressBar`: Move the indicator width styles from emotion to a CSS variable ([#60388](https://github.com/WordPress/gutenberg/pull/60388)).
+-   `Text`: Add `text-wrap: pretty;` to improve wrapping. ([#60164](https://github.com/WordPress/gutenberg/pull/60164)).
 
 ## 27.3.0 (2024-04-03)
 
 ### Bug Fix
 
--   `Text`: Add `text-wrap: pretty;` to improve wrapping. ([#60164](https://github.com/WordPress/gutenberg/pull/60164)).
 -   `Dropdown`: Fix bug with separator styling. ([#60336](https://github.com/WordPress/gutenberg/pull/60336)).
 -   `InputControl`: Ignore IME events when `isPressEnterToChange` is enabled ([#60090](https://github.com/WordPress/gutenberg/pull/60090)).
 -   `TextControl`: Apply zero margin to input element ([#60282](https://github.com/WordPress/gutenberg/pull/60282)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fix
 
+-   `Text`: Add `text-wrap: pretty;` to improve wrapping. ([#60164](https://github.com/WordPress/gutenberg/pull/60164)).
 -   `Dropdown`: Fix bug with separator styling. ([#60336](https://github.com/WordPress/gutenberg/pull/60336)).
 -   `InputControl`: Ignore IME events when `isPressEnterToChange` is enabled ([#60090](https://github.com/WordPress/gutenberg/pull/60090)).
 -   `TextControl`: Apply zero margin to input element ([#60282](https://github.com/WordPress/gutenberg/pull/60282)).

--- a/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
+++ b/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
@@ -61,6 +61,7 @@ exports[`DimensionControl rendering renders with custom sizes 1`] = `
   color: #1e1e1e;
   line-height: 1.4;
   margin: 0;
+  text-wrap: pretty;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }
@@ -332,6 +333,7 @@ exports[`DimensionControl rendering renders with defaults 1`] = `
   color: #1e1e1e;
   line-height: 1.4;
   margin: 0;
+  text-wrap: pretty;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }
@@ -613,6 +615,7 @@ exports[`DimensionControl rendering renders with icon and custom icon label 1`] 
   color: #1e1e1e;
   line-height: 1.4;
   margin: 0;
+  text-wrap: pretty;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }
@@ -906,6 +909,7 @@ exports[`DimensionControl rendering renders with icon and default icon label 1`]
   color: #1e1e1e;
   line-height: 1.4;
   margin: 0;
+  text-wrap: pretty;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }

--- a/packages/components/src/heading/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/heading/test/__snapshots__/index.tsx.snap
@@ -5,6 +5,7 @@ exports[`props should render correctly 1`] = `
   color: #1e1e1e;
   line-height: 1.4;
   margin: 0;
+  text-wrap: pretty;
   color: #1e1e1e;
   font-size: calc(1.95 * 13px);
   font-weight: 600;
@@ -25,6 +26,7 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
+@@ -1,10 +1,10 @@
   Array [
     Object {
       "color": "#1e1e1e",
@@ -34,8 +36,8 @@ Snapshot Diff:
       "font-weight": "600",
       "line-height": "1.4",
       "margin": "0",
+      "text-wrap": "pretty",
     },
-  ]
 `;
 
 exports[`props should render level as a string 1`] = `
@@ -43,6 +45,7 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
+@@ -1,10 +1,10 @@
   Array [
     Object {
       "color": "#1e1e1e",
@@ -52,6 +55,6 @@ Snapshot Diff:
       "font-weight": "600",
       "line-height": "1.4",
       "margin": "0",
+      "text-wrap": "pretty",
     },
-  ]
 `;

--- a/packages/components/src/text/styles.ts
+++ b/packages/components/src/text/styles.ts
@@ -12,6 +12,7 @@ export const Text = css`
 	color: ${ COLORS.gray[ 900 ] };
 	line-height: ${ CONFIG.fontLineHeightBase };
 	margin: 0;
+	text-wrap: pretty;
 `;
 
 export const block = css`

--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -5,13 +5,14 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -3,7 +3,8 @@
+@@ -3,8 +3,9 @@
       "color": "#1e1e1e",
       "font-size": "calc((13 / 13) * 13px)",
       "font-weight": "normal",
       "line-height": "1.4",
       "margin": "0",
 +     "text-align": "center",
+      "text-wrap": "pretty",
     },
   ]
 `;
@@ -21,6 +22,7 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
   color: #1e1e1e;
   line-height: 1.4;
   margin: 0;
+  text-wrap: pretty;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }
@@ -52,6 +54,7 @@ exports[`Text snapshot tests should render correctly 1`] = `
   color: #1e1e1e;
   line-height: 1.4;
   margin: 0;
+  text-wrap: pretty;
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }


### PR DESCRIPTION
## What?

Alternative to, and followup, to #58728.

Adds `text-wrap: pretty;` to the `<Text>` component, to avoid typographic widows.

![code sample showing the value](https://github.com/WordPress/gutenberg/assets/1204802/9b78b706-c0f8-41d2-95b1-bf853316bc44)

## Testing Instructions

Test using the inspector to edit the block card and try to add words to make a typographic widow happen. It shouldn't be possible:

![block card](https://github.com/WordPress/gutenberg/assets/1204802/da4a5a5a-d2ae-4b17-9c1c-e8434c2336ef)