### PR TITLE
Data views: Make trash a quick action again

### DIFF
--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -6,7 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -49,7 +49,7 @@ export const trashPostAction = {
 						  )
 						: sprintf(
 								// translators: %d: The number of pages (2 or more).
-								__(
+								_n(
 									'Are you sure you want to delete %d pages?'
 								),
 								posts.length

--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -51,7 +51,7 @@ export const trashPostAction = {
 								// translators: %d: The number of pages (2 or more).
 								_n(
 									'Are you sure you want to delete %d page?',
-									'Are you sure you want to delete %d pages?'
+									'Are you sure you want to delete %d pages?',
 									posts.length
 								),
 								posts.length

--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { external, edit, backup } from '@wordpress/icons';
+import { external, trash, edit, backup } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -27,6 +27,8 @@ const { useHistory } = unlock( routerPrivateApis );
 export const trashPostAction = {
 	id: 'move-to-trash',
 	label: __( 'Move to Trash' ),
+	isPrimary: true,
+	icon: trash,
 	isEligible( { status } ) {
 		return status !== 'trash';
 	},

--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -50,7 +50,9 @@ export const trashPostAction = {
 						: sprintf(
 								// translators: %d: The number of pages (2 or more).
 								_n(
+									'Are you sure you want to delete %d page?',
 									'Are you sure you want to delete %d pages?'
+									posts.length
 								),
 								posts.length
 						  ) }


### PR DESCRIPTION
## What?

Followup to #59551. I misunderstood some of the changes in the PR, as far as what type of destructive actions were moved to the ellipsis menu. This moves the "trash" button back as a quick action. 

![quick actions](https://github.com/WordPress/gutenberg/assets/1204802/fbdb3b73-a9d1-437f-bec9-6bcca6c94dce)

## Why?

Deleting pages are only partially destructive actions, insofar as they move a page or post to a trashcan vs. erasing them entirely. This is different from, say, reverting user customizations to a template, which is much harder to restore through revisions. This is the main nuance between _delete_ and _trash_ actions.

To that end, having quick actions for moving to trash also maintains parity with existing list views:

![pages list hover action](https://github.com/WordPress/gutenberg/assets/1204802/7d1df285-814c-466c-b288-406ab2c9266d)

_Anecdotally, I use the trash button there all the time._

I would even go as far as saying that there _shouldn't_ be a modal confirm action when deleting a page. Perhaps we can keep it if the page is published, but if it's just a draft, it should just move it to trash, which is easily visible in the left navigation sidebar:

![trash in navigation](https://github.com/WordPress/gutenberg/assets/1204802/575d8a92-372b-4779-9673-8ef0ab134d6c)

Removing this modal would also maintain parity with existing list views. But this would be something to consider exploring separately.

## Testing Instructions

* Open the site editor, go to Pages
* Change the view type to "Table"
* Hover the row of a page, and press the quick action trash button.