### PR TITLE
Fix root ID calculation when check if block can be transformed

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -182,7 +182,9 @@ export const BlockSwitcher = ( { clientIds, disabled } ) => {
 			if ( ! _blocks.length || _blocks.some( ( block ) => ! block ) ) {
 				return { invalidBlocks: true };
 			}
-			const rootClientId = getBlockRootClientId( clientIds );
+			const rootClientId = getBlockRootClientId(
+				Array.isArray( clientIds ) ? clientIds[ 0 ] : clientIds
+			);
 			const [ { name: firstBlockName } ] = _blocks;
 			const _isSingleBlockSelected = _blocks.length === 1;
 			const blockType = getBlockType( firstBlockName );


### PR DESCRIPTION
Fixes #60026. Fixing a regression introduced in #57892.

A `clientIds` array is passed to `getBlockRootClientId`, but the selector expects only one `clientId`. It leads to returning `null`, which means the root of the document.

Then a `canRemoveBlocks` permission check returns a wrong result, because it misses an intermediate "Group" block in the hierarchy that resets `templateLock` from the root `'all'` to `false`.

One thing I'm not happy about is that we're checking the root ID only of the first block in a multi-selection. That could lead to a wrong behavior where blocks are transformed even if the second and later blocks in the selection are not transformable/removable.