### PR TITLE
Popover / ToggleGroupControl: Use `useReducedMotion()` from `@wordpress/compose`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Internal
 
 -   `Popover`, `ColorPicker`: Obviate pointer event trap #59449 ([#59449](https://github.com/WordPress/gutenberg/pull/59449)).
+-   `Popover`, `ToggleGroupControl`: Use `useReducedMotion()` ([#60168](https://github.com/WordPress/gutenberg/pull/60168)).
 
 ## 27.2.0 (2024-03-21)
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -16,7 +16,7 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import type { HTMLMotionProps, MotionProps } from 'framer-motion';
 // eslint-disable-next-line no-restricted-imports
-import { motion, useReducedMotion } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 /**
  * WordPress dependencies
@@ -33,6 +33,7 @@ import {
 	createPortal,
 } from '@wordpress/element';
 import {
+	useReducedMotion,
 	useViewportMatch,
 	useMergeRefs,
 	__experimentalUseDialog as useDialog,

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -5,12 +5,12 @@ import type { ForwardedRef } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import * as Ariakit from '@ariakit/react';
 // eslint-disable-next-line no-restricted-imports
-import { motion, useReducedMotion } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 /**
  * WordPress dependencies
  */
-import { useInstanceId } from '@wordpress/compose';
+import { useReducedMotion, useInstanceId } from '@wordpress/compose';
 import { useMemo } from '@wordpress/element';
 
 /**


### PR DESCRIPTION
## What?
Use our internal `useReducedMotion()` utility instead of the `framer-motion` one. 

## Why?
Our version is more broadly utilized, and it does the same thing, so there's no good reason to use two different versions

## How?
We're using the version from `@wordpress/compose` which is already a dependency.

## Testing Instructions
* Use your browser dev tools to [emulate `prefers-reduced-motion`](https://developer.chrome.com/docs/devtools/rendering/emulate-css).
* Verify Popover appear/disappear animation still works well and is properly disabled when `prefers-reduced-motion` is enabled/disabled. 
  * You can test it by clicking the ellipsis in the block toolbar to reveal the block settings menu.
  * You can also test it in Storybook.
* Verify `ToggleGroupControl` selected toggle backdrop animation still works well and is properly disabled when `prefers-reduced-motion` is enabled/disabled.
  * You can test it with the "Size" field in the block sidebar for a Paragraph block.
  * You can also test it in Storybook.
* All tests should pass and all checks should be green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None