### PR TITLE
Media dialog push content in zoomed out mode

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -776,4 +776,8 @@ $block-inserter-tabs-height: 44px;
 	.block-editor-inserter__patterns-category-dialog {
 		position: static;
 	}
+
+	.block-editor-inserter__media-dialog {
+		position: static;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #60082

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Consistent UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replicating the CSS used to achieve the same for the pattern category listing.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

0. Enable zoom out mode
1. Edit a template
2. Open the inserter
3. Toggle the media tab
4. Click on a category
5. _Notice the category dialog shifts the layout, does not overlap it_

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/107534/1645f966-a6de-41d5-8418-dfd4e96aa3a6

