### PR TITLE
Restore Style book close button tooltip.

### DIFF
--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -134,7 +134,6 @@ function EditorCanvasContainer( {
 							icon={ closeSmall }
 							label={ closeButtonLabel || __( 'Close' ) }
 							onClick={ onCloseContainer }
-							showTooltip={ false }
 						/>
 					) }
 					{ childrenWithProps }

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -237,9 +237,7 @@ function StyleBook( {
 		<EditorCanvasContainer
 			onClose={ onClose }
 			enableResizing={ enableResizing }
-			closeButtonLabel={
-				showCloseButton ? __( 'Close Style Book' ) : null
-			}
+			closeButtonLabel={ showCloseButton ? __( 'Close' ) : null }
 		>
 			<div
 				className={ classnames( 'edit-site-style-book', {

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -132,9 +132,7 @@ test.describe( 'Style Book', () => {
 		} );
 
 		// Close Style Book via click event.
-		await styleBookRegion
-			.getByRole( 'button', { name: 'Close Style Book' } )
-			.click();
+		await styleBookRegion.getByRole( 'button', { name: 'Close' } ).click();
 
 		await expect(
 			styleBookRegion,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60176

## What?
<!-- In a few words, what is the PR actually doing? -->
The Style Book 'X close' button doesn't show a tooltip. It is explicitly disabled via `showTooltip={ false }`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Icon buttons must always visually expose their accessible name.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removes `showTooltip={ false }`.
- Shortens and simplifies the aria-label (which is used for the tooltip text) from `Close Style Book` to `Close`. Sufficient context is already provided by the wrapping ARIA region (a labeled `<section>` element) that is labeled 'Style Book'.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site Editor and switch to edit mode.
- Go to Styles > Style Book.
- Observe the editor canvas switches to the styles book mode.
- Hover or focus the X icon button of the Styles Book canvas.
- Observe the button does show a tooltip with text `Close`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Screenshots or screencast <!-- if applicable -->
