### PR TITLE
Font Library: install fonts in sequence to work around race condition

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -234,10 +234,21 @@ export function makeFontFacesFormData( font ) {
 }
 
 export async function batchInstallFontFaces( fontFamilyId, fontFacesData ) {
-	const promises = fontFacesData.map( ( faceData ) =>
-		fetchInstallFontFace( fontFamilyId, faceData )
-	);
-	const responses = await Promise.allSettled( promises );
+	const responses = [];
+
+	// Uses the same response format as Promise.allSettled, but executes requests in sequence to work around a race condition
+	// that can cause an error when the fonts directory doesn't exist yet.
+	for ( const faceData of fontFacesData ) {
+		try {
+			const response = await fetchInstallFontFace(
+				fontFamilyId,
+				faceData
+			);
+			responses.push( { status: 'fulfilled', value: response } );
+		} catch ( error ) {
+			responses.push( { status: 'rejected', reason: error } );
+		}
+	}
 
 	const results = {
 		errors: [],

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -236,8 +236,10 @@ export function makeFontFacesFormData( font ) {
 export async function batchInstallFontFaces( fontFamilyId, fontFacesData ) {
 	const responses = [];
 
-	// Uses the same response format as Promise.allSettled, but executes requests in sequence to work around a race condition
-	// that can cause an error when the fonts directory doesn't exist yet.
+	/*
+	 * Uses the same response format as Promise.allSettled, but executes requests in sequence to work 
+	 * around a race condition that can cause an error when the fonts directory doesn't exist yet.
+	 */
 	for ( const faceData of fontFacesData ) {
 		try {
 			const response = await fetchInstallFontFace(

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -237,7 +237,7 @@ export async function batchInstallFontFaces( fontFamilyId, fontFacesData ) {
 	const responses = [];
 
 	/*
-	 * Uses the same response format as Promise.allSettled, but executes requests in sequence to work 
+	 * Uses the same response format as Promise.allSettled, but executes requests in sequence to work
 	 * around a race condition that can cause an error when the fonts directory doesn't exist yet.
 	 */
 	for ( const faceData of fontFacesData ) {


### PR DESCRIPTION
## What?

Install new font faces sequentially, rather than in parallel, to prevent a race condition where font installation errors because two requests try to create the font directory at the same time.

Closes https://github.com/WordPress/gutenberg/issues/59023

## Why?

Prevents font installation from partially erroring when the fonts directory doesn't exist yet (such as on new installs of WordPress or those updating to WP 6.5).

## How?

Run the font-face creation requests in sequence using a for loop rather than `Promise.allSettled`.

## Testing Instructions

- Delete the fonts directory, if it already exists.
- Install multiple fonts
- See that they install successfully

Note that the race condition error can be difficult to replicate. There are specific instructions for that here: https://github.com/WordPress/gutenberg/issues/59023#issuecomment-2018324697
