### PR TITLE
Fix: Invalid documentation link to load JavaScript.

### DIFF
--- a/docs/how-to-guides/notices/README.md
+++ b/docs/how-to-guides/notices/README.md
@@ -71,7 +71,7 @@ To better understand the specific code example above:
 -   `wp.data.dispatch('core/notices')` accesses functionality registered to the block editor data store by the Notices package.
 -   `createNotice()` is a function offered by the Notices package to register a new notice. The block editor reads from the notice data store in order to know which notices to display.
 
-Check out the [_Loading JavaScript_](/docs/how-to-guides/javascript/loading-javascript.md) tutorial for a primer on how to load your custom JavaScript into the block editor.
+Check out the [_Enqueueing assets in the Editor_](/docs/how-to-guides/enqueueing-assets-in-the-editor.md) tutorial for a primer on how to load your custom JavaScript into the block editor.
 
 ## Learn more
 


### PR DESCRIPTION
The previous link /docs/how-to-guides/javascript/loading-javascript.md (https://github.com/WordPress/gutenberg/tree/trunk/docs/how-to-guides/javascript/loading-javascript.md) no longer exists. This PR updates the link to /docs/how-to-guides/enqueueing-assets-in-the-editor.md which is now the equivalent tutorial (https://github.com/WordPress/gutenberg/tree/trunk/docs/how-to-guides/enqueueing-assets-in-the-editor.md ).
