### PR TITLE
CustomSelectControlV2: Match v1 stories to test legacy component

### DIFF
--- a/packages/components/src/custom-select-control-v2/stories/legacy.story.tsx
+++ b/packages/components/src/custom-select-control-v2/stories/legacy.story.tsx
@@ -12,6 +12,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import CustomSelect from '../legacy-component';
+import * as V1Story from '../../custom-select-control/stories/index.story';
 
 const meta: Meta< typeof CustomSelect > = {
 	title: 'Components (Experimental)/CustomSelectControl v2/Legacy',
@@ -43,45 +44,23 @@ const meta: Meta< typeof CustomSelect > = {
 export default meta;
 
 const Template: StoryFn< typeof CustomSelect > = ( props ) => {
-	const [ fontSize, setFontSize ] = useState( props.options[ 0 ] );
+	const [ value, setValue ] = useState( props.options[ 0 ] );
 
 	const onChange: React.ComponentProps<
 		typeof CustomSelect
 	>[ 'onChange' ] = ( changeObject ) => {
-		setFontSize( changeObject.selectedItem );
+		setValue( changeObject.selectedItem );
 		props.onChange?.( changeObject );
 	};
 
-	return (
-		<CustomSelect { ...props } onChange={ onChange } value={ fontSize } />
-	);
+	return <CustomSelect { ...props } onChange={ onChange } value={ value } />;
 };
 
 export const Default = Template.bind( {} );
-Default.args = {
-	label: 'Label text',
-	options: [
-		{
-			key: 'small',
-			name: 'Small',
-			style: { fontSize: '50%' },
-			__experimentalHint: '50%',
-		},
-		{
-			key: 'normal',
-			name: 'Normal',
-			style: { fontSize: '100%' },
-			className: 'can-apply-custom-class-to-option',
-		},
-		{
-			key: 'large',
-			name: 'Large',
-			style: { fontSize: '200%' },
-		},
-		{
-			key: 'huge',
-			name: 'Huge',
-			style: { fontSize: '300%' },
-		},
-	],
-};
+Default.args = V1Story.Default.args;
+
+export const WithLongLabels = Template.bind( {} );
+WithLongLabels.args = V1Story.WithLongLabels.args;
+
+export const WithHints = Template.bind( {} );
+WithHints.args = V1Story.WithHints.args;

--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { StoryFn } from '@storybook/react';
+
+/**
  * Internal dependencies
  */
 import CustomSelectControl from '..';
@@ -18,7 +23,7 @@ export default {
 	},
 };
 
-export const Default = CustomSelectControl.bind( {} );
+export const Default: StoryFn = CustomSelectControl.bind( {} );
 Default.args = {
 	label: 'Label',
 	options: [
@@ -46,7 +51,7 @@ Default.args = {
 	],
 };
 
-export const WithLongLabels = CustomSelectControl.bind( {} );
+export const WithLongLabels: StoryFn = CustomSelectControl.bind( {} );
 WithLongLabels.args = {
 	...Default.args,
 	options: [
@@ -65,7 +70,7 @@ WithLongLabels.args = {
 	],
 };
 
-export const WithHints = CustomSelectControl.bind( {} );
+export const WithHints: StoryFn = CustomSelectControl.bind( {} );
 WithHints.args = {
 	...Default.args,
 	options: [


### PR DESCRIPTION
Part of #55023

## What?

Reuse the Storybook story props for CustomSelectControl (v1) in the stories for CustomSelectControlV2 legacy so we can more accurately test how styles and functionality match up.

## Why?

Although CustomSelectControlV2 legacy will soon completely replace CustomSelectControl (v1), we need this duplicated testing ground right now so we can brush things up and bring it up to parity.

## Testing Instructions

The stories for CustomSelectControlV2 Legacy should match the story settings for CustomSelectControl (v1). You may notice styling and functional differences at this point, but that's ok. We will start fixing them in separate PRs.
