### PR TITLE
CustomSelectControlV2: Fix hint behavior in legacy

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   `Popover`, `ColorPicker`: Obviate pointer event trap #59449 ([#59449](https://github.com/WordPress/gutenberg/pull/59449)).
 
+### Experimental
+
+-   `CustomSelectControlV2`: Fix hint behavior in legacy ([#60183](https://github.com/WordPress/gutenberg/pull/60183)).
+
 ## 27.2.0 (2024-03-21)
 
 -   `Dropdown` : Add styling support for `MenuGroup` ([#59723](https://github.com/WordPress/gutenberg/pull/59723)).

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -68,9 +68,7 @@ function CustomSelect( props: LegacyCustomSelectProps ) {
 				<CustomSelectItem
 					key={ key }
 					value={ name }
-					children={
-						__experimentalShowSelectedHint ? withHint : name
-					}
+					children={ __experimentalHint ? withHint : name }
 					{ ...rest }
 				/>
 			);

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -248,7 +248,7 @@ describe.each( [
 		);
 	} );
 
-	it( 'shows selected hint in list of options when added', async () => {
+	it( 'shows selected hint in list of options when added, regardless of __experimentalShowSelectedHint prop', async () => {
 		render(
 			<Component
 				{ ...legacyProps }
@@ -260,7 +260,6 @@ describe.each( [
 						__experimentalHint: 'Hint',
 					},
 				] }
-				__experimentalShowSelectedHint
 			/>
 		);
 

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -238,6 +238,30 @@ describe.each( [
 		).toHaveTextContent( 'Hint' );
 	} );
 
+	it( 'shows selected hint in list of options when added, regardless of __experimentalShowSelectedHint prop', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Component
+				{ ...props }
+				label="Custom select"
+				options={ [
+					{
+						key: 'one',
+						name: 'One',
+						__experimentalHint: 'Hint',
+					},
+				] }
+			/>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Custom select' } )
+		);
+
+		expect( screen.getByRole( 'option', { name: /hint/i } ) ).toBeVisible();
+	} );
+
 	describe( 'Keyboard behavior and accessibility', () => {
 		it( 'Captures the keypress event and does not let it propagate', async () => {
 			const user = userEvent.setup();


### PR DESCRIPTION
Part of #55023
Stacked on #60182

## What?

Fixes an incorrect back compat implementation in CustomSelectControlV2 Legacy where "hints" in the dropdown should always be shown if available, regardless of the `__experimentalShowSelectedHint` prop.

## Why?

The CustomSelectControlV2 Legacy implementation needs to match the v1 behavior as close as possible.

## How?

By adding a new unit test to v1, I established that hints in the dropdown options are always shown if provided, regardless of whether the `__experimentalShowSelectedHint` prop is enabled. (As the prop name accurately describes, the boolean is supposed to only control the visibility of the hint in the _selected_ option — the one shown in the dropdown trigger.)

I then fixed the unit test in v2 Legacy to reflect this correct spec.

Finally, I fixed the v2 Legacy implementation so the failing test passes.

## Testing Instructions

1. If you check out the first commit with the new tests, one of them fails.
2. In the second commit with the fix, the test passes.

This behavior can also be confirmed in the Storybook stories for CustomSelectControl V2 Legacy "With Hints" and CustomSelectControl "With Hints", by toggling the `__experimentalShowSelectedHint` prop control.

