### PR TITLE
Featured Image: Fix block support selectors after shadow support addition

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -642,7 +642,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 
 -	**Name:** core/post-featured-image
 -	**Category:** theme
--	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
+-	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
 -	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -61,7 +61,6 @@
 	"supports": {
 		"align": [ "left", "right", "center", "wide", "full" ],
 		"color": {
-			"__experimentalDuotone": "img, .wp-block-post-featured-image__placeholder, .components-placeholder__illustration, .components-placeholder::before",
 			"text": false,
 			"background": false
 		},
@@ -69,13 +68,15 @@
 			"color": true,
 			"radius": true,
 			"width": true,
-			"__experimentalSelector": "img, .block-editor-media-placeholder, .wp-block-post-featured-image__overlay",
 			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"color": true,
 				"radius": true,
 				"width": true
 			}
+		},
+		"filter": {
+			"duotone": true
 		},
 		"shadow": {
 			"__experimentalSkipSerialization": true
@@ -90,7 +91,11 @@
 		}
 	},
 	"selectors": {
-		"shadow": ".wp-block-post-featured-image img, .wp-block-post-featured-image .components-placeholder"
+		"border": ".wp-block-post-featured-image img, .wp-block-post-featured-image .block-editor-media-placeholder, .wp-block-post-featured-image .wp-block-post-featured-image__overlay",
+		"shadow": ".wp-block-post-featured-image img, .wp-block-post-featured-image .components-placeholder",
+		"filter": {
+			"duotone": ".wp-block-post-featured-image img, .wp-block-post-featured-image .wp-block-post-featured-image__placeholder, .wp-block-post-featured-image .components-placeholder__illustration, .wp-block-post-featured-image .components-placeholder::before"
+		}
 	},
 	"editorStyle": "wp-block-post-featured-image-editor",
 	"style": "wp-block-post-featured-image"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/59616

## What?

Fixes broken border radius and duotone block supports on the featured image block.

Note: Any odd behaviour with the location and display of the overlay was fixed in https://github.com/WordPress/gutenberg/pull/60187

## Why?

When shadow block support was added to the featured image block it used the Block Selectors API. When this is used theme.json and global styles expect all block supports selectors to be configured by the same approach i.e. the selectors API or the old `__experimentalSelectors` properties but not both.

## How?

Moves the selectors for duotone and borders support to the selectors API within the block.json file.

## Testing Instructions

1. Add a featured image block
2. Select the feature image block and add an image
4. Apply a border including border radius
5. Save and confirm the border displays correctly in the editor and frontend
6. Apply a duotone filter
7. Save and confirm the duotone is applied correctly on the frontend as well

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/512d32ec-b277-4328-b388-5cc67d07c942



