### PR TITLE
Featured Image: Fix overlay rendering in the editor

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -36,6 +36,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import DimensionControls from './dimension-controls';
+import OverlayControls from './overlay-controls';
 import Overlay from './overlay';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -181,7 +182,7 @@ export default function PostFeaturedImageEdit( {
 
 	const controls = blockEditingMode === 'default' && (
 		<>
-			<Overlay
+			<OverlayControls
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				clientId={ clientId }
@@ -262,6 +263,11 @@ export default function PostFeaturedImageEdit( {
 					) : (
 						placeholder()
 					) }
+					<Overlay
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						clientId={ clientId }
+					/>
 				</div>
 			</>
 		);
@@ -367,6 +373,11 @@ export default function PostFeaturedImageEdit( {
 				) : (
 					image
 				) }
+				<Overlay
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					clientId={ clientId }
+				/>
 			</figure>
 		</>
 	);

--- a/packages/block-library/src/post-featured-image/overlay-controls.js
+++ b/packages/block-library/src/post-featured-image/overlay-controls.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	RangeControl,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import {
+	InspectorControls,
+	withColors,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
+	__experimentalUseGradient,
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+} from '@wordpress/block-editor';
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+const Overlay = ( {
+	clientId,
+	attributes,
+	setAttributes,
+	overlayColor,
+	setOverlayColor,
+} ) => {
+	const { dimRatio } = attributes;
+	const { gradientValue, setGradient } = __experimentalUseGradient();
+	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+
+	if ( ! colorGradientSettings.hasColorsOrGradients ) {
+		return null;
+	}
+
+	return (
+		<InspectorControls group="color">
+			<ColorGradientSettingsDropdown
+				__experimentalIsRenderedInSidebar
+				settings={ [
+					{
+						colorValue: overlayColor.color,
+						gradientValue,
+						label: __( 'Overlay' ),
+						onColorChange: setOverlayColor,
+						onGradientChange: setGradient,
+						isShownByDefault: true,
+						resetAllFilter: () => ( {
+							overlayColor: undefined,
+							customOverlayColor: undefined,
+							gradient: undefined,
+							customGradient: undefined,
+						} ),
+					},
+				] }
+				panelId={ clientId }
+				{ ...colorGradientSettings }
+			/>
+			<ToolsPanelItem
+				hasValue={ () => dimRatio !== undefined }
+				label={ __( 'Overlay opacity' ) }
+				onDeselect={ () => setAttributes( { dimRatio: 0 } ) }
+				resetAllFilter={ () => ( {
+					dimRatio: 0,
+				} ) }
+				isShownByDefault
+				panelId={ clientId }
+			>
+				<RangeControl
+					__nextHasNoMarginBottom
+					label={ __( 'Overlay opacity' ) }
+					value={ dimRatio }
+					onChange={ ( newDimRatio ) =>
+						setAttributes( {
+							dimRatio: newDimRatio,
+						} )
+					}
+					min={ 0 }
+					max={ 100 }
+					step={ 10 }
+					required
+					__next40pxDefaultSize
+				/>
+			</ToolsPanelItem>
+		</InspectorControls>
+	);
+};
+
+export default compose( [
+	withColors( { overlayColor: 'background-color' } ),
+] )( Overlay );

--- a/packages/block-library/src/post-featured-image/overlay.js
+++ b/packages/block-library/src/post-featured-image/overlay.js
@@ -7,35 +7,21 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	RangeControl,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
-import {
-	InspectorControls,
 	withColors,
-	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 	__experimentalUseGradient,
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	__experimentalUseBorderProps as useBorderProps,
 } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { dimRatioToClass } from './utils';
 
-const Overlay = ( {
-	clientId,
-	attributes,
-	setAttributes,
-	overlayColor,
-	setOverlayColor,
-} ) => {
+const Overlay = ( { attributes, overlayColor } ) => {
 	const { dimRatio } = attributes;
-	const { gradientClass, gradientValue, setGradient } =
-		__experimentalUseGradient();
+	const { gradientClass, gradientValue } = __experimentalUseGradient();
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 
 	const borderProps = useBorderProps( attributes );
@@ -45,79 +31,26 @@ const Overlay = ( {
 		...borderProps.style,
 	};
 
-	if ( ! colorGradientSettings.hasColorsOrGradients ) {
+	if ( ! colorGradientSettings.hasColorsOrGradients || ! dimRatio ) {
 		return null;
 	}
 
 	return (
-		<>
-			{ !! dimRatio && (
-				<span
-					aria-hidden="true"
-					className={ classnames(
-						'wp-block-post-featured-image__overlay',
-						dimRatioToClass( dimRatio ),
-						{
-							[ overlayColor.class ]: overlayColor.class,
-							'has-background-dim': dimRatio !== undefined,
-							'has-background-gradient': gradientValue,
-							[ gradientClass ]: gradientClass,
-						},
-						borderProps.className
-					) }
-					style={ overlayStyles }
-				/>
+		<span
+			aria-hidden="true"
+			className={ classnames(
+				'wp-block-post-featured-image__overlay',
+				dimRatioToClass( dimRatio ),
+				{
+					[ overlayColor.class ]: overlayColor.class,
+					'has-background-dim': dimRatio !== undefined,
+					'has-background-gradient': gradientValue,
+					[ gradientClass ]: gradientClass,
+				},
+				borderProps.className
 			) }
-			<InspectorControls group="color">
-				<ColorGradientSettingsDropdown
-					__experimentalIsRenderedInSidebar
-					settings={ [
-						{
-							colorValue: overlayColor.color,
-							gradientValue,
-							label: __( 'Overlay' ),
-							onColorChange: setOverlayColor,
-							onGradientChange: setGradient,
-							isShownByDefault: true,
-							resetAllFilter: () => ( {
-								overlayColor: undefined,
-								customOverlayColor: undefined,
-								gradient: undefined,
-								customGradient: undefined,
-							} ),
-						},
-					] }
-					panelId={ clientId }
-					{ ...colorGradientSettings }
-				/>
-				<ToolsPanelItem
-					hasValue={ () => dimRatio !== undefined }
-					label={ __( 'Overlay opacity' ) }
-					onDeselect={ () => setAttributes( { dimRatio: 0 } ) }
-					resetAllFilter={ () => ( {
-						dimRatio: 0,
-					} ) }
-					isShownByDefault
-					panelId={ clientId }
-				>
-					<RangeControl
-						__nextHasNoMarginBottom
-						label={ __( 'Overlay opacity' ) }
-						value={ dimRatio }
-						onChange={ ( newDimRatio ) =>
-							setAttributes( {
-								dimRatio: newDimRatio,
-							} )
-						}
-						min={ 0 }
-						max={ 100 }
-						step={ 10 }
-						required
-						__next40pxDefaultSize
-					/>
-				</ToolsPanelItem>
-			</InspectorControls>
-		</>
+			style={ overlayStyles }
+		/>
 	);
 };
 


### PR DESCRIPTION
Addresses issue flagged in https://github.com/WordPress/gutenberg/pull/59295#issuecomment-2019196878

## What?

Fixes editor bug breaking the display of the Post Featured Image's overlay.

## Why?

Bug = bad
Overlay = good

## How?

Splits `Overlay` into two components. One for the overlay element itself and another for its block inspector controls.

## Testing Instructions

1. In the post or site editors, add a post featured image block
2. Select the featured image block and set an overlay color and opacity
3. Confirm the overlay displays correctly
4. Save and double check the display on the frontend as well
5. Back in the editor inspect the featured image block
6. Remove or reset the overlay values and confirm the overlay `span` isn't rendered
7. Navigate to Appearance > Editor > Pages and edit a page with a featured image block
8. Select the featured image block and confirm the overlay control is **not** available (behaviour introduced in [#59295](https://github.com/WordPress/gutenberg/pull/59295))

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/375049dd-3a40-4b3f-a36c-a54a9e8d237b

