### PR TITLE
Navigation Block: Add test coverage to check that post content is not removed

### DIFF
--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -122,4 +122,39 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 			'Post content did not match the original markup.'
 		);
 	}
+
+	/**
+	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
+	 */
+	public function test_block_core_navigation_retains_content_if_not_set() {
+		if ( ! function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
+			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionality.' );
+		}
+
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/navigation' => 'last_child',
+				),
+			)
+		);
+
+		$post             = new stdClass();
+		$post->ID         = self::$navigation_post->ID;
+		$post->post_title = 'Navigation Menu with changes';
+
+		$post = gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta( $post );
+
+		$this->assertSame(
+			'Navigation Menu with changes',
+			$post->post_title,
+			'Post title was changed.'
+		);
+
+		$this->assertFalse(
+			isset( $post->post_content ),
+			'Post content should not be set.'
+		);
+	}
 }


### PR DESCRIPTION
## What?
Add a unit test to cover #59991 (fixed in #60071). The issue was that if a navigation menu was renamed (but not changed otherwise), its content was accidentally deleted.

The reason for this was related to the `stdClass` object that's used to communicate required changes to `wp_update_post`: If its `post_content` field was not set (indicating no changes were to be made), `block_core_navigation_update_ignore_hooked_blocks_meta` would accidentally set that field to an empty string (meaning it would be replaced by that) -- thus causing loss of data.

## Why?
To prevent against regressions.

## How?
Verify that if the `stdClass` object's `post_content` is unset before running `block_core_navigation_update_ignore_hooked_blocks_meta`, it also is afterwards.

## Testing Instructions
Verify that tests pass.

To verify that the test covers the issue, revert https://github.com/WordPress/gutenberg/commit/7b6ac8d5a2c2ae3de969c09b9bbba707bdb8956e (i.e. #60071), rebuild Gutenberg, and re-run the tests. They should now fail.