### PR TITLE
Fix focus outline visibility and truncation in data view record titles

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -242,7 +242,6 @@
 	white-space: nowrap;
 	display: block;
 	width: 100%;
-	overflow: hidden;
 
 	a {
 		text-decoration: none;
@@ -420,6 +419,7 @@
 		}
 		.dataviews-view-list__primary-field {
 			min-height: $grid-unit-05 * 5;
+			overflow: hidden;
 		}
 	}
 


### PR DESCRIPTION
## What?
This PR fixes two small issues with titles in data views:

1. In table layout the focus outline gets clipped
2. In list layout truncation isn't working

| Before | After |
| --- | --- |
|  <img width="298" alt="Screenshot 2024-03-26 at 10 28 14" src="https://github.com/WordPress/gutenberg/assets/846565/f789048c-5b7b-4a2c-a467-a9c23b14e920"> | <img width="273" alt="Screenshot 2024-03-26 at 10 25 01" src="https://github.com/WordPress/gutenberg/assets/846565/f7252545-f767-4e22-832b-804c9ba126d5"> |
| <img width="386" alt="Screenshot 2024-03-26 at 10 24 28" src="https://github.com/WordPress/gutenberg/assets/846565/94e6d317-6903-414e-a373-c921c36ded1e"> | <img width="375" alt="Screenshot 2024-03-26 at 10 24 45" src="https://github.com/WordPress/gutenberg/assets/846565/60120a86-88c0-47c1-aa15-3467963c4ac6"> |


