### PR TITLE
Consolidate when showing revisions link or action

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
@@ -32,13 +32,17 @@ export default function SidebarNavigationScreenDetailsFooter( {
 	 * the following logic.
 	 */
 	const hrefProps = {};
-	if ( record?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id ) {
+	const lastRevisionId =
+		record?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id ?? null;
+	const revisionsCount =
+		record?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
+	// Enable the revisions link if there is a last revision and there are more than one revisions.
+	if ( lastRevisionId && revisionsCount > 1 ) {
 		hrefProps.href = addQueryArgs( 'revision.php', {
 			revision: record?._links[ 'predecessor-version' ][ 0 ].id,
 		} );
 		hrefProps.as = 'a';
 	}
-
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-details-footer">
 			<SidebarNavigationItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/56603

This should be the last part of the issue and this PR consolidates when to show the `view revisions` link/action. It uses the same logic we were using for lists, which is show the link/action if there are more than one revision. This effectively means that we don't show the first revision from empty content, which by the way is a revision that cannot be 'restored'.

## Testing Instructions
1. Observe that the revisions link in navigation sidebar is enabled only if there are more than one revisions.
2. Both the link and the action in lists are enabled/disabled when meeting the same conditions.

