### PR TITLE
Don't convert to pattern or part single blocks with no inner blocks

### DIFF
--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -42,5 +42,11 @@ function TemplatePartConverterMenuItem( { clientIds, onClose } ) {
 			/>
 		);
 	}
+	// Blocks which have no inner blocks and are not template part blocks
+	// should not have the option to convert to template part.
+	if ( blocks.length === 1 && blocks[ 0 ].innerBlocks.length === 0 ) {
+		return;
+	}
+
 	return <ConvertToTemplatePart clientIds={ clientIds } blocks={ blocks } />;
 }

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -70,16 +70,11 @@ export default function PatternConvertButton( {
 					blocks[ 0 ].attributes.ref
 				);
 
-			const isSingleBlockWithInnerBlocks =
-				blocks.length === 1 && blocks[ 0 ].innerBlocks.length > 0;
-
 			const _canConvert =
 				// Hide when this is already a synced pattern.
 				! isReusable &&
 				// Hide when patterns are disabled.
 				canInsertBlockType( 'core/block', rootId ) &&
-				// hide on single blocks with no inner blocks
-				isSingleBlockWithInnerBlocks &&
 				blocks.every(
 					( block ) =>
 						// Guard against the case where a regular block has *just* been converted.

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -70,11 +70,16 @@ export default function PatternConvertButton( {
 					blocks[ 0 ].attributes.ref
 				);
 
+			const isSingleBlockWithInnerBlocks =
+				blocks.length === 1 && blocks[ 0 ].innerBlocks.length > 0;
+
 			const _canConvert =
 				// Hide when this is already a synced pattern.
 				! isReusable &&
 				// Hide when patterns are disabled.
 				canInsertBlockType( 'core/block', rootId ) &&
+				// hide on single blocks with no inner blocks
+				isSingleBlockWithInnerBlocks &&
 				blocks.every(
 					( block ) =>
 						// Guard against the case where a regular block has *just* been converted.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #55521

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It makes little sense to create a template part or a pattern from one block that has no inner blocks. It also creates weird experiences like the linked issue describes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Hide the block controls that allow pattern and template part creation if there is a single block selected which has no inner blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the site editor
2. Open a template
3. Select a block like a paragraph or an image
4. Click in the block toolbar the three dots
5. _Notice the Create pattern and Create template part items don't appear_
6. Select a group with some contents
7. Click in the block toolbar the three dots
8. _Notice the Create pattern and Create template part items do appear_

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/107534/7182d999-a697-4097-a628-881eef25a27b

