### PR TITLE
Fix: Invalid links to the block supports api.

### DIFF
--- a/docs/explanations/architecture/styles.md
+++ b/docs/explanations/architecture/styles.md
@@ -78,7 +78,7 @@ For example:
 
 The paragraph declares support for font size in its `block.json`. This means the block will show a UI control for users to tweak its font size, unless it's disabled by the theme (learn more about how themes can disable UI controls in [the `theme.json` reference](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/)). The system will also take care of setting up the UI control data (the font size of the block if it has one already assigned, the list of available font sizes to show), and will serialize the block data into HTML markup upon user changes (attach classes and inline styles appropriately).
 
-By using the block supports mechanism via `block.json`, the block author is able to create the same experience as before just by writing a couple of lines. Check the tutorials for adding block supports to [static](/docs/how-to-guides/block-tutorial/block-supports-in-static-blocks.md) and [dynamic](/docs/how-to-guides/block-tutorial/block-supports-in-dynamic-blocks.md) blocks.
+By using the block supports mechanism via `block.json`, the block author is able to create the same experience as before just by writing a couple of lines. Check the [block supports api](docs/reference-guides/block-api/block-supports.md) for adding block supports to static or dynamic blocks.
 
 Besides the benefit of having to do less work to achieve the same results, there's a few other advantages:
 

--- a/docs/explanations/architecture/styles.md
+++ b/docs/explanations/architecture/styles.md
@@ -78,7 +78,7 @@ For example:
 
 The paragraph declares support for font size in its `block.json`. This means the block will show a UI control for users to tweak its font size, unless it's disabled by the theme (learn more about how themes can disable UI controls in [the `theme.json` reference](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/)). The system will also take care of setting up the UI control data (the font size of the block if it has one already assigned, the list of available font sizes to show), and will serialize the block data into HTML markup upon user changes (attach classes and inline styles appropriately).
 
-By using the block supports mechanism via `block.json`, the block author is able to create the same experience as before just by writing a couple of lines. Check the [block supports api](docs/reference-guides/block-api/block-supports.md) for adding block supports to static or dynamic blocks.
+By using the block supports mechanism via `block.json`, the block author is able to create the same experience as before just by writing a couple of lines. Check the [block supports api](/docs/reference-guides/block-api/block-supports.md) for adding block supports to static or dynamic blocks.
 
 Besides the benefit of having to do less work to achieve the same results, there's a few other advantages:
 


### PR DESCRIPTION
The links to /docs/how-to-guides/block-tutorial/block-supports-in-static-blocks.md (([https://github.com/WordPress/gutenberg/tree/trunk/](https://github.com/WordPress/gutenberg/tree/trunk/docs/how-to-guides/block-tutorial/block-supports-in-static-blocks.md) and /docs/how-to-guides/block-tutorial/block-supports-in-dynamic-blocks.md (https://github.com/WordPress/gutenberg/tree/trunk/docs/how-to-guides/block-tutorial/block-supports-in-dynamic-blocks.md)  no longer exist.

This PR updates the documentation to have a single link to /docs/reference-guides/block-api/block-supports.md (https://github.com/WordPress/gutenberg/tree/trunk/docs/reference-guides/block-api/block-supports.md) which documents how to add block supports in both static and dynamic blocks.
