### PR TITLE
Memoize the getTemplateInfo selector

### DIFF
--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -36,13 +36,13 @@ export default function PostCardPanel( { className, actions, children } ) {
 		const { getEditedEntityRecord } = select( coreStore );
 		const _type = getCurrentPostType();
 		const _id = getCurrentPostId();
-		let _templateInfo;
 		const _record = getEditedEntityRecord( 'postType', _type, _id );
+		const _templateInfo = __experimentalGetTemplateInfo( _record );
 		return {
 			title: _templateInfo?.title || getEditedPostAttribute( 'title' ),
 			modified: getEditedPostAttribute( 'modified' ),
 			id: _id,
-			templateInfo: __experimentalGetTemplateInfo( _record ),
+			templateInfo: _templateInfo,
 			icon: unlock( select( editorStore ) ).getPostIcon( _type, {
 				area: _record?.area,
 			} ),
@@ -88,8 +88,8 @@ export default function PostCardPanel( { className, actions, children } ) {
 							className="editor-post-card-panel__description"
 							spacing={ 2 }
 						>
-							{ !! description && <Text>{ description }</Text> }
-							{ !! lastEditedText && (
+							{ description && <Text>{ description }</Text> }
+							{ lastEditedText && (
 								<Text>{ lastEditedText }</Text>
 							) }
 						</VStack>

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1701,8 +1701,8 @@ export function __experimentalGetDefaultTemplateTypes( state ) {
 export const __experimentalGetDefaultTemplatePartAreas = createSelector(
 	( state ) => {
 		const areas =
-			getEditorSettings( state )?.defaultTemplatePartAreas || [];
-		return areas?.map( ( item ) => {
+			getEditorSettings( state )?.defaultTemplatePartAreas ?? [];
+		return areas.map( ( item ) => {
 			return { ...item, icon: getTemplatePartIcon( item.icon ) };
 		} );
 	},
@@ -1730,7 +1730,7 @@ export const __experimentalGetDefaultTemplateType = createSelector(
 			) ?? EMPTY_OBJECT
 		);
 	},
-	( state, slug ) => [ __experimentalGetDefaultTemplateTypes( state ), slug ]
+	( state ) => [ __experimentalGetDefaultTemplateTypes( state ) ]
 );
 
 /**
@@ -1741,32 +1741,39 @@ export const __experimentalGetDefaultTemplateType = createSelector(
  * @param {Object} template The template for which we need information.
  * @return {Object} Information about the template, including title, description, and icon.
  */
-export function __experimentalGetTemplateInfo( state, template ) {
-	if ( ! template ) {
-		return EMPTY_OBJECT;
-	}
+export const __experimentalGetTemplateInfo = createSelector(
+	( state, template ) => {
+		if ( ! template ) {
+			return EMPTY_OBJECT;
+		}
 
-	const { description, slug, title, area } = template;
-	const { title: defaultTitle, description: defaultDescription } =
-		__experimentalGetDefaultTemplateType( state, slug );
+		const { description, slug, title, area } = template;
+		const { title: defaultTitle, description: defaultDescription } =
+			__experimentalGetDefaultTemplateType( state, slug );
 
-	const templateTitle = typeof title === 'string' ? title : title?.rendered;
-	const templateDescription =
-		typeof description === 'string' ? description : description?.raw;
-	const templateIcon =
-		__experimentalGetDefaultTemplatePartAreas( state ).find(
-			( item ) => area === item.area
-		)?.icon || layout;
+		const templateTitle =
+			typeof title === 'string' ? title : title?.rendered;
+		const templateDescription =
+			typeof description === 'string' ? description : description?.raw;
+		const templateIcon =
+			__experimentalGetDefaultTemplatePartAreas( state ).find(
+				( item ) => area === item.area
+			)?.icon || layout;
 
-	return {
-		title:
-			templateTitle && templateTitle !== slug
-				? templateTitle
-				: defaultTitle || slug,
-		description: templateDescription || defaultDescription,
-		icon: templateIcon,
-	};
-}
+		return {
+			title:
+				templateTitle && templateTitle !== slug
+					? templateTitle
+					: defaultTitle || slug,
+			description: templateDescription || defaultDescription,
+			icon: templateIcon,
+		};
+	},
+	( state ) => [
+		__experimentalGetDefaultTemplateTypes( state ),
+		__experimentalGetDefaultTemplatePartAreas( state ),
+	]
+);
 
 /**
  * Returns a post type label depending on the current post.


### PR DESCRIPTION
I noticed there is a "The useSelect hook returns different values when called with the same state" warning in the console when the `PostCardPanel` component is rendered. Because it calls the `getTemplateInfo` selector and that selector is not memoized, returns a new `templateInfo` call on each call.

This PR adds the memoization and also adds a few little drive-by fixups in nearby code (see individual comments).

**How to test:** Start editing "Blog Home" in the Site Editor, and make sure this `PostCardPanel` is rendered:

<img width="284" alt="Screenshot 2024-03-26 at 13 32 44" src="https://github.com/WordPress/gutenberg/assets/664258/37612105-e2af-40b1-98da-ed4a4e7a89c1">

Before this PR, you'll see a console warning. After this PR, the warning should disappear.