### PR TITLE
Template Parts: Update replace flow to separate template parts from patterns

### DIFF
--- a/packages/block-library/src/template-part/edit/selection-modal.js
+++ b/packages/block-library/src/template-part/edit/selection-modal.js
@@ -18,7 +18,6 @@ import {
 import {
 	useAlternativeBlockPatterns,
 	useAlternativeTemplateParts,
-	useCreateTemplatePartFromBlocks,
 } from './utils/hooks';
 import { mapTemplatePartToBlockPattern } from './utils/map-template-part-to-block-pattern';
 import { searchPatterns } from '../../utils/search-patterns';
@@ -31,11 +30,11 @@ export default function TemplatePartSelectionModal( {
 	clientId,
 } ) {
 	const [ searchValue, setSearchValue ] = useState( '' );
-
 	const { templateParts } = useAlternativeTemplateParts(
 		area,
 		templatePartId
 	);
+
 	// We can map template parts to block patters to reuse the BlockPatternsList UI
 	const filteredTemplateParts = useMemo( () => {
 		const partsAsPatterns = templateParts.map( ( templatePart ) =>
@@ -49,7 +48,6 @@ export default function TemplatePartSelectionModal( {
 	const filteredBlockPatterns = useMemo( () => {
 		return searchPatterns( blockPatterns, searchValue );
 	}, [ blockPatterns, searchValue ] );
-	const shownBlockPatterns = useAsyncList( filteredBlockPatterns );
 
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
@@ -71,11 +69,6 @@ export default function TemplatePartSelectionModal( {
 		);
 		onClose();
 	};
-
-	const createFromBlocks = useCreateTemplatePartFromBlocks(
-		area,
-		setAttributes
-	);
 
 	const hasTemplateParts = !! filteredTemplateParts.length;
 	const hasBlockPatterns = !! filteredBlockPatterns.length;
@@ -99,20 +92,6 @@ export default function TemplatePartSelectionModal( {
 						shownPatterns={ shownTemplateParts }
 						onClickPattern={ ( pattern ) => {
 							onTemplatePartSelect( pattern.templatePart );
-						} }
-					/>
-				</div>
-			) }
-
-			{ hasBlockPatterns && (
-				<div>
-					<h2>{ __( 'Patterns' ) }</h2>
-					<BlockPatternsList
-						blockPatterns={ filteredBlockPatterns }
-						shownPatterns={ shownBlockPatterns }
-						onClickPattern={ ( pattern, blocks ) => {
-							createFromBlocks( blocks, pattern.title );
-							onClose();
 						} }
 					/>
 				</div>


### PR DESCRIPTION
## What?
In https://github.com/WordPress/gutenberg/pull/59883 I explored an update to the replacement flow for template parts. This is a different proposal which separates template part replacement from a pattern update.

## Why?
Since template part replacement and selecting a new pattern are different actions and should work differently, I think we should separate the actions to make it clear that they are different things.

## How?
1. Remove template parts from the "design" sidebar
2. Remove patterns from replacement modal
3. Change the pattern replacement flow so that rather than creating a new entity, we update the existing template part entity

## Testing Instructions
1. Open the Site Editor
2. Select a footer template part
3. Open the block inspector
4. Select a different pattern from the "Design" section
5. Confirm that the footer is changed across your site
6. Open the block options menu
7. Select "Replace"
8. Choose a different template part
9. Confirm that this template is updated 
10. Check that no other templates are updated

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/275961/2a9b1733-22d9-40f2-a85d-169d80afb494

