### PR TITLE
Image: Use the new 'useUploadMediaFromBlobURL' hook

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -117,7 +117,9 @@ export function ImageEdit( {
 		align,
 		metadata,
 	} = attributes;
-	const [ temporaryURL, setTemporaryURL ] = useState();
+	const [ temporaryURL, setTemporaryURL ] = useState( () => {
+		return isTemporaryImage( id, url ) ? url : undefined;
+	} );
 
 	const altRef = useRef();
 	useEffect( () => {
@@ -275,7 +277,6 @@ export function ImageEdit( {
 		onError: onUploadError,
 	} );
 
-	const isTemp = isTemporaryImage( id, url );
 	const isExternal = isExternalImage( id, url );
 	const src = isExternal ? url : undefined;
 	const mediaPreview = !! url && (
@@ -291,7 +292,7 @@ export function ImageEdit( {
 	const shadowProps = getShadowClassesAndStyles( attributes );
 
 	const classes = classnames( className, {
-		'is-transient': temporaryURL || isTemp,
+		'is-transient': temporaryURL,
 		'is-resized': !! width || !! height,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 		'has-custom-border':
@@ -380,7 +381,6 @@ export function ImageEdit( {
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				isSingleSelected={ isSingleSelected }
-				isTemporaryImage={ isTemp }
 				insertBlocksAfter={ insertBlocksAfter }
 				onReplace={ onReplace }
 				onSelectImage={ onSelectImage }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -99,7 +99,6 @@ export default function Image( {
 	attributes,
 	setAttributes,
 	isSingleSelected,
-	isTemporaryImage,
 	insertBlocksAfter,
 	onReplace,
 	onSelectImage,
@@ -785,7 +784,7 @@ export default function Image( {
 					...shadowProps.style,
 				} }
 			/>
-			{ ( temporaryURL || isTemporaryImage ) && <Spinner /> }
+			{ temporaryURL && <Spinner /> }
 		</>
 		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
 	);

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -99,6 +99,7 @@ export default function Image( {
 	attributes,
 	setAttributes,
 	isSingleSelected,
+	isTemporaryImage,
 	insertBlocksAfter,
 	onReplace,
 	onSelectImage,
@@ -784,7 +785,7 @@ export default function Image( {
 					...shadowProps.style,
 				} }
 			/>
-			{ temporaryURL && <Spinner /> }
+			{ ( temporaryURL || isTemporaryImage ) && <Spinner /> }
 		</>
 		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
 	);

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -67,6 +67,7 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 				onChange( media );
 			},
 			onError: ( message ) => {
+				revokeBlobURL( url );
 				onError( message );
 			},
 		} );


### PR DESCRIPTION
## What?
This is a follow-up to #59350.

PR updates the Image block to use the new `useUploadMediaFromBlobURL` hook for uploading media when a block is mounted.

## Why?
See #59350.

## Testing Instructions
1. Open a post or page.
2. Drop an image file on the editor canvas.
3. Confirm that the image block correctly handles upload when mounted.
4. Test upload failures. An error message should be displayed in the snackbar, and the blocks should revert to a placeholder state.

P.S. I've also tested #34371 to avoid any regressions. See the attached screencast.

### Emulate upload failure.
```
add_filter( 'wp_handle_upload_prefilter', function( $file ) {
	$file['error'] = 'File upload error.';
	return $file;
} );
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/48c69968-f2ac-4509-bca1-968c4ded3e21