### PR TITLE
Image: Remove temporary image check for rendering controls

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -934,9 +934,7 @@ export default function Image( {
 
 	return (
 		<>
-			{ /* Hide controls during upload to avoid component remount,
-				which causes duplicated image upload. */ }
-			{ ! temporaryURL && controls }
+			{ controls }
 			{ img }
 
 			<Caption


### PR DESCRIPTION
## What?
PR removes the condition for hiding controls while the image is uploading. It was initially introduced in #30891.

## Why?
tl;dr; It's no longer needed.

* Alignment controls are rendered via [block supports](https://github.com/WordPress/gutenberg/pull/55954), so the original solution is no longer applies.
* It looks like the remount during the alignment update was fixed. Probably via #48209.

## Testing Instructions
1. Open a post or page.
2. Throttle network to 3G via DevTools.
3. Drag the image to the editor.
4. Change image alignment while it's uploading.
5. Check the Network tab; there should be only one `POST` request for the `/media` endpoint.

### Testing Instructions for Keyboard
Same.
