### PR TITLE
Add a delete control to toolbar on zoom-out mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -6,8 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { dragHandle } from '@wordpress/icons';
-import { Button, Flex, FlexItem } from '@wordpress/components';
+import { dragHandle, trash } from '@wordpress/icons';
+import { Button, Flex, FlexItem, ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import {
@@ -316,7 +316,16 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 					) }
 				</FlexItem>
 				{ editorMode === 'zoom-out' && (
-					<Shuffle clientId={ clientId } as={ Button } />
+					<>
+						<Shuffle clientId={ clientId } as={ Button } />
+						<ToolbarButton
+							icon={ trash }
+							label="Delete"
+							onClick={ () => {
+								removeBlock( clientId );
+							} }
+						/>
+					</>
 				) }
 				<FlexItem>
 					<Button

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -316,16 +316,16 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 					) }
 				</FlexItem>
 				{ editorMode === 'zoom-out' && (
-					<>
-						<Shuffle clientId={ clientId } as={ Button } />
-						<ToolbarButton
-							icon={ trash }
-							label="Delete"
-							onClick={ () => {
-								removeBlock( clientId );
-							} }
-						/>
-					</>
+					<Shuffle clientId={ clientId } as={ Button } />
+				) }
+				{ editorMode === 'zoom-out' && ! isBlockTemplatePart && (
+					<ToolbarButton
+						icon={ trash }
+						label="Delete"
+						onClick={ () => {
+							removeBlock( clientId );
+						} }
+					/>
 				) }
 				<FlexItem>
 					<Button

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -62,6 +62,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				__unstableGetEditorMode,
 				getNextBlockClientId,
 				getPreviousBlockClientId,
+				canRemoveBlock,
 			} = select( blockEditorStore );
 			const { getActiveBlockVariation, getBlockType } =
 				select( blocksStore );
@@ -105,6 +106,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				isBlockTemplatePart,
 				isNextBlockTemplatePart,
 				isPrevBlockTemplatePart,
+				canRemove: canRemoveBlock( clientId, rootClientId ),
 			};
 		},
 		[ clientId, rootClientId ]
@@ -117,6 +119,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 		isBlockTemplatePart,
 		isNextBlockTemplatePart,
 		isPrevBlockTemplatePart,
+		canRemove,
 	} = selected;
 	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
@@ -318,15 +321,17 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				{ editorMode === 'zoom-out' && (
 					<Shuffle clientId={ clientId } as={ Button } />
 				) }
-				{ editorMode === 'zoom-out' && ! isBlockTemplatePart && (
-					<ToolbarButton
-						icon={ trash }
-						label="Delete"
-						onClick={ () => {
-							removeBlock( clientId );
-						} }
-					/>
-				) }
+				{ canRemove &&
+					editorMode === 'zoom-out' &&
+					! isBlockTemplatePart && (
+						<ToolbarButton
+							icon={ trash }
+							label="Delete"
+							onClick={ () => {
+								removeBlock( clientId );
+							} }
+						/>
+					) }
 				<FlexItem>
 					<Button
 						ref={ ref }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/60121

Adds a delete button to the BlockSelectionButton toolbar

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

So we don't need to move out from zoom out mode if we insert the wrong pattern to delete it

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In the site editor, click zoom-out mode.
Select one of the sections, the button should show on the toolbar and it should work as expected.

## Screenshots or screencast <!-- if applicable -->

<img width="1032" alt="Screenshot 2024-03-26 at 16 49 00" src="https://github.com/WordPress/gutenberg/assets/3593343/9d29d4d5-1f40-47b5-917a-85d9f6bb2fbf">

