### PR TITLE
Fix rendering PluginTemplateSettingPanel when we're editing a template

### DIFF
--- a/packages/edit-site/src/components/plugin-template-setting-panel/index.js
+++ b/packages/edit-site/src/components/plugin-template-setting-panel/index.js
@@ -5,11 +5,24 @@
 /**
  * WordPress dependencies
  */
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
 import { createSlotFill } from '@wordpress/components';
 
 const { Fill, Slot } = createSlotFill( 'PluginTemplateSettingPanel' );
 
-const PluginTemplateSettingPanel = Fill;
+const PluginTemplateSettingPanel = ( { children } ) => {
+	const isCurrentEntityTemplate = useSelect(
+		( select ) =>
+			select( editorStore ).getCurrentPostType() === 'wp_template',
+		[]
+	);
+	if ( ! isCurrentEntityTemplate ) {
+		return null;
+	}
+	return <Fill>{ children }</Fill>;
+};
+
 PluginTemplateSettingPanel.Slot = Slot;
 
 /**

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -22,7 +22,6 @@ import { STORE_NAME } from '../../store/constants';
 import SettingsHeader from './settings-header';
 import PagePanels from './page-panels';
 import TemplatePanel from './template-panel';
-import PluginTemplateSettingPanel from '../plugin-template-setting-panel';
 import { SIDEBAR_BLOCK, SIDEBAR_TEMPLATE } from './constants';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
@@ -96,7 +95,6 @@ const FillContents = ( {
 						focusable={ false }
 					>
 						{ isEditingPage ? <PagePanels /> : <TemplatePanel /> }
-						<PluginTemplateSettingPanel.Slot />
 					</Tabs.TabPanel>
 					<Tabs.TabPanel tabId={ SIDEBAR_BLOCK } focusable={ false }>
 						<InspectorSlot bubblesVirtually />

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -25,6 +25,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as editSiteStore } from '../../../store';
 import TemplateActions from '../../template-actions';
 import TemplateAreas from './template-areas';
+import PluginTemplateSettingPanel from '../../plugin-template-setting-panel';
 import { useAvailablePatterns } from './hooks';
 import { TEMPLATE_PART_POST_TYPE } from '../../../utils/constants';
 import { unlock } from '../../../lock-unlock';
@@ -115,6 +116,7 @@ export default function TemplatePanel() {
 			>
 				<TemplateAreas />
 			</PostCardPanel>
+			<PluginTemplateSettingPanel.Slot />
 			{ availablePatterns?.length > 0 && (
 				<PanelBody
 					title={ __( 'Transform into:' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In https://github.com/WordPress/gutenberg/pull/50257 we introduced a new slot in Template Sidebar below the main information like the Template Card. At some point when we added the ability to also edit the page, this slot would render in both cases(page and template) which was not the intent.

[Discussions](https://github.com/WordPress/gutenberg/pull/50257#issuecomment-2009381915) have started about how to migrate it's usage and use internally PluginDocumentSettingPanel, but for now we can fix the rendering.

## Testing Instructions
Code example:
```js
import { MyTemplateSettingTest } from '@wordpress/edit-site';
const MyTemplateSettingTest = () => (
	<PluginTemplateSettingPanel>
		<p>Hello, World!</p>
	</PluginTemplateSettingPanel>
);

1. With the above snippet in trunk it will be also rendered in inspector controls when we're editing a `page`
2. In this PR it will only render if we edit a template.
