### PR TITLE
Fix group block placeholder buttons color contrast ratio and improve consistency

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -48,6 +48,7 @@
 
 	// Let the parent be selectable in the placeholder area.
 	pointer-events: none;
+
 	.block-editor-inserter {
 		pointer-events: all;
 	}
@@ -64,15 +65,15 @@
 		padding: 0;
 		margin: 0;
 	}
+
 	.components-placeholder__instructions {
 		margin-bottom: 18px;
 	}
-	.wp-block-group-placeholder__variations svg {
-		fill: $gray-400 !important;
-	}
+
 	.wp-block-group-placeholder__variations svg:hover {
 		fill: var(--wp-admin-theme-color) !important;
 	}
+
 	.wp-block-group-placeholder__variations > li {
 		margin: 0 $grid-unit-15 $grid-unit-15 $grid-unit-15;
 		width: auto;
@@ -80,23 +81,31 @@
 		flex-direction: column;
 		align-items: center;
 	}
+
 	.wp-block-group-placeholder__variations li > .wp-block-group-placeholder__variation-button {
-		width: 44px;
-		height: 32px;
-		padding: 0;
-		&:hover {
-			box-shadow: none;
-		}
+		width: auto;
+		height: auto;
+		padding: $grid-unit-10;
+		margin-right: 0;
 	}
+
 	.components-placeholder {
 		min-height: auto;
 		padding: $grid-unit-30;
 		align-items: center;
 	}
+
 	.is-small,
 	.is-medium {
 		.wp-block-group-placeholder__variations > li {
 			margin: $grid-unit-15;
 		}
+	}
+
+	.wp-block-group-placeholder__variation-label {
+		font-family: $default-font;
+		font-size: 12px;
+		display: block;
+		line-height: 1.4;
 	}
 }

--- a/packages/block-library/src/group/placeholder.js
+++ b/packages/block-library/src/group/placeholder.js
@@ -159,15 +159,18 @@ function GroupPlaceHolder( { name, onSelect } ) {
 					{ variations.map( ( variation ) => (
 						<li key={ variation.name }>
 							<Button
-								variant="tertiary"
+								variant="secondary"
 								icon={ getGroupPlaceholderIcons(
 									variation.name
 								) }
-								iconSize={ 44 }
+								iconSize={ 48 }
 								onClick={ () => onSelect( variation ) }
 								className="wp-block-group-placeholder__variation-button"
 								label={ `${ variation.title }: ${ variation.description }` }
 							/>
+							<span className="wp-block-group-placeholder__variation-label">
+								{ variation.title }
+							</span>
 						</li>
 					) ) }
 				</ul>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60206

## What?
<!-- In a few words, what is the PR actually doing? -->
WIP

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
