### PR TITLE
Site Editor: Reuse inserter search term normalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55757,8 +55757,7 @@
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.2",
-				"remove-accents": "^0.5.0"
+				"rememo": "^4.0.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -71531,8 +71530,7 @@
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.2",
-				"remove-accents": "^0.5.0"
+				"rememo": "^4.0.2"
 			}
 		},
 		"@wordpress/edit-widgets": {

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -30,7 +30,7 @@ const normalizedStrings = new Map();
  *
  * @return {Array} Words, extracted from the input string.
  */
-function extractWords( input = '' ) {
+export function extractWords( input = '' ) {
 	if ( extractedWords.has( input ) ) {
 		return extractedWords.get( input );
 	}
@@ -54,7 +54,7 @@ function extractWords( input = '' ) {
  *
  * @return {string} The normalized search input.
  */
-function normalizeString( input = '' ) {
+export function normalizeString( input = '' ) {
 	if ( normalizedStrings.has( input ) ) {
 		return normalizedStrings.get( input );
 	}

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -8,6 +8,11 @@ import { getRichTextValues } from './components/rich-text/get-rich-text-values';
 import ResizableBoxPopover from './components/resizable-box-popover';
 import { ComposedPrivateInserter as PrivateInserter } from './components/inserter';
 import { default as PrivateQuickInserter } from './components/inserter/quick-inserter';
+import {
+	extractWords,
+	getNormalizedSearchTerms,
+	normalizeString,
+} from './components/inserter/search-items';
 import { PrivateListView } from './components/list-view';
 import BlockInfo from './components/block-info-slot-fill';
 import { useShowBlockTools } from './components/block-tools/use-show-block-tools';
@@ -42,6 +47,9 @@ lock( privateApis, {
 	getRichTextValues,
 	PrivateInserter,
 	PrivateQuickInserter,
+	extractWords,
+	getNormalizedSearchTerms,
+	normalizeString,
 	PrivateListView,
 	ResizableBoxPopover,
 	BlockInfo,

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -76,8 +76,7 @@
 		"is-plain-object": "^5.0.0",
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
-		"rememo": "^4.0.2",
-		"remove-accents": "^0.5.0"
+		"rememo": "^4.0.2"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/edit-site/src/components/page-patterns/search-items.js
+++ b/packages/edit-site/src/components/page-patterns/search-items.js
@@ -1,8 +1,16 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import removeAccents from 'remove-accents';
-import { noCase } from 'change-case';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { extractWords, getNormalizedSearchTerms, normalizeString } = unlock(
+	blockEditorPrivateApis
+);
 
 /**
  * Internal dependencies
@@ -19,59 +27,6 @@ const defaultGetTitle = ( item ) => item.title;
 const defaultGetDescription = ( item ) => item.description || '';
 const defaultGetKeywords = ( item ) => item.keywords || [];
 const defaultHasCategory = () => false;
-
-/**
- * Extracts words from an input string.
- *
- * @param {string} input The input string.
- *
- * @return {Array} Words, extracted from the input string.
- */
-function extractWords( input = '' ) {
-	return noCase( input, {
-		splitRegexp: [
-			/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
-			/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
-		],
-		stripRegexp: /(\p{C}|\p{P}|\p{S})+/giu, // Anything that's not a punctuation, symbol or control/format character.
-	} )
-		.split( ' ' )
-		.filter( Boolean );
-}
-
-/**
- * Sanitizes the search input string.
- *
- * @param {string} input The search input to normalize.
- *
- * @return {string} The normalized search input.
- */
-function normalizeSearchInput( input = '' ) {
-	// Disregard diacritics.
-	//  Input: "média"
-	input = removeAccents( input );
-
-	// Accommodate leading slash, matching autocomplete expectations.
-	//  Input: "/media"
-	input = input.replace( /^\//, '' );
-
-	// Lowercase.
-	//  Input: "MEDIA"
-	input = input.toLowerCase();
-
-	return input;
-}
-
-/**
- * Converts the search term into a list of normalized terms.
- *
- * @param {string} input The search term to normalize.
- *
- * @return {string[]} The normalized list of search terms.
- */
-export const getNormalizedSearchTerms = ( input = '' ) => {
-	return extractWords( normalizeSearchInput( input ) );
-};
 
 const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
 	return unmatchedTerms.filter(
@@ -162,8 +117,8 @@ function getItemSearchRank( item, searchTerm, config ) {
 	const description = getDescription( item );
 	const keywords = getKeywords( item );
 
-	const normalizedSearchInput = normalizeSearchInput( searchTerm );
-	const normalizedTitle = normalizeSearchInput( title );
+	const normalizedSearchInput = normalizeString( searchTerm );
+	const normalizedTitle = normalizeString( title );
 
 	// Prefers exact matches
 	// Then prefers if the beginning of the title matches the search term


### PR DESCRIPTION
## What?
In https://github.com/WordPress/gutenberg/pull/60080#discussion_r1539095874 @jsnajdr spotted that much of the search term normalization logic is being duplicated.

This PR deduplicates a big part of the search term normalization functionality that is essentially copied from the block editor. 

## Why?

To avoid duplication and to reuse code that already has some testing coverage. 

## How?
We're exposing those utilities as private APIs for the block editor and reusing them in the site editor. This also allows us to remove a direct dependency from the `edit-site` package.

There are more opportunities for deduplication, but I prefer addressing them in smaller and more digestible pieces.

## Testing Instructions
* Verify inserter search in post editor still works well.
* Verify pattern search in site editor - patterns still works well.
* Verify all checks are green

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None