### PR TITLE
Global Styles: Filter out color and typography variations

### DIFF
--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import PreviewStyles from './preview-styles';
 import Variation from './variations/variation';
+import { isVariationOfSingleProperty } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
 export default function StyleVariationsContainer( { gap = 2 } ) {
 	const variations = useSelect( ( select ) => {
@@ -20,6 +21,14 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		).__experimentalGetCurrentThemeGlobalStylesVariations();
 	}, [] );
 
+	// Filter out variations that are of single property type, i.e. color and typography variations.
+	const filteredVariations = variations?.filter( ( variation ) => {
+		return (
+			! isVariationOfSingleProperty( variation, 'color' ) &&
+			! isVariationOfSingleProperty( variation, 'typography' )
+		);
+	} );
+
 	const withEmptyVariation = useMemo( () => {
 		return [
 			{
@@ -27,13 +36,13 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				settings: {},
 				styles: {},
 			},
-			...( variations ?? [] ).map( ( variation ) => ( {
+			...( filteredVariations ?? [] ).map( ( variation ) => ( {
 				...variation,
 				settings: variation.settings ?? {},
 				styles: variation.styles ?? {},
 			} ) ),
 		];
-	}, [ variations ] );
+	}, [ filteredVariations ] );
 
 	return (
 		<Grid

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -22,7 +22,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 	}, [] );
 
 	// Filter out variations that are of single property type, i.e. color and typography variations.
-	const filteredVariations = variations?.filter( ( variation ) => {
+	const multiplePropertyVariations = variations?.filter( ( variation ) => {
 		return (
 			! isVariationOfSingleProperty( variation, 'color' ) &&
 			! isVariationOfSingleProperty( variation, 'typography' )

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -21,7 +21,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		).__experimentalGetCurrentThemeGlobalStylesVariations();
 	}, [] );
 
-	// Filter out variations that are of single property type, i.e. color and typography variations.
+	// Filter out variations that are of single property type, i.e. color or typography variations.
 	const multiplePropertyVariations = variations?.filter( ( variation ) => {
 		return (
 			! isVariationOfSingleProperty( variation, 'color' ) &&

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import PreviewStyles from './preview-styles';
 import Variation from './variations/variation';
-import { isVariationOfSingleProperty } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { isVariationWithSingleProperty } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
 export default function StyleVariationsContainer( { gap = 2 } ) {
 	const variations = useSelect( ( select ) => {
@@ -24,8 +24,8 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 	// Filter out variations that are of single property type, i.e. color or typography variations.
 	const multiplePropertyVariations = variations?.filter( ( variation ) => {
 		return (
-			! isVariationOfSingleProperty( variation, 'color' ) &&
-			! isVariationOfSingleProperty( variation, 'typography' )
+			! isVariationWithSingleProperty( variation, 'color' ) &&
+			! isVariationWithSingleProperty( variation, 'typography' )
 		);
 	} );
 
@@ -36,13 +36,13 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				settings: {},
 				styles: {},
 			},
-			...( filteredVariations ?? [] ).map( ( variation ) => ( {
+			...( multiplePropertyVariations ?? [] ).map( ( variation ) => ( {
 				...variation,
 				settings: variation.settings ?? {},
 				styles: variation.styles ?? {},
 			} ) ),
 		];
-	}, [ filteredVariations ] );
+	}, [ multiplePropertyVariations ] );
 
 	return (
 		<Grid

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -180,6 +180,21 @@ export default function useThemeStyleVariationsByProperty( {
 						result
 					);
 				}
+
+				// Detect if this is a duplicate variation.
+				const isDuplicate = accumulator.some( ( item ) => {
+					return (
+						JSON.stringify( item.styles ) ===
+							JSON.stringify( result?.styles ) &&
+						JSON.stringify( item.settings ) ===
+							JSON.stringify( result?.settings )
+					);
+				} );
+				if ( isDuplicate ) {
+					return accumulator;
+				}
+
+				// If the variation is not a duplicate, add it to the accumulator.
 				accumulator.push( result );
 				return accumulator;
 			},

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -153,20 +153,17 @@ export default function useThemeStyleVariationsByProperty( {
 				? cloneDeep( baseVariation )
 				: null;
 
-		let processedStyleVariations = variations
-			// Remove variations that are empty once the property is filtered out.
-			.filter( ( variation ) => {
+		let processedStyleVariations = variations.reduce(
+			( accumulator, variation ) => {
 				const variationFilteredByProperty = filterObjectByProperty(
 					cloneDeep( variation ),
 					property
 				);
-				return Object.keys( variationFilteredByProperty ).length > 0;
-			} )
-			.map( ( variation ) => {
-				const variationFilteredByProperty = filterObjectByProperty(
-					cloneDeep( variation ),
-					property
-				);
+				// Remove variations that are empty once the property is filtered out.
+				if ( Object.keys( variationFilteredByProperty ).length === 0 ) {
+					return accumulator;
+				}
+
 				let result = {
 					...variationFilteredByProperty,
 					title: variation?.title,
@@ -183,8 +180,11 @@ export default function useThemeStyleVariationsByProperty( {
 						result
 					);
 				}
-				return result;
-			} );
+				accumulator.push( result );
+				return accumulator;
+			},
+			[] // Initial accumulator value.
+		);
 
 		if ( 'function' === typeof filter ) {
 			processedStyleVariations =

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -153,22 +153,38 @@ export default function useThemeStyleVariationsByProperty( {
 				? cloneDeep( baseVariation )
 				: null;
 
-		let processedStyleVariations = variations.map( ( variation ) => {
-			let result = {
-				...filterObjectByProperty( cloneDeep( variation ), property ),
-				title: variation?.title,
-				description: variation?.description,
-			};
+		let processedStyleVariations = variations
+			// Remove variations that are empty once the property is filtered out.
+			.filter( ( variation ) => {
+				const variationFilteredByProperty = filterObjectByProperty(
+					cloneDeep( variation ),
+					property
+				);
+				return Object.keys( variationFilteredByProperty ).length > 0;
+			} )
+			.map( ( variation ) => {
+				const variationFilteredByProperty = filterObjectByProperty(
+					cloneDeep( variation ),
+					property
+				);
+				let result = {
+					...variationFilteredByProperty,
+					title: variation?.title,
+					description: variation?.description,
+				};
 
-			if ( clonedBaseVariation ) {
-				/*
-				 * Overwrites all baseVariation object `styleProperty` properties
-				 * with the theme variation `styleProperty` properties.
-				 */
-				result = mergeBaseAndUserConfigs( clonedBaseVariation, result );
-			}
-			return result;
-		} );
+				if ( clonedBaseVariation ) {
+					/*
+					 * Overwrites all baseVariation object `styleProperty` properties
+					 * with the theme variation `styleProperty` properties.
+					 */
+					result = mergeBaseAndUserConfigs(
+						clonedBaseVariation,
+						result
+					);
+				}
+				return result;
+			} );
 
 		if ( 'function' === typeof filter ) {
 			processedStyleVariations =

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -178,3 +178,25 @@ export default function useThemeStyleVariationsByProperty( {
 		return processedStyleVariations;
 	}, [ variations, property, baseVariation, filter ] );
 }
+
+/**
+ * Compares a style variation to the same variation filtered by a single property.
+ * Returns true if the variation contains only the property specified.
+ *
+ * @param {Object} variation The variation to compare.
+ * @param {string} property  The property to compare.
+ * @return {boolean} Whether the variation contains only a single property.
+ */
+export function isVariationOfSingleProperty( variation, property ) {
+	const variationWithProperty = filterObjectByProperty(
+		cloneDeep( variation ),
+		property
+	);
+
+	return (
+		JSON.stringify( variationWithProperty?.styles ) ===
+			JSON.stringify( variation?.styles ) &&
+		JSON.stringify( variationWithProperty?.settings ) ===
+			JSON.stringify( variation?.settings )
+	);
+}

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -187,7 +187,7 @@ export default function useThemeStyleVariationsByProperty( {
  * @param {string} property  The property to compare.
  * @return {boolean} Whether the variation contains only a single property.
  */
-export function isVariationOfSingleProperty( variation, property ) {
+export function isVariationWithSingleProperty( variation, property ) {
 	const variationWithProperty = filterObjectByProperty(
 		cloneDeep( variation ),
 		property


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Now that Global Styles displays color and typography settings separately we should find a way to allow theme authors to give access to these without needing to create full variations.

This filters color and typography variations out of the list of style variations so that theme authors can add variations that target only these properties without having to create full variations.

Related https://github.com/WordPress/gutenberg/issues/56604

## Why?
This gives theme authors the ability to create multiple color and typography settings.

## How?
Iterate over the style variations. For each one we extract the color settings/styles and typography settings/styles. If either one is the same as the variation itself then this variation must be a color/typography only setting, so we should remove it from the main list.

## Testing Instructions
1. Add some color only or typography variations to your theme (TT4 contains a variation called Onyx which is a color only variation).
2. Open the Site Editor
3. Open Global Styles
5. Check that the settings from these variations appear in the color and typographys sections but not in "styles" section of global styles.

## Screenshots or screencast <!-- if applicable -->
<img width="449" alt="Screenshot 2024-03-26 at 19 00 38" src="https://github.com/WordPress/gutenberg/assets/275961/45bfba9c-ff76-42f8-a798-e670b0422552">
