### PR TITLE
[Create block] Add new namespacePascalCase template variable.

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Add new `namespacePascalCase` template variable ([#60223](https://github.com/WordPress/gutenberg/pull/60223)).
+
 ## 4.38.0 (2024-03-21)
 
 ## 4.37.0 (2024-03-06)
@@ -14,7 +18,7 @@
 
 ### Internal
 
--   Remove deprecated `viewModule` field  ([#59198](https://github.com/WordPress/gutenberg/pull/59198)).
+-   Remove deprecated `viewModule` field ([#59198](https://github.com/WordPress/gutenberg/pull/59198)).
 
 ## 4.35.0 (2024-02-09)
 

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -98,7 +98,8 @@ module.exports = async (
 
 	const view = {
 		...transformedValues,
-		namespaceSnakeCase: snakeCase( transformedValues.slug ),
+		namespaceSnakeCase: snakeCase( transformedValues.namespace ),
+		namespacePascalCase: pascalCase( transformedValues.namespace ),
 		slugSnakeCase: snakeCase( transformedValues.slug ),
 		slugPascalCase: pascalCase( transformedValues.slug ),
 		...variantVars,

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -27,7 +27,7 @@
  * Update URI:        {{{updateURI}}}
 {{/updateURI}}
  *
- * @package           {{namespace}}
+ * @package {{namespacePascalCase}}
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## What?
This PR adds a new template variable called namespacePascalCase and fixes an issue with the existing namespaceSnakeCase variable incorrectly using the slug.

## Why?

There is currently no pascal case version of the namespace but there is for the slug. Adding this in will allow template authors to create valid PHP namespaces and `@package` tags.

The default templates use the {{namespace}} template variable to populate the `@package` tag in the plugin file([see here](https://github.com/WordPress/gutenberg/blob/trunk/packages/create-block/lib/templates/plugin/%24slug.php.mustache#L30)). 

If the namespace contains hypens as the default value does,  then this will generate a package of `create-block`. Which is not a valid PHP namespace.

What would be better is to have a pascalCase version that would create `CreateBlock`. This could then be combined with the pascal slug to create a full namespace for each block. `CreateBlock\MyCustomBlock`. For those creating plugins with multiple blocks to use the same namespace, this will keep all of the blocks contained in the same namespace.

## Testing Instructions
1. Checkout this branch
2. Form the root run `node ./packages/create-block/index.js test-namespace`
3. Confirm that the `@package` in test-namespace.php is set to `CreateBlock`