### PR TITLE
Fix zoom out mode toggling between pattern category selection

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-preview-panel.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-preview-panel.js
@@ -10,6 +10,7 @@ import { focus } from '@wordpress/dom';
  */
 
 import { PatternCategoryPreviews } from './pattern-category-previews';
+import { useZoomOut } from '../../../hooks/use-zoom-out';
 
 export function PatternCategoryPreviewPanel( {
 	rootClientId,
@@ -28,6 +29,10 @@ export function PatternCategoryPreviewPanel( {
 		} );
 		return () => clearTimeout( timeout );
 	}, [ category ] );
+
+	// Move to zoom out mode when this component is mounted
+	// and back to the previous mode when unmounted.
+	useZoomOut();
 
 	return (
 		<div

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -32,7 +32,6 @@ import {
 	myPatternsCategory,
 	INSERTER_PATTERN_TYPES,
 } from './utils';
-import { useZoomOut } from '../../../hooks/use-zoom-out';
 
 const noop = () => {};
 
@@ -49,10 +48,6 @@ export function PatternCategoryPreviews( {
 	);
 	const [ patternSyncFilter, setPatternSyncFilter ] = useState( 'all' );
 	const [ patternSourceFilter, setPatternSourceFilter ] = useState( 'all' );
-
-	// Move to zoom out mode when this component is mounted
-	// and back to the previous mode when unmounted.
-	useZoomOut();
 
 	const availableCategories = usePatternCategories(
 		rootClientId,

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,26 +20,15 @@ export function useZoomOut() {
 		};
 	}, [] );
 
-	const shouldRevertInitialMode = useRef( null );
-	useEffect( () => {
-		// ignore changes to zoom-out mode as we explictily change to it on mount.
-		if ( mode !== 'zoom-out' ) {
-			shouldRevertInitialMode.current = false;
-		}
-	}, [ mode ] );
-
 	// Intentionality left without any dependency.
-	// This effect should only run the first time the component is rendered.
+	// This effect should only run when the component is rendered and unmounted.
 	// The effect opens the zoom-out view if it is not open before when applying a style variation.
 	useEffect( () => {
 		if ( mode !== 'zoom-out' ) {
 			__unstableSetEditorMode( 'zoom-out' );
-			shouldRevertInitialMode.current = true;
 			return () => {
-				// if there were not mode changes revert to the initial mode when unmounting.
-				if ( shouldRevertInitialMode.current ) {
-					__unstableSetEditorMode( mode );
-				}
+				// Revert to original mode
+				__unstableSetEditorMode( mode );
 			};
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When viewing patterns on the site editor, the mode switches to zoom out mode. When selecting a new pattern category, it was incorrectly switching back to edit mode. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We only want to revert modes when the pattern panel collapses.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Move the useZoomOut hook up a level to the panel wrapper. Also, refactor the useZoomOut mode hook for simplicity.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the site editor
2. Open the inserter
3. Open the patterns tab
4. Select a pattern category
4. Check that the site is zoomed out
5. Select a new pattern category
7. Open a different tab or close the inserter
8. Check that the size is zoomed back in
9. Open global styles
10. Open the browse styles option
11. Check that the site is zoomed out
12. Close the browse styles option
13. Check that the site is zoomed in

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
