### PR TITLE
Export prop types as first party API for components

### DIFF
--- a/packages/components/src/alignment-matrix-control/index.tsx
+++ b/packages/components/src/alignment-matrix-control/index.tsx
@@ -18,7 +18,13 @@ import { Root, Row } from './styles/alignment-matrix-control-styles';
 import AlignmentMatrixControlIcon from './icon';
 import { GRID, getItemId, getItemValue } from './utils';
 import type { WordPressComponentProps } from '../context';
-import type { AlignmentMatrixControlProps } from './types';
+import type { AlignmentMatrixControlProps as AlignmentMatrixControlBaseProps } from './types';
+
+export type AlignmentMatrixControlProps = WordPressComponentProps<
+	AlignmentMatrixControlBaseProps,
+	'div',
+	false
+>;
 
 /**
  *
@@ -49,7 +55,7 @@ export function AlignmentMatrixControl( {
 	onChange,
 	width = 92,
 	...props
-}: WordPressComponentProps< AlignmentMatrixControlProps, 'div', false > ) {
+}: AlignmentMatrixControlProps ) {
 	const baseId = useInstanceId(
 		AlignmentMatrixControl,
 		'alignment-matrix-control',

--- a/packages/components/src/angle-picker-control/index.tsx
+++ b/packages/components/src/angle-picker-control/index.tsx
@@ -20,10 +20,15 @@ import AngleCircle from './angle-circle';
 import { UnitText } from './styles/angle-picker-control-styles';
 
 import type { WordPressComponentProps } from '../context';
-import type { AnglePickerControlProps } from './types';
+import type { AnglePickerControlProps as AnglePickerControlBaseProps } from './types';
+
+export type AnglePickerControlProps = WordPressComponentProps<
+	AnglePickerControlBaseProps,
+	'div'
+>;
 
 function UnforwardedAnglePickerControl(
-	props: WordPressComponentProps< AnglePickerControlProps, 'div' >,
+	props: AnglePickerControlProps,
 	ref: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/animate/index.tsx
+++ b/packages/components/src/animate/index.tsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import type { AnimateProps, GetAnimateOptions } from './types';
+export type { AnimateProps } from './types';
 
 /**
  * @param type The animation type

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -41,6 +41,7 @@ import type {
 	UseAutocompleteProps,
 	WPCompleter,
 } from './types';
+export type { AutocompleteProps } from './types';
 
 const getNodeText = ( node: React.ReactNode ): string => {
 	if ( node === null ) {

--- a/packages/components/src/base-control/index.tsx
+++ b/packages/components/src/base-control/index.tsx
@@ -7,7 +7,10 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { VisuallyHidden } from '../visually-hidden';
-import type { BaseControlProps, BaseControlVisualLabelProps } from './types';
+import type {
+	BaseControlProps as BaseControlBaseProps,
+	BaseControlVisualLabelProps,
+} from './types';
 import {
 	Wrapper,
 	StyledField,
@@ -19,6 +22,11 @@ import type { WordPressComponentProps } from '../context';
 import { contextConnectWithoutRef, useContextSystem } from '../context';
 
 export { useBaseControlProps } from './hooks';
+
+// This prop is exported differently than others because creating a type and
+// then using that type in the component below causes TS union error in other
+// files. `Expression produces a union type that is too complex to represent.`
+export type BaseControlProps = Parameters< typeof UnconnectedBaseControl >[ 0 ];
 
 /**
  * `BaseControl` is a component used to generate labels and help text for components handling user inputs.
@@ -44,7 +52,7 @@ export { useBaseControlProps } from './hooks';
  * ```
  */
 const UnconnectedBaseControl = (
-	props: WordPressComponentProps< BaseControlProps, null >
+	props: WordPressComponentProps< BaseControlBaseProps, null >
 ) => {
 	const {
 		__nextHasNoMarginBottom = false,

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -18,7 +18,7 @@ import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { useBorderBoxControl } from './hook';
 
-import type { BorderBoxControlProps } from '../types';
+import type { BorderBoxControlProps as BorderBoxControlBaseProps } from '../types';
 import type {
 	LabelProps,
 	BorderControlProps,
@@ -38,8 +38,14 @@ const BorderLabel = ( props: LabelProps ) => {
 	);
 };
 
+export type BorderBoxControlProps = WordPressComponentProps<
+	BorderBoxControlBaseProps,
+	'div',
+	false
+>;
+
 const UnconnectedBorderBoxControl = (
-	props: WordPressComponentProps< BorderBoxControlProps, 'div', false >,
+	props: BorderBoxControlProps,
 	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {

--- a/packages/components/src/border-box-control/border-box-control/index.ts
+++ b/packages/components/src/border-box-control/border-box-control/index.ts
@@ -1,2 +1,5 @@
-export { default as BorderBoxControl } from './component';
+export {
+	default as BorderBoxControl,
+	type BorderBoxControlProps,
+} from './component';
 export { useBorderBoxControl } from './hook';

--- a/packages/components/src/border-box-control/index.ts
+++ b/packages/components/src/border-box-control/index.ts
@@ -1,3 +1,6 @@
-export { default as BorderBoxControl } from './border-box-control/component';
+export {
+	default as BorderBoxControl,
+	type BorderBoxControlProps,
+} from './border-box-control/component';
 export { useBorderBoxControl } from './border-box-control/hook';
 export { hasSplitBorders, isEmptyBorder, isDefinedBorder } from './utils';

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -17,7 +17,10 @@ import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { useBorderControl } from './hook';
 
-import type { BorderControlProps, LabelProps } from '../types';
+import type {
+	BorderControlProps as BorderControlBaseProps,
+	LabelProps,
+} from '../types';
 
 const BorderLabel = ( props: LabelProps ) => {
 	const { label, hideLabelFromVision } = props;
@@ -33,8 +36,14 @@ const BorderLabel = ( props: LabelProps ) => {
 	);
 };
 
+export type BorderControlProps = WordPressComponentProps<
+	BorderControlBaseProps,
+	'div',
+	false
+>;
+
 const UnconnectedBorderControl = (
-	props: WordPressComponentProps< BorderControlProps, 'div', false >,
+	props: BorderControlProps,
 	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {

--- a/packages/components/src/border-control/border-control/index.ts
+++ b/packages/components/src/border-control/border-control/index.ts
@@ -1,2 +1,2 @@
-export { default as BorderControl } from './component';
+export { default as BorderControl, type BorderControlProps } from './component';
 export { useBorderControl } from './hook';

--- a/packages/components/src/border-control/index.ts
+++ b/packages/components/src/border-control/index.ts
@@ -1,2 +1,5 @@
-export { default as BorderControl } from './border-control/component';
+export {
+	default as BorderControl,
+	type BorderControlProps,
+} from './border-control/component';
 export { useBorderControl } from './border-control/hook';

--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -33,6 +33,7 @@ import type {
 	BoxControlProps,
 	BoxControlValue,
 } from './types';
+export type { BoxControlProps } from './types';
 
 const defaultInputProps = {
 	min: 0,

--- a/packages/components/src/button-group/index.tsx
+++ b/packages/components/src/button-group/index.tsx
@@ -12,11 +12,17 @@ import { forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { ButtonGroupProps } from './types';
+import type { ButtonGroupProps as ButtonGroupBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
+export type ButtonGroupProps = WordPressComponentProps<
+	ButtonGroupBaseProps,
+	'div',
+	false
+>;
+
 function UnforwardedButtonGroup(
-	props: WordPressComponentProps< ButtonGroupProps, 'div', false >,
+	props: ButtonGroupProps,
 	ref: ForwardedRef< HTMLDivElement >
 ) {
 	const { className, ...restProps } = props;

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -24,6 +24,7 @@ import Tooltip from '../tooltip';
 import Icon from '../icon';
 import { VisuallyHidden } from '../visually-hidden';
 import type { ButtonProps, DeprecatedButtonProps } from './types';
+export type { ButtonProps, DeprecatedButtonProps } from './types';
 import { positionToPlacement } from '../popover/utils';
 
 const disabledEventsOnDisabledButton = [ 'onMouseDown', 'onClick' ] as const;

--- a/packages/components/src/card/card-body/component.tsx
+++ b/packages/components/src/card/card-body/component.tsx
@@ -13,8 +13,10 @@ import { View } from '../../view';
 import { useCardBody } from './hook';
 import type { BodyProps } from '../types';
 
+export type CardBodyProps = WordPressComponentProps< BodyProps, 'div' >;
+
 function UnconnectedCardBody(
-	props: WordPressComponentProps< BodyProps, 'div' >,
+	props: CardBodyProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const { isScrollable, ...otherProps } = useCardBody( props );

--- a/packages/components/src/card/card-body/index.ts
+++ b/packages/components/src/card/card-body/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type CardBodyProps } from './component';
 export { useCardBody } from './hook';

--- a/packages/components/src/card/card-divider/component.tsx
+++ b/packages/components/src/card/card-divider/component.tsx
@@ -6,14 +6,13 @@ import type { ForwardedRef } from 'react';
 /**
  * Internal dependencies
  */
-import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import type { DividerProps } from '../../divider';
 import { Divider } from '../../divider';
 import { useCardDivider } from './hook';
 
 function UnconnectedCardDivider(
-	props: WordPressComponentProps< DividerProps, 'hr', false >,
+	props: DividerProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const dividerProps = useCardDivider( props );

--- a/packages/components/src/card/card-divider/hook.ts
+++ b/packages/components/src/card/card-divider/hook.ts
@@ -6,15 +6,12 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { WordPressComponentProps } from '../../context';
 import { useContextSystem } from '../../context';
 import * as styles from '../styles';
 import { useCx } from '../../utils/hooks/use-cx';
 import type { DividerProps } from '../../divider';
 
-export function useCardDivider(
-	props: WordPressComponentProps< DividerProps, 'hr', false >
-) {
+export function useCardDivider( props: DividerProps ) {
 	const { className, ...otherProps } = useContextSystem(
 		props,
 		'CardDivider'

--- a/packages/components/src/card/card-divider/index.ts
+++ b/packages/components/src/card/card-divider/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type CardDividerProps } from './component';
 export { useCardDivider } from './hook';

--- a/packages/components/src/card/card-footer/component.tsx
+++ b/packages/components/src/card/card-footer/component.tsx
@@ -12,8 +12,10 @@ import { Flex } from '../../flex';
 import { useCardFooter } from './hook';
 import type { FooterProps } from '../types';
 
+export type CardFooterProps = WordPressComponentProps< FooterProps, 'div' >;
+
 function UnconnectedCardFooter(
-	props: WordPressComponentProps< FooterProps, 'div' >,
+	props: CardFooterProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const footerProps = useCardFooter( props );

--- a/packages/components/src/card/card-footer/index.ts
+++ b/packages/components/src/card/card-footer/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type CardFooterProps } from './component';
 export { useCardFooter } from './hook';

--- a/packages/components/src/card/card-header/component.tsx
+++ b/packages/components/src/card/card-header/component.tsx
@@ -12,8 +12,10 @@ import { Flex } from '../../flex';
 import { useCardHeader } from './hook';
 import type { HeaderProps } from '../types';
 
+export type CardHeaderProps = WordPressComponentProps< HeaderProps, 'div' >;
+
 function UnconnectedCardHeader(
-	props: WordPressComponentProps< HeaderProps, 'div' >,
+	props: CardHeaderProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const headerProps = useCardHeader( props );

--- a/packages/components/src/card/card-header/index.ts
+++ b/packages/components/src/card/card-header/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type CardHeaderProps } from './component';
 export { useCardHeader } from './hook';

--- a/packages/components/src/card/card-media/component.tsx
+++ b/packages/components/src/card/card-media/component.tsx
@@ -12,8 +12,10 @@ import { View } from '../../view';
 import { useCardMedia } from './hook';
 import type { MediaProps } from '../types';
 
+export type CardMediaProps = WordPressComponentProps< MediaProps, 'div' >;
+
 function UnconnectedCardMedia(
-	props: WordPressComponentProps< MediaProps, 'div' >,
+	props: CardMediaProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const cardMediaProps = useCardMedia( props );

--- a/packages/components/src/card/card-media/index.ts
+++ b/packages/components/src/card/card-media/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type CardMediaProps } from './component';
 export { useCardMedia } from './hook';

--- a/packages/components/src/card/card/component.tsx
+++ b/packages/components/src/card/card/component.tsx
@@ -22,8 +22,10 @@ import CONFIG from '../../utils/config-values';
 import { useCx } from '../../utils/hooks/use-cx';
 import type { Props } from '../types';
 
+export type CardProps = WordPressComponentProps< Props, 'div' >;
+
 function UnconnectedCard(
-	props: WordPressComponentProps< Props, 'div' >,
+	props: CardProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/card/card/index.ts
+++ b/packages/components/src/card/card/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type CardProps } from './component';
 export { useCard } from './hook';

--- a/packages/components/src/card/index.ts
+++ b/packages/components/src/card/index.ts
@@ -1,6 +1,26 @@
-export { default as Card, useCard } from './card';
-export { default as CardBody, useCardBody } from './card-body';
-export { default as CardDivider, useCardDivider } from './card-divider';
-export { default as CardFooter, useCardFooter } from './card-footer';
-export { default as CardHeader, useCardHeader } from './card-header';
-export { default as CardMedia, useCardMedia } from './card-media';
+export { default as Card, type CardProps, useCard } from './card';
+export {
+	default as CardBody,
+	type CardBodyProps,
+	useCardBody,
+} from './card-body';
+export {
+	default as CardDivider,
+	type CardDividerProps,
+	useCardDivider,
+} from './card-divider';
+export {
+	default as CardFooter,
+	type CardFooterProps,
+	useCardFooter,
+} from './card-footer';
+export {
+	default as CardHeader,
+	type CardHeaderProps,
+	useCardHeader,
+} from './card-header';
+export {
+	default as CardMedia,
+	type CardMediaProps,
+	useCardMedia,
+} from './card-media';

--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -16,8 +16,14 @@ import { Icon, check, reset } from '@wordpress/icons';
  * Internal dependencies
  */
 import BaseControl from '../base-control';
-import type { CheckboxControlProps } from './types';
+import type { CheckboxControlProps as CheckboxControlBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
+
+export type CheckboxControlProps = WordPressComponentProps<
+	CheckboxControlBaseProps,
+	'input',
+	false
+>;
 
 /**
  * Checkboxes allow the user to select one or more items from a set.
@@ -39,9 +45,7 @@ import type { WordPressComponentProps } from '../context';
  * };
  * ```
  */
-export function CheckboxControl(
-	props: WordPressComponentProps< CheckboxControlProps, 'input', false >
-) {
+export function CheckboxControl( props: CheckboxControlProps ) {
 	const {
 		__nextHasNoMarginBottom,
 		label,

--- a/packages/components/src/clipboard-button/index.tsx
+++ b/packages/components/src/clipboard-button/index.tsx
@@ -14,8 +14,14 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import Button from '../button';
-import type { ClipboardButtonProps } from './types';
+import type { ClipboardButtonProps as ClipboardButtonBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
+
+export type ClipboardButtonProps = WordPressComponentProps<
+	ClipboardButtonBaseProps,
+	'button',
+	false
+>;
 
 const TIMEOUT = 4000;
 
@@ -26,7 +32,7 @@ export default function ClipboardButton( {
 	onFinishCopy,
 	text,
 	...buttonProps
-}: WordPressComponentProps< ClipboardButtonProps, 'button', false > ) {
+}: ClipboardButtonProps ) {
 	deprecated( 'wp.components.ClipboardButton', {
 		since: '5.8',
 		alternative: 'wp.compose.useCopyToClipboard',

--- a/packages/components/src/color-indicator/index.tsx
+++ b/packages/components/src/color-indicator/index.tsx
@@ -13,10 +13,16 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../context';
-import type { ColorIndicatorProps } from './types';
+import type { ColorIndicatorProps as ColorIndicatorBaseProps } from './types';
+
+export type ColorIndicatorProps = WordPressComponentProps<
+	ColorIndicatorBaseProps,
+	'span',
+	false
+>;
 
 function UnforwardedColorIndicator(
-	props: WordPressComponentProps< ColorIndicatorProps, 'span', false >,
+	props: ColorIndicatorProps,
 	forwardedRef: ForwardedRef< HTMLSpanElement >
 ) {
 	const { className, colorValue, ...additionalProps } = props;

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -26,7 +26,7 @@ import { ColorHeading } from './styles';
 import DropdownContentWrapper from '../dropdown/dropdown-content-wrapper';
 import type {
 	ColorObject,
-	ColorPaletteProps,
+	ColorPaletteProps as ColorPaletteBaseProps,
 	CustomColorPickerDropdownProps,
 	MultiplePalettesProps,
 	PaletteObject,
@@ -177,8 +177,13 @@ export function CustomColorPickerDropdown( {
 	);
 }
 
+export type ColorPaletteProps = WordPressComponentProps<
+	ColorPaletteBaseProps,
+	'div'
+>;
+
 function UnforwardedColorPalette(
-	props: WordPressComponentProps< ColorPaletteProps, 'div' >,
+	props: ColorPaletteProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/color-picker/index.ts
+++ b/packages/components/src/color-picker/index.ts
@@ -1,4 +1,7 @@
 /**
  * Internal dependencies
  */
-export { LegacyAdapter as ColorPicker } from './legacy-adapter';
+export {
+	LegacyAdapter as ColorPicker,
+	type LegacyAdapterProps as ColorPickerProps,
+} from './legacy-adapter';

--- a/packages/components/src/color-picker/legacy-adapter.tsx
+++ b/packages/components/src/color-picker/legacy-adapter.tsx
@@ -3,6 +3,7 @@
  */
 import ColorPicker from './component';
 import type { LegacyAdapterProps } from './types';
+export type { LegacyAdapterProps } from './types';
 import { useDeprecatedProps } from './use-deprecated-props';
 
 export const LegacyAdapter = ( props: LegacyAdapterProps ) => {

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -62,6 +62,8 @@ const getIndexOfMatchingSuggestion = (
 		? -1
 		: matchingSuggestions.indexOf( selectedSuggestion );
 
+export type { ComboboxControlProps } from './types';
+
 /**
  * `ComboboxControl` is an enhanced version of a [`SelectControl`](../select-control/README.md) with the addition of
  * being able to search for options using a search input.

--- a/packages/components/src/confirm-dialog/component.tsx
+++ b/packages/components/src/confirm-dialog/component.tsx
@@ -8,7 +8,10 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Modal from '../modal';
-import type { ConfirmDialogProps, DialogInputEvent } from './types';
+import type {
+	ConfirmDialogProps as ConfirmDialogBaseProps,
+	DialogInputEvent,
+} from './types';
 import type { WordPressComponentProps } from '../context';
 import { useContextSystem, contextConnect } from '../context';
 import { Flex } from '../flex';
@@ -18,8 +21,14 @@ import { VStack } from '../v-stack';
 import * as styles from './styles';
 import { useCx } from '../utils/hooks/use-cx';
 
+export type ConfirmDialogProps = WordPressComponentProps<
+	ConfirmDialogBaseProps,
+	'div',
+	false
+>;
+
 const UnconnectedConfirmDialog = (
-	props: WordPressComponentProps< ConfirmDialogProps, 'div', false >,
+	props: ConfirmDialogProps,
 	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {

--- a/packages/components/src/confirm-dialog/index.tsx
+++ b/packages/components/src/confirm-dialog/index.tsx
@@ -2,5 +2,6 @@
  * Internal dependencies
  */
 import ConfirmDialog from './component';
+import type { ConfirmDialogProps } from './component';
 
-export { ConfirmDialog };
+export { ConfirmDialog, type ConfirmDialogProps };

--- a/packages/components/src/custom-gradient-picker/index.tsx
+++ b/packages/components/src/custom-gradient-picker/index.tsx
@@ -38,6 +38,8 @@ import type {
 	GradientTypePickerProps,
 } from './types';
 
+export type { CustomGradientPickerProps } from './types';
+
 const GradientAnglePicker = ( {
 	gradientAST,
 	hasGradient,

--- a/packages/components/src/dashicon/index.tsx
+++ b/packages/components/src/dashicon/index.tsx
@@ -10,7 +10,13 @@
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../context';
-import type { DashiconProps } from './types';
+import type { DashiconProps as DashiconBaseProps } from './types';
+
+export type DashiconProps = WordPressComponentProps<
+	DashiconBaseProps,
+	'span',
+	false
+>;
 
 function Dashicon( {
 	icon,
@@ -18,7 +24,7 @@ function Dashicon( {
 	size = 20,
 	style = {},
 	...extraProps
-}: WordPressComponentProps< DashiconProps, 'span', false > ) {
+}: DashiconProps ) {
 	const iconClass = [
 		'dashicon',
 		'dashicons',

--- a/packages/components/src/date-time/date-time/index.tsx
+++ b/packages/components/src/date-time/date-time/index.tsx
@@ -17,6 +17,7 @@ import { default as TimePicker } from '../time';
 import type { DateTimePickerProps } from '../types';
 import { Wrapper } from './styles';
 
+export type { DateTimePickerProps } from '../types';
 export { DatePicker, TimePicker };
 
 const noop = () => {};

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -42,6 +42,7 @@ import { inputToDate } from '../utils';
 import Button from '../../button';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
+export type { DatePickerProps } from '../types';
 /**
  * DatePicker is a React component that renders a calendar for date selection.
  *

--- a/packages/components/src/date-time/index.ts
+++ b/packages/components/src/date-time/index.ts
@@ -1,9 +1,18 @@
 /**
  * Internal dependencies
  */
-import { default as DatePicker } from './date';
-import { default as TimePicker } from './time';
-import { default as DateTimePicker } from './date-time';
+import { default as DatePicker, type DatePickerProps } from './date';
+import { default as TimePicker, type TimePickerProps } from './time';
+import {
+	default as DateTimePicker,
+	type DateTimePickerProps,
+} from './date-time';
 
-export { DatePicker, TimePicker };
+export {
+	DatePicker,
+	TimePicker,
+	type DatePickerProps,
+	type TimePickerProps,
+	type DateTimePickerProps,
+};
 export default DateTimePicker;

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -42,6 +42,8 @@ import {
 import { inputToDate } from '../utils';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
+export type { TimePickerProps } from '../types';
+
 function from12hTo24h( hours: number, isPm: boolean ) {
 	return isPm ? ( ( hours % 12 ) + 12 ) % 24 : hours % 12;
 }

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -17,6 +17,7 @@ import sizesTable, { findSizeBySlug } from './sizes';
 import type { DimensionControlProps, Size } from './types';
 import type { SelectControlSingleSelectionProps } from '../select-control/types';
 
+export type { DimensionControlProps } from './types';
 /**
  * `DimensionControl` is a component designed to provide a UI to control spacing and/or dimensions.
  *

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -7,12 +7,14 @@ import { createContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { disabledStyles } from './styles/disabled-styles';
-import type { DisabledProps } from './types';
+import type { DisabledProps as DisabledBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 import { useCx } from '../utils';
 
 const Context = createContext< boolean >( false );
 const { Consumer, Provider } = Context;
+
+export type DisabledProps = WordPressComponentProps< DisabledBaseProps, 'div' >;
 
 /**
  * `Disabled` is a component which disables descendant tabbable elements and
@@ -56,7 +58,7 @@ function Disabled( {
 	children,
 	isDisabled = true,
 	...props
-}: WordPressComponentProps< DisabledProps, 'div' > ) {
+}: DisabledProps ) {
 	const cx = useCx();
 
 	return (

--- a/packages/components/src/disclosure/index.tsx
+++ b/packages/components/src/disclosure/index.tsx
@@ -12,19 +12,21 @@ import { forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { DisclosureContentProps } from './types';
+import type { DisclosureContentProps as DisclosureContentBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
+
+export type DisclosureContentProps = WordPressComponentProps<
+	DisclosureContentBaseProps,
+	'div',
+	false
+>;
 
 /**
  * Accessible Disclosure component that controls visibility of a section of
  * content. It follows the WAI-ARIA Disclosure Pattern.
  */
 const UnforwardedDisclosureContent = (
-	{
-		visible,
-		children,
-		...props
-	}: WordPressComponentProps< DisclosureContentProps, 'div', false >,
+	{ visible, children, ...props }: DisclosureContentProps,
 	ref: React.ForwardedRef< any >
 ) => {
 	const disclosure = Ariakit.useDisclosureStore( { open: visible } );

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -11,10 +11,16 @@ import type { ForwardedRef } from 'react';
 import type { WordPressComponentProps } from '../context';
 import { contextConnect, useContextSystem } from '../context';
 import { DividerView } from './styles';
-import type { DividerProps } from './types';
+import type { DividerProps as DividerBaseProps } from './types';
+
+export type DividerProps = WordPressComponentProps<
+	DividerBaseProps,
+	'hr',
+	false
+>;
 
 function UnconnectedDivider(
-	props: WordPressComponentProps< DividerProps, 'hr', false >,
+	props: DividerProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const contextProps = useContextSystem( props, 'Divider' );

--- a/packages/components/src/divider/index.ts
+++ b/packages/components/src/divider/index.ts
@@ -1,2 +1,1 @@
-export { default as Divider } from './component';
-export type { DividerProps } from './types';
+export { default as Divider, type DividerProps } from './component';

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -19,6 +19,8 @@ const cloneWrapperClass = 'components-draggable__clone';
 const clonePadding = 0;
 const bodyClass = 'is-dragging-components-draggable';
 
+export type { DraggableProps } from './types';
+
 /**
  * `Draggable` is a Component that provides a way to set up a cross-browser
  * (including IE) customizable drag image and the transfer data for the drag

--- a/packages/components/src/drop-zone/index.tsx
+++ b/packages/components/src/drop-zone/index.tsx
@@ -22,8 +22,14 @@ import {
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 } from '../animation';
-import type { DropType, DropZoneProps } from './types';
+import type { DropType, DropZoneProps as DropZoneBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
+
+export type DropZoneProps = WordPressComponentProps<
+	DropZoneBaseProps,
+	'div',
+	false
+>;
 
 /**
  * `DropZone` is a component creating a drop zone area taking the full size of its parent element. It supports dropping files, HTML content or any other HTML drop event.
@@ -55,7 +61,7 @@ export function DropZoneComponent( {
 	onHTMLDrop,
 	onDrop,
 	...restProps
-}: WordPressComponentProps< DropZoneProps, 'div', false > ) {
+}: DropZoneProps ) {
 	const [ isDraggingOverDocument, setIsDraggingOverDocument ] =
 		useState< boolean >();
 	const [ isDraggingOverElement, setIsDraggingOverElement ] =

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -43,6 +43,8 @@ function isFunction( maybeFunc: unknown ): maybeFunc is () => void {
 	return typeof maybeFunc === 'function';
 }
 
+export type { DropdownMenuProps } from './types';
+
 function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 	const {
 		children,

--- a/packages/components/src/dropdown/dropdown-content-wrapper.tsx
+++ b/packages/components/src/dropdown/dropdown-content-wrapper.tsx
@@ -9,10 +9,16 @@ import type { ForwardedRef } from 'react';
 import type { WordPressComponentProps } from '../context';
 import { contextConnect, useContextSystem } from '../context';
 import { DropdownContentWrapperDiv } from './styles';
-import type { DropdownContentWrapperProps } from './types';
+import type { DropdownContentWrapperProps as DropdownContentWrapperBaseProps } from './types';
+
+export type DropdownContentWrapperProps = WordPressComponentProps<
+	DropdownContentWrapperBaseProps,
+	'div',
+	false
+>;
 
 function UnconnectedDropdownContentWrapper(
-	props: WordPressComponentProps< DropdownContentWrapperProps, 'div', false >,
+	props: DropdownContentWrapperProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const { paddingSize = 'small', ...derivedProps } = useContextSystem(

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -18,6 +18,7 @@ import { contextConnect, useContextSystem } from '../context';
 import { useControlledValue } from '../utils/hooks';
 import Popover from '../popover';
 import type { DropdownProps, DropdownInternalContext } from './types';
+export type { DropdownProps } from './types';
 
 const UnconnectedDropdown = (
 	props: DropdownProps,

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -20,6 +20,7 @@ import CustomDuotoneBar from './custom-duotone-bar';
 import { getDefaultColors, getGradientFromCSSColors } from './utils';
 import { Spacer } from '../spacer';
 import type { DuotonePickerProps } from './types';
+export type { DuotonePickerProps } from './types';
 
 /**
  * ```jsx

--- a/packages/components/src/duotone-picker/duotone-swatch.tsx
+++ b/packages/components/src/duotone-picker/duotone-swatch.tsx
@@ -10,6 +10,7 @@ import ColorIndicator from '../color-indicator';
 import Icon from '../icon';
 import { getGradientFromCSSColors } from './utils';
 import type { DuotoneSwatchProps } from './types';
+export type { DuotoneSwatchProps } from './types';
 
 function DuotoneSwatch( { values }: DuotoneSwatchProps ) {
 	return values ? (

--- a/packages/components/src/duotone-picker/index.ts
+++ b/packages/components/src/duotone-picker/index.ts
@@ -1,2 +1,8 @@
-export { default as DuotonePicker } from './duotone-picker';
-export { default as DuotoneSwatch } from './duotone-swatch';
+export {
+	default as DuotonePicker,
+	type DuotonePickerProps,
+} from './duotone-picker';
+export {
+	default as DuotoneSwatch,
+	type DuotoneSwatchProps,
+} from './duotone-swatch';

--- a/packages/components/src/elevation/component.tsx
+++ b/packages/components/src/elevation/component.tsx
@@ -10,10 +10,15 @@ import type { WordPressComponentProps } from '../context';
 import { contextConnect } from '../context';
 import { View } from '../view';
 import { useElevation } from './hook';
-import type { ElevationProps } from './types';
+import type { ElevationProps as ElevationBaseProps } from './types';
+
+export type ElevationProps = WordPressComponentProps<
+	ElevationBaseProps,
+	'div'
+>;
 
 function UnconnectedElevation(
-	props: WordPressComponentProps< ElevationProps, 'div' >,
+	props: ElevationProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const elevationProps = useElevation( props );

--- a/packages/components/src/elevation/index.ts
+++ b/packages/components/src/elevation/index.ts
@@ -1,2 +1,2 @@
-export { default as Elevation } from './component';
+export { default as Elevation, type ElevationProps } from './component';
 export * from './hook';

--- a/packages/components/src/external-link/index.tsx
+++ b/packages/components/src/external-link/index.tsx
@@ -16,14 +16,16 @@ import { external } from '@wordpress/icons';
  */
 import { VisuallyHidden } from '../visually-hidden';
 import { StyledIcon } from './styles/external-link-styles';
-import type { ExternalLinkProps } from './types';
+import type { ExternalLinkProps as ExternalLinkBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
+export type ExternalLinkProps = Omit<
+	WordPressComponentProps< ExternalLinkBaseProps, 'a', false >,
+	'target'
+>;
+
 function UnforwardedExternalLink(
-	props: Omit<
-		WordPressComponentProps< ExternalLinkProps, 'a', false >,
-		'target'
-	>,
+	props: ExternalLinkProps,
 	ref: ForwardedRef< HTMLAnchorElement >
 ) {
 	const { href, children, className, rel = '', ...additionalProps } = props;

--- a/packages/components/src/flex/flex-block/component.tsx
+++ b/packages/components/src/flex/flex-block/component.tsx
@@ -9,11 +9,16 @@ import type { ForwardedRef } from 'react';
 import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { View } from '../../view';
-import type { FlexBlockProps } from '../types';
+import type { FlexBlockProps as FlexBlockBaseProps } from '../types';
 import { useFlexBlock } from './hook';
 
+export type FlexBlockProps = WordPressComponentProps<
+	FlexBlockBaseProps,
+	'div'
+>;
+
 function UnconnectedFlexBlock(
-	props: WordPressComponentProps< FlexBlockProps, 'div' >,
+	props: FlexBlockProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const flexBlockProps = useFlexBlock( props );

--- a/packages/components/src/flex/flex-block/index.ts
+++ b/packages/components/src/flex/flex-block/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type FlexBlockProps } from './component';
 export { useFlexBlock } from './hook';

--- a/packages/components/src/flex/flex-item/component.tsx
+++ b/packages/components/src/flex/flex-item/component.tsx
@@ -10,10 +10,12 @@ import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { View } from '../../view';
 import { useFlexItem } from './hook';
-import type { FlexItemProps } from '../types';
+import type { FlexItemProps as FlexItemBaseProps } from '../types';
+
+export type FlexItemProps = WordPressComponentProps< FlexItemBaseProps, 'div' >;
 
 function UnconnectedFlexItem(
-	props: WordPressComponentProps< FlexItemProps, 'div' >,
+	props: FlexItemProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const flexItemProps = useFlexItem( props );

--- a/packages/components/src/flex/flex-item/index.ts
+++ b/packages/components/src/flex/flex-item/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type FlexItemProps } from './component';
 export { useFlexItem } from './hook';

--- a/packages/components/src/flex/flex/component.tsx
+++ b/packages/components/src/flex/flex/component.tsx
@@ -11,10 +11,12 @@ import { contextConnect } from '../../context';
 import { useFlex } from './hook';
 import { FlexContext } from './../context';
 import { View } from '../../view';
-import type { FlexProps } from '../types';
+import type { FlexProps as FlexBaseProps } from '../types';
+
+export type FlexProps = WordPressComponentProps< FlexBaseProps, 'div' >;
 
 function UnconnectedFlex(
-	props: WordPressComponentProps< FlexProps, 'div' >,
+	props: FlexProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const { children, isColumn, ...otherProps } = useFlex( props );

--- a/packages/components/src/flex/flex/index.ts
+++ b/packages/components/src/flex/flex/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type FlexProps } from './component';
 export { useFlex } from './hook';

--- a/packages/components/src/flex/index.ts
+++ b/packages/components/src/flex/index.ts
@@ -1,3 +1,11 @@
-export { default as Flex, useFlex } from './flex';
-export { default as FlexItem, useFlexItem } from './flex-item';
-export { default as FlexBlock, useFlexBlock } from './flex-block';
+export { default as Flex, type FlexProps, useFlex } from './flex';
+export {
+	default as FlexItem,
+	type FlexItemProps,
+	useFlexItem,
+} from './flex-item';
+export {
+	default as FlexBlock,
+	type FlexBlockProps,
+	useFlexBlock,
+} from './flex-block';

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -31,11 +31,17 @@ import { useUpdateEffect } from '../utils/hooks';
 import type { WordPressComponentProps } from '../context/wordpress-component';
 import type {
 	FocalPoint as FocalPointType,
-	FocalPointPickerProps,
+	FocalPointPickerProps as FocalPointPickerBaseProps,
 } from './types';
 import type { KeyboardEventHandler } from 'react';
 
 const GRID_OVERLAY_TIMEOUT = 600;
+
+export type FocalPointPickerProps = WordPressComponentProps<
+	FocalPointPickerBaseProps,
+	'div',
+	false
+>;
 
 /**
  * Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image.
@@ -100,7 +106,7 @@ export function FocalPointPicker( {
 		y: 0.5,
 	},
 	...restProps
-}: WordPressComponentProps< FocalPointPickerProps, 'div', false > ) {
+}: FocalPointPickerProps ) {
 	const [ point, setPoint ] = useState( valueProp );
 	const [ showGridOverlay, setShowGridOverlay ] = useState( false );
 

--- a/packages/components/src/focal-point-picker/types.ts
+++ b/packages/components/src/focal-point-picker/types.ts
@@ -11,7 +11,7 @@ import type {
 /**
  * Internal dependencies
  */
-import type { BaseControlProps } from '../base-control/types';
+import type { BaseControlProps } from '../base-control';
 
 export type FocalPoint = Record< FocalPointAxis, number >;
 export type FocalPointAxis = 'x' | 'y';

--- a/packages/components/src/focusable-iframe/index.tsx
+++ b/packages/components/src/focusable-iframe/index.tsx
@@ -7,6 +7,7 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import type { FocusableIframeProps } from './types';
+export type { FocusableIframeProps } from './types';
 
 export default function FocusableIframe( {
 	iframeRef,

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -36,6 +36,8 @@ import FontSizePickerSelect from './font-size-picker-select';
 import FontSizePickerToggleGroup from './font-size-picker-toggle-group';
 import { T_SHIRT_NAMES } from './constants';
 
+export type { FontSizePickerProps } from './types';
+
 const UnforwardedFontSizePicker = (
 	props: FontSizePickerProps,
 	ref: ForwardedRef< any >

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -8,7 +8,13 @@ import { useRef } from '@wordpress/element';
  */
 import Button from '../button';
 import type { WordPressComponentProps } from '../context';
-import type { FormFileUploadProps } from './types';
+import type { FormFileUploadProps as FormFileUploadBaseProps } from './types';
+
+export type FormFileUploadProps = WordPressComponentProps<
+	FormFileUploadBaseProps,
+	'button',
+	false
+>;
 
 /**
  * FormFileUpload is a component that allows users to select files from their local device.
@@ -34,7 +40,7 @@ export function FormFileUpload( {
 	onClick,
 	render,
 	...props
-}: WordPressComponentProps< FormFileUploadProps, 'button', false > ) {
+}: FormFileUploadProps ) {
 	const ref = useRef< HTMLInputElement >( null );
 	const openFileDialog = () => {
 		ref.current?.click();

--- a/packages/components/src/form-toggle/index.tsx
+++ b/packages/components/src/form-toggle/index.tsx
@@ -6,10 +6,16 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import type { FormToggleProps } from './types';
+import type { FormToggleProps as FormToggleBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
 export const noop = () => {};
+
+export type FormToggleProps = WordPressComponentProps<
+	FormToggleBaseProps,
+	'input',
+	false
+>;
 
 /**
  * FormToggle switches a single setting on or off.
@@ -30,9 +36,7 @@ export const noop = () => {};
  * };
  * ```
  */
-export function FormToggle(
-	props: WordPressComponentProps< FormToggleProps, 'input', false >
-) {
+export function FormToggle( props: FormToggleProps ) {
 	const {
 		className,
 		checked,

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -32,6 +32,8 @@ import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 
 const identity = ( value: string ) => value;
 
+export type { FormTokenFieldProps } from './types';
+
 /**
  * A `FormTokenField` is a field similar to the tags and categories fields in the interim editor chrome,
  * or the "to" field in Mail on OS X. Tokens can be entered by typing them or selecting them from a list of suggested tokens.

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -18,6 +18,7 @@ import type {
 	OriginObject,
 	GradientObject,
 } from './types';
+export type { GradientPickerComponentProps } from './types';
 
 // The Multiple Origin Gradients have a `gradients` property (an array of
 // gradient objects), while Single Origin ones have a `gradient` property.

--- a/packages/components/src/grid/component.tsx
+++ b/packages/components/src/grid/component.tsx
@@ -10,10 +10,12 @@ import type { WordPressComponentProps } from '../context';
 import { contextConnect } from '../context';
 import { View } from '../view';
 import useGrid from './hook';
-import type { GridProps } from './types';
+import type { GridProps as GridBaseProps } from './types';
+
+export type GridProps = WordPressComponentProps< GridBaseProps, 'div' >;
 
 function UnconnectedGrid(
-	props: WordPressComponentProps< GridProps, 'div' >,
+	props: GridProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const gridProps = useGrid( props );

--- a/packages/components/src/grid/index.ts
+++ b/packages/components/src/grid/index.ts
@@ -1,2 +1,2 @@
-export { default as Grid } from './component';
+export { default as Grid, type GridProps } from './component';
 export { default as useGrid } from './hook';

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -18,6 +18,8 @@ import Button from '../button';
 import PageControl from './page-control';
 import type { GuideProps } from './types';
 
+export type { GuideProps } from './types';
+
 /**
  * `Guide` is a React component that renders a _user guide_ in a modal. The guide consists of several pages which the user can step through one by one. The guide is finished when the modal is closed or when the user clicks _Finish_ on the last page of the guide.
  *

--- a/packages/components/src/h-stack/component.tsx
+++ b/packages/components/src/h-stack/component.tsx
@@ -7,6 +7,11 @@ import { View } from '../view';
 import { useHStack } from './hook';
 import type { Props } from './types';
 
+// This prop is exported differently than others because creating a type and
+// then using that type in the component below causes TS union error in other
+// files. `Expression produces a union type that is too complex to represent.`
+export type HStackProps = Parameters< typeof UnconnectedHStack >[ 0 ];
+
 function UnconnectedHStack(
 	props: WordPressComponentProps< Props, 'div' >,
 	forwardedRef: React.ForwardedRef< any >

--- a/packages/components/src/h-stack/index.ts
+++ b/packages/components/src/h-stack/index.ts
@@ -1,2 +1,2 @@
-export { default as HStack } from './component';
+export { default as HStack, type HStackProps } from './component';
 export { useHStack } from './hook';

--- a/packages/components/src/heading/component.tsx
+++ b/packages/components/src/heading/component.tsx
@@ -10,10 +10,12 @@ import type { WordPressComponentProps } from '../context';
 import { contextConnect } from '../context';
 import { View } from '../view';
 import { useHeading } from './hook';
-import type { HeadingProps } from './types';
+import type { HeadingProps as HeadingBaseProps } from './types';
+
+export type HeadingProps = WordPressComponentProps< HeadingBaseProps, 'h1' >;
 
 function UnconnectedHeading(
-	props: WordPressComponentProps< HeadingProps, 'h1' >,
+	props: HeadingProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const headerProps = useHeading( props );

--- a/packages/components/src/heading/index.ts
+++ b/packages/components/src/heading/index.ts
@@ -1,2 +1,2 @@
-export { default as Heading } from './component';
+export { default as Heading, type HeadingProps } from './component';
 export { useHeading } from './hook';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -12,9 +12,13 @@ export {
 } from '@wordpress/primitives';
 
 // Components.
-export { default as __experimentalAlignmentMatrixControl } from './alignment-matrix-control';
+export {
+	default as __experimentalAlignmentMatrixControl,
+	type AlignmentMatrixControlProps as __experimentalAlignmentMatrixControlProps,
+} from './alignment-matrix-control';
 export {
 	default as Animate,
+	type AnimateProps,
 	getAnimateClassName as __unstableGetAnimateClassName,
 } from './animate';
 export {
@@ -22,185 +26,422 @@ export {
 	__unstableAnimatePresence,
 	__unstableMotionContext,
 } from './animation';
-export { default as AnglePickerControl } from './angle-picker-control';
+export {
+	default as AnglePickerControl,
+	type AnglePickerControlProps,
+} from './angle-picker-control';
 export {
 	default as Autocomplete,
+	type AutocompleteProps,
 	useAutocompleteProps as __unstableUseAutocompleteProps,
 } from './autocomplete';
-export { default as BaseControl, useBaseControlProps } from './base-control';
+export {
+	default as BaseControl,
+	type BaseControlProps,
+	useBaseControlProps,
+} from './base-control';
 export {
 	BorderBoxControl as __experimentalBorderBoxControl,
+	type BorderBoxControlProps as __experimentalBorderBoxControlProps,
 	hasSplitBorders as __experimentalHasSplitBorders,
 	isDefinedBorder as __experimentalIsDefinedBorder,
 	isEmptyBorder as __experimentalIsEmptyBorder,
 } from './border-box-control';
-export { BorderControl as __experimentalBorderControl } from './border-control';
+export {
+	BorderControl as __experimentalBorderControl,
+	type BorderControlProps as __experimentalBorderControlProps,
+} from './border-control';
 export {
 	default as __experimentalBoxControl,
+	type BoxControlProps as __experimentalBoxControlProps,
 	applyValueToSides as __experimentalApplyValueToSides,
 } from './box-control';
-export { default as Button } from './button';
-export { default as ButtonGroup } from './button-group';
+export {
+	default as Button,
+	type ButtonProps,
+	type DeprecatedButtonProps,
+} from './button';
+export { default as ButtonGroup, type ButtonGroupProps } from './button-group';
 export {
 	Card,
+	type CardProps,
 	CardBody,
+	type CardBodyProps,
 	CardDivider,
+	type CardDividerProps,
 	CardFooter,
+	type CardFooterProps,
 	CardHeader,
+	type CardHeaderProps,
 	CardMedia,
+	type CardMediaProps,
 } from './card';
-export { default as CheckboxControl } from './checkbox-control';
-export { default as ClipboardButton } from './clipboard-button';
-export { default as __experimentalPaletteEdit } from './palette-edit';
-export { default as ColorIndicator } from './color-indicator';
-export { default as ColorPalette } from './color-palette';
-export { ColorPicker } from './color-picker';
-export { default as ComboboxControl } from './combobox-control';
+export {
+	default as CheckboxControl,
+	type CheckboxControlProps,
+} from './checkbox-control';
+export {
+	default as ClipboardButton,
+	type ClipboardButtonProps,
+} from './clipboard-button';
+export {
+	default as __experimentalPaletteEdit,
+	type PaletteEditProps as __experimentalPaletteEditProps,
+} from './palette-edit';
+export {
+	default as ColorIndicator,
+	type ColorIndicatorProps,
+} from './color-indicator';
+export {
+	default as ColorPalette,
+	type ColorPaletteProps,
+} from './color-palette';
+export { ColorPicker, type ColorPickerProps } from './color-picker';
+export {
+	default as ComboboxControl,
+	type ComboboxControlProps,
+} from './combobox-control';
 export {
 	Composite as __unstableComposite,
 	CompositeGroup as __unstableCompositeGroup,
 	CompositeItem as __unstableCompositeItem,
 	useCompositeState as __unstableUseCompositeState,
 } from './composite';
-export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
+export {
+	ConfirmDialog as __experimentalConfirmDialog,
+	type ConfirmDialogProps as __experimentalConfirmDialogProps,
+} from './confirm-dialog';
 export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
-export { default as Dashicon } from './dashicon';
-export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
-export { default as __experimentalDimensionControl } from './dimension-control';
-export { default as Disabled } from './disabled';
-export { DisclosureContent as __unstableDisclosureContent } from './disclosure';
-export { Divider as __experimentalDivider } from './divider';
-export { default as Draggable } from './draggable';
-export { default as DropZone } from './drop-zone';
+export { default as Dashicon, type DashiconProps } from './dashicon';
+export {
+	default as DateTimePicker,
+	type DateTimePickerProps,
+	DatePicker,
+	type DatePickerProps,
+	TimePicker,
+	type TimePickerProps,
+} from './date-time';
+export {
+	default as __experimentalDimensionControl,
+	type DimensionControlProps as __experimentalDimensionControlProps,
+} from './dimension-control';
+export { default as Disabled, type DisabledProps } from './disabled';
+export {
+	DisclosureContent as __unstableDisclosureContent,
+	type DisclosureContentProps as __unstableDisclosureContentProps,
+} from './disclosure';
+export {
+	Divider as __experimentalDivider,
+	type DividerProps as __experimentalDividerProps,
+} from './divider';
+export { default as Draggable, type DraggableProps } from './draggable';
+export { default as DropZone, type DropZoneProps } from './drop-zone';
 export { default as DropZoneProvider } from './drop-zone/provider';
-export { default as Dropdown } from './dropdown';
-export { default as __experimentalDropdownContentWrapper } from './dropdown/dropdown-content-wrapper';
-export { default as DropdownMenu } from './dropdown-menu';
-export { DuotoneSwatch, DuotonePicker } from './duotone-picker';
-export { Elevation as __experimentalElevation } from './elevation';
-export { default as ExternalLink } from './external-link';
-export { Flex, FlexBlock, FlexItem } from './flex';
-export { default as FocalPointPicker } from './focal-point-picker';
-export { default as FocusableIframe } from './focusable-iframe';
-export { default as FontSizePicker } from './font-size-picker';
-export { default as FormFileUpload } from './form-file-upload';
-export { default as FormToggle } from './form-toggle';
-export { default as FormTokenField } from './form-token-field';
-export { default as GradientPicker } from './gradient-picker';
-export { default as CustomGradientPicker } from './custom-gradient-picker';
-export { Grid as __experimentalGrid } from './grid';
-export { default as Guide } from './guide';
+export { default as Dropdown, type DropdownProps } from './dropdown';
+export {
+	default as __experimentalDropdownContentWrapper,
+	type DropdownContentWrapperProps as __experimentalDropdownContentWrapperProps,
+} from './dropdown/dropdown-content-wrapper';
+export {
+	default as DropdownMenu,
+	type DropdownMenuProps,
+} from './dropdown-menu';
+export {
+	DuotoneSwatch,
+	type DuotoneSwatchProps,
+	DuotonePicker,
+	type DuotonePickerProps,
+} from './duotone-picker';
+export {
+	Elevation as __experimentalElevation,
+	type ElevationProps as __experimentalElevationProps,
+} from './elevation';
+export {
+	default as ExternalLink,
+	type ExternalLinkProps,
+} from './external-link';
+export {
+	Flex,
+	type FlexProps,
+	FlexBlock,
+	type FlexBlockProps,
+	FlexItem,
+	type FlexItemProps,
+} from './flex';
+export {
+	default as FocalPointPicker,
+	type FocalPointPickerProps,
+} from './focal-point-picker';
+export {
+	default as FocusableIframe,
+	type FocusableIframeProps,
+} from './focusable-iframe';
+export {
+	default as FontSizePicker,
+	type FontSizePickerProps,
+} from './font-size-picker';
+export {
+	default as FormFileUpload,
+	type FormFileUploadProps,
+} from './form-file-upload';
+export { default as FormToggle, type FormToggleProps } from './form-toggle';
+export {
+	default as FormTokenField,
+	type FormTokenFieldProps,
+} from './form-token-field';
+export {
+	default as GradientPicker,
+	type GradientPickerComponentProps,
+} from './gradient-picker';
+export {
+	default as CustomGradientPicker,
+	type CustomGradientPickerProps,
+} from './custom-gradient-picker';
+export {
+	Grid as __experimentalGrid,
+	type GridProps as __experimentalGridProps,
+} from './grid';
+export { default as Guide, type GuideProps } from './guide';
 export { default as GuidePage } from './guide/page';
-export { Heading as __experimentalHeading } from './heading';
-export { HStack as __experimentalHStack } from './h-stack';
-export { default as Icon } from './icon';
-export type { IconType } from './icon';
+export {
+	Heading as __experimentalHeading,
+	type HeadingProps as __experimentalHeadingProps,
+} from './heading';
+export {
+	HStack as __experimentalHStack,
+	type HStackProps as __experimentalHStackProps,
+} from './h-stack';
+export {
+	default as Icon,
+	type Props as IconProps,
+	type IconType,
+} from './icon';
 export { default as IconButton } from './button/deprecated';
 export {
 	ItemGroup as __experimentalItemGroup,
+	type ItemGroupProps as __experimentalItemGroupProps,
 	Item as __experimentalItem,
+	type ItemProps as __experimentalItemProps,
 } from './item-group';
-export { default as __experimentalInputControl } from './input-control';
-export { default as __experimentalInputControlPrefixWrapper } from './input-control/input-prefix-wrapper';
-export { default as __experimentalInputControlSuffixWrapper } from './input-control/input-suffix-wrapper';
-export { default as KeyboardShortcuts } from './keyboard-shortcuts';
-export { default as MenuGroup } from './menu-group';
-export { default as MenuItem } from './menu-item';
-export { default as MenuItemsChoice } from './menu-items-choice';
-export { default as Modal } from './modal';
+export {
+	default as __experimentalInputControl,
+	type InputControlProps as __experimentalInputControlProps,
+} from './input-control';
+export {
+	default as __experimentalInputControlPrefixWrapper,
+	type InputControlPrefixWrapperProps as __experimentalInputControlPrefixWrapperProps,
+} from './input-control/input-prefix-wrapper';
+export {
+	default as __experimentalInputControlSuffixWrapper,
+	type InputControlSuffixWrapperProps as __experimentalInputControlSuffixWrapperProps,
+} from './input-control/input-suffix-wrapper';
+export {
+	default as KeyboardShortcuts,
+	type KeyboardShortcutsProps,
+} from './keyboard-shortcuts';
+export { default as MenuGroup, type MenuGroupProps } from './menu-group';
+export { default as MenuItem, type MenuItemProps } from './menu-item';
+export {
+	default as MenuItemsChoice,
+	type MenuItemsChoiceProps,
+} from './menu-items-choice';
+export { default as Modal, type ModalProps } from './modal';
 export { default as ScrollLock } from './scroll-lock';
-export { NavigableMenu, TabbableContainer } from './navigable-container';
-export { default as __experimentalNavigation } from './navigation';
-export { default as __experimentalNavigationBackButton } from './navigation/back-button';
-export { default as __experimentalNavigationGroup } from './navigation/group';
-export { default as __experimentalNavigationItem } from './navigation/item';
-export { default as __experimentalNavigationMenu } from './navigation/menu';
+export {
+	NavigableMenu,
+	type NavigableMenuProps,
+	TabbableContainer,
+	type TabbableContainerProps,
+} from './navigable-container';
+export {
+	default as __experimentalNavigation,
+	type NavigationProps as __experimentalNavigationProps,
+} from './navigation';
+export {
+	default as __experimentalNavigationBackButton,
+	type NavigationBackButtonProps as __experimentalNavigationBackButtonProps,
+} from './navigation/back-button';
+export {
+	default as __experimentalNavigationGroup,
+	type NavigationGroupProps as __experimentalNavigationGroupProps,
+} from './navigation/group';
+export {
+	default as __experimentalNavigationItem,
+	type NavigationItemProps as __experimentalNavigationItemProps,
+} from './navigation/item';
+export {
+	default as __experimentalNavigationMenu,
+	type NavigationMenuProps as __experimentalNavigationMenuProps,
+} from './navigation/menu';
 export {
 	NavigatorProvider as __experimentalNavigatorProvider,
+	type NavigatorProviderProps as __experimentalNavigatorProviderProps,
 	NavigatorScreen as __experimentalNavigatorScreen,
+	type NavigatorScreenProps as __experimentalNavigatorScreenProps,
 	NavigatorButton as __experimentalNavigatorButton,
+	type NavigatorButtonProps as __experimentalNavigatorButtonProps,
 	NavigatorBackButton as __experimentalNavigatorBackButton,
+	type NavigatorBackButtonProps as __experimentalNavigatorBackButtonProps,
 	NavigatorToParentButton as __experimentalNavigatorToParentButton,
+	type NavigatorToParentButtonProps as __experimentalNavigatorToParentButtonProps,
 	useNavigator as __experimentalUseNavigator,
 } from './navigator';
-export { default as Notice } from './notice';
-export { default as __experimentalNumberControl } from './number-control';
-export { default as NoticeList } from './notice/list';
-export { default as Panel } from './panel';
-export { default as PanelBody } from './panel/body';
-export { default as PanelHeader } from './panel/header';
-export { default as PanelRow } from './panel/row';
-export { default as Placeholder } from './placeholder';
-export { default as Popover } from './popover';
-export { default as QueryControls } from './query-controls';
+export { default as Notice, type NoticeProps } from './notice';
+export {
+	default as __experimentalNumberControl,
+	type NumberControlProps as __experimentalNumberControlProps,
+} from './number-control';
+export { default as NoticeList, type NoticeListProps } from './notice/list';
+export { default as Panel, type PanelProps } from './panel';
+export { default as PanelBody, type PanelBodyProps } from './panel/body';
+export { default as PanelHeader, type PanelHeaderProps } from './panel/header';
+export { default as PanelRow, type PanelRowProps } from './panel/row';
+export { default as Placeholder, type PlaceholderProps } from './placeholder';
+export { default as Popover, type PopoverProps } from './popover';
+export {
+	default as QueryControls,
+	type QueryControlsProps,
+} from './query-controls';
 export { default as __experimentalRadio } from './radio-group/radio';
 export { default as __experimentalRadioGroup } from './radio-group';
-export { default as RadioControl } from './radio-control';
-export { default as RangeControl } from './range-control';
-export { default as ResizableBox } from './resizable-box';
-export { default as ResponsiveWrapper } from './responsive-wrapper';
-export { default as SandBox } from './sandbox';
-export { default as SearchControl } from './search-control';
-export { default as SelectControl } from './select-control';
-export { default as Snackbar } from './snackbar';
-export { default as SnackbarList } from './snackbar/list';
-export { Spacer as __experimentalSpacer } from './spacer';
-export { Scrollable as __experimentalScrollable } from './scrollable';
-export { default as Spinner } from './spinner';
-export { Surface as __experimentalSurface } from './surface';
-export { default as TabPanel } from './tab-panel';
-export { Text as __experimentalText } from './text';
-export { default as TextControl } from './text-control';
-export { default as TextareaControl } from './textarea-control';
-export { default as TextHighlight } from './text-highlight';
-export { default as Tip } from './tip';
-export { default as ToggleControl } from './toggle-control';
+export {
+	default as RadioControl,
+	type RadioControlProps,
+} from './radio-control';
+export {
+	default as RangeControl,
+	type RangeControlProps,
+} from './range-control';
+export {
+	default as ResizableBox,
+	type ResizableBoxProps,
+} from './resizable-box';
+export {
+	default as ResponsiveWrapper,
+	type ResponsiveWrapperProps,
+} from './responsive-wrapper';
+export { default as SandBox, type SandBoxProps } from './sandbox';
+export {
+	default as SearchControl,
+	type SearchControlProps,
+} from './search-control';
+export {
+	default as SelectControl,
+	type SelectControlProps,
+} from './select-control';
+export { default as Snackbar, type SnackbarProps } from './snackbar';
+export {
+	default as SnackbarList,
+	type SnackbarListProps,
+} from './snackbar/list';
+export {
+	Spacer as __experimentalSpacer,
+	type SpacerProps as __experimentalSpacerProps,
+} from './spacer';
+export {
+	Scrollable as __experimentalScrollable,
+	type ScrollableProps as __experimentalScrollableProps,
+} from './scrollable';
+export { default as Spinner, type SpinnerProps } from './spinner';
+export {
+	Surface as __experimentalSurface,
+	type SurfaceProps as __experimentalSurfaceProps,
+} from './surface';
+export { default as TabPanel, type TabPanelProps } from './tab-panel';
+export {
+	Text as __experimentalText,
+	type TextProps as __experimentalTextProps,
+} from './text';
+export { default as TextControl, type TextControlProps } from './text-control';
+export {
+	default as TextareaControl,
+	type TextareaControlProps,
+} from './textarea-control';
+export {
+	default as TextHighlight,
+	type TextHighlightProps,
+} from './text-highlight';
+export { default as Tip, type TipProps } from './tip';
+export {
+	default as ToggleControl,
+	type ToggleControlProps,
+} from './toggle-control';
 export {
 	ToggleGroupControl as __experimentalToggleGroupControl,
+	type ToggleGroupControlProps as __experimentalToggleGroupControlProps,
 	ToggleGroupControlOption as __experimentalToggleGroupControlOption,
+	type ToggleGroupControlOptionProps as __experimentalToggleGroupControlOptionProps,
 	ToggleGroupControlOptionIcon as __experimentalToggleGroupControlOptionIcon,
+	type ToggleGroupControlOptionIconProps as __experimentalToggleGroupControlOptionIconProps,
 } from './toggle-group-control';
 export {
 	Toolbar,
+	type ToolbarProps,
 	ToolbarButton,
+	type ToolbarButtonProps,
 	ToolbarContext as __experimentalToolbarContext,
 	ToolbarDropdownMenu,
+	type ToolbarDropdownMenuProps,
 	ToolbarGroup,
+	type ToolbarGroupProps,
 	ToolbarItem,
+	type ToolbarItemProps,
 } from './toolbar';
 export {
 	ToolsPanel as __experimentalToolsPanel,
+	type ToolsPanelProps as __experimentalToolsPanelProps,
 	ToolsPanelItem as __experimentalToolsPanelItem,
+	type ToolsPanelItemProps as __experimentalToolsPanelItemProps,
 	ToolsPanelContext as __experimentalToolsPanelContext,
 } from './tools-panel';
-export { default as Tooltip } from './tooltip';
+export { default as Tooltip, type TooltipProps } from './tooltip';
 export {
 	default as __experimentalTreeGrid,
+	type TreeGridProps as __experimentalTreeGridProps,
 	TreeGridRow as __experimentalTreeGridRow,
+	type TreeGridRowProps as __experimentalTreeGridRowProps,
 	TreeGridCell as __experimentalTreeGridCell,
+	type TreeGridCellProps as __experimentalTreeGridCellProps,
 	TreeGridItem as __experimentalTreeGridItem,
+	type TreeGridItemProps as __experimentalTreeGridItemProps,
 } from './tree-grid';
-export { default as TreeSelect } from './tree-select';
-export { Truncate as __experimentalTruncate } from './truncate';
+export { default as TreeSelect, type TreeSelectProps } from './tree-select';
+export {
+	Truncate as __experimentalTruncate,
+	type TruncateProps as __experimentalTruncateProps,
+} from './truncate';
 export {
 	default as __experimentalUnitControl,
+	type UnitControlProps as __experimentalUnitControlProps,
 	useCustomUnits as __experimentalUseCustomUnits,
 	parseQuantityAndUnitFromRawValue as __experimentalParseQuantityAndUnitFromRawValue,
 } from './unit-control';
 export { View as __experimentalView } from './view';
-export { VisuallyHidden } from './visually-hidden';
-export { VStack as __experimentalVStack } from './v-stack';
+export { VisuallyHidden, type VisuallyHiddenProps } from './visually-hidden';
+export {
+	VStack as __experimentalVStack,
+	type VStackProps as __experimentalVStackProps,
+} from './v-stack';
 export { default as IsolatedEventContainer } from './isolated-event-container';
 export {
 	createSlotFill,
 	Slot,
+	type SlotProps,
 	Fill,
+	type FillProps,
 	Provider as SlotFillProvider,
+	type SlotFillProviderProps,
 	useSlot as __experimentalUseSlot,
 	useSlotFills as __experimentalUseSlotFills,
 } from './slot-fill';
-export { default as __experimentalStyleProvider } from './style-provider';
-export { ZStack as __experimentalZStack } from './z-stack';
+export {
+	default as __experimentalStyleProvider,
+	type StyleProviderProps as __experimentalStyleProviderProps,
+} from './style-provider';
+export {
+	ZStack as __experimentalZStack,
+	type ZStackProps as __experimentalZStackProps,
+} from './z-stack';
 
 // Higher-Order Components.
 export {
@@ -220,3 +461,5 @@ export { default as withSpokenMessages } from './higher-order/with-spoken-messag
 
 // Private APIs.
 export { privateApis } from './private-apis';
+
+// Deprecated components

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -30,6 +30,7 @@ function useUniqueId( idProp?: string ) {
 	return idProp || id;
 }
 
+export type { InputControlProps } from './types';
 export function UnforwardedInputControl(
 	props: InputControlProps,
 	ref: ForwardedRef< HTMLInputElement >

--- a/packages/components/src/input-control/input-prefix-wrapper.tsx
+++ b/packages/components/src/input-control/input-prefix-wrapper.tsx
@@ -9,10 +9,15 @@ import type { ForwardedRef } from 'react';
 import { Spacer } from '../spacer';
 import type { WordPressComponentProps } from '../context';
 import { contextConnect, useContextSystem } from '../context';
-import type { InputControlPrefixWrapperProps } from './types';
+import type { InputControlPrefixWrapperProps as InputControlPrefixWrapperBaseProps } from './types';
+
+export type InputControlPrefixWrapperProps = WordPressComponentProps<
+	InputControlPrefixWrapperBaseProps,
+	'div'
+>;
 
 function UnconnectedInputControlPrefixWrapper(
-	props: WordPressComponentProps< InputControlPrefixWrapperProps, 'div' >,
+	props: InputControlPrefixWrapperProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const derivedProps = useContextSystem( props, 'InputControlPrefixWrapper' );

--- a/packages/components/src/input-control/input-suffix-wrapper.tsx
+++ b/packages/components/src/input-control/input-suffix-wrapper.tsx
@@ -9,10 +9,15 @@ import type { ForwardedRef } from 'react';
 import { Spacer } from '../spacer';
 import type { WordPressComponentProps } from '../context';
 import { contextConnect, useContextSystem } from '../context';
-import type { InputControlSuffixWrapperProps } from './types';
+import type { InputControlSuffixWrapperProps as InputControlSuffixWrapperBaseProps } from './types';
+
+export type InputControlSuffixWrapperProps = WordPressComponentProps<
+	InputControlSuffixWrapperBaseProps,
+	'div'
+>;
 
 function UnconnectedInputControlSuffixWrapper(
-	props: WordPressComponentProps< InputControlSuffixWrapperProps, 'div' >,
+	props: InputControlSuffixWrapperProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const derivedProps = useContextSystem( props, 'InputControlSuffixWrapper' );

--- a/packages/components/src/item-group/index.ts
+++ b/packages/components/src/item-group/index.ts
@@ -1,2 +1,2 @@
-export { default as Item } from './item';
-export { default as ItemGroup } from './item-group';
+export { default as Item, type ItemProps } from './item';
+export { default as ItemGroup, type ItemGroupProps } from './item-group';

--- a/packages/components/src/item-group/item-group/component.tsx
+++ b/packages/components/src/item-group/item-group/component.tsx
@@ -11,10 +11,15 @@ import { contextConnect } from '../../context';
 import { useItemGroup } from './hook';
 import { ItemGroupContext, useItemGroupContext } from '../context';
 import { View } from '../../view';
-import type { ItemGroupProps } from '../types';
+import type { ItemGroupProps as ItemGroupBaseProps } from '../types';
+
+export type ItemGroupProps = WordPressComponentProps<
+	ItemGroupBaseProps,
+	'div'
+>;
 
 function UnconnectedItemGroup(
-	props: WordPressComponentProps< ItemGroupProps, 'div' >,
+	props: ItemGroupProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/item-group/item-group/index.ts
+++ b/packages/components/src/item-group/item-group/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type ItemGroupProps } from './component';
 export { useItemGroup } from './hook';

--- a/packages/components/src/item-group/item/component.tsx
+++ b/packages/components/src/item-group/item/component.tsx
@@ -6,14 +6,16 @@ import type { ForwardedRef } from 'react';
 /**
  * Internal dependencies
  */
-import type { ItemProps } from '../types';
+import type { ItemProps as ItemBaseProps } from '../types';
 import { useItem } from './hook';
 import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { View } from '../../view';
 
+export type ItemProps = WordPressComponentProps< ItemBaseProps, 'div' >;
+
 function UnconnectedItem(
-	props: WordPressComponentProps< ItemProps, 'div' >,
+	props: ItemProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const { role, wrapperClassName, ...otherProps } = useItem( props );

--- a/packages/components/src/item-group/item/index.ts
+++ b/packages/components/src/item-group/item/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type ItemProps } from './component';
 export { useItem } from './hook';

--- a/packages/components/src/keyboard-shortcuts/index.tsx
+++ b/packages/components/src/keyboard-shortcuts/index.tsx
@@ -8,6 +8,7 @@ import { useKeyboardShortcut } from '@wordpress/compose';
  * Internal dependencies
  */
 import type { KeyboardShortcutProps, KeyboardShortcutsProps } from './types';
+export type { KeyboardShortcutsProps } from './types';
 
 function KeyboardShortcut( {
 	target,

--- a/packages/components/src/menu-group/index.tsx
+++ b/packages/components/src/menu-group/index.tsx
@@ -13,6 +13,7 @@ import { useInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import type { MenuGroupProps } from './types';
+export type { MenuGroupProps } from './types';
 
 /**
  * `MenuGroup` wraps a series of related `MenuItem` components into a common

--- a/packages/components/src/menu-item/index.tsx
+++ b/packages/components/src/menu-item/index.tsx
@@ -16,10 +16,16 @@ import Shortcut from '../shortcut';
 import Button from '../button';
 import Icon from '../icon';
 import type { WordPressComponentProps } from '../context';
-import type { MenuItemProps } from './types';
+import type { MenuItemProps as MenuItemBaseProps } from './types';
+
+export type MenuItemProps = WordPressComponentProps<
+	MenuItemBaseProps,
+	'button',
+	false
+>;
 
 function UnforwardedMenuItem(
-	props: WordPressComponentProps< MenuItemProps, 'button', false >,
+	props: MenuItemProps,
 	ref: ForwardedRef< HTMLButtonElement >
 ) {
 	let {

--- a/packages/components/src/menu-items-choice/index.tsx
+++ b/packages/components/src/menu-items-choice/index.tsx
@@ -8,6 +8,7 @@ import { check } from '@wordpress/icons';
  */
 import MenuItem from '../menu-item';
 import type { MenuItemsChoiceProps } from './types';
+export type { MenuItemsChoiceProps } from './types';
 
 const noop = () => {};
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -43,6 +43,8 @@ import StyleProvider from '../style-provider';
 import type { ModalProps } from './types';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 
+export type { ModalProps } from './types';
+
 // Used to track and dismiss the prior modal when another opens unless nested.
 const ModalContext = createContext<
 	MutableRefObject< ModalProps[ 'onRequestClose' ] | undefined >[]

--- a/packages/components/src/navigable-container/index.tsx
+++ b/packages/components/src/navigable-container/index.tsx
@@ -1,5 +1,8 @@
 /**
  * Internal Dependencies
  */
-export { default as NavigableMenu } from './menu';
-export { default as TabbableContainer } from './tabbable';
+export { default as NavigableMenu, type NavigableMenuProps } from './menu';
+export {
+	default as TabbableContainer,
+	type TabbableContainerProps,
+} from './tabbable';

--- a/packages/components/src/navigable-container/menu.tsx
+++ b/packages/components/src/navigable-container/menu.tsx
@@ -13,6 +13,7 @@ import { forwardRef } from '@wordpress/element';
  */
 import NavigableContainer from './container';
 import type { NavigableMenuProps } from './types';
+export type { NavigableMenuProps } from './types';
 
 export function UnforwardedNavigableMenu(
 	{ role = 'menu', orientation = 'vertical', ...rest }: NavigableMenuProps,

--- a/packages/components/src/navigable-container/tabbable.tsx
+++ b/packages/components/src/navigable-container/tabbable.tsx
@@ -13,6 +13,7 @@ import { forwardRef } from '@wordpress/element';
  */
 import NavigableContainer from './container';
 import type { TabbableContainerProps } from './types';
+export type { TabbableContainerProps } from './types';
 
 export function UnforwardedTabbableContainer(
 	{ eventToOffset, ...props }: TabbableContainerProps,

--- a/packages/components/src/navigation/back-button/index.tsx
+++ b/packages/components/src/navigation/back-button/index.tsx
@@ -16,6 +16,7 @@ import { useNavigationContext } from '../context';
 import { MenuBackButtonUI } from '../styles/navigation-styles';
 
 import type { NavigationBackButtonProps } from '../types';
+export type { NavigationBackButtonProps } from '../types';
 
 function UnforwardedNavigationBackButton(
 	{

--- a/packages/components/src/navigation/group/index.tsx
+++ b/packages/components/src/navigation/group/index.tsx
@@ -16,6 +16,7 @@ import { GroupTitleUI } from '../styles/navigation-styles';
 import { useNavigationContext } from '../context';
 
 import type { NavigationGroupProps } from '../types';
+export type { NavigationGroupProps } from '../types';
 
 let uniqueId = 0;
 

--- a/packages/components/src/navigation/index.tsx
+++ b/packages/components/src/navigation/index.tsx
@@ -22,6 +22,7 @@ import type {
 	NavigationProps,
 	NavigationContext as NavigationContextType,
 } from './types';
+export type { NavigationProps } from './types';
 
 const noop = () => {};
 

--- a/packages/components/src/navigation/item/index.tsx
+++ b/packages/components/src/navigation/item/index.tsx
@@ -19,6 +19,7 @@ import NavigationItemBaseContent from './base-content';
 import NavigationItemBase from './base';
 
 import type { NavigationItemProps } from '../types';
+export type { NavigationItemProps } from '../types';
 
 const noop = () => {};
 

--- a/packages/components/src/navigation/menu/index.tsx
+++ b/packages/components/src/navigation/menu/index.tsx
@@ -22,6 +22,7 @@ import { NavigableMenu } from '../../navigable-container';
 import { MenuUI } from '../styles/navigation-styles';
 
 import type { NavigationMenuProps } from '../types';
+export type { NavigationMenuProps } from '../types';
 
 export function NavigationMenu( props: NavigationMenuProps ) {
 	const {

--- a/packages/components/src/navigator/index.ts
+++ b/packages/components/src/navigator/index.ts
@@ -1,6 +1,15 @@
-export { NavigatorProvider } from './navigator-provider';
-export { NavigatorScreen } from './navigator-screen';
-export { NavigatorButton } from './navigator-button';
-export { NavigatorBackButton } from './navigator-back-button';
-export { NavigatorToParentButton } from './navigator-to-parent-button';
+export {
+	NavigatorProvider,
+	type NavigatorProviderProps,
+} from './navigator-provider';
+export { NavigatorScreen, type NavigatorScreenProps } from './navigator-screen';
+export { NavigatorButton, type NavigatorButtonProps } from './navigator-button';
+export {
+	NavigatorBackButton,
+	type NavigatorBackButtonProps,
+} from './navigator-back-button';
+export {
+	NavigatorToParentButton,
+	type NavigatorToParentButtonProps,
+} from './navigator-to-parent-button';
 export { default as useNavigator } from './use-navigator';

--- a/packages/components/src/navigator/navigator-back-button/component.tsx
+++ b/packages/components/src/navigator/navigator-back-button/component.tsx
@@ -10,10 +10,15 @@ import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { View } from '../../view';
 import { useNavigatorBackButton } from './hook';
-import type { NavigatorBackButtonProps } from '../types';
+import type { NavigatorBackButtonProps as NavigatorBackButtonBaseProps } from '../types';
+
+export type NavigatorBackButtonProps = WordPressComponentProps<
+	NavigatorBackButtonBaseProps,
+	'button'
+>;
 
 function UnconnectedNavigatorBackButton(
-	props: WordPressComponentProps< NavigatorBackButtonProps, 'button' >,
+	props: NavigatorBackButtonProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const navigatorBackButtonProps = useNavigatorBackButton( props );

--- a/packages/components/src/navigator/navigator-back-button/index.ts
+++ b/packages/components/src/navigator/navigator-back-button/index.ts
@@ -1,1 +1,4 @@
-export { default as NavigatorBackButton } from './component';
+export {
+	default as NavigatorBackButton,
+	type NavigatorBackButtonProps,
+} from './component';

--- a/packages/components/src/navigator/navigator-button/component.tsx
+++ b/packages/components/src/navigator/navigator-button/component.tsx
@@ -10,10 +10,15 @@ import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { View } from '../../view';
 import { useNavigatorButton } from './hook';
-import type { NavigatorButtonProps } from '../types';
+import type { NavigatorButtonProps as NavigatorButtonBaseProps } from '../types';
+
+export type NavigatorButtonProps = WordPressComponentProps<
+	NavigatorButtonBaseProps,
+	'button'
+>;
 
 function UnconnectedNavigatorButton(
-	props: WordPressComponentProps< NavigatorButtonProps, 'button' >,
+	props: NavigatorButtonProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const navigatorButtonProps = useNavigatorButton( props );

--- a/packages/components/src/navigator/navigator-button/index.ts
+++ b/packages/components/src/navigator/navigator-button/index.ts
@@ -1,1 +1,4 @@
-export { default as NavigatorButton } from './component';
+export {
+	default as NavigatorButton,
+	type NavigatorButtonProps,
+} from './component';

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -27,7 +27,7 @@ import { View } from '../../view';
 import { NavigatorContext } from '../context';
 import * as styles from '../styles';
 import type {
-	NavigatorProviderProps,
+	NavigatorProviderProps as NavigatorProviderBaseProps,
 	NavigatorLocation,
 	NavigatorContext as NavigatorContextType,
 	Screen,
@@ -52,8 +52,13 @@ function screensReducer(
 	return state;
 }
 
+export type NavigatorProviderProps = WordPressComponentProps<
+	NavigatorProviderBaseProps,
+	'div'
+>;
+
 function UnconnectedNavigatorProvider(
-	props: WordPressComponentProps< NavigatorProviderProps, 'div' >,
+	props: NavigatorProviderProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const { initialPath, children, className, ...otherProps } =

--- a/packages/components/src/navigator/navigator-provider/index.ts
+++ b/packages/components/src/navigator/navigator-provider/index.ts
@@ -1,1 +1,4 @@
-export { default as NavigatorProvider } from './component';
+export {
+	default as NavigatorProvider,
+	type NavigatorProviderProps,
+} from './component';

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -27,10 +27,16 @@ import { useCx } from '../../utils/hooks/use-cx';
 import { View } from '../../view';
 import { NavigatorContext } from '../context';
 import * as styles from '../styles';
-import type { NavigatorScreenProps } from '../types';
+import type { NavigatorScreenProps as NavigatorScreenBaseProps } from '../types';
+
+export type NavigatorScreenProps = WordPressComponentProps<
+	NavigatorScreenBaseProps,
+	'div',
+	false
+>;
 
 function UnconnectedNavigatorScreen(
-	props: WordPressComponentProps< NavigatorScreenProps, 'div', false >,
+	props: NavigatorScreenProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const screenId = useId();

--- a/packages/components/src/navigator/navigator-screen/index.ts
+++ b/packages/components/src/navigator/navigator-screen/index.ts
@@ -1,1 +1,4 @@
-export { default as NavigatorScreen } from './component';
+export {
+	default as NavigatorScreen,
+	type NavigatorScreenProps,
+} from './component';

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -10,10 +10,15 @@ import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { View } from '../../view';
 import { useNavigatorBackButton } from '../navigator-back-button/hook';
-import type { NavigatorToParentButtonProps } from '../types';
+import type { NavigatorToParentButtonProps as NavigatorToParentButtonBaseProps } from '../types';
+
+export type NavigatorToParentButtonProps = WordPressComponentProps<
+	NavigatorToParentButtonBaseProps,
+	'button'
+>;
 
 function UnconnectedNavigatorToParentButton(
-	props: WordPressComponentProps< NavigatorToParentButtonProps, 'button' >,
+	props: NavigatorToParentButtonProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const navigatorToParentButtonProps = useNavigatorBackButton( {

--- a/packages/components/src/navigator/navigator-to-parent-button/index.ts
+++ b/packages/components/src/navigator/navigator-to-parent-button/index.ts
@@ -1,1 +1,4 @@
-export { default as NavigatorToParentButton } from './component';
+export {
+	default as NavigatorToParentButton,
+	type NavigatorToParentButtonProps,
+} from './component';

--- a/packages/components/src/notice/index.tsx
+++ b/packages/components/src/notice/index.tsx
@@ -19,6 +19,7 @@ import type { NoticeAction, NoticeProps } from './types';
 import type { DeprecatedButtonProps } from '../button/types';
 import { VisuallyHidden } from '../visually-hidden';
 
+export type { NoticeProps } from './types';
 const noop = () => {};
 
 /**

--- a/packages/components/src/notice/list.tsx
+++ b/packages/components/src/notice/list.tsx
@@ -8,9 +8,15 @@ import classnames from 'classnames';
  */
 import Notice from '.';
 import type { WordPressComponentProps } from '../context';
-import type { NoticeListProps } from './types';
+import type { NoticeListProps as NoticeListBaseProps } from './types';
 
 const noop = () => {};
+
+export type NoticeListProps = WordPressComponentProps<
+	NoticeListBaseProps,
+	'div',
+	false
+>;
 
 /**
  * `NoticeList` is a component used to render a collection of notices.
@@ -43,7 +49,7 @@ function NoticeList( {
 	onRemove = noop,
 	className,
 	children,
-}: WordPressComponentProps< NoticeListProps, 'div', false > ) {
+}: NoticeListProps ) {
 	const removeNotice =
 		( id: NoticeListProps[ 'notices' ][ number ][ 'id' ] ) => () =>
 			onRemove( id );

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -21,7 +21,7 @@ import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { add, subtract, roundClamp } from '../utils/math';
 import { ensureNumber, isValueEmpty } from '../utils/values';
 import type { WordPressComponentProps } from '../context/wordpress-component';
-import type { NumberControlProps } from './types';
+import type { NumberControlProps as NumberControlBaseProps } from './types';
 import { HStack } from '../h-stack';
 import { Spacer } from '../spacer';
 import { useCx } from '../utils';
@@ -29,8 +29,14 @@ import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props'
 
 const noop = () => {};
 
+export type NumberControlProps = WordPressComponentProps<
+	NumberControlBaseProps,
+	'input',
+	false
+>;
+
 function UnforwardedNumberControl(
-	props: WordPressComponentProps< NumberControlProps, 'input', false >,
+	props: NumberControlProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -59,6 +59,7 @@ import type {
 	PaletteEditProps,
 	PaletteElement,
 } from './types';
+export type { PaletteEditProps } from './types';
 
 const DEFAULT_COLOR = '#000';
 

--- a/packages/components/src/panel/body.tsx
+++ b/packages/components/src/panel/body.tsx
@@ -19,6 +19,7 @@ import Button from '../button';
 import Icon from '../icon';
 import { useControlledState, useUpdateEffect } from '../utils';
 
+export type { PanelBodyProps } from './types';
 const noop = () => {};
 
 export function UnforwardedPanelBody(

--- a/packages/components/src/panel/header.tsx
+++ b/packages/components/src/panel/header.tsx
@@ -3,6 +3,8 @@
  */
 import type { PanelHeaderProps } from './types';
 
+export type { PanelHeaderProps } from './types';
+
 /**
  * `PanelHeader` renders the header for the `Panel`.
  * This is used by the `Panel` component under the hood,

--- a/packages/components/src/panel/index.tsx
+++ b/packages/components/src/panel/index.tsx
@@ -13,6 +13,7 @@ import { forwardRef } from '@wordpress/element';
  */
 import PanelHeader from './header';
 import type { PanelProps } from './types';
+export type { PanelProps } from './types';
 
 function UnforwardedPanel(
 	{ header, className, children }: PanelProps,

--- a/packages/components/src/panel/row.tsx
+++ b/packages/components/src/panel/row.tsx
@@ -13,6 +13,7 @@ import type { ForwardedRef } from 'react';
  * Internal dependencies
  */
 import type { PanelRowProps } from './types';
+export type { PanelRowProps } from './types';
 
 function UnforwardedPanelRow(
 	{ className, children }: PanelRowProps,

--- a/packages/components/src/placeholder/index.tsx
+++ b/packages/components/src/placeholder/index.tsx
@@ -15,7 +15,7 @@ import { speak } from '@wordpress/a11y';
  * Internal dependencies
  */
 import Icon from '../icon';
-import type { PlaceholderProps } from './types';
+import type { PlaceholderProps as PlaceholderBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
 const PlaceholderIllustration = (
@@ -30,6 +30,12 @@ const PlaceholderIllustration = (
 	</SVG>
 );
 
+export type PlaceholderProps = WordPressComponentProps<
+	PlaceholderBaseProps,
+	'div',
+	false
+>;
+
 /**
  * Renders a placeholder. Normally used by blocks to render their empty state.
  *
@@ -40,9 +46,7 @@ const PlaceholderIllustration = (
  * const MyPlaceholder = () => <Placeholder icon={ more } label="Placeholder" />;
  * ```
  */
-export function Placeholder(
-	props: WordPressComponentProps< PlaceholderProps, 'div', false >
-) {
+export function Placeholder( props: PlaceholderProps ) {
 	const {
 		icon,
 		children,

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -56,7 +56,7 @@ import {
 import { contextConnect, useContextSystem } from '../context';
 import type { WordPressComponentProps } from '../context';
 import type {
-	PopoverProps,
+	PopoverProps as PopoverBaseProps,
 	PopoverAnchorRefReference,
 	PopoverAnchorRefTopBottom,
 } from './types';
@@ -109,14 +109,16 @@ const getPopoverFallbackContainer = () => {
 	return container;
 };
 
+export type PopoverProps = Omit<
+	WordPressComponentProps< PopoverBaseProps, 'div', false >,
+	// To avoid overlaps between the standard HTML attributes and the props
+	// expected by `framer-motion`, omit all framer motion props from popover
+	// props (except for `animate` and `children`, which are re-defined in `PopoverProps`).
+	keyof Omit< MotionProps, 'animate' | 'children' >
+>;
+
 const UnforwardedPopover = (
-	props: Omit<
-		WordPressComponentProps< PopoverProps, 'div', false >,
-		// To avoid overlaps between the standard HTML attributes and the props
-		// expected by `framer-motion`, omit all framer motion props from popover
-		// props (except for `animate` and `children`, which are re-defined in `PopoverProps`).
-		keyof Omit< MotionProps, 'animate' | 'children' >
-	>,
+	props: PopoverProps,
 	forwardedRef: ForwardedRef< any >
 ) => {
 	const {

--- a/packages/components/src/query-controls/index.tsx
+++ b/packages/components/src/query-controls/index.tsx
@@ -18,6 +18,8 @@ import type {
 	QueryControlsWithSingleCategorySelectionProps,
 } from './types';
 
+export type { QueryControlsProps } from './types';
+
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 100;
 const MAX_CATEGORIES_SUGGESTIONS = 20;

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -14,8 +14,14 @@ import { useInstanceId } from '@wordpress/compose';
  */
 import BaseControl from '../base-control';
 import type { WordPressComponentProps } from '../context';
-import type { RadioControlProps } from './types';
+import type { RadioControlProps as RadioControlBaseProps } from './types';
 import { VStack } from '../v-stack';
+
+export type RadioControlProps = WordPressComponentProps<
+	RadioControlBaseProps,
+	'input',
+	false
+>;
 
 /**
  * Render a user interface to select the user type using radio inputs.
@@ -42,9 +48,7 @@ import { VStack } from '../v-stack';
  * };
  * ```
  */
-export function RadioControl(
-	props: WordPressComponentProps< RadioControlProps, 'input', false >
-) {
+export function RadioControl( props: RadioControlProps ) {
 	const {
 		label,
 		className,

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -35,14 +35,20 @@ import {
 	Wrapper,
 } from './styles/range-control-styles';
 
-import type { RangeControlProps } from './types';
+import type { RangeControlProps as RangeControlBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 import { space } from '../utils/space';
 
 const noop = () => {};
 
+export type RangeControlProps = WordPressComponentProps<
+	RangeControlBaseProps,
+	'input',
+	false
+>;
+
 function UnforwardedRangeControl(
-	props: WordPressComponentProps< RangeControlProps, 'input', false >,
+	props: RangeControlProps,
 	forwardedRef: ForwardedRef< HTMLInputElement >
 ) {
 	const {

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -87,7 +87,7 @@ const HANDLE_STYLES = {
 	bottomLeft: HANDLE_STYLES_OVERRIDES,
 };
 
-type ResizableBoxProps = ResizableProps & {
+export type ResizableBoxProps = ResizableProps & {
 	children: ReactNode;
 	showHandle?: boolean;
 	__experimentalShowTooltip?: boolean;

--- a/packages/components/src/responsive-wrapper/index.tsx
+++ b/packages/components/src/responsive-wrapper/index.tsx
@@ -12,6 +12,7 @@ import { cloneElement, Children } from '@wordpress/element';
  * Internal dependencies
  */
 import type { ResponsiveWrapperProps } from './types';
+export type { ResponsiveWrapperProps } from './types';
 
 /**
  * A wrapper component that maintains its aspect ratio when resized.

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -13,6 +13,7 @@ import { useFocusableIframe, useMergeRefs } from '@wordpress/compose';
  * Internal dependencies
  */
 import type { SandBoxProps } from './types';
+export type { SandBoxProps } from './types';
 
 const observeAndResizeJS = function () {
 	const { MutationObserver } = window;

--- a/packages/components/src/scrollable/component.tsx
+++ b/packages/components/src/scrollable/component.tsx
@@ -10,10 +10,15 @@ import type { WordPressComponentProps } from '../context';
 import { contextConnect } from '../context';
 import { View } from '../view';
 import { useScrollable } from './hook';
-import type { ScrollableProps } from './types';
+import type { ScrollableProps as ScrollableBaseProps } from './types';
+
+export type ScrollableProps = WordPressComponentProps<
+	ScrollableBaseProps,
+	'div'
+>;
 
 function UnconnectedScrollable(
-	props: WordPressComponentProps< ScrollableProps, 'div' >,
+	props: ScrollableProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const scrollableProps = useScrollable( props );

--- a/packages/components/src/scrollable/index.ts
+++ b/packages/components/src/scrollable/index.ts
@@ -1,3 +1,3 @@
-export { default as Scrollable } from './component';
+export { default as Scrollable, type ScrollableProps } from './component';
 
 export * from './hook';

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -16,7 +16,10 @@ import { forwardRef, useMemo, useRef } from '@wordpress/element';
  */
 import Button from '../button';
 import type { WordPressComponentProps } from '../context/wordpress-component';
-import type { SearchControlProps, SuffixItemProps } from './types';
+import type {
+	SearchControlProps as SearchControlBaseProps,
+	SuffixItemProps,
+} from './types';
 import type { ForwardedRef } from 'react';
 import { ContextSystemProvider } from '../context';
 import { StyledInputControl, SuffixItemWrapper } from './styles';
@@ -46,6 +49,12 @@ function SuffixItem( {
 	);
 }
 
+export type SearchControlProps = Omit<
+	WordPressComponentProps< SearchControlBaseProps, 'input', false >,
+	// TODO: Background styling currently doesn't support a disabled state. Needs design work.
+	'disabled'
+>;
+
 function UnforwardedSearchControl(
 	{
 		__nextHasNoMarginBottom = false,
@@ -58,11 +67,7 @@ function UnforwardedSearchControl(
 		onClose,
 		size = 'default',
 		...restProps
-	}: Omit<
-		WordPressComponentProps< SearchControlProps, 'input', false >,
-		// TODO: Background styling currently doesn't support a disabled state. Needs design work.
-		'disabled'
-	>,
+	}: SearchControlProps,
 	forwardedRef: ForwardedRef< HTMLInputElement >
 ) {
 	// @ts-expect-error The `disabled` prop is not yet supported in the SearchControl component.

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -16,7 +16,7 @@ import BaseControl from '../base-control';
 import InputBase from '../input-control/input-base';
 import { Select } from './styles/select-control-styles';
 import type { WordPressComponentProps } from '../context';
-import type { SelectControlProps } from './types';
+import type { SelectControlProps as SelectControlBaseProps } from './types';
 import SelectControlChevronDown from './chevron-down';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
 
@@ -29,8 +29,14 @@ function useUniqueId( idProp?: string ) {
 	return idProp || id;
 }
 
+export type SelectControlProps = WordPressComponentProps<
+	SelectControlBaseProps,
+	'select',
+	false
+>;
+
 function UnforwardedSelectControl(
-	props: WordPressComponentProps< SelectControlProps, 'select', false >,
+	props: SelectControlProps,
 	ref: React.ForwardedRef< HTMLSelectElement >
 ) {
 	const {

--- a/packages/components/src/slot-fill/index.tsx
+++ b/packages/components/src/slot-fill/index.tsx
@@ -24,13 +24,18 @@ export { default as useSlot } from './bubbles-virtually/use-slot';
 export { default as useSlotFills } from './bubbles-virtually/use-slot-fills';
 import type {
 	DistributiveOmit,
-	FillComponentProps,
+	FillComponentProps as FillProps,
 	SlotComponentProps,
 	SlotFillProviderProps,
 	SlotKey,
 } from './types';
 
-export function Fill( props: FillComponentProps ) {
+export type {
+	FillComponentProps as FillProps,
+	SlotFillProviderProps,
+} from './types';
+
+export function Fill( props: FillProps ) {
 	// We're adding both Fills here so they can register themselves before
 	// their respective slot has been registered. Only the Fill that has a slot
 	// will render. The other one will return null.
@@ -42,11 +47,10 @@ export function Fill( props: FillComponentProps ) {
 	);
 }
 
-export function UnforwardedSlot(
-	props: SlotComponentProps &
-		Omit< WordPressComponentProps< {}, 'div' >, 'className' >,
-	ref: ForwardedRef< any >
-) {
+export type SlotProps = SlotComponentProps &
+	Omit< WordPressComponentProps< {}, 'div' >, 'className' >;
+
+export function UnforwardedSlot( props: SlotProps, ref: ForwardedRef< any > ) {
 	const { bubblesVirtually, ...restProps } = props;
 	if ( bubblesVirtually ) {
 		return <BubblesVirtuallySlot { ...restProps } ref={ ref } />;
@@ -74,14 +78,14 @@ export function Provider( {
 
 export function createSlotFill( key: SlotKey ) {
 	const baseName = typeof key === 'symbol' ? key.description : key;
-	const FillComponent = ( props: Omit< FillComponentProps, 'name' > ) => (
+	const FillComponent = ( props: Omit< FillProps, 'name' > ) => (
 		<Fill name={ key } { ...props } />
 	);
 	FillComponent.displayName = `${ baseName }Fill`;
 
-	const SlotComponent = (
-		props: DistributiveOmit< SlotComponentProps, 'name' >
-	) => <Slot name={ key } { ...props } />;
+	const SlotComponent = ( props: DistributiveOmit< SlotProps, 'name' > ) => (
+		<Slot name={ key } { ...props } />
+	);
 	SlotComponent.displayName = `${ baseName }Slot`;
 	SlotComponent.__unstableName = key;
 

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -22,7 +22,7 @@ import warning from '@wordpress/warning';
  * Internal dependencies
  */
 import Button from '../button';
-import type { SnackbarProps } from './types';
+import type { SnackbarProps as SnackbarBaseProps } from './types';
 import type { NoticeAction } from '../notice/types';
 import type { WordPressComponentProps } from '../context';
 
@@ -49,6 +49,8 @@ function useSpokenMessage(
 	}, [ spokenMessage, politeness ] );
 }
 
+export type SnackbarProps = WordPressComponentProps< SnackbarBaseProps, 'div' >;
+
 function UnforwardedSnackbar(
 	{
 		className,
@@ -64,7 +66,7 @@ function UnforwardedSnackbar(
 		// actually the function to call to remove the snackbar from the UI.
 		onDismiss,
 		listRef,
-	}: WordPressComponentProps< SnackbarProps, 'div' >,
+	}: SnackbarProps,
 	ref: ForwardedRef< any >
 ) {
 	function dismissMe( event: KeyboardEvent | MouseEvent ) {

--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -17,7 +17,7 @@ import {
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
 } from '../animation';
-import type { SnackbarListProps } from './types';
+import type { SnackbarListProps as SnackbarListBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
 const SNACKBAR_VARIANTS = {
@@ -48,6 +48,10 @@ const SNACKBAR_VARIANTS = {
 	},
 };
 
+export type SnackbarListProps = WordPressComponentProps<
+	SnackbarListBaseProps,
+	'div'
+>;
 /**
  * Renders a list of notices.
  *
@@ -65,7 +69,7 @@ export function SnackbarList( {
 	className,
 	children,
 	onRemove,
-}: WordPressComponentProps< SnackbarListProps, 'div' > ) {
+}: SnackbarListProps ) {
 	const listRef = useRef< HTMLDivElement | null >( null );
 	const isReducedMotion = useReducedMotion();
 	className = classnames( 'components-snackbar-list', className );

--- a/packages/components/src/spacer/component.tsx
+++ b/packages/components/src/spacer/component.tsx
@@ -10,10 +10,12 @@ import type { WordPressComponentProps } from '../context';
 import { contextConnect } from '../context';
 import { View } from '../view';
 import { useSpacer } from './hook';
-import type { SpacerProps } from './types';
+import type { SpacerProps as SpacerBaseProps } from './types';
+
+export type SpacerProps = WordPressComponentProps< SpacerBaseProps, 'div' >;
 
 function UnconnectedSpacer(
-	props: WordPressComponentProps< SpacerProps, 'div' >,
+	props: SpacerProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const spacerProps = useSpacer( props );

--- a/packages/components/src/spacer/hook.ts
+++ b/packages/components/src/spacer/hook.ts
@@ -6,18 +6,15 @@ import { css } from '@emotion/react';
 /**
  * Internal dependencies
  */
-import type { WordPressComponentProps } from '../context';
 import { useContextSystem } from '../context';
 import { space } from '../utils/space';
 import { rtl, useCx } from '../utils';
-import type { SpacerProps } from './types';
+import type { SpacerProps } from './component';
 
 const isDefined = < T >( o: T ): o is Exclude< T, null | undefined > =>
 	typeof o !== 'undefined' && o !== null;
 
-export function useSpacer(
-	props: WordPressComponentProps< SpacerProps, 'div' >
-) {
+export function useSpacer( props: SpacerProps ) {
 	const {
 		className,
 		margin,

--- a/packages/components/src/spacer/index.ts
+++ b/packages/components/src/spacer/index.ts
@@ -1,3 +1,2 @@
-export { default as Spacer } from './component';
+export { default as Spacer, type SpacerProps } from './component';
 export { useSpacer } from './hook';
-export type { SpacerProps } from './types';

--- a/packages/components/src/spinner/index.tsx
+++ b/packages/components/src/spinner/index.tsx
@@ -15,8 +15,10 @@ import type { WordPressComponentProps } from '../context';
  */
 import { forwardRef } from '@wordpress/element';
 
+export type SpinnerProps = WordPressComponentProps< {}, 'svg', false >;
+
 export function UnforwardedSpinner(
-	{ className, ...props }: WordPressComponentProps< {}, 'svg', false >,
+	{ className, ...props }: SpinnerProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	return (

--- a/packages/components/src/style-provider/index.tsx
+++ b/packages/components/src/style-provider/index.tsx
@@ -10,6 +10,8 @@ import * as uuid from 'uuid';
  */
 import type { StyleProviderProps } from './types';
 
+export type { StyleProviderProps } from './types';
+
 const uuidCache = new Set();
 // Use a weak map so that when the container is detached it's automatically
 // dereferenced to avoid memory leak.

--- a/packages/components/src/surface/component.tsx
+++ b/packages/components/src/surface/component.tsx
@@ -9,11 +9,13 @@ import type { ForwardedRef } from 'react';
 import { contextConnect } from '../context';
 import { View } from '../view';
 import { useSurface } from './hook';
-import type { SurfaceProps } from './types';
+import type { SurfaceProps as SurfaceBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
+export type SurfaceProps = WordPressComponentProps< SurfaceBaseProps, 'div' >;
+
 function UnconnectedSurface(
-	props: WordPressComponentProps< SurfaceProps, 'div' >,
+	props: SurfaceProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const surfaceProps = useSurface( props );

--- a/packages/components/src/surface/index.ts
+++ b/packages/components/src/surface/index.ts
@@ -1,2 +1,2 @@
-export { default as Surface } from './component';
+export { default as Surface, type SurfaceProps } from './component';
 export * from './hook';

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -22,7 +22,7 @@ import { useInstanceId, usePrevious } from '@wordpress/compose';
  */
 
 import Button from '../button';
-import type { TabPanelProps } from './types';
+import type { TabPanelProps as TabPanelBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
 // Separate the actual tab name from the instance ID. This is
@@ -35,6 +35,12 @@ const extractTabName = ( id: string | undefined | null ) => {
 	}
 	return id.match( /^tab-panel-[0-9]*-(.*)/ )?.[ 1 ];
 };
+
+export type TabPanelProps = WordPressComponentProps<
+	TabPanelBaseProps,
+	'div',
+	false
+>;
 
 /**
  * TabPanel is an ARIA-compliant tabpanel.
@@ -82,7 +88,7 @@ const UnforwardedTabPanel = (
 		orientation = 'horizontal',
 		activeClass = 'is-active',
 		onSelect,
-	}: WordPressComponentProps< TabPanelProps, 'div', false >,
+	}: TabPanelProps,
 	ref: ForwardedRef< any >
 ) => {
 	const instanceId = useInstanceId( TabPanel, 'tab-panel' );

--- a/packages/components/src/text-control/index.tsx
+++ b/packages/components/src/text-control/index.tsx
@@ -15,10 +15,16 @@ import { forwardRef } from '@wordpress/element';
  */
 import BaseControl from '../base-control';
 import type { WordPressComponentProps } from '../context';
-import type { TextControlProps } from './types';
+import type { TextControlProps as TextControlBaseProps } from './types';
+
+export type TextControlProps = WordPressComponentProps<
+	TextControlBaseProps,
+	'input',
+	false
+>;
 
 function UnforwardedTextControl(
-	props: WordPressComponentProps< TextControlProps, 'input', false >,
+	props: TextControlProps,
 	ref: ForwardedRef< HTMLInputElement >
 ) {
 	const {

--- a/packages/components/src/text-highlight/index.tsx
+++ b/packages/components/src/text-highlight/index.tsx
@@ -8,6 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
  */
 import { escapeRegExp } from '../utils/strings';
 import type { TextHighlightProps } from './types';
+export type { TextHighlightProps } from './types';
 
 /**
  * Highlights occurrences of a given string within another string of text. Wraps

--- a/packages/components/src/text/component.tsx
+++ b/packages/components/src/text/component.tsx
@@ -7,6 +7,8 @@ import { View } from '../view';
 import useText from './hook';
 import type { Props } from './types';
 
+export type TextProps = WordPressComponentProps< Props, 'span' >;
+
 /**
  * @param props
  * @param forwardedRef

--- a/packages/components/src/text/index.ts
+++ b/packages/components/src/text/index.ts
@@ -1,2 +1,2 @@
-export { default as Text } from './component';
+export { default as Text, type TextProps } from './component';
 export { default as useText } from './hook';

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -9,11 +9,17 @@ import { forwardRef } from '@wordpress/element';
  */
 import BaseControl from '../base-control';
 import { StyledTextarea } from './styles/textarea-control-styles';
-import type { TextareaControlProps } from './types';
+import type { TextareaControlProps as TextareaControlBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
+export type TextareaControlProps = WordPressComponentProps<
+	TextareaControlBaseProps,
+	'textarea',
+	false
+>;
+
 function UnforwardedTextareaControl(
-	props: WordPressComponentProps< TextareaControlProps, 'textarea', false >,
+	props: TextareaControlProps,
 	ref: React.ForwardedRef< HTMLTextAreaElement >
 ) {
 	const {

--- a/packages/components/src/tip/index.tsx
+++ b/packages/components/src/tip/index.tsx
@@ -8,6 +8,8 @@ import { Icon, tip } from '@wordpress/icons';
  */
 import type { TipProps } from './types';
 
+export type { TipProps } from './types';
+
 export function Tip( props: TipProps ) {
 	const { children } = props;
 

--- a/packages/components/src/toggle-control/index.tsx
+++ b/packages/components/src/toggle-control/index.tsx
@@ -16,10 +16,16 @@ import { FlexBlock } from '../flex';
 import FormToggle from '../form-toggle';
 import BaseControl from '../base-control';
 import type { WordPressComponentProps } from '../context/wordpress-component';
-import type { ToggleControlProps } from './types';
+import type { ToggleControlProps as ToggleControlBaseProps } from './types';
 import { HStack } from '../h-stack';
 import { useCx } from '../utils';
 import { space } from '../utils/space';
+
+export type ToggleControlProps = WordPressComponentProps<
+	ToggleControlBaseProps,
+	'input',
+	false
+>;
 
 /**
  * ToggleControl is used to generate a toggle user interface.
@@ -49,7 +55,7 @@ export function ToggleControl( {
 	className,
 	onChange,
 	disabled,
-}: WordPressComponentProps< ToggleControlProps, 'input', false > ) {
+}: ToggleControlProps ) {
 	function onChangeToggle( event: ChangeEvent< HTMLInputElement > ) {
 		onChange( event.target.checked );
 	}

--- a/packages/components/src/toggle-group-control/index.ts
+++ b/packages/components/src/toggle-group-control/index.ts
@@ -1,3 +1,12 @@
-export { ToggleGroupControl } from './toggle-group-control';
-export { ToggleGroupControlOption } from './toggle-group-control-option';
-export { ToggleGroupControlOptionIcon } from './toggle-group-control-option-icon';
+export {
+	ToggleGroupControl,
+	type ToggleGroupControlProps,
+} from './toggle-group-control';
+export {
+	ToggleGroupControlOption,
+	type ToggleGroupControlOptionProps,
+} from './toggle-group-control-option';
+export {
+	ToggleGroupControlOptionIcon,
+	type ToggleGroupControlOptionIconProps,
+} from './toggle-group-control-option-icon';

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
@@ -12,16 +12,18 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../../context';
-import type { ToggleGroupControlOptionIconProps } from '../types';
+import type { ToggleGroupControlOptionIconProps as ToggleGroupControlOptionIconBaseProps } from '../types';
 import { ToggleGroupControlOptionBase } from '../toggle-group-control-option-base';
 import Icon from '../../icon';
 
+export type ToggleGroupControlOptionIconProps = WordPressComponentProps<
+	ToggleGroupControlOptionIconBaseProps,
+	'button',
+	false
+>;
+
 function UnforwardedToggleGroupControlOptionIcon(
-	props: WordPressComponentProps<
-		ToggleGroupControlOptionIconProps,
-		'button',
-		false
-	>,
+	props: ToggleGroupControlOptionIconProps,
 	ref: ForwardedRef< any >
 ) {
 	const { icon, label, ...restProps } = props;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/index.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/index.ts
@@ -1,1 +1,4 @@
-export { default as ToggleGroupControlOptionIcon } from './component';
+export {
+	default as ToggleGroupControlOptionIcon,
+	type ToggleGroupControlOptionIconProps,
+} from './component';

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -12,15 +12,17 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../../context';
-import type { ToggleGroupControlOptionProps } from '../types';
+import type { ToggleGroupControlOptionProps as ToggleGroupControlOptionBaseProps } from '../types';
 import { ToggleGroupControlOptionBase } from '../toggle-group-control-option-base';
 
+export type ToggleGroupControlOptionProps = WordPressComponentProps<
+	ToggleGroupControlOptionBaseProps,
+	'button',
+	false
+>;
+
 function UnforwardedToggleGroupControlOption(
-	props: WordPressComponentProps<
-		ToggleGroupControlOptionProps,
-		'button',
-		false
-	>,
+	props: ToggleGroupControlOptionProps,
 	ref: ForwardedRef< any >
 ) {
 	const { label, ...restProps } = props;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/index.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/index.ts
@@ -1,1 +1,4 @@
-export { default as ToggleGroupControlOption } from './component';
+export {
+	default as ToggleGroupControlOption,
+	type ToggleGroupControlOptionProps,
+} from './component';

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -19,14 +19,20 @@ import type { WordPressComponentProps } from '../../context';
 import { contextConnect, useContextSystem } from '../../context';
 import { useCx } from '../../utils/hooks';
 import BaseControl from '../../base-control';
-import type { ToggleGroupControlProps } from '../types';
+import type { ToggleGroupControlProps as ToggleGroupControlBaseProps } from '../types';
 import { VisualLabelWrapper } from './styles';
 import * as styles from './styles';
 import { ToggleGroupControlAsRadioGroup } from './as-radio-group';
 import { ToggleGroupControlAsButtonGroup } from './as-button-group';
 
+export type ToggleGroupControlProps = WordPressComponentProps<
+	ToggleGroupControlBaseProps,
+	'div',
+	false
+>;
+
 function UnconnectedToggleGroupControl(
-	props: WordPressComponentProps< ToggleGroupControlProps, 'div', false >,
+	props: ToggleGroupControlProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/toggle-group-control/toggle-group-control/index.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/index.ts
@@ -1,1 +1,4 @@
-export { default as ToggleGroupControl } from './component';
+export {
+	default as ToggleGroupControl,
+	type ToggleGroupControlProps,
+} from './component';

--- a/packages/components/src/toolbar/index.js
+++ b/packages/components/src/toolbar/index.js
@@ -1,6 +1,0 @@
-export { default as Toolbar } from './toolbar';
-export { default as ToolbarButton } from './toolbar-button';
-export { default as ToolbarContext } from './toolbar-context';
-export { default as ToolbarDropdownMenu } from './toolbar-dropdown-menu';
-export { default as ToolbarGroup } from './toolbar-group';
-export { default as ToolbarItem } from './toolbar-item';

--- a/packages/components/src/toolbar/index.ts
+++ b/packages/components/src/toolbar/index.ts
@@ -1,0 +1,15 @@
+export { default as Toolbar, type ToolbarProps } from './toolbar';
+export {
+	default as ToolbarButton,
+	type ToolbarButtonProps,
+} from './toolbar-button';
+export { default as ToolbarContext } from './toolbar-context';
+export {
+	default as ToolbarDropdownMenu,
+	type ToolbarDropdownMenuProps,
+} from './toolbar-dropdown-menu';
+export {
+	default as ToolbarGroup,
+	type ToolbarGroupProps,
+} from './toolbar-group';
+export { default as ToolbarItem, type ToolbarItemProps } from './toolbar-item';

--- a/packages/components/src/toolbar/toolbar-button/index.tsx
+++ b/packages/components/src/toolbar/toolbar-button/index.tsx
@@ -16,8 +16,14 @@ import Button from '../../button';
 import ToolbarItem from '../toolbar-item';
 import ToolbarContext from '../toolbar-context';
 import ToolbarButtonContainer from './toolbar-button-container';
-import type { ToolbarButtonProps } from './types';
+import type { ToolbarButtonProps as ToolbarButtonBaseProps } from './types';
 import type { WordPressComponentProps } from '../../context';
+
+export type ToolbarButtonProps = WordPressComponentProps<
+	ToolbarButtonBaseProps,
+	typeof Button,
+	false
+>;
 
 function UnforwardedToolbarButton(
 	{
@@ -29,7 +35,7 @@ function UnforwardedToolbarButton(
 		isDisabled,
 		title,
 		...props
-	}: WordPressComponentProps< ToolbarButtonProps, typeof Button, false >,
+	}: ToolbarButtonProps,
 	ref: ForwardedRef< any >
 ) {
 	const accessibleToolbarState = useContext( ToolbarContext );

--- a/packages/components/src/toolbar/toolbar-dropdown-menu/index.tsx
+++ b/packages/components/src/toolbar/toolbar-dropdown-menu/index.tsx
@@ -14,10 +14,12 @@ import type { ForwardedRef } from 'react';
 import ToolbarItem from '../toolbar-item';
 import ToolbarContext from '../toolbar-context';
 import DropdownMenu from '../../dropdown-menu';
-import type { DropdownMenuProps } from '../../dropdown-menu/types';
+import type { DropdownMenuProps } from '../../dropdown-menu';
+
+export type ToolbarDropdownMenuProps = DropdownMenuProps;
 
 function ToolbarDropdownMenu(
-	props: DropdownMenuProps,
+	props: ToolbarDropdownMenuProps,
 	ref: ForwardedRef< any >
 ) {
 	const accessibleToolbarState = useContext( ToolbarContext );

--- a/packages/components/src/toolbar/toolbar-group/index.tsx
+++ b/packages/components/src/toolbar/toolbar-group/index.tsx
@@ -21,6 +21,8 @@ function isNestedArray< T = any >( arr: T[] | T[][] ): arr is T[][] {
 	return Array.isArray( arr ) && Array.isArray( arr[ 0 ] );
 }
 
+export type { ToolbarGroupProps } from './types';
+
 /**
  * Renders a collapsible group of controls
  *

--- a/packages/components/src/toolbar/toolbar-item/index.tsx
+++ b/packages/components/src/toolbar/toolbar-item/index.tsx
@@ -17,6 +17,8 @@ import warning from '@wordpress/warning';
 import ToolbarContext from '../toolbar-context';
 import type { ToolbarItemProps } from './types';
 
+export type { ToolbarItemProps } from './types';
+
 function ToolbarItem(
 	{ children, as: Component, ...props }: ToolbarItemProps,
 	ref: ForwardedRef< any >

--- a/packages/components/src/toolbar/toolbar/index.tsx
+++ b/packages/components/src/toolbar/toolbar/index.tsx
@@ -15,17 +15,18 @@ import deprecated from '@wordpress/deprecated';
  */
 import ToolbarGroup from '../toolbar-group';
 import ToolbarContainer from './toolbar-container';
-import type { ToolbarProps } from './types';
+import type { ToolbarProps as ToolbarBaseProps } from './types';
 import type { WordPressComponentProps } from '../../context';
 import { ContextSystemProvider } from '../../context';
 
+export type ToolbarProps = WordPressComponentProps<
+	ToolbarBaseProps,
+	'div',
+	false
+>;
+
 function UnforwardedToolbar(
-	{
-		className,
-		label,
-		variant,
-		...props
-	}: WordPressComponentProps< ToolbarProps, 'div', false >,
+	{ className, label, variant, ...props }: ToolbarProps,
 	ref: ForwardedRef< any >
 ) {
 	const isVariantDefined = variant !== undefined;

--- a/packages/components/src/tools-panel/index.ts
+++ b/packages/components/src/tools-panel/index.ts
@@ -1,3 +1,6 @@
-export { default as ToolsPanel } from './tools-panel';
-export { default as ToolsPanelItem } from './tools-panel-item';
+export { default as ToolsPanel, type ToolsPanelProps } from './tools-panel';
+export {
+	default as ToolsPanelItem,
+	type ToolsPanelItemProps,
+} from './tools-panel-item';
 export { ToolsPanelContext } from './context';

--- a/packages/components/src/tools-panel/tools-panel-item/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-item/component.tsx
@@ -10,12 +10,17 @@ import { useToolsPanelItem } from './hook';
 import { View } from '../../view';
 import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
-import type { ToolsPanelItemProps } from '../types';
+import type { ToolsPanelItemProps as ToolsPanelItemBaseProps } from '../types';
+
+export type ToolsPanelItemProps = WordPressComponentProps<
+	ToolsPanelItemBaseProps,
+	'div'
+>;
 
 // This wraps controls to be conditionally displayed within a tools panel. It
 // prevents props being applied to HTML elements that would make them invalid.
 const UnconnectedToolsPanelItem = (
-	props: WordPressComponentProps< ToolsPanelItemProps, 'div' >,
+	props: ToolsPanelItemProps,
 	forwardedRef: ForwardedRef< any >
 ) => {
 	const {

--- a/packages/components/src/tools-panel/tools-panel-item/index.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type ToolsPanelItemProps } from './component';
 export { useToolsPanelItem } from './hook';

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -12,10 +12,15 @@ import { useToolsPanel } from './hook';
 import { Grid } from '../../grid';
 import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
-import type { ToolsPanelProps } from '../types';
+import type { ToolsPanelProps as ToolsPanelBaseProps } from '../types';
+
+export type ToolsPanelProps = WordPressComponentProps<
+	ToolsPanelBaseProps,
+	'div'
+>;
 
 const UnconnectedToolsPanel = (
-	props: WordPressComponentProps< ToolsPanelProps, 'div' >,
+	props: ToolsPanelProps,
 	forwardedRef: ForwardedRef< any >
 ) => {
 	const {

--- a/packages/components/src/tools-panel/tools-panel/index.ts
+++ b/packages/components/src/tools-panel/tools-panel/index.ts
@@ -1,2 +1,2 @@
-export { default } from './component';
+export { default, type ToolsPanelProps } from './component';
 export { useToolsPanel } from './hook';

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -39,6 +39,8 @@ const CONTEXT_VALUE = {
 	isNestedInTooltip: true,
 };
 
+export type { TooltipProps } from './types';
+
 function UnforwardedTooltip(
 	props: TooltipProps,
 	ref: React.ForwardedRef< any >

--- a/packages/components/src/tree-grid/cell.tsx
+++ b/packages/components/src/tree-grid/cell.tsx
@@ -8,14 +8,16 @@ import { forwardRef } from '@wordpress/element';
  */
 import TreeGridItem from './item';
 import type { WordPressComponentProps } from '../context';
-import type { TreeGridCellProps } from './types';
+import type { TreeGridCellProps as TreeGridCellBaseProps } from './types';
+
+export type TreeGridCellProps = WordPressComponentProps<
+	TreeGridCellBaseProps,
+	'td',
+	false
+>;
 
 function UnforwardedTreeGridCell(
-	{
-		children,
-		withoutGridItem = false,
-		...props
-	}: WordPressComponentProps< TreeGridCellProps, 'td', false >,
+	{ children, withoutGridItem = false, ...props }: TreeGridCellProps,
 	ref: React.ForwardedRef< any >
 ) {
 	return (

--- a/packages/components/src/tree-grid/index.tsx
+++ b/packages/components/src/tree-grid/index.tsx
@@ -9,7 +9,7 @@ import { UP, DOWN, LEFT, RIGHT, HOME, END } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import RovingTabIndexContainer from './roving-tab-index';
-import type { TreeGridProps } from './types';
+import type { TreeGridProps as TreeGridBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
 /**
@@ -30,6 +30,12 @@ function getRowFocusables( rowElement: HTMLElement ) {
 	} );
 }
 
+export type TreeGridProps = WordPressComponentProps<
+	TreeGridBaseProps,
+	'table',
+	false
+>;
+
 /**
  * Renders both a table and tbody element, used to create a tree hierarchy.
  *
@@ -42,7 +48,7 @@ function UnforwardedTreeGrid(
 		onFocusRow = () => {},
 		applicationAriaLabel,
 		...props
-	}: WordPressComponentProps< TreeGridProps, 'table', false >,
+	}: TreeGridProps,
 	/** A ref to the underlying DOM table element. */
 	ref: React.ForwardedRef< HTMLTableElement >
 ) {
@@ -388,6 +394,6 @@ function UnforwardedTreeGrid(
 export const TreeGrid = forwardRef( UnforwardedTreeGrid );
 
 export default TreeGrid;
-export { default as TreeGridRow } from './row';
-export { default as TreeGridCell } from './cell';
-export { default as TreeGridItem } from './item';
+export { default as TreeGridRow, type TreeGridRowProps } from './row';
+export { default as TreeGridCell, type TreeGridCellProps } from './cell';
+export { default as TreeGridItem, type TreeGridItemProps } from './item';

--- a/packages/components/src/tree-grid/item.tsx
+++ b/packages/components/src/tree-grid/item.tsx
@@ -7,10 +7,11 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import RovingTabIndexItem from './roving-tab-index-item';
-import type { RovingTabIndexItemProps } from './types';
+import type { RovingTabIndexItemProps as TreeGridItemProps } from './types';
+export type { RovingTabIndexItemProps as TreeGridItemProps } from './types';
 
 function UnforwardedTreeGridItem(
-	{ children, ...props }: RovingTabIndexItemProps,
+	{ children, ...props }: TreeGridItemProps,
 	ref: React.ForwardedRef< any >
 ) {
 	return (

--- a/packages/components/src/tree-grid/row.tsx
+++ b/packages/components/src/tree-grid/row.tsx
@@ -7,7 +7,13 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../context';
-import type { TreeGridRowProps } from './types';
+import type { TreeGridRowProps as TreeGridRowBaseProps } from './types';
+
+export type TreeGridRowProps = WordPressComponentProps<
+	TreeGridRowBaseProps,
+	'tr',
+	false
+>;
 
 function UnforwardedTreeGridRow(
 	{
@@ -17,7 +23,7 @@ function UnforwardedTreeGridRow(
 		setSize,
 		isExpanded,
 		...props
-	}: WordPressComponentProps< TreeGridRowProps, 'tr', false >,
+	}: TreeGridRowProps,
 	ref: React.ForwardedRef< HTMLTableRowElement >
 ) {
 	return (

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -25,6 +25,8 @@ function getSelectOptions(
 	] );
 }
 
+export type { TreeSelectProps } from './types';
+
 /**
  * TreeSelect component is used to generate select input fields.
  *

--- a/packages/components/src/truncate/component.tsx
+++ b/packages/components/src/truncate/component.tsx
@@ -10,10 +10,15 @@ import type { WordPressComponentProps } from '../context';
 import { contextConnect } from '../context';
 import { View } from '../view';
 import useTruncate from './hook';
-import type { TruncateProps } from './types';
+import type { TruncateProps as TruncateBaseProps } from './types';
+
+export type TruncateProps = WordPressComponentProps<
+	TruncateBaseProps,
+	'span'
+>;
 
 function UnconnectedTruncate(
-	props: WordPressComponentProps< TruncateProps, 'span' >,
+	props: TruncateProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const truncateProps = useTruncate( props );

--- a/packages/components/src/truncate/index.ts
+++ b/packages/components/src/truncate/index.ts
@@ -1,2 +1,2 @@
-export { default as Truncate } from './component';
+export { default as Truncate, type TruncateProps } from './component';
 export { default as useTruncate } from './hook';

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -25,15 +25,20 @@ import {
 } from './utils';
 import { useControlledState } from '../utils/hooks';
 import { escapeRegExp } from '../utils/strings';
-import type { UnitControlProps, UnitControlOnChangeCallback } from './types';
+import type {
+	UnitControlProps as UnitControlBaseProps,
+	UnitControlOnChangeCallback,
+} from './types';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
 
+export type UnitControlProps = WordPressComponentProps<
+	UnitControlBaseProps,
+	'input',
+	false
+>;
+
 function UnforwardedUnitControl(
-	unitControlProps: WordPressComponentProps<
-		UnitControlProps,
-		'input',
-		false
-	>,
+	unitControlProps: UnitControlProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/v-stack/component.tsx
+++ b/packages/components/src/v-stack/component.tsx
@@ -10,10 +10,12 @@ import type { WordPressComponentProps } from '../context';
 import { contextConnect } from '../context';
 import { View } from '../view';
 import { useVStack } from './hook';
-import type { VStackProps } from './types';
+import type { VStackProps as VStackBaseProps } from './types';
+
+export type VStackProps = WordPressComponentProps< VStackBaseProps, 'div' >;
 
 function UnconnectedVStack(
-	props: WordPressComponentProps< VStackProps, 'div' >,
+	props: VStackProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const vStackProps = useVStack( props );

--- a/packages/components/src/v-stack/index.ts
+++ b/packages/components/src/v-stack/index.ts
@@ -1,2 +1,2 @@
-export { default as VStack } from './component';
+export { default as VStack, type VStackProps } from './component';
 export { useVStack } from './hook';

--- a/packages/components/src/visually-hidden/component.tsx
+++ b/packages/components/src/visually-hidden/component.tsx
@@ -10,10 +10,15 @@ import type { WordPressComponentProps } from '../context';
 import { useContextSystem, contextConnect } from '../context';
 import { visuallyHidden } from './styles';
 import { View } from '../view';
-import type { VisuallyHiddenProps } from './types';
+import type { VisuallyHiddenProps as VisuallyHiddenBaseProps } from './types';
+
+export type VisuallyHiddenProps = WordPressComponentProps<
+	VisuallyHiddenBaseProps,
+	'div'
+>;
 
 function UnconnectedVisuallyHidden(
-	props: WordPressComponentProps< VisuallyHiddenProps, 'div' >,
+	props: VisuallyHiddenProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const { style: styleProp, ...contextProps } = useContextSystem(

--- a/packages/components/src/visually-hidden/index.ts
+++ b/packages/components/src/visually-hidden/index.ts
@@ -1,1 +1,4 @@
-export { default as VisuallyHidden } from './component';
+export {
+	default as VisuallyHidden,
+	type VisuallyHiddenProps,
+} from './component';

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -14,11 +14,13 @@ import { isValidElement } from '@wordpress/element';
 import { getValidChildren } from '../utils/get-valid-children';
 import { contextConnect, useContextSystem } from '../context';
 import { ZStackView, ZStackChildView } from './styles';
-import type { ZStackProps } from './types';
+import type { ZStackProps as ZStackBaseProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
+export type ZStackProps = WordPressComponentProps< ZStackBaseProps, 'div' >;
+
 function UnconnectedZStack(
-	props: WordPressComponentProps< ZStackProps, 'div' >,
+	props: ZStackProps,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/z-stack/index.ts
+++ b/packages/components/src/z-stack/index.ts
@@ -1,1 +1,1 @@
-export { default as ZStack } from './component';
+export { default as ZStack, type ZStackProps } from './component';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Exposing the Props types for all @wordpress/components components as a public API.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes #60193
Props types are often used in typescript when you nest components. The current method of getting prop types is inconsistent between different components, so this provides a consistent naming scheme `{ComponentName}Props` and ensures the prop types can be received correctly for all components.

## How?
I have taken the props types from the components and exported them. In most cases, there were prop names in the `types.ts` files, but these reference the custom component props, and were often then combined with props of a html element (e.g. div, input), so it was not correct to simply export the props types from those files.

A couple of components triggered Typescript only errors once I updated them, so they needed to be implemented slightly differently to avoid these errors. I have documented these in the code. `BaseControl` component is the main example.

DRAFT NOTE:
Posting as a draft because it's not fully tested/reviewed by myself yet.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
