### PR TITLE
Site Editor: Add rename and trash actions to page panel

### DIFF
--- a/packages/edit-site/src/components/page-actions/index.js
+++ b/packages/edit-site/src/components/page-actions/index.js
@@ -9,20 +9,24 @@ import { moreVertical } from '@wordpress/icons';
  * Internal dependencies
  */
 import TrashPageMenuItem from './trash-page-menu-item';
+import RenameMenuItem from '../rename-menu-item';
 
-export default function PageActions( { postId, toggleProps, onRemove } ) {
+export default function PageActions( { onRemove, page, toggleProps } ) {
 	return (
 		<DropdownMenu
 			icon={ moreVertical }
 			label={ __( 'Actions' ) }
 			toggleProps={ toggleProps }
 		>
-			{ () => (
+			{ ( { onClose } ) => (
 				<MenuGroup>
-					<TrashPageMenuItem
-						postId={ postId }
-						onRemove={ onRemove }
-					/>
+					<RenameMenuItem item={ page } onClose={ onClose } />
+					{ !! onRemove && (
+						<TrashPageMenuItem
+							page={ page }
+							onRemove={ onRemove }
+						/>
+					) }
 				</MenuGroup>
 			) }
 		</DropdownMenu>

--- a/packages/edit-site/src/components/page-actions/index.js
+++ b/packages/edit-site/src/components/page-actions/index.js
@@ -11,9 +11,15 @@ import { moreVertical } from '@wordpress/icons';
 import TrashPageMenuItem from './trash-page-menu-item';
 import RenamePostMenuItem from '../rename-post-menu-item';
 
-export default function PageActions( { onRemove, page, toggleProps } ) {
+export default function PageActions( {
+	className,
+	onRemove,
+	page,
+	toggleProps,
+} ) {
 	return (
 		<DropdownMenu
+			className={ className }
 			icon={ moreVertical }
 			label={ __( 'Actions' ) }
 			toggleProps={ toggleProps }

--- a/packages/edit-site/src/components/page-actions/index.js
+++ b/packages/edit-site/src/components/page-actions/index.js
@@ -9,7 +9,7 @@ import { moreVertical } from '@wordpress/icons';
  * Internal dependencies
  */
 import TrashPageMenuItem from './trash-page-menu-item';
-import RenameMenuItem from '../rename-menu-item';
+import RenamePostMenuItem from '../rename-post-menu-item';
 
 export default function PageActions( { onRemove, page, toggleProps } ) {
 	return (
@@ -20,7 +20,7 @@ export default function PageActions( { onRemove, page, toggleProps } ) {
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup>
-					<RenameMenuItem item={ page } onClose={ onClose } />
+					<RenamePostMenuItem item={ page } onClose={ onClose } />
 					{ !! onRemove && (
 						<TrashPageMenuItem
 							page={ page }

--- a/packages/edit-site/src/components/page-actions/index.js
+++ b/packages/edit-site/src/components/page-actions/index.js
@@ -24,9 +24,9 @@ export default function PageActions( {
 			label={ __( 'Actions' ) }
 			toggleProps={ toggleProps }
 		>
-			{ ( { onClose } ) => (
+			{ () => (
 				<MenuGroup>
-					<RenamePostMenuItem post={ page } onClose={ onClose } />
+					<RenamePostMenuItem post={ page } />
 					{ !! onRemove && (
 						<TrashPageMenuItem
 							page={ page }

--- a/packages/edit-site/src/components/page-actions/index.js
+++ b/packages/edit-site/src/components/page-actions/index.js
@@ -20,7 +20,7 @@ export default function PageActions( { onRemove, page, toggleProps } ) {
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup>
-					<RenamePostMenuItem item={ page } onClose={ onClose } />
+					<RenamePostMenuItem post={ page } onClose={ onClose } />
 					{ !! onRemove && (
 						<TrashPageMenuItem
 							page={ page }

--- a/packages/edit-site/src/components/page-actions/trash-page-menu-item.js
+++ b/packages/edit-site/src/components/page-actions/trash-page-menu-item.js
@@ -1,28 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
 
-export default function TrashPageMenuItem( { postId, onRemove } ) {
+export default function TrashPageMenuItem( { page, onRemove } ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 	const { deleteEntityRecord } = useDispatch( coreStore );
-	const page = useSelect(
-		( select ) =>
-			select( coreStore ).getEntityRecord( 'postType', 'page', postId ),
-		[ postId ]
+	const title = decodeEntities(
+		typeof page.title === 'string' ? page.title : page.title.rendered
 	);
+
 	async function removePage() {
 		try {
 			await deleteEntityRecord(
 				'postType',
 				'page',
-				postId,
+				page.id,
 				{},
 				{ throwOnError: true }
 			);
@@ -30,7 +29,7 @@ export default function TrashPageMenuItem( { postId, onRemove } ) {
 				sprintf(
 					/* translators: The page's title. */
 					__( '"%s" moved to the Trash.' ),
-					decodeEntities( page.title.rendered )
+					title
 				),
 				{
 					type: 'snackbar',
@@ -50,14 +49,8 @@ export default function TrashPageMenuItem( { postId, onRemove } ) {
 		}
 	}
 	return (
-		<>
-			<MenuItem
-				onClick={ () => removePage() }
-				isDestructive
-				variant="secondary"
-			>
-				{ __( 'Move to Trash' ) }
-			</MenuItem>
-		</>
+		<MenuItem onClick={ () => removePage() } isDestructive>
+			{ __( 'Move to Trash' ) }
+		</MenuItem>
 	);
 }

--- a/packages/edit-site/src/components/page-actions/trash-page-menu-item.js
+++ b/packages/edit-site/src/components/page-actions/trash-page-menu-item.js
@@ -12,6 +12,11 @@ export default function TrashPageMenuItem( { page, onRemove } ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 	const { deleteEntityRecord } = useDispatch( coreStore );
+
+	if ( page?.status === 'trash' ) {
+		return;
+	}
+
 	const title = decodeEntities(
 		typeof page.title === 'string' ? page.title : page.title.rendered
 	);

--- a/packages/edit-site/src/components/rename-post-menu-item/index.js
+++ b/packages/edit-site/src/components/rename-post-menu-item/index.js
@@ -21,7 +21,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
-export default function RenameMenuItem( { item, onClose } ) {
+export default function RenamePostMenuItem( { item, onClose } ) {
 	const title = decodeEntities(
 		typeof item.title === 'string' ? item.title : item.title.rendered
 	);

--- a/packages/edit-site/src/components/rename-post-menu-item/index.js
+++ b/packages/edit-site/src/components/rename-post-menu-item/index.js
@@ -21,9 +21,9 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
-export default function RenamePostMenuItem( { item, onClose } ) {
+export default function RenamePostMenuItem( { post, onClose } ) {
 	const title = decodeEntities(
-		typeof item.title === 'string' ? item.title : item.title.rendered
+		typeof post.title === 'string' ? post.title : post.title.rendered
 	);
 	const [ editedTitle, setEditedTitle ] = useState( title );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -35,7 +35,7 @@ export default function RenamePostMenuItem( { item, onClose } ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
-	if ( item.type === TEMPLATE_POST_TYPE && ! item.is_custom ) {
+	if ( post.type === TEMPLATE_POST_TYPE && ! post.is_custom ) {
 		return null;
 	}
 
@@ -43,7 +43,7 @@ export default function RenamePostMenuItem( { item, onClose } ) {
 		event.preventDefault();
 
 		try {
-			await editEntityRecord( 'postType', item.type, item.id, {
+			await editEntityRecord( 'postType', post.type, post.id, {
 				title: editedTitle,
 			} );
 
@@ -55,8 +55,8 @@ export default function RenamePostMenuItem( { item, onClose } ) {
 			// Persist edited entity.
 			await saveSpecifiedEntityEdits(
 				'postType',
-				item.type,
-				item.id,
+				post.type,
+				post.id,
 				[ 'title' ], // Only save title to avoid persisting other edits.
 				{
 					throwOnError: true,

--- a/packages/edit-site/src/components/rename-post-menu-item/index.js
+++ b/packages/edit-site/src/components/rename-post-menu-item/index.js
@@ -21,7 +21,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
-export default function RenamePostMenuItem( { post, onClose } ) {
+export default function RenamePostMenuItem( { post } ) {
 	const title = decodeEntities(
 		typeof post.title === 'string' ? post.title : post.title.rendered
 	);
@@ -54,7 +54,6 @@ export default function RenamePostMenuItem( { post, onClose } ) {
 			// Update state before saving rerenders the list.
 			setEditedTitle( '' );
 			setIsModalOpen( false );
-			onClose();
 
 			// Persist edited entity.
 			await saveSpecifiedEntityEdits(

--- a/packages/edit-site/src/components/rename-post-menu-item/index.js
+++ b/packages/edit-site/src/components/rename-post-menu-item/index.js
@@ -98,6 +98,7 @@ export default function RenamePostMenuItem( { post, onClose } ) {
 						setIsModalOpen( false );
 					} }
 					overlayClassName="edit-site-list__rename-modal"
+					focusOnMount="firstContentElement"
 				>
 					<form onSubmit={ onRename }>
 						<VStack spacing="5">

--- a/packages/edit-site/src/components/rename-post-menu-item/index.js
+++ b/packages/edit-site/src/components/rename-post-menu-item/index.js
@@ -42,6 +42,10 @@ export default function RenamePostMenuItem( { post, onClose } ) {
 	async function onRename( event ) {
 		event.preventDefault();
 
+		if ( editedTitle === title ) {
+			return;
+		}
+
 		try {
 			await editEntityRecord( 'postType', post.type, post.id, {
 				title: editedTitle,

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -1,4 +1,6 @@
-
+.edit-site-page-card__actions {
+	flex-shrink: 0;
+}
 
 .edit-site-page-panels__swap-template__confirm-modal__actions {
 	margin-top: $grid-unit-30;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -95,7 +95,7 @@ export default function SidebarNavigationScreenPage( { backPath } ) {
 			actions={
 				<>
 					<PageActions
-						postId={ postId }
+						page={ record }
 						toggleProps={ { as: SidebarButton } }
 						onRemove={ () => {
 							goTo( '/page' );

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -21,7 +21,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { store as editSiteStore } from '../../store';
 import isTemplateRemovable from '../../utils/is-template-removable';
 import isTemplateRevertable from '../../utils/is-template-revertable';
-import RenameMenuItem from './rename-menu-item';
+import RenameMenuItem from '../rename-menu-item';
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
 export default function TemplateActions( {
@@ -56,7 +56,7 @@ export default function TemplateActions( {
 					{ isRemovable && (
 						<>
 							<RenameMenuItem
-								template={ template }
+								item={ template }
 								onClose={ onClose }
 							/>
 							<DeleteMenuItem

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -56,7 +56,7 @@ export default function TemplateActions( {
 					{ isRemovable && (
 						<>
 							<RenamePostMenuItem
-								item={ template }
+								post={ template }
 								onClose={ onClose }
 							/>
 							<DeleteMenuItem

--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -21,7 +21,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { store as editSiteStore } from '../../store';
 import isTemplateRemovable from '../../utils/is-template-removable';
 import isTemplateRevertable from '../../utils/is-template-revertable';
-import RenameMenuItem from '../rename-menu-item';
+import RenamePostMenuItem from '../rename-post-menu-item';
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
 export default function TemplateActions( {
@@ -55,7 +55,7 @@ export default function TemplateActions( {
 				<MenuGroup>
 					{ isRemovable && (
 						<>
-							<RenameMenuItem
+							<RenamePostMenuItem
 								item={ template }
 								onClose={ onClose }
 							/>


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/54648
- https://github.com/WordPress/gutenberg/issues/52763
- https://github.com/WordPress/gutenberg/pull/60230
- https://github.com/WordPress/gutenberg/pull/60231

## What?

Alternative to https://github.com/WordPress/gutenberg/pull/54648.

Props to @SaxonF as this PR is mostly just an updated version of https://github.com/WordPress/gutenberg/pull/54648.

## Why?

https://github.com/WordPress/gutenberg/issues/52763

If a page has not Title block there is no means to update the title within the site editor.

## How?

- Refactors the existing `RenameMenuItem` component for templates to a shared location and support pages
- Some tweaks to pass `page` records rather than post id/type (happy to hear ideas on better approaches)
- Adds new actions to the Site Editor's `PostCardPanel`

## Testing Instructions

1. Navigate to Appearance > Editor > Templates
2. Check that the renaming of templates still functions correctly
3. Navigate to the Site Editor's Pages page
4. Select a page and click its preview to edit it
5. Confirm there are rename and trash actions available within the Page Panel
6. Test renaming works
7. Navigate back to the the Page details screen (e.g. via top left icon)
8. Confirm the page has rename and trash actions available in the navigation screen
9. Check the renaming works here as well
10. Via either the details screen or the Page Panel while editing, confirm the trash option works

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/ed973d79-2616-4de3-9af2-5d53e6e31431


