### PR TITLE
Change heading level on troubleshooting section

### DIFF
--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -223,7 +223,7 @@ Once approved, the new Gutenberg version will be available to WordPress users al
 
 The final step is to write a release post on [make.wordpress.org/core](https://make.wordpress.org/core/). You can find some tips on that below.
 
-#### Troubleshooting the release
+### Troubleshooting the release
 
 > The plugin was published to the WordPress.org plugin directory but the workflow failed.
 


### PR DESCRIPTION


## What?
Change from h4 to h3,

## Why?
 When pushed to the documentation site, the header now receives an anchor link, that can be used when help is needed to manually fix the plugin deployment. 

_Documentation only_ 