### PR TITLE
[Site Editor]: Fix ability to edit trashed pages

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -237,7 +237,7 @@
 .dataviews-view-table__primary-field {
 	font-size: $default-font-size;
 	font-weight: 500;
-	color: $gray-900;
+	color: $gray-700;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	display: block;
@@ -245,12 +245,12 @@
 
 	a {
 		text-decoration: none;
-		color: inherit;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
 		display: block;
 		flex-grow: 0;
+		color: $gray-900;
 
 		&:hover {
 			color: var(--wp-admin-theme-color);
@@ -386,6 +386,9 @@
 		}
 
 		&:not(.is-selected) {
+			.dataviews-view-list__primary-field {
+				color: $gray-900;
+			}
 			&:hover,
 			&:focus-within {
 				color: var(--wp-admin-theme-color);

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -92,13 +92,16 @@ function EditorCanvas( {
 			}
 		},
 		onClick: () => {
-			if ( currentPostIsTrashed ) {
-				return;
-			}
 			if ( !! onClick ) {
 				onClick();
 			} else {
 				setCanvasMode( 'edit' );
+			}
+		},
+		onClickCapture: ( event ) => {
+			if ( currentPostIsTrashed ) {
+				event.preventDefault();
+				event.stopPropagation();
 			}
 		},
 		readonly: true,

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -75,6 +75,7 @@ function EditorCanvas( {
 	// to switch to edit mode, with a meaningful label and no title attribute.
 	const viewModeIframeProps = {
 		'aria-label': __( 'Edit' ),
+		'aria-disabled': currentPostIsTrashed,
 		title: null,
 		role: 'button',
 		tabIndex: 0,
@@ -82,7 +83,10 @@ function EditorCanvas( {
 		onBlur: () => setIsFocused( false ),
 		onKeyDown: ( event ) => {
 			const { keyCode } = event;
-			if ( keyCode === ENTER || keyCode === SPACE ) {
+			if (
+				( keyCode === ENTER || keyCode === SPACE ) &&
+				! currentPostIsTrashed
+			) {
 				event.preventDefault();
 				setCanvasMode( 'edit' );
 			}

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -92,6 +92,9 @@ function EditorCanvas( {
 			}
 		},
 		onClick: () => {
+			if ( currentPostIsTrashed ) {
+				return;
+			}
 			if ( !! onClick ) {
 				onClick();
 			} else {

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -1,7 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -25,6 +27,12 @@ export default function useLayoutAreas() {
 	const history = useHistory();
 	const { params } = useLocation();
 	const { postType, postId, path, layout, isCustom, canvas } = params ?? {};
+	const currentPostIsTrashed = useSelect(
+		( select ) =>
+			select( editorStore ).getCurrentPostAttribute( 'status' ) ===
+			'trash',
+		[]
+	);
 
 	// Note: Since "sidebar" is not yet supported here,
 	// returning undefined from "mobile" means show the sidebar.
@@ -39,14 +47,16 @@ export default function useLayoutAreas() {
 				preview: isListLayout && (
 					<Editor
 						isLoading={ isSiteEditorLoading }
-						onClick={ () =>
-							history.push( {
-								path,
-								postType: 'page',
-								postId,
-								canvas: 'edit',
-							} )
-						}
+						onClick={ () => {
+							if ( ! currentPostIsTrashed ) {
+								history.push( {
+									path,
+									postType: 'page',
+									postId,
+									canvas: 'edit',
+								} );
+							}
+						} }
 					/>
 				),
 				mobile:

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -1,9 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -27,12 +25,6 @@ export default function useLayoutAreas() {
 	const history = useHistory();
 	const { params } = useLocation();
 	const { postType, postId, path, layout, isCustom, canvas } = params ?? {};
-	const currentPostIsTrashed = useSelect(
-		( select ) =>
-			select( editorStore ).getCurrentPostAttribute( 'status' ) ===
-			'trash',
-		[]
-	);
 
 	// Note: Since "sidebar" is not yet supported here,
 	// returning undefined from "mobile" means show the sidebar.
@@ -47,16 +39,14 @@ export default function useLayoutAreas() {
 				preview: isListLayout && (
 					<Editor
 						isLoading={ isSiteEditorLoading }
-						onClick={ () => {
-							if ( ! currentPostIsTrashed ) {
-								history.push( {
-									path,
-									postType: 'page',
-									postId,
-									canvas: 'edit',
-								} );
-							}
-						} }
+						onClick={ () =>
+							history.push( {
+								path,
+								postType: 'page',
+								postId,
+								canvas: 'edit',
+							} )
+						}
 					/>
 				),
 				mobile:

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -155,6 +155,7 @@ const STATUSES = [
 const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.
 
 function FeaturedImage( { item, viewType } ) {
+	const isDisabled = item.status === 'trash';
 	const { onClick } = useLink( {
 		postId: item.id,
 		postType: item.type,
@@ -182,7 +183,8 @@ function FeaturedImage( { item, viewType } ) {
 					viewType === LAYOUT_TABLE,
 			} ) }
 			type="button"
-			onClick={ onClick }
+			onClick={ isDisabled ? undefined : onClick }
+			aria-disabled={ isDisabled }
 			aria-label={ item.title?.rendered || __( '(no title)' ) }
 		>
 			{ media }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
@@ -173,23 +168,24 @@ function FeaturedImage( { item, viewType } ) {
 			size={ size }
 		/>
 	) : null;
-	if ( viewType === LAYOUT_LIST ) {
-		return media;
-	}
+	const renderButton = viewType !== LAYOUT_LIST && ! isDisabled;
 	return (
-		<button
-			className={ classNames( 'page-pages-preview-field__button', {
-				'edit-site-page-pages__media-wrapper':
-					viewType === LAYOUT_TABLE,
-				'is-disabled': isDisabled,
-			} ) }
-			type="button"
-			onClick={ isDisabled ? undefined : onClick }
-			aria-disabled={ isDisabled }
-			aria-label={ item.title?.rendered || __( '(no title)' ) }
+		<div
+			className={ `edit-site-page-pages__featured-image-wrapper is-layout-${ viewType }` }
 		>
-			{ media }
-		</button>
+			{ renderButton ? (
+				<button
+					className="page-pages-preview-field__button"
+					type="button"
+					onClick={ onClick }
+					aria-label={ item.title?.rendered || __( '(no title)' ) }
+				>
+					{ media }
+				</button>
+			) : (
+				media
+			) }
+		</div>
 	);
 }
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -181,6 +181,7 @@ function FeaturedImage( { item, viewType } ) {
 			className={ classNames( 'page-pages-preview-field__button', {
 				'edit-site-page-pages__media-wrapper':
 					viewType === LAYOUT_TABLE,
+				'is-disabled': isDisabled,
 			} ) }
 			type="button"
 			onClick={ isDisabled ? undefined : onClick }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -281,9 +281,10 @@ export default function PagePages() {
 				id: 'title',
 				getValue: ( { item } ) => item.title?.rendered,
 				render: ( { item } ) => {
-					return [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
-						view.type
-					) ? (
+					const addLink =
+						[ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
+						item.status !== 'trash';
+					return addLink ? (
 						<Link
 							params={ {
 								postId: item.id,

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -1,39 +1,24 @@
-.page-pages-preview-field__button {
-	box-shadow: none;
-	border: none;
-	padding: 0;
-	background-color: unset;
-	box-sizing: border-box;
-	overflow: hidden;
+.edit-site-page-pages__featured-image {
+	height: 100%;
+	object-fit: cover;
+	width: 100%;
+}
+
+.edit-site-page-pages__featured-image-wrapper {
 	height: 100%;
 	width: 100%;
-	border-radius: 3px 3px 0 0;
+	border-radius: $grid-unit-05;
 
-	&:not(.is-disabled) {
-		cursor: pointer;
-	}
-
-	&:focus-visible {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
-	}
-
-	&.edit-site-page-pages__media-wrapper {
+	&.is-layout-table:not(:has(.page-pages-preview-field__button)),
+	&.is-layout-table .page-pages-preview-field__button {
 		width: $grid-unit-40;
 		height: $grid-unit-40;
 		display: block;
 		border-radius: $grid-unit-05;
 		position: relative;
-		background-color: $gray-100;
 		overflow: hidden;
+		background-color: $gray-100;
 		flex-grow: 0 !important;
-
-		.edit-site-page-pages__featured-image {
-			height: 100%;
-			object-fit: cover;
-			width: 100%;
-		}
 
 		&::after {
 			border-radius: 4px;
@@ -45,5 +30,24 @@
 			top: 0;
 			width: 100%;
 		}
+	}
+}
+
+.page-pages-preview-field__button {
+	box-shadow: none;
+	border: none;
+	padding: 0;
+	background-color: unset;
+	box-sizing: border-box;
+	cursor: pointer;
+	overflow: hidden;
+	height: 100%;
+	width: 100%;
+	border-radius: 3px 3px 0 0;
+
+	&:focus-visible {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
 	}
 }

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -4,11 +4,14 @@
 	padding: 0;
 	background-color: unset;
 	box-sizing: border-box;
-	cursor: pointer;
 	overflow: hidden;
 	height: 100%;
 	width: 100%;
 	border-radius: 3px 3px 0 0;
+
+	&:not(.is-disabled) {
+		cursor: pointer;
+	}
 
 	&:focus-visible {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Thanks to @aaronrobertshaw 's [comment](https://github.com/WordPress/gutenberg/pull/60230#discussion_r1540650574) I realised that we allow pages with `trash` status to be edited in site editor. This shouldn't be the case and this PR fixes that.

## Testing Instructions
1. In pages list apply the `trash` status filter. Observe that there is no link to the title.
2. In `list` layout observe that the preview is not redirecting to edit the page.
