### PR TITLE
Media: Display an unsupported image type error when uploading HEIC format

### DIFF
--- a/packages/media-utils/src/utils/upload-media.js
+++ b/packages/media-utils/src/utils/upload-media.js
@@ -117,6 +117,18 @@ export async function uploadMedia( {
 			continue;
 		}
 
+		// Special handling for the `.heic` file format, which most modern browsers cannot display.
+		if ( mediaFile.type && mediaFile.type === 'image/heic' ) {
+			onError( {
+				code: 'MIME_TYPE_NOT_SUPPORTED',
+				message: __(
+					'This image cannot be displayed in a web browser. For best results convert it to JPEG before uploading.'
+				),
+				file: mediaFile,
+			} );
+			continue;
+		}
+
 		// Check if the block supports this mime type.
 		// Defer to the server when type not detected.
 		if ( mediaFile.type && ! isAllowedType( mediaFile.type ) ) {


### PR DESCRIPTION
## What?
Fixes #34181.

PR updates the `uploadMedia` utility method to display an error when uploading the HEIC file format.

## Why?
Most browsers still don't support displaying [HEIF/HEIC](https://caniuse.com/heif) image formats - special handling for this [format landed in WP 5.5](https://core.trac.wordpress.org/ticket/42775#comment:42).

## How?
Check the media file's type and display the error notice when it matches `image/heic`. The media upload will abort on error without starting the actual upload.

## Note
If we decide to fully match the editor's upload behavior to the Core, we'll need to introduce an editor setting similar to `wp_show_heic_upload_error`.

## Testing Instructions
1. Open a post or page.
2. Drop the `.heic` image file on the editor canvas.
3. Confirm

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-03-27 at 16 23 03](https://github.com/WordPress/gutenberg/assets/240569/d70adb18-820f-46cb-8c77-4d0c201881be)
