### PR TITLE
Add test for Font Library and Theme Style Variations

### DIFF
--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -105,7 +105,7 @@ test.describe( 'Font Library', () => {
 			// Click "Browse styles"
 			await page.getByRole( 'button', { name: 'Browse styles' } ).click();
 
-			// Click the button labeled "Ember"
+			// Activate "Ember" Theme Variation.
 			await page.getByRole( 'button', { name: 'Ember' } ).click();
 
 			// Click "Back" button
@@ -115,7 +115,7 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'button', { name: 'Typography styles' } )
 				.click();
 
-			// CLick "Jost 2 variants" button
+			// Click "Jost 2 variants" button
 			await page
 				.getByRole( 'button', { name: 'Jost 2 variants' } )
 				.click();
@@ -128,6 +128,40 @@ test.describe( 'Font Library', () => {
 			// Check correct font is displayed in Font Library
 			await expect(
 				page.getByRole( 'heading', { name: 'Jost' } )
+			).toBeVisible();
+
+			// Close the Font Library dialog
+			await page.getByRole( 'button', { name: 'Close' } ).click();
+
+			// Click "Back"
+			await page.getByRole( 'button', { name: 'Back' } ).click();
+
+			// Click "Browse styles"
+			await page.getByRole( 'button', { name: 'Browse styles' } ).click();
+
+			// Activate "Maelstrom" Theme Variation.
+			await page.getByRole( 'button', { name: 'Maelstrom' } ).click();
+
+			// Click "Back" button
+			await page.getByRole( 'button', { name: 'Back' } ).click();
+
+			await page
+				.getByRole( 'button', { name: 'Typography styles' } )
+				.click();
+
+			// Click Cardo font-family.
+			await page
+				.getByRole( 'button', { name: 'Cardo 3 variants' } )
+				.click();
+
+			await expect( page.getByRole( 'dialog' ) ).toBeVisible();
+			await expect(
+				page.getByRole( 'heading', { name: 'Fonts' } )
+			).toBeVisible();
+
+			// Check correct font is displayed in Font Library
+			await expect(
+				page.getByRole( 'heading', { name: 'Cardo' } )
 			).toBeVisible();
 		} );
 	} );

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -86,4 +86,49 @@ test.describe( 'Font Library', () => {
 			).toBeVisible();
 		} );
 	} );
+
+	test.describe( 'When switching Theme Style variations', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'twentytwentyfour' );
+		} );
+
+		test.beforeEach( async ( { admin, editor } ) => {
+			await admin.visitSiteEditor();
+			await editor.canvas.locator( 'body' ).click();
+		} );
+
+		test( 'clicking on a font in the global styles sidebar should activate the font in the overlay when switching Theme Style variation', async ( {
+			page,
+		} ) => {
+			await page.getByRole( 'button', { name: /styles/i } ).click();
+
+			// Click "Browse styles"
+			await page.getByRole( 'button', { name: 'Browse styles' } ).click();
+
+			// Click the button labeled "Ember"
+			await page.getByRole( 'button', { name: 'Ember' } ).click();
+
+			// Click "Back" button
+			await page.getByRole( 'button', { name: 'Back' } ).click();
+
+			await page
+				.getByRole( 'button', { name: 'Typography styles' } )
+				.click();
+
+			// CLick "Jost 2 variants" button
+			await page
+				.getByRole( 'button', { name: 'Jost 2 variants' } )
+				.click();
+
+			await expect( page.getByRole( 'dialog' ) ).toBeVisible();
+			await expect(
+				page.getByRole( 'heading', { name: 'Fonts' } )
+			).toBeVisible();
+
+			// Check correct font is displayed in Font Library
+			await expect(
+				page.getByRole( 'heading', { name: 'Jost' } )
+			).toBeVisible();
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds test coverage for https://github.com/WordPress/gutenberg/pull/59959.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Increase confidence for shipping this in WP 6.5 RC4. Also for code quality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Write a test that mirrors the instructions for replicating the original bug report in https://github.com/WordPress/gutenberg/issues/59818


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

```
npm run test:e2e:playwright -- -g "When switching Theme Style variations"
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
