### PR TITLE
Data views list layout: Apply focus styles to items on `focus-visible` rather than `focus`

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -421,7 +421,7 @@
 		width: 100%;
 		scroll-margin: $grid-unit-10 0;
 
-		&:focus {
+		&:focus-visible {
 			&::before {
 				position: absolute;
 				content: "";


### PR DESCRIPTION
## What?
Updates the focus styles in list layout so they are applied on `focus-visible` rather than `focus`.

## Why?
The outlines add a lot of visual noise which adds no value on click interactions given the strong 'selected' state. 

Important to note that the outlines still appear when navigating by keyboard.

## Testing Instructions
1. Open a data view like
2. Switch to list layout if needed
3. Click items in the list
4. Observe there is no outline on the item
5. Navigate up and down the list using the keyboard (up/down arrows), and observe the is an outline on the focussed item as you do so
6. Select an item (spacebar or return), notice an outline is applied to the selected item

| Before on click | After on click |
| --- | --- |
| <img width="398" alt="Screenshot 2024-03-27 at 16 26 41" src="https://github.com/WordPress/gutenberg/assets/846565/ae4cbcd6-d5be-40c9-bf4f-aaa1f5b8c6c1"> | <img width="402" alt="Screenshot 2024-03-27 at 16 28 07" src="https://github.com/WordPress/gutenberg/assets/846565/f7709667-7bfa-4290-9105-4738ebdaeca2"> |

