### PR TITLE
E2E: Test BlockSwitcher availability in l-post-ul-group CPT

### DIFF
--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -328,6 +328,47 @@ test.describe( 'Post-type locking', () => {
 				},
 			] );
 		} );
+
+		test( 'should allow blocks to be switched to other types', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.canvas
+				.getByRole( 'document', {
+					name: 'Empty block',
+				} )
+				.first()
+				.fill( 'p1' );
+
+			const blockSwitcher = page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Paragraph' } );
+
+			// Verify the block switcher exists.
+			await expect( blockSwitcher ).toHaveAttribute(
+				'aria-haspopup',
+				'true'
+			);
+
+			// Verify the correct block transforms appear.
+			await blockSwitcher.click();
+			await expect(
+				page
+					.getByRole( 'menu', { name: 'Paragraph' } )
+					.getByRole( 'menuitem' )
+			).toHaveText( [
+				'Heading',
+				'List',
+				'Quote',
+				'Buttons',
+				'Code',
+				'Columns',
+				'Group',
+				'Preformatted',
+				'Pullquote',
+				'Verse',
+			] );
+		} );
 	} );
 
 	test.describe( 'template_lock all locked group', () => {


### PR DESCRIPTION
Adds an E2E test for the fix in #60167 / 447c008, which fixed the template-locking regression described in #60026.

In other words, when a post is locked at the root but contains an unlocked group, any blocks in the latter should retain their block-switching ability.

## Testing Instructions
1. Run `npm run test:e2e:playwright -- post-type-locking.spec.js`, ensure all tests pass.
2. Check out an ancestor of 447c008 (relatively ^447c008^`, absolutely dbd4cecdf862f481560dda325eb07fed58f26e3b), run the test sequence again to verify that the new test fails.