### PR TITLE
Update standardisation of 'Navigation Menu' to have both words capitalised in user-facing menus

### DIFF
--- a/packages/block-library/src/navigation/edit/accessible-menu-description.js
+++ b/packages/block-library/src/navigation/edit/accessible-menu-description.js
@@ -12,7 +12,7 @@ import AccessibleDescription from './accessible-description';
 export default function AccessibleMenuDescription( { id } ) {
 	const [ menuTitle ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
 	/* translators: %s: Title of a Navigation Menu post. */
-	const description = sprintf( __( `Navigation menu: "%s"` ), menuTitle );
+	const description = sprintf( __( `Navigation Menu: "%s"` ), menuTitle );
 
 	return (
 		<AccessibleDescription id={ id }>{ description }</AccessibleDescription>

--- a/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
+++ b/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
@@ -11,7 +11,7 @@ function DeletedNavigationWarning( { onCreateNew } ) {
 		<Warning>
 			{ createInterpolateElement(
 				__(
-					'Navigation menu has been deleted or is unavailable. <button>Create a new menu?</button>'
+					'Navigation Menu has been deleted or is unavailable. <button>Create a new menu?</button>'
 				),
 				{
 					button: <Button onClick={ onCreateNew } variant="link" />,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -847,7 +847,7 @@ function Navigation( {
 										replaceInnerBlocks( clientId, [] );
 										showNavigationMenuStatusNotice(
 											__(
-												'Navigation menu successfully deleted.'
+												'Navigation Menu successfully deleted.'
 											)
 										);
 									} }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -102,7 +102,7 @@ const MainContent = ( {
 	const description = navigationMenu
 		? sprintf(
 				/* translators: %s: The name of a menu. */
-				__( 'Structure for navigation menu: %s' ),
+				__( 'Structure for Navigation Menu: %s' ),
 				navigationMenu?.title || __( 'Untitled menu' )
 		  )
 		: __(
@@ -113,7 +113,7 @@ const MainContent = ( {
 		<div className="wp-block-navigation__menu-inspector-controls">
 			{ ! hasChildren && (
 				<p className="wp-block-navigation__menu-inspector-controls__empty-message">
-					{ __( 'This navigation menu is empty.' ) }
+					{ __( 'This Navigation Menu is empty.' ) }
 				</p>
 			) }
 			<PrivateListView

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -43,7 +43,7 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 					confirmButtonText={ __( 'Delete' ) }
 				>
 					{ __(
-						'Are you sure you want to delete this Navigation menu?'
+						'Are you sure you want to delete this Navigation Menu?'
 					) }
 				</ConfirmDialog>
 			) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -113,7 +113,7 @@ function NavigationMenuSelector( {
 		selectorLabel = __( 'Loading…' );
 	} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
 		// Note: classic Menus may be available.
-		selectorLabel = __( 'Choose or create a Navigation menu' );
+		selectorLabel = __( 'Choose or create a Navigation Menu' );
 	} else {
 		// Current Menu's title.
 		selectorLabel = currentTitle;

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -89,7 +89,7 @@ describe( 'NavigationMenuSelector', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'should show correct dropdown toggle prompt to choose a menu when navigation menus have resolved', async () => {
+		it( 'should show correct dropdown toggle prompt to choose a menu when Navigation Menus have resolved', async () => {
 			useNavigationMenu.mockReturnValue( {
 				navigationMenus: [],
 				hasResolvedNavigationMenus: true,
@@ -101,7 +101,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			expect(
 				screen.getByRole( 'button', {
-					name: 'Choose or create a Navigation menu',
+					name: 'Choose or create a Navigation Menu',
 				} )
 			).toBeInTheDocument();
 		} );
@@ -159,7 +159,7 @@ describe( 'NavigationMenuSelector', () => {
 				render( <NavigationMenuSelector /> );
 
 				const toggleButton = screen.getByRole( 'button', {
-					name: 'Choose or create a Navigation menu',
+					name: 'Choose or create a Navigation Menu',
 				} );
 
 				await user.click( toggleButton );
@@ -169,7 +169,7 @@ describe( 'NavigationMenuSelector', () => {
 				expect( menuPopover ).toHaveAttribute(
 					'aria-label',
 					expect.stringContaining(
-						'Choose or create a Navigation menu'
+						'Choose or create a Navigation Menu'
 					)
 				);
 
@@ -324,7 +324,7 @@ describe( 'NavigationMenuSelector', () => {
 			} );
 		} );
 
-		describe( 'Navigation menus', () => {
+		describe( 'Navigation Menus', () => {
 			it( 'should not show a list of menus when menus exist but user does not have permission to switch menus', async () => {
 				const user = userEvent.setup();
 
@@ -445,7 +445,7 @@ describe( 'NavigationMenuSelector', () => {
 				expect( menuItem ).toBeChecked();
 			} );
 
-			it( 'should call the handler when the navigation menu is selected', async () => {
+			it( 'should call the handler when the Navigation Menu is selected', async () => {
 				const user = userEvent.setup();
 
 				const handler = jest.fn();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #59442
Standardising the capitalisation of the phrase "Navigation Menu" within any user-facing labels.

## Why?
#59442 mentions this is an issue with the code base. So this is to fix those inconsistencies on the user-facing labels

## How?
Manually reviewed files within `packages/block-library/src/navigation/edit` to check the capitalisation of the phrase. Any that did not have a capital M or N were changed to this standard.

## Testing Instructions
Nothing to test as this only changes user-facing labels

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast
One example:
#### Before 
![image](https://github.com/WordPress/gutenberg/assets/91919183/24b5b10a-88d3-41c2-96c3-9999cc3b88f4)


#### After
![image](https://github.com/WordPress/gutenberg/assets/91919183/2764bdf3-58ad-4667-9142-b6e011bc7ebb)

