### PR TITLE
Global styles: background UI control labels

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -300,7 +300,7 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 					<InspectorControls.Slot group="styles" />
 					<InspectorControls.Slot
 						group="background"
-						label={ __( 'Background' ) }
+						label={ __( 'Background image' ) }
 					/>
 					<PositionControls />
 					<div>

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -135,7 +135,13 @@ export const backgroundPositionToCoords = ( value ) => {
 };
 
 function InspectorImagePreview( { label, filename, url: imgUrl } ) {
-	const imgLabel = label || getFilename( imgUrl );
+	let imgLabel = label || getFilename( imgUrl );
+	// getFilename returns 'undefined' as a string.
+	imgLabel =
+		!! imgLabel && imgLabel !== 'undefined'
+			? imgLabel
+			: __( 'Select or upload image' );
+
 	return (
 		<ItemGroup as="span">
 			<HStack justify="flex-start" as="span">
@@ -295,7 +301,7 @@ function BackgroundImageToolsPanelItem( {
 					onSelect={ onSelectMedia }
 					name={
 						<InspectorImagePreview
-							label={ __( 'Background image' ) }
+							label={ title }
 							filename={ title || __( 'Untitled' ) }
 							url={ url }
 						/>
@@ -518,6 +524,7 @@ function BackgroundToolsPanel( {
 	value,
 	panelId,
 	children,
+	headerLabel,
 } ) {
 	const resetAll = () => {
 		const updatedValue = resetAllFilter( value );
@@ -528,7 +535,7 @@ function BackgroundToolsPanel( {
 		<VStack
 			as={ ToolsPanel }
 			spacing={ 6 }
-			label={ __( 'Background' ) }
+			label={ headerLabel }
 			resetAll={ resetAll }
 			panelId={ panelId }
 			dropdownMenuProps={ TOOLSPANEL_DROPDOWNMENU_PROPS }
@@ -552,6 +559,7 @@ export default function BackgroundPanel( {
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
 	defaultValues = {},
+	headerLabel = __( 'Background image' ),
 } ) {
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {
@@ -568,6 +576,7 @@ export default function BackgroundPanel( {
 			value={ value }
 			onChange={ onChange }
 			panelId={ panelId }
+			headerLabel={ headerLabel }
 		>
 			<BackgroundImageToolsPanelItem
 				onChange={ onChange }

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -135,10 +135,7 @@ export const backgroundPositionToCoords = ( value ) => {
 };
 
 function InspectorImagePreview( { label, filename, url: imgUrl } ) {
-	let imgLabel = label || getFilename( imgUrl );
-	// getFilename returns 'undefined' as a string.
-	imgLabel =
-		!! imgLabel && imgLabel !== 'undefined' ? imgLabel : __( 'Add image' );
+	const imgLabel = label || getFilename( imgUrl ) || __( 'Add image' );
 
 	return (
 		<ItemGroup as="span">

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -139,25 +139,25 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 
 	return (
 		<ItemGroup as="span">
-			<HStack justify="flex-start" as="span">
-				<span
-					className={ classnames(
-						'block-editor-global-styles-background-panel__inspector-image-indicator-wrapper',
-						{
-							'has-image': imgUrl,
-						}
-					) }
-					aria-hidden
-				>
-					{ imgUrl && (
+			<HStack justify={ imgUrl ? 'flex-start' : 'center' } as="span">
+				{ imgUrl && (
+					<span
+						className={ classnames(
+							'block-editor-global-styles-background-panel__inspector-image-indicator-wrapper',
+							{
+								'has-image': imgUrl,
+							}
+						) }
+						aria-hidden
+					>
 						<span
 							className="block-editor-global-styles-background-panel__inspector-image-indicator"
 							style={ {
 								backgroundImage: `url(${ imgUrl })`,
 							} }
 						/>
-					) }
-				</span>
+					</span>
+				) }
 				<FlexItem as="span">
 					<Truncate
 						numberOfLines={ 1 }

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -138,9 +138,7 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 	let imgLabel = label || getFilename( imgUrl );
 	// getFilename returns 'undefined' as a string.
 	imgLabel =
-		!! imgLabel && imgLabel !== 'undefined'
-			? imgLabel
-			: __( 'Select or upload image' );
+		!! imgLabel && imgLabel !== 'undefined' ? imgLabel : __( 'Add image' );
 
 	return (
 		<ItemGroup as="span">

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -529,7 +529,7 @@ function BackgroundToolsPanel( {
 	return (
 		<VStack
 			as={ ToolsPanel }
-			spacing={ 6 }
+			spacing={ 4 }
 			label={ headerLabel }
 			resetAll={ resetAll }
 			panelId={ panelId }
@@ -542,7 +542,7 @@ function BackgroundToolsPanel( {
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
-	backgroundSize: true,
+	backgroundSize: false,
 };
 
 export default function BackgroundPanel( {

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -40,6 +40,10 @@ import MediaReplaceFlow from '../media-replace-flow';
 import { store as blockEditorStore } from '../../store';
 
 const IMAGE_BACKGROUND_TYPE = 'image';
+const DEFAULT_CONTROLS = {
+	backgroundImage: true,
+	backgroundSize: false,
+};
 
 /**
  * Checks site settings to see if the background panel may be used.
@@ -248,7 +252,7 @@ function BackgroundImageToolsPanelItem( {
 
 	const onFilesDrop = ( filesList ) => {
 		mediaUpload( {
-			allowedTypes: [ 'image' ],
+			allowedTypes: [ IMAGE_BACKGROUND_TYPE ],
 			filesList,
 			onFileChange( [ image ] ) {
 				if ( isBlobURL( image?.url ) ) {
@@ -539,11 +543,6 @@ function BackgroundToolsPanel( {
 		</VStack>
 	);
 }
-
-const DEFAULT_CONTROLS = {
-	backgroundImage: true,
-	backgroundSize: false,
-};
 
 export default function BackgroundPanel( {
 	as: Wrapper = BackgroundToolsPanel,

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -139,7 +139,8 @@ export const backgroundPositionToCoords = ( value ) => {
 };
 
 function InspectorImagePreview( { label, filename, url: imgUrl } ) {
-	const imgLabel = label || getFilename( imgUrl ) || __( 'Add image' );
+	const imgLabel =
+		label || getFilename( imgUrl ) || __( 'Add background image' );
 
 	return (
 		<ItemGroup as="span">

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -111,17 +111,11 @@
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator-wrapper {
-	background: #fff linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%); // Show a diagonal line (crossed out) for empty background image.
-	border-radius: $radius-round !important; // Override the default border-radius inherited from FlexItem.
-	box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 	display: block;
 	width: 20px;
 	height: 20px;
 	flex: none;
-
-	&.has-image {
-		background: #fff; // No diagonal line for non-empty background image. A background color is in use to account for partially transparent images.
-	}
+	background: #fff;
 }
 
 .block-editor-global-styles-background-panel__inspector-image-indicator {

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -81,7 +81,7 @@
 
 	button.components-button {
 		color: $gray-900;
-		box-shadow: inset 0 0 0 $border-width $gray-300;
+		box-shadow: inset 0 0 0 $border-width $gray-400;
 		width: 100%;
 		display: block;
 		height: $grid-unit-50;

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -30,7 +30,7 @@ const StylesTab = ( { blockName, clientId, hasBlockStyles } ) => {
 			/>
 			<InspectorControls.Slot
 				group="background"
-				label={ __( 'Background' ) }
+				label={ __( 'Background image' ) }
 			/>
 			<InspectorControls.Slot group="filter" />
 			<InspectorControls.Slot

--- a/packages/edit-site/src/components/global-styles/background-panel.js
+++ b/packages/edit-site/src/components/global-styles/background-panel.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ export default function BackgroundPanel() {
 			value={ style }
 			onChange={ setStyle }
 			settings={ settings }
+			headerLabel={ __( 'Image' ) }
 			defaultValues={ BACKGROUND_DEFAULT_VALUES }
 		/>
 	);

--- a/packages/edit-site/src/components/global-styles/background-panel.js
+++ b/packages/edit-site/src/components/global-styles/background-panel.js
@@ -29,6 +29,13 @@ export default function BackgroundPanel() {
 	} );
 	const [ settings ] = useGlobalSetting( '' );
 
+	const defaultControls = {
+		backgroundImage: true,
+		backgroundSize:
+			!! style?.background?.backgroundImage &&
+			!! inheritedStyle?.background?.backgroundImage,
+	};
+
 	return (
 		<StylesBackgroundPanel
 			inheritedValue={ inheritedStyle }
@@ -37,6 +44,7 @@ export default function BackgroundPanel() {
 			settings={ settings }
 			headerLabel={ __( 'Image' ) }
 			defaultValues={ BACKGROUND_DEFAULT_VALUES }
+			defaultControls={ defaultControls }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/root-menu.js
+++ b/packages/edit-site/src/components/global-styles/root-menu.js
@@ -64,9 +64,9 @@ function RootMenu() {
 					<NavigationButtonAsItem
 						icon={ image }
 						path="/background"
-						aria-label={ __( 'Background styles' ) }
+						aria-label={ __( 'Background image styles' ) }
 					>
-						{ __( 'Background' ) }
+						{ __( 'Background image' ) }
 					</NavigationButtonAsItem>
 				) }
 			</ItemGroup>

--- a/packages/edit-site/src/components/global-styles/screen-background.js
+++ b/packages/edit-site/src/components/global-styles/screen-background.js
@@ -20,7 +20,7 @@ function ScreenBackground() {
 	const hasBackgroundPanel = useHasBackgroundPanel( settings );
 	return (
 		<>
-			<ScreenHeader title={ __( 'Background' ) } />
+			<ScreenHeader title={ __( 'Background image' ) } />
 			{ hasBackgroundPanel && <BackgroundPanel /> }
 		</>
 	);


### PR DESCRIPTION
Part of:

- https://github.com/WordPress/gutenberg/issues/54336

Follow up to:

- https://github.com/WordPress/gutenberg/pull/59454


## What?

This PR changes the heading labels for background block supports tools panel and global styles.

### Post editor

- "Background" > "Background image" for the tools panel

### Site editor

- "Background" > "Background image" for the styles panel
- "Background" > "Image" for the tools panel, to reduce repetition between the style panel header.

It also applies the following label logic for the media upload component: 

- If an image has been selected, then `truncatedImageTitle || truncatedImageFilename`
- No image: `"Select or upload an image"`


See context: https://github.com/WordPress/gutenberg/pull/59454#issuecomment-2022531023

> [!TIP]
> This PR also harmonizes the tool panel items between block and site editors except for global styles, where the background size panel displays by default for top-level styles, but only when there's an image available.


## Why?

To reduce confusion between background color. Since the only available functionality relates to background image, then I think it's okay to be precise.



## Testing Instructions

I'm using 2024 to test.

1. In the post editor, insert a Group block. 
2. Open the block settings sidebar and select the styles tab.
3. Confirm that the tools panel title is `"Background image"` and the status of media upload component: `"Select or upload an image"`
4. Upload and image and check that it uses either the title or the file name of the image. 
5. Reset the values. The upload component should revert to  `"Select or upload an image"`
6. Now repeat the above steps in the site editor, checking the the tools panel header is "Image"
7. Finally check that the background size controls are not activated by default, except for top-level global files where it's displayed by default, but only when there's an image available:



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


### Post editor
<img width="281" alt="Screenshot 2024-04-15 at 10 01 11 am" src="https://github.com/WordPress/gutenberg/assets/6458278/1f9d546d-047d-412f-beaf-ff741c5a37b5">


<img width="281" alt="Screenshot 2024-03-28 at 11 08 08 am" src="https://github.com/WordPress/gutenberg/assets/6458278/2221c7f9-6165-4acf-9a6d-76d90b5e7cc9">


### Site editor
<img width="282" alt="Screenshot 2024-04-15 at 9 58 56 am" src="https://github.com/WordPress/gutenberg/assets/6458278/37e8df27-bb07-42c6-80df-2112ded922ab">


<img width="284" alt="Screenshot 2024-03-28 at 11 08 42 am" src="https://github.com/WordPress/gutenberg/assets/6458278/652f31ba-b5a6-4f62-aa1f-2f148dea5eb1">


<img width="279" alt="Screenshot 2024-03-28 at 11 08 19 am" src="https://github.com/WordPress/gutenberg/assets/6458278/e97b7c25-05de-4e65-ad38-5e5a78fdc267">






