### PR TITLE
URL: return early in getFilename where url argument is falsy

### DIFF
--- a/packages/url/src/get-filename.js
+++ b/packages/url/src/get-filename.js
@@ -13,6 +13,11 @@
  */
 export function getFilename( url ) {
 	let filename;
+
+	if ( ! url ) {
+		return;
+	}
+
 	try {
 		filename = new URL( url, 'http://example.com' ).pathname
 			.split( '/' )

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -285,14 +285,6 @@ describe( 'getFilename', () => {
 		expect( getFilename( '/' ) ).toBe( undefined );
 		expect( getFilename( undefined ) ).toBe( undefined );
 		expect( getFilename( null ) ).toBe( undefined );
-
-		/*
-		 * The URL() constructor accepts a string or any other object with a stringifier, e.g., <a>.
-		 * See https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
-		 */
-		const aElement = document.createElement( 'a' );
-		aElement.href = 'http://localhost:8080/file.jpg';
-		expect( getFilename( aElement ) ).toBe( 'file.jpg' );
 	} );
 } );
 

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -283,6 +283,16 @@ describe( 'getFilename', () => {
 		);
 		expect( getFilename( 'a/path/' ) ).toBe( undefined );
 		expect( getFilename( '/' ) ).toBe( undefined );
+		expect( getFilename( undefined ) ).toBe( undefined );
+		expect( getFilename( null ) ).toBe( undefined );
+
+		/*
+		 * The URL() constructor accepts a string or any other object with a stringifier, e.g., <a>.
+		 * See https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
+		 */
+		const aElement = document.createElement( 'a' );
+		aElement.href = 'http://localhost:8080/file.jpg';
+		expect( getFilename( aElement ) ).toBe( 'file.jpg' );
 	} );
 } );
 


### PR DESCRIPTION


## What? How? Why? When?

`getFilename` should return early for falsy values so the URL constructor doesn't return `'undefined' <string>` which could be interpreted by consumers as truthy. Now.

First seen: https://github.com/WordPress/gutenberg/pull/60264/files#r1542177474

### Before

```js
wp.url.getFilename( undefined ) // 'undefined'
```

### After

```js
wp.url.getFilename( undefined ) // undefined
```

## Testing Instructions

Fire up the editor and run in the browser console

```js
wp.url.getFilename( undefined )
```

Unit test it.

`npm run test:unit packages/url/src/test/index.js`

