### PR TITLE
Reset specificity of body selector when processing with postcss.

### DIFF
--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -19,6 +19,7 @@ function transformStyle(
 		return css;
 	}
 
+	const postcssFriendlyCSS = css.replace( ':where(body)', 'body' );
 	try {
 		return postcss(
 			[
@@ -31,7 +32,7 @@ function transformStyle(
 					} ),
 				baseURL && rebaseUrl( { rootUrl: baseURL } ),
 			].filter( Boolean )
-		).process( css, {} ).css; // use sync PostCSS API
+		).process( postcssFriendlyCSS, {} ).css; // use sync PostCSS API
 	} catch ( error ) {
 		if ( error instanceof CssSyntaxError ) {
 			// eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a bug introduced in #60106, in which global styles selectors were wrapped in `:where()` to reduce their specificity.

When the editor isn't iframed, its styles are wrapped in a scoping selector using [this postcss plugin ](https://github.com/dbtedman/postcss-prefixwrap). The plugin is smart enough to recognise and replace root selectors such as `body` and `html`, but it doesn't work for `:where(body)`. 

To fix this, we can replace any occurrences of `:where(body)` with `body` before feeding them into postcss. (We don't seem to use `html` for global styles which is why I haven't added it.)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In trunk, activate TT4 with a style variation that has a coloured background;
2. In the post editor preferences, check the "custom fields" toggle is on (this loads the non-iframed editor);
3. See that post background/text colors don't correspond to the active theme style variation;
4. Check out this branch and verify the issue is fixed. The base global styles should now be using `.editor-styles-wrapper`:

<img width="341" alt="Screenshot 2024-03-28 at 3 33 32 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/b1f41a81-4753-42dd-878a-50a10a2a0046">
