### PR TITLE
Additional CSS: Add code comments contextualising tranformStyles for clarity

### DIFF
--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -28,6 +28,10 @@ export default function AdvancedPanel( {
 			css: newValue,
 		} );
 		if ( cssError ) {
+			// Pass a wrapping selector to transformStyles to ensure that the CSS
+			// tested resembles actual CSS rules. This is necessary because the additional CSS
+			// field supports CSS rules that are not wrapped in a selector.
+			// Note: The wrapping selector here is not used in the actual output of any styles.
 			const [ transformed ] = transformStyles(
 				[ { css: newValue } ],
 				'.editor-styles-wrapper'
@@ -43,6 +47,10 @@ export default function AdvancedPanel( {
 			return;
 		}
 
+		// Pass a wrapping selector to transformStyles to ensure that the CSS
+		// tested resembles actual CSS rules. This is necessary because the additional CSS
+		// field supports CSS rules that are not wrapped in a selector.
+		// Note: The wrapping selector here is not used in the actual output of any styles.
 		const [ transformed ] = transformStyles(
 			[ { css: event.target.value } ],
 			'.editor-styles-wrapper'

--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -28,13 +28,12 @@ export default function AdvancedPanel( {
 			css: newValue,
 		} );
 		if ( cssError ) {
-			// Pass a wrapping selector to transformStyles to ensure that the CSS
-			// tested resembles actual CSS rules. This is necessary because the additional CSS
-			// field supports CSS rules that are not wrapped in a selector.
-			// Note: The wrapping selector here is not used in the actual output of any styles.
+			// Check if the new value is valid CSS, and pass a wrapping selector
+			// to ensure that `transformStyles` validates the CSS. Note that the
+			// wrapping selector here is not used in the actual output of any styles.
 			const [ transformed ] = transformStyles(
 				[ { css: newValue } ],
-				'.editor-styles-wrapper'
+				'.for-validation-only'
 			);
 			if ( transformed ) {
 				setCSSError( null );
@@ -47,13 +46,12 @@ export default function AdvancedPanel( {
 			return;
 		}
 
-		// Pass a wrapping selector to transformStyles to ensure that the CSS
-		// tested resembles actual CSS rules. This is necessary because the additional CSS
-		// field supports CSS rules that are not wrapped in a selector.
-		// Note: The wrapping selector here is not used in the actual output of any styles.
+		// Check if the new value is valid CSS, and pass a wrapping selector
+		// to ensure that `transformStyles` validates the CSS. Note that the
+		// wrapping selector here is not used in the actual output of any styles.
 		const [ transformed ] = transformStyles(
 			[ { css: event.target.value } ],
-			'.editor-styles-wrapper'
+			'.for-validation-only'
 		);
 
 		setCSSError(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the AdvancedPanel for Additional CSS, add a couple of code comments clarifying that what looks like the styles being transform is actually just a transformation being used for _validation_ only, it does not transform any of the styling rules that will be output.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While reviewing #56649, a few of us were tripped up by these lines. As described in this comment (https://github.com/WordPress/gutenberg/pull/56649#issuecomment-2024383614) the reviewers got to the bottom of it, but I believe it'd help to add some code comments here for clarity, and to hopefully avoid confusion further down the track.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add code comments, following the findings in https://github.com/WordPress/gutenberg/pull/56649#issuecomment-2024383614 (clarify that the calls are only used for CSS validation, not output of CSS).
* Update the classname used to make it clearer that the classname will not be used in any output.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Proofreading that what's written is accurate 🙂
2. To be sure this doesn't cause any issues, in global styles add Additional CSS, and enter it in an malformed way. Blur the field and check that the error message still appears. Then, go to fix the error in the CSS, and check that once it's resolved, the error disappears.
3. Do the same at the block-level in global styles. E.g. go to the Group block in global styles, and enter additional CSS under the Advanced panel. Example illegal CSS: `asdf`, example legal CSS: `border: 1px solid;`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
