### PR TITLE
Details Block: remove `overflow:hidden` style

### DIFF
--- a/packages/block-library/src/details/style.scss
+++ b/packages/block-library/src/details/style.scss
@@ -1,6 +1,5 @@
 .wp-block-details {
 	box-sizing: border-box;
-	overflow: hidden;
 }
 
 .wp-block-details summary {


### PR DESCRIPTION
Fixes #60269

## What?

This PR removes the `overflow: hidden` applied to the Details block. This will eliminate the unnatural outline when the `summary` element is focused, as reported in #60269.

This is a screenshot in TT4.

### Summary element is focused

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/d079c961-7999-4e99-ac2a-2e4c3284b4ba) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/bb6355a5-2d03-490b-b7c0-eb9818969dcc) | 

### When content is open

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/55c739b0-d1a5-4284-bf1f-3d150ad7b037) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/e2e42ed9-da78-45c1-95de-31a352a69c4d) | 

## Why?

To avoid cutting off the focus outline. Especially when the focus style is customized, [like in Twenty Twenty-Four](https://github.com/WordPress/wordpress-develop/blob/18c6a302a40c837ec5ddcd3c109a4af4d39facbf/src/wp-content/themes/twentytwentyfour/theme.json#L910), the focus outline can disappear completely or the outline of certain sides can disappear.

## How?

I simply deleted `overflow: hidden`. As far as I've tested, this doesn't cause any problems. I also looked into #45055 and #49808 and couldn't find any reason why this style was explicitly applied either.

## Testing Instructions for Keyboard

- Insert a Details block and save the post.
- Use the tab key on the front end to focus the summary element.
- Press enter to see the focus style when the content is opened.
- Check out focus outlines in various themes.