### PR TITLE
Router: update history package to 5.3.0, fix query string generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31137,9 +31137,9 @@
 			"integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg=="
 		},
 		"node_modules/history": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
-			"integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+			"integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.7.6"
 			}
@@ -56891,7 +56891,7 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/url": "file:../url",
-				"history": "^5.1.0"
+				"history": "^5.3.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -72236,7 +72236,7 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/url": "file:../url",
-				"history": "^5.1.0"
+				"history": "^5.3.0"
 			}
 		},
 		"@wordpress/scripts": {
@@ -81484,9 +81484,9 @@
 			"integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg=="
 		},
 		"history": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
-			"integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+			"integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
 			"requires": {
 				"@babel/runtime": "^7.7.6"
 			}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url",
-		"history": "^5.1.0"
+		"history": "^5.3.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/router/src/history.js
+++ b/packages/router/src/history.js
@@ -13,18 +13,13 @@ const history = createBrowserHistory();
 const originalHistoryPush = history.push;
 const originalHistoryReplace = history.replace;
 
-function buildSearch( params ) {
-	const queryString = buildQueryString( params );
-	return queryString.length > 0 ? '?' + queryString : queryString;
-}
-
 function push( params, state ) {
-	const search = buildSearch( params );
+	const search = buildQueryString( params );
 	return originalHistoryPush.call( history, { search }, state );
 }
 
 function replace( params, state ) {
-	const search = buildSearch( params );
+	const search = buildQueryString( params );
 	return originalHistoryReplace.call( history, { search }, state );
 }
 


### PR DESCRIPTION
Upgrades the `history` package (dependency of `@wordpress/router`) from 5.1.0 to 5.3.0.

It fixes a regression ([fixed in 5.2.0](https://github.com/remix-run/history/releases/tag/v5.2.0)) where the `push`/`replace` methods didn't automatically add a `?` prefix to the `search` query string. If you were on a `/foo` URL, then navigating with `history.push( { search: 'a=b' } )` was supposed to go to `/foo?a=b`, but it navigated to `/fooa=b` instead.

Now it works correctly and we don't need to add the `?` character manually. The behavior is now similar to the native browser API, where `window.location.search = 'a=b'` also adds `?` automatically.