### PR TITLE
Navigator: fix two nits

### DIFF
--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -106,7 +106,7 @@ function UnconnectedNavigatorScreen(
 
 		// When navigating back, if a selector is provided, use it to look for the
 		// target element (assumed to be a node inside the current NavigatorScreen)
-		if ( location.isBack && location?.focusTargetSelector ) {
+		if ( location.isBack && location.focusTargetSelector ) {
 			elementToFocus = wrapperRef.current.querySelector(
 				location.focusTargetSelector
 			);

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -19,7 +19,6 @@ function ScreenStyleVariations() {
 	return (
 		<>
 			<ScreenHeader
-				back="/"
 				title={ __( 'Browse styles' ) }
 				description={ __(
 					'Choose a variation to change the look of the site.'


### PR DESCRIPTION
Fixed two little things that I noticed while learning about the `Navigator` components:
- remove optional chaining when looking at `location.focusTargetSelector`, as `location` is always a valid object
- remove a `back` prop from `<ScreenHeader>` instance as that prop no longer exists. The `ScreenHeader` always navigates to parent.