### PR TITLE
Block Bindings: avoid using local state for bound attributes

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -329,7 +329,7 @@ export function RichTextWrapper(
 		onChange,
 	} );
 
-	useMarkPersistent( { html: adjustedValue, value } );
+	useMarkPersistent( value );
 
 	const keyboardShortcuts = useRef( new Set() );
 	const inputEvents = useRef( new Set() );

--- a/packages/block-editor/src/components/rich-text/use-mark-persistent.js
+++ b/packages/block-editor/src/components/rich-text/use-mark-persistent.js
@@ -9,7 +9,7 @@ import { useDispatch } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
-export function useMarkPersistent( { html, value } ) {
+export function useMarkPersistent( value ) {
 	const previousText = useRef();
 	const hasActiveFormats = !! value.activeFormats?.length;
 	const { __unstableMarkLastChangeAsPersistent } =
@@ -36,5 +36,5 @@ export function useMarkPersistent( { html, value } ) {
 		}
 
 		__unstableMarkLastChangeAsPersistent();
-	}, [ html, hasActiveFormats ] );
+	}, [ value.text, hasActiveFormats ] );
 }

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -4,7 +4,7 @@
 import { getBlockType, store as blocksStore } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { useLayoutEffect, useCallback, useState } from '@wordpress/element';
+import { useLayoutEffect, useCallback } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { RichTextData } from '@wordpress/rich-text';
 
@@ -154,13 +154,12 @@ const BindingConnector = ( {
  * to the source handlers.
  * For this, it creates a BindingConnector for each bound attribute.
  *
- * @param {Object}   props                   - The component props.
- * @param {Object}   props.blockProps        - The BlockEdit props object.
- * @param {Object}   props.bindings          - The block bindings settings.
- * @param {Function} props.onPropValueChange - The function to call when the attribute value changes.
- * @return {null}                              Data-handling component. Render nothing.
+ * @param {Object} props            - The component props.
+ * @param {Object} props.blockProps - The BlockEdit props object.
+ * @param {Object} props.bindings   - The block bindings settings.
+ * @return {null}                     Data-handling component. Render nothing.
  */
-function BlockBindingBridge( { blockProps, bindings, onPropValueChange } ) {
+function BlockBindingBridge( { blockProps, bindings } ) {
 	const blockBindingsSources = unlock(
 		useSelect( blocksStore )
 	).getAllBlockBindingsSources();
@@ -183,7 +182,7 @@ function BlockBindingBridge( { blockProps, bindings, onPropValueChange } ) {
 							source={ source }
 							blockProps={ blockProps }
 							args={ boundAttribute.args }
-							onPropValueChange={ onPropValueChange }
+							onPropValueChange={ blockProps.setAttributes }
 						/>
 					);
 				}
@@ -194,20 +193,6 @@ function BlockBindingBridge( { blockProps, bindings, onPropValueChange } ) {
 
 const withBlockBindingSupport = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		/*
-		 * Collect and update the bound attributes
-		 * in a separate state.
-		 */
-		const [ boundAttributes, setBoundAttributes ] = useState( {} );
-		const updateBoundAttributes = useCallback(
-			( newAttributes ) =>
-				setBoundAttributes( ( prev ) => ( {
-					...prev,
-					...newAttributes,
-				} ) ),
-			[]
-		);
-
 		/*
 		 * Create binding object filtering
 		 * only the attributes that can be bound.
@@ -224,14 +209,10 @@ const withBlockBindingSupport = createHigherOrderComponent(
 					<BlockBindingBridge
 						blockProps={ props }
 						bindings={ bindings }
-						onPropValueChange={ updateBoundAttributes }
 					/>
 				) }
 
-				<BlockEdit
-					{ ...props }
-					attributes={ { ...props.attributes, ...boundAttributes } }
-				/>
+				<BlockEdit { ...props } />
 			</>
 		);
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This pull request removes the local state that stores the bound attribute values and instead relies on the block attributes object, like a regular block.

The changes to the bound attribute values are made non-persistent, to avoid adding undesired events in the editor history.

Additionally, it fixes an issue with the use of the MarkPersistent() RichText hook (props to @michalczaplinski)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because creating an instance of a local state can negatively impact the implementation's efficiency in terms of resources, no matter how small. Additionally, it makes the implementation more unnecessarily complex.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Taking advantage of the `syncDerivedUpdates()` action, and fixing the MarkPersistent() issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Register a few custom fields:

```php
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'This is the content of the text custom field',
	)
);
register_meta(
	'post',
	'url_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

2. Edit a post
3. Switch to the editor mode
4. Create a few blocks with bound attributes to the custom fields

**core/paragraph**
```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<p> <strong>STATIC</strong> value</p>
<!-- /wp:paragraph -->
```

**core/image**
```html
<!-- wp:image {"id":248,"width":"168px","height":"auto","sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}},"alt":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg" alt="STATIC <strong&gt;field</strong&gt; value" class="wp-image-248" style="width:168px;height:auto"/></figure>
<!-- /wp:image -->
```

5. Save the post
6. Hard refresh (it ensures clean up the editor history)
7. Switch to the visual mode
8. Confirm the attributes get the values of the custom fields
9. Confirm the editor doesn't register any changes
  * The UNDO button keeps disabling
  * Save draft / Update keeps disabled


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/77539/53649763-b9a5-4657-9dd7-da646a8db1bb

