### PR TITLE
Block Editor: Deprecate '__experimentalGetReusableBlockTitle' selector

### DIFF
--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -6,6 +6,7 @@ import {
 	store as blocksStore,
 	isReusableBlock,
 	isTemplatePart,
+	__experimentalGetBlockLabel as getBlockLabel,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -68,11 +69,8 @@ export default function useBlockDisplayInformation( clientId ) {
 	return useSelect(
 		( select ) => {
 			if ( ! clientId ) return null;
-			const {
-				getBlockName,
-				getBlockAttributes,
-				__experimentalGetReusableBlockTitle,
-			} = select( blockEditorStore );
+			const { getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 			const blockName = getBlockName( clientId );
@@ -80,12 +78,12 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! blockType ) return null;
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
-			const isReusable = isReusableBlock( blockType );
-			const resusableTitle = isReusable
-				? __experimentalGetReusableBlockTitle( attributes.ref )
+			const isSynced =
+				isReusableBlock( blockType ) || isTemplatePart( blockType );
+			const syncedTitle = isSynced
+				? getBlockLabel( blockType, attributes )
 				: undefined;
-			const title = resusableTitle || blockType.title;
-			const isSynced = isReusable || isTemplatePart( blockType );
+			const title = syncedTitle || blockType.title;
 			const positionLabel = getPositionTypeLabel( attributes );
 			const blockTypeInfo = {
 				isSynced,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2534,6 +2534,14 @@ export const __experimentalGetReusableBlockTitle = createRegistrySelector(
 	( select ) =>
 		createSelector(
 			( state, ref ) => {
+				deprecated(
+					"wp.data.select( 'core/block-editor' ).__experimentalGetReusableBlockTitle",
+					{
+						since: '6.6',
+						version: '6.8',
+					}
+				);
+
 				const reusableBlock = unlock( select( STORE_NAME ) )
 					.getReusableBlocks()
 					.find( ( block ) => block.id === ref );


### PR DESCRIPTION
## What?
This is a follow-up #58646.

PR deprecates the `__experimentalGetReusableBlockTitle` selector and removes its usage from the `useBlockDisplayInformation` hook.

## Why?
Now that the Pattern block uses the `__experimentalLabel` method for labels, there's no need to keep the selector around.

## Testing Instructions
 1. Open a post or page.
 2. Insert a synced Pattern.
 3. Confirm its title is correctly displayed in the sidebar's block card.
 4. Running the selector in the console should display a deprecation warning - `wp.data.select( 'core/block-editor' ).__experimentalGetReusableBlockTitle( patternRef );`

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-03-28 at 14 53 25](https://github.com/WordPress/gutenberg/assets/240569/a5a018d5-cd83-49a7-83fb-8a51a3d586d5)
