### PR TITLE
TextControl: Apply zero margin to input element

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   `InputControl`: Ignore IME events when `isPressEnterToChange` is enabled ([#60090](https://github.com/WordPress/gutenberg/pull/60090)).
+-   `TextControl`: Apply zero margin to input element ([#60282](https://github.com/WordPress/gutenberg/pull/60282)).
 
 ### Experimental
 

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -14,6 +14,7 @@
 .components-text-control__input[type="number"] {
 	width: 100%;
 	height: $grid-unit-40;
+	// Override input style margin in WP forms.css.
 	margin: 0;
 	@include input-control;
 

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -14,6 +14,7 @@
 .components-text-control__input[type="number"] {
 	width: 100%;
 	height: $grid-unit-40;
+	margin: 0;
 	@include input-control;
 
 	&.is-next-40px-default-size {


### PR DESCRIPTION
Fixes #59761

## What?

This PR applies `margin:0` to the `input` element inside the `Textcontrol` component.

## Why?

As the screenshot in #59761 shows, WP Core applies a 1px margin on both sides of the `input` and `select` elements as a form style. This may make sense on the dashboard, but on a `TextControl` component it's an unintended style and causes a 1px misalignment.

## How?

Applies `margin: 0` to the `input` element inside the `TextControl` component.

As another approach, I considered applying the margin to the `input-control` mixin itself, but I rejected it for the following reasons:

- Some developers may be using this mixin by importing the `base-styles` package themselves, and it may affect their UI.
- As far as I've researched, it's only the `TextControl` component that is causing this problem. For example, in other components we override the left and right margins with zero as below:
  - SelectControl
  https://github.com/WordPress/gutenberg/blob/6ebbb8b2c2724bbc293650ed82b723bcc02ed8ec/packages/components/src/select-control/styles/select-control-styles.ts#L132
  - InputControl
  https://github.com/WordPress/gutenberg/blob/6ebbb8b2c2724bbc293650ed82b723bcc02ed8ec/packages/components/src/input-control/styles/input-control-styles.tsx#L219
  - RadioControl
  https://github.com/WordPress/gutenberg/blob/6ebbb8b2c2724bbc293650ed82b723bcc02ed8ec/packages/components/src/radio-control/style.scss#L10
## Testing Instructions

- See the TextControl story in Storybook.
- Enable WP core global CSS from the toolbar.
- Use developer tools to ensure that the input element is not affected by WP core form styles.

![storybook](https://github.com/WordPress/gutenberg/assets/54422211/a2aa3568-4a41-420c-90eb-1fd4c8ac1749)

## Screenshots or screencast <!-- if applicable -->

Below is an example of a block sidebar.

### Before

The 1px margin pushes the component to the right and doesn't line up with other components.

![before](https://github.com/WordPress/gutenberg/assets/54422211/76dee76c-4380-44a9-8a85-159873fcde3b)

### After

It should line up perfectly with the other components.

![after](https://github.com/WordPress/gutenberg/assets/54422211/eb1d7f37-7466-4a8b-9943-bd5221ec8d98)

