### PR TITLE
Fix Font Collection JSON schema definition

### DIFF
--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -138,12 +138,7 @@
 								}
 							}
 						},
-						"required": [
-							"name",
-							"fontFamily",
-							"slug",
-							"fontFace"
-						],
+						"required": [ "name", "fontFamily", "slug" ],
 						"additionalProperties": false
 					},
 					"categories": {

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -4,7 +4,7 @@
 	"type": "object",
 	"definitions": {
 		"fontFace": {
-			"description": "Font face theme.json settings, with added preview property.",
+			"description": "Font face settings, with added preview property.",
 			"type": "object",
 			"properties": {
 				"preview": {
@@ -107,7 +107,7 @@
 				"type": "object",
 				"properties": {
 					"font_family_settings": {
-						"description": "Font family theme.json settings, with added preview property.",
+						"description": "Font family settings, with added preview property.",
 						"type": "object",
 						"properties": {
 							"name": {
@@ -138,6 +138,12 @@
 								}
 							}
 						},
+						"required": [
+							"name",
+							"fontFamily",
+							"slug",
+							"fontFace"
+						],
 						"additionalProperties": false
 					},
 					"categories": {
@@ -154,5 +160,5 @@
 		}
 	},
 	"additionalProperties": false,
-	"required": [ "$schema", "slug", "name", "font_families" ]
+	"required": [ "font_families" ]
 }


### PR DESCRIPTION
Fixes #60259

## What?
This PR correctly updates the JSON schema according to the actual font collection specifications.

## Why?

If we don't update it correctly, the code editor will show an error even though the actual definition is correct. Also, we don't know what properties are definable in the `font_family_settings` field.

## How?

I've updated the schema according to the spec as I understand it. In particular, it is expected that properties `name`, `fontFamily`, `slug`, and `fontFace` are required for the `font_family_settings` field, but if I am wrong, please let me know.

## Testing Instructions

Create a JSON file like the one below locally and make sure the code editor validates or completes all fields correctly.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/fix/font-collection-schema/schemas/json/font-collection.json"
}
```

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/e06a31ce-7271-4fdc-824f-ecfda1fefe16

