### PR TITLE
Exploration: Simpler outlines and synced pattern interactions

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/content.scss
+++ b/packages/block-editor/src/components/block-content-overlay/content.scss
@@ -1,41 +1,4 @@
 .block-editor-block-list__block.has-block-overlay {
-	cursor: default;
-
-	&::before {
-		content: "";
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		background: transparent;
-		border: none;
-		border-radius: $radius-block-ui;
-		z-index: z-index(".block-editor-block-list__block.has-block-overlay");
-	}
-
-	&:not(.is-multi-selected)::after {
-		content: none !important;
-	}
-
-	&:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
-	}
-
-	&.is-reusable:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before,
-	&.wp-block-template-part:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before {
-		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
-		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color) inset;
-	}
-
-	&.is-selected:not(.is-dragging-blocks)::before {
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
-	}
-
-	.block-editor-block-list__block {
-		pointer-events: none;
-	}
 
 	.block-editor-iframe__body.is-zoomed-out &::before {
 		// Unfortunately because of the vw unit, this is not always going to be exact

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -310,29 +310,30 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 }
 
+// Add fade in/out background for editable blocks in synced patterns.
 @keyframes block-editor-is-editable__animation {
 	from {
-		background-color: rgba(var(--wp-block-synced-color--rgb), 0.08);
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 	}
 	to {
-		background-color: rgba(var(--wp-block-synced-color--rgb), 0);
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0);
 	}
 }
 
-.is-root-container:not([inert]) .block-editor-block-list__block.has-editable-outline {
-	&::after {
-		content: "";
-		position: absolute;
-		pointer-events: none;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		animation: block-editor-is-editable__animation 0.35s ease-out;
-		animation-delay: 0.5s;
-		animation-fill-mode: backwards;
-		@include reduce-motion("animation");
-	}
+.is-root-container:not([inert]) .block-editor-block-list__block.is-reusable.is-selected .block-editor-block-list__block.has-editable-outline::after {
+	content: "";
+	position: absolute;
+	pointer-events: none;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	animation-name: block-editor-is-editable__animation;
+	animation-duration: 0.35s;
+	animation-timing-function: ease-out;
+	animation-delay: 0.5s;
+	animation-fill-mode: backwards;
+	@include reduce-motion("animation");
 }
 
 // Spotlight mode. Fade out blocks unless they contain a selected block.

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -99,17 +99,18 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 			position: absolute;
 			z-index: 1;
 			pointer-events: none;
-			top: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			left: $border-width;
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-			outline: 2px solid transparent; // This shows up in Windows High Contrast Mode.
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			outline-color: var(--wp-admin-theme-color);
+			outline-style: solid;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
 
-			// Show a light color for dark themes.
+			// Show a light color for dark themes (@todo, is this even helpful?)
 			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+				outline-color: $dark-theme-focus;
 			}
 		}
 	}
@@ -122,10 +123,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 			position: absolute;
 			z-index: 0;
 			pointer-events: none;
-			transition:
-				border-color 0.1s linear,
-				border-style 0.1s linear,
-				box-shadow 0.1s linear;
+			transition: outline 0.1s linear;
 			right: 0;
 			left: 0;
 			top: -$default-block-margin * 0.5;
@@ -263,19 +261,22 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 }
 
 .is-outline-mode .block-editor-block-list__block:not(.remove-outline) {
-	&.is-hovered {
+
+	&.is-hovered:not(.is-selected) {
 		cursor: default;
 
 		&::after {
 			content: "";
 			position: absolute;
 			pointer-events: none;
-			top: $border-width;
-			left: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			outline-color: var(--wp-admin-theme-color);
+			outline-style: solid;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
 		}
 	}
 
@@ -285,27 +286,36 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		&.rich-text {
 			cursor: unset;
 		}
+	}
+
+	&:not(.rich-text).is-selected {
+
+		&.rich-text::after {
+			outline-offset: 0;
+		}
 
 		&::after {
 			content: "";
 			position: absolute;
 			pointer-events: none;
-			top: $border-width;
-			left: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			outline-color: var(--wp-admin-theme-color);
+			outline-style: solid;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
 		}
 	}
 }
 
-@keyframes block-editor-has-editable-outline__fade-out-animation {
+@keyframes block-editor-is-editable__animation {
 	from {
-		border-color: rgba(var(--wp-admin-theme-color--rgb), 1);
+		background-color: rgba(var(--wp-block-synced-color--rgb), 0.08);
 	}
 	to {
-		border-color: rgba(var(--wp-admin-theme-color--rgb), 0);
+		background-color: rgba(var(--wp-block-synced-color--rgb), 0);
 	}
 }
 
@@ -318,11 +328,9 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		left: 0;
 		right: 0;
 		bottom: 0;
-		border: 1px dotted rgba(var(--wp-admin-theme-color--rgb), 1);
-		border-radius: $radius-block-ui;
-		animation: block-editor-has-editable-outline__fade-out-animation 0.3s ease-out;
-		animation-delay: 1s;
-		animation-fill-mode: forwards;
+		animation: block-editor-is-editable__animation 0.35s ease-out;
+		animation-delay: 0.5s;
+		animation-fill-mode: backwards;
 		@include reduce-motion("animation");
 	}
 }
@@ -360,9 +368,15 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	z-index: z-index("{core/image aligned left or right} .wp-block");
 }
 
+// Increase width when zoomed out to match visually.
 body.is-zoomed-out {
 	display: flex;
 	flex-direction: column;
+
+	.is-outline-mode .block-editor-block-list__block:not(.remove-outline):not(.rich-text).is-selected::after,
+	.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-hovered:not(.is-selected)::after {
+		outline-width: calc(2 * var(--wp-admin-border-width-focus)); // Adjusted for the zoom scale of 0.5.
+	}
 
 	> .is-root-container {
 		flex: 1;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -310,6 +310,34 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 }
 
+// Colorize outlines for template parts and synced patterns (.is-reusable).
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-reusable {
+	&.is-highlighted::after,
+	&.is-selected::after {
+		outline-color: var(--wp-block-synced-color);
+	}
+
+	&.is-hovered::after {
+		outline-color: var(--wp-block-synced-color);
+	}
+
+	&.block-editor-block-list__block:not([contenteditable]):focus {
+		&::after {
+			outline-color: var(--wp-block-synced-color);
+
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				outline-color: $dark-theme-focus; //@todo, is this even helpful?
+			}
+		}
+	}
+}
+
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part.has-editable-outline::after {
+	border: none;
+}
+
 // Add fade in/out background for editable blocks in synced patterns.
 @keyframes block-editor-is-editable__animation {
 	from {
@@ -376,7 +404,7 @@ body.is-zoomed-out {
 
 	.is-outline-mode .block-editor-block-list__block:not(.remove-outline):not(.rich-text).is-selected::after,
 	.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-hovered:not(.is-selected)::after {
-		outline-width: calc(2 * var(--wp-admin-border-width-focus)); // Adjusted for the zoom scale of 0.5.
+		outline-width: calc(2 * var(--wp-admin-border-width-focus)); // Adjusted for the zoom scale of 0.5; not perfect but its ok.
 	}
 
 	> .is-root-container {

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -260,6 +260,16 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 }
 
+// Add fade in/out background for editable blocks in synced patterns.
+@keyframes block-editor-outline__animation {
+	from {
+		outline-color: transparent;
+	}
+	to {
+		outline-color: var(--wp-admin-theme-color);
+	}
+}
+
 .is-outline-mode .block-editor-block-list__block:not(.remove-outline) {
 
 	&.is-hovered:not(.is-selected) {
@@ -277,6 +287,10 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 			outline-style: solid;
 			outline-width: var(--wp-admin-border-width-focus);
 			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
+			animation-name: block-editor-outline__animation;
+			animation-duration: 0.15s;
+			animation-timing-function: ease-out;
+			@include reduce-motion("animation");
 		}
 	}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -130,7 +130,11 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const hasBlockBindings = !! blockEditContext[ blockBindingsKey ];
 	const bindingsStyle =
 		hasBlockBindings && canBindBlock( name )
-			? { '--wp-admin-theme-color': 'var(--wp-block-synced-color)' }
+			? {
+					'--wp-admin-theme-color': 'var(--wp-block-synced-color)',
+					'--wp-admin-theme-color--rgb':
+						'var(--wp-block-synced-color--rgb)',
+			  }
 			: {};
 
 	// Ensures it warns only inside the `edit` implementation for the block.

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -130,7 +130,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const hasBlockBindings = !! blockEditContext[ blockBindingsKey ];
 	const bindingsStyle =
 		hasBlockBindings && canBindBlock( name )
-			? { '--wp-admin-theme-color': 'var(--wp-bound-block-color)' }
+			? { '--wp-admin-theme-color': 'var(--wp-block-synced-color)' }
 			: {};
 
 	// Ensures it warns only inside the `edit` implementation for the block.

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -182,8 +182,8 @@
 	.block-editor-block-list__block-selection-button,
 	.block-editor-block-contextual-toolbar {
 		pointer-events: all;
-		margin-top: $grid-unit-15;
-		margin-bottom: $grid-unit-15;
+		margin-top: $grid-unit-10;
+		margin-bottom: $grid-unit-10;
 	}
 
 	.block-editor-block-contextual-toolbar {

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -23,28 +23,3 @@
 	z-index: z-index(".block-library-template-part__selection-search");
 }
 
-.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
-.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-reusable {
-	&.is-highlighted::after,
-	&.is-selected::after {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
-	}
-
-	&.is-hovered::after {
-		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color);
-	}
-
-	&.block-editor-block-list__block:not([contenteditable]):focus {
-		&::after {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
-			}
-		}
-	}
-}
-
-.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part.has-editable-outline::after {
-	border: none;
-}

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -288,7 +288,7 @@
 	.edit-post-header {
 		backdrop-filter: blur(20px) !important;
 		background-color: rgba(255, 255, 255, 0.9);
-		border-bottom: 1px solid #e0e0e0;
+		box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133);
 		position: absolute;
 		width: 100%;
 

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -88,7 +88,6 @@ body.js.block-editor-page {
 
 	.is-sidebar-opened & {
 		@include break-medium() {
-			border-left: $border-width solid $gray-200;
 			overflow: hidden scroll;
 		}
 	}

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -120,7 +120,7 @@ function EditorCanvas( {
 	const scale = isZoomOutMode
 		? ( contentWidth ) =>
 				computeIFrameScale(
-					{ width: 1000, scale: 0.45 },
+					{ width: 1000, scale: 0.5 },
 					{ width: 400, scale: 0.9 },
 					contentWidth
 				)

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -48,7 +48,6 @@
 		}
 
 		.edit-site-visual-editor__editor-canvas {
-			border-radius: $radius-block-ui;
 			max-height: 100%;
 		}
 

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -7,7 +7,7 @@
 	box-sizing: border-box;
 	width: 100%;
 	justify-content: space-between;
-	border-bottom: $border-width solid $gray-200;
+	box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133);
 	padding-left: $header-height;
 
 	.edit-site-header-edit-mode__start {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -175,12 +175,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	border-bottom: 1px solid transparent;
-
-	.edit-site-layout.is-full-canvas & {
-		border-bottom-color: $gray-200;
-		transition: border-bottom-color 0.15s 0.4s ease-out;
-	}
 
 	&:hover,
 	&:active {

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -101,7 +101,7 @@ html.interface-interface-skeleton__html-container {
 	flex-shrink: 0;
 	position: absolute;
 	z-index: z-index(".interface-interface-skeleton__sidebar");
-	top: 0;
+	top: $border-width;
 	right: 0;
 	bottom: 0;
 	left: 0;
@@ -126,20 +126,20 @@ html.interface-interface-skeleton__html-container {
 	overflow: auto;
 
 	@include break-medium() {
-		border-left: $border-width solid $gray-200;
+		box-shadow: -$border-width 0 0 0 rgba($color: #000, $alpha: 0.133);
 	}
 }
 
 .interface-interface-skeleton__secondary-sidebar {
 	@include break-medium() {
-		border-right: $border-width solid $gray-200;
+		box-shadow: $border-width 0 0 0 rgba($color: #000, $alpha: 0.133);
 	}
 }
 
 .interface-interface-skeleton__header {
 	flex-shrink: 0;
 	height: auto;  // Keep the height flexible.
-	border-bottom: $border-width solid $gray-200;
+	box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133);
 	z-index: z-index(".interface-interface-skeleton__header");
 	color: $gray-900;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

**Not intended for direct merge.** 

This is an exploration of a number of ideas around block selection, outlines and related interactions, combined to get a solid sense of how these will work together. 

My goal is to try and make it less "weighty" selecting blocks in the Site Editor, more predictable, and less concepts to understand. Less moving parts if you would. 

If we like the direction we can split it into proper PRs. 

## What?
1. Changed the editable block indicator to render only for synced patterns, as you can now select headers and footers when editing pages in the Site Editor. These editable indicators are now background color, rather than the existing dotted outline. 
2. Try `outline` and `outline-offset` as the mechanism for visible outlines, rather than shadows. Allows for borders to be clearly seen on fullwidth block selection, while also reducing clashing borders when hovering/selecting blocks near each other.
3. Use a consistent `var(--wp-admin-border-width-focus)` width for outlines, rather than `1px` on hover and `1.5px` on selection. 
4. Does not render the `.is-selected` outline when selecting RichText, making text editing less disruptive by outlines.
5. Moves the block toolbar 8px away from the selection, rather than 12px away—just to get a bit less coverage over other blocks.
6. Another pass at using shadows for interface borders that are edge-to-edge with the editable canvas, reducing visual blurry edges when having any color that's not white or black against the header toolbar or either editor sidebar.
7. Try removing border radius from outlines, to reduce visual conflicts when against or over non-radii elements (images, fullwidth blocks, edge of the canvas, etc).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Explore the changes listed above by selecting blocks. 
3. Add a synced pattern with overrides, to see the editable block indicators.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/1813435/798051a9-ffcd-4a59-b3b6-c3ee3db45b9d

![CleanShot 2024-03-28 at 09 51 52](https://github.com/WordPress/gutenberg/assets/1813435/a458b92b-18e7-4a16-86d8-90d2ed7f1bda)

