### PR TITLE
Fix editor canvas overflow on search results with position: relative

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -22,7 +22,6 @@ $block-inserter-tabs-height: 44px;
 	flex-direction: column;
 	height: 100%;
 	gap: $grid-unit-20;
-	overflow-y: hidden;
 
 	&.show-as-tabs {
 		gap: 0;
@@ -142,6 +141,8 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__no-tab-container {
 	overflow-y: auto;
 	flex-grow: 1;
+	// Fixes the editor canvas scrolling on search results https://github.com/WordPress/gutenberg/issues/56811
+	position: relative;
 }
 
 .block-editor-inserter__panel-header {


### PR DESCRIPTION
Original issue: https://github.com/WordPress/gutenberg/issues/56811

Previously this was fixed with overflow: hidden; which is more restrictive. position: relative also fixes the issue and is less restrictive of allowing other styling options and ui elements on the inserter such as a block pattern fly out in  https://github.com/WordPress/gutenberg/pull/60257

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What/Why/How?
<!-- In a few words, what is the PR actually doing? -->
Removes overflow: hidden from the block inserter wrapper and replaces it with a more appropriate fix of position: relative on the container causing the overflow.

Props to @t-hamano for [identifying the correct container](https://github.com/WordPress/gutenberg/pull/57127#issuecomment-2024676017) to apply this rule to.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open the site editor or post editor
- Open the inserter on the top left
- Enter the search term 'List'
- Scroll the inserter container to the bottom
- Try to scroll the editor canvas. There should be no scrolling of the editor canvas.
- Search 'a'
- Scroll the inserter to the bottom 
- Try to scroll the editor canvas. 
