### PR TITLE
Blocks: Fix double `gutenberg_` prefix in built dynamic blocks PHP

### DIFF
--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -188,7 +188,8 @@ module.exports = [
 												// other core prefix (e.g. "wp_").
 												return result.replace(
 													new RegExp(
-														functionName,
+														functionName +
+															'(?![a-zA-Z0-9_])',
 														'g'
 													),
 													( match ) =>


### PR DESCRIPTION
## What?
During the build step of the block-library package, function names found in dynamic blocks' PHP code are prefixed with `gutenberg_` (to avoid collisions with their unprefixed counterparts in Core).

If a function name is fully included in another function's name -- e.g. [`block_core_navigation_insert_hooked_blocks`](https://github.com/WordPress/gutenberg/blob/6ebbb8b2c2724bbc293650ed82b723bcc02ed8ec/packages/block-library/src/navigation/index.php#L1464) and [`block_core_navigation_insert_hooked_blocks_into_rest_response`](https://github.com/WordPress/gutenberg/blob/6ebbb8b2c2724bbc293650ed82b723bcc02ed8ec/packages/block-library/src/navigation/index.php#L1596) -- the latter is prefixed twice, due to the way the function name is searched for. In the example above, this results in the function being named in `gutenberg_gutenberg_block_core_navigation_insert_hooked_blocks_into_rest_response` in `build/block-library/blocks/navigation.php`.

This PR fixes this problem.

## Why?
To fix https://github.com/WordPress/gutenberg/issues/40938.

## How?
By making sure a function call is only replaced if the matched string isn't part of a longer function name.

## Testing Instructions
1. `rm -rf build && npm run build`
2. Open `build/block-library/blocks/navigation.php`.
3. Verify that the function name is now prefixed only once, i.e. `gutenberg_block_core_navigation_insert_hooked_blocks_into_rest_response`.
