### PR TITLE
Improve select control typescript types

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 -   `CustomSelectControlV2`: Fix hint behavior in legacy ([#60183](https://github.com/WordPress/gutenberg/pull/60183)).
 
+### Enhancement
+
+-   `SelectControl`: Make component type generic to allow type narrowing ([#60293](https://github.com/WordPress/gutenberg/pull/60293)).
+
 ## 27.2.0 (2024-03-21)
 
 -   `Dropdown` : Add styling support for `MenuGroup` ([#59723](https://github.com/WordPress/gutenberg/pull/59723)).

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -71,6 +71,20 @@ function buildPadInputStateReducer( pad: number ) {
 	};
 }
 
+type MonthValue =
+	| '01'
+	| '02'
+	| '03'
+	| '04'
+	| '05'
+	| '06'
+	| '07'
+	| '08'
+	| '09'
+	| '10'
+	| '11'
+	| '12';
+
 /**
  * TimePicker is a React component that renders a clock for time selection.
  *
@@ -114,7 +128,7 @@ export function TimePicker( {
 	const { day, month, year, minutes, hours, am } = useMemo(
 		() => ( {
 			day: format( date, 'dd' ),
-			month: format( date, 'MM' ),
+			month: format( date, 'MM' ) as MonthValue,
 			year: format( date, 'yyyy' ),
 			minutes: format( date, 'mm' ),
 			hours: format( date, is12Hour ? 'hh' : 'HH' ),
@@ -197,7 +211,7 @@ export function TimePicker( {
 
 	const monthField = (
 		<MonthSelectWrapper>
-			<SelectControl
+			<SelectControl< MonthValue >
 				className="components-datetime__time-field components-datetime__time-field-month" // Unused, for backwards compatibility.
 				label={ __( 'Month' ) }
 				hideLabelFromVision

--- a/packages/components/src/query-controls/index.tsx
+++ b/packages/components/src/query-controls/index.tsx
@@ -85,7 +85,11 @@ export function QueryControls( {
 						__next40pxDefaultSize={ __next40pxDefaultSize }
 						key="query-controls-order-select"
 						label={ __( 'Order by' ) }
-						value={ `${ orderBy }/${ order }` }
+						value={
+							orderBy === undefined || order === undefined
+								? undefined
+								: `${ orderBy }/${ order }`
+						}
 						options={ [
 							{
 								label: __( 'Newest to oldest' ),

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -29,8 +29,12 @@ function useUniqueId( idProp?: string ) {
 	return idProp || id;
 }
 
-function UnforwardedSelectControl(
-	props: WordPressComponentProps< SelectControlProps, 'select', false >,
+function UnforwardedSelectControl< OptionType extends string >(
+	props: WordPressComponentProps<
+		SelectControlProps< OptionType >,
+		'select',
+		false
+	>,
 	ref: React.ForwardedRef< HTMLSelectElement >
 ) {
 	const {
@@ -174,6 +178,14 @@ function UnforwardedSelectControl(
  * };
  * ```
  */
-export const SelectControl = forwardRef( UnforwardedSelectControl );
+export const SelectControl = forwardRef( UnforwardedSelectControl ) as <
+	OptionType extends string,
+>(
+	props: WordPressComponentProps<
+		SelectControlProps< OptionType >,
+		'select',
+		false
+	> & { ref?: React.ForwardedRef< HTMLSelectElement > }
+) => ReturnType< typeof UnforwardedSelectControl >;
 
 export default SelectControl;

--- a/packages/components/src/select-control/test/types-test.tsx
+++ b/packages/components/src/select-control/test/types-test.tsx
@@ -79,7 +79,7 @@ import SelectControl from '..';
 			label: 'String',
 		},
 		{
-			// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+			// @ts-expect-error "otherstring" is not "narrow" or "value", so throw an error
 			value: 'otherstring',
 			label: 'Other String',
 		},
@@ -192,7 +192,7 @@ import SelectControl from '..';
 			label: 'String',
 		},
 		{
-			// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+			// @ts-expect-error "otherstring" is not "narrow" or "value", so throw an error
 			value: 'otherstring',
 			label: 'Other String',
 		},

--- a/packages/components/src/select-control/test/types-test.tsx
+++ b/packages/components/src/select-control/test/types-test.tsx
@@ -1,0 +1,245 @@
+/**
+ * Internal dependencies
+ */
+import SelectControl from '..';
+
+/**
+ * Single type
+ */
+// Normal select, no generic or option provided. Any value is allowed here.
+<SelectControl
+	value="string"
+	multiple={ false }
+	onChange={ ( value ) => {
+		return value === 'string';
+	} }
+/>;
+
+// Normal select, no generic provided. Value type is inferred from available options.
+<SelectControl
+	value="string"
+	multiple={ false }
+	options={ [
+		{
+			value: 'string',
+			label: 'String',
+		},
+		{
+			value: 'otherstring',
+			label: 'Other String',
+		},
+	] }
+	onChange={ ( value ) => {
+		return value === 'string';
+	} }
+/>;
+
+// Normal select, no generic provided. Value type is inferred from available options.
+// Incorrect value type provided to test validation is working.
+<SelectControl
+	// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+	value="string"
+	multiple={ false }
+	options={ [
+		{
+			value: 'narrow',
+			label: 'Narrow',
+		},
+		{
+			value: 'value',
+			label: 'Value',
+		},
+	] }
+	onChange={ ( value ) => {
+		return value === 'string';
+	} }
+/>;
+
+// Select with explicit generic provided.
+// Both value and options.value must match the provided generic.
+<SelectControl< 'narrow' | 'value' >
+	value="narrow"
+	options={ [
+		{
+			value: 'narrow',
+			label: 'Narrow',
+		},
+		{
+			value: 'value',
+			label: 'Value',
+		},
+	] }
+	multiple={ false }
+	onChange={ ( value ) => {
+		return value === 'narrow';
+	} }
+/>;
+
+// Select with explicit generic provided.
+// Both value and options.value must match the provided generic.
+// Incorrect value type provided to test validation is working.
+<SelectControl< 'narrow' | 'value' >
+	// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+	value="string"
+	multiple={ false }
+	options={ [
+		{
+			// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+			value: 'string',
+			label: 'String',
+		},
+		{
+			// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+			value: 'otherstring',
+			label: 'Other String',
+		},
+	] }
+	onChange={ ( value ) => {
+		// Typescript can't guarantee the value isn't modified by the
+		// user, so we can't assign a type to value here.
+		return value === 'string';
+	} }
+/>;
+
+/**
+ * Multiple type
+ */
+// Normal select, no generic or option provided. Any value is allowed here.
+<SelectControl
+	value={ [ 'string' ] }
+	multiple
+	onChange={ ( values ) => {
+		return values.includes( 'string' );
+	} }
+/>;
+
+// Normal select, no generic provided. Value type is inferred from available options.
+<SelectControl
+	value={ [ 'string' ] }
+	multiple
+	options={ [
+		{
+			value: 'string',
+			label: 'String',
+		},
+		{
+			value: 'otherstring',
+			label: 'Other String',
+		},
+	] }
+	onChange={ ( values ) => {
+		return values.includes( 'string' );
+	} }
+/>;
+
+// Normal select, no generic provided. Value type is inferred from available options.
+// Incorrect value type provided to test validation is working.
+<SelectControl
+	// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+	value={ [ 'string' ] }
+	multiple
+	options={ [
+		{
+			value: 'narrow',
+			label: 'Narrow',
+		},
+		{
+			value: 'value',
+			label: 'Value',
+		},
+	] }
+	onChange={ ( values ) => {
+		return values.includes( 'string' );
+	} }
+/>;
+
+// Select with explicit generic provided.
+// Both value and options.value must match the provided generic.
+<SelectControl< 'narrow' | 'value' >
+	value={ [ 'narrow' ] }
+	multiple
+	options={ [
+		{
+			value: 'narrow',
+			label: 'Narrow',
+		},
+		{
+			value: 'value',
+			label: 'Value',
+		},
+	] }
+	onChange={ ( values ) => {
+		return values.includes( 'narrow' );
+	} }
+/>;
+// Select with explicit generic provided.
+// Both value and options.value must match the provided generic.
+// Value used with multiple matching strings in array.
+<SelectControl< 'narrow' | 'value' >
+	value={ [ 'narrow', 'value' ] }
+	multiple
+	options={ [
+		{
+			value: 'narrow',
+			label: 'Narrow',
+		},
+		{
+			value: 'value',
+			label: 'Value',
+		},
+	] }
+	onChange={ ( values ) => {
+		return values.includes( 'narrow' );
+	} }
+/>;
+
+// Select with explicit generic provided.
+// Both value and options.value must match the provided generic.
+// Incorrect value type provided to test validation is working.
+<SelectControl< 'narrow' | 'value' >
+	// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+	value={ [ 'string' ] }
+	multiple
+	options={ [
+		{
+			// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+			value: 'string',
+			label: 'String',
+		},
+		{
+			// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+			value: 'otherstring',
+			label: 'Other String',
+		},
+	] }
+	onChange={ ( values ) => {
+		// Typescript can't guarantee the value isn't modified by the
+		// user, so we can't assign a type to values here.
+		return values.includes( 'string' );
+	} }
+/>;
+
+// Select with explicit generic provided.
+// Both value and options.value must match the provided generic.
+// Value with 1 matching and 1 non-matching value provided to test validation is working.
+<SelectControl< 'narrow' | 'value' >
+	// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+	value={ [ 'string', 'narrow' ] }
+	multiple
+	options={ [
+		{
+			value: 'narrow',
+			label: 'Narrow',
+		},
+		{
+			// @ts-expect-error "string" is not "narrow" or "value", so throw an error
+			value: 'string',
+			label: 'String',
+		},
+	] }
+	onChange={ ( values ) => {
+		// Typescript can't guarantee the value isn't modified by the
+		// user, so we can't assign a type to values here.
+		return values.includes( 'string' );
+	} }
+/>;

--- a/packages/components/src/select-control/test/types-test.tsx
+++ b/packages/components/src/select-control/test/types-test.tsx
@@ -86,6 +86,24 @@ import SelectControl from '..';
 	] }
 />;
 
+// Select with explicit generic provided.
+// Usually this would result in a type error with no generic,
+// but this has been explicitly loosened to bypass errors.
+<SelectControl< string >
+	value="string"
+	multiple={ false }
+	options={ [
+		{
+			value: 'narrow',
+			label: 'Narrow',
+		},
+		{
+			value: 'value',
+			label: 'Value',
+		},
+	] }
+/>;
+
 /**
  * Multiple type
  */

--- a/packages/components/src/select-control/test/types-test.tsx
+++ b/packages/components/src/select-control/test/types-test.tsx
@@ -7,13 +7,7 @@ import SelectControl from '..';
  * Single type
  */
 // Normal select, no generic or option provided. Any value is allowed here.
-<SelectControl
-	value="string"
-	multiple={ false }
-	onChange={ ( value ) => {
-		return value === 'string';
-	} }
-/>;
+<SelectControl value="string" multiple={ false } />;
 
 // Normal select, no generic provided. Value type is inferred from available options.
 <SelectControl
@@ -29,9 +23,6 @@ import SelectControl from '..';
 			label: 'Other String',
 		},
 	] }
-	onChange={ ( value ) => {
-		return value === 'string';
-	} }
 />;
 
 // Normal select, no generic provided. Value type is inferred from available options.
@@ -51,6 +42,8 @@ import SelectControl from '..';
 		},
 	] }
 	onChange={ ( value ) => {
+		// Typescript can't guarantee the value isn't modified by the
+		// user, so we can't assign a type to value here.
 		return value === 'string';
 	} }
 />;
@@ -70,9 +63,6 @@ import SelectControl from '..';
 		},
 	] }
 	multiple={ false }
-	onChange={ ( value ) => {
-		return value === 'narrow';
-	} }
 />;
 
 // Select with explicit generic provided.
@@ -94,24 +84,13 @@ import SelectControl from '..';
 			label: 'Other String',
 		},
 	] }
-	onChange={ ( value ) => {
-		// Typescript can't guarantee the value isn't modified by the
-		// user, so we can't assign a type to value here.
-		return value === 'string';
-	} }
 />;
 
 /**
  * Multiple type
  */
 // Normal select, no generic or option provided. Any value is allowed here.
-<SelectControl
-	value={ [ 'string' ] }
-	multiple
-	onChange={ ( values ) => {
-		return values.includes( 'string' );
-	} }
-/>;
+<SelectControl value={ [ 'string' ] } multiple />;
 
 // Normal select, no generic provided. Value type is inferred from available options.
 <SelectControl
@@ -127,9 +106,6 @@ import SelectControl from '..';
 			label: 'Other String',
 		},
 	] }
-	onChange={ ( values ) => {
-		return values.includes( 'string' );
-	} }
 />;
 
 // Normal select, no generic provided. Value type is inferred from available options.
@@ -148,9 +124,6 @@ import SelectControl from '..';
 			label: 'Value',
 		},
 	] }
-	onChange={ ( values ) => {
-		return values.includes( 'string' );
-	} }
 />;
 
 // Select with explicit generic provided.
@@ -168,9 +141,6 @@ import SelectControl from '..';
 			label: 'Value',
 		},
 	] }
-	onChange={ ( values ) => {
-		return values.includes( 'narrow' );
-	} }
 />;
 // Select with explicit generic provided.
 // Both value and options.value must match the provided generic.
@@ -188,9 +158,6 @@ import SelectControl from '..';
 			label: 'Value',
 		},
 	] }
-	onChange={ ( values ) => {
-		return values.includes( 'narrow' );
-	} }
 />;
 
 // Select with explicit generic provided.
@@ -212,11 +179,6 @@ import SelectControl from '..';
 			label: 'Other String',
 		},
 	] }
-	onChange={ ( values ) => {
-		// Typescript can't guarantee the value isn't modified by the
-		// user, so we can't assign a type to values here.
-		return values.includes( 'string' );
-	} }
 />;
 
 // Select with explicit generic provided.
@@ -237,9 +199,4 @@ import SelectControl from '..';
 			label: 'String',
 		},
 	] }
-	onChange={ ( values ) => {
-		// Typescript can't guarantee the value isn't modified by the
-		// user, so we can't assign a type to values here.
-		return values.includes( 'string' );
-	} }
 />;

--- a/packages/components/src/select-control/types-test.tsx
+++ b/packages/components/src/select-control/types-test.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import SelectControl from '..';
+import SelectControl from '.';
 
 /**
  * Single type

--- a/packages/components/src/select-control/types.ts
+++ b/packages/components/src/select-control/types.ts
@@ -9,7 +9,7 @@ import type { ChangeEvent, FocusEvent, ReactNode } from 'react';
 import type { InputBaseProps } from '../input-control/types';
 import type { BaseControlProps } from '../base-control/types';
 
-type SelectControlBaseProps = Pick<
+type SelectControlBaseProps< OptionType extends string = string > = Pick<
 	InputBaseProps,
 	| '__next36pxDefaultSize'
 	| '__next40pxDefaultSize'
@@ -33,7 +33,7 @@ type SelectControlBaseProps = Pick<
 			 * The internal value used to choose the selected value.
 			 * This is also the value passed to `onChange` when the option is selected.
 			 */
-			value: string;
+			value: OptionType;
 			id?: string;
 			/**
 			 * Whether or not the option should have the disabled attribute.
@@ -55,7 +55,9 @@ type SelectControlBaseProps = Pick<
 		children?: ReactNode;
 	};
 
-export type SelectControlSingleSelectionProps = SelectControlBaseProps & {
+export type SelectControlSingleSelectionProps<
+	OptionType extends string = string,
+> = SelectControlBaseProps< OptionType > & {
 	/**
 	 * If this property is added, multiple values can be selected. The `value` passed should be an array.
 	 *
@@ -64,7 +66,7 @@ export type SelectControlSingleSelectionProps = SelectControlBaseProps & {
 	 * @default false
 	 */
 	multiple?: false;
-	value?: string;
+	value?: OptionType & {};
 	/**
 	 * A function that receives the value of the new option that is being selected as input.
 	 *
@@ -77,7 +79,9 @@ export type SelectControlSingleSelectionProps = SelectControlBaseProps & {
 	) => void;
 };
 
-export type SelectControlMultipleSelectionProps = SelectControlBaseProps & {
+export type SelectControlMultipleSelectionProps<
+	OptionType extends string = string,
+> = SelectControlBaseProps< OptionType > & {
 	/**
 	 * If this property is added, multiple values can be selected. The `value` passed should be an array.
 	 *
@@ -86,7 +90,7 @@ export type SelectControlMultipleSelectionProps = SelectControlBaseProps & {
 	 * @default false
 	 */
 	multiple: true;
-	value?: string[];
+	value?: ( OptionType & {} )[];
 	/**
 	 * A function that receives the value of the new option that is being selected as input.
 	 *
@@ -99,6 +103,6 @@ export type SelectControlMultipleSelectionProps = SelectControlBaseProps & {
 	) => void;
 };
 
-export type SelectControlProps =
-	| SelectControlSingleSelectionProps
-	| SelectControlMultipleSelectionProps;
+export type SelectControlProps< OptionType extends string = string > =
+	| SelectControlSingleSelectionProps< OptionType >
+	| SelectControlMultipleSelectionProps< OptionType >;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Allow optional narrowing of the SelectControl component for better type validation.

## Why?
This is an enhancement to the type of the SelectControl. It will help users of Typescript narrow down their types to prevent errors. It also infers types if options is provided which may flag code errors with some implementations. There is no change to the base JS code, this is only a typescript change.
This generic type was previously available in the 3rd party types package, but was removed when components moved to 1st party types.

Fixes #16060

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I have made the type for the SelectControl component generic, which allows users to explicitly provide an option type, or infers that type from the provided options array.
If you have provided an `options` array but don't want the narrower type, you can specify `<string>` as the generic to re-loosen this type.

In adding this enhancement, there are two implementations with `@wordpress/components` which needed to be updated.
1. `TimePicker` in date-time/time which was using a select for the month. I have added the necessary type to tighten the type here.
2. `QueryControls` in `query-controls` which actually had a bug in its implementation. The `undefined` states were not being accounted for in the string interpolation, leading potentially to `undefined/undefined` as the value. This would not affect runtime as the browser knows that option doesn't exist and defaults to the first option, but I have fixed the bug to satisfy typescript.

## Testing Instructions
I have included a file to add type-related tests, and added each possible test case. For testing, see that file (`select-control/types-test.tsx`). Future changes which break implementation would throw a type error in that file, preventing linting from passing.

### Implementation examples taken from `types-test.tsx`
```tsx
// Normal select, no generic provided. Value type is inferred from available options.
// Incorrect value type provided to test validation is working.
<SelectControl
  // @ts-expect-error "string" is not "narrow" or "value", so throw an error
  value="string"
  multiple={ false }
  options={ [
    {
      value: 'narrow',
      label: 'Narrow',
    },
    {
      value: 'value',
      label: 'Value',
    },
  ] }
  onChange={ ( value ) => {
    // Typescript can't guarantee the value isn't modified by the
    // user, so we can't assign a type to value here.
    return value === 'string';
  } }
/>;

// Select with explicit generic provided.
// Both value and options.value must match the provided generic.
// Incorrect value type provided to test validation is working.
<SelectControl< 'narrow' | 'value' >
  // @ts-expect-error "string" is not "narrow" or "value", so throw an error
  value="string"
  multiple={ false }
  options={ [
    {
      // @ts-expect-error "string" is not "narrow" or "value", so throw an error
      value: 'string',
      label: 'String',
    },
    {
      // @ts-expect-error "otherstring" is not "narrow" or "value", so throw an error
      value: 'otherstring',
      label: 'Other String',
    },
  ] }
/>;

// Select with explicit generic provided.
// Usually this would result in a type error with no generic,
// but this has been explicitly loosened to bypass errors.
<SelectControl< string >
  value="string"
  multiple={ false }
  options={ [
    {
      value: 'narrow',
      label: 'Narrow',
    },
    {
      value: 'value',
      label: 'Value',
    },
  ] }
/>;
```
