### PR TITLE
Block Bindings: edit external property bound to block attribute

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -141,7 +141,7 @@ const BindingConnector = ( {
 	 * @param {string} current - The current attribute value.
 	 * @return {void}
 	 */
-	const updateBoundAttibute = useCallback(
+	const updateBoundAttribute = useCallback(
 		( next, current ) =>
 			onPropValueChange( {
 				[ attrName ]: castValue( next, current ),
@@ -164,7 +164,7 @@ const BindingConnector = ( {
 				prevPropValue.current = propValue;
 
 				if ( propValue !== rawAttrValue ) {
-					updateBoundAttibute( propValue, attrValue );
+					updateBoundAttribute( propValue, attrValue );
 					return; // close the sync cycle.
 				}
 			}
@@ -180,11 +180,11 @@ const BindingConnector = ( {
 				getBlockType( blockName ).attributes[ attrName ].attribute;
 
 			if ( htmlAttribute === 'src' || htmlAttribute === 'href' ) {
-				updateBoundAttibute( null );
+				updateBoundAttribute( null );
 				return; // close the sync cycle.
 			}
 
-			updateBoundAttibute( placeholder );
+			updateBoundAttribute( placeholder );
 			return; // close the sync cycle.
 		}
 
@@ -198,7 +198,7 @@ const BindingConnector = ( {
 			updatePropValue( rawAttrValue );
 		}
 	}, [
-		updateBoundAttibute,
+		updateBoundAttribute,
 		propValue,
 		placeholder,
 		blockName,

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -289,8 +289,9 @@ const withBlockBindingSupport = createHigherOrderComponent(
 		);
 
 		/**
-		 * Custom setAttributes function that
-		 * updates the bound and unbound attributes.
+		 * Custom setAttributes function.
+		 * It reorganizes bound and unbound attributes
+		 * in a new object and treats their updating separately.
 		 *
 		 * @param {Object} newAttributes - The new attributes values.
 		 * @return {void}
@@ -299,23 +300,19 @@ const withBlockBindingSupport = createHigherOrderComponent(
 			// Get the bound and unbound attributes.
 			const attrs = Object.entries( newAttributes ).reduce(
 				( acc, [ key, value ] ) => {
-					if ( key in bindings ) {
-						acc.bounds[ key ] = value;
-					} else {
-						acc.unbounds[ key ] = value;
-					}
-
+					acc[ key in bindings ? 'bounds' : 'unbounds' ][ key ] =
+						value;
 					return acc;
 				},
 				{ bounds: {}, unbounds: {} }
 			);
 
-			// Update the unbound attributes in case of any.
+			// Update the `unbound` attributes in case of any.
 			if ( Object.keys( attrs.unbounds ).length > 0 ) {
 				props.setAttributes( attrs.unbounds );
 			}
 
-			// Update the bound attributes in case of any.
+			// Update the `bound` attributes in case of any.
 			if ( Object.keys( attrs.bounds ).length > 0 ) {
 				updateBoundAttributes( attrs.bounds );
 			}

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -132,6 +132,14 @@ const BindingConnector = ( {
 	const prevAttrValue = useRef( attrValue );
 	const prevPropValue = useRef(); // `undefined` for the fisrt sync (from source to block).
 
+	/*
+	 * Update the bound attribute value,
+	 * casting the value to the original type.
+	 *
+	 * @param {string} next    - The new attribute value.
+	 * @param {string} current - The current attribute value.
+	 * @return {void}
+	 */
 	const updateBoundAttibute = useCallback(
 		( next, current ) =>
 			onPropValueChange( {
@@ -142,6 +150,7 @@ const BindingConnector = ( {
 
 	useLayoutEffect( () => {
 		const rawAttrValue = getAttributeValue( attrValue );
+
 		if ( typeof propValue !== 'undefined' ) {
 			/*
 			 * On-sync from external property to attribute.
@@ -150,13 +159,13 @@ const BindingConnector = ( {
 			 * update the attribute value.
 			 */
 			if ( propValue !== prevPropValue.current ) {
+				// Store the current propValue to compare in the next render.
+				prevPropValue.current = propValue;
+
 				if ( propValue !== rawAttrValue ) {
 					updateBoundAttibute( propValue, attrValue );
 					return; // close the sync cycle.
 				}
-
-				// Store the current propValue to compare in the next render.
-				prevPropValue.current = propValue;
 			}
 		} else if ( placeholder ) {
 			/*

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -77,12 +77,12 @@ function getAttributeValue( value ) {
 }
 
 /**
- * Create a new attribute value instance,
- * based on the original value type.
+ * Create a new attribute instance,
+ * based on the original type.
  *
  * @param {string} value    - The attribute value.
  * @param {*}      original - The original attribute instance.
- * @return {*}                The new attribute value instance.
+ * @return {*}                The new attribute instance.
  */
 function castValue( value, original ) {
 	if ( original instanceof RichTextData ) {
@@ -133,7 +133,7 @@ const BindingConnector = ( {
 	const rawAttrValue = getAttributeValue( attrValue );
 	const prevAttrValue = useRef( rawAttrValue );
 
-	const prevPropValue = useRef(); // intially undefined for the initial sync.
+	const prevPropValue = useRef(); // `undefined` for the fisrt sync (from source to block).
 
 	useLayoutEffect( () => {
 		if ( typeof propValue !== 'undefined' ) {

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -41,4 +41,5 @@ export default {
 			updateValue: updateMetaValue,
 		};
 	},
+	lockAttributesEditing: false,
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -41,5 +41,4 @@ export default {
 			updateValue: updateMetaValue,
 		};
 	},
-	lockAttributesEditing: false,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

~Follow-up of https://github.com/WordPress/gutenberg/pull/60276~

This PR introduces a synchronization mechanism that updates the external property value in response to its bound block attribute changes.

### What?
This implementation utilizes the source handler's custom hook `useSource` to propagate changes between the block's bound attributes and the corresponding external properties.

### Why?
The ability to synchronize changes between a block attribute and an external property is required for the Block Bindings API to function correctly. This ensures that the block's UI reflects the actual data state and vice versa.

### How?
Through the React Hook lifecycle, this solution detects changes in the external property or the bound block attribute and updates the other accordingly. To manage these updates:
- All bound attribute values are maintained locally using a local state (useState instance), which isolates them from the block's primary attributes property.
- A custom setAttributes function is introduced. It categorizes incoming attribute updates into bound and unbound groups. Unbound attributes are updated immediately using the existing setAttributes method, whereas bound attributes undergo a custom update process through updateBoundAttributes function to ensure correct synchronization.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


1. Register a few custom fields:

```php
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'This is the content of the text custom field',
	)
);
register_meta(
	'post',
	'url_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

2. Create a new post
3. Switch to the editor mode
4. Add a few blocks with bound attributes to the custom fields

**core/paragraph**
```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<p>ORIGINAL ATTRIBUTE VALUE</p>
<!-- /wp:paragraph -->
```

**core/image**
```html
<!-- wp:image {"id":248,"width":"168px","height":"auto","sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}},"alt":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg" alt="ORIGINAL ATTRIBUTE VALUE" class="wp-image-248" style="width:168px;height:auto"/></figure>
<!-- /wp:image -->
```
**core/button**
```html
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"bindings":{"text":{"source":"core/post-meta","args":{"key":"text_custom_field"}},"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">ORIGINAL ATTRIBUTE VALUE</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --> 
```

5. Go back to the visual mode
6. Confirm the blocks show the default values defined in the custom fields:

<img width="300" alt="image" src="https://github.com/WordPress/gutenberg/assets/77539/19e81ab3-152b-43c6-87d1-ef979c6052bf">

`(008) Custom Field / Default value`, the `The Godfather image`, etc.

7. Save the post
8. Hard refresh (it ensures clean up the editor history)
9. Update the property value of the external source dispatching the following action (**replace with the post ID of your testing post!**):

```es6
const postId = <post-id>;
wp.data.dispatch( 'core' ).editEntityRecord(
  'postType',
  'post',
  postId,
  {
    meta: {
      text_custom_field:  '<strong>Spirited away</strong>',
      url_custom_field: 'https://wpmovies.dev/wp-content/uploads/2023/03/39wmItIWsg5sZMyRUHLkWBcuVCM.jpg'
    }
  }
);
```
11. Confirm all block instances with bound attributes to the external property update.

#### Test editing bound block attribute values

1. Unlock the bound attributes to the `core/post-meta` source handler adding this line [here](https://github.com/WordPress/gutenberg/blob/c86e77f8efd59054ef216053d5caa29c36353588/packages/editor/src/bindings/post-meta.js#L43):

```es6
	lockAttributesEditing: false,
```

2. Build - Hard refresh
3. Edit any bound attribute value
4. Confirm the other attributes bound to the same external property are updated, too
5. Save the post
6. Confirm the client now updates the custom fields when saving the post:

<img width="721" alt="image" src="https://github.com/WordPress/gutenberg/assets/77539/dd0a760a-5258-4d6e-9471-69ea9f27d8bb">


### 🍿 

https://github.com/WordPress/gutenberg/assets/77539/56ce432c-9b7c-4c72-8da8-f76186067972


## Screenshots or screencast <!-- if applicable -->

