### PR TITLE
Template part: avoid pattern fetch on mount

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -48,6 +48,8 @@ function ReplaceButton( {
 	isTemplatePartSelectionOpen,
 	setIsTemplatePartSelectionOpen,
 } ) {
+	// This hook fetches patterns, so don't run it unconditionally in the main
+	// edit function!
 	const { templateParts } = useAlternativeTemplateParts(
 		area,
 		templatePartId
@@ -76,6 +78,8 @@ function ReplaceButton( {
 }
 
 function TemplatesList( { area, clientId, isEntityAvailable, onSelect } ) {
+	// This hook fetches patterns, so don't run it unconditionally in the main
+	// edit function!
 	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
 	const canReplace =
 		isEntityAvailable &&

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -75,21 +75,28 @@ function ReplaceButton( {
 	);
 }
 
-function TemplatesList( { availableTemplates, onSelect } ) {
-	const shownTemplates = useAsyncList( availableTemplates );
+function TemplatesList( { area, clientId, isEntityAvailable, onSelect } ) {
+	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
+	const canReplace =
+		isEntityAvailable &&
+		!! blockPatterns.length &&
+		( area === 'header' || area === 'footer' );
+	const shownTemplates = useAsyncList( blockPatterns );
 
-	if ( ! availableTemplates ) {
+	if ( ! canReplace ) {
 		return null;
 	}
 
 	return (
-		<BlockPatternsList
-			label={ __( 'Templates' ) }
-			blockPatterns={ availableTemplates }
-			shownPatterns={ shownTemplates }
-			onClickPattern={ onSelect }
-			showTitle={ false }
-		/>
+		<PanelBody title={ __( 'Design' ) }>
+			<BlockPatternsList
+				label={ __( 'Templates' ) }
+				blockPatterns={ blockPatterns }
+				shownPatterns={ shownTemplates }
+				onClickPattern={ onSelect }
+				showTitle={ false }
+			/>
+		</PanelBody>
 	);
 }
 
@@ -155,22 +162,11 @@ export default function TemplatePartEdit( {
 		[ templatePartId, attributes.area, clientId ]
 	);
 
-	const { templateParts } = useAlternativeTemplateParts(
-		area,
-		templatePartId
-	);
-	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
-	const hasReplacements = !! templateParts.length || !! blockPatterns.length;
 	const areaObject = useTemplatePartArea( area );
 	const blockProps = useBlockProps();
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
 	const TagName = tagName || areaObject.tagName;
-
-	const canReplace =
-		isEntityAvailable &&
-		hasReplacements &&
-		( area === 'header' || area === 'footer' );
 
 	const onPatternSelect = async ( pattern ) => {
 		await editEntityRecord(
@@ -293,18 +289,14 @@ export default function TemplatePartEdit( {
 					} }
 				</BlockSettingsMenuControls>
 
-				{ canReplace && blockPatterns.length > 0 && (
-					<InspectorControls>
-						<PanelBody title={ __( 'Design' ) }>
-							<TemplatesList
-								availableTemplates={ blockPatterns }
-								onSelect={ ( pattern ) =>
-									onPatternSelect( pattern )
-								}
-							/>
-						</PanelBody>
-					</InspectorControls>
-				) }
+				<InspectorControls>
+					<TemplatesList
+						area={ area }
+						clientId={ clientId }
+						isEntityAvailable={ isEntityAvailable }
+						onSelect={ ( pattern ) => onPatternSelect( pattern ) }
+					/>
+				</InspectorControls>
 
 				{ isEntityAvailable && (
 					<TemplatePartInnerBlocks


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This was accidentally re-introduced in #55128. See #57856 where I had also removed it for the replace button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We shouldn't be fetching all patterns when mounting a template part. Only do it when the block is selected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Make sure the hooks are called in a subcomponent of `InspectorControls`, which only mounts children if the block is selected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See testing instructions of #55128.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
