### PR TITLE
Make sure the CSS class is-dark-theme is added to the editor iframe body

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -141,6 +141,13 @@ function Iframe( {
 		function onLoad() {
 			const { contentDocument, ownerDocument } = node;
 			const { documentElement } = contentDocument;
+			// Get any CSS classes the iframe document body may initially have
+			// to re-apply them later together with the ones of the main document
+			// body. This is necessary for some CSS classes for example the
+			// `is-dark-theme` class added by useDarkThemeBodyClassName.
+			const initialIframeBodyClasses = Array.from(
+				contentDocument.body.classList
+			);
 			iFrameDocument = contentDocument;
 
 			documentElement.classList.add( 'block-editor-iframe__html' );
@@ -151,12 +158,15 @@ function Iframe( {
 			// be added in the editor too, which we'll somehow have to get from
 			// the server in the future (which will run the PHP filters).
 			setBodyClasses(
-				Array.from( ownerDocument.body.classList ).filter(
-					( name ) =>
-						name.startsWith( 'admin-color-' ) ||
-						name.startsWith( 'post-type-' ) ||
-						name === 'wp-embed-responsive'
-				)
+				Array.from( ownerDocument.body.classList )
+					.concat( initialIframeBodyClasses )
+					.filter(
+						( name ) =>
+							name.startsWith( 'admin-color-' ) ||
+							name.startsWith( 'post-type-' ) ||
+							name === 'wp-embed-responsive' ||
+							name === 'is-dark-theme'
+					)
 			);
 
 			contentDocument.dir = ownerDocument.dir;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60299

Cc @youknowriad @ellatrix 
When you have a chance, I'd appreciate a review, as this is a blocker for another issue I'm working on.
For more details, please see the associated issue.

## What?
<!-- In a few words, what is the PR actually doing? -->
When a theme has a dark background, the editor is supposed to set a CSS class `is-dark-theme` to the editor iframe document body. This works in the Site editor, It doesn't in the Post editor.

The editor `Iframe` component has some internal logic to get some of the CSS classes set on the main document body like for example `post-type-post admin-color-fresh wp-embed-responsive` and then copy them to the iframe document body.
That makes sense but by doing so it _replaces_ the `is-dark-theme` class, if it is set. Actually, I think the whole `body` is replaced? Regardless, the `is-dark-theme` class is missing. 
This happens only in the Post editor. In the Site editor, the CSS class is present so that I'm guessing it's also something related to timing.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `is-dark-theme` CSS class is necessary for some styling in the editor. The lack of this CSS class is also a blocker for https://github.com/WordPress/gutenberg/issues/60275

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Makes sure the `Iframe` component handling of the CSS classes also gets the classes that are initially set on the iframe body.
- Adds these classes to the ones that are already copied from the main document body, then filters the `is-dark-theme' together with the ones that are meant to be added to the iframe document body.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- First, reproduce the bug on trunk by following the instructions in the issue https://github.com/WordPress/gutenberg/issues/60299
- Set Twenty Twenty-Four as active theme.
- Go to the Site editor > Styles, set a theme style variant that has a dark background e.g. 'Onyx' and save.
- In your browser dev tools, inspect the editor iframe body ie. the body with CSS classes `block-editor-iframe__body editor-styles-wrapper`.
- Observe the body does have a CSS class `is-dark-theme`.
- Go to the Post editor.
- In your browser dev tools, inspect the editor iframe body ie. the body with CSS classes `block-editor-iframe__body editor-styles-wrapper`.
- Observe the body does have a CSS class `is-dark-theme`.
- Observe the CSS class `is-dark-theme` stays there also when the iframe is fully loaded.



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
