### PR TITLE
[Site Editor]: Add create pattern button in patterns page

### DIFF
--- a/lib/compat/wordpress-6.6/post.php
+++ b/lib/compat/wordpress-6.6/post.php
@@ -21,7 +21,7 @@ add_action( 'init', 'gutenberg_add_excerpt_support_to_wp_block' );
  * @return object Object with all the labels as member variables.
  */
 function gutenberg_update_wp_template_labels( $labels ) {
-	$labels->add_new = __( 'Add Template', 'gutenberg' );
+	$labels->add_new      = __( 'Add Template', 'gutenberg' );
 	$labels->add_new_item = __( 'Add Template', 'gutenberg' );
 	$labels->item_updated = __( 'Template updated.', 'gutenberg' );
 	return $labels;
@@ -35,7 +35,7 @@ add_filter( 'post_type_labels_wp_template', 'gutenberg_update_wp_template_labels
  * @return object Object with all the labels as member variables.
  */
 function gutenberg_update_wp_template__part_labels( $labels ) {
-	$labels->add_new = __( 'Add Template Part', 'gutenberg' );
+	$labels->add_new      = __( 'Add Template Part', 'gutenberg' );
 	$labels->add_new_item = __( 'Add Template Part', 'gutenberg' );
 	$labels->item_updated = __( 'Template part updated.', 'gutenberg' );
 	return $labels;
@@ -49,7 +49,7 @@ add_filter( 'post_type_labels_wp_template_part', 'gutenberg_update_wp_template__
  * @return object Object with all the labels as member variables.
  */
 function gutenberg_update_wp_block_labels( $labels ) {
-	$labels->add_new = __( 'Add Pattern', 'gutenberg' );
+	$labels->add_new      = __( 'Add Pattern', 'gutenberg' );
 	$labels->add_new_item = __( 'Add Pattern', 'gutenberg' );
 	return $labels;
 }
@@ -62,7 +62,7 @@ add_filter( 'post_type_labels_wp_block', 'gutenberg_update_wp_block_labels', 10,
  * @return object Object with all the labels as member variables.
  */
 function gutenberg_update_page_labels( $labels ) {
-	$labels->add_new = __( 'Add Page', 'gutenberg' );
+	$labels->add_new      = __( 'Add Page', 'gutenberg' );
 	$labels->add_new_item = __( 'Add Page', 'gutenberg' );
 	return $labels;
 }

--- a/lib/compat/wordpress-6.6/post.php
+++ b/lib/compat/wordpress-6.6/post.php
@@ -21,6 +21,8 @@ add_action( 'init', 'gutenberg_add_excerpt_support_to_wp_block' );
  * @return object Object with all the labels as member variables.
  */
 function gutenberg_update_wp_template_labels( $labels ) {
+	$labels->add_new = __( 'Add Template', 'gutenberg' );
+	$labels->add_new_item = __( 'Add Template', 'gutenberg' );
 	$labels->item_updated = __( 'Template updated.', 'gutenberg' );
 	return $labels;
 }
@@ -33,7 +35,35 @@ add_filter( 'post_type_labels_wp_template', 'gutenberg_update_wp_template_labels
  * @return object Object with all the labels as member variables.
  */
 function gutenberg_update_wp_template__part_labels( $labels ) {
+	$labels->add_new = __( 'Add Template Part', 'gutenberg' );
+	$labels->add_new_item = __( 'Add Template Part', 'gutenberg' );
 	$labels->item_updated = __( 'Template part updated.', 'gutenberg' );
 	return $labels;
 }
 add_filter( 'post_type_labels_wp_template_part', 'gutenberg_update_wp_template__part_labels', 10, 1 );
+
+/**
+ * Updates the labels for the pattern post type.
+ *
+ * @param  object $labels Object with labels for the post type as member variables.
+ * @return object Object with all the labels as member variables.
+ */
+function gutenberg_update_wp_block_labels( $labels ) {
+	$labels->add_new = __( 'Add Pattern', 'gutenberg' );
+	$labels->add_new_item = __( 'Add Pattern', 'gutenberg' );
+	return $labels;
+}
+add_filter( 'post_type_labels_wp_block', 'gutenberg_update_wp_block_labels', 10, 1 );
+
+/**
+ * Updates the labels for the page post type.
+ *
+ * @param  object $labels Object with labels for the post type as member variables.
+ * @return object Object with all the labels as member variables.
+ */
+function gutenberg_update_page_labels( $labels ) {
+	$labels->add_new = __( 'Add Page', 'gutenberg' );
+	$labels->add_new_item = __( 'Add Page', 'gutenberg' );
+	return $labels;
+}
+add_filter( 'post_type_labels_page', 'gutenberg_update_page_labels', 10, 1 );

--- a/lib/compat/wordpress-6.6/post.php
+++ b/lib/compat/wordpress-6.6/post.php
@@ -21,8 +21,6 @@ add_action( 'init', 'gutenberg_add_excerpt_support_to_wp_block' );
  * @return object Object with all the labels as member variables.
  */
 function gutenberg_update_wp_template_labels( $labels ) {
-	$labels->add_new      = __( 'Add Template', 'gutenberg' );
-	$labels->add_new_item = __( 'Add Template', 'gutenberg' );
 	$labels->item_updated = __( 'Template updated.', 'gutenberg' );
 	return $labels;
 }
@@ -35,35 +33,7 @@ add_filter( 'post_type_labels_wp_template', 'gutenberg_update_wp_template_labels
  * @return object Object with all the labels as member variables.
  */
 function gutenberg_update_wp_template__part_labels( $labels ) {
-	$labels->add_new      = __( 'Add Template Part', 'gutenberg' );
-	$labels->add_new_item = __( 'Add Template Part', 'gutenberg' );
 	$labels->item_updated = __( 'Template part updated.', 'gutenberg' );
 	return $labels;
 }
 add_filter( 'post_type_labels_wp_template_part', 'gutenberg_update_wp_template__part_labels', 10, 1 );
-
-/**
- * Updates the labels for the pattern post type.
- *
- * @param  object $labels Object with labels for the post type as member variables.
- * @return object Object with all the labels as member variables.
- */
-function gutenberg_update_wp_block_labels( $labels ) {
-	$labels->add_new      = __( 'Add Pattern', 'gutenberg' );
-	$labels->add_new_item = __( 'Add Pattern', 'gutenberg' );
-	return $labels;
-}
-add_filter( 'post_type_labels_wp_block', 'gutenberg_update_wp_block_labels', 10, 1 );
-
-/**
- * Updates the labels for the page post type.
- *
- * @param  object $labels Object with labels for the post type as member variables.
- * @return object Object with all the labels as member variables.
- */
-function gutenberg_update_page_labels( $labels ) {
-	$labels->add_new      = __( 'Add Page', 'gutenberg' );
-	$labels->add_new_item = __( 'Add Page', 'gutenberg' );
-	return $labels;
-}
-add_filter( 'post_type_labels_page', 'gutenberg_update_page_labels', 10, 1 );

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { DropdownMenu } from '@wordpress/components';
+import { DropdownMenu, Button } from '@wordpress/components';
 import { useState, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { plus, symbol, symbolFilled, upload } from '@wordpress/icons';
@@ -31,7 +31,7 @@ const { CreatePatternModal, useAddPatternCategory } = unlock(
 	editPatternsPrivateApis
 );
 
-export default function AddNewPattern() {
+export default function AddNewPattern( { showTextButton } ) {
 	const history = useHistory();
 	const { params } = useLocation();
 	const [ showPatternModal, setShowPatternModal ] = useState( false );
@@ -104,10 +104,12 @@ export default function AddNewPattern() {
 			<DropdownMenu
 				controls={ controls }
 				toggleProps={ {
-					as: SidebarButton,
+					as: showTextButton ? Button : SidebarButton,
+					variant: showTextButton ? 'primary' : undefined,
 				} }
-				icon={ plus }
-				label={ __( 'Create pattern' ) }
+				icon={ showTextButton ? null : plus }
+				label={ showTextButton ? undefined : __( 'Create pattern' ) }
+				text={ showTextButton ? __( 'Create pattern' ) : undefined }
 			/>
 			{ showPatternModal && (
 				<CreatePatternModal

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -105,11 +105,11 @@ export default function AddNewPattern( { showTextButton } ) {
 				controls={ controls }
 				toggleProps={ {
 					as: showTextButton ? Button : SidebarButton,
-					variant: showTextButton ? 'primary' : undefined,
+					variant: showTextButton ? 'secondary' : undefined,
 				} }
 				icon={ showTextButton ? null : plus }
-				label={ showTextButton ? undefined : __( 'Create pattern' ) }
-				text={ showTextButton ? __( 'Create pattern' ) : undefined }
+				label={ showTextButton ? undefined : __( 'Add new pattern' ) }
+				text={ showTextButton ? __( 'Add new pattern' ) : undefined }
 			/>
 			{ showPatternModal && (
 				<CreatePatternModal

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -101,7 +101,7 @@ export default function AddNewPattern() {
 		onClick: () => {
 			patternUploadInputRef.current.click();
 		},
-		title: __( 'Import from JSON' ),
+		title: __( 'Import pattern from JSON' ),
 	} );
 
 	const { categoryMap, findOrCreateTerm } = useAddPatternCategory();

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -111,8 +111,9 @@ export default function AddNewPattern() {
 				<DropdownMenu
 					controls={ controls }
 					icon={ null }
-					toggleProps={ { variant: 'primary' } }
+					toggleProps={ { variant: 'primary', showTooltip: false } }
 					text={ addNewPatternLabel }
+					label={ addNewPatternLabel }
 				/>
 			) }
 			{ showPatternModal && (

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -39,12 +39,18 @@ import {
 } from '../../utils/template-part-create';
 
 export default function CreateTemplatePartModal( {
-	modalTitle = __( 'Add Template Part' ),
+	modalTitle,
 	...restProps
 } ) {
+	const defaultModalTitle = useSelect(
+		( select ) =>
+			select( coreStore ).getPostType( TEMPLATE_PART_POST_TYPE )?.labels
+				?.add_new_item,
+		[]
+	);
 	return (
 		<Modal
-			title={ modalTitle }
+			title={ modalTitle || defaultModalTitle }
 			onRequestClose={ restProps.closeModal }
 			overlayClassName="edit-site-create-template-part-modal"
 		>

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -39,7 +39,7 @@ import {
 } from '../../utils/template-part-create';
 
 export default function CreateTemplatePartModal( {
-	modalTitle = __( 'Create template part' ),
+	modalTitle = __( 'Add Template Part' ),
 	...restProps
 } ) {
 	return (
@@ -56,7 +56,7 @@ export default function CreateTemplatePartModal( {
 export function CreateTemplatePartModalContents( {
 	defaultArea = TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 	blocks = [],
-	confirmLabel = __( 'Create' ),
+	confirmLabel = __( 'Add' ),
 	closeModal,
 	onCreate,
 	onError,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -494,7 +494,7 @@ export default function PagePages() {
 			title={ __( 'Pages' ) }
 			actions={
 				<>
-					<Button variant="primary" onClick={ openModal }>
+					<Button variant="secondary" onClick={ openModal }>
 						{ __( 'Add new page' ) }
 					</Button>
 					{ showAddPageModal && (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -273,13 +273,13 @@ export default function PagePages() {
 		[ totalItems, totalPages ]
 	);
 
-	const { frontPageId, postsPageId } = useSelect( ( select ) => {
-		const { getEntityRecord } = select( coreStore );
+	const { frontPageId, postsPageId, addNewLabel } = useSelect( ( select ) => {
+		const { getEntityRecord, getPostType } = select( coreStore );
 		const siteSettings = getEntityRecord( 'root', 'site' );
-
 		return {
 			frontPageId: siteSettings?.page_on_front,
 			postsPageId: siteSettings?.page_for_posts,
+			addNewLabel: getPostType( 'page' )?.labels?.add_new_item,
 		};
 	} );
 
@@ -488,22 +488,23 @@ export default function PagePages() {
 		closeModal();
 	};
 
-	// TODO: we need to handle properly `data={ data || EMPTY_ARRAY }` for when `isLoading`.
 	return (
 		<Page
 			title={ __( 'Pages' ) }
 			actions={
-				<>
-					<Button variant="secondary" onClick={ openModal }>
-						{ __( 'Add new page' ) }
-					</Button>
-					{ showAddPageModal && (
-						<AddNewPageModal
-							onSave={ handleNewPage }
-							onClose={ closeModal }
-						/>
-					) }
-				</>
+				addNewLabel && (
+					<>
+						<Button variant="primary" onClick={ openModal }>
+							{ addNewLabel }
+						</Button>
+						{ showAddPageModal && (
+							<AddNewPageModal
+								onSave={ handleNewPage }
+								onClose={ closeModal }
+							/>
+						) }
+					</>
+				)
 			}
 		>
 			<DataViews

--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -17,6 +17,7 @@ import { moreVertical } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import AddNewPattern from '../add-new-pattern';
 import RenameCategoryMenuItem from './rename-category-menu-item';
 import DeleteCategoryMenuItem from './delete-category-menu-item';
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
@@ -57,39 +58,42 @@ export default function PatternsHeader( {
 	}
 
 	return (
-		<VStack className="edit-site-patterns__section-header">
+		<VStack className="edit-site-patterns__section-header" gap={ 3 }>
 			<HStack justify="space-between">
 				<Heading as="h2" level={ 4 } id={ titleId }>
 					{ title }
 				</Heading>
-				{ !! patternCategory?.id && (
-					<DropdownMenu
-						icon={ moreVertical }
-						label={ __( 'Actions' ) }
-						toggleProps={ {
-							className: 'edit-site-patterns__button',
-							describedBy: sprintf(
-								/* translators: %s: pattern category name */
-								__( 'Action menu for %s pattern category' ),
-								title
-							),
-							size: 'compact',
-						} }
-					>
-						{ ( { onClose } ) => (
-							<MenuGroup>
-								<RenameCategoryMenuItem
-									category={ patternCategory }
-									onClose={ onClose }
-								/>
-								<DeleteCategoryMenuItem
-									category={ patternCategory }
-									onClose={ onClose }
-								/>
-							</MenuGroup>
-						) }
-					</DropdownMenu>
-				) }
+				<HStack expanded={ false }>
+					<AddNewPattern showTextButton />
+					{ !! patternCategory?.id && (
+						<DropdownMenu
+							icon={ moreVertical }
+							label={ __( 'Actions' ) }
+							toggleProps={ {
+								className: 'edit-site-patterns__button',
+								describedBy: sprintf(
+									/* translators: %s: pattern category name */
+									__( 'Action menu for %s pattern category' ),
+									title
+								),
+								size: 'compact',
+							} }
+						>
+							{ ( { onClose } ) => (
+								<MenuGroup>
+									<RenameCategoryMenuItem
+										category={ patternCategory }
+										onClose={ onClose }
+									/>
+									<DeleteCategoryMenuItem
+										category={ patternCategory }
+										onClose={ onClose }
+									/>
+								</MenuGroup>
+							) }
+						</DropdownMenu>
+					) }
+				</HStack>
 			</HStack>
 			{ description ? (
 				<Text variant="muted" as="p" id={ descriptionId }>

--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -64,7 +64,7 @@ export default function PatternsHeader( {
 					{ title }
 				</Heading>
 				<HStack expanded={ false }>
-					<AddNewPattern showTextButton />
+					<AddNewPattern />
 					{ !! patternCategory?.id && (
 						<DropdownMenu
 							icon={ moreVertical }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -15,7 +15,6 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import AddNewPattern from '../add-new-pattern';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import CategoryItem from './category-item';
 import {
@@ -133,7 +132,6 @@ export default function SidebarNavigationScreenPatterns( { backPath } ) {
 				'Manage what patterns are available when editing the site.'
 			) }
 			backPath={ backPath }
-			actions={ <AddNewPattern /> }
 			content={
 				<>
 					{ isLoading && __( 'Loading items…' ) }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -25,7 +25,7 @@ import { unlock } from '../lock-unlock';
 
 export default function CreatePatternModal( {
 	className = 'patterns-menu-items__convert-modal',
-	modalTitle = __( 'Create pattern' ),
+	modalTitle = __( 'Add pattern' ),
 	...restProps
 } ) {
 	return (
@@ -40,7 +40,7 @@ export default function CreatePatternModal( {
 }
 
 export function CreatePatternModalContents( {
-	confirmLabel = __( 'Create' ),
+	confirmLabel = __( 'Add' ),
 	defaultCategories = [],
 	content,
 	onClose,

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -11,13 +11,18 @@ import {
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import { PATTERN_DEFAULT_CATEGORY, PATTERN_SYNC_TYPES } from '../constants';
+import {
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_SYNC_TYPES,
+	PATTERN_TYPES,
+} from '../constants';
 import { store as patternsStore } from '../store';
 import CategorySelector from './category-selector';
 import { useAddPatternCategory } from '../private-hooks';
@@ -25,12 +30,18 @@ import { unlock } from '../lock-unlock';
 
 export default function CreatePatternModal( {
 	className = 'patterns-menu-items__convert-modal',
-	modalTitle = __( 'Add pattern' ),
+	modalTitle,
 	...restProps
 } ) {
+	const defaultModalTitle = useSelect(
+		( select ) =>
+			select( coreStore ).getPostType( PATTERN_TYPES.user )?.labels
+				?.add_new_item,
+		[]
+	);
 	return (
 		<Modal
-			title={ modalTitle }
+			title={ modalTitle || defaultModalTitle }
 			onRequestClose={ restProps.onClose }
 			overlayClassName={ className }
 		>

--- a/test/e2e/specs/editor/various/block-editor-keyboard-shortcuts.spec.js
+++ b/test/e2e/specs/editor/various/block-editor-keyboard-shortcuts.spec.js
@@ -192,7 +192,7 @@ test.describe( 'Block editor keyboard shortcuts', () => {
 				.getByRole( 'menuitem', { name: 'Create pattern' } )
 				.click();
 			await page
-				.getByRole( 'dialog', { name: 'Create pattern' } )
+				.getByRole( 'dialog', { name: 'add new pattern' } )
 				.getByRole( 'textbox', { name: 'Name' } )
 				.fill( 'hi' );
 

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -265,7 +265,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Create pattern' } ).click();
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'Create pattern',
+			name: 'add new pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -274,7 +274,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.getByRole( 'checkbox', { name: 'Synced' } )
 			.setChecked( true );
 		await createPatternDialog
-			.getByRole( 'button', { name: 'Create' } )
+			.getByRole( 'button', { name: 'Add' } )
 			.click();
 		const patternBlock = page.getByRole( 'document', {
 			name: 'Block: Pattern',

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -38,17 +38,17 @@ test.describe( 'Pattern Overrides', () => {
 			await admin.visitSiteEditor( { path: '/patterns' } );
 
 			await page
-				.getByRole( 'region', { name: 'Navigation' } )
-				.getByRole( 'button', { name: 'Create pattern' } )
+				.getByRole( 'region', { name: 'Patterns content' } )
+				.getByRole( 'button', { name: 'add new pattern' } )
 				.click();
 
 			await page
-				.getByRole( 'menu', { name: 'Create pattern' } )
-				.getByRole( 'menuitem', { name: 'Create pattern' } )
+				.getByRole( 'menu', { name: 'add new pattern' } )
+				.getByRole( 'menuitem', { name: 'add new pattern' } )
 				.click();
 
 			const createPatternDialog = page.getByRole( 'dialog', {
-				name: 'Create pattern',
+				name: 'add new pattern',
 			} );
 			await createPatternDialog
 				.getByRole( 'textbox', { name: 'Name' } )
@@ -57,7 +57,7 @@ test.describe( 'Pattern Overrides', () => {
 				.getByRole( 'checkbox', { name: 'Synced' } )
 				.setChecked( true );
 			await createPatternDialog
-				.getByRole( 'button', { name: 'Create' } )
+				.getByRole( 'button', { name: 'Add' } )
 				.click();
 
 			await editor.canvas

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Unsynced pattern', () => {
 		await page.getByRole( 'menuitem', { name: 'Create pattern' } ).click();
 
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'Create pattern',
+			name: 'add new pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -136,7 +136,7 @@ test.describe( 'Synced pattern', () => {
 		await page.getByRole( 'menuitem', { name: 'Create pattern' } ).click();
 
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'Create pattern',
+			name: 'add new pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -150,7 +150,7 @@ test.describe( 'Synced pattern', () => {
 			.setChecked( true );
 
 		await createPatternDialog
-			.getByRole( 'button', { name: 'Create' } )
+			.getByRole( 'button', { name: 'Add' } )
 			.click();
 
 		// Check the pattern is focused.
@@ -376,7 +376,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.clickBlockOptionsMenuItem( 'Create pattern' );
 
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'Create pattern',
+			name: 'add new pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -385,7 +385,7 @@ test.describe( 'Synced pattern', () => {
 			.getByRole( 'checkbox', { name: 'Synced' } )
 			.setChecked( true );
 		await createPatternDialog
-			.getByRole( 'button', { name: 'Create' } )
+			.getByRole( 'button', { name: 'Add' } )
 			.click();
 
 		await admin.createNewPost();
@@ -419,7 +419,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.clickBlockOptionsMenuItem( 'Create pattern' );
 
 		const createPatternDialog = editor.page.getByRole( 'dialog', {
-			name: 'Create pattern',
+			name: 'add new pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -428,7 +428,7 @@ test.describe( 'Synced pattern', () => {
 			.getByRole( 'checkbox', { name: 'Synced' } )
 			.setChecked( true );
 		await createPatternDialog
-			.getByRole( 'button', { name: 'Create' } )
+			.getByRole( 'button', { name: 'Add' } )
 			.click();
 
 		// Wait until the pattern is created.
@@ -603,7 +603,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.clickBlockOptionsMenuItem( 'Create pattern' );
 
 		const createPatternDialog = editor.page.getByRole( 'dialog', {
-			name: 'Create pattern',
+			name: 'add new pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -612,7 +612,7 @@ test.describe( 'Synced pattern', () => {
 			.getByRole( 'checkbox', { name: 'Synced' } )
 			.setChecked( true );
 		await createPatternDialog
-			.getByRole( 'button', { name: 'Create' } )
+			.getByRole( 'button', { name: 'Add' } )
 			.click();
 
 		await expect(

--- a/test/e2e/specs/site-editor/patterns.spec.js
+++ b/test/e2e/specs/site-editor/patterns.spec.js
@@ -42,24 +42,22 @@ test.describe( 'Patterns', () => {
 		).toBeVisible();
 		await expect( patterns.content ).toContainText( 'No results' );
 
-		await patterns.navigation
-			.getByRole( 'button', { name: 'Create pattern' } )
+		await patterns.content
+			.getByRole( 'button', { name: 'add new pattern' } )
 			.click();
 
-		const createPatternMenu = page.getByRole( 'menu', {
-			name: 'Create pattern',
-		} );
-		await expect(
-			createPatternMenu.getByRole( 'menuitem', {
-				name: 'Create pattern',
+		const addNewMenuItem = page
+			.getByRole( 'menu', {
+				name: 'add new pattern',
 			} )
-		).toBeFocused();
-		await createPatternMenu
-			.getByRole( 'menuitem', { name: 'Create pattern' } )
-			.click();
+			.getByRole( 'menuitem', {
+				name: 'add new pattern',
+			} );
+		await expect( addNewMenuItem ).toBeFocused();
+		await addNewMenuItem.click();
 
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'Create pattern',
+			name: 'add new pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -54,10 +54,10 @@ test.describe( 'Site editor url navigation', () => {
 	} ) => {
 		await admin.visitSiteEditor();
 		await page.click( 'role=button[name="Patterns"i]' );
-		await page.click( 'role=button[name="Create pattern"i]' );
+		await page.click( 'role=button[name="add new pattern"i]' );
 		await page
-			.getByRole( 'menu', { name: 'Create pattern' } )
-			.getByRole( 'menuitem', { name: 'Create template part' } )
+			.getByRole( 'menu', { name: 'add new pattern' } )
+			.getByRole( 'menuitem', { name: 'add new template part' } )
 			.click();
 		// Fill in a name in the dialog that pops up.
 		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Demo' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/59099
Resolves: https://github.com/WordPress/gutenberg/issues/58198


This PR adds a `Create pattern` button in patterns page header and uses the same modal for creating patterns/template parts in the sidebar, as suggested here: https://github.com/WordPress/gutenberg/issues/58198


## Testing Instructions
1. Go to patterns page and observe the new `Create pattern` button
2. Test the menu items that work properly

## Screenshots or screencast <!-- if applicable -->


<img width="631" alt="Screenshot 2024-05-20 at 7 44 58 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/ddcf4e12-07c3-4b56-b329-63279002c413">



