### PR TITLE
Removed pointer-events none inline style due it blocking crop action

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -83,8 +83,7 @@ const ImageWrapper = ( { href, children } ) => {
 				// When the Image block is linked,
 				// it's wrapped with a disabled <a /> tag.
 				// Restore cursor style so it doesn't appear 'clickable'
-				// and remove pointer events. Safari needs the display property.
-				pointerEvents: 'none',
+				// Safari needs the display property.
 				cursor: 'default',
 				display: 'inline',
 			} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the block editor using Image block if image has a link it is impossible to use crop action. This PR fixes that issue.

## Why?
Closes #60081 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When editor adds `<a>` tag around the image, the link has inline styles. One of those styles is `pointer-events: none` which will block all actions related directly to link and all its children. This PR removes that style because it creates the issue and it is redundant since `<a>` already has `onClick` handler which prevents user from triggering link action

## Testing Instructions
1. Open any post or page in the editor
2. Insert "Image" block and set a image there
3. Crop that image. You now should have brand new cropped image in the editor (and public side). This is for reference, actual testing starts now.
4. Set new Image block and set a image there
5. Add link around the image. Actual URL does not matter
6. Try to click link (in the editor) and observe nothing happens
7. Crop that image and enjoy your new cropped image in the public side

Also linked issue contains really good documentation how the issue can be replicated.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
