### PR TITLE
Add bulk actions for block editing modes

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1632,7 +1632,7 @@ _Related_
 
 _Parameters_
 
--   _clientId_ `ClientId`: The block client ID, or `''` for the root container.
+-   _clientId_ `string`: The block client ID, or `''` for the root container.
 -   _mode_ `BlockEditingMode`: The block editing mode. One of `'disabled'`, `'contentOnly'`, or `'default'`.
 
 _Returns_
@@ -1659,7 +1659,7 @@ wp.data.dispatch( 'core/block-editor' ).setBlockEditingModes( [
 
 _Parameters_
 
--   _modes_ `Iterable<[ClientId, BlockEditingMode]>`: Iterable of tuples of client ids and block editing modes.
+-   _modes_ `Iterable<[string, BlockEditingMode]>`: Iterable of tuples of client ids and block editing modes.
 
 _Returns_
 
@@ -1832,7 +1832,7 @@ _Related_
 
 _Parameters_
 
--   _clientId_ `ClientId`: The block client ID, or `''` for the root container.
+-   _clientId_ `string`: The block client ID, or `''` for the root container.
 
 _Returns_
 
@@ -1848,7 +1848,7 @@ _Related_
 
 _Parameters_
 
--   _clientIds_ `Iterable<ClientId>`: List of the block client IDs. Use `''` for the root container.
+-   _clientIds_ `Iterable<string>`: List of the block client IDs. Use `''` for the root container.
 
 _Returns_
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1632,12 +1632,38 @@ _Related_
 
 _Parameters_
 
--   _clientId_ `string`: The block client ID, or `''` for the root container.
+-   _clientId_ `ClientId`: The block client ID, or `''` for the root container.
 -   _mode_ `BlockEditingMode`: The block editing mode. One of `'disabled'`, `'contentOnly'`, or `'default'`.
 
 _Returns_
 
--   `Object`: Action object.
+-   `ActionSetBlockEditingMode`: Action object.
+
+### setBlockEditingModes
+
+Sets the block editing mode for a multiple blocks.
+
+_Related_
+
+-   useBlockEditingMode
+
+_Usage_
+
+```js
+wp.data.dispatch( 'core/block-editor' ).setBlockEditingModes( [
+	[ 'block-1', 'disabled' ],
+	[ 'block-2', 'contentOnly' ],
+	[ 'block-3', 'default' ],
+] );
+```
+
+_Parameters_
+
+-   _modes_ `Iterable<[ClientId, BlockEditingMode]>`: Iterable of tuples of client ids and block editing modes.
+
+_Returns_
+
+-   `ActionSetBlockEditingModes`: Action object.
 
 ### setBlockMovingClientId
 
@@ -1806,11 +1832,27 @@ _Related_
 
 _Parameters_
 
--   _clientId_ `string`: The block client ID, or `''` for the root container.
+-   _clientId_ `ClientId`: The block client ID, or `''` for the root container.
 
 _Returns_
 
--   `Object`: Action object.
+-   `ActionUnsetBlockEditingMode`: Action object.
+
+### unsetBlockEditingModes
+
+Clears the block editing mode for a given block.
+
+_Related_
+
+-   useBlockEditingMode
+
+_Parameters_
+
+-   _clientIds_ `Iterable<ClientId>`: List of the block client IDs. Use `''` for the root container.
+
+_Returns_
+
+-   `ActionUnsetBlockEditingModes`: Action object.
 
 ### updateBlock
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1889,7 +1889,18 @@ export const registerInserterMediaCategory =
 	};
 
 /**
+ * @typedef {string} ClientId
+ */
+
+/**
  * @typedef {import('../components/block-editing-mode').BlockEditingMode} BlockEditingMode
+ */
+
+/**
+ * @typedef {Object} ActionSetBlockEditingMode
+ * @property {'SET_BLOCK_EDITING_MODE'} type     Action type.
+ * @property {ClientId}                 clientId Block client ID.
+ * @property {BlockEditingMode}         mode     Block editing mode.
  */
 
 /**
@@ -1897,11 +1908,11 @@ export const registerInserterMediaCategory =
  *
  * @see useBlockEditingMode
  *
- * @param {string}           clientId The block client ID, or `''` for the root container.
+ * @param {ClientId}         clientId The block client ID, or `''` for the root container.
  * @param {BlockEditingMode} mode     The block editing mode. One of `'disabled'`,
  *                                    `'contentOnly'`, or `'default'`.
  *
- * @return {Object} Action object.
+ * @return {ActionSetBlockEditingMode} Action object.
  */
 export function setBlockEditingMode( clientId = '', mode ) {
 	return {
@@ -1912,13 +1923,50 @@ export function setBlockEditingMode( clientId = '', mode ) {
 }
 
 /**
+ * @typedef {Object} ActionSetBlockEditingModes
+ * @property {'SET_BLOCK_EDITING_MODES'}              type  Action type.
+ * @property {Iterable<[ClientId, BlockEditingMode]>} modes Iterable of tuples of client ids and block editing modes.
+ */
+
+/**
+ * Sets the block editing mode for a multiple blocks.
+ *
+ * @see useBlockEditingMode
+ *
+ * @example
+ * ```js
+ * wp.data.dispatch('core/block-editor').setBlockEditingModes([
+ * 	['block-1', 'disabled'],
+ * 	['block-2', 'contentOnly'],
+ * 	['block-3', 'default'],
+ * ]);
+ * ```
+ *
+ * @param {Iterable<[ClientId, BlockEditingMode]>} modes Iterable of tuples of client ids and block editing modes.
+ *
+ * @return {ActionSetBlockEditingModes} Action object.
+ */
+export function setBlockEditingModes( modes ) {
+	return {
+		type: 'SET_BLOCK_EDITING_MODES',
+		modes,
+	};
+}
+
+/**
+ * @typedef {Object} ActionUnsetBlockEditingMode
+ * @property {'UNSET_BLOCK_EDITING_MODE'} type     Action type.
+ * @property {ClientId}                   clientId Block client ID.
+ */
+
+/**
  * Clears the block editing mode for a given block.
  *
  * @see useBlockEditingMode
  *
- * @param {string} clientId The block client ID, or `''` for the root container.
+ * @param {ClientId} clientId The block client ID, or `''` for the root container.
  *
- * @return {Object} Action object.
+ * @return {ActionUnsetBlockEditingMode} Action object.
  */
 export function unsetBlockEditingMode( clientId = '' ) {
 	return {
@@ -1926,3 +1974,30 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
+
+/**
+ * @typedef {Object} ActionUnsetBlockEditingModes
+ * @property {'UNSET_BLOCK_EDITING_MODES'} type      Action type.
+ * @property {Iterable<ClientId>}          clientIds Block client IDs.
+ */
+
+/**
+ * Clears the block editing mode for a given block.
+ *
+ * @see useBlockEditingMode
+ *
+ * @param {Iterable<ClientId>} clientIds List of the block client IDs. Use `''` for the root container.
+ *
+ * @return {ActionUnsetBlockEditingModes} Action object.
+ */
+export function unsetBlockEditingModes( clientIds = [] ) {
+	return {
+		type: 'UNSET_BLOCK_EDITING_MODES',
+		clientIds,
+	};
+}
+
+/**
+ * @typedef {Object} ActionResetBlocks
+ * @property {'RESET_BLOCKS'} type Action type.
+ */

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1889,17 +1889,13 @@ export const registerInserterMediaCategory =
 	};
 
 /**
- * @typedef {string} ClientId
- */
-
-/**
  * @typedef {import('../components/block-editing-mode').BlockEditingMode} BlockEditingMode
  */
 
 /**
  * @typedef {Object} ActionSetBlockEditingMode
  * @property {'SET_BLOCK_EDITING_MODE'} type     Action type.
- * @property {ClientId}                 clientId Block client ID.
+ * @property {string}                   clientId Block client ID.
  * @property {BlockEditingMode}         mode     Block editing mode.
  */
 
@@ -1908,7 +1904,7 @@ export const registerInserterMediaCategory =
  *
  * @see useBlockEditingMode
  *
- * @param {ClientId}         clientId The block client ID, or `''` for the root container.
+ * @param {string}           clientId The block client ID, or `''` for the root container.
  * @param {BlockEditingMode} mode     The block editing mode. One of `'disabled'`,
  *                                    `'contentOnly'`, or `'default'`.
  *
@@ -1924,8 +1920,8 @@ export function setBlockEditingMode( clientId = '', mode ) {
 
 /**
  * @typedef {Object} ActionSetBlockEditingModes
- * @property {'SET_BLOCK_EDITING_MODES'}              type  Action type.
- * @property {Iterable<[ClientId, BlockEditingMode]>} modes Iterable of tuples of client ids and block editing modes.
+ * @property {'SET_BLOCK_EDITING_MODES'}            type  Action type.
+ * @property {Iterable<[string, BlockEditingMode]>} modes Iterable of tuples of client ids and block editing modes.
  */
 
 /**
@@ -1942,7 +1938,7 @@ export function setBlockEditingMode( clientId = '', mode ) {
  * ]);
  * ```
  *
- * @param {Iterable<[ClientId, BlockEditingMode]>} modes Iterable of tuples of client ids and block editing modes.
+ * @param {Iterable<[string, BlockEditingMode]>} modes Iterable of tuples of client ids and block editing modes.
  *
  * @return {ActionSetBlockEditingModes} Action object.
  */
@@ -1956,7 +1952,7 @@ export function setBlockEditingModes( modes ) {
 /**
  * @typedef {Object} ActionUnsetBlockEditingMode
  * @property {'UNSET_BLOCK_EDITING_MODE'} type     Action type.
- * @property {ClientId}                   clientId Block client ID.
+ * @property {string}                     clientId Block client ID.
  */
 
 /**
@@ -1964,7 +1960,7 @@ export function setBlockEditingModes( modes ) {
  *
  * @see useBlockEditingMode
  *
- * @param {ClientId} clientId The block client ID, or `''` for the root container.
+ * @param {string} clientId The block client ID, or `''` for the root container.
  *
  * @return {ActionUnsetBlockEditingMode} Action object.
  */
@@ -1978,7 +1974,7 @@ export function unsetBlockEditingMode( clientId = '' ) {
 /**
  * @typedef {Object} ActionUnsetBlockEditingModes
  * @property {'UNSET_BLOCK_EDITING_MODES'} type      Action type.
- * @property {Iterable<ClientId>}          clientIds Block client IDs.
+ * @property {Iterable<string>}            clientIds Block client IDs.
  */
 
 /**
@@ -1986,7 +1982,7 @@ export function unsetBlockEditingMode( clientId = '' ) {
  *
  * @see useBlockEditingMode
  *
- * @param {Iterable<ClientId>} clientIds List of the block client IDs. Use `''` for the root container.
+ * @param {Iterable<string>} clientIds List of the block client IDs. Use `''` for the root container.
  *
  * @return {ActionUnsetBlockEditingModes} Action object.
  */

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1974,10 +1974,6 @@ export function temporarilyEditingFocusModeRevert( state = '', action ) {
  */
 
 /**
- * @typedef {import('./actions').ClientId} ClientId
- */
-
-/**
  * @typedef {import('./actions').ActionSetBlockEditingMode} ActionSetBlockEditingMode
  */
 
@@ -2002,7 +1998,7 @@ export function temporarilyEditingFocusModeRevert( state = '', action ) {
  */
 
 /**
- * @typedef {Map<ClientId, BlockEditingMode>} BlockEditingModesState
+ * @typedef {Map<string, BlockEditingMode>} BlockEditingModesState
  */
 
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1970,20 +1970,65 @@ export function temporarilyEditingFocusModeRevert( state = '', action ) {
 }
 
 /**
+ * @typedef {import('../components/block-editing-mode').BlockEditingMode} BlockEditingMode
+ */
+
+/**
+ * @typedef {import('./actions').ClientId} ClientId
+ */
+
+/**
+ * @typedef {import('./actions').ActionSetBlockEditingMode} ActionSetBlockEditingMode
+ */
+
+/**
+ * @typedef {import('./actions').ActionSetBlockEditingModes} ActionSetBlockEditingModes
+ */
+
+/**
+ * @typedef {import('./actions').ActionUnsetBlockEditingMode} ActionUnsetBlockEditingMode
+ */
+
+/**
+ * @typedef {import('./actions').ActionUnsetBlockEditingModes} ActionUnsetBlockEditingModes
+ */
+
+/**
+ * @typedef {import('./actions').ActionResetBlocks} ActionResetBlocks
+ */
+
+/**
+ * @typedef {ActionSetBlockEditingMode|ActionSetBlockEditingModes|ActionUnsetBlockEditingMode|ActionUnsetBlockEditingModes|ActionResetBlocks} BlockEditingModesAction
+ */
+
+/**
+ * @typedef {Map<ClientId, BlockEditingMode>} BlockEditingModesState
+ */
+
+/**
  * Reducer returning a map of block client IDs to block editing modes.
  *
- * @param {Map}    state  Current state.
- * @param {Object} action Dispatched action.
+ * @param {BlockEditingModesState}  state  Current state.
+ * @param {BlockEditingModesAction} action Dispatched action.
  *
- * @return {Map} Updated state.
+ * @return {BlockEditingModesState} Updated state.
  */
 export function blockEditingModes( state = new Map(), action ) {
 	switch ( action.type ) {
 		case 'SET_BLOCK_EDITING_MODE':
 			return new Map( state ).set( action.clientId, action.mode );
+		case 'SET_BLOCK_EDITING_MODES':
+			return new Map( [ ...state, ...action.modes ] );
 		case 'UNSET_BLOCK_EDITING_MODE': {
 			const newState = new Map( state );
 			newState.delete( action.clientId );
+			return newState;
+		}
+		case 'UNSET_BLOCK_EDITING_MODES': {
+			const newState = new Map( state );
+			for ( const clientId of action.clientIds ) {
+				newState.delete( clientId );
+			}
 			return newState;
 		}
 		case 'RESET_BLOCKS': {

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -41,32 +41,27 @@ export default function DisableNonPageContentBlocks() {
 		);
 	}, [] );
 
-	const { setBlockEditingMode, unsetBlockEditingMode } =
+	const { setBlockEditingModes, unsetBlockEditingModes } =
 		useDispatch( blockEditorStore );
 
 	useEffect( () => {
-		setBlockEditingMode( '', 'disabled' );
-		for ( const clientId of contentOnlyIds ) {
-			setBlockEditingMode( clientId, 'contentOnly' );
-		}
-		for ( const clientId of disabledIds ) {
-			setBlockEditingMode( clientId, 'disabled' );
-		}
+		setBlockEditingModes( [
+			[ '', 'disabled' ],
+			...contentOnlyIds.map( ( clientId ) => [
+				clientId,
+				'contentOnly',
+			] ),
+			...disabledIds.map( ( clientId ) => [ clientId, 'disabled' ] ),
+		] );
 
 		return () => {
-			unsetBlockEditingMode( '' );
-			for ( const clientId of contentOnlyIds ) {
-				unsetBlockEditingMode( clientId );
-			}
-			for ( const clientId of disabledIds ) {
-				unsetBlockEditingMode( clientId );
-			}
+			unsetBlockEditingModes( [ '', ...contentOnlyIds, ...disabledIds ] );
 		};
 	}, [
 		contentOnlyIds,
 		disabledIds,
-		setBlockEditingMode,
-		unsetBlockEditingMode,
+		setBlockEditingModes,
+		unsetBlockEditingModes,
 	] );
 
 	return null;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds two new actions for bulk editing block editing modes.
- `setBlockEditingModes` which takes an iterable (`Array`, `Map`, etc.) of client id and mode tuples to set.
- `unsetBlockEditingModes` which takes an interable of client ids to unset.

Updates the places that could benefit from using the new actions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #59249 we were running into performance issues around setting block editing modes in a loop. Each action causes a `new Map()` to be created which was causing memory thrashing and really bad performance when switching editing modes.

@Mamaduka pointed out in https://github.com/WordPress/gutenberg/pull/59249#discussion_r1542617990 that there were other places that could benefit from the change, so I've extracted this into a separate PR.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Only creating one `new Map()` for a full set of changes is much more friendly to the garbage collector. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Make sure pattern editing works the same as before. (see https://github.com/WordPress/gutenberg/pull/58541)
2. Make sure page editing works the same as before. (see https://github.com/WordPress/gutenberg/pull/60010)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
