### PR TITLE
Fix: use `viewportWidth` in pattern preview data view

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -171,7 +171,12 @@ function Preview( { item, categoryId, viewType } ) {
 				>
 					{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
 					{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
-					{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
+					{ ! isEmpty && (
+						<BlockPreview
+							blocks={ item.blocks }
+							viewportWidth={ item?.viewportWidth }
+						/>
+					) }
 				</PreviewWrapper>
 			</div>
 			{ ariaDescriptions.map( ( ariaDescription, index ) => (

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -174,7 +174,7 @@ function Preview( { item, categoryId, viewType } ) {
 					{ ! isEmpty && (
 						<BlockPreview
 							blocks={ item.blocks }
-							viewportWidth={ item?.viewportWidth }
+							viewportWidth={ item.viewportWidth }
 						/>
 					) }
 				</PreviewWrapper>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closing #60314 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In order to respect the patterns defined `viewportWidth`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Passing the `viewportWidth` setting of the pattern into the `BlockPreview` component

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Register a custom pattern in code and add a custom `viewportWidth` to the metadata header
2. Navigate to the pattern data view and see that the preview uses the correct viewport width.
