### PR TITLE
Allow view access of template rest endpoint to anyone with the `edit_post` capability

### DIFF
--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Templates_Controller_6_6 class
+ *
+ * @package    gutenberg
+ */
+
+/**
+ * Gutenberg_REST_Templates_Controller_6_6 class
+ *
+ * Templates and template parts currently only allow access to administrators with the
+ * `edit_theme_options` capability. In order to allow other roles to also view the templates,
+ * we need to override the permissions check for the REST API endpoints.
+ */
+class Gutenberg_REST_Templates_Controller_6_6 extends Gutenberg_REST_Templates_Controller_6_4 {
+
+	/**
+	 * Checks if a given request has access to read templates.
+	 *
+	 * @since 6.6
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				return true;
+			}
+		}
+
+		return new WP_Error(
+			'rest_cannot_manage_templates',
+			__( 'Sorry, you are not allowed to access the templates on this site.', 'default' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to read templates.
+	 *
+	 * @since 6.6
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				return true;
+			}
+		}
+
+		return new WP_Error(
+			'rest_cannot_manage_templates',
+			__( 'Sorry, you are not allowed to access the templates on this site.', 'default' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
+	}
+}

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * PHP and WordPress configuration compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+if ( ! function_exists( 'wp_api_template_access_controller' ) ) {
+	/**
+	 * Hook in to the template and template part post types and modify the
+	 * access control for the rest endpoint to allow lower user roles to access
+	 * the templates and template parts.
+	 *
+	 * @param array  $args Current registered post type args.
+	 * @param string $post_type Name of post type.
+	 *
+	 * @return array
+	 */
+	function wp_api_template_access_controller( $args, $post_type ) {
+		if ( 'wp_template' === $post_type || 'wp_template_part' === $post_type ) {
+			$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_6_6';
+		}
+		return $args;
+	}
+}
+add_filter( 'register_post_type_args', 'wp_api_template_access_controller', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -127,6 +127,8 @@ require __DIR__ . '/compat/wordpress-6.5/script-loader.php';
 // WordPress 6.6 compat.
 require __DIR__ . '/compat/wordpress-6.6/block-bindings/pattern-overrides.php';
 require __DIR__ . '/compat/wordpress-6.6/option.php';
+require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';
+require __DIR__ . '/compat/wordpress-6.6/rest-api.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #60316 as requested in https://github.com/WordPress/gutenberg/pull/58301#issuecomment-2012136167

Modify the template / template part rest endpoint to allow any user role with the `edit_post` capability to view entities. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In order to render the block template in the locked template preview inside the post editor we need to be able to fetch the contents of any block templates / template parts for any user role that can edit a post. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Overwriting the `get_items_permissions_check` and `get_item_permissions_check` methods of the `rest_controller_class` of the `wp_template` post type to check whether the current user can `edit_posts`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Try making an authenticated rest request to the template rest endpoint with any user role that has the `edit_post` capability. -> The template should get returned 
Try making an unauthenticated request and still get an unauthorized error