### PR TITLE
Added CSS which truncates long texts inside suggestions list

### DIFF
--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -61,7 +61,6 @@ $input-size: 300px;
 	padding: 4px 0;
 	// To match the url-input width: input width + padding + 2 buttons.
 	width: $input-size + 2;
-	overflow-y: auto;
 }
 
 // Hide suggestions on mobile until we @todo find a better way to show them
@@ -85,6 +84,8 @@ $input-size: 300px;
 	border: none;
 	text-align: left;
 	box-shadow: none;
+	text-overflow: ellipsis;
+	overflow: hidden;
 
 	&:hover {
 		background: $gray-300;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR removes horizontal scrolling from link suggestion list which appears when adding link to Image block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Closes #58497 

Horizontal scrolling creates accessibility concerns.
It is also nice that feel and function between different suggestions lists are same

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
With the power of CSS. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Image block.
3. Add link to that Image block. Navigate the list of suggestion using keyboards

It should be noted that you need have page(s) or post(s) with really long titles to see any

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
**Before**
<img width="588" alt="Screenshot 2024-03-30 at 13 09 04" src="https://github.com/WordPress/gutenberg/assets/62872075/bc940725-746f-4ed2-9b31-92dafcf98557">

**After**
<img width="671" alt="Screenshot 2024-03-30 at 13 07 17" src="https://github.com/WordPress/gutenberg/assets/62872075/0a808d30-c85e-4c72-b6b1-a8fa9e5098a8">
