### PR TITLE
Perf: site editor: adjust load test to wait for content

### DIFF
--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -90,7 +90,7 @@ test.describe( 'Site Editor Performance', () => {
 				// patterns are replaced.
 				await Promise.all( [
 					canvas
-						.locator( '.wp-block-post-content' )
+						.locator( '.wp-block-post-content .wp-block' )
 						.first()
 						.waitFor(),
 					page.waitForFunction(

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -76,6 +76,7 @@ test.describe( 'Site Editor Performance', () => {
 				admin,
 				perfUtils,
 				metrics,
+				page,
 			} ) => {
 				// Go to the test draft.
 				await admin.visitSiteEditor( {
@@ -85,7 +86,20 @@ test.describe( 'Site Editor Performance', () => {
 
 				// Wait for the first block.
 				const canvas = await perfUtils.getCanvas();
-				await canvas.locator( '.wp-block' ).first().waitFor();
+				// Wait until the post content block is rendered AND all
+				// patterns are replaced.
+				await Promise.all( [
+					canvas
+						.locator( '.wp-block-post-content' )
+						.first()
+						.waitFor(),
+					page.waitForFunction(
+						() =>
+							document.querySelectorAll(
+								'[data-type="core/pattern"]'
+							).length === 0
+					),
+				] );
 
 				// Get the durations.
 				const loadingDurations = await metrics.getLoadingDurations();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently the site editor loading test a bit too simple: we just wait for any block to show up, without waiting for all patterns to get replaced and for the post content to show.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's hard to improve what we don't measure.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
