### PR TITLE
Search Block: Apply font-related style inheritance to input field

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -97,6 +97,15 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	}
 }
 
+// We are lowering the specificity so that the input element can override the rule for the input element inside the search block.
+:where(.wp-block-search__input) {
+	font-family: inherit;
+	font-weight: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	letter-spacing: inherit;
+}
+
 // We are lowering the specificity so that the button element can override the rule for the button inside the search block.
 :where(.wp-block-search__button-inside .wp-block-search__inside-wrapper) {
 	padding: $grid-unit-05;

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -104,6 +104,8 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	font-size: inherit;
 	line-height: inherit;
 	letter-spacing: inherit;
+	text-transform: inherit;
+	font-style: inherit;
 }
 
 // We are lowering the specificity so that the button element can override the rule for the button inside the search block.


### PR DESCRIPTION
Fixes #60174

## What?

This PR adds CSS properties to the input element inside the Search block that inherits font-related styles. This ensures that when typography styles are defined at **the root level**, they are correctly applied to the input element as well.

The screenshot below is from Emptytheme:

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/999abeaa-979d-486a-bf93-d9600ab9058c)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/b57f8dea-8b6c-468e-b560-008b654999b5)

## Why?

According to [MDN](https://developer.mozilla.org/en-US/docs/Learn/Forms/Styling_web_forms#fonts_and_text), form-related elements are browser-specific and do not inherit font-related styles. This is not an issue when typography-related styles are applied at the block level in the global styles or on individual blocks, but it becomes an issue when typography-related settings are applied at the root level in the global styles.

## How?

Applies CSS to the input element that inherits all font-related styles. We also use :where to reduce the CSS specificity so that we can override this style. Only `text-decoration` is not inherited. This is because it causes problems with text input, as discussed in  #43499.

Ideally, it would be more convenient to define these styles for the input field in the default theme.json, but the current theme.json does not support input elements.

## Testing Instructions

- Insert a Search block into one of templates.
- Apply typography related styles at the root level via the global styles. Those styles should now be applied correctly to the input element, including the placeholder.
- Apply typography-related styles to the Search block via the global styles. All styles should be overridden correctly.
- Apply typography-related styles to the individual Search block. All styles should be overridden correctly.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/66afc426-52cf-46a9-96f4-026fbb3eef71

