### PR TITLE
Global Styles: Remove letter-spacing from typography element preview

### DIFF
--- a/packages/edit-site/src/components/global-styles/typography-elements.js
+++ b/packages/edit-site/src/components/global-styles/typography-elements.js
@@ -31,9 +31,6 @@ function ElementItem( { parentMenu, element, label } ) {
 	const [ fontFamily ] = useGlobalStyle( prefix + 'typography.fontFamily' );
 	const [ fontStyle ] = useGlobalStyle( prefix + 'typography.fontStyle' );
 	const [ fontWeight ] = useGlobalStyle( prefix + 'typography.fontWeight' );
-	const [ letterSpacing ] = useGlobalStyle(
-		prefix + 'typography.letterSpacing'
-	);
 	const [ backgroundColor ] = useGlobalStyle( prefix + 'color.background' );
 	const [ fallbackBackgroundColor ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( prefix + 'color.gradient' );
@@ -62,7 +59,6 @@ function ElementItem( { parentMenu, element, label } ) {
 						color,
 						fontStyle,
 						fontWeight,
-						letterSpacing,
 						...extraStyles,
 					} }
 				>


### PR DESCRIPTION
## What?

This PR removes the letter-spacing style in the global styles Typography > Elements panel.

| Before | After |
|--------|--------|
|  ![before](https://github.com/WordPress/gutenberg/assets/54422211/7c9fc913-6045-4373-a491-53f4dbfdf8d8) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/5636aed8-3f45-49a9-a280-70e3a0050eb3) | 

## Why?

This preview should reflect the actual font style as much as possible, but I think `letter-spacing` is unnecessary as it causes unintended layout disruption.

## How?

Removed `letter-spacing` from preview styles. This does not affect the preview when accessing Global Styles > Typography > Text.

![global-styles-preview](https://github.com/WordPress/gutenberg/assets/54422211/9fbfcdd8-20fc-4eaa-aebe-358ecbd73e92)

## Testing Instructions

- Access the Site Editor > Global Styles > Typography > Text.
- Increase the value of Letter Spacing.
- Back to the Typography Panel.
- In the Elements panel, the preview should not reflect the `letter-spacing` style.
