### PR TITLE
Render non-editable preview of template part when user does not have capability to edit template part

### DIFF
--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -38,8 +38,6 @@ function useLayout( layout ) {
 	}
 }
 
-const parsedBlocksCache = new WeakMap();
-
 function NonEditableTemplatePartPreview( {
 	postId: id,
 	layout,
@@ -57,7 +55,8 @@ function NonEditableTemplatePartPreview( {
 			const editedRecord = getEditedEntityRecord(
 				'postType',
 				'wp_template_part',
-				id
+				id,
+				{ context: 'view' }
 			);
 			return {
 				editedBlocks: editedRecord.blocks,
@@ -66,8 +65,6 @@ function NonEditableTemplatePartPreview( {
 		},
 		[ id ]
 	);
-
-	const { getEntityRecord, getEntityRecordEdits } = useSelect( coreStore );
 
 	const blocks = useMemo( () => {
 		if ( ! id ) {
@@ -82,26 +79,8 @@ function NonEditableTemplatePartPreview( {
 			return [];
 		}
 
-		// If there's an edit, cache the parsed blocks by the edit.
-		// If not, cache by the original entry record.
-		const edits = getEntityRecordEdits(
-			'postType',
-			'wp_template_part',
-			id
-		);
-		const isUnedited = ! edits || ! Object.keys( edits ).length;
-		const cacheKey = isUnedited
-			? getEntityRecord( 'postType', 'wp_template_part', id )
-			: edits;
-		let _blocks = parsedBlocksCache.get( cacheKey );
-
-		if ( ! _blocks ) {
-			_blocks = parse( content );
-			parsedBlocksCache.set( cacheKey, _blocks );
-		}
-
-		return _blocks;
-	}, [ id, editedBlocks, content, getEntityRecord, getEntityRecordEdits ] );
+		return parse( content );
+	}, [ id, editedBlocks, content ] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		value: blocks,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #60316. Building on top of: https://github.com/WordPress/gutenberg/pull/60317 and https://github.com/WordPress/gutenberg/pull/58301

Adds a new non-editable mode to the template part block that renders the block list as disabled and non-editable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This mode will be needed to render a preview of a template part for users that can view a template but not edit it. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding a user capability check before rendering the editable template part preview and for users that cannot edit it rendering an alternative locked down mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Apply the following patch locally:

```patch
diff --git a/packages/block-library/src/template-part/edit/inner-blocks.js b/packages/block-library/src/template-part/edit/inner-blocks.js
index 0bd9bc61f3..2784577931 100644
--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -162,7 +162,7 @@ export default function TemplatePartInnerBlocks( {
 		return null;
 	}
 
-	const TemplatePartInnerBlocksComponent = canEditTemplatePart
+	const TemplatePartInnerBlocksComponent = false
 		? EditableTemplatePartInnerBlocks
 		: NonEditableTemplatePartPreview;

```

Open the site editor and see that the template parts like the header are rendering fully but are not editable/selectable. 
