### PR TITLE
RichText: Switch from disableEditing to standard html readonly attribute

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -111,7 +111,7 @@ export function RichTextWrapper(
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
 		__unstableAllowPrefixTransformations,
-		readonly,
+		readOnly,
 		...props
 	},
 	forwardedRef
@@ -202,7 +202,7 @@ export function RichTextWrapper(
 		[ blockBindings, blockName ]
 	);
 
-	const shouldDisableEditing = readonly || disableBoundBlocks;
+	const shouldDisableEditing = readOnly || disableBoundBlocks;
 
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -485,7 +485,7 @@ PrivateRichText.isEmpty = ( value ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md
  */
 const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
-	return <PrivateRichText ref={ ref } { ...props } readonly={ false } />;
+	return <PrivateRichText ref={ ref } { ...props } readOnly={ false } />;
 } );
 
 PublicForwardedRichTextContainer.Content = Content;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -485,9 +485,7 @@ PrivateRichText.isEmpty = ( value ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md
  */
 const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
-	return (
-		<PrivateRichText ref={ ref } { ...props } disableEditing={ false } />
-	);
+	return <PrivateRichText ref={ ref } { ...props } readonly={ false } />;
 } );
 
 PublicForwardedRichTextContainer.Content = Content;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -111,7 +111,7 @@ export function RichTextWrapper(
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
 		__unstableAllowPrefixTransformations,
-		disableEditing,
+		readonly,
 		...props
 	},
 	forwardedRef
@@ -202,7 +202,7 @@ export function RichTextWrapper(
 		[ blockBindings, blockName ]
 	);
 
-	const shouldDisableEditing = disableEditing || disableBoundBlocks;
+	const shouldDisableEditing = readonly || disableBoundBlocks;
 
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -944,7 +944,7 @@ export default function Image( {
 				insertBlocksAfter={ insertBlocksAfter }
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={ isSingleSelected && hasNonContentControls }
-				readonly={ lockCaption }
+				readOnly={ lockCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -944,7 +944,7 @@ export default function Image( {
 				insertBlocksAfter={ insertBlocksAfter }
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={ isSingleSelected && hasNonContentControls }
-				disableEditing={ lockCaption }
+				readonly={ lockCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -33,7 +33,7 @@ export function Caption( {
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
 	className,
-	readonly,
+	readOnly,
 	tagName = 'figcaption',
 	addLabel = __( 'Add caption' ),
 	removeLabel = __( 'Remove caption' ),
@@ -111,7 +111,7 @@ export function Caption( {
 								createBlock( getDefaultBlockName() )
 							)
 						}
-						readonly={ readonly }
+						readOnly={ readOnly }
 						{ ...props }
 					/>
 				) }

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -33,7 +33,7 @@ export function Caption( {
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
 	className,
-	disableEditing,
+	readonly,
 	tagName = 'figcaption',
 	addLabel = __( 'Add caption' ),
 	removeLabel = __( 'Remove caption' ),
@@ -111,7 +111,7 @@ export function Caption( {
 								createBlock( getDefaultBlockName() )
 							)
 						}
-						disableEditing={ disableEditing }
+						readonly={ readonly }
 						{ ...props }
 					/>
 				) }


### PR DESCRIPTION
## What?
Implements [suggestion here](https://github.com/WordPress/gutenberg/pull/59755#issuecomment-2028084394) to switch to using a standard html attrib to flag RichText field as read only.

## Why?
This is a more standard way of indicating this, and will make a better public API if we move this from private.

## How?
Renames prop from `disableEditing` to `readonly`

## Testing Instructions

- Create a sync pattern and add an image with a caption.
- Make the image overridable by renaming it in list view
- Insert the pattern in a post and make sure the caption is no editable

