### PR TITLE
[Editor]: Unify publish sidebar preference

### DIFF
--- a/packages/e2e-test-utils/src/are-pre-publish-checks-enabled.js
+++ b/packages/e2e-test-utils/src/are-pre-publish-checks-enabled.js
@@ -9,5 +9,5 @@ import { wpDataSelect } from './wp-data-select';
  * @return {Promise<boolean>} Boolean which represents the state of prepublish checks.
  */
 export async function arePrePublishChecksEnabled() {
-	return wpDataSelect( 'core/editor', 'isPublishSidebarEnabled' );
+	return wpDataSelect( 'core', 'isPublishSidebarEnabled' );
 }

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -126,13 +126,13 @@ export default function useCommonCommands() {
 		icon: formatListBullets,
 		callback: ( { close } ) => {
 			close();
-			toggle( 'core/edit-post', 'isPublishSidebarEnabled' );
+			toggle( 'core', 'isPublishSidebarEnabled' );
 			createInfoNotice(
 				isPublishSidebarEnabled
 					? __( 'Pre-publish checks disabled.' )
 					: __( 'Pre-publish checks enabled.' ),
 				{
-					id: 'core/edit-post/publish-sidebar/notice',
+					id: 'core/editor/publish-sidebar/notice',
 					type: 'snackbar',
 				}
 			);

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -72,6 +72,7 @@ export function initializeEditor(
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		showListViewByDefault: false,
+		isPublishSidebarEnabled: true,
 	} );
 
 	dispatch( blocksStore ).reapplyBlockTypeFilters();

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -56,7 +56,6 @@ export function initializeEditor(
 
 	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
 		fullscreenMode: true,
-		isPublishSidebarEnabled: true,
 		themeStyles: true,
 		welcomeGuide: true,
 		welcomeGuideTemplate: true,

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -25,7 +25,6 @@ export function initializeEditor( id, postType, postId ) {
 		editorMode: 'visual',
 		fullscreenMode: true,
 		inactivePanels: [],
-		isPublishSidebarEnabled: true,
 		openPanels: [ 'post-status' ],
 		welcomeGuide: true,
 	} );
@@ -33,9 +32,7 @@ export function initializeEditor( id, postType, postId ) {
 		hiddenBlockTypes: [],
 		inactivePanels: [],
 		openPanels: [ 'post-status' ],
-	} );
-
-	dispatch( preferencesStore ).setDefaults( 'core', {
+		isPublishSidebarEnabled: true,
 		fixedToolbar: false,
 	} );
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -406,7 +406,7 @@ export const enablePublishSidebar =
 	( { registry } ) => {
 		registry
 			.dispatch( preferencesStore )
-			.set( 'core/edit-post', 'isPublishSidebarEnabled', true );
+			.set( 'core', 'isPublishSidebarEnabled', true );
 	};
 
 /**
@@ -417,7 +417,7 @@ export const disablePublishSidebar =
 	( { registry } ) => {
 		registry
 			.dispatch( preferencesStore )
-			.set( 'core/edit-post', 'isPublishSidebarEnabled', false );
+			.set( 'core', 'isPublishSidebarEnabled', false );
 	};
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1107,10 +1107,7 @@ export function canUserUseUnfilteredHTML( state ) {
  */
 export const isPublishSidebarEnabled = createRegistrySelector(
 	( select ) => () =>
-		!! select( preferencesStore ).get(
-			'core/edit-post',
-			'isPublishSidebarEnabled'
-		)
+		!! select( preferencesStore ).get( 'core', 'isPublishSidebarEnabled' )
 );
 
 /**

--- a/packages/preferences-persistence/src/migrations/legacy-local-storage-data/index.js
+++ b/packages/preferences-persistence/src/migrations/legacy-local-storage-data/index.js
@@ -68,7 +68,12 @@ export function convertLegacyData( data ) {
 	);
 	data = moveIndividualPreference(
 		data,
-		{ from: 'core/editor', to: 'core/edit-post' },
+		{ from: 'core/editor', to: 'core' },
+		'isPublishSidebarEnabled'
+	);
+	data = moveIndividualPreference(
+		data,
+		{ from: 'core/edit-post', to: 'core' },
 		'isPublishSidebarEnabled'
 	);
 	data = moveIndividualPreference(

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
@@ -18,6 +18,7 @@ export default function convertEditorSettings( data ) {
 		'showBlockBreadcrumbs',
 		'showIconLabels',
 		'showListViewByDefault',
+		'isPublishSidebarEnabled',
 	];
 
 	settingsToMoveToCore.forEach( ( setting ) => {

--- a/packages/preferences/src/store/selectors.js
+++ b/packages/preferences/src/store/selectors.js
@@ -18,6 +18,7 @@ const withDeprecatedKeys = ( originalGet ) => ( state, scope, name ) => {
 		'showBlockBreadcrumbs',
 		'showIconLabels',
 		'showListViewByDefault',
+		'isPublishSidebarEnabled',
 	];
 
 	if (

--- a/test/e2e/specs/editor/various/multi-entity-saving.spec.js
+++ b/test/e2e/specs/editor/various/multi-entity-saving.spec.js
@@ -20,7 +20,7 @@ test.describe( 'Editor - Multi-entity save flow', () => {
 		} );
 
 		// Restore the Publish sidebar.
-		await editor.setPreferences( 'core/edit-post', {
+		await editor.setPreferences( 'core', {
 			isPublishSidebarEnabled: true,
 		} );
 	} );
@@ -154,7 +154,7 @@ test.describe( 'Editor - Multi-entity save flow', () => {
 		page,
 	} ) => {
 		await admin.createNewPost();
-		await editor.setPreferences( 'core/edit-post', {
+		await editor.setPreferences( 'core', {
 			isPublishSidebarEnabled: false,
 		} );
 

--- a/test/e2e/specs/editor/various/publishing.spec.js
+++ b/test/e2e/specs/editor/various/publishing.spec.js
@@ -70,13 +70,13 @@ test.describe( 'Publishing', () => {
 		test.describe( `a ${ postType } with pre-publish checks disabled`, () => {
 			test.beforeEach( async ( { admin, editor } ) => {
 				await admin.createNewPost( { postType } );
-				await editor.setPreferences( 'core/edit-post', {
+				await editor.setPreferences( 'core', {
 					isPublishSidebarEnabled: false,
 				} );
 			} );
 
 			test.afterEach( async ( { editor } ) => {
-				await editor.setPreferences( 'core/edit-post', {
+				await editor.setPreferences( 'core', {
 					isPublishSidebarEnabled: true,
 				} );
 			} );
@@ -127,14 +127,14 @@ test.describe( 'Publishing', () => {
 		test.describe( `a ${ postType } in small viewports`, () => {
 			test.beforeEach( async ( { admin, editor, pageUtils } ) => {
 				await admin.createNewPost( { postType } );
-				await editor.setPreferences( 'core/edit-post', {
+				await editor.setPreferences( 'core', {
 					isPublishSidebarEnabled: false,
 				} );
 				await pageUtils.setBrowserViewport( 'small' );
 			} );
 
 			test.afterEach( async ( { editor, pageUtils } ) => {
-				await editor.setPreferences( 'core/edit-post', {
+				await editor.setPreferences( 'core', {
 					isPublishSidebarEnabled: true,
 				} );
 				await pageUtils.setBrowserViewport( 'large' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/52632, https://github.com/WordPress/gutenberg/issues/59878
Extracted from: https://github.com/WordPress/gutenberg/pull/60289

This PR  moves the `Enable pre-publish checks` preference to later on be the same between both post and site editors. Right now there is no UI in site editor and will be added when we consolidate the publishing flow.



## Testing Instructions
1. Everything should work as before regarding this setting(toggling from Preferences modal or command) in post editor
2. In the initial refresh of the page when testing, the proper value should have been preserved(thus indicating the migration works properly).

