### PR TITLE
Block Bindings: set allow blocks list from source handler

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -183,8 +183,9 @@ function BlockBindingBridge( { blockProps, bindings, onPropValueChange } ) {
 	).getAllBlockBindingsSources();
 
 	/*
-	 * Create binding object filtering
-	 * only the attributes that can be bound.
+	 * Create allow binding object,
+	 * filtering only the valid bindings,
+	 * and populating the source handler.
 	 */
 	const allowBindings = Object.entries( bindings ).reduce(
 		( acc, [ attrName, settings ] ) => {

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -23,7 +23,7 @@ import { unlock } from '../lock-unlock';
  * @return {WPHigherOrderComponent} Higher-order component.
  */
 
-const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
+const DEFAULT_BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 	'core/paragraph': [ 'content' ],
 	'core/heading': [ 'content' ],
 	'core/image': [ 'url', 'title', 'alt' ],
@@ -38,7 +38,7 @@ const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
  * @return {boolean} Whether it is possible to bind the block to sources.
  */
 export function canBindBlock( blockName ) {
-	return blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS;
+	return blockName in DEFAULT_BLOCK_BINDINGS_ALLOWED_BLOCKS;
 }
 
 /**
@@ -52,7 +52,9 @@ export function canBindBlock( blockName ) {
 export function canBindAttribute( blockName, attributeName ) {
 	return (
 		canBindBlock( blockName ) &&
-		BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].includes( attributeName )
+		DEFAULT_BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].includes(
+			attributeName
+		)
 	);
 }
 

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -189,18 +189,18 @@ function BlockBindingBridge( { blockProps, bindings, onPropValueChange } ) {
 	 */
 	const allowBindings = Object.entries( bindings ).reduce(
 		( acc, [ attrName, settings ] ) => {
-			const source = blockBindingsSources[ settings.source ];
+			const handler = blockBindingsSources[ settings.source ];
 			// Check if the block has a valid source handler.
-			if ( ! source?.useSource ) {
+			if ( ! handler?.useSource ) {
 				return false;
 			}
 
 			// Check if the attribute can be bound.
-			const allowBlocks = source?.settings?.blocks;
+			const allowBlocks = handler?.settings?.blocks;
 			if ( canBindAttribute( blockProps.name, attrName, allowBlocks ) ) {
 				acc[ attrName ] = {
 					...settings,
-					handler: source, // populate the source handler.
+					handler, // populate the source handler.
 				};
 			}
 

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -236,17 +236,19 @@ const withBlockBindingSupport = createHigherOrderComponent(
 			[]
 		);
 
+		// Bail early if the block has no bindings metadata attribute.
 		const bindings = props.attributes.metadata?.bindings || {};
+		if ( ! Object.keys( bindings ).length ) {
+			return <BlockEdit { ...props } />;
+		}
 
 		return (
 			<>
-				{ Object.keys( bindings ).length > 0 && (
-					<BlockBindingBridge
-						blockProps={ props }
-						bindings={ bindings }
-						onPropValueChange={ updateBoundAttributes }
-					/>
-				) }
+				<BlockBindingBridge
+					blockProps={ props }
+					bindings={ bindings }
+					onPropValueChange={ updateBoundAttributes }
+				/>
 
 				<BlockEdit
 					{ ...props }

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -100,7 +100,7 @@ const BindingConnector = ( {
 	const { name: blockName } = blockProps;
 	const attrValue = blockProps.attributes[ attrName ];
 
-	const updateBoundAttibute = useCallback(
+	const updateBoundAttribute = useCallback(
 		( newAttrValue, prevAttrValue ) => {
 			/*
 			 * If the attribute is a RichTextData instance,
@@ -134,7 +134,7 @@ const BindingConnector = ( {
 
 	useLayoutEffect( () => {
 		if ( typeof propValue !== 'undefined' ) {
-			updateBoundAttibute( propValue, attrValue );
+			updateBoundAttribute( propValue, attrValue );
 		} else if ( placeholder ) {
 			/*
 			 * Placeholder fallback.
@@ -147,14 +147,14 @@ const BindingConnector = ( {
 				getBlockType( blockName ).attributes[ attrName ].attribute;
 
 			if ( htmlAttribute === 'src' || htmlAttribute === 'href' ) {
-				updateBoundAttibute( null );
+				updateBoundAttribute( null );
 				return;
 			}
 
-			updateBoundAttibute( placeholder );
+			updateBoundAttribute( placeholder );
 		}
 	}, [
-		updateBoundAttibute,
+		updateBoundAttribute,
 		propValue,
 		attrValue,
 		placeholder,

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -52,6 +52,7 @@ export function registerBlockBindingsSource( source ) {
 		sourceName: source.name,
 		sourceLabel: source.label,
 		useSource: source.useSource,
+		settings: source.settings,
 		lockAttributesEditing: source.lockAttributesEditing,
 	};
 }

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -390,6 +390,7 @@ export function blockBindingsSources( state = {}, action ) {
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
 				useSource: action.useSource,
+				settings: action.settings || {},
 				lockAttributesEditing: action.lockAttributesEditing ?? true,
 			},
 		};

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -41,4 +41,12 @@ export default {
 			updateValue: updateMetaValue,
 		};
 	},
+	settings: {
+		blocks: {
+			'core/paragraph': [ 'content' ],
+			'core/heading': [ 'content' ],
+			'core/image': [ 'url', 'title', 'alt' ],
+			'core/button': [ 'url', 'text', 'linkTarget' ],
+		},
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR allows defining the block attributes that can be bound from the source handler instead of a hardcoded list.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It allows for binding an attribute of a custom block, for instance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For this purpose, the PR introduces the `settings` property to the source handler, which makes it possible to define the block attributes allowed to bind. For instance, for [the core/post-meta source handler](https://github.com/WordPress/gutenberg/blob/1cec195e9d2e395020df7cab9f91087b307f27ca/packages/editor/src/bindings/post-meta.js#L44-L51):

```js
	settings: {
		blocks: {
			'core/paragraph': [ 'content' ],
			'core/heading': [ 'content' ],
			'core/image': [ 'url', 'title', 'alt' ],
			'core/button': [ 'url', 'text', 'linkTarget' ],
		},
	},
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

0. Register a new custom field however you prefer. You can use a snippet similar to this:

```PHP
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'This is the content of the text custom field',
	)
);
register_meta(
	'post',
	'url_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

1. Go to the editor mode
2. Add the following blocks with bound attributes:

```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<p>STATIC <strong>field</strong> value</p>
<!-- /wp:paragraph -->

<!-- wp:image {"id":248,"width":"168px","height":"auto","sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}},"alt":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg" alt="STATIC <strong&gt;field</strong&gt; value" class="wp-image-248" style="width:168px;height:auto"/></figure>
<!-- /wp:image -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"bindings":{"text":{"source":"core/post-meta","args":{"key":"text_custom_field"}},"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">STATIC <strong>field</strong> value</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --> 
```

3. Return to the visual mode
4. Confirm the app shows the block with the default values of the custom fields
<img width="783" alt="image" src="https://github.com/WordPress/gutenberg/assets/77539/f7092064-a6a0-4e23-bf1d-24f7b4676d3c">
5. Confirm it isn't possible to edit the bound attributes
6. Confirm the app shows the bound attributes in the UI (icon, color, etc...)
7. Update the custom field values by dispatching the following action from the dev console

```js
const postId = 1341
wp.data.dispatch( 'core' ).editEntityRecord(
    'postType',
    'post',
    postId,
    {
       meta: {
        text_custom_field:  '<strong>Goncharov</strong>',
        url_custom_field: 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg'
      }
    }
);
```
8. Save the post
9. Hard refresh
10. Confirm the post shows the updated values of the custom fields
<img width="779" alt="image" src="https://github.com/WordPress/gutenberg/assets/77539/6e366320-b5c4-4dce-8d32-b5f4b4fc2ee1">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
