### PR TITLE
Fix block toolbar dropdown separator color.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   `Dropdown`: Fix bug with separator styling. ([#60336](https://github.com/WordPress/gutenberg/pull/60336)).
 -   `InputControl`: Ignore IME events when `isPressEnterToChange` is enabled ([#60090](https://github.com/WordPress/gutenberg/pull/60090)).
 -   `TextControl`: Apply zero margin to input element ([#60282](https://github.com/WordPress/gutenberg/pull/60282)).
 

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -31,9 +31,9 @@
 		margin-top: 0;
 		border-top: $border-width solid $gray-400;
 		padding: $grid-unit-10;
-
-		.is-alternate & {
-			border-color: $gray-900;
-		}
 	}
+}
+
+.is-alternate .components-menu-group + .components-menu-group {
+	border-color: $gray-900;
 }

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -32,8 +32,8 @@
 		border-top: $border-width solid $gray-400;
 		padding: $grid-unit-10;
 	}
-}
 
-.is-alternate .components-menu-group + .components-menu-group {
-	border-color: $gray-900;
+	&.is-alternate .components-menu-group + .components-menu-group {
+		border-color: $gray-900;
+	}
 }


### PR DESCRIPTION
## What?

Followup to #59723. The CSS present to correctly color the separator color inside dropdowns extending from the block toolbar did not work, so the separator is gray:
![gray separator](https://github.com/WordPress/gutenberg/assets/1204802/43e28dd1-0c38-48e1-b0e8-4fb89098e36c)

The CSS simply didn't output any CSS that worked. This PR fixes it so the separator is the correct black color:

![black separator](https://github.com/WordPress/gutenberg/assets/1204802/ff525d3a-7d1c-4290-9ce3-7ae99b415790)
