### PR TITLE
Patterns page: enable table layout

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -151,6 +151,7 @@ function Preview( { item, categoryId, viewType } ) {
 		postId: isUserPattern ? item.id : item.name,
 		categoryId,
 		categoryType: isTemplatePart ? item.type : PATTERN_TYPES.theme,
+		canvas: 'edit',
 	} );
 
 	return (
@@ -201,6 +202,7 @@ function Title( { item, categoryId } ) {
 		postId: isUserPattern ? item.id : item.name,
 		categoryId,
 		categoryType: isTemplatePart ? item.type : PATTERN_TYPES.theme,
+		canvas: 'edit',
 	} );
 	if ( ! isUserPattern && templatePartIcons[ categoryId ] ) {
 		itemIcon = templatePartIcons[ categoryId ];

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -37,6 +37,7 @@ import { usePrevious } from '@wordpress/compose';
 import Page from '../page';
 import {
 	LAYOUT_GRID,
+	LAYOUT_TABLE,
 	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_SYNC_TYPES,
@@ -65,6 +66,9 @@ const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 const templatePartIcons = { header, footer, uncategorized };
 const EMPTY_ARRAY = [];
 const defaultConfigPerViewType = {
+	[ LAYOUT_TABLE ]: {
+		primaryField: 'title',
+	},
 	[ LAYOUT_GRID ]: {
 		mediaField: 'preview',
 		primaryField: 'title',
@@ -394,7 +398,7 @@ export default function DataviewsPatterns() {
 					view={ view }
 					onChangeView={ onChangeView }
 					deferredRendering
-					supportedLayouts={ [ LAYOUT_GRID ] }
+					supportedLayouts={ [ LAYOUT_GRID, LAYOUT_TABLE ] }
 				/>
 			</Page>
 		</ExperimentalBlockEditorProvider>


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/59659

## What?

Enables the `table` layout for the Patterns page.

| |  |
| --- | --- |
| <img width="1507" alt="Captura de ecrã 2024-04-01, às 13 11 52" src="https://github.com/WordPress/gutenberg/assets/583546/d948680f-6fb8-4297-9575-8b51e8b0bbc3"> | <img width="1507" alt="Captura de ecrã 2024-04-01, às 13 16 45" src="https://github.com/WordPress/gutenberg/assets/583546/12e753d0-7ea6-4e3b-8311-272eac30f4be"> |

When clicking the preview or the title for user-provided patterns, it goes directly to the editor instead of visiting the details page:

https://github.com/WordPress/gutenberg/assets/583546/62235d98-689d-4ba9-9792-2777c3deccfd

## Why?

It's part of the design goal, see https://github.com/WordPress/gutenberg/issues/59659

## How?

- Enables the `table` layout and sets its `primaryField` https://github.com/WordPress/gutenberg/pull/60337/commits/b59dcd48eea0b78f00f841be26a25846ef8ff943
- Navigate directly to the editor when clicking the preview or title https://github.com/WordPress/gutenberg/pull/60337/commits/611e996f5355f9e24eef648625255dd38a86e9ae

## Testing Instructions

Visit Patterns page and switch to table layout via the view actions menu.

## TODO

- Review the locked/diamond icon in the title field for this layout.
