### PR TITLE
Update image role description text to fix spacing.

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -71,8 +71,7 @@ function BlockEditAnchorControlPure( { anchor, setAttributes } ) {
 					<>
 						{ __(
 							'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
-						) }
-
+						) }{ ' ' }
 						{ isWeb && (
 							<ExternalLink
 								href={ __(

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -70,7 +70,7 @@ function BlockEditAnchorControlPure( { anchor, setAttributes } ) {
 				help={
 					<>
 						{ __(
-							'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
+							'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor”. Then, you’ll be able to link directly to this section of your page.'
 						) }{ ' ' }
 						{ isWeb && (
 							<ExternalLink

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -71,15 +71,18 @@ function BlockEditAnchorControlPure( { anchor, setAttributes } ) {
 					<>
 						{ __(
 							'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor”. Then, you’ll be able to link directly to this section of your page.'
-						) }{ ' ' }
+						) }
 						{ isWeb && (
-							<ExternalLink
-								href={ __(
-									'https://wordpress.org/documentation/article/page-jumps/'
-								) }
-							>
-								{ __( 'Learn more about anchors' ) }
-							</ExternalLink>
+							<>
+								{ ' ' }
+								<ExternalLink
+									href={ __(
+										'https://wordpress.org/documentation/article/page-jumps/'
+									) }
+								>
+									{ __( 'Learn more about anchors' ) }
+								</ExternalLink>
+							</>
 						) }
 					</>
 				}

--- a/packages/block-editor/src/hooks/anchor.scss
+++ b/packages/block-editor/src/hooks/anchor.scss
@@ -1,4 +1,0 @@
-.html-anchor-control .components-external-link {
-	display: inline-block;
-	margin-top: $grid-unit-10;
-}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -47,7 +47,6 @@
 @import "./components/tool-selector/style.scss";
 @import "./components/url-input/style.scss";
 @import "./components/url-popover/style.scss";
-@import "./hooks/anchor.scss";
 @import "./hooks/block-hooks.scss";
 @import "./hooks/border.scss";
 @import "./hooks/color.scss";


### PR DESCRIPTION
## What?

The help text for the image role is poorly wrapped and lacks a space:


![html anchor description before](https://github.com/WordPress/gutenberg/assets/1204802/698232f8-13b6-4776-8b70-dec5d0ef742a)

This PR removes the separate style for the link URL, for consistency, and adds a space:

![html anchor after](https://github.com/WordPress/gutenberg/assets/1204802/4257ee78-7c84-496b-9c80-d3bc649587f4)


