### PR TITLE
Try: Show copy shortcut in block options.

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -11,6 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 import { Children, cloneElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { displayShortcut } from '@wordpress/keycodes';
 import {
 	store as keyboardShortcutsStore,
 	__unstableUseShortcutEventMatch,
@@ -40,7 +41,11 @@ function CopyMenuItem( { clientIds, onCopy, label } ) {
 		onCopy
 	);
 	const copyMenuItemLabel = label ? label : __( 'Copy' );
-	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
+	return (
+		<MenuItem ref={ ref } shortcut={ displayShortcut.primary( 'c' ) }>
+			{ copyMenuItemLabel }
+		</MenuItem>
+	);
 }
 
 export function BlockSettingsDropdown( {

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -34,7 +34,7 @@ const POPOVER_PROPS = {
 	placement: 'bottom-start',
 };
 
-function CopyMenuItem( { clientIds, onCopy, label } ) {
+function CopyMenuItem( { clientIds, onCopy, label, shortcut } ) {
 	const { getBlocksByClientId } = useSelect( blockEditorStore );
 	const ref = useCopyToClipboard(
 		() => serialize( getBlocksByClientId( clientIds ) ),
@@ -42,7 +42,7 @@ function CopyMenuItem( { clientIds, onCopy, label } ) {
 	);
 	const copyMenuItemLabel = label ? label : __( 'Copy' );
 	return (
-		<MenuItem ref={ ref } shortcut={ displayShortcut.primary( 'c' ) }>
+		<MenuItem ref={ ref } shortcut={ shortcut }>
 			{ copyMenuItemLabel }
 		</MenuItem>
 	);
@@ -284,6 +284,7 @@ export function BlockSettingsDropdown( {
 								<CopyMenuItem
 									clientIds={ clientIds }
 									onCopy={ onCopy }
+									shortcut={ displayShortcut.primary( 'c' ) }
 								/>
 								{ canDuplicate && (
 									<MenuItem


### PR DESCRIPTION
## What?

I noticed we don't show the ⌘C shortcut for the block Copy option in the block options:

![block options](https://github.com/WordPress/gutenberg/assets/1204802/d57da5f5-d33d-4524-b005-834d395eceb5)

This PR adds that:

![block options with command c shortcut](https://github.com/WordPress/gutenberg/assets/1204802/ec5e5415-24c5-467f-97fc-cc7702e05123)

It's not clear to me the code for showing this is right, so would appreciate a code check. Feel free to push directly to this branch.

It also has the side effect of showing this same shortcut for "copy styles" — probably technically correct, since it's the same action, but worth noting.

## Testing Instructions

Select the block options button in the block toolbar. The ⌘C (or your operating system modifier, e.g. CTRL) shortcut should show up.