### PR TITLE
Editor: Move publish panel handling to `editor` store

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -306,6 +306,8 @@ _Returns_
 
 ### isPublishSidebarOpened
 
+> **Deprecated**
+
 Returns true if the publish sidebar is opened.
 
 _Parameters_
@@ -349,6 +351,8 @@ _Returns_
 -   `Object`: Action object.
 
 ### closePublishSidebar
+
+> **Deprecated**
 
 Returns an action object used in signalling that the user closed the publish sidebar.
 
@@ -407,6 +411,8 @@ _Returns_
 -   `Object`: Action object.
 
 ### openPublishSidebar
+
+> **Deprecated**
 
 Returns an action object used in signalling that the user opened the publish sidebar.
 
@@ -531,6 +537,8 @@ _Parameters_
 -   _pluginName_ `string`: Plugin name.
 
 ### togglePublishSidebar
+
+> **Deprecated**
 
 Returns an action object used in signalling that the user toggles the publish sidebar.
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1058,6 +1058,18 @@ _Returns_
 
 -   `boolean`: Whether the pre-publish panel should be shown or not.
 
+### isPublishSidebarOpened
+
+Returns true if the publish sidebar is opened.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state
+
+_Returns_
+
+-   `boolean`: Whether the publish sidebar is open.
+
 ### isSavingNonPostEntityChanges
 
 Returns true if non-post entities are currently being saved, or false otherwise.
@@ -1119,6 +1131,14 @@ _Parameters_
 _Related_
 
 -   clearSelectedBlock in core/block-editor store.
+
+### closePublishSidebar
+
+Returns an action object used in signalling that the user closed the publish sidebar.
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### createUndoLevel
 
@@ -1272,6 +1292,14 @@ _Related_
 _Related_
 
 -   multiSelect in core/block-editor store.
+
+### openPublishSidebar
+
+Returns an action object used in signalling that the user opened the publish sidebar.
+
+_Returns_
+
+-   `Object`: Action object
 
 ### receiveBlocks
 
@@ -1521,6 +1549,14 @@ Opens a closed panel and closes an open panel.
 _Parameters_
 
 -   _panelName_ `string`: A string that identifies the panel to open or close.
+
+### togglePublishSidebar
+
+Returns an action object used in signalling that the user toggles the publish sidebar.
+
+_Returns_
+
+-   `Object`: Action object
 
 ### toggleSelection
 

--- a/packages/data/src/controls.js
+++ b/packages/data/src/controls.js
@@ -95,7 +95,7 @@ function resolveSelect( storeNameOrDescriptor, selectorName, ...args ) {
  *
  * // Action generator using dispatch
  * export function* myAction() {
- *   yield controls.dispatch( 'core/edit-post', 'togglePublishSidebar' );
+ *   yield controls.dispatch( 'core/editor', 'togglePublishSidebar' );
  *   // do some other things.
  * }
  * ```

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -81,7 +81,7 @@ function Header( { setEntitiesSavedStatesCallback, initialPost } ) {
 				!! select( editorStore ).getEditorSettings()
 					.onNavigateToPreviousEntityRecord,
 			isPublishSidebarOpened:
-				select( editPostStore ).isPublishSidebarOpened(),
+				select( editorStore ).isPublishSidebarOpened(),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
 		};
 	}, [] );

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -5,11 +5,6 @@ import { useViewportMatch, compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { PostPublishButton, store as editorStore } from '@wordpress/editor';
 
-/**
- * Internal dependencies
- */
-import { store as editPostStore } from '../../store';
-
 export function PostPublishButtonOrToggle( {
 	forceIsDirty,
 	hasPublishAction,
@@ -85,12 +80,11 @@ export default compose(
 		isPublished: select( editorStore ).isCurrentPostPublished(),
 		isPublishSidebarEnabled:
 			select( editorStore ).isPublishSidebarEnabled(),
-		isPublishSidebarOpened:
-			select( editPostStore ).isPublishSidebarOpened(),
+		isPublishSidebarOpened: select( editorStore ).isPublishSidebarOpened(),
 		isScheduled: select( editorStore ).isCurrentPostScheduled(),
 	} ) ),
 	withDispatch( ( dispatch ) => {
-		const { togglePublishSidebar } = dispatch( editPostStore );
+		const { togglePublishSidebar } = dispatch( editorStore );
 		return {
 			togglePublishSidebar,
 		};

--- a/packages/edit-post/src/components/layout/actions-panel.js
+++ b/packages/edit-post/src/components/layout/actions-panel.js
@@ -10,6 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, createSlotFill } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */
@@ -27,7 +28,7 @@ export default function ActionsPanel( {
 	isEntitiesSavedStatesOpen,
 } ) {
 	const { closePublishSidebar, togglePublishSidebar } =
-		useDispatch( editPostStore );
+		useDispatch( editorStore );
 	const {
 		publishSidebarOpened,
 		hasActiveMetaboxes,
@@ -35,7 +36,7 @@ export default function ActionsPanel( {
 	} = useSelect(
 		( select ) => ( {
 			publishSidebarOpened:
-				select( editPostStore ).isPublishSidebarOpened(),
+				select( editorStore ).isPublishSidebarOpened(),
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			hasNonPostEntityChanges:
 				select( editorStore ).hasNonPostEntityChanges(),

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -172,7 +172,7 @@ function Layout( { initialPost } ) {
 			sidebarIsOpened: !! (
 				select( interfaceStore ).getActiveComplementaryArea(
 					editPostStore.name
-				) || select( editPostStore ).isPublishSidebarOpened()
+				) || select( editorStore ).isPublishSidebarOpened()
 			),
 			isFullscreenActive:
 				select( editPostStore ).isFeatureActive( 'fullscreenMode' ),

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -78,37 +78,52 @@ export const closeModal =
 /**
  * Returns an action object used in signalling that the user opened the publish
  * sidebar.
+ * @deprecated
  *
  * @return {Object} Action object
  */
-export function openPublishSidebar() {
-	return {
-		type: 'OPEN_PUBLISH_SIDEBAR',
+export const openPublishSidebar =
+	() =>
+	( { registry } ) => {
+		deprecated( "dispatch( 'core/edit-post' ).openPublishSidebar", {
+			since: '6.6',
+			alternative: "dispatch( 'core/editor').openPublishSidebar",
+		} );
+		registry.dispatch( editorStore ).openPublishSidebar();
 	};
-}
 
 /**
  * Returns an action object used in signalling that the user closed the
  * publish sidebar.
+ * @deprecated
  *
  * @return {Object} Action object.
  */
-export function closePublishSidebar() {
-	return {
-		type: 'CLOSE_PUBLISH_SIDEBAR',
+export const closePublishSidebar =
+	() =>
+	( { registry } ) => {
+		deprecated( "dispatch( 'core/edit-post' ).closePublishSidebar", {
+			since: '6.6',
+			alternative: "dispatch( 'core/editor').closePublishSidebar",
+		} );
+		registry.dispatch( editorStore ).closePublishSidebar();
 	};
-}
 
 /**
  * Returns an action object used in signalling that the user toggles the publish sidebar.
+ * @deprecated
  *
  * @return {Object} Action object
  */
-export function togglePublishSidebar() {
-	return {
-		type: 'TOGGLE_PUBLISH_SIDEBAR',
+export const togglePublishSidebar =
+	() =>
+	( { registry } ) => {
+		deprecated( "dispatch( 'core/edit-post' ).togglePublishSidebar", {
+			since: '6.6',
+			alternative: "dispatch( 'core/editor').togglePublishSidebar",
+		} );
+		registry.dispatch( editorStore ).togglePublishSidebar();
 	};
-}
 
 /**
  * Returns an action object used to enable or disable a panel in the editor.

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -3,18 +3,6 @@
  */
 import { combineReducers } from '@wordpress/data';
 
-export function publishSidebarActive( state = false, action ) {
-	switch ( action.type ) {
-		case 'OPEN_PUBLISH_SIDEBAR':
-			return true;
-		case 'CLOSE_PUBLISH_SIDEBAR':
-			return false;
-		case 'TOGGLE_PUBLISH_SIDEBAR':
-			return ! state;
-	}
-	return state;
-}
-
 /**
  * Reducer keeping track of the meta boxes isSaving state.
  * A "true" value means the meta boxes saving request is in-flight.
@@ -103,5 +91,4 @@ const metaBoxes = combineReducers( {
 
 export default combineReducers( {
 	metaBoxes,
-	publishSidebarActive,
 } );

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -228,13 +228,21 @@ export const getHiddenBlockTypes = createRegistrySelector( ( select ) => () => {
 /**
  * Returns true if the publish sidebar is opened.
  *
+ * @deprecated
+ *
  * @param {Object} state Global application state
  *
  * @return {boolean} Whether the publish sidebar is open.
  */
-export function isPublishSidebarOpened( state ) {
-	return state.publishSidebarActive;
-}
+export const isPublishSidebarOpened = createRegistrySelector(
+	( select ) => () => {
+		deprecated( `select( 'core/edit-post' ).isPublishSidebarOpened`, {
+			since: '6.6',
+			alternative: `select( 'core/editor' ).isPublishSidebarOpened`,
+		} );
+		return select( editorStore ).isPublishSidebarOpened();
+	}
+);
 
 /**
  * Returns true if the given panel was programmatically removed, or false otherwise.

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -820,6 +820,41 @@ export const switchEditorMode =
 	};
 
 /**
+ * Returns an action object used in signalling that the user opened the publish
+ * sidebar.
+ *
+ * @return {Object} Action object
+ */
+export function openPublishSidebar() {
+	return {
+		type: 'OPEN_PUBLISH_SIDEBAR',
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the user closed the
+ * publish sidebar.
+ *
+ * @return {Object} Action object.
+ */
+export function closePublishSidebar() {
+	return {
+		type: 'CLOSE_PUBLISH_SIDEBAR',
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the user toggles the publish sidebar.
+ *
+ * @return {Object} Action object
+ */
+export function togglePublishSidebar() {
+	return {
+		type: 'TOGGLE_PUBLISH_SIDEBAR',
+	};
+}
+
+/**
  * Backward compatibility
  */
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -360,6 +360,18 @@ export function listViewToggleRef( state = { current: null } ) {
 	return state;
 }
 
+export function publishSidebarActive( state = false, action ) {
+	switch ( action.type ) {
+		case 'OPEN_PUBLISH_SIDEBAR':
+			return true;
+		case 'CLOSE_PUBLISH_SIDEBAR':
+			return false;
+		case 'TOGGLE_PUBLISH_SIDEBAR':
+			return ! state;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	postId,
 	postType,
@@ -377,4 +389,5 @@ export default combineReducers( {
 	blockInserterPanel,
 	listViewPanel,
 	listViewToggleRef,
+	publishSidebarActive,
 } );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1791,3 +1791,14 @@ export const getPostTypeLabel = createRegistrySelector(
 		return postType?.labels?.singular_name;
 	}
 );
+
+/**
+ * Returns true if the publish sidebar is opened.
+ *
+ * @param {Object} state Global application state
+ *
+ * @return {boolean} Whether the publish sidebar is open.
+ */
+export function isPublishSidebarOpened( state ) {
+	return state.publishSidebarActive;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/52632, https://github.com/WordPress/gutenberg/issues/59878
Extracted from: https://github.com/WordPress/gutenberg/pull/60289

This PR  moves the related actions/selectors, etc.. from `edit-post` package to `editor` package. This is a prerequisite for unifying the publishing flow between post and site editors.



## Testing Instructions
1. Everything should work as before
2. The affected flows are when we want to publish a post and if the publish panel is opened, closed, etc.. properly.

