### PR TITLE
Patterns: remove manage all of my patterns link

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -115,13 +115,6 @@ export default function SidebarNavigationScreenPatterns() {
 
 	const footer = ! isMobileViewport ? (
 		<ItemGroup>
-			<SidebarNavigationItem
-				as="a"
-				href="edit.php?post_type=wp_block"
-				withChevron
-			>
-				{ __( 'Manage all of my patterns' ) }
-			</SidebarNavigationItem>
 			{ ( isBlockBasedTheme || isTemplatePartsMode ) && (
 				<SidebarNavigationItem withChevron { ...templatePartsLink }>
 					{ __( 'Manage all template parts' ) }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/59659

## What?

Removes the "Manage all of my patterns link" in the Patterns page sidebar:

| Before | After |
| --- | --- |
| <img width="1507" alt="Captura de ecrã 2024-04-01, às 17 11 06" src="https://github.com/WordPress/gutenberg/assets/583546/36a03822-7fc4-49aa-979d-62a9d9ee0d87"> | <img width="1507" alt="Captura de ecrã 2024-04-01, às 17 10 31" src="https://github.com/WordPress/gutenberg/assets/583546/5a71badd-4c02-4421-a6a9-996a78f4178e"> |

## Why?

It's the target design, see https://github.com/WordPress/gutenberg/issues/59659

## How?

- Remove link from the sidebar https://github.com/WordPress/gutenberg/pull/60345/commits/a6c977917940bcf1c625bab01950e3ea252e18c2

## Testing Instructions

Visit the Patterns page and verify the "Manage all of my patterns" link is present.