### PR TITLE
Allow negative values for margin controls

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -4,6 +4,7 @@
 
 $z-layers: (
 	".block-editor-block-list__block::before": 0,
+	".block-editor-block-list__block.is-selected": 9999,
 	".block-editor-block-switcher__arrow": 1,
 	".block-editor-block-list__block {core/image aligned wide or fullwide}": 20,
 	".block-library-classic__toolbar": 31, // When scrolled to top this toolbar needs to sit over block-editor-block-toolbar

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -4,7 +4,7 @@
 
 $z-layers: (
 	".block-editor-block-list__block::before": 0,
-	".block-editor-block-list__block.is-selected": 1,
+	".block-editor-block-list__block.is-selected": 20,
 	".block-editor-block-switcher__arrow": 1,
 	".block-editor-block-list__block {core/image aligned wide or fullwide}": 20,
 	".block-library-classic__toolbar": 31, // When scrolled to top this toolbar needs to sit over block-editor-block-toolbar

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -4,7 +4,7 @@
 
 $z-layers: (
 	".block-editor-block-list__block::before": 0,
-	".block-editor-block-list__block.is-selected": 9999,
+	".block-editor-block-list__block.is-selected": 1,
 	".block-editor-block-switcher__arrow": 1,
 	".block-editor-block-list__block {core/image aligned wide or fullwide}": 20,
 	".block-library-classic__toolbar": 31, // When scrolled to top this toolbar needs to sit over block-editor-block-toolbar

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -183,10 +183,12 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		user-select: none;
 	}
 
-	&.is-selected,
-	&.has-child-selected {
-		// Bring the selected block forward so we can see it.
-		z-index: z-index(".block-editor-block-list__block.is-selected");
+	&.has-negative-margin {
+		&.is-selected,
+		&.has-child-selected {
+			// Bring the selected block forward so we can see it.
+			z-index: z-index(".block-editor-block-list__block.is-selected");
+		}
 	}
 
 	.reusable-block-edit-panel * {

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -183,8 +183,9 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		user-select: none;
 	}
 
-	&.is-selected {
-		// So we can see it if a block is overlaping the selected one
+	&.is-selected,
+	&.has-child-selected {
+		// Bring the selected block forward so we can see it.
 		z-index: z-index(".block-editor-block-list__block.is-selected");
 	}
 

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -183,6 +183,11 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		user-select: none;
 	}
 
+	&.is-selected {
+		// So we can see it if a block is overlaping the selected one
+		z-index: z-index(".block-editor-block-list__block.is-selected");
+	}
+
 	.reusable-block-edit-panel * {
 		z-index: z-index(".block-editor-block-list__block .reusable-block-edit-panel *");
 	}

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -144,6 +144,16 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		);
 	}
 
+	let hasNegativeMargin = false;
+	if (
+		wrapperProps?.style?.marginTop?.charAt( 0 ) === '-' ||
+		wrapperProps?.style?.marginBottom?.charAt( 0 ) === '-' ||
+		wrapperProps?.style?.marginLeft?.charAt( 0 ) === '-' ||
+		wrapperProps?.style?.marginRight?.charAt( 0 ) === '-'
+	) {
+		hasNegativeMargin = true;
+	}
+
 	return {
 		tabIndex: blockEditingMode === 'disabled' ? -1 : 0,
 		...wrapperProps,
@@ -174,6 +184,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				'can-insert-moving-block': canInsertMovingBlock,
 				'is-editing-disabled': isEditingDisabled,
 				'has-editable-outline': hasEditableOutline,
+				'has-negative-margin': hasNegativeMargin,
 				'is-content-locked-temporarily-editing-as-blocks':
 					isTemporarilyEditingAsBlocks,
 			},

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -561,6 +561,7 @@ export default function DimensionsPanel( {
 						<BoxControl
 							values={ marginValues }
 							onChange={ setMarginValues }
+							min={ -Infinity }
 							label={ __( 'Margin' ) }
 							sides={ marginSides }
 							units={ units }

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -574,6 +574,7 @@ export default function DimensionsPanel( {
 						<SpacingSizesControl
 							values={ marginValues }
 							onChange={ setMarginValues }
+							minimumCustomValue={ -Infinity }
 							label={ __( 'Margin' ) }
 							sides={ marginSides }
 							units={ units }

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -92,6 +92,8 @@ export default function SpacingInputControl( {
 			! isValueSpacingPreset( value )
 	);
 
+	const [ minValue, setMinValue ] = useState( minimumCustomValue );
+
 	const previousValue = usePrevious( value );
 	if (
 		!! value &&
@@ -222,13 +224,26 @@ export default function SpacingInputControl( {
 						}
 						value={ currentValue }
 						units={ units }
-						min={ minimumCustomValue }
+						min={ minValue }
 						placeholder={ allPlaceholder }
 						disableUnits={ isMixed }
 						label={ ariaLabel }
 						hideLabelFromVision
 						className="spacing-sizes-control__custom-value-input"
 						size={ '__unstable-large' }
+						onDragStart={ () => {
+							if ( value?.charAt( 0 ) === '-' ) {
+								setMinValue( 0 );
+							}
+						} }
+						onDrag={ () => {
+							if ( value?.charAt( 0 ) === '-' ) {
+								setMinValue( 0 );
+							}
+						} }
+						onDragEnd={ () => {
+							setMinValue( -Infinity );
+						} }
 					/>
 					<RangeControl
 						onMouseOver={ onMouseOver }

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -242,7 +242,7 @@ export default function SpacingInputControl( {
 							}
 						} }
 						onDragEnd={ () => {
-							setMinValue( -Infinity );
+							setMinValue( minimumCustomValue );
 						} }
 					/>
 					<RangeControl

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -203,6 +203,8 @@ export default function SpacingInputControl( {
 		typeLabel
 	).trim();
 
+	const areNegativeValuesAllowed = minValue < 0;
+
 	return (
 		<HStack className="spacing-sizes-control__wrapper">
 			{ icon && (
@@ -250,6 +252,7 @@ export default function SpacingInputControl( {
 						onMouseOut={ onMouseOut }
 						onFocus={ onMouseOver }
 						onBlur={ onMouseOut }
+						disabled={ areNegativeValuesAllowed }
 						value={ customRangeValue }
 						min={ 0 }
 						max={ CUSTOM_VALUE_SETTINGS[ selectedUnit ]?.max ?? 10 }

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -203,8 +203,6 @@ export default function SpacingInputControl( {
 		typeLabel
 	).trim();
 
-	const areNegativeValuesAllowed = minValue < 0;
-
 	return (
 		<HStack className="spacing-sizes-control__wrapper">
 			{ icon && (
@@ -252,7 +250,6 @@ export default function SpacingInputControl( {
 						onMouseOut={ onMouseOut }
 						onFocus={ onMouseOver }
 						onBlur={ onMouseOut }
-						disabled={ areNegativeValuesAllowed }
 						value={ customRangeValue }
 						min={ 0 }
 						max={ CUSTOM_VALUE_SETTINGS[ selectedUnit ]?.max ?? 10 }

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -2,3 +2,8 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
+
+// We need this so groups with negative margins overlap as expected
+:where(.wp-block-group.has-background) {
+	position: relative;
+}

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -3,7 +3,7 @@
 	box-sizing: border-box;
 }
 
-// We need this so groups with negative margins overlap as expected
+// We need this so groups with negative margins overlap as expected.
 :where(.wp-block-group.wp-block-group-is-layout-constrained) {
 	position: relative;
 }

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -4,6 +4,6 @@
 }
 
 // We need this so groups with negative margins overlap as expected
-:where(.wp-block-group.has-background) {
+:where(.wp-block-group.wp-block-group-is-layout-constrained) {
 	position: relative;
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   `Navigator`: Navigation to the active path doesn't create a new location history ([#60561](https://github.com/WordPress/gutenberg/pull/60561))
 -   `FormToggle`: Forwards ref to input ([#60234](https://github.com/WordPress/gutenberg/pull/60234)).
 -   `ToggleControl`: Forwards ref to FormToggle ([#60234](https://github.com/WordPress/gutenberg/pull/60234)).
+-   `BoxControl`: Allow negative values for margin controls ([#60347](https://github.com/WordPress/gutenberg/pull/60347)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `BoxControl`: Allow negative values for margin controls ([#60347](https://github.com/WordPress/gutenberg/pull/60347)).
+
 ### Bug Fix
 
 -   `SlotFill`: fixed missing `getServerSnapshot` parameter in slot map ([#60943](https://github.com/WordPress/gutenberg/pull/60943)).
@@ -21,7 +25,6 @@
 -   `Navigator`: Navigation to the active path doesn't create a new location history ([#60561](https://github.com/WordPress/gutenberg/pull/60561))
 -   `FormToggle`: Forwards ref to input ([#60234](https://github.com/WordPress/gutenberg/pull/60234)).
 -   `ToggleControl`: Forwards ref to FormToggle ([#60234](https://github.com/WordPress/gutenberg/pull/60234)).
--   `BoxControl`: Allow negative values for margin controls ([#60347](https://github.com/WordPress/gutenberg/pull/60347)).
 
 ### Bug Fix
 

--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -34,10 +34,6 @@ import type {
 	BoxControlValue,
 } from './types';
 
-const defaultInputProps = {
-	min: 0,
-};
-
 const noop = () => {};
 
 function useUniqueId( idProp?: string ) {
@@ -74,7 +70,6 @@ function useUniqueId( idProp?: string ) {
 function BoxControl( {
 	__next40pxDefaultSize = false,
 	id: idProp,
-	inputProps = defaultInputProps,
 	onChange = noop,
 	label = __( 'Box Control' ),
 	values: valuesProp,
@@ -85,6 +80,7 @@ function BoxControl( {
 	resetValues = DEFAULT_VALUES,
 	onMouseOver,
 	onMouseOut,
+	...inputProps
 }: BoxControlProps ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
@@ -140,8 +136,11 @@ function BoxControl( {
 		setIsDirty( false );
 	};
 
+	const min = 'min' in inputProps ? inputProps.min : 0;
+	const newInputProps = { ...inputProps, min };
+
 	const inputControlProps = {
-		...inputProps,
+		newInputProps,
 		onChange: handleOnChange,
 		onFocus: handleOnFocus,
 		isLinked,

--- a/packages/components/src/box-control/input-controls.tsx
+++ b/packages/components/src/box-control/input-controls.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -28,6 +29,8 @@ export default function BoxInputControls( {
 	sides,
 	...props
 }: BoxControlInputControlProps ) {
+	const minimumCustomValue = props.min;
+	const [ minValue, setMinValue ] = useState( minimumCustomValue );
 	const generatedId = useInstanceId( BoxInputControls, 'box-control-input' );
 
 	const createHandleOnFocus =
@@ -100,6 +103,9 @@ export default function BoxInputControls( {
 					? parsedUnit
 					: selectedUnits[ side ];
 
+				const isNegativeValue =
+					parsedQuantity !== undefined && parsedQuantity < 0;
+
 				const inputId = [ generatedId, side ].join( '-' );
 
 				return (
@@ -115,6 +121,7 @@ export default function BoxInputControls( {
 								value={ [ parsedQuantity, computedUnit ].join(
 									''
 								) }
+								min={ minValue }
 								onChange={ ( nextValue, extra ) =>
 									handleOnValueChange(
 										side,
@@ -126,6 +133,19 @@ export default function BoxInputControls( {
 									side
 								) }
 								onFocus={ createHandleOnFocus( side ) }
+								onDragStart={ () => {
+									if ( isNegativeValue ) {
+										setMinValue( 0 );
+									}
+								} }
+								onDrag={ () => {
+									if ( isNegativeValue ) {
+										setMinValue( 0 );
+									}
+								} }
+								onDragEnd={ () => {
+									setMinValue( minimumCustomValue );
+								} }
 								label={ LABELS[ side ] }
 								hideLabelFromVision
 							/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
An alternative to #40464
Closes #32644

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To bring parity from theme.json to the controls. A theme can define negative margins via theme.json but not via the templates, which is when they are most useful.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Looking at the previous conversations we have a few things to consider to achieve this:

1. Block selection in the editor when blocks overlap each other. The UX can get a little complicated.
2. The previous attempt to do this was adding a new prop, we don't need this anymore, so we are not adding new APIs to achieve this, we are only altering the minimum value that the input accepts only for the margin spacing controls
3. We need to update the block support's visualizer to show the negative margin. @jasmussen suggests to use a gray color instead of blue. This could happen in a follow up.


Of all of these, 1 is the most concerning. The idea behind this PR is that we only allow negative values if the user consciously choses to add a minus before the margin values. This PR adds a z-index value to the currently selected block in order to keep it in the front to help with this. 

To do:

- [x] disallow negative values on drag to make the negative values 
- [ ] Update the visualizer to show negative margins
- [ ] https://github.com/WordPress/gutenberg/issues/60633

These can be done on separate PRs

To consider:

- Should we limit the value that a negative margin can achieve to prevent block navigation issues? I'm hesitant to do this but [it has been suggested](https://github.com/WordPress/gutenberg/pull/40464#issuecomment-1253264554).


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check that you can add negative margins on any blocks that support them such as: group, paragraph, columns, code, cover, separator, spacer...

Check that the frontend and the editor show the same thing

Check that in the editor when you select a block it brings it to the forefront even if it's being overlapped by another. This should not happen in the frontend.

If a theme doesn't have `spacingSizes` declared (no spacing presets), the above should behave the same way.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


