### PR TITLE
Templates perf: resolve patterns server side

### DIFF
--- a/lib/compat/wordpress-6.6/resolve-patterns.php
+++ b/lib/compat/wordpress-6.6/resolve-patterns.php
@@ -45,3 +45,13 @@ add_filter(
 	}
 );
 
+add_filter(
+	'get_block_template',
+	function( $template ) {
+		$blocks = parse_blocks( $template->content );
+		$blocks = replace_pattern_blocks( $blocks );
+		$template->content = serialize_blocks( $blocks );
+		return $template;
+	}
+);
+

--- a/lib/compat/wordpress-6.6/resolve-patterns.php
+++ b/lib/compat/wordpress-6.6/resolve-patterns.php
@@ -10,7 +10,7 @@
 function gutenberg_replace_pattern_blocks( $blocks, &$inner_content = null ) {
 	// Keep track of seen references to avoid infinite loops.
 	static $seen_refs = array();
-	$i = 0;
+	$i                = 0;
 	while ( $i < count( $blocks ) ) {
 		if ( 'core/pattern' === $blocks[ $i ]['blockName'] ) {
 			$slug = $blocks[ $i ]['attrs']['slug'];
@@ -21,11 +21,11 @@ function gutenberg_replace_pattern_blocks( $blocks, &$inner_content = null ) {
 				continue;
 			}
 
-			$registry         = WP_Block_Patterns_Registry::get_instance();
-			$pattern          = $registry->get_registered( $slug );
-			$blocks_to_insert = parse_blocks( $pattern['content'] );
+			$registry          = WP_Block_Patterns_Registry::get_instance();
+			$pattern           = $registry->get_registered( $slug );
+			$blocks_to_insert  = parse_blocks( $pattern['content'] );
 			$seen_refs[ $slug ] = true;
-			$blocks_to_insert = gutenberg_replace_pattern_blocks( $blocks_to_insert );
+			$blocks_to_insert  = gutenberg_replace_pattern_blocks( $blocks_to_insert );
 			unset( $seen_refs[ $slug ] );
 			array_splice( $blocks, $i, 1, $blocks_to_insert );
 

--- a/lib/compat/wordpress-6.6/resolve-patterns.php
+++ b/lib/compat/wordpress-6.6/resolve-patterns.php
@@ -55,3 +55,21 @@ add_filter(
 	}
 );
 
+add_filter( 'rest_post_dispatch', function( $result, $server, $request ) {
+	if ( $request->get_route() !== '/wp/v2/block-patterns/patterns' ) {
+		return $result;
+	}
+
+	$data = $result->get_data();
+
+	foreach ( $data as $index => $pattern ) {
+		$blocks = parse_blocks( $pattern['content'] );
+		$blocks = replace_pattern_blocks( $blocks );
+		$data[ $index ]['content'] = serialize_blocks( $blocks );
+	}
+
+	$result->set_data( $data );
+
+	return $result;
+}, 10, 3 );
+

--- a/lib/compat/wordpress-6.6/resolve-patterns.php
+++ b/lib/compat/wordpress-6.6/resolve-patterns.php
@@ -1,0 +1,47 @@
+<?php
+
+function replace_pattern_blocks( $blocks, &$inner_content = null ) {
+	$i = 0;
+	// Also process new blocks that are inserted.
+	while ( $i < count( $blocks ) ) {
+		if ( 'core/pattern' === $blocks[ $i ]['blockName'] ) {
+			$registry = WP_Block_Patterns_Registry::get_instance();
+			$pattern = $registry->get_registered( $blocks[ $i ]['attrs']['slug'] );
+			$pattern_content = $pattern['content'];
+			$blocks_to_insert = parse_blocks( $pattern_content );
+			array_splice( $blocks, $i, 1, $blocks_to_insert );
+
+			if ( $inner_content ) {
+				$nullIndices = array_keys( $inner_content, null, true );
+				$content_index = $nullIndices[ $i ];
+				$nulls = array_fill( 0, count( $blocks_to_insert ), null );
+				array_splice( $inner_content, $content_index, 1, $nulls );
+			}
+		} else if ( ! empty( $blocks[ $i ]['innerBlocks'] ) ) {
+			$blocks[ $i ]['innerBlocks'] = replace_pattern_blocks(
+				$blocks[ $i ]['innerBlocks'],
+				$blocks[ $i ]['innerContent']
+			);
+		}
+		$i++;
+	}
+	return $blocks;
+}
+
+add_filter(
+	'get_block_templates',
+	/**
+	 * Resolves all pattern blocks in the template content.
+	 *
+	 * @param WP_Block_Template[] $query_result Array of found block templates.
+	 */
+	function( $templates ) {
+		foreach ( $templates as $template ) {
+			$blocks = parse_blocks( $template->content );
+			$blocks = replace_pattern_blocks( $blocks );
+			$template->content = serialize_blocks( $blocks );
+		}
+		return $templates;
+	}
+);
+

--- a/lib/compat/wordpress-6.6/resolve-patterns.php
+++ b/lib/compat/wordpress-6.6/resolve-patterns.php
@@ -21,11 +21,11 @@ function gutenberg_replace_pattern_blocks( $blocks, &$inner_content = null ) {
 				continue;
 			}
 
-			$registry          = WP_Block_Patterns_Registry::get_instance();
-			$pattern           = $registry->get_registered( $slug );
-			$blocks_to_insert  = parse_blocks( $pattern['content'] );
+			$registry           = WP_Block_Patterns_Registry::get_instance();
+			$pattern            = $registry->get_registered( $slug );
+			$blocks_to_insert   = parse_blocks( $pattern['content'] );
 			$seen_refs[ $slug ] = true;
-			$blocks_to_insert  = gutenberg_replace_pattern_blocks( $blocks_to_insert );
+			$blocks_to_insert   = gutenberg_replace_pattern_blocks( $blocks_to_insert );
 			unset( $seen_refs[ $slug ] );
 			array_splice( $blocks, $i, 1, $blocks_to_insert );
 

--- a/lib/compat/wordpress-6.6/resolve-patterns.php
+++ b/lib/compat/wordpress-6.6/resolve-patterns.php
@@ -23,7 +23,7 @@ if ( ! function_exists( 'gutenberg_replace_pattern_blocks' ) ) {
 				// inner content array, otherwise serialize_blocks will skip
 				// blocks.
 				if ( $inner_content ) {
-					$null_indices   = array_keys( $inner_content, null, true );
+					$null_indices  = array_keys( $inner_content, null, true );
 					$content_index = $null_indices[ $i ];
 					$nulls         = array_fill( 0, count( $blocks_to_insert ), null );
 					array_splice( $inner_content, $content_index, 1, $nulls );
@@ -84,4 +84,3 @@ add_filter(
 	10,
 	3
 );
-

--- a/lib/load.php
+++ b/lib/load.php
@@ -125,6 +125,7 @@ require __DIR__ . '/compat/wordpress-6.5/block-bindings/post-meta.php';
 require __DIR__ . '/compat/wordpress-6.5/script-loader.php';
 
 // WordPress 6.6 compat.
+require __DIR__ . '/compat/wordpress-6.6/resolve-patterns.php';
 require __DIR__ . '/compat/wordpress-6.6/block-bindings/pattern-overrides.php';
 require __DIR__ . '/compat/wordpress-6.6/option.php';
 require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This should render template previews faster since the editor does not have replace these patterns in the editor, causing blocks to re-render.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A 6% improvement for template/pattern loading.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
