### PR TITLE
Templates: fix deferred rendering

### DIFF
--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -419,7 +419,10 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 				view={ view }
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
-				deferredRendering={ ! view.hiddenFields?.includes( 'preview' ) }
+				deferredRendering={
+					view.type === LAYOUT_GRID ||
+					! view.hiddenFields?.includes( 'preview' )
+				}
 			/>
 		</Page>
 	);


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Extracted from https://github.com/WordPress/gutenberg/pull/60069

## What?

The deferred rendering mechanism is used in templates when the `preview` field is visible. This renders template items in batches of 3. However, we've missed that the preview is always visible in the grid layout.

This PR activates deferred loading when the grid layout is in use as well:

https://github.com/WordPress/gutenberg/assets/583546/92ffcd68-d1de-4750-a505-a26d9d0d0498

## How?

- `deferredRendering` should be active when the preview field is present or the grid layout is in use (that contains previews). https://github.com/WordPress/gutenberg/pull/60361/commits/d593443d85e5c8363a1fe52db3a2a8670ab18490

## Testing Instructions

Visit the Templates page and switch to the grid layout. Verify items load in batches of 3.

