### PR TITLE
CodeMirror: rearrange imports to simplify webpack chunks

### DIFF
--- a/packages/block-editor/src/components/global-styles/code-mirror.js
+++ b/packages/block-editor/src/components/global-styles/code-mirror.js
@@ -1,0 +1,54 @@
+import { EditorView, basicSetup } from 'codemirror';
+import { indentWithTab } from '@codemirror/commands';
+import { keymap } from '@codemirror/view';
+
+function importLanguageSupport( mode ) {
+	switch ( mode ) {
+		case 'html':
+			return import(
+				/* webpackChunkName: "codemirror-lang-html" */ '@codemirror/lang-html'
+			);
+		case 'css':
+		default:
+			return import(
+				/* webpackChunkName: "codemirror-lang-css" */ '@codemirror/lang-css'
+			);
+	}
+}
+
+export default async function createEditorView( {
+	parent,
+	mode,
+	content,
+	onChange,
+	onBlur,
+} ) {
+	const languageSupport = await importLanguageSupport( mode );
+
+	return new EditorView( {
+		doc: content,
+		extensions: [
+			basicSetup,
+			languageSupport[ mode ](),
+			keymap.of( [ indentWithTab ] ),
+			EditorView.updateListener.of( ( editor ) => {
+				if ( editor.docChanged ) {
+					onChange( editor.state.doc.toString() );
+				}
+			} ),
+			...( onBlur
+				? [
+						EditorView.focusChangeEffect.of(
+							( editorState, focusing ) => {
+								if ( ! focusing ) {
+									onBlur( editorState.doc.toString() );
+								}
+								return null;
+							}
+						),
+				  ]
+				: [] ),
+		],
+		parent,
+	} );
+}

--- a/packages/block-editor/src/components/global-styles/editor-view.js
+++ b/packages/block-editor/src/components/global-styles/editor-view.js
@@ -7,22 +7,6 @@ import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Dynamically import the language support for the editor.
- * 
- * @param {string} mode - Language mode for the editor. Currently supports 'css' and 'html'.
- */
-function importLanguageSupport( mode ) {
-	switch ( mode ) {
-		case 'css':
-			return import( '@codemirror/lang-css' );
-		case 'html':
-			return import( '@codemirror/lang-html' );
-		default:
-			return import( '@codemirror/lang-css' );
-	}
-}
-
-/**
  * @typedef {Object} Config
  * @property {Function} [callback] - Callback after the editor is initialized.
  * @property {string}   content    - Text content of the editor.
@@ -39,76 +23,46 @@ function importLanguageSupport( mode ) {
  * @param {string} [props.editorInstructionsText] - Instructions text for accessibility.
  * @param {Config} props.initialConfig            - Initial configuration for the editor. This can only be used for the initial setup of the editor.
  */
-const EditorView = ({
+const EditorView = ( {
 	editorId,
-	editorInstructionsText, 
-	initialConfig: {
-		callback,
-		content,
-		onChange,
-		onBlur,
-		mode,
-	},
-}) => {
-	const editorRef = useRef(null);
+	editorInstructionsText,
+	initialConfig: { callback, content, onChange, onBlur, mode },
+} ) => {
+	const editorRef = useRef( null );
 	const instanceId = useInstanceId( EditorView );
-	useEffect( () => {
-		( async () => {
-			/**
-			 * Lazy load CodeMirror by using Webpack's dynamic import.
-			 * This should be replaced with native dynamic import once it's supported.
-			 * @see https://github.com/WordPress/gutenberg/pull/60155
-			 */
-			const [{ EditorView: CmEditorView, basicSetup }, { indentWithTab }, { keymap }, languageSupport] = 
-				await Promise.all([
-					import( 'codemirror' ), 
-					import( '@codemirror/commands' ), 
-					import( '@codemirror/view' ),
-					importLanguageSupport( mode )
-				])
 
-			if ( editorRef.current ) {
-				new CmEditorView( {
-					doc: content,
-					extensions: [
-						basicSetup,
-						languageSupport[mode](),
-						keymap.of( [ indentWithTab ] ),
-						CmEditorView.updateListener.of( ( editor ) => {
-							if ( editor.docChanged ) {
-								onChange( editor.state.doc.toString() );
-							}
-						} ),
-						...(onBlur ?
-						[CmEditorView.focusChangeEffect.of(
-							( editorState, focusing ) => {
-								if ( ! focusing ) {
-									onBlur( editorState.doc.toString() );
-								}
-								return null;
-							}
-						)] : []),
-					],
-					parent: editorRef.current,
-				} );
-				if (typeof callback === 'function') {
+	useEffect( () => {
+		import( /* webpackChunkName: "codemirror" */ './code-mirror' )
+			.then( ( { default: createEditorView } ) => {
+				if ( editorRef.current ) {
+					return createEditorView( {
+						parent: editorRef.current,
+						mode,
+						content,
+						onChange,
+						onBlur,
+					} );
+				}
+			} )
+			.then( () => {
+				if ( typeof callback === 'function' ) {
 					callback();
 				}
-			}
-		} )();
-		// We only want to run this once when the editor is initialized, so we can ignore the dependency array.
+			} );
+		// We only want to run this once, so we can ignore the dependency array.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
+
 	return (
 		<>
-			{editorInstructionsText && (<VisuallyHidden
-				id={ instanceId }
-			>
-				{ editorInstructionsText }
-				{ __(
-					`Press Escape then Tab to move focus out of the editor.`
-				) }
-			</VisuallyHidden>)}
+			{ editorInstructionsText && (
+				<VisuallyHidden id={ instanceId }>
+					{ editorInstructionsText }
+					{ __(
+						`Press Escape then Tab to move focus out of the editor.`
+					) }
+				</VisuallyHidden>
+			) }
 			<div
 				ref={ editorRef }
 				id={ editorId }

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -165,6 +165,14 @@ module.exports = {
 	performance: {
 		hints: false, // disable warnings about package sizes
 	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				default: false,
+				defaultVendors: false,
+			},
+		},
+	},
 	plugins: [
 		...plugins,
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),


### PR DESCRIPTION
Exploration that rearranges CodeMirror imports in #60155 so that the chunk layout is simpler.