### PR TITLE
Site Editor: Improve the frame animation

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -158,7 +158,6 @@ jobs:
             - name: Docker debug information
               run: |
                   docker -v
-                  docker-compose -v
 
             - name: General debug information
               run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -55701,6 +55701,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
+				"@react-spring/web": "^9.4.5",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/blob": "file:../blob",
@@ -71474,6 +71475,7 @@
 			"version": "file:packages/edit-site",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
+				"@react-spring/web": "^9.4.5",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/blob": "file:../blob",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -27,6 +27,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"@react-spring/web": "^9.4.5",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",

--- a/packages/edit-site/src/components/layout/animation.js
+++ b/packages/edit-site/src/components/layout/animation.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { Controller } from '@react-spring/web';
+
+/**
+ * WordPress dependencies
+ */
+import { useLayoutEffect, useMemo, useRef } from '@wordpress/element';
+
+function getAbsolutePosition( element ) {
+	return {
+		top: element.offsetTop,
+		left: element.offsetLeft,
+	};
+}
+
+const ANIMATION_DURATION = 500;
+
+/**
+ * Hook used to compute the styles required to move a div into a new position.
+ *
+ * The way this animation works is the following:
+ *  - It first renders the element as if there was no animation.
+ *  - It takes a snapshot of the position of the block to use it
+ *    as a destination point for the animation.
+ *  - It restores the element to the previous position using a CSS transform
+ *  - It uses the "resetAnimation" flag to reset the animation
+ *    from the beginning in order to animate to the new destination point.
+ *
+ * @param {Object} $1                          Options
+ * @param {*}      $1.triggerAnimationOnChange Variable used to trigger the animation if it changes.
+ */
+function useMovingAnimation( { triggerAnimationOnChange } ) {
+	const ref = useRef();
+
+	// Whenever the trigger changes, we need to take a snapshot of the current
+	// position of the block to use it as a destination point for the animation.
+	const { previous, prevRect } = useMemo(
+		() => ( {
+			previous: ref.current && getAbsolutePosition( ref.current ),
+			prevRect: ref.current && ref.current.getBoundingClientRect(),
+		} ),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[ triggerAnimationOnChange ]
+	);
+
+	useLayoutEffect( () => {
+		if ( ! previous || ! ref.current ) {
+			return;
+		}
+
+		// We disable the animation if the user has a preference for reduced
+		// motion.
+		const disableAnimation = window.matchMedia(
+			'(prefers-reduced-motion: reduce)'
+		).matches;
+
+		if ( disableAnimation ) {
+			return;
+		}
+
+		const controller = new Controller( {
+			x: 0,
+			y: 0,
+			width: prevRect.width,
+			height: prevRect.height,
+			config: { duration: ANIMATION_DURATION },
+			onChange( { value } ) {
+				if ( ! ref.current ) {
+					return;
+				}
+				let { x, y, width, height } = value;
+				x = Math.round( x );
+				y = Math.round( y );
+				width = Math.round( width );
+				height = Math.round( height );
+				const finishedMoving = x === 0 && y === 0;
+				ref.current.style.transformOrigin = 'center center';
+				ref.current.style.transform = finishedMoving
+					? null // Set to `null` to explicitly remove the transform.
+					: `translate3d(${ x }px,${ y }px,0)`;
+				ref.current.style.width = finishedMoving
+					? null
+					: `${ width }px`;
+				ref.current.style.height = finishedMoving
+					? null
+					: `${ height }px`;
+			},
+		} );
+
+		ref.current.style.transform = undefined;
+		const destination = ref.current.getBoundingClientRect();
+
+		const x = Math.round( prevRect.left - destination.left );
+		const y = Math.round( prevRect.top - destination.top );
+		const width = destination.width;
+		const height = destination.height;
+
+		controller.start( {
+			x: 0,
+			y: 0,
+			width,
+			height,
+			from: { x, y, width: prevRect.width, height: prevRect.height },
+		} );
+
+		return () => {
+			controller.stop();
+			controller.set( {
+				x: 0,
+				y: 0,
+				width: prevRect.width,
+				height: prevRect.height,
+			} );
+		};
+	}, [ previous, prevRect ] );
+
+	return ref;
+}
+
+export default useMovingAnimation;

--- a/packages/edit-site/src/components/layout/animation.js
+++ b/packages/edit-site/src/components/layout/animation.js
@@ -15,7 +15,7 @@ function getAbsolutePosition( element ) {
 	};
 }
 
-const ANIMATION_DURATION = 500;
+const ANIMATION_DURATION = 300;
 
 /**
  * Hook used to compute the styles required to move a div into a new position.

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -57,7 +57,7 @@ const { useCommands } = unlock( coreCommandsPrivateApis );
 const { useCommandContext } = unlock( commandsPrivateApis );
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
-const ANIMATION_DURATION = 0.5;
+const ANIMATION_DURATION = 0.3;
 
 export default function Layout() {
 	// This ensures the edited entity id and type are initialized properly.
@@ -243,7 +243,9 @@ export default function Layout() {
 								} }
 								transition={ {
 									type: 'tween',
-									duration: disableMotion ? 0 : 0.2,
+									duration: disableMotion
+										? 0
+										: ANIMATION_DURATION,
 									ease: 'easeOut',
 								} }
 							>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -51,6 +51,7 @@ import { useCommonCommands } from '../../hooks/commands/use-common-commands';
 import { useEditModeCommands } from '../../hooks/commands/use-edit-mode-commands';
 import { useIsSiteEditorLoading } from './hooks';
 import useLayoutAreas from './router';
+import useMovingAnimation from './animation';
 
 const { useCommands } = unlock( coreCommandsPrivateApis );
 const { useCommandContext } = unlock( commandsPrivateApis );
@@ -115,6 +116,9 @@ export default function Layout() {
 	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
 		useState( false );
 	const { areas, widths } = useLayoutAreas();
+	const animationRef = useMovingAnimation( {
+		triggerAnimationOnChange: canvasMode,
+	} );
 
 	// This determines which animation variant should apply to the header.
 	// There is also a `isDistractionFreeHovering` state that gets priority
@@ -315,22 +319,7 @@ export default function Layout() {
 						<div className="edit-site-layout__canvas-container">
 							{ canvasResizer }
 							{ !! canvasSize.width && (
-								<motion.div
-									whileHover={
-										canvasMode === 'view'
-											? {
-													scale: 1.005,
-													transition: {
-														duration: disableMotion
-															? 0
-															: 0.5,
-														ease: 'easeOut',
-													},
-											  }
-											: {}
-									}
-									initial={ false }
-									layout="position"
+								<div
 									className={ classnames(
 										'edit-site-layout__canvas',
 										{
@@ -338,13 +327,7 @@ export default function Layout() {
 												isResizableFrameOversized,
 										}
 									) }
-									transition={ {
-										type: 'tween',
-										duration: disableMotion
-											? 0
-											: ANIMATION_DURATION,
-										ease: 'easeOut',
-									} }
+									ref={ animationRef }
 								>
 									<ErrorBoundary>
 										<ResizableFrame
@@ -373,7 +356,7 @@ export default function Layout() {
 											{ areas.preview }
 										</ResizableFrame>
 									</ErrorBoundary>
-								</motion.div>
+								</div>
 							) }
 						</div>
 					) }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -115,9 +115,9 @@ export default function Layout() {
 	const isEditorLoading = useIsSiteEditorLoading();
 	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
 		useState( false );
-	const { areas, widths } = useLayoutAreas();
+	const { key: routeKey, areas, widths } = useLayoutAreas();
 	const animationRef = useMovingAnimation( {
-		triggerAnimationOnChange: canvasMode,
+		triggerAnimationOnChange: canvasMode + '__' + routeKey,
 	} );
 
 	// This determines which animation variant should apply to the header.

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -33,6 +33,7 @@ export default function useLayoutAreas() {
 	if ( path === '/page' ) {
 		const isListLayout = layout === 'list' || ! layout;
 		return {
+			key: 'pages-list',
 			areas: {
 				content: <PagePages />,
 				preview: isListLayout && (
@@ -62,6 +63,7 @@ export default function useLayoutAreas() {
 	// Regular other post types
 	if ( postType && postId ) {
 		return {
+			key: 'page',
 			areas: {
 				preview: <Editor isLoading={ isSiteEditorLoading } />,
 				mobile:
@@ -76,6 +78,7 @@ export default function useLayoutAreas() {
 	if ( path === '/wp_template' ) {
 		const isListLayout = isCustom !== 'true' && layout === 'list';
 		return {
+			key: 'templates-list',
 			areas: {
 				content: (
 					<PageTemplatesTemplateParts
@@ -101,6 +104,7 @@ export default function useLayoutAreas() {
 	if ( path === '/wp_template_part/all' ) {
 		const isListLayout = isCustom !== 'true' && layout === 'list';
 		return {
+			key: 'template-parts',
 			areas: {
 				content: (
 					<PageTemplatesTemplateParts
@@ -125,6 +129,7 @@ export default function useLayoutAreas() {
 	// Patterns
 	if ( path === '/patterns' ) {
 		return {
+			key: 'patterns',
 			areas: {
 				content: <PagePatterns />,
 				mobile: <PagePatterns />,
@@ -134,6 +139,7 @@ export default function useLayoutAreas() {
 
 	// Fallback shows the home page preview
 	return {
+		key: 'default',
 		areas: {
 			preview: <Editor isLoading={ isSiteEditorLoading } />,
 			mobile:

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -93,6 +93,8 @@
 	position: relative;
 	flex-grow: 1;
 	z-index: z-index(".edit-site-layout__canvas-container");
+	// When animating the frame size can exceed its container size.
+	overflow: visible;
 
 	&.is-resizing::after {
 		// This covers the whole content which ensures mouse up triggers


### PR DESCRIPTION
Alternative to #58924 

## What?

The site editor frame animation when entering and existing the edit mode is a bit clunky on trunk (especially when exiting the frame). This PR solves that by relying on a technique we've used before in the block animations in the canvas.

Basically, we compute the destination position, restore the previous position and animate the "ref" of the frame to reach the final destination.

## Why?

I think this improves the experience a lot. The site editor feels smoother.

## Testing Instructions

1- Try entering and exiting the editor either from the list view or from regular views.
