### PR TITLE
Confirm dialog: use more descriptive text for the confirm button 

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -215,7 +215,7 @@ function ScreenRevisions() {
 					}
 				>
 					{ __(
-						'Any unsaved changes will be lost when you apply this revision.'
+						'Are you sure you want to apply this revision? Any unsaved changes will be lost.'
 					) }
 				</ConfirmDialog>
 			) }

--- a/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
@@ -68,7 +68,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 			onCancel={ () => setIsDialogOpen( false ) }
 		>
 			{ __(
-				'You’ve tried to select a block that is part of a template, which may be used on other posts and pages.'
+				'Would you like to edit the template this block is part of?'
 			) }
 		</ConfirmDialog>
 	);

--- a/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
@@ -68,7 +68,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 			onCancel={ () => setIsDialogOpen( false ) }
 		>
 			{ __(
-				'Would you like to edit the template this block is part of?'
+				'You’ve tried to select a block that is part of a template, which may be used on other posts and pages. Would you like to edit the template?.'
 			) }
 		</ConfirmDialog>
 	);

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -31,10 +31,13 @@ export default function PostSwitchToDraftButton() {
 	const isDisabled = isSaving || ( ! isPublished && ! isScheduled );
 
 	let alertMessage;
+	let confirmButtonText;
 	if ( isPublished ) {
 		alertMessage = __( 'Are you sure you want to unpublish this post?' );
+		confirmButtonText = __( 'Unpublish' );
 	} else if ( isScheduled ) {
 		alertMessage = __( 'Are you sure you want to unschedule this post?' );
+		confirmButtonText = __( 'Unschedule' );
 	}
 
 	const handleConfirm = () => {
@@ -63,6 +66,7 @@ export default function PostSwitchToDraftButton() {
 				isOpen={ showConfirmDialog }
 				onConfirm={ handleConfirm }
 				onCancel={ () => setShowConfirmDialog( false ) }
+				confirmButtonText={ confirmButtonText }
 			>
 				{ alertMessage }
 			</ConfirmDialog>

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -54,6 +54,7 @@ export default function PostTrash() {
 				isOpen={ showConfirmDialog }
 				onConfirm={ handleConfirm }
 				onCancel={ () => setShowConfirmDialog( false ) }
+				confirmButtonText={ __( 'Move to the trash' ) }
 			>
 				{ __(
 					'Are you sure you want to move this post to the trash?'

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -54,7 +54,7 @@ export default function PostTrash() {
 				isOpen={ showConfirmDialog }
 				onConfirm={ handleConfirm }
 				onCancel={ () => setShowConfirmDialog( false ) }
-				confirmButtonText={ __( 'Move to the trash' ) }
+				confirmButtonText={ __( 'Move to trash' ) }
 			>
 				{ __(
 					'Are you sure you want to move this post to the trash?'

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -125,6 +125,7 @@ export default function PostVisibility( { onClose } ) {
 				isOpen={ showPrivateConfirmDialog }
 				onConfirm={ confirmPrivate }
 				onCancel={ handleDialogCancel }
+				confirmButtonText={ __( 'Publish' ) }
 			>
 				{ __( 'Would you like to privately publish this post now?' ) }
 			</ConfirmDialog>

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -417,7 +417,7 @@ test.describe( 'Change detection', () => {
 			.click();
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'OK' } )
+			.getByRole( 'button', { name: 'Move to trash' } )
 			.click();
 
 		await expect(

--- a/test/e2e/specs/editor/various/post-visibility.spec.js
+++ b/test/e2e/specs/editor/various/post-visibility.spec.js
@@ -23,7 +23,7 @@ test.describe( 'Post visibility', () => {
 
 			await page.click( 'role=radio[name="Private"i]' );
 
-			await page.click( 'role=button[name="OK"i]' );
+			await page.click( 'role=button[name="Publish"i]' );
 
 			const currentStatus = await page.evaluate( () => {
 				return window.wp.data
@@ -99,7 +99,7 @@ test.describe( 'Post visibility', () => {
 
 		await page.click( 'role=radio[name="Private"i]' );
 
-		await page.click( 'role=button[name="OK"i]' );
+		await page.click( 'role=button[name="Publish"i]' );
 
 		const currentStatus = await page.evaluate( () => {
 			return window.wp.data

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -188,7 +188,7 @@ test.describe( 'Preview', () => {
 			.getByRole( 'button', { name: 'Switch to draft' } )
 			.click();
 		// FIXME: The confirmation dialog is not named yet.
-		await page.click( 'role=dialog >> role=button[name="OK"i]' );
+		await page.click( 'role=dialog >> role=button[name="Unpublish"i]' );
 
 		// Wait for the status change.
 		// @see https://github.com/WordPress/gutenberg/pull/43933

--- a/test/e2e/specs/editor/various/switch-to-draft.spec.js
+++ b/test/e2e/specs/editor/various/switch-to-draft.spec.js
@@ -65,9 +65,12 @@ test.describe( 'Clicking "Switch to draft" on a published/scheduled post/page', 
 
 					await switchToDraftUtils.switchToDraftButton.click();
 
+					const confirmButtonText =
+						postStatus === 'publish' ? 'Unpublish' : 'Unschedule';
+
 					await page
 						.getByRole( 'dialog' )
-						.getByRole( 'button', { name: 'OK' } )
+						.getByRole( 'button', { name: confirmButtonText } )
 						.click();
 
 					await expect(

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -101,7 +101,7 @@ test.describe( 'Style Revisions', () => {
 		const confirm = page.getByRole( 'dialog' );
 		await expect( confirm ).toBeVisible();
 		await expect( confirm ).toHaveText(
-			/^Any unsaved changes will be lost when you apply this revision./
+			/^Are you sure you want to apply this revision? Any unsaved changes will be lost./
 		);
 
 		// This is to make sure there are no lingering unsaved changes.

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -101,7 +101,7 @@ test.describe( 'Style Revisions', () => {
 		const confirm = page.getByRole( 'dialog' );
 		await expect( confirm ).toBeVisible();
 		await expect( confirm ).toHaveText(
-			/^Are you sure you want to apply this revision? Any unsaved changes will be lost./
+			/^Are you sure you want to apply this revision\? Any unsaved changes will be lost./
 		);
 
 		// This is to make sure there are no lingering unsaved changes.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60360

## What?
<!-- In a few words, what is the PR actually doing? -->
Some of the `ConfirmDialg` instances use the generic, default 'OK' text for the confirm button. They should use a more descriptive text.
Also, ideally the confirm dialog copy should always _ask a question_.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A more descriptive text helps users better understand what the 'confirm' action does. Also, the `ConfirmDialg` was implemented with the purpose of providing a more descriptive text than the generic 'OK'. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Provides a more descriptive text for the copy and the confirm button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the post editor and trash a post.
- Observe the confirm button text is 'Move to trash' instead of 'OK'.
- Switch to draft a published post.
- Observe the confirm button text is 'Unpublish' instead of 'OK'.
- Switch to draft a scheduled post.
- Observe the confirm button text is 'Unschedule' instead of 'OK'.
- Set a post to visibility: Private.
- Observe the confirm button text is 'Publish' instead of 'OK'.
- Go to the Site editor > Pages > edit a page.
- Double click on an empty area at the side of a block provided by the page template, e.g. at the side of the page title.
- Observe the confirm dialog copy is `Would you like to edit the template this block is part of?`.
- Go to the Site editor > Styles > Revisions.
- Select a revision and click 'Apply'.
- Observe the confirm dialog copy is `Are you sure you want to apply this revision? Any unsaved changes will be lost.`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
