### PR TITLE
Update 'Add template' screen to prefer template_name label instead of singular_name

### DIFF
--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -196,9 +196,6 @@ export const usePostTypeMenuItems = ( onClickMenuItem ) => {
 	);
 	const needsUniqueIdentifier = useCallback(
 		( { labels, slug } ) => {
-			if ( [ 'post', 'page' ].includes( slug ) ) {
-				return false;
-			}
 			const templateName = (
 				labels.template_name || labels.singular_name
 			).toLowerCase();

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -100,7 +100,15 @@ const usePublicTaxonomies = () => {
 	}, [ taxonomies ] );
 };
 
-function usePostTypeNeedsUniqueIdentifier( publicPostTypes ) {
+export function usePostTypeArchiveMenuItems() {
+	const publicPostTypes = usePublicPostTypes();
+	const postTypesWithArchives = useMemo(
+		() => publicPostTypes?.filter( ( postType ) => postType.has_archive ),
+		[ publicPostTypes ]
+	);
+	const existingTemplates = useExistingTemplates();
+	// We need to keep track of naming conflicts. If a conflict
+	// occurs, we need to add slug.
 	const postTypeLabels = useMemo(
 		() =>
 			publicPostTypes?.reduce( ( accumulator, { labels } ) => {
@@ -111,24 +119,12 @@ function usePostTypeNeedsUniqueIdentifier( publicPostTypes ) {
 			}, {} ),
 		[ publicPostTypes ]
 	);
-	return useCallback(
+	const needsUniqueIdentifier = useCallback(
 		( { labels, slug } ) => {
 			const singularName = labels.singular_name.toLowerCase();
 			return postTypeLabels[ singularName ] > 1 && singularName !== slug;
 		},
 		[ postTypeLabels ]
-	);
-}
-
-export function usePostTypeArchiveMenuItems() {
-	const publicPostTypes = usePublicPostTypes();
-	const postTypesWithArchives = useMemo(
-		() => publicPostTypes?.filter( ( postType ) => postType.has_archive ),
-		[ publicPostTypes ]
-	);
-	const existingTemplates = useExistingTemplates();
-	const needsUniqueIdentifier = usePostTypeNeedsUniqueIdentifier(
-		postTypesWithArchives
 	);
 	return useMemo(
 		() =>
@@ -184,8 +180,33 @@ export const usePostTypeMenuItems = ( onClickMenuItem ) => {
 	const publicPostTypes = usePublicPostTypes();
 	const existingTemplates = useExistingTemplates();
 	const defaultTemplateTypes = useDefaultTemplateTypes();
-	const needsUniqueIdentifier =
-		usePostTypeNeedsUniqueIdentifier( publicPostTypes );
+	// We need to keep track of naming conflicts. If a conflict
+	// occurs, we need to add slug.
+	const templateLabels = useMemo(
+		() =>
+			publicPostTypes?.reduce( ( accumulator, { labels } ) => {
+				const templateName = (
+					labels.template_name || labels.singular_name
+				).toLowerCase();
+				accumulator[ templateName ] =
+					( accumulator[ templateName ] || 0 ) + 1;
+				return accumulator;
+			}, {} ),
+		[ publicPostTypes ]
+	);
+	const needsUniqueIdentifier = useCallback(
+		( { labels, slug } ) => {
+			if ( [ 'post', 'page' ].includes( slug ) ) {
+				return false;
+			}
+			const templateName = (
+				labels.template_name || labels.singular_name
+			).toLowerCase();
+			return templateLabels[ templateName ] > 1 && templateName !== slug;
+		},
+		[ templateLabels ]
+	);
+
 	// `page`is a special case in template hierarchy.
 	const templatePrefixes = useMemo(
 		() =>
@@ -216,18 +237,27 @@ export const usePostTypeMenuItems = ( onClickMenuItem ) => {
 			const hasGeneralTemplate =
 				existingTemplateSlugs?.includes( generalTemplateSlug );
 			const _needsUniqueIdentifier = needsUniqueIdentifier( postType );
-			let menuItemTitle = sprintf(
-				// translators: %s: Name of the post type e.g: "Post".
-				__( 'Single item: %s' ),
-				labels.singular_name
-			);
-			if ( _needsUniqueIdentifier ) {
-				menuItemTitle = sprintf(
-					// translators: %1s: Name of the post type e.g: "Post"; %2s: Slug of the post type e.g: "book".
-					__( 'Single item: %1$s (%2$s)' ),
-					labels.singular_name,
-					slug
+			let menuItemTitle =
+				labels.template_name ||
+				sprintf(
+					// translators: %s: Name of the post type e.g: "Post".
+					__( 'Single item: %s' ),
+					labels.singular_name
 				);
+			if ( _needsUniqueIdentifier ) {
+				menuItemTitle = labels.template_name
+					? sprintf(
+							// translators: %1s: Name of the template e.g: "Single Item: Post"; %2s: Slug of the post type e.g: "book".
+							__( '%1$s (%2$s)' ),
+							labels.template_name,
+							slug
+					  )
+					: sprintf(
+							// translators: %1s: Name of the post type e.g: "Post"; %2s: Slug of the post type e.g: "book".
+							__( 'Single item: %1$s (%2$s)' ),
+							labels.singular_name,
+							slug
+					  );
 			}
 			const menuItem = defaultTemplateType
 				? {
@@ -337,9 +367,11 @@ export const useTaxonomiesMenuItems = ( onClickMenuItem ) => {
 	// occurs, we need to add slug.
 	const taxonomyLabels = publicTaxonomies?.reduce(
 		( accumulator, { labels } ) => {
-			const singularName = labels.singular_name.toLowerCase();
-			accumulator[ singularName ] =
-				( accumulator[ singularName ] || 0 ) + 1;
+			const templateName = (
+				labels.template_name || labels.singular_name
+			).toLowerCase();
+			accumulator[ templateName ] =
+				( accumulator[ templateName ] || 0 ) + 1;
 			return accumulator;
 		},
 		{}
@@ -348,8 +380,10 @@ export const useTaxonomiesMenuItems = ( onClickMenuItem ) => {
 		if ( [ 'category', 'post_tag' ].includes( slug ) ) {
 			return false;
 		}
-		const singularName = labels.singular_name.toLowerCase();
-		return taxonomyLabels[ singularName ] > 1 && singularName !== slug;
+		const templateName = (
+			labels.template_name || labels.singular_name
+		).toLowerCase();
+		return taxonomyLabels[ templateName ] > 1 && templateName !== slug;
 	};
 	const taxonomiesInfo = useEntitiesInfo( 'taxonomy', templatePrefixes );
 	const existingTemplateSlugs = ( existingTemplates || [] ).map(
@@ -371,14 +405,21 @@ export const useTaxonomiesMenuItems = ( onClickMenuItem ) => {
 				labels,
 				slug
 			);
-			let menuItemTitle = labels.singular_name;
+			let menuItemTitle = labels.template_name || labels.singular_name;
 			if ( _needsUniqueIdentifier ) {
-				menuItemTitle = sprintf(
-					// translators: %1s: Name of the taxonomy e.g: "Category"; %2s: Slug of the taxonomy e.g: "product_cat".
-					__( '%1$s (%2$s)' ),
-					labels.singular_name,
-					slug
-				);
+				menuItemTitle = labels.template_name
+					? sprintf(
+							// translators: %1s: Name of the template e.g: "Products by Category"; %2s: Slug of the taxonomy e.g: "product_cat".
+							__( '%1$s (%2$s)' ),
+							labels.template_name,
+							slug
+					  )
+					: sprintf(
+							// translators: %1s: Name of the taxonomy e.g: "Category"; %2s: Slug of the taxonomy e.g: "product_cat".
+							__( '%1$s (%2$s)' ),
+							labels.singular_name,
+							slug
+					  );
 			}
 			const menuItem = defaultTemplateType
 				? {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/60283.

Related PR on WordPress: https://github.com/WordPress/wordpress-develop/pull/6344.

## What?

This PR makes it so the _Add template_ screen displays the `template_name` label for CPT and custom taxonomy templates, instead of relying on `singular_name`.

## Why?

This way, we allow plugins to add user-friendly names to templates related to their CPT/custom taxonomies.

## How?

This PR makes it so `template_name` takes priority over `singular_name` when possible. It also accounts for the cases of:

1. `template_name` being missing, in which case we fall back to `singular_name`, as it used to work.
2. `template_name` being duplicate, in which case the CPT/custom taxonomy slug is displayed.

## Testing Instructions


1. Add this code snippet to your site in order to create a Recipes post type and a Recipe category taxonomy (you can use the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin if needed):

```PHP
add_action( 'init', function () {
	register_post_type(
		'recipe',
		array(
			'labels'       => array(
				'name'          => 'Recipes',
				'singular_name' => 'Recipe',
			),
			'public'       => true,
			'show_in_rest' => true,
		)
	);
	register_taxonomy(
		'recipe_cat',
		'recipe',
		array(
			'label'        => 'Categories',
			'labels'       => array(
				'name'          => 'Recipe categories',
				'singular_name' => 'Category',
			),
			'show_in_rest' => true,
		)
	);
} );
```

2. Go to Appearance > Editor > Templates > Add new and verify there are no regressions in the Add template screen: two items related to the code snippet should appear there: _Single item: Recipe_ and _Category (recipe_cat)_.

![Add template screen with default labels](https://github.com/WordPress/gutenberg/assets/3616980/c76df58d-2d87-4097-9e41-b2ec90a32c09)

3. Now, modify the code snippet you created before, adding `template_name` to the post type and taxonomy:

```diff
add_action( 'init', function () {
	register_post_type(
		'recipe',
		array(
			'labels'       => array(
				'name'          => 'Recipes',
				'singular_name' => 'Recipe',
+				'template_name' => 'Single recipe',
			),
			'public'       => true,
			'show_in_rest' => true,
		)
	);
	register_taxonomy(
		'recipe_cat',
		'recipe',
		array(
			'label'        => 'Categories',
			'labels'       => array(
				'name'          => 'Recipe categories',
				'singular_name' => 'Category',
+				'template_name' => 'Recipes by category',
			),
			'show_in_rest' => true,
		)
	);
} );
```

4. Repeat step 2 and verify the user-friendly template labels are shown:

![Add template screen with user-friendly labels](https://github.com/WordPress/gutenberg/assets/3616980/57e675fc-7cf0-4c5c-9ad1-8afa9ef1302b)
