### PR TITLE
Snackbar: Make the `explicitDismiss` string translatable

### DIFF
--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -168,7 +168,7 @@ function UnforwardedSnackbar(
 				{ explicitDismiss && (
 					<span
 						role="button"
-						aria-label="Dismiss this notice"
+						aria-label={ __( 'Dismiss this notice' ) }
 						tabIndex={ 0 }
 						className="components-snackbar__dismiss-button"
 						onClick={ dismissMe }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Submitting this PR without an associated issue because [this is a trivial change](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/repository-management.md#pull-requests) that doesn't need a broader discussion.

## What?
<!-- In a few words, what is the PR actually doing? -->
When snackbars have the `explicitDismiss` prop set to true, they show an X close button. The button aria-label is not translatable, [it's a hardcoded string](https://github.com/WordPress/gutenberg/blob/b68641dcdcaefeecb54398907cf1aacab0e675d5/packages/components/src/snackbar/index.tsx#L171).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All user facing text, including non-visible ARIA properties, should be translatable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Makes the string translatable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
