### PR TITLE
Fix: Honor 'template_hierarchy' filters on template fallbacks.

### DIFF
--- a/lib/compat/wordpress-6.6/block-template-utils.php
+++ b/lib/compat/wordpress-6.6/block-template-utils.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
- /**
+/**
  * Gets the template hierarchy for the given template slug to be created.
  *
  * Note: Always add `index` as the last fallback template.
@@ -20,7 +20,7 @@
  *                                Default empty string.
  * @return string[] The template hierarchy.
  */
- function gutenberg_get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
+function gutenberg_get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
 	if ( 'index' === $slug ) {
 		/** This filter is documented in wp-includes/template.php */
 		return apply_filters( 'index_template_hierarchy', array( 'index' ) );
@@ -105,7 +105,7 @@
 		list( $template_type ) = explode( '-', $slug );
 	}
 	$valid_template_types = array( '404', 'archive', 'attachment', 'author', 'category', 'date', 'embed', 'frontpage', 'home', 'index', 'page', 'paged', 'privacypolicy', 'search', 'single', 'singular', 'tag', 'taxonomy' );
-	if ( in_array( $template_type, $valid_template_types ) ) {
+	if ( in_array( $template_type, $valid_template_types, true ) ) {
 		/** This filter is documented in wp-includes/template.php */
 		return apply_filters( "{$template_type}_template_hierarchy", $template_hierarchy );
 	}

--- a/lib/compat/wordpress-6.6/block-template-utils.php
+++ b/lib/compat/wordpress-6.6/block-template-utils.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Utilities used to fetch and create templates and template parts.
+ *
+ * @package gutenberg
+ */
+
+ /**
+ * Gets the template hierarchy for the given template slug to be created.
+ *
+ * Note: Always add `index` as the last fallback template.
+ *
+ *
+ * @param string $slug            The template slug to be created.
+ * @param bool   $is_custom       Optional. Indicates if a template is custom or
+ *                                part of the template hierarchy. Default false.
+ * @param string $template_prefix Optional. The template prefix for the created template.
+ *                                Used to extract the main template type, e.g.
+ *                                in `taxonomy-books` the `taxonomy` is extracted.
+ *                                Default empty string.
+ * @return string[] The template hierarchy.
+ */
+ function gutenberg_get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
+	if ( 'index' === $slug ) {
+		/** This filter is documented in wp-includes/template.php */
+		return apply_filters( 'index_template_hierarchy', array( 'index' ) );
+	}
+	if ( $is_custom ) {
+		/** This filter is documented in wp-includes/template.php */
+		return apply_filters( 'page_template_hierarchy', array( 'page', 'singular', 'index' ) );
+	}
+	if ( 'front-page' === $slug ) {
+		/** This filter is documented in wp-includes/template.php */
+		return apply_filters( 'frontpage_template_hierarchy', array( 'front-page', 'home', 'index' ) );
+	}
+
+	$matches = array();
+
+	$template_hierarchy = array( $slug );
+	// Most default templates don't have `$template_prefix` assigned.
+	if ( ! empty( $template_prefix ) ) {
+		list( $type ) = explode( '-', $template_prefix );
+		// We need these checks because we always add the `$slug` above.
+		if ( ! in_array( $template_prefix, array( $slug, $type ), true ) ) {
+			$template_hierarchy[] = $template_prefix;
+		}
+		if ( $slug !== $type ) {
+			$template_hierarchy[] = $type;
+		}
+	} elseif ( preg_match( '/^(author|category|archive|tag|page)-.+$/', $slug, $matches ) ) {
+		$template_hierarchy[] = $matches[1];
+	} elseif ( preg_match( '/^(taxonomy|single)-(.+)$/', $slug, $matches ) ) {
+		$type           = $matches[1];
+		$slug_remaining = $matches[2];
+
+		$items = 'single' === $type ? get_post_types() : get_taxonomies();
+		foreach ( $items as $item ) {
+			if ( ! str_starts_with( $slug_remaining, $item ) ) {
+					continue;
+			}
+
+			// If $slug_remaining is equal to $post_type or $taxonomy we have
+			// the single-$post_type template or the taxonomy-$taxonomy template.
+			if ( $slug_remaining === $item ) {
+				$template_hierarchy[] = $type;
+				break;
+			}
+
+			// If $slug_remaining is single-$post_type-$slug template.
+			if ( strlen( $slug_remaining ) > strlen( $item ) + 1 ) {
+				$template_hierarchy[] = "$type-$item";
+				$template_hierarchy[] = $type;
+				break;
+			}
+		}
+	}
+	// Handle `archive` template.
+	if (
+		str_starts_with( $slug, 'author' ) ||
+		str_starts_with( $slug, 'taxonomy' ) ||
+		str_starts_with( $slug, 'category' ) ||
+		str_starts_with( $slug, 'tag' ) ||
+		'date' === $slug
+	) {
+		$template_hierarchy[] = 'archive';
+	}
+	// Handle `single` template.
+	if ( 'attachment' === $slug ) {
+		$template_hierarchy[] = 'single';
+	}
+	// Handle `singular` template.
+	if (
+		str_starts_with( $slug, 'single' ) ||
+		str_starts_with( $slug, 'page' ) ||
+		'attachment' === $slug
+	) {
+		$template_hierarchy[] = 'singular';
+	}
+	$template_hierarchy[] = 'index';
+
+	$template_type = '';
+	if ( ! empty( $template_prefix ) ) {
+		list( $template_type ) = explode( '-', $template_prefix );
+	} else {
+		list( $template_type ) = explode( '-', $slug );
+	}
+	$valid_template_types = array( '404', 'archive', 'attachment', 'author', 'category', 'date', 'embed', 'frontpage', 'home', 'index', 'page', 'paged', 'privacypolicy', 'search', 'single', 'singular', 'tag', 'taxonomy' );
+	if ( in_array( $template_type, $valid_template_types ) ) {
+		/** This filter is documented in wp-includes/template.php */
+		return apply_filters( "{$template_type}_template_hierarchy", $template_hierarchy );
+	}
+	return $template_hierarchy;
+}

--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
@@ -67,4 +67,25 @@ class Gutenberg_REST_Templates_Controller_6_6 extends Gutenberg_REST_Templates_C
 			)
 		);
 	}
+
+	/**
+	 * Returns the fallback template for the given slug.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param WP_REST_Request $request The request instance.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_template_fallback( $request ) {
+		$hierarchy = gutenberg_get_template_hierarchy( $request['slug'], $request['is_custom'], $request['template_prefix'] );
+
+		do {
+			$fallback_template = resolve_block_template( $request['slug'], $hierarchy, '' );
+			array_shift( $hierarchy );
+		} while ( ! empty( $hierarchy ) && empty( $fallback_template->content ) );
+
+		$response = $this->prepare_item_for_response( $fallback_template, $request );
+
+		return rest_ensure_response( $response );
+	}
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -127,6 +127,7 @@ require __DIR__ . '/compat/wordpress-6.5/script-loader.php';
 // WordPress 6.6 compat.
 require __DIR__ . '/compat/wordpress-6.6/resolve-patterns.php';
 require __DIR__ . '/compat/wordpress-6.6/block-bindings/pattern-overrides.php';
+require __DIR__ . '/compat/wordpress-6.6/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.6/option.php';
 require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';
 require __DIR__ . '/compat/wordpress-6.6/rest-api.php';


### PR DESCRIPTION
Reverse ports PR https://github.com/WordPress/wordpress-develop/pull/6322 into the Gutenberg plugin. The core PR was already approved and ready to be committed this PR just adds the equivalent changes on the Gutenberg plugin so it gets wider testing before the next release.

Props to @Aljullu for the original core PR.

## Testing steps
1. Add this code snippet to your site. You can use the [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/):

```
add_filter( 'page_template_hierarchy', function ( $templates ) {
        return ['single'];
} );
```

2. Visit any page in the frontend. You will notice the Single template is used, instead of the Page template.
3. Now, go to Appearance Editor Templates Add New Template Pages and select any page.
4. Verify the suggested content to start with in the Choose a pattern screen is from the Single template, instead of the Page template.

Before	After
![](https://private-user-images.githubusercontent.com/3616980/316864472-7598c990-1a64-4df3-b509-47d83fc59239.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTIwNjc2MTksIm5iZiI6MTcxMjA2NzMxOSwicGF0aCI6Ii8zNjE2OTgwLzMxNjg2NDQ3Mi03NTk4Yzk5MC0xYTY0LTRkZjMtYjUwOS00N2Q4M2ZjNTkyMzkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDQwMiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA0MDJUMTQxNTE5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MzkzZjQ3YTY3YTk5NjA4Mjg3N2IzMzhhOTUwYmY0OWNmNmNjNTk0MjkxNGMzOTc3Y2JiZDUxZGZjYTg4MDU3OSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.v6ZBVFjCzlux3v6IO0iHQHAMWK3RvmLJ-8fhKSW7dHU)	![](https://private-user-images.githubusercontent.com/3616980/316864451-fff09fd9-5600-4969-89f6-dab6523f50de.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTIwNjc2MTksIm5iZiI6MTcxMjA2NzMxOSwicGF0aCI6Ii8zNjE2OTgwLzMxNjg2NDQ1MS1mZmYwOWZkOS01NjAwLTQ5NjktODlmNi1kYWI2NTIzZjUwZGUucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDQwMiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA0MDJUMTQxNTE5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YTFjNzE2ZjY5NmMxZWExNTIyMzZjYTg0NDI2NTkwNmFiMjI3YWI5NWQzNjU1MDFhYWFjZjAxYWVkY2E5MjU0MCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.RzzUzLYnQ58CLIf5BqEFky2xq8vztpeIR3uopV2YV_s)



