### PR TITLE
Don't allow shuffle for locked patterns

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -63,6 +63,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				getNextBlockClientId,
 				getPreviousBlockClientId,
 				canRemoveBlock,
+				canMoveBlock,
 			} = select( blockEditorStore );
 			const { getActiveBlockVariation, getBlockType } =
 				select( blocksStore );
@@ -107,6 +108,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				isNextBlockTemplatePart,
 				isPrevBlockTemplatePart,
 				canRemove: canRemoveBlock( clientId, rootClientId ),
+				canMove: canMoveBlock( clientId, rootClientId ),
 			};
 		},
 		[ clientId, rootClientId ]
@@ -120,6 +122,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 		isNextBlockTemplatePart,
 		isPrevBlockTemplatePart,
 		canRemove,
+		canMove,
 	} = selected;
 	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
@@ -318,7 +321,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 						</BlockDraggable>
 					) }
 				</FlexItem>
-				{ editorMode === 'zoom-out' && (
+				{ canMove && canRemove && editorMode === 'zoom-out' && (
 					<Shuffle clientId={ clientId } as={ Button } />
 				) }
 				{ canRemove &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Disable pattern shuffling UI if the pattern can not be moved or removed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because that is why it's locked, so it can't be changed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Hide the UI.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

0. Enable the zoom out experiemnt
1. In a page add multiple patterns
2. Select one of them (in the list view one of the top level groups)
3. Lock the pattern, disable move, removed
4. Activate zoom out mode
5. Check that when selecting the pattern container the shuffle icon only appear on unlocked patterns

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/f5df447d-c1c4-4f59-849f-bfef0ad1b4cc


