### PR TITLE
Performance: move style overrides to context

### DIFF
--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -36,10 +36,6 @@ export function ExperimentalBlockCanvas( {
 				__unstableContentRef={ localRef }
 				style={ { height, display: 'flex' } }
 			>
-				<EditorStyles
-					styles={ styles }
-					scope=".editor-styles-wrapper"
-				/>
 				<WritingFlow
 					ref={ contentRef }
 					className="editor-styles-wrapper"
@@ -49,7 +45,12 @@ export function ExperimentalBlockCanvas( {
 						width: '100%',
 					} }
 				>
-					{ children }
+					<EditorStyles
+						styles={ styles }
+						scope=".editor-styles-wrapper"
+					>
+						{ children }
+					</EditorStyles>
 				</WritingFlow>
 			</BlockTools>
 		);
@@ -69,8 +70,7 @@ export function ExperimentalBlockCanvas( {
 				} }
 				name="editor-canvas"
 			>
-				<EditorStyles styles={ styles } />
-				{ children }
+				<EditorStyles styles={ styles }>{ children }</EditorStyles>
 			</Iframe>
 		</BlockTools>
 	);

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -109,9 +109,10 @@ function ScaledBlockPreview( {
 							: minHeight,
 				} }
 			>
-				<EditorStyles styles={ editorStyles } />
-				{ contentResizeListener }
-				<MemoizedBlockList renderAppender={ false } />
+				<EditorStyles styles={ editorStyles }>
+					{ contentResizeListener }
+					<MemoizedBlockList renderAppender={ false } />
+				</EditorStyles>
 			</Iframe>
 		</Disabled>
 	);

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -140,8 +140,9 @@ export function useBlockPreview( { blocks, props = {}, layout } ) {
 			value={ renderedBlocks }
 			settings={ settings }
 		>
-			<EditorStyles />
-			<BlockListItems renderAppender={ false } layout={ layout } />
+			<EditorStyles>
+				<BlockListItems renderAppender={ false } layout={ layout } />
+			</EditorStyles>
 		</ExperimentalBlockEditorProvider>
 	);
 

--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -9,15 +9,19 @@ import a11yPlugin from 'colord/plugins/a11y';
  * WordPress dependencies
  */
 import { SVG } from '@wordpress/components';
-import { useCallback, useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import {
+	useCallback,
+	useMemo,
+	createContext,
+	useState,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import transformStyles from '../../utils/transform-styles';
-import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
+
+export const updateStyleContext = createContext( () => {} );
 
 extend( [ namesPlugin, a11yPlugin ] );
 
@@ -68,10 +72,7 @@ function useDarkThemeBodyClassName( styles, scope ) {
 }
 
 export default function EditorStyles( { styles, scope } ) {
-	const overrides = useSelect(
-		( select ) => unlock( select( blockEditorStore ) ).getStyleOverrides(),
-		[]
-	);
+	const [ overrides, setOverrides ] = useState( new Map() );
 	const [ transformedStyles, transformedSvgs ] = useMemo( () => {
 		const _styles = Object.values( styles ?? [] );
 
@@ -98,7 +99,7 @@ export default function EditorStyles( { styles, scope } ) {
 	}, [ styles, overrides, scope ] );
 
 	return (
-		<>
+		<updateStyleContext.Provider value={ setOverrides }>
 			{ /* Use an empty style element to have a document reference,
 			     but this could be any element. */ }
 			<style
@@ -121,6 +122,6 @@ export default function EditorStyles( { styles, scope } ) {
 				} }
 				dangerouslySetInnerHTML={ { __html: transformedSvgs } }
 			/>
-		</>
+		</updateStyleContext.Provider>
 	);
 }

--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -21,7 +21,7 @@ import {
  */
 import transformStyles from '../../utils/transform-styles';
 
-export const updateStyleContext = createContext( () => {} );
+export const updateStyleContext = createContext();
 
 extend( [ namesPlugin, a11yPlugin ] );
 
@@ -71,7 +71,7 @@ function useDarkThemeBodyClassName( styles, scope ) {
 	);
 }
 
-export default function EditorStyles( { styles, scope } ) {
+export default function EditorStyles( { styles, scope, children } ) {
 	const [ overrides, setOverrides ] = useState( new Map() );
 	const [ transformedStyles, transformedSvgs ] = useMemo( () => {
 		const _styles = Object.values( styles ?? [] );
@@ -122,6 +122,7 @@ export default function EditorStyles( { styles, scope } ) {
 				} }
 				dangerouslySetInnerHTML={ { __html: transformedSvgs } }
 			/>
+			{ children }
 		</updateStyleContext.Provider>
 	);
 }

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -275,21 +275,6 @@ export function setOpenedBlockSettingsMenu( clientId ) {
 	};
 }
 
-export function setStyleOverride( id, style ) {
-	return {
-		type: 'SET_STYLE_OVERRIDE',
-		id,
-		style,
-	};
-}
-
-export function deleteStyleOverride( id ) {
-	return {
-		type: 'DELETE_STYLE_OVERRIDE',
-		id,
-	};
-}
-
 /**
  * A higher-order action that mark every change inside a callback as "non-persistent"
  * and ignore pushing to the undo history stack. It's primarily used for synchronized

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -175,17 +175,6 @@ export function getOpenedBlockSettingsMenu( state ) {
 	return state.openedBlockSettingsMenu;
 }
 
-/**
- * Returns all style overrides, intended to be merged with global editor styles.
- *
- * @param {Object} state Global application state.
- *
- * @return {Map} A map of style IDs to style overrides.
- */
-export function getStyleOverrides( state ) {
-	return state.styleOverrides;
-}
-
 /** @typedef {import('./actions').InserterMediaCategory} InserterMediaCategory */
 /**
  * Returns the registered inserter media categories through the public API.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2011,27 +2011,6 @@ export function openedBlockSettingsMenu( state = null, action ) {
 }
 
 /**
- * Reducer returning a map of style IDs to style overrides.
- *
- * @param {Map}    state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Map} Updated state.
- */
-export function styleOverrides( state = new Map(), action ) {
-	switch ( action.type ) {
-		case 'SET_STYLE_OVERRIDE':
-			return new Map( state ).set( action.id, action.style );
-		case 'DELETE_STYLE_OVERRIDE': {
-			const newState = new Map( state );
-			newState.delete( action.id );
-			return newState;
-		}
-	}
-	return state;
-}
-
-/**
  * Reducer returning a map of the registered inserter media categories.
  *
  * @param {Array}  state  Current state.
@@ -2092,7 +2071,6 @@ const combinedReducers = combineReducers( {
 	temporarilyEditingFocusModeRevert,
 	blockVisibility,
 	blockEditingModes,
-	styleOverrides,
 	removalPromptData,
 	blockRemovalRules,
 	openedBlockSettingsMenu,

--- a/packages/edit-site/src/components/global-styles/preview-iframe.js
+++ b/packages/edit-site/src/components/global-styles/preview-iframe.js
@@ -124,7 +124,6 @@ export default function PreviewIframe( {
 					onMouseLeave={ () => setIsHovered( false ) }
 					tabIndex={ -1 }
 				>
-					<EditorStyles styles={ editorStyles } />
 					<motion.div
 						style={ {
 							height: normalizedHeight * ratio,
@@ -141,9 +140,13 @@ export default function PreviewIframe( {
 								: 'start'
 						}
 					>
-						{ []
-							.concat( children ) // This makes sure children is always an array.
-							.map( ( child, key ) => child( { ratio, key } ) ) }
+						<EditorStyles styles={ editorStyles }>
+							{ []
+								.concat( children ) // This makes sure children is always an array.
+								.map( ( child, key ) =>
+									child( { ratio, key } )
+								) }
+						</EditorStyles>
 					</motion.div>
 				</Iframe>
 			) }

--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -73,22 +73,23 @@ function Revisions( { userConfig, blocks } ) {
 				name="revisions"
 				tabIndex={ 0 }
 			>
-				<EditorStyles styles={ editorStyles } />
-				<style>
-					{
-						// Forming a "block formatting context" to prevent margin collapsing.
-						// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-						`.is-root-container { display: flow-root; }`
-					}
-				</style>
-				<Disabled className="edit-site-revisions__example-preview__content">
-					<ExperimentalBlockEditorProvider
-						value={ renderedBlocksArray }
-						settings={ settings }
-					>
-						<BlockList renderAppender={ false } />
-					</ExperimentalBlockEditorProvider>
-				</Disabled>
+				<EditorStyles styles={ editorStyles }>
+					<style>
+						{
+							// Forming a "block formatting context" to prevent margin collapsing.
+							// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
+							`.is-root-container { display: flow-root; }`
+						}
+					</style>
+					<Disabled className="edit-site-revisions__example-preview__content">
+						<ExperimentalBlockEditorProvider
+							value={ renderedBlocksArray }
+							settings={ settings }
+						>
+							<BlockList renderAppender={ false } />
+						</ExperimentalBlockEditorProvider>
+					</Disabled>
+				</EditorStyles>
 			</Iframe>
 		</EditorCanvasContainer>
 	);

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -351,36 +351,39 @@ const StyleBookBody = ( {
 			tabIndex={ 0 }
 			{ ...( onClick ? buttonModeProps : {} ) }
 		>
-			<EditorStyles styles={ settings.styles } />
-			<style>
-				{
-					// Forming a "block formatting context" to prevent margin collapsing.
-					// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-					`.is-root-container { display: flow-root; }
+			<EditorStyles styles={ settings.styles }>
+				<style>
+					{
+						// Forming a "block formatting context" to prevent margin collapsing.
+						// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
+						`.is-root-container { display: flow-root; }
 						body { position: relative; padding: 32px !important; }` +
-						STYLE_BOOK_IFRAME_STYLES +
-						buttonModeStyles
-				}
-			</style>
-			<Examples
-				className={ classnames( 'edit-site-style-book__examples', {
-					'is-wide': sizes.width > 600,
-				} ) }
-				examples={ examples }
-				category={ category }
-				label={
-					title
-						? sprintf(
-								// translators: %s: Category of blocks, e.g. Text.
-								__( 'Examples of blocks in the %s category' ),
-								title
-						  )
-						: __( 'Examples of blocks' )
-				}
-				isSelected={ isSelected }
-				onSelect={ onSelect }
-				key={ category }
-			/>
+							STYLE_BOOK_IFRAME_STYLES +
+							buttonModeStyles
+					}
+				</style>
+				<Examples
+					className={ classnames( 'edit-site-style-book__examples', {
+						'is-wide': sizes.width > 600,
+					} ) }
+					examples={ examples }
+					category={ category }
+					label={
+						title
+							? sprintf(
+									// translators: %s: Category of blocks, e.g. Text.
+									__(
+										'Examples of blocks in the %s category'
+									),
+									title
+							  )
+							: __( 'Examples of blocks' )
+					}
+					isSelected={ isSelected }
+					onSelect={ onSelect }
+					key={ category }
+				/>
+			</EditorStyles>
 		</Iframe>
 	);
 };

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -43,13 +43,14 @@ export default function WidgetAreasBlockEditorContent( {
 			{ ! isLargeViewport && <BlockToolbar hideDragHandle /> }
 			<BlockTools>
 				<KeyboardShortcuts />
-				<EditorStyles
-					styles={ styles }
-					scope=".editor-styles-wrapper"
-				/>
 				<BlockSelectionClearer>
 					<WritingFlow>
-						<BlockList className="edit-widgets-main-block-list" />
+						<EditorStyles
+							styles={ styles }
+							scope=".editor-styles-wrapper"
+						>
+							<BlockList className="edit-widgets-main-block-list" />
+						</EditorStyles>
 					</WritingFlow>
 				</BlockSelectionClearer>
 			</BlockTools>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Move style overrides from the block editor store to context. Originally I thought the block editor store would be best because it could eventually act as the public API, but now we have a much better hook `useStyleOverride` that can be used inside blocks or block hooks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These style overrides are causing too many dispatches to the block editor store during load. We should avoid polluting the block editor store with unrelated state. Every change causes selectors to be re-evaluated.

1st run -2.5% Replace template modal (Site Editor)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
