### PR TITLE
createSelector: don't forget results when dependency is null/boolean

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54678,7 +54678,6 @@
 				"@wordpress/hooks": "file:../hooks",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/rich-text": "file:../rich-text",
-				"rememo": "^4.0.2",
 				"uuid": "^9.0.1"
 			},
 			"engines": {
@@ -54874,7 +54873,6 @@
 				"postcss-urlrebase": "^1.0.0",
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^4.5.1",
-				"rememo": "^4.0.2",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -55035,7 +55033,6 @@
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"react-is": "^18.2.0",
-				"rememo": "^4.0.2",
 				"remove-accents": "^0.5.0",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
@@ -55084,8 +55081,7 @@
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/private-apis": "file:../private-apis",
 				"classnames": "^2.3.1",
-				"cmdk": "^0.2.0",
-				"rememo": "^4.0.2"
+				"cmdk": "^0.2.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -55285,7 +55281,6 @@
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
-				"rememo": "^4.0.2",
 				"uuid": "^9.0.1"
 			},
 			"engines": {
@@ -55684,8 +55679,7 @@
 				"@wordpress/warning": "file:../warning",
 				"@wordpress/widgets": "file:../widgets",
 				"classnames": "^2.3.1",
-				"memize": "^2.1.0",
-				"rememo": "^4.0.2"
+				"memize": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -55749,8 +55743,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
-				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.2"
+				"react-autosize-textarea": "^7.1.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -55792,8 +55785,7 @@
 				"@wordpress/reusable-blocks": "file:../reusable-blocks",
 				"@wordpress/url": "file:../url",
 				"@wordpress/widgets": "file:../widgets",
-				"classnames": "^2.3.1",
-				"rememo": "^4.0.2"
+				"classnames": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=12"
@@ -55845,7 +55837,6 @@
 				"date-fns": "^3.6.0",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.2",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -56321,8 +56312,7 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element",
-				"@wordpress/keycodes": "file:../keycodes",
-				"rememo": "^4.0.2"
+				"@wordpress/keycodes": "file:../keycodes"
 			},
 			"engines": {
 				"node": ">=12"
@@ -56434,8 +56424,7 @@
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
-				"@wordpress/icons": "file:../icons",
-				"rememo": "^4.0.2"
+				"@wordpress/icons": "file:../icons"
 			},
 			"engines": {
 				"node": ">=12"
@@ -56865,8 +56854,7 @@
 				"@wordpress/escape-html": "file:../escape-html",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/keycodes": "file:../keycodes",
-				"memize": "^2.1.0",
-				"rememo": "^4.0.2"
+				"memize": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -70763,7 +70751,6 @@
 				"@wordpress/hooks": "file:../hooks",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/rich-text": "file:../rich-text",
-				"rememo": "^4.0.2",
 				"uuid": "^9.0.1"
 			},
 			"dependencies": {
@@ -70898,7 +70885,6 @@
 				"postcss-urlrebase": "^1.0.0",
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^4.5.1",
-				"rememo": "^4.0.2",
 				"remove-accents": "^0.5.0"
 			},
 			"dependencies": {
@@ -71011,7 +70997,6 @@
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"react-is": "^18.2.0",
-				"rememo": "^4.0.2",
 				"remove-accents": "^0.5.0",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
@@ -71044,8 +71029,7 @@
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/private-apis": "file:../private-apis",
 				"classnames": "^2.3.1",
-				"cmdk": "^0.2.0",
-				"rememo": "^4.0.2"
+				"cmdk": "^0.2.0"
 			}
 		},
 		"@wordpress/components": {
@@ -71203,7 +71187,6 @@
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
-				"rememo": "^4.0.2",
 				"uuid": "^9.0.1"
 			},
 			"dependencies": {
@@ -71466,8 +71449,7 @@
 				"@wordpress/warning": "file:../warning",
 				"@wordpress/widgets": "file:../widgets",
 				"classnames": "^2.3.1",
-				"memize": "^2.1.0",
-				"rememo": "^4.0.2"
+				"memize": "^2.1.0"
 			}
 		},
 		"@wordpress/edit-site": {
@@ -71522,8 +71504,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
-				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.2"
+				"react-autosize-textarea": "^7.1.0"
 			}
 		},
 		"@wordpress/edit-widgets": {
@@ -71556,8 +71537,7 @@
 				"@wordpress/reusable-blocks": "file:../reusable-blocks",
 				"@wordpress/url": "file:../url",
 				"@wordpress/widgets": "file:../widgets",
-				"classnames": "^2.3.1",
-				"rememo": "^4.0.2"
+				"classnames": "^2.3.1"
 			}
 		},
 		"@wordpress/editor": {
@@ -71600,7 +71580,6 @@
 				"date-fns": "^3.6.0",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.2",
 				"remove-accents": "^0.5.0"
 			}
 		},
@@ -71885,8 +71864,7 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element",
-				"@wordpress/keycodes": "file:../keycodes",
-				"rememo": "^4.0.2"
+				"@wordpress/keycodes": "file:../keycodes"
 			}
 		},
 		"@wordpress/keycodes": {
@@ -71948,8 +71926,7 @@
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
-				"@wordpress/icons": "file:../icons",
-				"rememo": "^4.0.2"
+				"@wordpress/icons": "file:../icons"
 			}
 		},
 		"@wordpress/patterns": {
@@ -72218,8 +72195,7 @@
 				"@wordpress/escape-html": "file:../escape-html",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/keycodes": "file:../keycodes",
-				"memize": "^2.1.0",
-				"rememo": "^4.0.2"
+				"memize": "^2.1.0"
 			}
 		},
 		"@wordpress/router": {

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -30,7 +30,6 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
-		"rememo": "^4.0.2",
 		"uuid": "^9.0.1"
 	},
 	"peerDependencies": {

--- a/packages/annotations/src/store/selectors.js
+++ b/packages/annotations/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -76,7 +76,6 @@
 		"postcss-urlrebase": "^1.0.0",
 		"react-autosize-textarea": "^7.1.0",
 		"react-easy-crop": "^4.5.1",
-		"rememo": "^4.0.2",
 		"remove-accents": "^0.5.0"
 	},
 	"peerDependencies": {

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -21,7 +16,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { symbol } from '@wordpress/icons';
 import { create, remove, toHTMLString } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -51,7 +51,6 @@
 		"is-plain-object": "^5.0.0",
 		"memize": "^2.1.0",
 		"react-is": "^18.2.0",
-		"rememo": "^4.0.2",
 		"remove-accents": "^0.5.0",
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
 import removeAccents from 'remove-accents';
 
 /**
  * WordPress dependencies
  */
 import { pipe } from '@wordpress/compose';
+import { createSelector } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -35,8 +35,7 @@
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/private-apis": "file:../private-apis",
 		"classnames": "^2.3.1",
-		"cmdk": "^0.2.0",
-		"rememo": "^4.0.2"
+		"cmdk": "^0.2.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/commands/src/store/selectors.js
+++ b/packages/commands/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 
 /**
  * Returns the registered static commands.

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -50,7 +50,6 @@
 		"equivalent-key-map": "^0.2.2",
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^2.1.0",
-		"rememo": "^4.0.2",
 		"uuid": "^9.0.1"
 	},
 	"peerDependencies": {

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
 import EquivalentKeyMap from 'equivalent-key-map';
+
+/**
+ * WordPress dependencies
+ */
+import { createSelector } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -4,11 +4,6 @@
 import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
- * WordPress dependencies
- */
-import { createSelector } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import getQueryParts from './get-query-parts';
@@ -108,7 +103,7 @@ function getQueriedItemsUncached( state, query ) {
  *
  * @return {?Array} Query items.
  */
-export const getQueriedItems = createSelector( ( state, query = {} ) => {
+export const getQueriedItems = ( state, query = {} ) => {
 	let queriedItemsCache = queriedItemsCacheByState.get( state );
 	if ( queriedItemsCache ) {
 		const queriedItems = queriedItemsCache.get( query );
@@ -123,7 +118,7 @@ export const getQueriedItems = createSelector( ( state, query = {} ) => {
 	const items = getQueriedItemsUncached( state, query );
 	queriedItemsCache.set( query, items );
 	return items;
-} );
+};
 
 export function getQueriedTotalItems( state, query = {} ) {
 	const { stableKey, context } = getQueryParts( query );

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -482,6 +482,10 @@ _Returns_
 
 -   `Function`: Registry selector that can be registered with a store.
 
+### createSelector
+
+Undocumented declaration.
+
 ### dispatch
 
 Given a store descriptor, returns an object of the store's action creators. Calling an action creator will cause it to be dispatched, updating the state value accordingly.

--- a/packages/data/src/create-selector.js
+++ b/packages/data/src/create-selector.js
@@ -1,1 +1,0 @@
-export { default as createSelector } from 'rememo';

--- a/packages/data/src/create-selector.js
+++ b/packages/data/src/create-selector.js
@@ -1,0 +1,1 @@
+export { default as createSelector } from 'rememo';

--- a/packages/data/src/create-selector.ts
+++ b/packages/data/src/create-selector.ts
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import createSel from 'rememo';
+
+const NULL_OBJ = {};
+const TRUE_OBJ = {};
+const FALSE_OBJ = {};
+
+export function createSelector< S extends ( ...args: any[] ) => any >(
+	sel: S,
+	dep: any
+): S {
+	return createSel( sel, ( ...args ) => {
+		if ( ! dep ) {
+			return [];
+		}
+
+		const deps = dep( ...args );
+
+		return deps.map( ( d: any ) => {
+			if ( d === null || d === undefined ) {
+				return NULL_OBJ;
+			}
+			if ( d === true ) {
+				return TRUE_OBJ;
+			}
+
+			if ( d === false ) {
+				return FALSE_OBJ;
+			}
+
+			return d;
+		} );
+	} );
+}

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -23,6 +23,7 @@ export { useDispatch } from './components/use-dispatch';
 export { AsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { createRegistrySelector, createRegistryControl } from './factory';
+export { createSelector } from './create-selector';
 export { controls } from './controls';
 export { default as createReduxStore } from './redux-store';
 export { dispatch } from './dispatch';

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
@@ -11,6 +6,7 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
+import { createSelector } from '../../create-selector';
 import { selectorArgsToStateKey } from './utils';
 
 /** @typedef {Record<string, import('./reducer').State>} State */

--- a/packages/data/src/test/registry-selectors.js
+++ b/packages/data/src/test/registry-selectors.js
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * Internal dependencies
  */
 import { createRegistry } from '../registry';
 import { createRegistrySelector } from '../factory';
+import { createSelector } from '..';
 import createReduxStore from '../redux-store';
 
 const getElementCount = createRegistrySelector( ( select ) => () => {

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -58,8 +58,7 @@
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/widgets": "file:../widgets",
 		"classnames": "^2.3.1",
-		"memize": "^2.1.0",
-		"rememo": "^4.0.2"
+		"memize": "^2.1.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as coreStore } from '@wordpress/core-data';

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -75,8 +75,7 @@
 		"fast-deep-equal": "^3.1.3",
 		"is-plain-object": "^5.0.0",
 		"memize": "^2.1.0",
-		"react-autosize-textarea": "^7.1.0",
-		"rememo": "^4.0.2"
+		"react-autosize-textarea": "^7.1.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
 import { parse } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useSelect, createSelector } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { decodeEntities } from '@wordpress/html-entities';

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -53,8 +53,7 @@
 		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/url": "file:../url",
 		"@wordpress/widgets": "file:../widgets",
-		"classnames": "^2.3.1",
-		"rememo": "^4.0.2"
+		"classnames": "^2.3.1"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -67,7 +67,6 @@
 		"date-fns": "^3.6.0",
 		"memize": "^2.1.0",
 		"react-autosize-textarea": "^7.1.0",
-		"rememo": "^4.0.2",
 		"remove-accents": "^0.5.0"
 	},
 	"peerDependencies": {

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 import {
 	layout,
 	symbol,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -14,7 +9,7 @@ import {
 } from '@wordpress/blocks';
 import { isInTheFuture, getDate } from '@wordpress/date';
 import { addQueryArgs, cleanForSlug } from '@wordpress/url';
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { Platform } from '@wordpress/element';
 import { layout } from '@wordpress/icons';

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -28,8 +28,7 @@
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
-		"@wordpress/keycodes": "file:../keycodes",
-		"rememo": "^4.0.2"
+		"@wordpress/keycodes": "file:../keycodes"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/keyboard-shortcuts/src/store/selectors.js
+++ b/packages/keyboard-shortcuts/src/store/selectors.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
+import { createSelector } from '@wordpress/data';
 import {
 	displayShortcut,
 	shortcutAriaLabel,

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -37,8 +37,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"@wordpress/icons": "file:../icons",
-		"rememo": "^4.0.2"
+		"@wordpress/icons": "file:../icons"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/nux/src/store/selectors.js
+++ b/packages/nux/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 
 /**
  * An object containing information about a guide.

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -39,8 +39,7 @@
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/keycodes": "file:../keycodes",
-		"memize": "^2.1.0",
-		"rememo": "^4.0.2"
+		"memize": "^2.1.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/rich-text/src/store/selectors.js
+++ b/packages/rich-text/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 
 /**
  * Returns all the available format types.


### PR DESCRIPTION
Patch `createSelector` so that it converts `null`/`true`/`false` values to constant objects. Should prevent `rememo` cache from forgetting good calculated results too often.