### PR TITLE
Editor: Use the 'ConfirmDialog' component in template validation notice

### DIFF
--- a/packages/editor/src/components/template-validation-notice/index.js
+++ b/packages/editor/src/components/template-validation-notice/index.js
@@ -1,50 +1,57 @@
 /**
  * WordPress dependencies
  */
-import { Notice } from '@wordpress/components';
+import {
+	Notice,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 function TemplateValidationNotice( { isValid, ...props } ) {
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
 	if ( isValid ) {
 		return null;
 	}
 
-	const confirmSynchronization = () => {
-		if (
-			// eslint-disable-next-line no-alert
-			window.confirm(
-				__(
-					'Resetting the template may result in loss of content, do you want to continue?'
-				)
-			)
-		) {
-			props.synchronizeTemplate();
-		}
-	};
-
 	return (
-		<Notice
-			className="editor-template-validation-notice"
-			isDismissible={ false }
-			status="warning"
-			actions={ [
-				{
-					label: __( 'Keep it as is' ),
-					onClick: props.resetTemplateValidity,
-				},
-				{
-					label: __( 'Reset the template' ),
-					onClick: confirmSynchronization,
-				},
-			] }
-		>
-			{ __(
-				'The content of your post doesn’t match the template assigned to your post type.'
-			) }
-		</Notice>
+		<>
+			<Notice
+				className="editor-template-validation-notice"
+				isDismissible={ false }
+				status="warning"
+				actions={ [
+					{
+						label: __( 'Keep it as is' ),
+						onClick: props.resetTemplateValidity,
+					},
+					{
+						label: __( 'Reset the template' ),
+						onClick: () => setShowConfirmDialog( true ),
+					},
+				] }
+			>
+				{ __(
+					'The content of your post doesn’t match the template assigned to your post type.'
+				) }
+			</Notice>
+			<ConfirmDialog
+				isOpen={ showConfirmDialog }
+				onConfirm={ () => {
+					setShowConfirmDialog( false );
+					props.synchronizeTemplate();
+				} }
+				onCancel={ () => setShowConfirmDialog( false ) }
+			>
+				{ __(
+					'Resetting the template may result in loss of content, do you want to continue?'
+				) }
+			</ConfirmDialog>
+		</>
 	);
 }
 

--- a/packages/editor/src/components/template-validation-notice/index.js
+++ b/packages/editor/src/components/template-validation-notice/index.js
@@ -47,6 +47,7 @@ export default function TemplateValidationNotice() {
 			</Notice>
 			<ConfirmDialog
 				isOpen={ showConfirmDialog }
+				confirmButtonText={ __( 'Reset' ) }
 				onConfirm={ () => {
 					setShowConfirmDialog( false );
 					synchronizeTemplate();

--- a/packages/editor/src/components/template-validation-notice/index.js
+++ b/packages/editor/src/components/template-validation-notice/index.js
@@ -12,10 +12,8 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 
 export default function TemplateValidationNotice() {
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
-	const { isValid } = useSelect( ( select ) => {
-		return {
-			isValid: select( blockEditorStore ).isValidTemplate(),
-		};
+	const isValid = useSelect( ( select ) => {
+		return select( blockEditorStore ).isValidTemplate();
 	}, [] );
 	const { setTemplateValidity, synchronizeTemplate } =
 		useDispatch( blockEditorStore );

--- a/packages/editor/src/components/template-validation-notice/index.js
+++ b/packages/editor/src/components/template-validation-notice/index.js
@@ -6,13 +6,19 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-function TemplateValidationNotice( { isValid, ...props } ) {
+export default function TemplateValidationNotice() {
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+	const { isValid } = useSelect( ( select ) => {
+		return {
+			isValid: select( blockEditorStore ).isValidTemplate(),
+		};
+	}, [] );
+	const { setTemplateValidity, synchronizeTemplate } =
+		useDispatch( blockEditorStore );
 
 	if ( isValid ) {
 		return null;
@@ -27,7 +33,7 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 				actions={ [
 					{
 						label: __( 'Keep it as is' ),
-						onClick: props.resetTemplateValidity,
+						onClick: () => setTemplateValidity( true ),
 					},
 					{
 						label: __( 'Reset the template' ),
@@ -43,7 +49,7 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 				isOpen={ showConfirmDialog }
 				onConfirm={ () => {
 					setShowConfirmDialog( false );
-					props.synchronizeTemplate();
+					synchronizeTemplate();
 				} }
 				onCancel={ () => setShowConfirmDialog( false ) }
 			>
@@ -54,17 +60,3 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 		</>
 	);
 }
-
-export default compose( [
-	withSelect( ( select ) => ( {
-		isValid: select( blockEditorStore ).isValidTemplate(),
-	} ) ),
-	withDispatch( ( dispatch ) => {
-		const { setTemplateValidity, synchronizeTemplate } =
-			dispatch( blockEditorStore );
-		return {
-			resetTemplateValidity: () => setTemplateValidity( true ),
-			synchronizeTemplate,
-		};
-	} ),
-] )( TemplateValidationNotice );

--- a/packages/editor/src/components/template-validation-notice/style.scss
+++ b/packages/editor/src/components/template-validation-notice/style.scss
@@ -1,9 +1,0 @@
-.editor-template-validation-notice {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-
-	.components-button {
-		margin-left: 5px;
-	}
-}

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -31,4 +31,3 @@
 @import "./components/preview-dropdown/style.scss";
 @import "./components/table-of-contents/style.scss";
 @import "./components/template-areas/style.scss";
-@import "./components/template-validation-notice/style.scss";


### PR DESCRIPTION
## What?
Closes #16583.
Closes #33937.

PR updates `TemplateValidationNotice` to use the `ConfirmDialog` component instead of the native `window.config` for displaying the confirmation message.

It also includes two additional code quality improvements:
* Updates component to use data hooks instead of HoCs.
* Removes custom styles, which I think became redundant after #16891 and #20578.

## Why?
The new `ConfirmDialog` is a recommended component for handling confirmation logic.

## Testing Instructions
1. Open a post or page.
2. Emulate invalid template by running snippet in DevTools console - `wp.data.dispatch( 'core/block-editor' ).setTemplateValidity( false );`
3. Confirm notice is displayed as before (without style regression).
4. Clicking "Reset the template" should display a confirmation modal.
5. Confirm you can discard or accept the action.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-02 at 19 06 56](https://github.com/WordPress/gutenberg/assets/240569/7d25057e-d485-47ca-8e87-20e772ca4a91)
