### PR TITLE
Add __experimentalUpdateSpecifiedEntityEdits and use it on the Font Library update button

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -39,8 +39,9 @@ import { toggleFont } from './utils/toggleFont';
 export const FontLibraryContext = createContext( {} );
 
 function FontLibraryProvider( { children } ) {
-	const { __experimentalSaveSpecifiedEntityEdits: saveSpecifiedEntityEdits } =
-		useDispatch( coreStore );
+	const {
+		__experimentalUpdateSpecifiedEntityEdits: updateSpecifiedEntityEdits,
+	} = useDispatch( coreStore );
 	const { globalStylesId } = useSelect( ( select ) => {
 		const { __experimentalGetCurrentGlobalStylesId } = select( coreStore );
 		return { globalStylesId: __experimentalGetCurrentGlobalStylesId() };
@@ -96,7 +97,7 @@ function FontLibraryProvider( { children } ) {
 
 	// Save font families to the global styles post in the database.
 	const saveFontFamilies = () => {
-		saveSpecifiedEntityEdits( 'root', 'globalStyles', globalStylesId, [
+		updateSpecifiedEntityEdits( 'root', 'globalStyles', globalStylesId, [
 			'settings.typography.fontFamilies',
 		] );
 	};
@@ -325,7 +326,7 @@ function FontLibraryProvider( { children } ) {
 				activateCustomFontFamilies( fontFamiliesToActivate );
 
 				// Save the global styles to the database.
-				await saveSpecifiedEntityEdits(
+				await updateSpecifiedEntityEdits(
 					'root',
 					'globalStyles',
 					globalStylesId,
@@ -362,7 +363,7 @@ function FontLibraryProvider( { children } ) {
 			if ( uninstalledFontFamily.deleted ) {
 				deactivateFontFamily( fontFamilyToUninstall );
 				// Save the global styles to the database.
-				await saveSpecifiedEntityEdits(
+				await updateSpecifiedEntityEdits(
 					'root',
 					'globalStyles',
 					globalStylesId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Adds `__experimentalUpdateSpecifiedEntityEdits`.
- Uses `__experimentalUpdateSpecifiedEntityEdits` instead of `__experimentalSaveSpecifiedEntityEdits` to persist changes to global styles with the Font Library,

## Why?
To allow update only some specified entity edits to the database.
Fixes: https://github.com/WordPress/gutenberg/issues/60343

## How?
Adding `__experimentalUpdateSpecifiedEntityEdits` that gets the content of the database as the base to apply certain edits.


## Example and comparisons:

Let's say we have a post and the following conditions.

- Database has this content:
```json
{ "a": "a"}
```

Client-side code made some changes to the data coming from the database.

- Client-side entity has:
```json
{ "a": "a", "b":"b", "c":"c" }
```

- We want to persist to the database only the following JSON without changing the client-side entity:
```json
{ "a": "a", "c":"c" }
```


**Using `saveEntityRecord`**

```
saveEntityRecord( 'root', 'post-type', 1, { "a": "a", "b":"b", "c":"c" } )
```

`{ "a": "a", "b":"b", "c":"c" }` is persisted to the database.



**Using `__experimentalUpdateSpecifiedEntityEdits`:**
```js
__experimentalUpdateSpecifiedEntityEdits( 'root', 'post-type', 1, [  'c'  ] );
```
 `{ "a": "a", "c":"c" }` is to the database.



**Using `__experimentalSaveSpecifiedEntityEdits`:**
```js
__experimentalSaveSpecifiedEntityEdits( 'root', 'post-type', 1, [  'c'  ] );
```
`{"c":"c" }` is to the database without changing the client-side entity.

