### PR TITLE
Only close inserter on Escape or button press on inserter toggle

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -6,14 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	forwardRef,
-	useState,
-	useCallback,
-	useMemo,
-	useImperativeHandle,
-	useRef,
-} from '@wordpress/element';
+import { forwardRef, useState, useCallback, useMemo } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -36,6 +29,7 @@ import { store as blockEditorStore } from '../../store';
 import { useZoomOut } from '../../hooks/use-zoom-out';
 
 const NOOP = () => {};
+
 function InserterMenu(
 	{
 		rootClientId,
@@ -131,37 +125,104 @@ function InserterMenu(
 	);
 
 	const showPatternPanel =
-		selectedTab === 'patterns' &&
-		! delayedFilterValue &&
-		selectedPatternCategory;
+		selectedTab === 'patterns' && selectedPatternCategory;
 
 	const showMediaPanel =
 		selectedTab === 'media' &&
 		! delayedFilterValue &&
 		selectedMediaCategory;
 
+	const SearchPanel = ( { searchType } ) => (
+		<>
+			<SearchControl
+				__nextHasNoMarginBottom
+				className="block-editor-inserter__search"
+				onChange={ ( value ) => {
+					if ( hoveredItem ) setHoveredItem( null );
+					setFilterValue( value );
+				} }
+				value={ filterValue }
+				label={ __( 'Search for blocks and patterns' ) }
+				placeholder={ __( 'Search' ) }
+			/>
+			{ !! delayedFilterValue && (
+				<InserterSearchResults
+					filterValue={ delayedFilterValue }
+					onSelect={ onSelect }
+					onHover={ onHover }
+					onHoverPattern={ onHoverPattern }
+					rootClientId={ rootClientId }
+					clientId={ clientId }
+					isAppender={ isAppender }
+					__experimentalInsertionIndex={
+						__experimentalInsertionIndex
+					}
+					showBlockDirectory
+					shouldFocusBlock={ shouldFocusBlock }
+					maxBlockPatterns={
+						searchType !== 'patterns' ? 0 : undefined
+					}
+					maxBlockTypes={ searchType !== 'blocks' ? 0 : undefined }
+				/>
+			) }
+		</>
+	);
+
 	const blocksTab = useMemo(
 		() => (
 			<>
-				<div className="block-editor-inserter__block-list">
-					<BlockTypesTab
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsert }
+				<SearchControl
+					__nextHasNoMarginBottom
+					className="block-editor-inserter__search"
+					onChange={ ( value ) => {
+						if ( hoveredItem ) setHoveredItem( null );
+						setFilterValue( value );
+					} }
+					value={ filterValue }
+					label={ __( 'Search for blocks and patterns' ) }
+					placeholder={ __( 'Search' ) }
+				/>
+				{ !! delayedFilterValue && (
+					<InserterSearchResults
+						filterValue={ delayedFilterValue }
+						onSelect={ onSelect }
 						onHover={ onHover }
-						showMostUsedBlocks={ showMostUsedBlocks }
+						onHoverPattern={ onHoverPattern }
+						rootClientId={ rootClientId }
+						clientId={ clientId }
+						isAppender={ isAppender }
+						__experimentalInsertionIndex={
+							__experimentalInsertionIndex
+						}
+						showBlockDirectory
+						shouldFocusBlock={ shouldFocusBlock }
+						maxBlockPatterns={ 0 }
 					/>
-				</div>
-				{ showInserterHelpPanel && (
-					<div className="block-editor-inserter__tips">
-						<VisuallyHidden as="h2">
-							{ __( 'A tip for using the block editor' ) }
-						</VisuallyHidden>
-						<Tips />
-					</div>
+				) }
+				{ ! delayedFilterValue && (
+					<>
+						<div className="block-editor-inserter__block-list">
+							<BlockTypesTab
+								rootClientId={ destinationRootClientId }
+								onInsert={ onInsert }
+								onHover={ onHover }
+								showMostUsedBlocks={ showMostUsedBlocks }
+							/>
+						</div>
+						{ showInserterHelpPanel && (
+							<div className="block-editor-inserter__tips">
+								<VisuallyHidden as="h2">
+									{ __( 'A tip for using the block editor' ) }
+								</VisuallyHidden>
+								<Tips />
+							</div>
+						) }
+					</>
 				) }
 			</>
 		),
 		[
+			delayedFilterValue,
 			destinationRootClientId,
 			onInsert,
 			onHover,
@@ -172,25 +233,58 @@ function InserterMenu(
 
 	const patternsTab = useMemo(
 		() => (
-			<BlockPatternsTab
-				rootClientId={ destinationRootClientId }
-				onInsert={ onInsertPattern }
-				onSelectCategory={ onClickPatternCategory }
-				selectedCategory={ selectedPatternCategory }
-			>
-				{ showPatternPanel && (
-					<PatternCategoryPreviewPanel
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsertPattern }
-						onHover={ onHoverPattern }
-						category={ selectedPatternCategory }
-						patternFilter={ patternFilter }
-						showTitlesAsTooltip
+			<>
+				<SearchControl
+					__nextHasNoMarginBottom
+					className="block-editor-inserter__search"
+					onChange={ ( value ) => {
+						if ( hoveredItem ) setHoveredItem( null );
+						setFilterValue( value );
+					} }
+					value={ filterValue }
+					label={ __( 'Search for blocks and patterns' ) }
+					placeholder={ __( 'Search' ) }
+				/>
+				{ !! delayedFilterValue && (
+					<InserterSearchResults
+						filterValue={ delayedFilterValue }
+						onSelect={ onSelect }
+						onHover={ onHover }
+						onHoverPattern={ onHoverPattern }
+						rootClientId={ rootClientId }
+						clientId={ clientId }
+						isAppender={ isAppender }
+						__experimentalInsertionIndex={
+							__experimentalInsertionIndex
+						}
+						showBlockDirectory
+						shouldFocusBlock={ shouldFocusBlock }
+						maxBlockTypes={ 0 }
 					/>
 				) }
-			</BlockPatternsTab>
+				{ ! delayedFilterValue && (
+					<BlockPatternsTab
+						rootClientId={ destinationRootClientId }
+						onInsert={ onInsertPattern }
+						onSelectCategory={ onClickPatternCategory }
+						selectedCategory={ selectedPatternCategory }
+					>
+						{ showPatternPanel && (
+							<PatternCategoryPreviewPanel
+								rootClientId={ destinationRootClientId }
+								onInsert={ onInsertPattern }
+								onHover={ onHoverPattern }
+								category={ selectedPatternCategory }
+								patternFilter={ patternFilter }
+								showTitlesAsTooltip
+							/>
+						) }
+					</BlockPatternsTab>
+				) }
+			</>
 		),
 		[
+			delayedFilterValue,
 			destinationRootClientId,
 			onHoverPattern,
 			onInsertPattern,
@@ -236,14 +330,7 @@ function InserterMenu(
 		[ blocksTab, mediaTab, patternsTab ]
 	);
 
-	const searchRef = useRef();
-	useImperativeHandle( ref, () => ( {
-		focusSearch: () => {
-			searchRef.current.focus();
-		},
-	} ) );
-
-	const showAsTabs = ! delayedFilterValue && ( showPatterns || showMedia );
+	const showAsTabs = showPatterns || showMedia;
 
 	// When the pattern panel is showing, we want to use zoom out mode
 	useZoomOut( showPatternPanel );
@@ -261,42 +348,14 @@ function InserterMenu(
 			className={ classnames( 'block-editor-inserter__menu', {
 				'show-panel': showPatternPanel || showMediaPanel,
 			} ) }
+			ref={ ref }
+			tabIndex={ -1 } // Fallback if there are no focusables
 		>
 			<div
 				className={ classnames( 'block-editor-inserter__main-area', {
 					'show-as-tabs': showAsTabs,
 				} ) }
 			>
-				<SearchControl
-					__nextHasNoMarginBottom
-					className="block-editor-inserter__search"
-					onChange={ ( value ) => {
-						if ( hoveredItem ) setHoveredItem( null );
-						setFilterValue( value );
-					} }
-					value={ filterValue }
-					label={ __( 'Search for blocks and patterns' ) }
-					placeholder={ __( 'Search' ) }
-					ref={ searchRef }
-				/>
-				{ !! delayedFilterValue && (
-					<div className="block-editor-inserter__no-tab-container">
-						<InserterSearchResults
-							filterValue={ delayedFilterValue }
-							onSelect={ onSelect }
-							onHover={ onHover }
-							onHoverPattern={ onHoverPattern }
-							rootClientId={ rootClientId }
-							clientId={ clientId }
-							isAppender={ isAppender }
-							__experimentalInsertionIndex={
-								__experimentalInsertionIndex
-							}
-							showBlockDirectory
-							shouldFocusBlock={ shouldFocusBlock }
-						/>
-					</div>
-				) }
 				{ showAsTabs && (
 					<InserterTabs
 						showPatterns={ showPatterns }
@@ -305,7 +364,7 @@ function InserterMenu(
 						tabsContents={ inserterTabsContents }
 					/>
 				) }
-				{ ! delayedFilterValue && ! showAsTabs && (
+				{ ! showAsTabs && (
 					<div className="block-editor-inserter__no-tab-container">
 						{ blocksTab }
 					</div>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -132,40 +132,34 @@ function InserterMenu(
 		! delayedFilterValue &&
 		selectedMediaCategory;
 
-	const SearchPanel = ( { searchType } ) => (
-		<>
-			<SearchControl
-				__nextHasNoMarginBottom
-				className="block-editor-inserter__search"
-				onChange={ ( value ) => {
-					if ( hoveredItem ) setHoveredItem( null );
-					setFilterValue( value );
-				} }
-				value={ filterValue }
-				label={ __( 'Search for blocks and patterns' ) }
-				placeholder={ __( 'Search' ) }
-			/>
-			{ !! delayedFilterValue && (
-				<InserterSearchResults
-					filterValue={ delayedFilterValue }
-					onSelect={ onSelect }
-					onHover={ onHover }
-					onHoverPattern={ onHoverPattern }
-					rootClientId={ rootClientId }
-					clientId={ clientId }
-					isAppender={ isAppender }
-					__experimentalInsertionIndex={
-						__experimentalInsertionIndex
-					}
-					showBlockDirectory
-					shouldFocusBlock={ shouldFocusBlock }
-					maxBlockPatterns={
-						searchType !== 'patterns' ? 0 : undefined
-					}
-					maxBlockTypes={ searchType !== 'blocks' ? 0 : undefined }
-				/>
-			) }
-		</>
+	const BlocksTabContents = useMemo(
+		() => (
+			<>
+				<div className="block-editor-inserter__block-list">
+					<BlockTypesTab
+						rootClientId={ destinationRootClientId }
+						onInsert={ onInsert }
+						onHover={ onHover }
+						showMostUsedBlocks={ showMostUsedBlocks }
+					/>
+				</div>
+				{ showInserterHelpPanel && (
+					<div className="block-editor-inserter__tips">
+						<VisuallyHidden as="h2">
+							{ __( 'A tip for using the block editor' ) }
+						</VisuallyHidden>
+						<Tips />
+					</div>
+				) }
+			</>
+		),
+		[
+			destinationRootClientId,
+			onInsert,
+			onHover,
+			showMostUsedBlocks,
+			showInserterHelpPanel,
+		]
 	);
 
 	const blocksTab = useMemo(
@@ -199,35 +193,41 @@ function InserterMenu(
 						maxBlockPatterns={ 0 }
 					/>
 				) }
-				{ ! delayedFilterValue && (
-					<>
-						<div className="block-editor-inserter__block-list">
-							<BlockTypesTab
-								rootClientId={ destinationRootClientId }
-								onInsert={ onInsert }
-								onHover={ onHover }
-								showMostUsedBlocks={ showMostUsedBlocks }
-							/>
-						</div>
-						{ showInserterHelpPanel && (
-							<div className="block-editor-inserter__tips">
-								<VisuallyHidden as="h2">
-									{ __( 'A tip for using the block editor' ) }
-								</VisuallyHidden>
-								<Tips />
-							</div>
-						) }
-					</>
-				) }
+				{ ! delayedFilterValue && BlocksTabContents }
 			</>
+		),
+		[ delayedFilterValue ]
+	);
+
+	const PatternsTabContents = useMemo(
+		() => (
+			<BlockPatternsTab
+				rootClientId={ destinationRootClientId }
+				onInsert={ onInsertPattern }
+				onSelectCategory={ onClickPatternCategory }
+				selectedCategory={ selectedPatternCategory }
+			>
+				{ showPatternPanel && (
+					<PatternCategoryPreviewPanel
+						rootClientId={ destinationRootClientId }
+						onInsert={ onInsertPattern }
+						onHover={ onHoverPattern }
+						category={ selectedPatternCategory }
+						patternFilter={ patternFilter }
+						showTitlesAsTooltip
+					/>
+				) }
+			</BlockPatternsTab>
 		),
 		[
 			delayedFilterValue,
 			destinationRootClientId,
-			onInsert,
-			onHover,
-			showMostUsedBlocks,
-			showInserterHelpPanel,
+			onHoverPattern,
+			onInsertPattern,
+			onClickPatternCategory,
+			patternFilter,
+			selectedPatternCategory,
+			showPatternPanel,
 		]
 	);
 
@@ -262,37 +262,10 @@ function InserterMenu(
 						maxBlockTypes={ 0 }
 					/>
 				) }
-				{ ! delayedFilterValue && (
-					<BlockPatternsTab
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsertPattern }
-						onSelectCategory={ onClickPatternCategory }
-						selectedCategory={ selectedPatternCategory }
-					>
-						{ showPatternPanel && (
-							<PatternCategoryPreviewPanel
-								rootClientId={ destinationRootClientId }
-								onInsert={ onInsertPattern }
-								onHover={ onHoverPattern }
-								category={ selectedPatternCategory }
-								patternFilter={ patternFilter }
-								showTitlesAsTooltip
-							/>
-						) }
-					</BlockPatternsTab>
-				) }
+				{ ! delayedFilterValue && PatternsTabContents }
 			</>
 		),
-		[
-			delayedFilterValue,
-			destinationRootClientId,
-			onHoverPattern,
-			onInsertPattern,
-			onClickPatternCategory,
-			patternFilter,
-			selectedPatternCategory,
-			showPatternPanel,
-		]
+		[ delayedFilterValue ]
 	);
 
 	const mediaTab = useMemo(

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -5,13 +5,11 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, VisuallyHidden } from '@wordpress/components';
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
 import { close } from '@wordpress/icons';
-import {
-	useViewportMatch,
-	__experimentalUseDialog as useDialog,
-} from '@wordpress/compose';
+import { useViewportMatch, useRefEffect } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -35,22 +33,34 @@ export default function InserterSidebar( {
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
-	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: () => setIsInserterOpened( false ),
-		focusOnMount: null,
-	} );
 
 	const libraryRef = useRef();
 	useEffect( () => {
 		libraryRef.current.focusSearch();
 	}, [] );
 
+	const useEscape = useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			const { keyCode } = event;
+
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			if ( keyCode === ESCAPE ) {
+				event.preventDefault();
+				setIsInserterOpened( false );
+			}
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+
 	return (
-		<div
-			ref={ inserterDialogRef }
-			{ ...inserterDialogProps }
-			className="editor-inserter-sidebar"
-		>
+		<div ref={ useEscape } className="editor-inserter-sidebar">
 			<TagName className="editor-inserter-sidebar__header">
 				<Button
 					icon={ close }

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ESCAPE } from '@wordpress/keycodes';
+import { focus } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -34,12 +35,9 @@ export default function InserterSidebar( {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 
-	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
+	const libraryRef = useRefEffect( ( element ) => {
+		focus.focusable.find( element )[ 0 ]?.focus() || element.focus();
 
-	const useEscape = useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
 			const { keyCode } = event;
 
@@ -60,7 +58,7 @@ export default function InserterSidebar( {
 	}, [] );
 
 	return (
-		<div ref={ useEscape } className="editor-inserter-sidebar">
+		<div ref={ libraryRef } className="editor-inserter-sidebar">
 			<TagName className="editor-inserter-sidebar__header">
 				<Button
 					icon={ close }


### PR DESCRIPTION
Remove the useDialog hook, as it was only used for focus outside and escape keypresses to close the inserter. It doesn't appear any semantics were added. This manually implements an escape keypress hook to close the inserter when focus is inside the inserter.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
