### PR TITLE
Don't enter zoom-out mode unless on site editor

### DIFF
--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -3,6 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { getPath } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -13,6 +14,16 @@ import { store as blockEditorStore } from '../store';
  * A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
  */
 export function useZoomOut() {
+	const isSiteEditor = getPath( window.location.href )?.includes(
+		'site-editor.php'
+	);
+
+	// The site editor is the only one that should be allowed to enter zoom out mode.
+	// It's OK to violate the rules of hooks here, as this will always return the same on the same page load.
+	if ( ! isSiteEditor ) {
+		return;
+	}
+	/* eslint-disable react-hooks/rules-of-hooks */
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 	const { mode } = useSelect( ( select ) => {
 		return {
@@ -33,4 +44,5 @@ export function useZoomOut() {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
+	/* eslint-enable react-hooks/rules-of-hooks */
 }


### PR DESCRIPTION
The useZoomOut hook is the only place in the codebase that sets zoom-out mode outside of the site editor. This may be better as a developer preference passed into the block editor though, like `allowZoomOut`? I'm worried about going straight for an option that we need to support long-term though. May be better to try this way first and see how it feels.

## What?
<!-- In a few words, what is the PR actually doing? -->
Don't allow zoom out mode unless on the site editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The post-editor does not have zoom-out mode, so when it tries to enter zoom-out mode some odd things happen, such as all of the potential appender buttons appearing at once.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Return early on the useZoomOut hook. This is OK, as it will always evaluate the same on each page. The order of the hooks should never change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Test the useZoomOut hook by doing these steps on the post editor and site editor:
- Open the sidebar inserter
- Click Patterns
- Select a pattern category
- On the site editor, it should enter zoom out mode
- On the post editor, it should not enter zoom out mode

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
