### PR TITLE
Editor styles: relocate .editor-styles-wrapper class to the HTML element

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -150,7 +150,9 @@ function Iframe( {
 			);
 			iFrameDocument = contentDocument;
 
-			documentElement.classList.add( 'block-editor-iframe__html' );
+			documentElement.classList.add(
+				'block-editor-iframe__html editor-styles-wrapper'
+			);
 
 			clearerRef( documentElement );
 
@@ -370,14 +372,13 @@ function Iframe( {
 			>
 				{ iframeDocument &&
 					createPortal(
-						// We want to prevent React events from bubbling throught the iframe
+						// We want to prevent React events from bubbling through the iframe
 						// we bubble these manually.
 						/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
 						<body
 							ref={ bodyRef }
 							className={ classnames(
 								'block-editor-iframe__body',
-								'editor-styles-wrapper',
 								...bodyClasses
 							) }
 						>

--- a/packages/block-editor/src/layouts/utils.js
+++ b/packages/block-editor/src/layouts/utils.js
@@ -17,12 +17,15 @@ import { LAYOUT_DEFINITIONS } from './definitions';
  * @return {string} - CSS selector.
  */
 export function appendSelectors( selectors, append = '' ) {
-	// Ideally we shouldn't need the `.editor-styles-wrapper` increased specificity here
-	// The problem though is that we have a `.editor-styles-wrapper p { margin: reset; }` style
-	// it's used to reset the default margin added by wp-admin to paragraphs
-	// so we need this to be higher speficity otherwise, it won't be applied to paragraphs inside containers
-	// When the post editor is fully iframed, this extra classname could be removed.
-
+	/*
+	 * Ideally we shouldn't need the `.editor-styles-wrapper` increased specificity here.
+	 * The problem though is that we have a `.editor-styles-wrapper p { margin: reset; }` style
+	 * that's used to reset the default margin added by wp-admin to paragraphs,
+	 * so we need this to be higher specificity otherwise it won't be applied to paragraphs inside containers.
+	 * When the post editor is fully i-framed, this extra classname could be removed.
+	 * Note: in the block editor,  `.editor-styles-wrapper` is added to the HTML element
+	 * in the `IFrame` component, packages/block-editor/src/components/iframe/index.js.
+	 */
 	return selectors
 		.split( ',' )
 		.map(

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -58,7 +58,7 @@
 
 @import "./editor-elements.scss";
 
-:root .editor-styles-wrapper {
+:where(html.editor-styles-wrapper) {
 	@include background-colors-deprecated();
 	@include foreground-colors-deprecated();
 	@include gradient-colors-deprecated();

--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -11,7 +11,7 @@
 // Themes with theme.json can control this themselves.
 // For full-wide blocks, we compensate for the base padding.
 // These margins should match the padding value above.
-html :where(.editor-styles-wrapper) {
+:where(html.editor-styles-wrapper) {
 	padding: 8px;
 	.block-editor-block-list__layout.is-root-container > .wp-block[data-align="full"] {
 		margin-left: -8px;


### PR DESCRIPTION
> [!WARNING]
> This PR is just an exploration. A lot of the code depends on the .editor-styles-wrapper class being on the body tag, so it's probably not viable.

## What and how? And why?

Exploring solutions to:

- https://github.com/WordPress/gutenberg/issues/59701
- https://github.com/WordPress/gutenberg/issues/56293


This is a test to move the reduce the .editor-styles-wrapper class to the HTML element in the block editor.

Doing this effectively reduces specificity of backwards compatibility rules using :where() so they do not override any theme rules in :root.


## Testing Instructions

1. To come...
