### PR TITLE
Editor styles: delete duplicate backwards compat CSS custom properties

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -247,14 +247,6 @@ function Iframe( {
 				height: auto !important;
 				min-height: 100%;
 			}
-			/*
-				This CSS Custom Properties aren't used anymore as defaults, but we still need to keep them for backward compatibility.
-				See: https://github.com/WordPress/gutenberg/pull/37381
-			 */
-			:root {
-				--wp--preset--font-size--normal: 16px;
-				--wp--preset--font-size--huge: 42px;
-			}
 			/* Lowest specificity to not override global styles */
 			:where(body) {
 				margin: 0;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -247,6 +247,13 @@ function Iframe( {
 				height: auto !important;
 				min-height: 100%;
 			}
+			/*
+				This CSS Custom Properties aren't used anymore as defaults, but we still need to keep them for backward compatibility.
+			 */
+			:root {
+				--wp--preset--font-size--normal: 16px;
+				--wp--preset--font-size--huge: 42px;
+			}
 			/* Lowest specificity to not override global styles */
 			:where(body) {
 				margin: 0;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -249,6 +249,7 @@ function Iframe( {
 			}
 			/*
 				This CSS Custom Properties aren't used anymore as defaults, but we still need to keep them for backward compatibility.
+				See: https://github.com/WordPress/gutenberg/pull/37381
 			 */
 			:root {
 				--wp--preset--font-size--normal: 16px;

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -55,34 +55,7 @@
 @import "./post-featured-image/editor.scss";
 @import "./post-comments-form/editor.scss";
 @import "./post-content/editor.scss";
-
 @import "./editor-elements.scss";
-
-:root .editor-styles-wrapper {
-	@include background-colors-deprecated();
-	@include foreground-colors-deprecated();
-	@include gradient-colors-deprecated();
-}
-
-// Font sizes (not used now, kept because of backward compatibility).
-//
-// The reason we add the editor class wrapper here is
-// to avoid enqueing the classes twice: here and in ./editor.scss
-:where(.editor-styles-wrapper) .has-regular-font-size {
-	font-size: 16px;
-}
-
-:where(.editor-styles-wrapper) .has-larger-font-size {
-	font-size: 42px;
-}
-
-:where(.editor-styles-wrapper) .has-normal-font-size {
-	font-size: var(--wp--preset--font-size--normal);
-}
-
-:where(.editor-styles-wrapper) .has-huge-font-size {
-	font-size: var(--wp--preset--font-size--huge);
-}
 
 /**
  * Editor Normalization Styles

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -57,6 +57,32 @@
 @import "./post-content/editor.scss";
 @import "./editor-elements.scss";
 
+:root .editor-styles-wrapper {
+	@include background-colors-deprecated();
+	@include foreground-colors-deprecated();
+	@include gradient-colors-deprecated();
+}
+
+// Font sizes (not used now, kept because of backward compatibility).
+//
+// The reason we add the editor class wrapper here is
+// to avoid enqueing the classes twice: here and in ./editor.scss
+:where(.editor-styles-wrapper) .has-regular-font-size {
+	font-size: 16px;
+}
+
+:where(.editor-styles-wrapper) .has-larger-font-size {
+	font-size: 42px;
+}
+
+:where(.editor-styles-wrapper) .has-normal-font-size {
+	font-size: var(--wp--preset--font-size--normal);
+}
+
+:where(.editor-styles-wrapper) .has-huge-font-size {
+	font-size: var(--wp--preset--font-size--huge);
+}
+
 /**
  * Editor Normalization Styles
  *

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -57,12 +57,6 @@
 @import "./post-content/editor.scss";
 @import "./editor-elements.scss";
 
-:root .editor-styles-wrapper {
-	@include background-colors-deprecated();
-	@include foreground-colors-deprecated();
-	@include gradient-colors-deprecated();
-}
-
 // Font sizes (not used now, kept because of backward compatibility).
 //
 // The reason we add the editor class wrapper here is
@@ -73,14 +67,6 @@
 
 :where(.editor-styles-wrapper) .has-larger-font-size {
 	font-size: 42px;
-}
-
-:where(.editor-styles-wrapper) .has-normal-font-size {
-	font-size: var(--wp--preset--font-size--normal);
-}
-
-:where(.editor-styles-wrapper) .has-huge-font-size {
-	font-size: var(--wp--preset--font-size--huge);
 }
 
 /**

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -64,13 +64,6 @@
 	@include gradient-colors-deprecated();
 }
 
-// This CSS Custom Properties aren't used anymore as defaults,
-// but we still need to keep them for backward compatibility.
-:where(.editor-styles-wrapper) {
-	--wp--preset--font-size--normal: 16px;
-	--wp--preset--font-size--huge: 42px;
-}
-
 // Font sizes (not used now, kept because of backward compatibility).
 //
 // The reason we add the editor class wrapper here is

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -57,6 +57,12 @@
 @import "./post-content/editor.scss";
 @import "./editor-elements.scss";
 
+:root .editor-styles-wrapper {
+	@include background-colors-deprecated();
+	@include foreground-colors-deprecated();
+	@include gradient-colors-deprecated();
+}
+
 // Font sizes (not used now, kept because of backward compatibility).
 //
 // The reason we add the editor class wrapper here is


### PR DESCRIPTION
## What and how? And why?

Fixes https://github.com/WordPress/gutenberg/issues/59701 https://github.com/WordPress/gutenberg/issues/56293

----- 

Exploring solutions to:

- https://github.com/WordPress/gutenberg/issues/59701
- https://github.com/WordPress/gutenberg/issues/56293

Alternative to:

- https://github.com/WordPress/gutenberg/pull/60398

---- 

Since https://github.com/WordPress/gutenberg/pull/42084, theme CSS custom properties reside in `:root`, and not `body`. 

`:root`, however, has less specificity than `body` and won't overwrite some low-specificity backwards compat CSS custom properties.

This PR deals exclusively with backwards compat CSS custom properties in the block editor:

```css
:where(.editor-styles-wrapper) {
	--wp--preset--font-size--normal: 16px;
	--wp--preset--font-size--huge: 42px;
}
```

This is a test to delete these properties as they are duplicates of those on [common.scss](https://github.com/WordPress/gutenberg/blob/965454f2e166819d7c78b1770340411643a24d48/packages/block-library/src/common.scss#L7), which appear both in the top and editor frames. 

The `:root` selector is more appropriate as it reduces specificity of backwards compatibility rules using `:where()` so they do not override any theme rules in `:root`, and it's compatible with the hierarchy on the frontend:

https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/common.scss#L7-L15

## Testing Instructions

Go ahead and define some theme.json font sizes using the "normal" and "huge" slugs:

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"fluid": {
						"min": ".888rem",
						"max": "1rem"
					},
					"name": "Normal",
					"size": "1rem",
					"slug": "normal"
				},
				{
					"fluid": {
						"min": "1.333rem",
						"max": "1.777rem"
					},
					"name": "Huge",
					"size": "3rem",
					"slug": "huge"
				}
			]
		}
	}
}
```

Now apply these font size presets to text elements:

```html
<!-- wp:paragraph {"fontSize":"normal"} -->
<p class="has-normal-font-size">Normal</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"huge"} -->
<p class="has-huge-font-size">Huge</p>
<!-- /wp:paragraph -->
```

In the editor, ensure that the theme.json preset values for `--wp--preset--font-size--normal` and `--wp--preset--font-size--huge` overwrite the backwards compat values.

To test that the backwards compat values still kick in, you can delete one or all of the presets from your theme.json and then refresh the editor.
