### PR TITLE
WIP: Background images: set "cover" as default for global styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -30,6 +30,7 @@ import { GlobalStylesContext } from './context';
 import { useGlobalSetting } from './hooks';
 import { getDuotoneFilter } from '../duotone/utils';
 import { getGapCSSValue } from '../../hooks/gap';
+import { setBackgroundStyleDefaults } from '../../hooks/background';
 import { store as blockEditorStore } from '../../store';
 import { LAYOUT_DEFINITIONS } from '../../layouts/definitions';
 import { getValueFromObjectPath, setImmutably } from '../../utils/object';
@@ -390,6 +391,16 @@ export function getStylesDeclarations(
 		},
 		[]
 	);
+
+	// Set background defaults.
+	// Applies to all blocks/global styles.
+	blockStyles = {
+		...blockStyles,
+		background: {
+			...blockStyles.background,
+			...setBackgroundStyleDefaults( blockStyles.background ),
+		},
+	};
 
 	// The goal is to move everything to server side generated engine styles
 	// This is temporary as we absorb more and more styles into the engine.

--- a/packages/edit-site/src/components/global-styles/background-panel.js
+++ b/packages/edit-site/src/components/global-styles/background-panel.js
@@ -8,6 +8,11 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
+// Initial control values where no block style is set.
+const BACKGROUND_BLOCK_DEFAULT_VALUES = {
+	backgroundSize: 'cover',
+};
+
 const {
 	useGlobalStyle,
 	useGlobalSetting,
@@ -23,12 +28,21 @@ export default function BackgroundPanel() {
 	} );
 	const [ settings ] = useGlobalSetting( '' );
 
+	const defaultControls = {
+		backgroundImage: true,
+		backgroundSize:
+			!! style?.background?.backgroundImage ||
+			!! inheritedStyle?.background?.backgroundImage,
+	};
+
 	return (
 		<StylesBackgroundPanel
 			inheritedValue={ inheritedStyle }
+			defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
 			value={ style }
 			onChange={ setStyle }
 			settings={ settings }
+			defaultControls={ defaultControls }
 		/>
 	);
 }


### PR DESCRIPTION
## What?

Adding default values for global styles so that site backgrounds have the same defaults as blocks.

See discussion: 

https://github.com/WordPress/gutenberg/pull/60264#issuecomment-2031646546

### TODO

- [ ] Also revert https://github.com/WordPress/gutenberg/pull/59889 so that the frontend works

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
