### PR TITLE
Site editor: Update hub markup and animation

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -97,70 +97,55 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 				ease: 'easeOut',
 			} }
 		>
-			<HStack
-				justify="space-between"
-				alignment="center"
-				className="edit-site-site-hub__container"
-			>
-				<HStack
-					justify="flex-start"
-					className="edit-site-site-hub__text-content"
-					spacing="0"
+			<HStack justify="flex-start" spacing="0">
+				<motion.div
+					className={ classnames(
+						'edit-site-site-hub__view-mode-toggle-container',
+						{
+							'has-transparent-background': isTransparent,
+						}
+					) }
+					layout
+					transition={ {
+						type: 'tween',
+						duration: disableMotion ? 0 : HUB_ANIMATION_DURATION,
+						ease: 'easeOut',
+					} }
 				>
-					<motion.div
-						className={ classnames(
-							'edit-site-site-hub__view-mode-toggle-container',
-							{
-								'has-transparent-background': isTransparent,
-							}
-						) }
-						layout
-						transition={ {
-							type: 'tween',
-							duration: disableMotion
-								? 0
-								: HUB_ANIMATION_DURATION,
-							ease: 'easeOut',
-						} }
+					<Button
+						{ ...siteIconButtonProps }
+						className="edit-site-layout__view-mode-toggle"
 					>
-						<Button
-							{ ...siteIconButtonProps }
-							className="edit-site-layout__view-mode-toggle"
-						>
-							<motion.div
-								initial={ false }
-								animate={ {
-									scale: canvasMode === 'view' ? 0.5 : 1,
-								} }
-								whileHover={ {
-									scale: canvasMode === 'view' ? 0.5 : 0.96,
-								} }
-								transition={ {
-									type: 'tween',
-									duration: disableMotion
-										? 0
-										: HUB_ANIMATION_DURATION,
-									ease: 'easeOut',
-								} }
-							>
-								<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-							</motion.div>
-						</Button>
-					</motion.div>
-
-					<AnimatePresence>
 						<motion.div
-							layout={ canvasMode === 'edit' }
+							initial={ false }
 							animate={ {
-								opacity: canvasMode === 'view' ? 1 : 0,
+								scale: canvasMode === 'view' ? 0.5 : 1,
 							} }
-							exit={ {
-								opacity: 0,
+							whileHover={ {
+								scale: canvasMode === 'view' ? 0.5 : 0.96,
 							} }
-							className={ classnames(
-								'edit-site-site-hub__site-title',
-								{ 'is-transparent': isTransparent }
-							) }
+							transition={ {
+								type: 'tween',
+								duration: disableMotion
+									? 0
+									: HUB_ANIMATION_DURATION,
+								ease: 'easeOut',
+							} }
+						>
+							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+						</motion.div>
+					</Button>
+				</motion.div>
+
+				<AnimatePresence initial={ false }>
+					{ canvasMode === 'view' && (
+						<HStack
+							as={ motion.div }
+							initial={ { opacity: 0 } }
+							animate={ {
+								opacity: isTransparent ? 0 : 1,
+							} }
+							exit={ { opacity: 0 } }
 							transition={ {
 								type: 'tween',
 								duration: disableMotion ? 0 : 0.2,
@@ -168,37 +153,31 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 								delay: canvasMode === 'view' ? 0.1 : 0,
 							} }
 						>
-							{ decodeEntities( siteTitle ) }
-						</motion.div>
-					</AnimatePresence>
-					{ canvasMode === 'view' && (
-						<Button
-							href={ homeUrl }
-							target="_blank"
-							label={ __( 'View site (opens in a new tab)' ) }
-							aria-label={ __(
-								'View site (opens in a new tab)'
-							) }
-							icon={ external }
-							className={ classnames(
-								'edit-site-site-hub__site-view-link',
-								{ 'is-transparent': isTransparent }
-							) }
-						/>
+							<div className="edit-site-site-hub__title">
+								{ decodeEntities( siteTitle ) }
+							</div>
+
+							<Button
+								href={ homeUrl }
+								target="_blank"
+								label={ __( 'View site (opens in a new tab)' ) }
+								aria-label={ __(
+									'View site (opens in a new tab)'
+								) }
+								icon={ external }
+								className="edit-site-site-hub__site-view-link"
+							/>
+
+							<Button
+								className="edit-site-site-hub_toggle-command-center"
+								icon={ search }
+								onClick={ () => openCommandCenter() }
+								label={ __( 'Open command palette' ) }
+								shortcut={ displayShortcut.primary( 'k' ) }
+							/>
+						</HStack>
 					) }
-				</HStack>
-				{ canvasMode === 'view' && (
-					<Button
-						className={ classnames(
-							'edit-site-site-hub_toggle-command-center',
-							{ 'is-transparent': isTransparent }
-						) }
-						icon={ search }
-						onClick={ () => openCommandCenter() }
-						label={ __( 'Open command palette' ) }
-						shortcut={ displayShortcut.primary( 'k' ) }
-					/>
-				) }
+				</AnimatePresence>
 			</HStack>
 		</motion.div>
 	);

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -3,32 +3,7 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: $grid-unit-10;
-
-	.edit-site-site-hub__container {
-		gap: 0;
-	}
-
-	.edit-site-site-hub__site-title,
-	.edit-site-site-hub__site-view-link,
-	.edit-site-site-hub_toggle-command-center {
-		transition: opacity ease 0.1s;
-
-		&.is-transparent {
-			opacity: 0 !important;
-		}
-	}
-
-	.edit-site-site-hub__site-view-link {
-		flex-grow: 0;
-		margin-right: var(--wp-admin-border-width-focus);
-		svg {
-			fill: $gray-200;
-		}
-	}
-}
-
-.edit-site-site-hub__post-type {
-	opacity: 0.6;
+	overflow: hidden;
 }
 
 .edit-site-site-hub__view-mode-toggle-container {
@@ -42,20 +17,20 @@
 	}
 }
 
-.edit-site-site-hub__text-content {
-	// Necessary for the ellipsis to work.
-	overflow: hidden;
-}
-
 .edit-site-site-hub__title {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	overflow: hidden;
-}
-
-.edit-site-site-hub__site-title {
 	flex-grow: 1;
 	color: $gray-200;
+}
+
+.edit-site-site-hub__site-view-link {
+	flex-grow: 0;
+	margin-right: var(--wp-admin-border-width-focus);
+	svg {
+		fill: $gray-200;
+	}
 }
 
 .edit-site-site-hub_toggle-command-center {


### PR DESCRIPTION
## What?

In trunk, I've noticed that the site title flickers when you move from "edit" to "view" mode in the site editor. This PR fixes that. In addition, it applies multiple simplification to the SiteHub markup and animation.  It keeps the animation mostly the same, it just brings more clarity to a code base that evolved very organically over time.

## Testing Instructions

- Check that the site title doesn't Flickr when you move from "edit" to "view" mode.
- Check that when over resizing the canvas, the site title hides.
- Check the different animations.