### PR TITLE
WIP: Try surfacing content inspector controls for `contentOnly` inner blocks

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -11,6 +11,7 @@ import {
 	Button,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
+	__experimentalUseSlotFills as useSlotFills,
 } from '@wordpress/components';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { __, _x, isRTL, sprintf } from '@wordpress/i18n';
@@ -21,6 +22,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
+import useBlockDisplayInformation from '../use-block-display-information';
+import { unlock } from '../../lock-unlock';
 
 function BlockCard( { title, icon, description, blockType, className, name } ) {
 	if ( blockType ) {
@@ -31,29 +34,54 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 		( { title, icon, description } = blockType );
 	}
 
-	const { parentNavBlockClientId } = useSelect( ( select ) => {
-		const { getSelectedBlockClientId, getBlockParentsByBlockName } =
-			select( blockEditorStore );
+	const { isParentNavigationBlock, parentClientId } = useSelect(
+		( select ) => {
+			const {
+				getSelectedBlockClientId,
+				getBlockParentsByBlockName,
+				getContentLockingParent,
+			} = unlock( select( blockEditorStore ) );
 
-		const _selectedBlockClientId = getSelectedBlockClientId();
+			const _selectedBlockClientId = getSelectedBlockClientId();
 
-		return {
-			parentNavBlockClientId: getBlockParentsByBlockName(
+			let _parentClientId = getBlockParentsByBlockName(
 				_selectedBlockClientId,
 				'core/navigation',
 				true
-			)[ 0 ],
-		};
-	}, [] );
+			)[ 0 ];
+			const _isParentNavigationBlock = !! _parentClientId;
 
+			if ( ! _parentClientId ) {
+				_parentClientId = getContentLockingParent(
+					_selectedBlockClientId
+				);
+			}
+
+			return {
+				isParentNavigationBlock: _isParentNavigationBlock,
+				parentClientId: _parentClientId,
+			};
+		},
+		[]
+	);
+
+	const parentDisplayInfo = useBlockDisplayInformation( parentClientId );
+	const contentOnlyFills = useSlotFills( 'InspectorControlsContentOnly' );
 	const { selectBlock } = useDispatch( blockEditorStore );
+	const hasParentBackArrow =
+		isParentNavigationBlock ||
+		( parentClientId && !! contentOnlyFills?.length );
 
 	return (
 		<div className={ clsx( 'block-editor-block-card', className ) }>
-			{ parentNavBlockClientId && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
+			{ hasParentBackArrow && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
 				<Button
-					onClick={ () => selectBlock( parentNavBlockClientId ) }
-					label={ __( 'Go to parent Navigation block' ) }
+					onClick={ () => selectBlock( parentClientId ) }
+					label={ sprintf(
+						// translators: %s: the block title of the parent.
+						__( 'Go to parent: %s' ),
+						parentDisplayInfo?.title
+					) }
 					style={
 						// TODO: This style override is also used in ToolsPanelHeader.
 						// It should be supported out-of-the-box by Button.

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -9,7 +9,9 @@ import {
 	Flex,
 	FlexBlock,
 	FlexItem,
+	Icon,
 } from '@wordpress/components';
+import { chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -19,7 +21,11 @@ import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
-export default function BlockQuickNavigation( { clientIds, onSelect } ) {
+export default function BlockQuickNavigation( {
+	clientIds,
+	clientIdsWithControls,
+	onSelect,
+} ) {
 	if ( ! clientIds.length ) {
 		return null;
 	}
@@ -30,13 +36,14 @@ export default function BlockQuickNavigation( { clientIds, onSelect } ) {
 					onSelect={ onSelect }
 					key={ clientId }
 					clientId={ clientId }
+					hasControls={ clientIdsWithControls?.includes( clientId ) }
 				/>
 			) ) }
 		</VStack>
 	);
 }
 
-function BlockQuickNavigationItem( { clientId, onSelect } ) {
+function BlockQuickNavigationItem( { clientId, hasControls, onSelect } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
@@ -75,6 +82,11 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 				<FlexBlock style={ { textAlign: 'left' } }>
 					<Truncate>{ blockTitle }</Truncate>
 				</FlexBlock>
+				{ hasControls && (
+					<FlexItem>
+						<Icon icon={ chevronRight } />
+					</FlexItem>
+				) }
 			</Flex>
 		</Button>
 	);

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -22,6 +22,9 @@ const InspectorControlsTypography = createSlotFill(
 const InspectorControlsListView = createSlotFill( 'InspectorControlsListView' );
 const InspectorControlsStyles = createSlotFill( 'InspectorControlsStyles' );
 const InspectorControlsEffects = createSlotFill( 'InspectorControlsEffects' );
+const InspectorControlsContentOnly = createSlotFill(
+	'InspectorControlsContentOnly'
+);
 
 const groups = {
 	default: InspectorControlsDefault,
@@ -38,6 +41,7 @@ const groups = {
 	settings: InspectorControlsDefault, // Alias for default.
 	styles: InspectorControlsStyles,
 	typography: InspectorControlsTypography,
+	contentOnly: InspectorControlsContentOnly,
 };
 
 export default groups;

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { sprintf, _n } from '@wordpress/i18n';
+import { sprintf, _n, __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { serialize } from '@wordpress/blocks';
 import { count as wordCount } from '@wordpress/wordcount';
@@ -12,6 +12,41 @@ import { copy } from '@wordpress/icons';
  */
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
+import { useBorderPanelLabel } from '../../hooks/border';
+import useInspectorControlsTabs from '../inspector-controls-tabs/use-inspector-controls-tabs';
+import { default as InspectorControls } from '../inspector-controls';
+import { default as InspectorControlsTabs } from '../inspector-controls-tabs';
+
+export function MultiSelectionControls( { blockType, blockName } ) {
+	const availableTabs = useInspectorControlsTabs( blockType?.name );
+	const showTabs = availableTabs?.length > 1;
+	const borderPanelLabel = useBorderPanelLabel( {
+		blockName,
+	} );
+
+	return showTabs ? (
+		<InspectorControlsTabs tabs={ availableTabs } />
+	) : (
+		<>
+			<InspectorControls.Slot />
+			<InspectorControls.Slot
+				group="color"
+				label={ __( 'Color' ) }
+				className="color-block-support-panel__inner-wrapper"
+			/>
+			<InspectorControls.Slot
+				group="typography"
+				label={ __( 'Typography' ) }
+			/>
+			<InspectorControls.Slot
+				group="dimensions"
+				label={ __( 'Dimensions' ) }
+			/>
+			<InspectorControls.Slot group="border" label={ borderPanelLabel } />
+			<InspectorControls.Slot group="styles" />
+		</>
+	);
+}
 
 export default function MultiSelectionInspector() {
 	const { blocks } = useSelect( ( select ) => {

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -380,6 +380,20 @@ export function expandBlock( clientId ) {
 	};
 }
 
+export function addContentOnlyControlsBlock( clientId ) {
+	return {
+		type: 'ADD_CONTENT_ONLY_CONTROLS_BLOCK',
+		clientId,
+	};
+}
+
+export function removeContentOnlyControlsBlock( clientId ) {
+	return {
+		type: 'REMOVE_CONTENT_ONLY_CONTROLS_BLOCK',
+		clientId,
+	};
+}
+
 /**
  * @param {Object} value
  * @param {string} value.rootClientId The root client ID to insert at.

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -490,6 +490,10 @@ export const getContentLockingParent = ( state, clientId ) => {
 	return result;
 };
 
+export function getContentOnlyControlsBlocks( state ) {
+	return state.contentOnlyControlsBlocks;
+}
+
 /**
  * Retrieves the client ID of the parent section block.
  *

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2041,6 +2041,26 @@ export function lastFocus( state = false, action ) {
 	return state;
 }
 
+export function contentOnlyControlsBlocks( state = [], action ) {
+	switch ( action.type ) {
+		case 'ADD_CONTENT_ONLY_CONTROLS_BLOCK': {
+			if ( state.includes( action.clientId ) ) {
+				return state;
+			}
+			return [ ...state, action.clientId ];
+		}
+		case 'DELETE_CONTENT_ONLY_CONTROLS_BLOCK': {
+			if ( ! state.includes( action.clientId ) ) {
+				return state;
+			}
+
+			return state.filter( ( item ) => item !== action.clientId );
+		}
+	}
+
+	return state;
+}
+
 /**
  * Reducer setting currently hovered block.
  *
@@ -2129,6 +2149,7 @@ const combinedReducers = combineReducers( {
 	registeredInserterMediaCategories,
 	hoveredBlockClientId,
 	zoomLevel,
+	contentOnlyControlsBlocks,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -10,7 +10,6 @@ import {
 	TextControl,
 	ToolbarButton,
 	ToolbarGroup,
-	Dropdown,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUseCustomUnits as useCustomUnits,
@@ -32,7 +31,6 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
-import { DOWN } from '@wordpress/keycodes';
 import { getFilename } from '@wordpress/url';
 import { getBlockBindingsSource, switchToBlockType } from '@wordpress/blocks';
 import { crop, overlayText, upload } from '@wordpress/icons';
@@ -623,49 +621,31 @@ export default function Image( {
 			) }
 			{ isContentOnlyMode && (
 				// Add some extra controls for content attributes when content only mode is active.
-				// With content only mode active, the inspector is hidden, so users need another way
-				// to edit these attributes.
-				<BlockControls group="other">
-					<Dropdown
-						popoverProps={ { position: 'bottom right' } }
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<ToolbarButton
-								onClick={ onToggle }
-								aria-haspopup="true"
-								aria-expanded={ isOpen }
-								onKeyDown={ ( event ) => {
-									if ( ! isOpen && event.keyCode === DOWN ) {
-										event.preventDefault();
-										onToggle();
-									}
-								} }
-							>
-								{ _x(
-									'Alternative text',
-									'Alternative text for an image. Block toolbar label, a low character count is preferred.'
-								) }
-							</ToolbarButton>
-						) }
-						renderContent={ () => (
+				<InspectorControls group="contentOnly">
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ resetAll }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						<ToolsPanelItem
+							label={ __( 'Alternative text' ) }
+							isShownByDefault
+							hasValue={ () => !! alt }
+							onDeselect={ () =>
+								setAttributes( { alt: undefined } )
+							}
+						>
 							<TextareaControl
-								className="wp-block-image__toolbar_content_textarea"
 								label={ __( 'Alternative text' ) }
 								value={ alt || '' }
 								onChange={ updateAlt }
-								disabled={ lockAltControls }
+								readOnly={ lockAltControls }
 								help={
 									lockAltControls ? (
 										<>{ lockAltControlsMessage }</>
 									) : (
 										<>
-											<ExternalLink
-												href={
-													// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
-													__(
-														'https://www.w3.org/WAI/tutorials/images/decision-tree/'
-													)
-												}
-											>
+											<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
 												{ __(
 													'Describe the purpose of the image.'
 												) }
@@ -679,59 +659,41 @@ export default function Image( {
 								}
 								__nextHasNoMarginBottom
 							/>
-						) }
-					/>
-					{ title && (
-						<Dropdown
-							popoverProps={ { position: 'bottom right' } }
-							renderToggle={ ( { isOpen, onToggle } ) => (
-								<ToolbarButton
-									onClick={ onToggle }
-									aria-haspopup="true"
-									aria-expanded={ isOpen }
-									onKeyDown={ ( event ) => {
-										if (
-											! isOpen &&
-											event.keyCode === DOWN
-										) {
-											event.preventDefault();
-											onToggle();
-										}
-									} }
-								>
-									{ __( 'Title' ) }
-								</ToolbarButton>
-							) }
-							renderContent={ () => (
-								<TextControl
-									__next40pxDefaultSize
-									className="wp-block-image__toolbar_content_textarea"
-									__nextHasNoMarginBottom
-									label={ __( 'Title attribute' ) }
-									value={ title || '' }
-									onChange={ onSetTitle }
-									disabled={ lockTitleControls }
-									help={
-										lockTitleControls ? (
-											<>{ lockTitleControlsMessage }</>
-										) : (
-											<>
+						</ToolsPanelItem>
+						<ToolsPanelItem
+							label={ __( 'Title attribute' ) }
+							hasValue={ () => !! title }
+							onDeselect={ () =>
+								setAttributes( { title: undefined } )
+							}
+						>
+							<TextControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ __( 'Title attribute' ) }
+								value={ title || '' }
+								onChange={ onSetTitle }
+								readOnly={ lockTitleControls }
+								help={
+									lockTitleControls ? (
+										<>{ lockTitleControlsMessage }</>
+									) : (
+										<>
+											{ __(
+												'Describe the role of this image on the page.'
+											) }
+											<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
 												{ __(
-													'Describe the role of this image on the page.'
+													'(Note: many devices and browsers do not display this text.)'
 												) }
-												<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
-													{ __(
-														'(Note: many devices and browsers do not display this text.)'
-													) }
-												</ExternalLink>
-											</>
-										)
-									}
-								/>
-							) }
-						/>
-					) }
-				</BlockControls>
+											</ExternalLink>
+										</>
+									)
+								}
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				</InspectorControls>
 			) }
 			<InspectorControls>
 				<ToolsPanel


### PR DESCRIPTION
## What?
See #60021, #57911

Related #65699

This is an exploratory PR that modifies `contentOnly` mode to show some inspector controls for selected child blocks, starting with the image block. It's a potential first iteration to solving #60021 more thoroughly and solves some issues for the image block, but I also plan to explore a fuller implementation of that issue in parallel.

The difference between this and `trunk` for `contentOnly` parents:
- When selecting a child block the inspector controls are revealed for that block, but only `contentOnly` inspector controls are displayed.
- The child block has a back arrow in the block card allowing easy navigation back to the parent (borrowing this concept from the navigation block)

## How?
- The 'back arrow' that appears in the inspector for the navigation block's inner blocks is now also enabled for content locked inner blocks
- A new `<InspectorControls>` `contentOnly` group is introduced for blocks to show content controls in the inspector
- Some logic around how the inspector renders is changed, allowing the `contentOnly` `<InspectorControls>` group to be shown

Some potential changes that could improve this:
- A way to declare a parent that should show the back arrow (e.g. using block supports or changes to `useBlockEditingMode`)
- We may want to avoid showing the inspector controls for blocks that don't have any content controls there (paragraph, heading), and so stick closer to the behavior in `trunk`. An arrow could be used to indicate the blocks that can be drilled into.
- The image block probably shouldn't show alt text unless there's an image uploaded (that may also be an issue in `trunk` with the toolbar controls)

## Testing Instructions
1. Create a pattern (or a `contentOnly` group) and add an image and a paragraph
2. Mark those block as allowing overrides by giving them a name
3. Insert that pattern into a post
4. Select the image
5. See the alt and title control (the latter available from the tools panel dropdown)
6. Click the back arrow

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/677833/e4b4589a-586a-459c-9a11-4fde91b7fa10

