### PR TITLE
Site Editor: Animate the radius of the frame

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -131,16 +131,13 @@
 		top: $canvas-padding;
 		bottom: $canvas-padding;
 		width: calc(100% - #{$canvas-padding});
+		transition: border-radius 0.4s;
+		// This ensure the radius work properly.
+		overflow: hidden;
 
-		& > div {
+		.edit-site-layout:not(.is-full-canvas) & {
 			border-radius: $radius-block-ui * 4;
-			// Not sure why this is necessary.
-			.edit-site-layout:not(.is-full-canvas) & .edit-site-visual-editor__editor-canvas,
-			.edit-site-layout:not(.is-full-canvas) & .interface-interface-skeleton__content {
-				border-radius: $radius-block-ui * 4;
-			}
 		}
-
 	}
 
 	.edit-site-layout.is-full-canvas & {


### PR DESCRIPTION
In trunk when moving between "edit" and "view" mode in the site editor, the border radius of the frame abruptly changes from rounded to sharp. This PR animates the border radius instead.

It's a small thing but I believe the details matter.