### PR TITLE
Site Editor: Fix site icon animation

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -179,11 +179,6 @@
 	justify-content: center;
 	border-bottom: 1px solid transparent;
 
-	.edit-site-layout.is-full-canvas & {
-		border-bottom-color: $gray-200;
-		transition: border-bottom-color 0.15s 0.4s ease-out;
-	}
-
 	&:hover,
 	&:active {
 		color: $white;

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -10,9 +10,12 @@
 	height: $header-height;
 	width: $header-height;
 	flex-shrink: 0;
-	background: $gray-900;
 
-	&.has-transparent-background {
+	.edit-site-layout__view-mode-toggle-icon {
+		background: $gray-900;
+	}
+
+	&.has-transparent-background .edit-site-layout__view-mode-toggle-icon {
 		background: transparent;
 	}
 }


### PR DESCRIPTION
Raised by @jameskoster here https://github.com/WordPress/gutenberg/pull/60415#pullrequestreview-1976361749

In Chrome, when you enter "edit mode", you see a small black border under the site icon and it disappears at the end. This PR fixes this weird effect.

**Testing instructions**

 - Testing the site icon animation with and without a site icon defined (Safari and Chrome)