### PR TITLE
Editor: Optimize the 'PostSlug' component

### DIFF
--- a/packages/editor/src/components/post-slug/test/index.js
+++ b/packages/editor/src/components/post-slug/test/index.js
@@ -5,22 +5,45 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { PostSlug } from '../';
+import PostSlug from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '@wordpress/data/src/components/use-dispatch/use-dispatch', () =>
+	jest.fn()
+);
 
 describe( 'PostSlug', () => {
 	it( 'should update slug with sanitized input', async () => {
 		const user = userEvent.setup();
-		const onUpdateSlug = jest.fn();
+		const editPost = jest.fn();
 
-		render( <PostSlug postSlug="index" onUpdateSlug={ onUpdateSlug } /> );
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getPostType: () => null,
+				getEditedPostAttribute: () => 'post',
+				getEditedPostSlug: () => '1',
+			} ) )
+		);
+		useDispatch.mockImplementation( () => ( {
+			editPost,
+		} ) );
+
+		render( <PostSlug /> );
 
 		const input = screen.getByRole( 'textbox', { name: 'Slug' } );
-		await user.clear( input );
-		await user.type( input, 'Foo Bar-Baz 9!' );
+		await user.type( input, '2', {
+			initialSelectionStart: 0,
+			initialSelectionEnd: 1,
+		} );
 		act( () => input.blur() );
 
-		expect( onUpdateSlug ).toHaveBeenCalledWith( 'foo-bar-baz-9' );
+		expect( editPost ).toHaveBeenCalledWith( { slug: '2' } );
 	} );
 } );


### PR DESCRIPTION
## What?
PR contains the following updates and optimizations for the `PostSlug` component:

* Don't subscribe to the store when the feature isn't supported.
* Refactor it to a function component.
* Use data hooks instead of HoC.
* Match behavior to URL popover input.

> [!NOTE]  
> We have to maintain this component for backward compatibility.

## Why?
While `core/editor` isn't as active a store as `core/block-editor`, there's no need to create unnecessary store subscriptions.

## Testing Instructions
1. Enable feature support for a post - `add_post_type_support( 'post', 'slug' );`
2. Open a post.
3. The new "Slug" field should be visible in the Document Settings.
4. Smoke test the control. It should match the URL control's behavior.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/fe1fb5d8-c649-43c9-ab4b-e40dce6a6cd3

