### PR TITLE
POC: Animate the editor areas (sidebar, footer)

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -24,7 +24,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { Button, ScrollLock } from '@wordpress/components';
+import { ScrollLock } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -139,8 +139,7 @@ function Layout( { initialPost } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 
-	const { openGeneralSidebar, closeGeneralSidebar } =
-		useDispatch( editPostStore );
+	const { closeGeneralSidebar } = useDispatch( editPostStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { setIsInserterOpened } = useDispatch( editorStore );
 	const {
@@ -205,11 +204,6 @@ function Layout( { initialPost } ) {
 	useCommandContext( commandContext );
 
 	const styles = useEditorStyles();
-
-	const openSidebarPanel = () =>
-		openGeneralSidebar(
-			hasBlockSelected ? 'edit-post/block' : 'edit-post/document'
-		);
 
 	// Inserter and Sidebars are mutually exclusive
 	useEffect( () => {
@@ -314,24 +308,10 @@ function Layout( { initialPost } ) {
 				secondarySidebar={ secondarySidebar() }
 				sidebar={
 					( ( isMobileViewport && sidebarIsOpened ) ||
-						( ! isMobileViewport && ! isDistractionFree ) ) && (
-						<>
-							{ ! isMobileViewport && ! sidebarIsOpened && (
-								<div className="edit-post-layout__toggle-sidebar-panel">
-									<Button
-										variant="secondary"
-										className="edit-post-layout__toggle-sidebar-panel-button"
-										onClick={ openSidebarPanel }
-										aria-expanded={ false }
-									>
-										{ hasBlockSelected
-											? __( 'Open block settings' )
-											: __( 'Open document settings' ) }
-									</Button>
-								</div>
-							) }
-							<ComplementaryArea.Slot scope="core/edit-post" />
-						</>
+						( ! isMobileViewport &&
+							sidebarIsOpened &&
+							! isDistractionFree ) ) && (
+						<ComplementaryArea.Slot scope="core/edit-post" />
 					)
 				}
 				notices={ <EditorSnackbars /> }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -254,7 +254,6 @@ export default function Editor( { isLoading, onClick } ) {
 								( shouldShowListView && <ListViewSidebar /> ) )
 						}
 						sidebar={
-							! isDistractionFree &&
 							isEditMode &&
 							isRightSidebarOpen &&
 							! isDistractionFree && (

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -10,14 +10,17 @@ import { forwardRef, useEffect } from '@wordpress/element';
 import {
 	__unstableUseNavigateRegions as useNavigateRegions,
 	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, useReducedMotion } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import NavigableRegion from '../navigable-region';
+
+const ANIMATION_DURATION = 0.2;
 
 function useHTMLClass( className ) {
 	useEffect( () => {
@@ -62,7 +65,13 @@ function InterfaceSkeleton(
 	},
 	ref
 ) {
+	const disableMotion = useReducedMotion();
 	const navigateRegionsProps = useNavigateRegions( shortcuts );
+	const defaultTransition = {
+		type: 'tween',
+		duration: disableMotion ? 0 : ANIMATION_DURATION,
+		ease: 'easeOut',
+	};
 
 	useHTMLClass( 'interface-interface-skeleton__html-container' );
 
@@ -134,14 +143,21 @@ function InterfaceSkeleton(
 					</div>
 				) }
 				<div className="interface-interface-skeleton__body">
-					{ !! secondarySidebar && (
-						<NavigableRegion
-							className="interface-interface-skeleton__secondary-sidebar"
-							ariaLabel={ mergedLabels.secondarySidebar }
-						>
-							{ secondarySidebar }
-						</NavigableRegion>
-					) }
+					<AnimatePresence initial={ false }>
+						{ !! secondarySidebar && (
+							<NavigableRegion
+								className="interface-interface-skeleton__secondary-sidebar"
+								ariaLabel={ mergedLabels.secondarySidebar }
+								as={ motion.div }
+								initial={ { x: '-100%' } }
+								animate={ { x: 0 } }
+								exit={ { x: '-100%' } }
+								transition={ defaultTransition }
+							>
+								{ secondarySidebar }
+							</NavigableRegion>
+						) }
+					</AnimatePresence>
 					{ !! notices && (
 						<div className="interface-interface-skeleton__notices">
 							{ notices }
@@ -153,14 +169,21 @@ function InterfaceSkeleton(
 					>
 						{ content }
 					</NavigableRegion>
-					{ !! sidebar && (
-						<NavigableRegion
-							className="interface-interface-skeleton__sidebar"
-							ariaLabel={ mergedLabels.sidebar }
-						>
-							{ sidebar }
-						</NavigableRegion>
-					) }
+					<AnimatePresence initial={ false }>
+						{ !! sidebar && (
+							<NavigableRegion
+								className="interface-interface-skeleton__sidebar"
+								ariaLabel={ mergedLabels.sidebar }
+								as={ motion.div }
+								initial={ { x: '100%' } }
+								animate={ { x: 0 } }
+								exit={ { x: '100%' } }
+								transition={ defaultTransition }
+							>
+								{ sidebar }
+							</NavigableRegion>
+						) }
+					</AnimatePresence>
 					{ !! actions && (
 						<NavigableRegion
 							className="interface-interface-skeleton__actions"
@@ -171,14 +194,21 @@ function InterfaceSkeleton(
 					) }
 				</div>
 			</div>
-			{ !! footer && (
-				<NavigableRegion
-					className="interface-interface-skeleton__footer"
-					ariaLabel={ mergedLabels.footer }
-				>
-					{ footer }
-				</NavigableRegion>
-			) }
+			<AnimatePresence initial={ false }>
+				{ !! footer && (
+					<NavigableRegion
+						className="interface-interface-skeleton__footer"
+						ariaLabel={ mergedLabels.footer }
+						as={ motion.div }
+						initial={ { y: '100%' } }
+						animate={ { y: 0 } }
+						exit={ { y: '100%' } }
+						transition={ defaultTransition }
+					>
+						{ footer }
+					</NavigableRegion>
+				) }
+			</AnimatePresence>
 		</div>
 	);
 }


### PR DESCRIPTION
This is a POC to unify how the different UI pieces of the editor (left sidebar, right sidebar, footer, later the header) animate.
The editors already use `InterfaceSkeleton` component to render sidebars, headers... and the skeleton is "mostly" (we'll get to that later) aware when to show and hide the different pieces which means, it should be possible to animate these UI pieces as they appear/disappear.

You can try the current state of the PR where you will see the left and right sidebars be animated and even showing/hiding the breadcrumb also animates.

But the PR is a POC for a reason, we have made a few decisions over time that make this hard to achieve consistently:

 - Closing the right sidebar doesn't animate.
 - The global styles sidebar behaves in a weird way some times.

Most of the issues come down to the same problems: In order to animate properly, showing and hiding the UI should be handled by the `InterfaceSkeleton` itself which is not always the case for us:

 - Sometimes we show extra "hidden" button in these areas, so the skeleton doesn't know that it needs to animate out: This is solved "easily" by moving these hidden buttons or removing them. (thus the removal of the button in the post editor in the diff)
 - Sometimes we hide things in two different ways: We have the InterfaceSkeleton hiding the sidebar content if not present but we also have things like `ComplementaryArea.Slot` that hides stuff (we support showing different sidebars in the same area and switching between them). This is harder to solve because it basically means that we should "bundle" the complementary areas API into the skeleton. To be honest, I think it makes sense to be able to say: the "sidebar" area of the skeleton corresponds to the "edit-post" complementary area without necessarily rendering the slot or passing anything to the "sidebar" prop manually. It's doable though.

---

The other challenge here is that you can see sometimes that the sidebars animate but the "main" area doesn't. We can solve that using framer motion's `layout` animation potentially but it would create some distortion when animating. Maybe we can apply the same technique we use for the frame animation of the site editor though.