### PR TITLE
Site Editor: Fix small regression on the resize handle

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -131,12 +131,15 @@
 		top: $canvas-padding;
 		bottom: $canvas-padding;
 		width: calc(100% - #{$canvas-padding});
-		transition: border-radius 0.4s;
-		// This ensure the radius work properly.
-		overflow: hidden;
 
-		.edit-site-layout:not(.is-full-canvas) & {
-			border-radius: $radius-block-ui * 4;
+		.edit-site-resizable-frame__inner-content {
+			transition: border-radius 0.4s;
+			// This ensure the radius work properly.
+			overflow: hidden;
+
+			.edit-site-layout:not(.is-full-canvas) & {
+				border-radius: $radius-block-ui * 4;
+			}
 		}
 	}
 


### PR DESCRIPTION
I introduced a small regression in #60415 
The resize handles of the site editor frame were not visible anymore. This PR fixes that.

## Testing Instructions

- Open the site editor
- The resize handle of the frame should be visible when you hover the frame
- You can resize properly.