### PR TITLE
Tests: Share JavaScript build assets across PHP workflows

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -179,6 +179,7 @@ jobs:
               uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
               with:
                   name: build-assets
+                  path: ./build
 
             - name: General debug information
               run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -172,15 +172,15 @@ jobs:
               with:
                   custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
-            - name: Docker debug information
-              run: |
-                  docker -v
-
             - name: Download assets
               uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
               with:
                   name: build-assets
                   path: ./build
+
+            - name: Docker debug information
+              run: |
+                  docker -v
 
             - name: General debug information
               run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -91,10 +91,10 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
 
-            - name: Npm build
+            - name: Run build scripts
               run: npm run build
 
-            - name: Upload assets
+            - name: Upload built JavaScript assets
               uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
               with:
                   name: build-assets
@@ -172,7 +172,7 @@ jobs:
               with:
                   custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
-            - name: Download assets
+            - name: Download built JavaScript assets
               uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
               with:
                   name: build-assets

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -81,6 +81,7 @@ jobs:
                   rm versions.json
 
     build-assets:
+        name: Build JavaScript assets for PHP unit tests
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -188,7 +188,6 @@ jobs:
                   node --version
                   curl --version
                   git --version
-                  svn --version
                   locale -a
 
             - name: Start Docker environment

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -80,9 +80,28 @@ jobs:
                   echo "previous-wordpress-version=${PREVIOUS_WP_VERSION}" >> $GITHUB_OUTPUT
                   rm versions.json
 
+    build-assets:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+
+            - name: Npm build
+              run: npm run build
+
+            - name: Upload assets
+              uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+              with:
+                  name: build-assets
+                  path: ./build/
+
     test-php:
         name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.wordpress != '' && format( ' (WP {0}) ', matrix.wordpress ) || '' }} on ubuntu-latest
-        needs: compute-previous-wordpress-version
+        needs: [compute-previous-wordpress-version, build-assets]
         runs-on: ubuntu-latest
         timeout-minutes: 20
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
@@ -152,12 +171,14 @@ jobs:
               with:
                   custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
-            - name: Npm build
-              run: npm run build
-
             - name: Docker debug information
               run: |
                   docker -v
+
+            - name: Download assets
+              uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+              with:
+                  name: build-assets
 
             - name: General debug information
               run: |


### PR DESCRIPTION
## What?

Share the `npm run build` result across PHP unit test workflows.

## Why?

I noticed that the PHP unit tests tend to be one of the slowest parts of the unit tests and that one of the slowest steps tends to be building JavaScript assets. These assets are the same across all the PHP tests so if we can build them once and reuse them it may give us a significant speed up!

## How?

Instead of running `npm run build` on every PHP unit test run, we run it 1 time and use upload/download actions to store and retrieve the assets. The PHP unit tests depend on the build, so we shift this part of the work earlier and the use the stored result in all of the runs.

Compare the [same job](https://github.com/WordPress/gutenberg/actions/runs/8540566678/job/23398089366?pr=60428) on this branch with [the job on trunk](https://github.com/WordPress/gutenberg/actions/runs/8540044690/job/23396197433).

The build step takes 3m 34s on trunk while the download step that replaces it on this branch takes 11s. The extra build job on this branch takes ~4:20, so we save around 3:20 x 19 PHP jobs - the additional 4:20 dedicated build job. Unless my math is off, this save 1:03:20 in total - 4:20 for the additional job. **That's almost an hour of overall workflow time saved.** If we compare the total time, that seems accurate. [Usage on this branch reports 1:04:45](https://github.com/WordPress/gutenberg/actions/runs/8540566678/usage) while [a recent trunk build reports 2:11:50](https://github.com/WordPress/gutenberg/actions/runs/8540044690/usage).

As a follow-up, we may be able to simplify the npm installation from the PHP jobs as well. After this change I think it's only used to run `wp-env`.