### PR TITLE
fix change `focus` to `focus-visible` in navigation block css

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -61,7 +61,7 @@ $navigation-icon-size: 24px;
 	&.has-text-decoration-underline .wp-block-navigation-item__content {
 		text-decoration: underline;
 
-		&:focus,
+		&:focus-visible,
 		&:active {
 			text-decoration: underline;
 		}
@@ -70,7 +70,7 @@ $navigation-icon-size: 24px;
 	&.has-text-decoration-line-through .wp-block-navigation-item__content {
 		text-decoration: line-through;
 
-		&:focus,
+		&:focus-visible,
 		&:active {
 			text-decoration: line-through;
 		}
@@ -80,7 +80,7 @@ $navigation-icon-size: 24px;
 		a {
 			text-decoration: none;
 
-			&:focus,
+			&:focus-visible,
 			&:active {
 				text-decoration: none;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Changes the styling of the Navigation block to use the `focus-visible` selector instead of the `focus` selector

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the navigation overlay opens the first item receives focus. As it should. However it is confusing to users why the element looks different than all the other elements. `focus-visible` is meant for this exact purpose. To style elements when they receive focus through the keyboard etc. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

changing the instances of `focus` to `focus-visible`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Ensure the navigation block still has proper focus states

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
