### PR TITLE
Remove alpha from edit post header

### DIFF
--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -286,8 +286,7 @@
 	}
 
 	.edit-post-header {
-		backdrop-filter: blur(20px) !important;
-		background-color: rgba(255, 255, 255, 0.9);
+		background-color: $white;
 		border-bottom: 1px solid #e0e0e0;
 		position: absolute;
 		width: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

There seems to be some leftover alpha in the background of the editor header when distraction free is active in the post / page editor. This conflicts with the now visible block toolbar which is solid.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it looks bad.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the alpha.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

0. Go to the post editor
1. Add a post
2. Add some blocks
3. Enable distraction free mode
4. Select a block
5. Hover over the top
6. Notice the header is solid white

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1121" alt="Screenshot 2024-04-03 at 19 15 53" src="https://github.com/WordPress/gutenberg/assets/107534/c3051d8b-ebb5-4734-a8e7-2fefb021197c">

### After

<img width="1119" alt="Screenshot 2024-04-03 at 19 16 22" src="https://github.com/WordPress/gutenberg/assets/107534/81dc70f1-a7b1-421c-ae46-7bbc2a8cb2f4">

