### PR TITLE
Fix external link indicator in Link Control

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -265,6 +265,7 @@ $block-editor-link-control-number-of-actions: 1;
 		}
 
 		span {
+			display: inline;
 			font-weight: normal;
 		}
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -249,6 +249,7 @@ $block-editor-link-control-number-of-actions: 1;
 		border-radius: $radius-block-ui;
 		line-height: 1.1;
 
+
 		&:focus {
 			box-shadow: none;
 		}
@@ -269,7 +270,14 @@ $block-editor-link-control-number-of-actions: 1;
 		}
 
 		.components-external-link__icon {
-			display: none; // specifically requested to be removed visually as well.
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0); // specifically requested to be removed visually as well.
+			border: 0;
 		}
 	}
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -265,11 +265,10 @@ $block-editor-link-control-number-of-actions: 1;
 		}
 
 		span {
-			display: inline;
 			font-weight: normal;
 		}
 
-		svg {
+		.components-external-link__icon {
 			display: none; // specifically requested to be removed visually as well.
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to https://github.com/WordPress/gutenberg/pull/60255 for Link Control. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Add a link.
3. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-04-03 at 15 39 13](https://github.com/WordPress/gutenberg/assets/1813435/4e7c83f7-1e36-4100-82a3-914275eedb05)|![CleanShot 2024-04-03 at 15 38 50](https://github.com/WordPress/gutenberg/assets/1813435/543a300c-bf62-45f9-be87-9cd32c3266ae)|


