### PR TITLE
Prevent exiting Zoom Out mode from stealing focus

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -620,7 +620,9 @@ function BlockListBlockProvider( props ) {
 					__unstableHasActiveBlockOverlayActive( clientId ) &&
 					! isDragging(),
 				initialPosition:
-					_isSelected && __unstableGetEditorMode() === 'edit'
+					_isSelected &&
+					( __unstableGetEditorMode() === 'edit' ||
+						__unstableGetEditorMode() === 'zoom-out' ) // Don't recalculate the initialPosition when toggling in/out of zoom-out mode
 						? getSelectedBlocksInitialCaretPosition()
 						: undefined,
 				isHighlighted: isBlockHighlighted( clientId ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -15,7 +15,6 @@ import { useSelect } from '@wordpress/data';
  */
 import { isInsideRootBlock } from '../../../utils/dom';
 import { store as blockEditorStore } from '../../../store';
-import { usePrevious } from '@wordpress/compose';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
@@ -31,18 +30,14 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 	const ref = useRef();
 	const { isBlockSelected, isMultiSelecting, __unstableGetEditorMode } =
 		useSelect( blockEditorStore );
-	const prevMode = usePrevious( __unstableGetEditorMode() );
 
 	useEffect( () => {
 		// Check if the block is still selected at the time this effect runs.
-		if ( ! isBlockSelected( clientId ) || isMultiSelecting() ) {
-			return;
-		}
-
-		// This reruns when the editing mode changes, and if it changed from zoom-out
-		// we don't want to auto-focus the previously selected block as this will steal
-		// focus when the mode changes
-		if ( prevMode === 'zoom-out' ) {
+		if (
+			! isBlockSelected( clientId ) ||
+			isMultiSelecting() ||
+			__unstableGetEditorMode() === 'zoom-out'
+		) {
 			return;
 		}
 
@@ -91,7 +86,7 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 			}
 		}
 		placeCaretAtHorizontalEdge( target, isReverse );
-	}, [ initialPosition, clientId, prevMode ] );
+	}, [ initialPosition, clientId ] );
 
 	return ref;
 }

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -4,7 +4,7 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Zoom Out', () => {
-	test.beforeAll( async ( { requestUtils, admin, page } ) => {
+	test.beforeEach( async ( { requestUtils, admin, page, editor } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
 
@@ -15,9 +15,16 @@ test.describe( 'Zoom Out', () => {
 		await zoomedOutCheckbox.setChecked( true );
 		await expect( zoomedOutCheckbox ).toBeChecked();
 		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+
+		// Select a template part with a few blocks.
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//header',
+			postType: 'wp_template_part',
+		} );
+		await editor.canvas.locator( 'body' ).click();
 	} );
 
-	test.afterAll( async ( { requestUtils, admin, page } ) => {
+	test.afterEach( async ( { requestUtils, admin, page } ) => {
 		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
 		const zoomedOutCheckbox = page.getByLabel(
 			'Test a new zoomed out view on'
@@ -26,15 +33,6 @@ test.describe( 'Zoom Out', () => {
 		await expect( zoomedOutCheckbox ).not.toBeChecked();
 		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
-	test.beforeEach( async ( { admin, editor } ) => {
-		// Select a template part with a few blocks.
-		await admin.visitSiteEditor( {
-			postId: 'emptytheme//header',
-			postType: 'wp_template_part',
-		} );
-		await editor.canvas.locator( 'body' ).click();
 	} );
 
 	test( 'Zoom-out button should not steal focus when a block is focused', async ( {

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -4,8 +4,11 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Zoom Out', () => {
-	test.beforeEach( async ( { requestUtils, admin, page, editor } ) => {
+	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { admin, page, editor } ) => {
 		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
 
 		const zoomedOutCheckbox = page.getByLabel(
@@ -24,7 +27,7 @@ test.describe( 'Zoom Out', () => {
 		await editor.canvas.locator( 'body' ).click();
 	} );
 
-	test.afterEach( async ( { requestUtils, admin, page } ) => {
+	test.afterEach( async ( { admin, page } ) => {
 		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
 		const zoomedOutCheckbox = page.getByLabel(
 			'Test a new zoomed out view on'
@@ -32,6 +35,9 @@ test.describe( 'Zoom Out', () => {
 		await zoomedOutCheckbox.setChecked( false );
 		await expect( zoomedOutCheckbox ).not.toBeChecked();
 		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -11,7 +11,8 @@ test.describe( 'Zoom Out', () => {
 		const zoomedOutCheckbox = page.getByLabel(
 			'Test a new zoomed out view on'
 		);
-		await zoomedOutCheckbox.click();
+
+		await zoomedOutCheckbox.setChecked( true );
 		await expect( zoomedOutCheckbox ).toBeChecked();
 		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 	} );
@@ -21,8 +22,7 @@ test.describe( 'Zoom Out', () => {
 		const zoomedOutCheckbox = page.getByLabel(
 			'Test a new zoomed out view on'
 		);
-		await expect( zoomedOutCheckbox ).toBeChecked();
-		await zoomedOutCheckbox.click();
+		await zoomedOutCheckbox.setChecked( false );
 		await expect( zoomedOutCheckbox ).not.toBeChecked();
 		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 		await requestUtils.activateTheme( 'twentytwentyone' );
@@ -37,13 +37,17 @@ test.describe( 'Zoom Out', () => {
 		await editor.canvas.locator( 'body' ).click();
 	} );
 
-	test( 'Zoom-out button should be available and actionable', async ( {
+	test( 'Zoom-out button should not steal focus when a block is focused', async ( {
 		page,
+		editor,
 	} ) => {
 		const zoomOutButton = page.getByRole( 'button', {
 			name: 'Zoom-out View',
 			exact: true,
 		} );
+
+		// Select a block for this test to surface the potential focus-stealing behavior
+		await editor.canvas.getByLabel( 'Site title text' ).click();
 
 		await zoomOutButton.click();
 

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Zoom Out', () => {
+	test.beforeAll( async ( { requestUtils, admin, page } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
+
+		const zoomedOutCheckbox = page.getByLabel(
+			'Test a new zoomed out view on'
+		);
+		await zoomedOutCheckbox.click();
+		await expect( zoomedOutCheckbox ).toBeChecked();
+		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+	} );
+
+	test.afterAll( async ( { requestUtils, admin, page } ) => {
+		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
+		const zoomedOutCheckbox = page.getByLabel(
+			'Test a new zoomed out view on'
+		);
+		await expect( zoomedOutCheckbox ).toBeChecked();
+		await zoomedOutCheckbox.click();
+		await expect( zoomedOutCheckbox ).not.toBeChecked();
+		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test.beforeEach( async ( { admin, editor } ) => {
+		// Select a template part with a few blocks.
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//header',
+			postType: 'wp_template_part',
+		} );
+		await editor.canvas.locator( 'body' ).click();
+	} );
+
+	test( 'Zoom-out button should be available and actionable', async ( {
+		page,
+	} ) => {
+		const zoomOutButton = page.getByRole( 'button', {
+			name: 'Zoom-out View',
+			exact: true,
+		} );
+
+		await zoomOutButton.click();
+
+		await expect( zoomOutButton ).toBeFocused();
+
+		await page.keyboard.press( 'Enter' );
+
+		await expect( zoomOutButton ).toBeFocused();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevents exiting zoom out mode from stealing focus if a block is selected.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Exiting zoom out mode should not steal focus.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
If we are exiting zoom out mode, don't automatically focus the selected block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Enable the zoom out mode experiment (Gutenberg Experiments)
- Go to site editor
- Select a block
- Click the zoom out button in the top toolbar
- Zoom out mode should be active
- Click the zoom out button again
- Zoom out mode should not be active
- Focus should be on the zoom out button

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
