### PR TITLE
Fix experimental useHasRecursion deprecation

### DIFF
--- a/packages/block-editor/src/components/recursion-provider/index.js
+++ b/packages/block-editor/src/components/recursion-provider/index.js
@@ -92,10 +92,10 @@ export const DeprecatedExperimentalRecursionProvider = ( props ) => {
 	return <RecursionProvider { ...props } />;
 };
 
-export const DeprecatedExperimentalUseHasRecursion = ( props ) => {
+export const DeprecatedExperimentalUseHasRecursion = ( ...args ) => {
 	deprecated( 'wp.blockEditor.__experimentalUseHasRecursion', {
 		since: '6.5',
 		alternative: 'wp.blockEditor.useHasRecursion',
 	} );
-	return useHasRecursion( ...props );
+	return useHasRecursion( ...args );
 };


### PR DESCRIPTION
## What?
Fixes #60437

Fixes the deprecation for `useHasRecursion`. I believe the intention was to apply all the arguments to the stable function, but `...` is missing in the function params, so only the first argument was being spread. Probably a copy/paste error.

## How?
Add `...`. Also renamed `props` to `args` as that confused me for a second.

## Testing Instructions
1. Find usage of `useHasRecursion` in a block (e.g. the `wp:block` block) and replace it with `__experimentalUseHasRecursion`. 
2. Insert that block in an editor and check it doesn't cause an error

## Screenshots or screencast <!-- if applicable -->
### Before
![Screenshot 2024-04-04 at 11 28 10 am](https://github.com/WordPress/gutenberg/assets/677833/653ad380-a3d0-431e-b347-99325c16726f)

### After
![Screenshot 2024-04-04 at 11 28 24 am](https://github.com/WordPress/gutenberg/assets/677833/81318784-d8a8-4323-9f99-40e569472b3f)
