### PR TITLE
Site Editor: Remove outdated border radius animation

### DIFF
--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -302,16 +302,12 @@ function ResizableFrame( {
 			} ) }
 			showHandle={ false } // Do not show the default handle, as we're using a custom one.
 		>
-			<motion.div
+			<div
 				className="edit-site-resizable-frame__inner-content"
-				animate={ {
-					borderRadius: isFullWidth ? 0 : 8,
-				} }
-				transition={ FRAME_TRANSITION }
 				style={ innerContentStyle }
 			>
 				{ children }
-			</motion.div>
+			</div>
 		</ResizableBox>
 	);
 }


### PR DESCRIPTION
Small PR that removes an outdated border radius animation which is now done in CSS. Also this code creates a bug where in some occasions the radius remain 0 even in "view" mode.

**Testing instructions**

 - In the site editor.
 - Enter and then exit "edit" mode.
 - The border radius of the frame should be correct.