### PR TITLE
Avoid calling getBlocks selector for navigation link blocks

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -190,7 +190,6 @@ export default function NavigationLinkEdit( {
 	const [ isLabelFieldFocused, setIsLabelFieldFocused ] = useState( false );
 
 	const {
-		innerBlocks,
 		isAtMaxNesting,
 		isTopLevelLink,
 		isParentOfSelectedBlock,
@@ -198,7 +197,6 @@ export default function NavigationLinkEdit( {
 	} = useSelect(
 		( select ) => {
 			const {
-				getBlocks,
 				getBlockCount,
 				getBlockName,
 				getBlockRootClientId,
@@ -207,7 +205,6 @@ export default function NavigationLinkEdit( {
 			} = select( blockEditorStore );
 
 			return {
-				innerBlocks: getBlocks( clientId ),
 				isAtMaxNesting:
 					getBlockParentsByBlockName( clientId, [
 						'core/navigation-link',
@@ -225,11 +222,13 @@ export default function NavigationLinkEdit( {
 		},
 		[ clientId, maxNestingLevel ]
 	);
+	const { getBlocks } = useSelect( blockEditorStore );
 
 	/**
 	 * Transform to submenu block.
 	 */
 	const transformToSubmenu = () => {
+		const innerBlocks = getBlocks( clientId );
 		const newSubmenu = createBlock(
 			'core/navigation-submenu',
 			attributes,


### PR DESCRIPTION
## What?

I was trying to check the performance trace of a template rendering in the editor, I've noticed that rendering `NavigationEditLink` is a bit slow (2ms) compared to other components (most other components around 0.1 or 0.2ms). I'm not entirely sure why but in this PR I'm making a small perf optimization (avoid calling a selector). It's probably not going to have a huge impact but it's better code anyway.

This PR has no impact at all in terms of behavior.