### PR TITLE
Priority queue: try once setting

### DIFF
--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { flushSync, useEffect, useState } from '@wordpress/element';
 import { createQueue } from '@wordpress/priority-queue';
 
 type AsyncListConfig = {
@@ -56,13 +56,15 @@ function useAsyncList< T >(
 		}
 		setCurrent( firstItems );
 
-		const asyncQueue = createQueue( { once: true } );
+		const asyncQueue = createQueue();
 		for ( let i = firstItems.length; i < list.length; i += step ) {
 			asyncQueue.add( {}, () => {
-				setCurrent( ( state ) => [
-					...state,
-					...list.slice( i, i + step ),
-				] );
+				flushSync( () => {
+					setCurrent( ( state ) => [
+						...state,
+						...list.slice( i, i + step ),
+					] );
+				} );
 			} );
 		}
 

--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -56,7 +56,7 @@ function useAsyncList< T >(
 		}
 		setCurrent( firstItems );
 
-		const asyncQueue = createQueue();
+		const asyncQueue = createQueue( { once: true } );
 		for ( let i = firstItems.length; i < list.length; i += step ) {
 			asyncQueue.add( {}, () => {
 				flushSync( () => {

--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { flushSync, useEffect, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { createQueue } from '@wordpress/priority-queue';
 
 type AsyncListConfig = {
@@ -56,15 +56,13 @@ function useAsyncList< T >(
 		}
 		setCurrent( firstItems );
 
-		const asyncQueue = createQueue();
+		const asyncQueue = createQueue( { once: true } );
 		for ( let i = firstItems.length; i < list.length; i += step ) {
 			asyncQueue.add( {}, () => {
-				flushSync( () => {
-					setCurrent( ( state ) => [
-						...state,
-						...list.slice( i, i + step ),
-					] );
-				} );
+				setCurrent( ( state ) => [
+					...state,
+					...list.slice( i, i + step ),
+				] );
 			} );
 		}
 

--- a/packages/edit-site/src/components/async/index.js
+++ b/packages/edit-site/src/components/async/index.js
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState, flushSync } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { createQueue } from '@wordpress/priority-queue';
 
-const blockPreviewQueue = createQueue();
+const blockPreviewQueue = createQueue( { once: true } );
 
 /**
  * Renders a component at the next idle time.
@@ -24,11 +24,7 @@ export function Async( { children, placeholder } ) {
 	useEffect( () => {
 		const context = {};
 		blockPreviewQueue.add( context, () => {
-			// Synchronously run all renders so it consumes timeRemaining.
-			// See https://github.com/WordPress/gutenberg/pull/48238
-			flushSync( () => {
-				setShouldRender( true );
-			} );
+			setShouldRender( true );
 		} );
 		return () => {
 			blockPreviewQueue.cancel( context );

--- a/packages/edit-site/src/components/async/index.js
+++ b/packages/edit-site/src/components/async/index.js
@@ -4,7 +4,7 @@
 import { useEffect, useState, flushSync } from '@wordpress/element';
 import { createQueue } from '@wordpress/priority-queue';
 
-const blockPreviewQueue = createQueue();
+const blockPreviewQueue = createQueue( { once: true } );
 
 /**
  * Renders a component at the next idle time.

--- a/packages/edit-site/src/components/async/index.js
+++ b/packages/edit-site/src/components/async/index.js
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, flushSync } from '@wordpress/element';
 import { createQueue } from '@wordpress/priority-queue';
 
-const blockPreviewQueue = createQueue( { once: true } );
+const blockPreviewQueue = createQueue();
 
 /**
  * Renders a component at the next idle time.
@@ -24,7 +24,11 @@ export function Async( { children, placeholder } ) {
 	useEffect( () => {
 		const context = {};
 		blockPreviewQueue.add( context, () => {
-			setShouldRender( true );
+			// Synchronously run all renders so it consumes timeRemaining.
+			// See https://github.com/WordPress/gutenberg/pull/48238
+			flushSync( () => {
+				setShouldRender( true );
+			} );
 		} );
 		return () => {
 			blockPreviewQueue.cancel( context );

--- a/packages/priority-queue/README.md
+++ b/packages/priority-queue/README.md
@@ -37,6 +37,11 @@ queue.add( ctx2, () => console.log( "This won't be printed" ) );
 queue.add( ctx2, () => console.log( 'This will be printed second' ) );
 ```
 
+_Parameters_
+
+-   _options_ `Object`:
+-   _options.once_ `boolean`: Execute only a callback once per idle callback.
+
 _Returns_
 
 -   `WPPriorityQueue`: Queue object with `add`, `flush` and `reset` methods.

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -48,6 +48,9 @@ import requestIdleCallback from './request-idle-callback';
  * Creates a context-aware queue that only executes
  * the last task of a given context.
  *
+ * @param {Object}  options
+ * @param {boolean} options.once Execute only a callback once per idle callback.
+ *
  * @example
  *```js
  * import { createQueue } from '@wordpress/priority-queue';
@@ -66,7 +69,7 @@ import requestIdleCallback from './request-idle-callback';
  *
  * @return {WPPriorityQueue} Queue object with `add`, `flush` and `reset` methods.
  */
-export const createQueue = () => {
+export const createQueue = ( { once } = { once: false } ) => {
 	/** @type {Map<WPPriorityQueueContext, WPPriorityQueueCallback>} */
 	const waitingList = new Map();
 	let isRunning = false;
@@ -93,6 +96,7 @@ export const createQueue = () => {
 			callback();
 
 			if (
+				once ||
 				'number' === typeof deadline ||
 				deadline.timeRemaining() <= 0
 			) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is an idea from @youknowriad https://github.com/WordPress/gutenberg/pull/60425#discussion_r1551470585

Basically instead of running multiple priority queue callback in one idle callback and checking idle time remaining, ~~forcing us to render sync~~, we could try an option to force one callback per idle callback. 

This would prevent multiple previews sneaking into a single idle callback, theoretically reducing lag.

~~The question is if the browser actually waits for the async rendering by React until it run the next idle callback. In my testing, it seem to. I wonder if @oandregal tests any regressions from #60425 with this PR.~~

~~I want to also look in @jsnajdr because he initially fixed async list in #48238 (reported by @fullofcaffeine). We could check if #48085 doesn't regress. In my testing, image patterns still render one by one after searching for them in the inserter.~~

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
