### PR TITLE
Interactivity: Return useMemo and useCallback hooks

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Hooks useMemo and useCallback should return a value. ([#59886](https://github.com/WordPress/gutenberg/pull/59886))
+-   Hooks useMemo and useCallback should return a value. ([#60474](https://github.com/WordPress/gutenberg/pull/60474))
 
 ## 5.4.0 (2024-04-03)
 

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Hooks useMemo and useCallback should return a value. ([#59886](https://github.com/WordPress/gutenberg/pull/59886))
+
 ## 5.4.0 (2024-04-03)
 
 ## 5.3.0 (2024-03-21)

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -192,7 +192,7 @@ export function useLayoutEffect( callback, inputs ) {
  *                            values in the list change (using `===`).
  */
 export function useCallback( callback, inputs ) {
-	_useCallback( withScope( callback ), inputs );
+	return _useCallback( withScope( callback ), inputs );
 }
 
 /**
@@ -209,7 +209,7 @@ export function useCallback( callback, inputs ) {
  *                           values in the list change (using `===`).
  */
 export function useMemo( factory, inputs ) {
-	_useMemo( withScope( factory ), inputs );
+	return _useMemo( withScope( factory ), inputs );
 }
 
 // For wrapperless hydration.

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -186,9 +186,13 @@ export function useLayoutEffect( callback, inputs ) {
  * scope available so functions like `getElement()` and `getContext()` can be
  * used inside the passed callback.
  *
- * @param {Function} callback Callback function.
- * @param {any[]}    inputs   If present, the callback will only be updated if the
- *                            values in the list change (using `===`).
+ * @template {Function} T The callback function type.
+ *
+ * @param {T}                      callback Callback function.
+ * @param {ReadonlyArray<unknown>} inputs   If present, the callback will only be updated if the
+ *                                          values in the list change (using `===`).
+ *
+ * @return {T} The callback function.
  */
 export function useCallback( callback, inputs ) {
 	return _useCallback( withScope( callback ), inputs );
@@ -202,9 +206,13 @@ export function useCallback( callback, inputs ) {
  * available so functions like `getElement()` and `getContext()` can be used
  * inside the passed factory function.
  *
- * @param {Function} factory Factory function that returns that value for memoization.
- * @param {any[]}    inputs  If present, the factory will only be run to recompute if the
- *                           values in the list change (using `===`).
+ * @template {unknown} T The momized value.
+ *
+ * @param {() => T}                factory Factory function that returns that value for memoization.
+ * @param {ReadonlyArray<unknown>} inputs  If present, the factory will only be run to recompute if
+ *                                         the values in the list change (using `===`).
+ *
+ * @return {T} The memoized value.
  */
 export function useMemo( factory, inputs ) {
 	return _useMemo( withScope( factory ), inputs );

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -206,7 +206,7 @@ export function useCallback( callback, inputs ) {
  * available so functions like `getElement()` and `getContext()` can be used
  * inside the passed factory function.
  *
- * @template {unknown} T The momized value.
+ * @template {unknown} T The memoized value.
  *
  * @param {() => T}                factory Factory function that returns that value for memoization.
  * @param {ReadonlyArray<unknown>} inputs  If present, the factory will only be run to recompute if

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -186,9 +186,8 @@ export function useLayoutEffect( callback, inputs ) {
  * scope available so functions like `getElement()` and `getContext()` can be
  * used inside the passed callback.
  *
- * @param {Function} callback Imperative function that can return a cleanup
- *                            function.
- * @param {any[]}    inputs   If present, effect will only activate if the
+ * @param {Function} callback Callback function.
+ * @param {any[]}    inputs   If present, the callback will only be updated if the
  *                            values in the list change (using `===`).
  */
 export function useCallback( callback, inputs ) {
@@ -203,9 +202,8 @@ export function useCallback( callback, inputs ) {
  * available so functions like `getElement()` and `getContext()` can be used
  * inside the passed factory function.
  *
- * @param {Function} factory Imperative function that can return a cleanup
- *                           function.
- * @param {any[]}    inputs  If present, effect will only activate if the
+ * @param {Function} factory Factory function that returns that value for memoization.
+ * @param {any[]}    inputs  If present, the factory will only be run to recompute if the
  *                           values in the list change (using `===`).
  */
 export function useMemo( factory, inputs ) {


### PR DESCRIPTION

## What?

Return a value from `useMemo` and `useCallback` hooks.

Observed while reviewing #60149.

## Why?

The `useCallback` and `useMemo` hooks are intended to be analogous to preact hooks and should return a value.

## Testing Instructions
Run this with a plugin with a `viewScriptModule` that uses these hooks, like this:

```js
import {
  store,
  useMemo,
  useRef,
  useCallback,
} from "@wordpress/interactivity";

store("myplugin/demo", {
  run() {
    const m = useMemo(() => "memoized");
    const cb = useCallback(() => "called back");
    const r = useRef("ref");
    console.log({ cb, cb_: cb(), m, r: r.current });
  },
});
```

Render some HTML like this:

```html
<div data-wp-interactive="myplugin/demo" data-wp-run="run"></div>
```

You should see this logged to the console:


```json
{
    "cb": ƒ,
    "cb_": "called back",
    "m": "memoized",
    "r": "ref"
}
```