### PR TITLE
[Mobile] - Fix Quote Block styles

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -106,7 +106,7 @@ export default function QuoteEdit( {
 				{ innerBlocksProps.children }
 				<Caption
 					attributeKey="citation"
-					tagName={ isWebPlatform ? 'cite' : undefined }
+					tagName={ isWebPlatform ? 'cite' : 'p' }
 					style={ isWebPlatform && { display: 'block' } }
 					isSelected={ isSelected }
 					attributes={ attributes }

--- a/packages/primitives/src/block-quotation/index.native.js
+++ b/packages/primitives/src/block-quotation/index.native.js
@@ -32,7 +32,10 @@ export const BlockQuotation = forwardRef( ( { ...props }, ref ) => {
 	const colorStyle = style?.color ? { color: style.color } : {};
 
 	const newChildren = Children.map( props.children, ( child ) => {
-		if ( child && child.props.identifier === 'citation' ) {
+		const { identifier, attributeKey } = child?.props || {};
+		const identifierKey = identifier ?? attributeKey;
+
+		if ( identifierKey === 'citation' ) {
 			return cloneElement( child, {
 				style: {
 					...styles.wpBlockQuoteCitation,

--- a/packages/primitives/src/block-quotation/style.native.scss
+++ b/packages/primitives/src/block-quotation/style.native.scss
@@ -2,7 +2,6 @@
 	border-left-width: 4px;
 	border-left-style: solid;
 	padding-left: $block-edge-to-content;
-	padding-top: $dashed-border-space;
 	margin-left: 0;
 }
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,7 +10,8 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
--   [*] Add empty fallback option for the BottomSheetSelectControl component
+-   [*] Add empty fallback option for the BottomSheetSelectControl component [#60333]
+-   [*] Fix Quote Block styles [#60476]
 
 ## 1.116.0
 -   [**] Highlight color formatting style improvements [#57650]

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -186,29 +186,29 @@ exports.spacerBlock = `<!-- wp:spacer -->
 
 exports.galleryBlock = `<!-- wp:gallery {"columns":8,"linkTo":"none","className":"alignfull"} -->
 <figure class="wp-block-gallery has-nested-images columns-8 is-cropped alignfull"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/njpygC0aF7.png"" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
 <!-- /wp:image -->
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption">Heading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/HOeupVqCwe.png" alt=""/><figcaption class="wp-element-caption">Heading</figcaption></figure>
 <!-- /wp:image -->
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption">Subheading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/s-OlAVlGJS.png" alt=""/><figcaption class="wp-element-caption">Image</figcaption></figure>
 <!-- /wp:image -->
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Quote.png" alt=""/><figcaption class="wp-element-caption">Quote</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/aBnr4SymR1.png" alt=""/><figcaption class="wp-element-caption">Cover</figcaption></figure>
 <!-- /wp:image -->
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Image.png" alt=""/><figcaption class="wp-element-caption">Image</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/aDIyKHI6Up.png" alt=""/><figcaption class="wp-element-caption">Video</figcaption></figure>
 <!-- /wp:image -->
 </figure>
 <!-- /wp:gallery -->`;
 
 exports.galleryBlockTwoImages = `<!-- wp:gallery {"columns":8,"linkTo":"none","className":"alignfull"} -->
 <figure class="wp-block-gallery has-nested-images columns-8 is-cropped alignfull"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/njpygC0aF7.png" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
 <!-- /wp:image -->
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption">Heading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/s-OlAVlGJS.png" alt=""/><figcaption class="wp-element-caption">Image</figcaption></figure>
 <!-- /wp:image -->
 </figure>
 <!-- /wp:gallery -->`;


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6790

## What?
Addresses styling regression after recent changes in https://github.com/WordPress/gutenberg/pull/59073

## Why?
To show the expected styles for this block.

## How?
By setting the `tagName` for the Citation component as well as updating the `BlockQuotation` component to use the `attributeKey` identifier as a fallback as well as updating some styles.

## Testing Instructions
- Open the app with metro running using the host apps
- Add a Quote block
- Type some text
- Select the parent Quote block
- Tap on the Citation button in the toolbar
- Type some text
- Expect the block to have the expected styles 

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

> [!NOTE]  
> The first block is a Quote block with a citation, the second block is a Quote block with two paragraphs without a citation.

Standard Theme Before (Light Mode)|Standard Theme After (Light Mode)
-|-
<kbd><img width=250 src="https://github.com/WordPress/gutenberg/assets/4885740/7e924050-0f26-40af-991c-ce1e373f84bc" /></kbd>|<kbd><img width=250 src="https://github.com/WordPress/gutenberg/assets/4885740/7145b8f2-8e21-4d38-bc82-33c28bf6a6e5" /></kbd>

Standard Theme After (Dark Mode)|Standard Theme After (Dark Mode)
-|-
<kbd><img width=250 src="https://github.com/WordPress/gutenberg/assets/4885740/9ac691a0-2070-45f8-8010-38392e7889f5" /></kbd>|<kbd><img width=250 src="https://github.com/WordPress/gutenberg/assets/4885740/bab36e1a-e597-4eaf-b708-74bb9d89e48c" /></kbd>

Block-based Theme Before|Block-based Theme After
-|-
<kbd><img width=250 src="https://github.com/WordPress/gutenberg/assets/4885740/aa0f6ce9-dce9-4b62-9e25-4ad515ccf524" /></kbd>|<kbd><img width=250 src="https://github.com/WordPress/gutenberg/assets/4885740/d18a565e-3ba5-45dd-b1be-1515d8e058e8" /></kbd>