### PR TITLE
Move block toolbar check to before rendering the block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -130,11 +130,6 @@ export function PrivateBlockToolbar( {
 
 	const isLargeViewport = ! useViewportMatch( 'medium', '<' );
 
-	const hasBlockToolbar = useHasBlockToolbar();
-	if ( ! hasBlockToolbar ) {
-		return null;
-	}
-
 	const isMultiToolbar = blockClientIds.length > 1;
 	const isSynced =
 		isReusableBlock( blockType ) || isTemplatePart( blockType );
@@ -242,6 +237,11 @@ export function PrivateBlockToolbar( {
  * @param {string}  props.variant        Style variant of the toolbar, also passed to the Dropdowns rendered from Block Toolbar Buttons.
  */
 export default function BlockToolbar( { hideDragHandle, variant } ) {
+	const hasBlockToolbar = useHasBlockToolbar();
+	if ( ! hasBlockToolbar ) {
+		return null;
+	}
+
 	return (
 		<PrivateBlockToolbar
 			hideDragHandle={ hideDragHandle }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Trying to improve performance of block toolbar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
🏇🏻 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
There's a check within block toolbar for `hasBlockToolbar` that happens after a useSelect. If `hasBlockToolbar` is false, we know we won't show the toolbar, so there's no reason to make a `useSelect` afterwards. However, I don't think this will speed up anything for block toolbars that _do_ render, just for the times where there is no block toolbar.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
