### PR TITLE
DataViews: set fixed preview height & reduce glitchiness

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -22,6 +22,7 @@ const EMPTY_ADDITIONAL_STYLES = [];
 
 function ScaledBlockPreview( {
 	viewportWidth,
+	viewportHeight,
 	containerWidth,
 	minHeight,
 	additionalStyles = EMPTY_ADDITIONAL_STYLES,
@@ -30,8 +31,13 @@ function ScaledBlockPreview( {
 		viewportWidth = containerWidth;
 	}
 
-	const [ contentResizeListener, { height: contentHeight } ] =
+	let [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
+
+	if ( viewportHeight ) {
+		contentHeight = viewportHeight;
+	}
+
 	const { styles } = useSelect( ( select ) => {
 		const settings = select( store ).getSettings();
 		return {
@@ -75,6 +81,7 @@ function ScaledBlockPreview( {
 				maxHeight:
 					contentHeight > MAX_HEIGHT ? MAX_HEIGHT * scale : undefined,
 				minHeight,
+				height: viewportHeight,
 			} }
 		>
 			<Iframe

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -25,6 +25,7 @@ const EMPTY_ADDITIONAL_STYLES = [];
 export function BlockPreview( {
 	blocks,
 	viewportWidth = 1200,
+	viewportHeight,
 	minHeight,
 	additionalStyles = EMPTY_ADDITIONAL_STYLES,
 	// Deprecated props:
@@ -79,6 +80,7 @@ export function BlockPreview( {
 		>
 			<AutoHeightBlockPreview
 				viewportWidth={ viewportWidth }
+				viewportHeight={ viewportHeight }
 				minHeight={ minHeight }
 				additionalStyles={ additionalStyles }
 			/>

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -182,6 +182,7 @@ function Preview( { item, categoryId, viewType } ) {
 							<BlockPreview
 								blocks={ item.blocks }
 								viewportWidth={ item.viewportWidth }
+								viewportHeight={ item.viewportWidth }
 							/>
 						</Async>
 					) }

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -175,7 +175,11 @@ function Preview( { item, viewType } ) {
 			>
 				{ viewType === LAYOUT_LIST && ! isEmpty && (
 					<Async>
-						<BlockPreview blocks={ blocks } />
+						<BlockPreview
+							blocks={ blocks }
+							viewportWidth={ 1200 }
+							viewportHeight={ 1200 }
+						/>
 					</Async>
 				) }
 				{ viewType !== LAYOUT_LIST && (
@@ -191,7 +195,11 @@ function Preview( { item, viewType } ) {
 								: __( 'Empty template part' ) ) }
 						{ ! isEmpty && (
 							<Async>
-								<BlockPreview blocks={ blocks } />
+								<BlockPreview
+									blocks={ blocks }
+									viewportWidth={ 1200 }
+									viewportHeight={ 1200 }
+								/>
 							</Async>
 						) }
 					</button>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

See for yourself the way the preview height looks glitchy before, and much more immediate after.

We can take advantage of the fixed tile size to also fix the iframe size, which makes iframe resizing unnecessary.

|Before|After|
|-|-|
|![patterns-before](https://github.com/WordPress/gutenberg/assets/4710635/85034117-1a47-45dd-9cef-592c369919b1)|![patterns-after](https://github.com/WordPress/gutenberg/assets/4710635/6f18e5e3-6e0a-4123-a513-711dd4fbbbed)|


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
