### PR TITLE
Add support for some user supplied props in ColorGradientSettingsDropdown

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/dropdown.js
+++ b/packages/block-editor/src/components/colors-gradients/dropdown.js
@@ -33,11 +33,19 @@ const WithToolsPanelItem = ( { setting, children, panelId, ...props } ) => {
 	};
 	return (
 		<ToolsPanelItem
-			hasValue={ () => {
-				return !! setting.colorValue || !! setting.gradientValue;
-			} }
+			hasValue={
+				typeof setting.hasValue === 'function'
+					? setting.hasValue
+					: () => {
+						return !! setting.colorValue || !! setting.gradientValue;
+					}
+			}
 			label={ setting.label }
-			onDeselect={ clearValue }
+			onDeselect={
+				typeof setting.onDeselect === 'function'
+					? setting.onDeselect
+					: clearValue
+			}
 			isShownByDefault={
 				setting.isShownByDefault !== undefined
 					? setting.isShownByDefault


### PR DESCRIPTION
## What?
In the `ColorGradientSettingsDropdown` component in `@wordpress/block-editor`, props `onDeselect` and `hasValue` can be supplied by the user. if they're undefined or not a function, falls back to the default behavior.

## Why?
The current behavior assumes that the default color value is empty - which isn't true sometimes. This small PR solves that.

## How?
It checks whether or not the props `setting.onDeselect` and `setting.hasValue` for the component `ColorGradientSettingsDropdown` are functions. If they are functions, then they are run respectively when a color is reset and to check if the control has a value.

## Testing Instructions
1. Import the `ColorGradientSettingsDropdown` component from `@wordpress/block-editor` package.
2. Set it up as needed, then include test functions for properties `onDeselect` and `hasValue` in a setting object. Example:
```jsx
<ColorGradientSettingsDropdown
    enableAlpha
    panelId={clientId}
    title={__("Color Settings", "plugin_textdomain")}
    popoverProps={{
        placement: "left start",
    }}
    settings={[{
        /* rest of your settings */
        onDeselect: () => {
            console.log("color deselected");
            setAttribute({ starColor: "#FFB901" });
        }
        hasValue: () => {
            if (starColor.toUpperCase() !== "#FFB901") {
                return true;
            }
            return false;
        }
    }]}
/>
```

### Testing Instructions for Keyboard

## Screenshots or screencast <!-- if applicable -->
