### PR TITLE
Enable justifying text

### DIFF
--- a/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
@@ -164,6 +164,29 @@ exports[`AlignmentUI should match snapshot when controls are visible 1`] = `
         </svg>
       </button>
     </div>
+    <div>
+      <button
+        align="justify"
+        aria-label="Justify text"
+        aria-pressed="false"
+        class="components-button components-toolbar__control has-icon"
+        data-toolbar-item="true"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4 12.8h16v-1.5H4v1.5zm0 7h12.4v-1.5H4v1.5zM4 4.3v1.5h16V4.3H4z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/packages/block-editor/src/components/alignment-control/ui.js
+++ b/packages/block-editor/src/components/alignment-control/ui.js
@@ -3,7 +3,7 @@
  */
 import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarDropdownMenu, ToolbarGroup } from '@wordpress/components';
-import { alignLeft, alignRight, alignCenter } from '@wordpress/icons';
+import {alignLeft, alignRight, alignCenter, alignJustify} from '@wordpress/icons';
 
 const DEFAULT_ALIGNMENT_CONTROLS = [
 	{
@@ -21,6 +21,11 @@ const DEFAULT_ALIGNMENT_CONTROLS = [
 		title: __( 'Align text right' ),
 		align: 'right',
 	},
+	{
+		icon: alignJustify,
+		title: __( 'Justify text' ),
+		align: 'justify',
+	}
 ];
 
 const POPOVER_PROPS = {

--- a/packages/block-editor/src/components/alignment-control/ui.js
+++ b/packages/block-editor/src/components/alignment-control/ui.js
@@ -3,7 +3,7 @@
  */
 import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarDropdownMenu, ToolbarGroup } from '@wordpress/components';
-import {alignLeft, alignRight, alignCenter, alignJustify} from '@wordpress/icons';
+import { alignLeft, alignRight, alignCenter, alignJustify } from '@wordpress/icons';
 
 const DEFAULT_ALIGNMENT_CONTROLS = [
 	{
@@ -25,7 +25,7 @@ const DEFAULT_ALIGNMENT_CONTROLS = [
 		icon: alignJustify,
 		title: __( 'Justify text' ),
 		align: 'justify',
-	}
+	},
 ];
 
 const POPOVER_PROPS = {

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -46,6 +46,11 @@
 	text-align: right;
 }
 
+.has-text-align-justify {
+	/*rtl:ignore*/
+	text-align: justify;
+}
+
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
 #end-resizable-editor-section {
 	display: none;


### PR DESCRIPTION
## What?
Add the "Justify text" option to alignment controls

## Why?
I wanted to justify text on some of my pages and was able to get it implemented, so I thought I would share (I even went and made my own SVG until I realized that the `align-justify` icon already exists 🤦‍♂️)

## How?
Adds an option to `DEFAULT_ALIGNMENT_CONTROLS` as well as the corresponding CSS class (I was trying to follow `.has-text-align-left` around as it seems to have a bunch of references near blockquotes and vertical writing modes and I wasn't sure if `.has-text-align-justify` should be put there as well, feel free to let me know and I'll add them)

## Testing Instructions
1. Create a paragraph block
2. Open the alignment controls
3. "Justify text" should be available and should justify the text when selected

### Testing Instructions for Keyboard
"Justify text" is navigable to via the arrow keys and selectable using space like the other alignment controls

## Screenshots or screencast

![image](https://github.com/WordPress/gutenberg/assets/10109659/ed371f7c-37ec-4f19-b826-a516e92dfa18)

Thanks!