### PR TITLE
Background image: display default background size value in global styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -492,9 +492,9 @@ function BackgroundSizeToolsPanelItem( {
 					label={ __( 'Fixed' ) }
 				/>
 			</ToggleGroupControl>
-			{ sizeValue !== undefined &&
-			sizeValue !== 'cover' &&
-			sizeValue !== 'contain' ? (
+			{ currentValueForToggle !== undefined &&
+			currentValueForToggle !== 'cover' &&
+			currentValueForToggle !== 'contain' ? (
 				<UnitControl
 					size={ '__unstable-large' }
 					onChange={ updateBackgroundSize }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -20,7 +20,7 @@ import {
 export const BACKGROUND_SUPPORT_KEY = 'background';
 
 // Initial control values where no block style is set.
-const BACKGROUND_BLOCK_DEFAULT_VALUES = {
+const BACKGROUND_DEFAULT_VALUES = {
 	backgroundSize: 'cover',
 };
 
@@ -173,7 +173,7 @@ export function BackgroundImagePanel( {
 			as={ BackgroundInspectorControl }
 			panelId={ clientId }
 			defaultControls={ defaultControls }
-			defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
+			defaultValues={ BACKGROUND_DEFAULT_VALUES }
 			settings={ updatedSettings }
 			onChange={ onChange }
 			value={ style }

--- a/packages/edit-site/src/components/global-styles/background-panel.js
+++ b/packages/edit-site/src/components/global-styles/background-panel.js
@@ -8,6 +8,11 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
+// Initial control values where no block style is set.
+const BACKGROUND_DEFAULT_VALUES = {
+	backgroundSize: 'auto',
+};
+
 const {
 	useGlobalStyle,
 	useGlobalSetting,
@@ -29,6 +34,7 @@ export default function BackgroundPanel() {
 			value={ style }
 			onChange={ setStyle }
 			settings={ settings }
+			defaultValues={ BACKGROUND_DEFAULT_VALUES }
 		/>
 	);
 }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of:

- https://github.com/WordPress/gutenberg/issues/54336

Follow up to:

- https://github.com/WordPress/gutenberg/pull/59454

This PR:
 - renames constant to `BACKGROUND_DEFAULT_VALUES`
 - ensures that the default background size for global styles is displayed in the control


## Why?
The default background size is not displayed on the control.

## How?
Passing the default background size.

## Testing Instructions

Using a block theme like 2024, head over to the site editor.

Select "Background" in global styles.

Ensure that "Fixed" is selected in the background size toggle control.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| <img width="283" alt="Screenshot 2024-04-05 at 2 20 35 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/696a5bfd-0be8-4be2-a64a-b45da12c72ba"> | <img width="283" alt="Screenshot 2024-04-05 at 2 18 48 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/6db70382-df0e-4046-89fb-a3bcd03de6c1"> | 





