### PR TITLE
Add null check to prevent errors in `get_block_template` filter

### DIFF
--- a/lib/compat/wordpress-6.6/resolve-patterns.php
+++ b/lib/compat/wordpress-6.6/resolve-patterns.php
@@ -71,6 +71,9 @@ function gutenberg_replace_pattern_blocks_get_block_templates( $templates ) {
 }
 
 function gutenberg_replace_pattern_blocks_get_block_template( $template ) {
+	if ( null === $template ) {
+		return $template;
+	}
 	$blocks            = parse_blocks( $template->content );
 	$blocks            = gutenberg_replace_pattern_blocks( $blocks );
 	$template->content = serialize_blocks( $blocks );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds null check to prevent `Error : Attempt to assign property "content" on null` in `gutenberg_replace_pattern_blocks_get_block_template` filter introduced in https://github.com/WordPress/gutenberg/pull/60349.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Since the first param `$template` is `WP_Block_Template` or `null` if there isn't one.
https://github.com/WordPress/wordpress-develop/blob/8d0aed455b1790c5d51386f7675d9e8d68e48edf/src/wp-includes/block-template-utils.php#L1113

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added null check before assigning the content. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
