### PR TITLE
File: Mark update for setting default label as non-persistent

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -84,7 +84,8 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 	);
 
 	const { createErrorNotice } = useDispatch( noticesStore );
-	const { toggleSelection } = useDispatch( blockEditorStore );
+	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 
 	useUploadMediaFromBlobURL( {
 		url: href,
@@ -92,12 +93,17 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		onError: onUploadError,
 	} );
 
+	// Note: Handle setting a default value for `downloadButtonText` via HTML API
+	// when it supports replacing text content for HTML tags.
 	useEffect( () => {
 		if ( RichText.isEmpty( downloadButtonText ) ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				downloadButtonText: _x( 'Download', 'button label' ),
 			} );
 		}
+		// Reason: This effect should only run on mount.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	function onSelectFile( newMedia ) {


### PR DESCRIPTION
## What?
Fix #60461.

PR fixes a bug for the File block and avoids triggering unsaved changes when the editor is loaded.

## Why?
The store update inside the side-effect should be marked as non-persistent to avoid history glitches or bugs described in the issue.

## How?
Use the `__unstableMarkNextChangeAsNotPersistent` action to mark the attribute update inside the side-effect as non-persistent.

## Testing Instructions
1. Open a post or page.
2. Insert a File block and select a file.
3. Publish the post.
4. Reload the editor.
5. Confirm that the post "Update" is disabled.

### Testing Instructions for Keyboard
Same.
