### PR TITLE
File: Use HTML API to update the PDF preview label

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -41,7 +41,11 @@ function render_block_core_file( $attributes, $content ) {
 
 		$filename     = $processor->get_attribute( 'aria-label' );
 		$has_filename = ! empty( $filename ) && 'PDF embed' !== $filename;
-		$label        = $has_filename ? sprintf( __( 'Embed of %s.' ), $filename ) : __( 'PDF embed' );
+		$label        = $has_filename ? sprintf(
+			/* translators: %s: filename. */
+			__( 'Embed of %s.' ),
+			$filename
+		) : __( 'PDF embed' );
 
 		// Update object's aria-label attribute if present in block HTML.
 		// Match an aria-label attribute from an object tag.

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -17,27 +17,6 @@
  * @return string Returns the block content.
  */
 function render_block_core_file( $attributes, $content ) {
-	// Update object's aria-label attribute if present in block HTML.
-	// Match an aria-label attribute from an object tag.
-	$pattern = '@<object.+(?<attribute>aria-label="(?<filename>[^"]+)?")@i';
-	$content = preg_replace_callback(
-		$pattern,
-		static function ( $matches ) {
-			$filename     = ! empty( $matches['filename'] ) ? $matches['filename'] : '';
-			$has_filename = ! empty( $filename ) && 'PDF embed' !== $filename;
-			$label        = $has_filename ?
-				sprintf(
-					/* translators: %s: filename. */
-					__( 'Embed of %s.' ),
-					$filename
-				)
-				: __( 'PDF embed' );
-
-			return str_replace( $matches['attribute'], sprintf( 'aria-label="%s"', $label ), $matches[0] );
-		},
-		$content
-	);
-
 	// If it's interactive, enqueue the script module and add the directives.
 	if ( ! empty( $attributes['displayPreview'] ) ) {
 		$suffix = wp_scripts_get_suffix();
@@ -59,6 +38,15 @@ function render_block_core_file( $attributes, $content ) {
 		$processor->next_tag( 'object' );
 		$processor->set_attribute( 'data-wp-bind--hidden', '!state.hasPdfPreview' );
 		$processor->set_attribute( 'hidden', true );
+
+		$filename     = $processor->get_attribute( 'aria-label' );
+		$has_filename = ! empty( $filename ) && 'PDF embed' !== $filename;
+		$label        = $has_filename ? sprintf( __( 'Embed of %s.' ), $filename ) : __( 'PDF embed' );
+
+		// Update object's aria-label attribute if present in block HTML.
+		// Match an aria-label attribute from an object tag.
+		$processor->set_attribute( 'aria-label', $label );
+
 		return $processor->get_updated_html();
 	}
 


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/43050#discussion_r941244171.

PR updates the File block rendered to use HTML API instead of custom regex to update the PDF preview label.

## Why?
HTML API is a recommended way to make similar modifications.

## Testing Instructions
1. Open a post.
2. Insert a File block.
3. Upload and select a PDF file.
4. Enable "Show inline embed".
5. Preview the post.
6. Inspect the file block's HTML via DevTools.
7. Confirm that the label is correct for an object tag.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-05 at 10 51 21](https://github.com/WordPress/gutenberg/assets/240569/57bdbaf7-05a2-4914-a8ce-f2299a21a895)
