### PR TITLE
Allow async callback function for registry.batch()

### DIFF
--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -313,16 +313,16 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		return store.store;
 	}
 
-	function batch( callback ) {
+	async function batch( callback ) {
 		// If we're already batching, just call the callback.
 		if ( emitter.isPaused ) {
-			callback();
+			await callback();
 			return;
 		}
 
 		emitter.pause();
 		Object.values( stores ).forEach( ( store ) => store.emitter.pause() );
-		callback();
+		await callback();
 		emitter.resume();
 		Object.values( stores ).forEach( ( store ) => store.emitter.resume() );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR allows registry.batch function to await for async callback function, so it can properly stop the emitter after the callback is actually done.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When the callback function has more than just sync logic, the batch function doesn't await for the promise to fulfill, causing emitter to resume earlier than desired.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Code review should be good. It doesn't change existing behaviour when it's a synchronous function. Only adds support for async function
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
