### PR TITLE
Media & Text: Hide the alt text option for featured images

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -318,7 +318,7 @@ function MediaTextEdit( {
 						onDrag={ imperativeFocalPointPreview }
 					/>
 				) }
-			{ mediaType === 'image' && mediaUrl && ! featuredImageURL && (
+			{ mediaType === 'image' && mediaUrl && ! useFeaturedImage && (
 				<TextareaControl
 					__nextHasNoMarginBottom
 					label={ __( 'Alternative text' ) }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -318,11 +318,11 @@ function MediaTextEdit( {
 						onDrag={ imperativeFocalPointPreview }
 					/>
 				) }
-			{ mediaType === 'image' && ( mediaUrl || featuredImageURL ) && (
+			{ mediaType === 'image' && mediaUrl && ! featuredImageURL && (
 				<TextareaControl
 					__nextHasNoMarginBottom
 					label={ __( 'Alternative text' ) }
-					value={ mediaAlt || featuredImageAlt }
+					value={ mediaAlt }
 					onChange={ onMediaAltChange }
 					help={
 						<>

--- a/packages/block-library/src/media-text/index.php
+++ b/packages/block-library/src/media-text/index.php
@@ -48,7 +48,7 @@ function render_block_core_media_text( $attributes, $content ) {
 	}
 	$processor->set_attribute( 'src', esc_url( $current_featured_image ) );
 	$processor->set_attribute( 'class', 'wp-image-' . get_post_thumbnail_id() . ' size-' . $media_size_slug );
-	$processor->set_attribute( 'alt', esc_attr( get_post_meta( get_post_thumbnail_id(), '_wp_attachment_image_alt', true ) ) );
+	$processor->set_attribute( 'alt', trim( strip_tags( get_post_meta( get_post_thumbnail_id(), '_wp_attachment_image_alt', true ) ) ) );
 
 	$content = $processor->get_updated_html();
 

--- a/packages/block-library/src/media-text/index.php
+++ b/packages/block-library/src/media-text/index.php
@@ -48,6 +48,7 @@ function render_block_core_media_text( $attributes, $content ) {
 	}
 	$processor->set_attribute( 'src', esc_url( $current_featured_image ) );
 	$processor->set_attribute( 'class', 'wp-image-' . get_post_thumbnail_id() . ' size-' . $media_size_slug );
+	$processor->set_attribute( 'alt', esc_attr( get_post_meta( get_post_thumbnail_id(), '_wp_attachment_image_alt', true ) ) );
 
 	$content = $processor->get_updated_html();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Hides the TextareaControl for the alternative text if the block uses a featured image.
Adds the alt attribute to the img tag on the front.

Closes https://github.com/WordPress/gutenberg/issues/60023

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The alt text option does not work correctly in the editor, it is problematic inside query loops, and the alt text is not output on the front. Please see the discussion in the linked issue.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR:
- Updates the condition that shows the option for editing the alternative text, so that it is hidden when a featured image is used.
- Adds the alt attribute to the img tag on the front, using the WP_HTML_Tag_Processor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

With Gutenberg **trunk**:
Add three media & text blocks:
One with a video, one with a standard image, and one with a featured image. The featured image should not have an alt text in the media library.
Save.

Apply the PR.
Refresh the post and confirm that the PR does not cause any block validation errors with the existing blocks.
Select the media & text block that has the standard image. Confirm that the alternative text option shows in the block settings panel.
Select the media & text block that has the featured image. Confirm that the alternative text option does not show.

Confirm that the block with the featured image has an empty alt attribute in the editor and the front.
Return to the editor, open the media library and add an alt text to the featured image.
Confirm that the block with the featured image uses the correct text in the alt attribute in the editor and the front.
