### PR TITLE
Data Views: Rename displayAsColumnFields to columnFields API

### DIFF
--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -35,7 +35,7 @@ function GridItem( {
 	primaryField,
 	visibleFields,
 	badgeFields,
-	displayAsColumnFields,
+	columnFields,
 } ) {
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
@@ -139,7 +139,7 @@ function GridItem( {
 							<Flex
 								className={ classnames(
 									'dataviews-view-grid__field',
-									displayAsColumnFields?.includes( field.id )
+									columnFields?.includes( field.id )
 										? 'is-column'
 										: 'is-row'
 								) }
@@ -149,7 +149,7 @@ function GridItem( {
 								expanded
 								style={ { height: 'auto' } }
 								direction={
-									displayAsColumnFields?.includes( field.id )
+									columnFields?.includes( field.id )
 										? 'column'
 										: 'row'
 								}
@@ -235,9 +235,7 @@ export default function ViewGrid( {
 								primaryField={ primaryField }
 								visibleFields={ visibleFields }
 								badgeFields={ badgeFields }
-								displayAsColumnFields={
-									view.layout.displayAsColumnFields
-								}
+								columnFields={ view.layout.columnFields }
 							/>
 						);
 					} ) }

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -67,7 +67,7 @@ const defaultConfigPerViewType = {
 	[ LAYOUT_GRID ]: {
 		mediaField: 'preview',
 		primaryField: 'title',
-		displayAsColumnFields: [ 'description' ],
+		columnFields: [ 'description' ],
 	},
 	[ LAYOUT_LIST ]: {
 		primaryField: 'title',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small follow up of: https://github.com/WordPress/gutenberg/pull/60284#pullrequestreview-1979460298

This PR just renames `displayAsColumnFields` to `columnFields` API.

## Testing Instructions
1. In templates list and in `grid` layout description should be displayed as a column, as is currently in trunk.
