### PR TITLE
Inserter: custom appender should only render if parent is selected

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -184,6 +184,9 @@ function Items( {
 					__unstableGetEditorMode,
 				} = select( blockEditorStore );
 				const selectedBlockClientId = getSelectedBlockClientId();
+				const isParentSelected = selectedBlockClientId === rootClientId;
+				const isRootWithoutSelectedBlock =
+					! selectedBlockClientId && ! rootClientId;
 				return {
 					order: getBlockOrder( rootClientId ),
 					selectedBlocks: getSelectedBlockClientIds(),
@@ -191,11 +194,12 @@ function Items( {
 					shouldRenderAppender:
 						hasAppender &&
 						( hasCustomAppender
-							? ! getTemplateLock( rootClientId ) &&
+							? isParentSelected &&
+							  ! getTemplateLock( rootClientId ) &&
 							  getBlockEditingMode( rootClientId ) !==
 									'disabled' &&
 							  __unstableGetEditorMode() !== 'zoom-out'
-							: rootClientId === selectedBlockClientId ),
+							: isParentSelected || isRootWithoutSelectedBlock ),
 				};
 			},
 			[ rootClientId, hasAppender, hasCustomAppender ]

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -195,8 +195,7 @@ function Items( {
 							  getBlockEditingMode( rootClientId ) !==
 									'disabled' &&
 							  __unstableGetEditorMode() !== 'zoom-out'
-							: rootClientId === selectedBlockClientId ||
-							  ( ! rootClientId && ! selectedBlockClientId ) ),
+							: rootClientId === selectedBlockClientId ),
 				};
 			},
 			[ rootClientId, hasAppender, hasCustomAppender ]

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -187,6 +187,8 @@ function Items( {
 				const isParentSelected = selectedBlockClientId === rootClientId;
 				const isRootWithoutSelectedBlock =
 					! selectedBlockClientId && ! rootClientId;
+				const canRenderAppender =
+					isParentSelected || isRootWithoutSelectedBlock;
 				return {
 					order: getBlockOrder( rootClientId ),
 					selectedBlocks: getSelectedBlockClientIds(),
@@ -194,12 +196,12 @@ function Items( {
 					shouldRenderAppender:
 						hasAppender &&
 						( hasCustomAppender
-							? isParentSelected &&
+							? canRenderAppender &&
 							  ! getTemplateLock( rootClientId ) &&
 							  getBlockEditingMode( rootClientId ) !==
 									'disabled' &&
 							  __unstableGetEditorMode() !== 'zoom-out'
-							: isParentSelected || isRootWithoutSelectedBlock ),
+							: canRenderAppender ),
 				};
 			},
 			[ rootClientId, hasAppender, hasCustomAppender ]

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -391,7 +391,6 @@ test.describe( 'Columns', () => {
 		} );
 
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Delete' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Whenever a block renders inner blocks with a custom appender, this appender should not render if container block is not selected. The behaviour should be the same as the default appender.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
