### PR TITLE
Update site hub action positioning

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -15,7 +15,7 @@
 	z-index: z-index(".edit-site-layout__hub");
 
 	@include break-medium {
-		width: calc(#{$nav-sidebar-width} - #{$grid-unit-30});
+		width: calc(#{$nav-sidebar-width} - #{$grid-unit-15});
 	}
 
 	.edit-site-layout.is-full-canvas & {

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -159,7 +159,7 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 							<HStack
 								spacing={ 0 }
 								expanded={ false }
-								style={ { flexShrink: '0' } }
+								className="edit-site-site-hub__actions"
 							>
 								<Button
 									href={ homeUrl }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -156,7 +156,11 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 							<div className="edit-site-site-hub__title">
 								{ decodeEntities( siteTitle ) }
 							</div>
-							<HStack spacing={ 0 } expanded={ false }>
+							<HStack
+								spacing={ 0 }
+								expanded={ false }
+								style={ { flexShrink: '0' } }
+							>
 								<Button
 									href={ homeUrl }
 									target="_blank"

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -156,25 +156,28 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 							<div className="edit-site-site-hub__title">
 								{ decodeEntities( siteTitle ) }
 							</div>
+							<HStack spacing={ 0 } expanded={ false }>
+								<Button
+									href={ homeUrl }
+									target="_blank"
+									label={ __(
+										'View site (opens in a new tab)'
+									) }
+									aria-label={ __(
+										'View site (opens in a new tab)'
+									) }
+									icon={ external }
+									className="edit-site-site-hub__site-view-link"
+								/>
 
-							<Button
-								href={ homeUrl }
-								target="_blank"
-								label={ __( 'View site (opens in a new tab)' ) }
-								aria-label={ __(
-									'View site (opens in a new tab)'
-								) }
-								icon={ external }
-								className="edit-site-site-hub__site-view-link"
-							/>
-
-							<Button
-								className="edit-site-site-hub_toggle-command-center"
-								icon={ search }
-								onClick={ () => openCommandCenter() }
-								label={ __( 'Open command palette' ) }
-								shortcut={ displayShortcut.primary( 'k' ) }
-							/>
+								<Button
+									className="edit-site-site-hub_toggle-command-center"
+									icon={ search }
+									onClick={ () => openCommandCenter() }
+									label={ __( 'Open command palette' ) }
+									shortcut={ displayShortcut.primary( 'k' ) }
+								/>
+							</HStack>
 						</HStack>
 					) }
 				</AnimatePresence>

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -3,7 +3,6 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: $grid-unit-10;
-	overflow: hidden;
 }
 
 .edit-site-site-hub__view-mode-toggle-container {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -28,7 +28,6 @@
 }
 
 .edit-site-site-hub__site-view-link {
-	flex-grow: 0;
 	margin-right: var(--wp-admin-border-width-focus);
 	svg {
 		fill: $gray-200;

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -5,6 +5,10 @@
 	gap: $grid-unit-10;
 }
 
+.edit-site-site-hub__actions {
+	flex-shrink: 0;
+}
+
 .edit-site-site-hub__view-mode-toggle-container {
 	height: $header-height;
 	width: $header-height;


### PR DESCRIPTION
The spacing of icons in the sidebar is a bit messy, this PR aims to start tidying that up by updating the site hub. 

### Before
<img width="891" alt="Screenshot 2024-04-05 at 13 35 17" src="https://github.com/WordPress/gutenberg/assets/846565/8d44bc90-5f9f-441b-b794-156ec75f0ff1">

Notice how the search icon is not aligned with the plus / chevron from other panels.

### After
<img width="893" alt="Screenshot 2024-04-05 at 13 35 37" src="https://github.com/WordPress/gutenberg/assets/846565/7a3d4c91-460d-4d5a-9789-54f53ac1bb61">

Notice the search icon is now aligned with the plus / chevron. I also reduced the gap between search / view buttons.
