### PR TITLE
Interactivity API: Include `preact/debug` when `SCRIPT_DEBUG` is enabled

### DIFF
--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -14,11 +14,9 @@ function gutenberg_reregister_interactivity_script_modules() {
 	wp_deregister_script_module( '@wordpress/interactivity' );
 	wp_deregister_script_module( '@wordpress/interactivity-router' );
 
-	$should_use_debug_version = wp_is_development_mode( 'plugin' ) || wp_is_development_mode( 'core' );
-
 	wp_register_script_module(
 		'@wordpress/interactivity',
-		gutenberg_url( '/build/interactivity/' . ( $should_use_debug_version ? 'debug.min.js' : 'index.min.js' ) ),
+		gutenberg_url( '/build/interactivity/' . ( SCRIPT_DEBUG ? 'debug.min.js' : 'index.min.js' ) ),
 		array(),
 		$default_version
 	);

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -14,9 +14,11 @@ function gutenberg_reregister_interactivity_script_modules() {
 	wp_deregister_script_module( '@wordpress/interactivity' );
 	wp_deregister_script_module( '@wordpress/interactivity-router' );
 
+	$should_use_debug_version = wp_is_development_mode( 'plugin' ) || wp_is_development_mode( 'core' );
+
 	wp_register_script_module(
 		'@wordpress/interactivity',
-		gutenberg_url( '/build/interactivity/' . ( wp_is_development_mode( 'plugin' ) ? 'debug.min.js' : 'index.min.js' ) ),
+		gutenberg_url( '/build/interactivity/' . ( $should_use_debug_version ? 'debug.min.js' : 'index.min.js' ) ),
 		array(),
 		$default_version
 	);

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -16,7 +16,7 @@ function gutenberg_reregister_interactivity_script_modules() {
 
 	wp_register_script_module(
 		'@wordpress/interactivity',
-		gutenberg_url( '/build/interactivity/index.min.js' ),
+		gutenberg_url( '/build/interactivity/' . ( wp_is_development_mode( 'plugin' ) ? 'debug.min.js' : 'index.min.js' ) ),
 		array(),
 		$default_version
 	);

--- a/packages/interactivity/src/debug.ts
+++ b/packages/interactivity/src/debug.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import 'preact/debug';
+
+export * from './index';

--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -18,6 +18,7 @@ module.exports = {
 	name: 'interactivity',
 	entry: {
 		index: './packages/interactivity',
+		debug: './packages/interactivity/src/debug',
 		router: './packages/interactivity-router',
 		navigation: './packages/block-library/src/navigation/view.js',
 		query: './packages/block-library/src/query/view.js',


### PR DESCRIPTION
## What?

Closes #59829.

This PR introduces `preact/debug` in the Interactivity API runtime when `SCRIPT_DEBUG` is enabled.

## Why?
To integrate the Interactivity API runtime with the [Preact Devtools](https://preactjs.github.io/preact-devtools/), helping developers debug their interactive blocks.

## How?

Creating another bundle with the Interactivity API runtime with `preact/debug` at the top.

As `preact/debug` imports `preact` internally, both libraries need to be included in the same bundle. That's why I haven't created a separate bundle with only `preact/debug`.

In addition, we may want to include more stuff in the debug version of the Interactivity API.

## Testing Instructions

ℹ️ Note that your browser needs the [Peact Devtools](https://preactjs.github.io/preact-devtools/) installed.
ℹ️ `SCRIPT_DEBUG` is enabled by default in `@wordpress/env` (see [this](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#default-wp-config-values)).

1. Visit a page with interactive blocks.
2. Open the dev tools, go to the Network tab, and ensure `build/interactivity/debug.min.js` appears there.
3. Check that the Preact Devtools extension is enabled and works as expected.
4. Change `SCRIPT_DEBUG` to false in your development site config. If you are using `wp-env`, you can add this to your `.wp-ev.override.json` file:
   ```
   	"config": {
		"SCRIPT_DEBUG": false
	},
   ```
5. Visit the same page with interactive blocks again
6. Open the dev tools, go to the Network tab, and that now the file is `build/interactivity/index.min.js`.
7. Check that the Preact Devtools extension displays _This page doesn't seem to be using Preact._