### PR TITLE
Add better explanation on when to use PanelRow

### DIFF
--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -50,6 +50,8 @@ Panels should be expanded by default if the content is important or essential. P
 
 The `Panel` creates a container with a header that can take collapsible `PanelBody` components to easily create a user friendly interface for affecting state and attributes.
 
+A `PanelRow` is only necessary when you want to wrap multiple components in a row. With only one component, there is no difference in wrapping it in a `PanelRow` or not.
+
 ### Usage
 
 ```jsx


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds better explanation on when to use a `PanelRow` component and when not.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In #41671 it was mentioned ([comment](https://github.com/WordPress/gutenberg/issues/41671#issuecomment-2027329733)), that using a PanelRow for single components is not necessary / may have side-effects. For example some inputs may not render as expected, since they are flex-children. For my self, the documentation suggested, that the structure should always be `Panel` > `PanelBody` > `PanelRow`. I think it may make sense, to explicitly state, that using a PanelRow is not necessary. 

Here's a screenshot showing the difference:


PanelRow is a flex-child and adds margin-top.
![gb-panel-rows](https://github.com/WordPress/gutenberg/assets/5585580/83e00118-e3cc-4220-aa3a-99b4cda601f2)

## Open Questions
The markdown file in question has some linting errors: missing image alt texts and especially duplicate heading ids. Is there a rule on how to avoid duplicate heading ids if the headings are the same (`Usage`)?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
