### PR TITLE
Fix: Link to the block building tutorial.

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -314,7 +314,7 @@ See the [Meta Box Tutorial](https://developer.wordpress.org/block-editor/how-to-
 
 ### How can plugins extend the Gutenberg UI?
 
-The main extension point we want to emphasize is creating new blocks. Blocks are added to the block editor using plugins, see the [Create a Block Tutorial](https://developer.wordpress.org/block-editor/getting-stared/create-block/) to get started.
+The main extension point we want to emphasize is creating new blocks. Blocks are added to the block editor using plugins, see the [Build your first block Tutorial](https://developer.wordpress.org/block-editor/getting-started/tutorial/) to get started.
 
 ### Are Custom Post Types still supported?
 


### PR DESCRIPTION
The link https://developer.wordpress.org/block-editor/getting-stared/create-block/ does not exist anymore and returns a 404 error. This PR updates the link and link description to the new similar tutorial available at https://developer.wordpress.org/block-editor/getting-started/tutorial/.