### PR TITLE
I18N: Add context to 'Library' string

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	Modal,
 	privateApis as componentsPrivateApis,
@@ -23,7 +23,7 @@ const { Tabs } = unlock( componentsPrivateApis );
 
 const DEFAULT_TAB = {
 	id: 'installed-fonts',
-	title: __( 'Library' ),
+	title: _x( 'Library', 'Font library' ),
 };
 
 const UPLOAD_TAB = {


### PR DESCRIPTION
## What?
To help translators, this PR adds a context to the 'Library' string used in the font library.

<img width="258" alt="fonts" src="https://github.com/WordPress/gutenberg/assets/617637/f6c2957b-505e-4dfd-94dd-ba81185dbcef">


## Why?
WordPress core is also using 'Library' as the menu label for the media library. In some languages like German we have to use different translations based on the context.

<img width="378" alt="media-library" src="https://github.com/WordPress/gutenberg/assets/617637/dc3371c1-074b-41b8-bcd1-b164687aa004">



## How?
Uses `_x()` with a context.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
