### PR TITLE
Perf testing: wait for links in templates

### DIFF
--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -328,17 +328,14 @@ test.describe( 'Site Editor Performance', () => {
 								.getByTitle( 'Editor canvas' )
 						);
 
-						// Wait until the first block is rendered AND all
-						// patterns are replaced.
-						await Promise.all( [
-							canvas.locator( '.wp-block' ).first().waitFor(),
-							page.waitForFunction(
-								() =>
-									document.querySelectorAll(
-										'[data-type="core/pattern"]'
-									).length === 0
-							),
-						] );
+						// We need to wait for some essential content that all
+						// index patterns have in common. A portfolio index
+						// template does not have a title or content, but all
+						// patterns do have links to the posts.
+						await canvas
+							.locator( '[data-type="core/post-template"] a' )
+							.first()
+							.waitFor();
 					} )
 				);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Instead of just waiting for the first block, we should wait until a link in the post template appears. Looking for a link is a robust way to wait for content because that's the only thing all post templates have in common (e.g. portfolio is just a list of linked featured images).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently we only performance test up to the point when the first block wrapper block appears. This is not a good metric for how fast a template loads. There's no perfect way, but this seems better.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
