### PR TITLE
Standardise capitalisation of Navigation Menu in sidebar

### DIFF
--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -5,7 +5,7 @@ import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export const convertDescription = __(
-	"This navigation menu displays your website's pages. Editing it will enable you to add, delete, or reorder pages. However, new pages will no longer be added automatically."
+	"This Navigation Menu displays your website's pages. Editing it will enable you to add, delete, or reorder pages. However, new pages will no longer be added automatically."
 );
 
 export function ConvertToLinksModal( { onClick, onClose, disabled } ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-confirm-dialog.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-confirm-dialog.js
@@ -17,7 +17,7 @@ export default function DeleteConfirmDialog( { onClose, onConfirm } ) {
 			onCancel={ onClose }
 			confirmButtonText={ __( 'Delete' ) }
 		>
-			{ __( 'Are you sure you want to delete this Navigation menu?' ) }
+			{ __( 'Are you sure you want to delete this Navigation Menu?' ) }
 		</ConfirmDialog>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -64,7 +64,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 		return (
 			<SidebarNavigationScreenWrapper
 				description={ __(
-					'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
+					'Navigation Menus are a curated collection of blocks that allow visitors to get around your site.'
 				) }
 			>
 				<Spinner className="edit-site-sidebar-navigation-screen-navigation-menus__loading" />

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -37,7 +37,7 @@ export default function SingleNavigationMenu( {
 				navigationMenu?.status
 			) }
 			description={ __(
-				'Navigation menus are a curated collection of blocks that allow visitors to get around your site.'
+				'Navigation Menus are a curated collection of blocks that allow visitors to get around your site.'
 			) }
 		>
 			<NavigationMenuEditor navigationMenuId={ navigationMenu?.id } />

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -36,7 +36,7 @@ function useDeleteNavigationMenu() {
 				}
 			);
 			createSuccessNotice(
-				__( 'Navigation menu successfully deleted.' ),
+				__( 'Navigation Menu successfully deleted.' ),
 				{
 					type: 'snackbar',
 				}
@@ -46,7 +46,7 @@ function useDeleteNavigationMenu() {
 			createErrorNotice(
 				sprintf(
 					/* translators: %s: error message describing why the navigation menu could not be deleted. */
-					__( `Unable to delete Navigation menu (%s).` ),
+					__( `Unable to delete Navigation Menu (%s).` ),
 					error?.message
 				),
 
@@ -107,7 +107,7 @@ function useSaveNavigationMenu() {
 					throwOnError: true,
 				}
 			);
-			createSuccessNotice( __( 'Renamed Navigation menu' ), {
+			createSuccessNotice( __( 'Renamed Navigation Menu' ), {
 				type: 'snackbar',
 			} );
 		} catch ( error ) {
@@ -117,7 +117,7 @@ function useSaveNavigationMenu() {
 			createErrorNotice(
 				sprintf(
 					/* translators: %s: error message describing why the navigation menu could not be renamed. */
-					__( `Unable to rename Navigation menu (%s).` ),
+					__( `Unable to rename Navigation Menu (%s).` ),
 					error?.message
 				),
 
@@ -162,7 +162,7 @@ function useDuplicateNavigationMenu() {
 			);
 
 			if ( savedRecord ) {
-				createSuccessNotice( __( 'Duplicated Navigation menu' ), {
+				createSuccessNotice( __( 'Duplicated Navigation Menu' ), {
 					type: 'snackbar',
 				} );
 				goTo( `/navigation/${ postType }/${ savedRecord.id }` );
@@ -171,7 +171,7 @@ function useDuplicateNavigationMenu() {
 			createErrorNotice(
 				sprintf(
 					/* translators: %s: error message describing why the navigation menu could not be deleted. */
-					__( `Unable to duplicate Navigation menu (%s).` ),
+					__( `Unable to duplicate Navigation Menu (%s).` ),
 					error?.message
 				),
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -143,7 +143,7 @@ export function SidebarNavigationScreenWrapper( {
 		<SidebarNavigationScreen
 			title={ title || __( 'Navigation' ) }
 			actions={ actions }
-			description={ description || __( 'Manage your Navigation menus.' ) }
+			description={ description || __( 'Manage your Navigation Menus.' ) }
 			content={ children }
 		/>
 	);

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -32,7 +32,7 @@ const TYPE_LABELS = {
 	// translators: 1: Pattern title.
 	wp_pattern: __( 'Editing pattern: %s' ),
 	// translators: 1: Navigation menu title.
-	wp_navigation: __( 'Editing navigation menu: %s' ),
+	wp_navigation: __( 'Editing Navigation Menu: %s' ),
 	// translators: 1: Template title.
 	wp_template: __( 'Editing template: %s' ),
 	// translators: 1: Template part title.

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -32,7 +32,7 @@ const TYPE_LABELS = {
 	// translators: 1: Pattern title.
 	wp_pattern: __( 'Editing pattern: %s' ),
 	// translators: 1: Navigation menu title.
-	wp_navigation: __( 'Editing Navigation Menu: %s' ),
+	wp_navigation: __( 'Editing navigation menu: %s' ),
 	// translators: 1: Template title.
 	wp_template: __( 'Editing template: %s' ),
 	// translators: 1: Template part title.


### PR DESCRIPTION
## What?
Standardising the capitalisation of the phrase "Navigation Menu" in the sidebar. Carrying on from last PR #60262 

## Why?
Pull request #60262 does this for some text, however I missed some. Now they should all be updated across the plugin with this PR.

## How?
Manually reviewed codebase for outstanding uncapitalised uses of "Navigation Menu" in user-facing labels

## Testing Instructions
Nothing to test as this only changes user-facing labels