### PR TITLE
Post Title: avoid accidental types requests

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -18,12 +18,8 @@ import {
 import { ToggleControl, TextControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
-import { useEntityProp } from '@wordpress/core-data';
-
-/**
- * Internal dependencies
- */
-import { useCanEditEntity } from '../utils/hooks';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 
 export default function PostTitleEdit( {
 	attributes: { level, textAlign, isLink, rel, linkTarget },
@@ -33,16 +29,26 @@ export default function PostTitleEdit( {
 } ) {
 	const TagName = 'h' + level;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
-	/**
-	 * Hack: useCanEditEntity may trigger an OPTIONS request to the REST API via the canUser resolver.
-	 * However, when the Post Title is a descendant of a Query Loop block, the title cannot be edited.
-	 * In order to avoid these unnecessary requests, we call the hook without
-	 * the proper data, resulting in returning early without making them.
-	 */
-	const userCanEdit = useCanEditEntity(
-		'postType',
-		! isDescendentOfQueryLoop && postType,
-		postId
+	const userCanEdit = useSelect(
+		( select ) => {
+			/**
+			 * useCanEditEntity may trigger an OPTIONS request to the REST API
+			 * via the canUser resolver. However, when the Post Title is a
+			 * descendant of a Query Loop block, the title cannot be edited. In
+			 * order to avoid these unnecessary requests, we call the hook
+			 * without the proper data, resulting in returning early without
+			 * making them.
+			 */
+			if ( isDescendentOfQueryLoop ) {
+				return false;
+			}
+			return select( coreStore ).canUserEditEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+		},
+		[ isDescendentOfQueryLoop, postType, postId ]
 	);
 	const [ rawTitle = '', setTitle, fullTitle ] = useEntityProp(
 		'postType',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In #49839, an effort was made to avoid OPTIONS requests, however the hack introduced there is causing incorrect calls to `getEntityConfig` (with the `postType` being set to `false`) and causes many requests to the `/wp/v2/types?context=view` endpoint because it cannot find the config.

Let's adjust the `useSelect` call to correctly return early and avoid calling the `canUserEditEntityRecord` altogether.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Return early inside the `useSelect` call.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
