### PR TITLE
Remove store subscription in useGradient

### DIFF
--- a/packages/block-editor/src/components/gradients/use-gradient.js
+++ b/packages/block-editor/src/components/gradients/use-gradient.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useMemo } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -55,6 +55,7 @@ export function getGradientSlugByValue( gradients, value ) {
 }
 
 export function __experimentalUseGradient( {
+	attributes,
 	gradientAttribute = 'gradient',
 	customGradientAttribute = 'customGradient',
 } = {} ) {
@@ -77,17 +78,8 @@ export function __experimentalUseGradient( {
 		],
 		[ userGradientPalette, themeGradientPalette, defaultGradientPalette ]
 	);
-	const { gradient, customGradient } = useSelect(
-		( select ) => {
-			const { getBlockAttributes } = select( blockEditorStore );
-			const attributes = getBlockAttributes( clientId ) || {};
-			return {
-				customGradient: attributes[ customGradientAttribute ],
-				gradient: attributes[ gradientAttribute ],
-			};
-		},
-		[ clientId, gradientAttribute, customGradientAttribute ]
-	);
+	const customGradient = attributes[ customGradientAttribute ];
+	const gradient = attributes[ gradientAttribute ];
 
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const setGradient = useCallback(

--- a/packages/block-editor/src/components/gradients/with-gradient.js
+++ b/packages/block-editor/src/components/gradients/with-gradient.js
@@ -1,9 +1,0 @@
-/**
- * Internal dependencies
- */
-import { __experimentalUseGradient } from './use-gradient';
-
-export const withGradient = ( WrappedComponent ) => ( props ) => {
-	const { gradientValue } = __experimentalUseGradient();
-	return <WrappedComponent { ...props } gradientValue={ gradientValue } />;
-};

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -162,7 +162,9 @@ function CoverEdit( {
 		: originalBackgroundType;
 
 	const { createErrorNotice } = useDispatch( noticesStore );
-	const { gradientClass, gradientValue } = __experimentalUseGradient();
+	const { gradientClass, gradientValue } = __experimentalUseGradient( {
+		attributes,
+	} );
 
 	const onSelectMedia = async ( newMedia ) => {
 		const mediaAttributes = attributesFromMedia( newMedia );

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -114,7 +114,9 @@ export default function CoverInspectorControls( {
 		overlayColor,
 	} = currentSettings;
 
-	const { gradientValue, setGradient } = __experimentalUseGradient();
+	const { gradientValue, setGradient } = __experimentalUseGradient( {
+		attributes,
+	} );
 
 	const toggleParallax = () => {
 		setAttributes( {

--- a/packages/block-library/src/post-featured-image/overlay-controls.js
+++ b/packages/block-library/src/post-featured-image/overlay-controls.js
@@ -23,7 +23,9 @@ const Overlay = ( {
 	setOverlayColor,
 } ) => {
 	const { dimRatio } = attributes;
-	const { gradientValue, setGradient } = __experimentalUseGradient();
+	const { gradientValue, setGradient } = __experimentalUseGradient( {
+		attributes,
+	} );
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 
 	if ( ! colorGradientSettings.hasColorsOrGradients ) {

--- a/packages/block-library/src/post-featured-image/overlay.js
+++ b/packages/block-library/src/post-featured-image/overlay.js
@@ -21,7 +21,9 @@ import { dimRatioToClass } from './utils';
 
 const Overlay = ( { attributes, overlayColor } ) => {
 	const { dimRatio } = attributes;
-	const { gradientClass, gradientValue } = __experimentalUseGradient();
+	const { gradientClass, gradientValue } = __experimentalUseGradient( {
+		attributes,
+	} );
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 
 	const borderProps = useBorderProps( attributes );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

All the use cases of this hook have direct access to the block attributes. We should avoid an extra store subscription.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
