### PR TITLE
useBlockSync: avoid replacing same blocks

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -10,6 +10,7 @@ import { cloneBlock } from '@wordpress/blocks';
  */
 import { store as blockEditorStore } from '../../store';
 import { undoIgnoreBlocks } from '../../store/undo-ignore';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 const noop = () => {};
 
@@ -94,11 +95,20 @@ export default function useBlockSync( {
 
 	const pendingChanges = useRef( { incoming: null, outgoing: [] } );
 	const subscribed = useRef( false );
+	const lastControlledBlocks = useRef( [] );
 
 	const setControlledBlocks = () => {
 		if ( ! controlledBlocks ) {
 			return;
 		}
+
+		if (
+			isShallowEqual( controlledBlocks, lastControlledBlocks.current )
+		) {
+			return;
+		}
+
+		lastControlledBlocks.current = controlledBlocks;
 
 		// We don't need to persist this change because we only replace
 		// controlled inner blocks when the change was caused by an entity,

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -95,7 +95,7 @@ export default function useBlockSync( {
 
 	const pendingChanges = useRef( { incoming: null, outgoing: [] } );
 	const subscribed = useRef( false );
-	const lastControlledBlocks = useRef( [] );
+	const lastControlledBlocks = useRef();
 
 	const setControlledBlocks = () => {
 		if ( ! controlledBlocks ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently `setControlledBlocks` is often called twice on load for exactly the same array of blocks. This seems to happen because there is a second effect that runs when a block becomes controlled, though blocks may already have been set by an effect that also sets this `isControlled` flag.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The amount of calls to the `setControlledBlocks` is reduce from 38 to 24 times for the TT4 business index template.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
