### PR TITLE
adds: div tag on 'latest posts' block's frontend to match with editor markup

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -214,7 +214,7 @@ function render_block_core_latest_posts( $attributes ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
 	return sprintf(
-		'<ul %1$s>%2$s</ul>',
+		'<div><ul %1$s>%2$s</ul></div',
 		$wrapper_attributes,
 		$list_items_markup
 	);


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make consistent Markup in the Editor vs front-end for Latest Posts block.

## Why?
There was inconsistent markup in the editor vs. front-end on the 'Latest Posts' block.

Reference: https://github.com/WordPress/gutenberg/issues/60540

## How?
Add an extra 'div' tag on the frontend to keep consistency in markup in both the frontend and editor and resolving styling issues caused by the inconsistency.

## Testing Instructions

- Go to the editor and create a new post or page.
- Add the "Latest Posts" block.
- Save.
- Inspect the markup rendered in the editor vs. on the front-end.
- Markup will be in same pattern which was not, previously in frontend there was no 'div' which caused styling issues

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
