### PR TITLE
Fix safari bug with classes not being added to iframe elements

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -134,13 +134,26 @@ function Iframe( {
 			setIframeDocument( node.contentDocument );
 		};
 		let iFrameDocument;
+		let iFrameLoadTimeout;
+
 		// Prevent the default browser action for files dropped outside of dropzones.
 		function preventFileDropDefault( event ) {
 			event.preventDefault();
 		}
-		function onLoad() {
+		function onLoad( event, retry = 0 ) {
 			const { contentDocument, ownerDocument } = node;
 			const { documentElement } = contentDocument;
+
+			// Sometimes Safari fires the load event before the document is ready.
+			if ( contentDocument.body === null && retry < 3 ) {
+				retry++;
+				iFrameLoadTimeout = setTimeout(
+					() => onLoad( event, retry ),
+					100
+				);
+				return;
+			}
+
 			// Get any CSS classes the iframe document body may initially have
 			// to re-apply them later together with the ones of the main document
 			// body. This is necessary for some CSS classes for example the
@@ -214,6 +227,7 @@ function Iframe( {
 				'drop',
 				preventFileDropDefault
 			);
+			clearTimeout( iFrameLoadTimeout );
 		};
 	}, [] );
 


### PR DESCRIPTION
## What?
Often in Safari the correct styles are not applied to the editor iframe elements. This currently only shows itself in zoomed out mode as the `.block-editor-iframe__html` class is not applied, so the required transformation styles to make zoomed out mode work are not applied.

You might need to refresh the browser several times to see the issue, it does not happen with every load.

## Why?
Sometimes Safari fires the load event before `contentDocument` is properly loaded in the iFrame, so a `contentDocument.body` is null exception is thrown and the correct classes are not applied.

<img width="1274" alt="Screenshot 2024-04-09 at 12 44 09 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/e9fa7a55-5114-4821-b5be-93f18875be10">


## How?
Checks that `contentDocument.body !== null` and if it is run `onLoad` again after a timeout.

## Testing Instructions

- Enable the zoomed out mode experiment
- In Chrome and Safari reload the site editor multiple times and toggle in and out of zoom mode and make sure the iframe is resized and aligned correctly

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/dc152038-9e06-4028-80d0-1442e776d1a4

After:

https://github.com/WordPress/gutenberg/assets/3629020/535f02e4-94db-40e6-b938-7a296f32ab08


