### PR TITLE
Global Styles: fix browser warning regarding highlight colors

### DIFF
--- a/packages/edit-site/src/components/global-styles/highlighted-colors.js
+++ b/packages/edit-site/src/components/global-styles/highlighted-colors.js
@@ -16,7 +16,7 @@ export default function HighlightedColors( {
 	const scaledSwatchSize = normalizedColorSwatchSize * ratio;
 	return highlightedColors.map( ( { slug, color }, index ) => (
 		<motion.div
-			key={ slug }
+			key={ `${ slug }-${ index }` }
 			style={ {
 				height: scaledSwatchSize,
 				width: scaledSwatchSize,


### PR DESCRIPTION
Related to #59498, #56622

## What?

This PR fixes a browser warning error that occurs when two highlight color slugs in the global style preview are the same.

![highlighted-colors](https://github.com/WordPress/gutenberg/assets/54422211/6fdd9bef-43fd-4f3e-8811-7a7dc021bc86)

## Why?

The two calculated highlight colors do not necessarily have different slugs.

## How?

Add the `index` to the `slug` as a key for the child element of the `map()` function. An `index` alone would probably be fine, but this approach has been [used in several places](https://github.com/search?q=repo%3AWordPress%2Fgutenberg+%2Fkey%3D.*-%5C%24%5C%7B+index+%5C%7D%2F&type=code).

## Testing Instructions

- Go to the Site Editor > Styles
- Confirm that no browser warning errors occur.