### PR TITLE
Block: reduce fn executions in selector

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -14,15 +14,12 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import {
-	getBlockType,
 	getSaveContent,
 	isUnmodifiedDefaultBlock,
 	serializeRawBlock,
 	switchToBlockType,
 	getDefaultBlockName,
 	isUnmodifiedBlock,
-	isReusableBlock,
-	getBlockDefaultClassName,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
@@ -146,7 +143,7 @@ function BlockListBlock( {
 		/>
 	);
 
-	const blockType = getBlockType( name );
+	const { blockType } = context;
 
 	// Determine whether the block has props to apply to the wrapper.
 	if ( blockType?.getEditWrapperProps ) {
@@ -561,6 +558,7 @@ function BlockListBlockProvider( props ) {
 			const {
 				hasBlockSupport: _hasBlockSupport,
 				getActiveBlockVariation,
+				getBlockType,
 			} = select( blocksStore );
 			const attributes = getBlockAttributes( clientId );
 			const { name: blockName, isValid } = blockWithoutAttributes;
@@ -570,7 +568,6 @@ function BlockListBlockProvider( props ) {
 				supportsLayout,
 				__unstableIsPreviewMode: isPreviewMode,
 			} = getSettings();
-			const hasLightBlockWrapper = blockType?.apiVersion > 1;
 			const previewContext = {
 				blockWithoutAttributes,
 				name: blockName,
@@ -578,13 +575,7 @@ function BlockListBlockProvider( props ) {
 				isValid,
 				themeSupportsLayout: supportsLayout,
 				index: getBlockIndex( clientId ),
-				isReusable: isReusableBlock( blockType ),
-				className: hasLightBlockWrapper
-					? attributes.className
-					: undefined,
-				defaultClassName: hasLightBlockWrapper
-					? getBlockDefaultClassName( blockName )
-					: undefined,
+				blockType,
 				blockTitle: blockType?.title,
 			};
 
@@ -632,7 +623,6 @@ function BlockListBlockProvider( props ) {
 						'__experimentalExposeControlsToChildren',
 						false
 					) && hasSelectedInnerBlock( clientId ),
-				blockApiVersion: blockType?.apiVersion || 1,
 				blockTitle: match?.title || blockType?.title,
 				isSubtreeDisabled:
 					blockEditingMode === 'disabled' &&
@@ -689,7 +679,6 @@ function BlockListBlockProvider( props ) {
 		mayDisplayControls,
 		mayDisplayParentControls,
 		index,
-		blockApiVersion,
 		blockTitle,
 		isSubtreeDisabled,
 		isOutlineEnabled,
@@ -698,7 +687,7 @@ function BlockListBlockProvider( props ) {
 		isHighlighted,
 		isMultiSelected,
 		isPartiallySelected,
-		isReusable,
+		blockType,
 		isDragging,
 		hasChildSelected,
 		removeOutline,
@@ -707,8 +696,6 @@ function BlockListBlockProvider( props ) {
 		templateLock,
 		isEditingDisabled,
 		hasEditableOutline,
-		className,
-		defaultClassName,
 	} = selectedProps;
 
 	// Users of the editor.BlockListBlock filter used to be able to
@@ -729,11 +716,10 @@ function BlockListBlockProvider( props ) {
 
 	const privateContext = {
 		clientId,
-		className,
+		attributes,
 		index,
 		mode,
 		name,
-		blockApiVersion,
 		blockTitle,
 		isSelected,
 		isSubtreeDisabled,
@@ -744,7 +730,7 @@ function BlockListBlockProvider( props ) {
 		isHighlighted,
 		isMultiSelected,
 		isPartiallySelected,
-		isReusable,
+		blockType,
 		isDragging,
 		hasChildSelected,
 		removeOutline,
@@ -754,7 +740,6 @@ function BlockListBlockProvider( props ) {
 		isEditingDisabled,
 		hasEditableOutline,
 		isTemporarilyEditingAsBlocks,
-		defaultClassName,
 		mayDisplayControls,
 		mayDisplayParentControls,
 		themeSupportsLayout,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -8,7 +8,11 @@ import classnames from 'classnames';
  */
 import { useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
+import {
+	__unstableGetBlockProps as getBlockProps,
+	isReusableBlock,
+	getBlockDefaultClassName,
+} from '@wordpress/blocks';
 import { useMergeRefs, useDisabled } from '@wordpress/compose';
 import warning from '@wordpress/warning';
 
@@ -76,13 +80,12 @@ import { canBindBlock } from '../../../hooks/use-bindings-attributes';
 export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const {
 		clientId,
-		className,
+		attributes,
 		wrapperProps = {},
 		isAligned,
 		index,
 		mode,
 		name,
-		blockApiVersion,
 		blockTitle,
 		isSelected,
 		isSubtreeDisabled,
@@ -93,7 +96,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isHighlighted,
 		isMultiSelected,
 		isPartiallySelected,
-		isReusable,
+		blockType,
 		isDragging,
 		hasChildSelected,
 		removeOutline,
@@ -102,7 +105,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isEditingDisabled,
 		hasEditableOutline,
 		isTemporarilyEditingAsBlocks,
-		defaultClassName,
 		templateLock,
 	} = useContext( PrivateBlockContext );
 
@@ -132,6 +134,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		hasBlockBindings && canBindBlock( name )
 			? { '--wp-admin-theme-color': 'var(--wp-bound-block-color)' }
 			: {};
+	const blockApiVersion = blockType?.apiVersion || 1;
+	const hasLightBlockWrapper = blockApiVersion > 1;
 
 	// Ensures it warns only inside the `edit` implementation for the block.
 	if ( blockApiVersion < 2 && clientId === blockEditContext.clientId ) {
@@ -162,7 +166,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				'is-highlighted': isHighlighted,
 				'is-multi-selected': isMultiSelected,
 				'is-partially-selected': isPartiallySelected,
-				'is-reusable': isReusable,
+				'is-reusable': isReusableBlock( blockType ),
 				'is-dragging': isDragging,
 				'has-child-selected': hasChildSelected,
 				'remove-outline': removeOutline,
@@ -173,10 +177,10 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				'is-content-locked-temporarily-editing-as-blocks':
 					isTemporarilyEditingAsBlocks,
 			},
-			className,
+			hasLightBlockWrapper ? attributes.className : undefined,
 			props.className,
 			wrapperProps.className,
-			defaultClassName
+			hasLightBlockWrapper ? getBlockDefaultClassName( name ) : undefined
 		),
 		style: { ...wrapperProps.style, ...props.style, ...bindingsStyle },
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Both `getBlockDefaultClassName` and `isReusableBlock` are not store selectors and should not be called inside a selector function, which is executed many more times than a render function. Let's moved them to the render hook instead. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Above sums it up, and `getBlockDefaultClassName` contains some regexes, so it's worth reducing calls to it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
