### PR TITLE
[Mobile] - ColorPalette - Check for ScrollView reference

### DIFF
--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -61,6 +61,7 @@ function ColorPalette( {
 
 	const scale = useRef( new Animated.Value( 1 ) ).current;
 	const opacity = useRef( new Animated.Value( 1 ) ).current;
+	const delayedScrollRef = useRef();
 
 	const mergedColors = [
 		...new Set(
@@ -216,11 +217,11 @@ function ColorPalette( {
 	}
 
 	function scrollToEndWithDelay() {
-		const delayedScroll = setTimeout( () => {
-			scrollViewRef.current.scrollToEnd();
+		delayedScrollRef.current = setTimeout( () => {
+			scrollViewRef?.current.scrollToEnd();
 		}, ANIMATION_DURATION );
 		return () => {
-			clearTimeout( delayedScroll );
+			clearTimeout( delayedScrollRef.current );
 		};
 	}
 


### PR DESCRIPTION
## What?
Related to this [issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/6793), where in some cases the Scroll View reference is undefined when the timeout is called.

## Why?
To prevent the app from crashing.

## How?
First by storing the timeout reference to keep just one reference and to clear it correctly. 

It also adds an optional chaining before calling `scrollToEnd` to prevent it from crashing for `undefined` references.

## Testing Instructions
> [!NOTE]  
> I couldn't find steps to reproduce the issue so testing the scrolling functionality is enough

- Open the app with metro running
- Add a Buttons block
- Open the block settings
- Tap on Background
- Tap on the Gradient option
- Select the last color
- Tap on Customize gradient
- Change the Angle of the Gradient
- Dismiss the bottom sheet
- Open the block settings
- Tap on Background
- **Expect** the list to scroll to the end automatically

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/4885740/f0edde2f-f709-4327-87d9-17edb8f9965b