### PR TITLE
[Mobile] - Error Boundary - Remove usage of deprecated SASS syntax

### DIFF
--- a/packages/editor/src/components/error-boundary/style.native.scss
+++ b/packages/editor/src/components/error-boundary/style.native.scss
@@ -28,7 +28,7 @@
 	justify-content: center;
 	margin-bottom: 8px;
 	background-color: rgba(60, 60, 67, 0.3);
-	border-radius: $size/2;
+	border-radius: 20px;
 }
 
 .error-boundary__icon-container--dark {


### PR DESCRIPTION
## What?
This PR addresses a deprecation warning in metro.

## Why?
After https://github.com/WordPress/gutenberg/pull/59823 was added, a new warning is constantly showing whenever metro is running, even when generating bundles.

```console
transform[stderr]: DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
transform[stderr]: 
transform[stderr]: Recommendation: math.div($size, 2)
transform[stderr]: 
transform[stderr]: More info and automated migrator: https://sass-lang.com/d/slash-div
transform[stderr]: 
transform[stderr]:    ╷
transform[stderr]: 39 │     border-radius: $size/2;
```

## How?
Since we can't use `math.div` in mobile, this PR sets the fixed value of `20px`, this value comes from the variable `$size` that has a value of `40px`.

## Testing Instructions
- Open the app with metro running
- Once the editor loads, there shouldn't be any warning related to this code in the console.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A