### PR TITLE
Fix undefined var error

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2112,6 +2112,7 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 export const getBlockTransformItems = createSelector(
 	( state, blocks, rootClientId = null ) => {
 		const normalizedBlocks = Array.isArray( blocks ) ? blocks : [ blocks ];
+		const filteredBlocks = normalizedBlocks.filter( ( block ) => !! block );
 		const buildBlockTypeTransformItem = buildBlockTypeItem( state, {
 			buildScope: 'transform',
 		} );
@@ -2129,7 +2130,7 @@ export const getBlockTransformItems = createSelector(
 		);
 
 		const possibleTransforms = getPossibleBlockTransformations(
-			normalizedBlocks
+			filteredBlocks
 		).reduce( ( accumulator, block ) => {
 			if ( itemsByName[ block?.name ] ) {
 				accumulator.push( itemsByName[ block.name ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix error where blocks list contains [null] as value.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Here is a screenshot of the bug. 
![image](https://github.com/WordPress/gutenberg/assets/6070516/4e52b503-eb1d-4450-a1b1-37eda6168193)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By filtering the blocks first, we avoid passing null value in the blocks down the callstack.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Unfortunately I don't know how to reproduce this in vanilla Gutenberg setup. But it happens in a plugin we are working on.
