### PR TITLE
Fix: Do not show pattern and template actions on the post editor.

### DIFF
--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -18,6 +18,11 @@ import { moreVertical } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
 import { usePostActions } from './actions';
 import { store as editorStore } from '../../store';
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+} from '../../store/constants';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -71,6 +76,15 @@ export default function PostActions( { onActionPerformed } ) {
 			{ primaryActions: [], secondaryActions: [] }
 		);
 	}, [ actions, item ] );
+	if (
+		[
+			TEMPLATE_POST_TYPE,
+			TEMPLATE_PART_POST_TYPE,
+			PATTERN_POST_TYPE,
+		].includes( postType )
+	) {
+		return null;
+	}
 	return (
 		<DropdownMenu
 			trigger={

--- a/packages/editor/src/store/constants.js
+++ b/packages/editor/src/store/constants.js
@@ -20,3 +20,4 @@ export const ONE_MINUTE_IN_MS = 60 * 1000;
 export const AUTOSAVE_PROPERTIES = [ 'title', 'excerpt', 'content' ];
 export const TEMPLATE_POST_TYPE = 'wp_template';
 export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
+export const PATTERN_POST_TYPE = 'wp_block';


### PR DESCRIPTION
We are showing generic post actions on templates and patterns in the post editor. Some of these actions don't make sense (e.g. view post), we should hide these actions until template and pattern actions are ported to the editor module making them available on edit post too.

### Testing Instructions for Keyboard
Edit a sync pattern on the post editor (e.g: add a sync pattern and then click edit original) and verify no actions are available on the top of the right sidebar.
Edit a template on the post editor and verify no actions are available on the top of the right sidebar.
