### PR TITLE
Block support hooks: avoid style* hooks if not present

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -410,7 +410,14 @@ function useBlockProps( {
 export default {
 	useBlockProps,
 	addSaveProps,
-	attributeKeys: [ 'backgroundColor', 'textColor', 'gradient', 'style' ],
+	attributeKeys: [
+		'backgroundColor',
+		'textColor',
+		'gradient',
+		'style.color',
+		'style.background',
+		'elements.link.color',
+	],
 	hasSupport: hasColorSupport,
 };
 

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -156,7 +156,7 @@ export function hasDimensionsSupport( blockName, feature = 'any' ) {
 
 export default {
 	useBlockProps,
-	attributeKeys: [ 'minHeight', 'style' ],
+	attributeKeys: [ 'minHeight', 'style.dimensions' ],
 	hasSupport( name ) {
 		return hasDimensionsSupport( name, 'aspectRatio' );
 	},

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -178,7 +178,7 @@ export default {
 	shareWithChildBlocks: true,
 	edit: DuotonePanelPure,
 	useBlockProps,
-	attributeKeys: [ 'style' ],
+	attributeKeys: [ 'style.color.duotone' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, 'filter.duotone' );
 	},

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -207,7 +207,7 @@ function useBlockProps( { name, fontSize, style } ) {
 export default {
 	useBlockProps,
 	addSaveProps,
-	attributeKeys: [ 'fontSize', 'style' ],
+	attributeKeys: [ 'fontSize', 'style.typography.fontSize' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, FONT_SIZE_SUPPORT_KEY );
 	},

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -172,7 +172,7 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 export default {
 	useBlockProps: useBlockPropsChildLayoutStyles,
 	edit: ChildLayoutControlsPure,
-	attributeKeys: [ 'style' ],
+	attributeKeys: [ 'style.layout' ],
 	hasSupport() {
 		return true;
 	},

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -321,7 +321,7 @@ export default {
 		return <PositionPanelPure { ...props } />;
 	},
 	useBlockProps,
-	attributeKeys: [ 'style' ],
+	attributeKeys: [ 'style.position' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, POSITION_SUPPORT_KEY );
 	},

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -10,7 +10,7 @@
  */
 export function setImmutably( object, path, value ) {
 	// Normalize path
-	path = Array.isArray( path ) ? [ ...path ] : [ path ];
+	path = Array.isArray( path ) ? [ ...path ] : path.split( '.' );
 
 	// Shallowly clone the base of the object
 	object = Array.isArray( object ) ? [ ...object ] : { ...object };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently we have quite a few "block support hooks" that depend on the `style` attribute, and so only run when the `style` attribute is present. The problem is that, for templates, most blocks actually have `style` attribute, which means that all of these hooks run, even if the necessary style keys are not present.

This PR adjusts the the utility so nested keys can be passed to `attributeKeys`. For example, you can pass, `style.duotone`, which will cause the `useBlockProps` and `addSaveProps` to only be called if `style.duotone` if it's present in the block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Explained above I hope.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This is done by flattening the needed attributes, check if there are needed attributes. For components, we pass this to a pure component so the component only changes if the needed value changes. After that we reconstruct an attributes object that only contains the needed values. (Note that in the future we could redesign this private API a bit so we don't need to reconstruct an object, if we choose to do so.)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
