### PR TITLE
Allow tab to be active but not selected

### DIFF
--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -30,13 +30,18 @@ function Tabs( {
 	orientation = 'horizontal',
 	onSelect,
 	children,
+	selectedOnMount = true,
 	selectedTabId,
 }: TabsProps ) {
 	const instanceId = useInstanceId( Tabs, 'tabs' );
+
 	const store = Ariakit.useTabStore( {
 		selectOnMove,
 		orientation,
-		defaultSelectedId: defaultTabId && `${ instanceId }-${ defaultTabId }`,
+		defaultSelectedId:
+			defaultTabId && selectedOnMount
+				? `${ instanceId }-${ defaultTabId }`
+				: null,
 		setSelectedId: ( selectedId ) => {
 			const strippedDownId =
 				typeof selectedId === 'string'
@@ -48,7 +53,6 @@ function Tabs( {
 	} );
 
 	const isControlled = selectedTabId !== undefined;
-
 	const { items, selectedId, activeId } = store.useState();
 	const { setSelectedId, setActiveId } = store;
 
@@ -83,17 +87,25 @@ function Tabs( {
 			return;
 		}
 
+		const setInitialTab = ( tabId: string | undefined ) => {
+			if ( selectedOnMount ) {
+				setSelectedId( tabId );
+			} else {
+				setActiveId( tabId );
+			}
+		};
+
 		// If the currently selected tab is missing (i.e. removed from the DOM),
 		// fall back to the initial tab or the first enabled tab if there is
 		// one. Otherwise, no tab should be selected.
 		if ( ! items.find( ( item ) => item.id === selectedId ) ) {
 			if ( initialTab && ! initialTab.dimmed ) {
-				setSelectedId( initialTab?.id );
+				setInitialTab( initialTab?.id );
 				return;
 			}
 
 			if ( firstEnabledTab ) {
-				setSelectedId( firstEnabledTab.id );
+				setInitialTab( firstEnabledTab.id );
 			} else if ( tabsHavePopulated.current ) {
 				setSelectedId( null );
 			}
@@ -105,6 +117,8 @@ function Tabs( {
 		isControlled,
 		items,
 		selectedId,
+		selectedOnMount,
+		setActiveId,
 		setSelectedId,
 	] );
 

--- a/packages/components/src/tabs/types.ts
+++ b/packages/components/src/tabs/types.ts
@@ -45,6 +45,13 @@ export type TabsProps = {
 	 */
 	defaultTabId?: string;
 	/**
+	 * If the initial tab should show the tab pane (be selected) or only
+	 * show the active tab.
+	 *
+	 * @default true
+	 */
+	selectedOnMount?: boolean;
+	/**
 	 * The function called when a tab has been selected.
 	 * It is passed the id of the newly selected tab as an argument.
 	 */


### PR DESCRIPTION
More context in https://github.com/WordPress/gutenberg/issues/52997#issuecomment-2035568332

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
There is not a way to have the first tab be active (the one receiving focus) but not _selected_ (have its tab pane visible). For the patterns inserter, I needed this behavior: https://github.com/WordPress/gutenberg/pull/60257

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Sometimes you don't want any tab pane selected by default. This was possible before, but the focus was set to the wrapping element, not the first tab.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a `selectedOnMount` prop that defaults to `true` to preserve the existing behavior. If you set `selectedOnMount` to false, it will set the first tab as the active one (receives focus) but not select it until an enter keypress on that tab.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Test the patterns inserter in https://github.com/WordPress/gutenberg/pull/60257.
- Open Block inserter (in post editor and in site editor)
- Select Pattern Tab
- Tab to patten categories panel
- Focus should be on first tab
- Use arrows to navigate between the patterns
- Select a pattern
- Tab into patterns panel
- Shift + Tab out
- Focus should be on the selected category
- Arrow between patterns and repeat switching between categories

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
