### PR TITLE
Remove animation from InlineLinkUI

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -252,10 +252,11 @@ function InlineLinkUI( {
 	return (
 		<Popover
 			anchor={ popoverAnchor }
+			animate={ false }
 			onClose={ stopAddingLink }
 			onFocusOutside={ onFocusOutside }
 			placement="bottom"
-			offset={ 10 }
+			offset={ 8 }
 			shift
 			focusOnMount={ focusOnMount }
 			constrainTabbing


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removing the animation for the InlineLinkUI popover, creating a more immediate interaction experience for the user. Small tweak to the popover offset to use our grid unit while I'm here. 

## Why?
I was exploring LinkControl further, to see how we can optimize for efficiency; this feels like a quick win. The popovers already don't animate when you select one link from another. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a paragraph. 
3. Add a few links.
4. Click into, out of, and between the links.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/1813435/85fc3911-3dbb-4dde-8997-69776a3298ae

### After

https://github.com/WordPress/gutenberg/assets/1813435/178d765e-397b-4a8c-85b5-2b259f507021


