### PR TITLE
ProgressBar: Fix CSS variable with invalid value

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,10 @@
 -   `ProgressBar`: Move the indicator width styles from emotion to a CSS variable ([#60388](https://github.com/WordPress/gutenberg/pull/60388)).
 -   `Text`: Add `text-wrap: pretty;` to improve wrapping. ([#60164](https://github.com/WordPress/gutenberg/pull/60164)).
 
+### Bug Fix
+
+-   `ProgressBar`: Fix CSS variable with invalid value ([#60576](https://github.com/WordPress/gutenberg/pull/60576)).
+
 ## 27.3.0 (2024-04-03)
 
 ### Bug Fix

--- a/packages/components/src/progress-bar/index.tsx
+++ b/packages/components/src/progress-bar/index.tsx
@@ -28,7 +28,9 @@ function UnforwardedProgressBar(
 			<ProgressBarStyled.Indicator
 				style={
 					{
-						'--indicator-width': `${ value }%`,
+						'--indicator-width': ! isIndeterminate
+							? `${ value }%`
+							: undefined,
 					} as CSSProperties
 				}
 				isIndeterminate={ isIndeterminate }

--- a/packages/components/src/progress-bar/test/index.tsx
+++ b/packages/components/src/progress-bar/test/index.tsx
@@ -43,6 +43,9 @@ describe( 'ProgressBar', () => {
 		expect( indicator ).toHaveStyle( {
 			width: `${ INDETERMINATE_TRACK_WIDTH }%`,
 		} );
+		expect( indicator ).not.toHaveStyle( {
+			'--indicator-width': expect.any( String ),
+		} );
 	} );
 
 	it( 'should use `value`% as width for determinate progress bar', () => {


### PR DESCRIPTION
## What?

This PR prevents the `ProgressBar` component from outputting invalid CSS variables when the value prop is undefined or has an indeterminate value.

![progress-bar](https://github.com/WordPress/gutenberg/assets/54422211/548bb77c-b45c-46ba-97eb-40d324cff808)

## How?

Since the CSS var is used as a value [only when `isIndeterminate` is `false`](https://github.com/WordPress/gutenberg/blob/e9edf6581866b70260485651c28b9264aaf9c570/packages/components/src/progress-bar/styles.ts#L72), I changed it so that the CSS var itself is not output when `isIndeterminate` is `true`.

## Testing Instructions

- Open Storybook.
- Make sure that no CSS var is applied to this component.
- Make sure that when you change the value of the `value` prop, that value is applied as the width as before.