### PR TITLE
Image: fix cropper resize on align change (react-easy-crop upgrade)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43924,24 +43924,6 @@
 				"react": "^18.2.0"
 			}
 		},
-		"node_modules/react-easy-crop": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-4.5.1.tgz",
-			"integrity": "sha512-MVzCWmKXTwZTK0iYqlF/gPLdLqvUGrLGX7SQ4g+DO3b/lCiVAwxZKLeZ1wjDfG+r/yEWUoL7At5a0kkDJeU+rQ==",
-			"dependencies": {
-				"normalize-wheel": "^1.0.1",
-				"tslib": "2.0.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.4.0",
-				"react-dom": ">=16.4.0"
-			}
-		},
-		"node_modules/react-easy-crop/node_modules/tslib": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
-		},
 		"node_modules/react-element-to-jsx-string": {
 			"version": "15.0.0",
 			"resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-15.0.0.tgz",
@@ -53294,7 +53276,7 @@
 				"postcss-prefixwrap": "^1.41.0",
 				"postcss-urlrebase": "^1.0.0",
 				"react-autosize-textarea": "^7.1.0",
-				"react-easy-crop": "^4.5.1",
+				"react-easy-crop": "^5.0.6",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -53332,6 +53314,19 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"packages/block-editor/node_modules/react-easy-crop": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.0.6.tgz",
+			"integrity": "sha512-LV8te8NGC72k3l8uAqPAw73D2i9AbRlZqyo1Xz8VetwiMfkSKYgyqE3IFEwf5h+1g7AS1nMxBKk6ZPdhvLw6MQ==",
+			"dependencies": {
+				"normalize-wheel": "^1.0.1",
+				"tslib": "2.0.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.0",
+				"react-dom": ">=16.4.0"
+			}
+		},
 		"packages/block-editor/node_modules/source-map-js": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -53339,6 +53334,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"packages/block-editor/node_modules/tslib": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
@@ -68627,7 +68627,7 @@
 				"postcss-prefixwrap": "^1.41.0",
 				"postcss-urlrebase": "^1.0.0",
 				"react-autosize-textarea": "^7.1.0",
-				"react-easy-crop": "^4.5.1",
+				"react-easy-crop": "^5.0.6",
 				"remove-accents": "^0.5.0"
 			},
 			"dependencies": {
@@ -68641,10 +68641,24 @@
 						"source-map-js": "^1.2.0"
 					}
 				},
+				"react-easy-crop": {
+					"version": "5.0.6",
+					"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.0.6.tgz",
+					"integrity": "sha512-LV8te8NGC72k3l8uAqPAw73D2i9AbRlZqyo1Xz8VetwiMfkSKYgyqE3IFEwf5h+1g7AS1nMxBKk6ZPdhvLw6MQ==",
+					"requires": {
+						"normalize-wheel": "^1.0.1",
+						"tslib": "2.0.1"
+					}
+				},
 				"source-map-js": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
 					"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
+				},
+				"tslib": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
 				}
 			}
 		},
@@ -89847,22 +89861,6 @@
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"
-			}
-		},
-		"react-easy-crop": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-4.5.1.tgz",
-			"integrity": "sha512-MVzCWmKXTwZTK0iYqlF/gPLdLqvUGrLGX7SQ4g+DO3b/lCiVAwxZKLeZ1wjDfG+r/yEWUoL7At5a0kkDJeU+rQ==",
-			"requires": {
-				"normalize-wheel": "^1.0.1",
-				"tslib": "2.0.1"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
-				}
 			}
 		},
 		"react-element-to-jsx-string": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -75,7 +75,7 @@
 		"postcss-prefixwrap": "^1.41.0",
 		"postcss-urlrebase": "^1.0.0",
 		"react-autosize-textarea": "^7.1.0",
-		"react-easy-crop": "^4.5.1",
+		"react-easy-crop": "^5.0.6",
 		"remove-accents": "^0.5.0"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently the cropper does not resize after changing the image alignment. After debugging, I couldn't find an issue with our code. I upgraded the `react-easy-crop` package and that seems to fix the problem. The last update happened in #44408.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**Please run `npm install` after checking out this branch!**

Create an image block. Click on the cropper button. Now switch between align none and align full. The cropper won't resize without this PR.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

The problem:

<img width="1067" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/32314570-52c2-4f10-aa15-c5e274dcc448">

