### PR TITLE
Prevent resizing from triggering re-renders

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -238,7 +238,7 @@ function Iframe( {
 		clearerRef,
 		writingFlowRef,
 		disabledRef,
-		windowResizeRef,
+		scale === 1 ? null : windowResizeRef,
 	] );
 
 	// Correct doctype is required to enable rendering in standards

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -93,6 +93,19 @@ const ImageWrapper = ( { href, children } ) => {
 	);
 };
 
+function ImageEditorWithClientWidth( {
+	imageRef,
+	containerRef,
+	align,
+	...props
+} ) {
+	const clientWidth = useClientWidth( containerRef, [ align ] );
+	// clientWidth needs to be a number for the image Cropper to work, but sometimes it's 0
+	// So we try using the imageRef width first and fallback to clientWidth.
+	const fallbackClientWidth = imageRef.current?.width || clientWidth;
+	return <ImageEditor { ...props } clientWidth={ fallbackClientWidth } />;
+}
+
 export default function Image( {
 	temporaryURL,
 	attributes,
@@ -176,7 +189,6 @@ export default function Image( {
 	] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const [ externalBlob, setExternalBlob ] = useState();
-	const clientWidth = useClientWidth( containerRef, [ align ] );
 	const hasNonContentControls = blockEditingMode === 'default';
 	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 	const isResizable =
@@ -788,19 +800,14 @@ export default function Image( {
 		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
 	);
 
-	// clientWidth needs to be a number for the image Cropper to work, but sometimes it's 0
-	// So we try using the imageRef width first and fallback to clientWidth.
-	const fallbackClientWidth = imageRef.current?.width || clientWidth;
-
 	if ( canEditImage && isEditingImage ) {
 		img = (
 			<ImageWrapper href={ href }>
-				<ImageEditor
+				<ImageEditorWithClientWidth
 					id={ id }
 					url={ url }
 					width={ numericWidth }
 					height={ numericHeight }
-					clientWidth={ fallbackClientWidth }
 					naturalHeight={ naturalHeight }
 					naturalWidth={ naturalWidth }
 					onSaveImage={ ( imageAttributes ) =>
@@ -810,6 +817,9 @@ export default function Image( {
 						setIsEditingImage( false );
 					} }
 					borderProps={ isRounded ? undefined : borderProps }
+					imageRef={ imageRef }
+					containerRef={ containerRef }
+					align={ align }
 				/>
 			</ImageWrapper>
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

All this work getting done, seemingly because of an innocent `calculateClientWidth`. Although I'm having a hard time figuring out why React is re-rendering so many things, it should be contained within the image and site logo blocks.

first run -2.90%, second run -5.65% (template replace)

<img width="950" alt="Screenshot 2024-04-09 at 10 28 07" src="https://github.com/WordPress/gutenberg/assets/4710635/5fd8e422-565e-4eea-80ac-32c97afd7076">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
