### PR TITLE
Update: Remove keyCode usage from dataviews package.

### DIFF
--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -18,7 +18,9 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, createInterpolateElement } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
-import { ENTER, SPACE } from '@wordpress/keycodes';
+
+const ENTER = 'Enter';
+const SPACE = ' ';
 
 /**
  * Internal dependencies
@@ -229,9 +231,7 @@ export default function FilterSummary( {
 							tabIndex={ 0 }
 							onClick={ onToggle }
 							onKeyDown={ ( event ) => {
-								if (
-									[ ENTER, SPACE ].includes( event.keyCode )
-								) {
+								if ( [ ENTER, SPACE ].includes( event.key ) ) {
 									onToggle();
 									event.preventDefault();
 								}


### PR DESCRIPTION
The keyCode property has been deprecated (see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode). We should avoid the property on new packages/features being actively developed.
This PR removes the keyCode usage from the dataviews package.


## Testing Instructions
- Open the templates list on the site editor.
- Add an author filter.
- Tab until "Author is: YYY" at the top has focus.
- Press space and verify the filter is removed.
- Repeat the same for the enter key.