### PR TITLE
Adjust frame animation profile

### DIFF
--- a/packages/edit-site/src/components/layout/animation.js
+++ b/packages/edit-site/src/components/layout/animation.js
@@ -15,7 +15,7 @@ function getAbsolutePosition( element ) {
 	};
 }
 
-const ANIMATION_DURATION = 250;
+const ANIMATION_DURATION = 400;
 
 /**
  * Hook used to compute the styles required to move a div into a new position.

--- a/packages/edit-site/src/components/layout/animation.js
+++ b/packages/edit-site/src/components/layout/animation.js
@@ -15,7 +15,7 @@ function getAbsolutePosition( element ) {
 	};
 }
 
-const ANIMATION_DURATION = 325;
+const ANIMATION_DURATION = 250;
 
 /**
  * Hook used to compute the styles required to move a div into a new position.
@@ -67,7 +67,7 @@ function useMovingAnimation( { triggerAnimationOnChange } ) {
 			height: prevRect.height,
 			config: {
 				duration: ANIMATION_DURATION,
-				easing: easings.easeInOutQuad,
+				easing: easings.easeInOutQuint,
 			},
 			onChange( { value } ) {
 				if ( ! ref.current ) {

--- a/packages/edit-site/src/components/layout/animation.js
+++ b/packages/edit-site/src/components/layout/animation.js
@@ -67,7 +67,7 @@ function useMovingAnimation( { triggerAnimationOnChange } ) {
 			height: prevRect.height,
 			config: {
 				duration: ANIMATION_DURATION,
-				easing: easings.easeInOutExpo,
+				easing: easings.easeInOutQuad,
 			},
 			onChange( { value } ) {
 				if ( ! ref.current ) {

--- a/packages/edit-site/src/components/layout/animation.js
+++ b/packages/edit-site/src/components/layout/animation.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Controller } from '@react-spring/web';
+import { Controller, easings } from '@react-spring/web';
 
 /**
  * WordPress dependencies
@@ -15,7 +15,7 @@ function getAbsolutePosition( element ) {
 	};
 }
 
-const ANIMATION_DURATION = 250;
+const ANIMATION_DURATION = 325;
 
 /**
  * Hook used to compute the styles required to move a div into a new position.
@@ -65,7 +65,10 @@ function useMovingAnimation( { triggerAnimationOnChange } ) {
 			y: 0,
 			width: prevRect.width,
 			height: prevRect.height,
-			config: { duration: ANIMATION_DURATION },
+			config: {
+				duration: ANIMATION_DURATION,
+				easing: easings.easeInOutExpo,
+			},
 			onChange( { value } ) {
 				if ( ! ref.current ) {
 					return;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/60408.

## What?
Subtly adjusts the animation profile of the site editor 'frame' to more closely resemble a [prototype](https://www.figma.com/proto/e3u7Q1ChpEbl485EvSoD58/Frame-animation?page-id=20%3A3702&type=design&node-id=20-4138&viewport=11%2C-1151%2C0.28&t=I4XzjODr5GAksmW2-1&scaling=min-zoom&starting-point-node-id=20%3A4212&show-proto-sidebar=1&mode=design) we've been exploring. 

## Why?
It feels a bit smoother than the existing linear animation.

## How?
* Import `easing` from react spring and and apply `easeInOutQuint`.
* Adjust duration.

## Testing Instructions
1. Open the site editor
2. Click the frame
3. Click the site icon
4. Notice the updated animation effect
5. Try at different screen sizes

### Before


https://github.com/WordPress/gutenberg/assets/846565/817f7e0e-c9d8-4d83-a178-01223be424b9





### After



https://github.com/WordPress/gutenberg/assets/846565/859ce4a3-b65b-483c-85d0-2c2be705487b





