### PR TITLE
Redux store: batch resolver startResolution actions

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -638,13 +638,15 @@ function mapSelectorWithResolver(
 			}
 		} );
 
+		// Many resolvers can be called at once. The point of this is to at
+		// least batch `startResolution` actions all together.
 		window.queueMicrotask( () => {
 			if ( queue.length ) {
-				const _queue = [ ...queue ];
-				queue.length = 0;
-				registry.batch( async () => {
-					while ( _queue.length ) {
-						await _queue.shift()();
+				registry.batch( () => {
+					while ( queue.length ) {
+						// Do not await here, we only want to batch the sync
+						// actions.
+						queue.shift()();
 					}
 				} );
 			}

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -650,7 +650,7 @@ function mapSelectorWithResolver(
 
 		queue.push( [ startResolution, fulfillResolution ] );
 
-		window.queueMicrotask( () => {
+		setTimeout( () => {
 			if ( queue.length ) {
 				// Many resolvers can be called at once. The point of this is to
 				// at least batch `startResolution` actions all together.
@@ -666,7 +666,7 @@ function mapSelectorWithResolver(
 
 				queue.length = 0;
 			}
-		} );
+		}, 0 );
 	}
 
 	const selectorResolver = ( ...args ) => {

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -250,7 +250,7 @@ describe( 'createRegistry', () => {
 			expect( registry.select( 'demo' ).getValue() ).toBe( 'OK' );
 		} );
 
-		it( 'should behave as a side effect for the given selector, with arguments', async () => {
+		it( 'should behave as a side effect for the given selector, with arguments', () => {
 			const resolver = jest.fn();
 			registry.registerStore( 'demo', {
 				reducer: ( state = 'OK' ) => state,
@@ -263,14 +263,14 @@ describe( 'createRegistry', () => {
 			} );
 
 			const value = registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
+			jest.runAllTimers();
 			expect( value ).toBe( 'OK' );
-			await new Promise( process.nextTick );
 			expect( resolver ).toHaveBeenCalledWith( 'arg1', 'arg2' );
 			registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
-			await new Promise( process.nextTick );
+			jest.runAllTimers();
 			expect( resolver ).toHaveBeenCalledTimes( 1 );
 			registry.select( 'demo' ).getValue( 'arg3', 'arg4' );
-			await new Promise( process.nextTick );
+			jest.runAllTimers();
 			expect( resolver ).toHaveBeenCalledTimes( 2 );
 		} );
 
@@ -287,10 +287,11 @@ describe( 'createRegistry', () => {
 			} );
 
 			const value = registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
+			jest.runAllTimers();
 			expect( value ).toBe( 'OK' );
 		} );
 
-		it( 'should use isFulfilled definition before calling the side effect', async () => {
+		it( 'should use isFulfilled definition before calling the side effect', () => {
 			const fulfill = jest.fn().mockImplementation( ( state, page ) => {
 				return { type: 'SET_PAGE', page, result: [] };
 			} );
@@ -322,28 +323,30 @@ describe( 'createRegistry', () => {
 
 			store.dispatch( { type: 'SET_PAGE', page: 4, result: [] } );
 			registry.select( 'demo' ).getPage( 1 );
+			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
-
-			await new Promise( process.nextTick );
+			jest.runAllTimers();
 
 			expect( fulfill ).toHaveBeenCalledTimes( 2 );
 
 			registry.select( 'demo' ).getPage( 1 );
+			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
+			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 3, {} );
-
-			await new Promise( process.nextTick );
+			jest.runAllTimers();
 
 			// Expected: First and second page fulfillments already triggered, so
 			// should only be one more than previous assertion set.
 			expect( fulfill ).toHaveBeenCalledTimes( 3 );
 
 			registry.select( 'demo' ).getPage( 1 );
+			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
+			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 3, {} );
+			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 4 );
-
-			await new Promise( process.nextTick );
 
 			// Expected:
 			//  - Fourth page was pre-filled. Necessary to determine via

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -250,7 +250,7 @@ describe( 'createRegistry', () => {
 			expect( registry.select( 'demo' ).getValue() ).toBe( 'OK' );
 		} );
 
-		it( 'should behave as a side effect for the given selector, with arguments', () => {
+		it( 'should behave as a side effect for the given selector, with arguments', async () => {
 			const resolver = jest.fn();
 			registry.registerStore( 'demo', {
 				reducer: ( state = 'OK' ) => state,
@@ -263,14 +263,14 @@ describe( 'createRegistry', () => {
 			} );
 
 			const value = registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
-			jest.runAllTimers();
 			expect( value ).toBe( 'OK' );
+			await new Promise( process.nextTick );
 			expect( resolver ).toHaveBeenCalledWith( 'arg1', 'arg2' );
 			registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
-			jest.runAllTimers();
+			await new Promise( process.nextTick );
 			expect( resolver ).toHaveBeenCalledTimes( 1 );
 			registry.select( 'demo' ).getValue( 'arg3', 'arg4' );
-			jest.runAllTimers();
+			await new Promise( process.nextTick );
 			expect( resolver ).toHaveBeenCalledTimes( 2 );
 		} );
 
@@ -287,11 +287,10 @@ describe( 'createRegistry', () => {
 			} );
 
 			const value = registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
-			jest.runAllTimers();
 			expect( value ).toBe( 'OK' );
 		} );
 
-		it( 'should use isFulfilled definition before calling the side effect', () => {
+		it( 'should use isFulfilled definition before calling the side effect', async () => {
 			const fulfill = jest.fn().mockImplementation( ( state, page ) => {
 				return { type: 'SET_PAGE', page, result: [] };
 			} );
@@ -323,30 +322,28 @@ describe( 'createRegistry', () => {
 
 			store.dispatch( { type: 'SET_PAGE', page: 4, result: [] } );
 			registry.select( 'demo' ).getPage( 1 );
-			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
-			jest.runAllTimers();
+
+			await new Promise( process.nextTick );
 
 			expect( fulfill ).toHaveBeenCalledTimes( 2 );
 
 			registry.select( 'demo' ).getPage( 1 );
-			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
-			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 3, {} );
-			jest.runAllTimers();
+
+			await new Promise( process.nextTick );
 
 			// Expected: First and second page fulfillments already triggered, so
 			// should only be one more than previous assertion set.
 			expect( fulfill ).toHaveBeenCalledTimes( 3 );
 
 			registry.select( 'demo' ).getPage( 1 );
-			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
-			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 3, {} );
-			jest.runAllTimers();
 			registry.select( 'demo' ).getPage( 4 );
+
+			await new Promise( process.nextTick );
 
 			// Expected:
 			//  - Fourth page was pre-filled. Necessary to determine via


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Lots of resolver selectors get instantly fulfilled. We should batch them if we can.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I expect the biggest result to come for the initial site editor load (first block):
-2.53% first run
-1.14% second run

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
