### PR TITLE
Fix: Style issue on page actions button.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
@@ -64,4 +64,7 @@
 
 .edit-site-sidebar-navigation-screen__actions .editor-all-actions-button {
 	color: inherit;
+	&:active {
+		color: inherit;
+	}
 }


### PR DESCRIPTION
Fixes style issue pointed at https://github.com/WordPress/gutenberg/pull/60486#pullrequestreview-1985831972 by @aaronrobertshaw.


## Testing
Open the pages section on the site editor and select a page.
Open the page details panel.
Click continuously on the actions button and verify the styles seem ok (the button is still visible).