### PR TITLE
Chore: Fix missing comma on welcome guide styles.

### DIFF
--- a/packages/edit-site/src/components/welcome-guide/style.scss
+++ b/packages/edit-site/src/components/welcome-guide/style.scss
@@ -1,7 +1,7 @@
 .edit-site-welcome-guide {
 	width: 312px;
 
-	&.guide-editor .edit-site-welcome-guide__image
+	&.guide-editor .edit-site-welcome-guide__image,
 	&.guide-styles .edit-site-welcome-guide__image {
 		background: #00a0d2;
 	}


### PR DESCRIPTION
There was a missing comma that was making the welcome guide background style useless.

## Testing
On file packages/edit-site/src/components/welcome-guide/image.js I set both srcSet and src to an empty string (so the images don't load, these styles are only used while images are loading so to make it easier to test we should avoid loading the images).
I opened the welcome guide (ellipsis menu at the top right corner of the site editor) and styles welcome guide (open the styles sidebar and press the ellipsis menu there) and verified the background of both images is blue (on trunk it is white).