### PR TITLE
Fix: Trash Post action and permanently delete post action do not show errors on single item

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -145,10 +145,10 @@ export const trashPostAction = {
 											[ ...errorMessages ].join( ',' )
 										);
 									}
-									createErrorNotice( errorMessage, {
-										type: 'snackbar',
-									} );
 								}
+								createErrorNotice( errorMessage, {
+									type: 'snackbar',
+								} );
 							}
 							if ( onActionPerformed ) {
 								onActionPerformed( posts );
@@ -260,10 +260,10 @@ export function usePermanentlyDeletePostAction() {
 								[ ...errorMessages ].join( ',' )
 							);
 						}
-						createErrorNotice( errorMessage, {
-							type: 'snackbar',
-						} );
 					}
+					createErrorNotice( errorMessage, {
+						type: 'snackbar',
+					} );
 				}
 			},
 		} ),


### PR DESCRIPTION
The createErrorNotice instruction is positioned inside an else clause for trash Post action and permanently delete post action while it should be outside. This causes an issue where if the actions are executed on a single item and something fails no notice is shown at all to the user.


## Testing

- Load the pages list at /wp-admin/site-editor.php?path=%2Fpage&layout=table.
- Add an "exit;" instruction at the top of "lib/load.php" and do not reload the editor (the instruction will make any backend call fail).
- Press the trash action button on any of the pages, and verify an error notice is shown (on trunk no errors are shown).
- Repeat the process for the permanently delete post action.