### PR TITLE
Improve override indication for editable blocks in synced patterns

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -300,31 +300,31 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 }
 
-@keyframes block-editor-has-editable-outline__fade-out-animation {
+// Add fade in/out background for editable blocks in synced patterns.
+@keyframes block-editor-is-editable__animation {
 	from {
-		border-color: rgba(var(--wp-admin-theme-color--rgb), 1);
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 	}
 	to {
-		border-color: rgba(var(--wp-admin-theme-color--rgb), 0);
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0);
 	}
 }
 
-.is-root-container:not([inert]) .block-editor-block-list__block.has-editable-outline {
-	&::after {
-		content: "";
-		position: absolute;
-		pointer-events: none;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		border: 1px dotted rgba(var(--wp-admin-theme-color--rgb), 1);
-		border-radius: $radius-block-ui;
-		animation: block-editor-has-editable-outline__fade-out-animation 0.3s ease-out;
-		animation-delay: 1s;
-		animation-fill-mode: forwards;
-		@include reduce-motion("animation");
-	}
+.is-root-container:not([inert]) .block-editor-block-list__block.is-reusable.is-selected .block-editor-block-list__block.has-editable-outline::after {
+	animation-name: block-editor-is-editable__animation;
+	animation-duration: 0.3s;
+	animation-timing-function: ease-out;
+	animation-delay: 0.5s;
+	animation-fill-mode: backwards;
+	border-radius: $radius-block-ui;
+	bottom: 0;
+	content: "";
+	left: 0;
+	pointer-events: none;
+	position: absolute;
+	right: 0;
+	top: 0;
+	@include reduce-motion("animation");
 }
 
 // Spotlight mode. Fade out blocks unless they contain a selected block.

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -307,6 +307,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 	to {
 		background-color: rgba(var(--wp-admin-theme-color--rgb), 0);
+		outline-color: rgba(var(--wp-admin-theme-color--rgb), 0);
 	}
 }
 
@@ -317,6 +318,10 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	animation-delay: 0.1s;
 	animation-fill-mode: backwards;
 	border-radius: $radius-block-ui;
+	outline-color: transparent;
+	outline-style: solid;
+	outline-width: $border-width;
+	outline-offset: calc(-1 * $border-width);
 	bottom: 0;
 	content: "";
 	left: 0;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -303,20 +303,26 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 // Add fade in/out background for editable blocks in synced patterns.
 @keyframes block-editor-is-editable__animation {
 	from {
-		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+		outline-color: rgba(var(--wp-admin-theme-color--rgb), 0.5);
 	}
 	to {
 		background-color: rgba(var(--wp-admin-theme-color--rgb), 0);
+		outline-color: rgba(var(--wp-admin-theme-color--rgb), 0);
 	}
 }
 
 .is-root-container:not([inert]) .block-editor-block-list__block.is-reusable.is-selected .block-editor-block-list__block.has-editable-outline::after {
 	animation-name: block-editor-is-editable__animation;
-	animation-duration: 0.3s;
+	animation-duration: 0.8s;
 	animation-timing-function: ease-out;
-	animation-delay: 0.5s;
+	animation-delay: 0.1s;
 	animation-fill-mode: backwards;
 	border-radius: $radius-block-ui;
+	outline-color: transparent;
+	outline-style: solid;
+	outline-width: $border-width;
+	outline-offset: calc(-1 * $border-width);
 	bottom: 0;
 	content: "";
 	left: 0;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -307,7 +307,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 	to {
 		background-color: rgba(var(--wp-admin-theme-color--rgb), 0);
-		outline-color: rgba(var(--wp-admin-theme-color--rgb), 0);
 	}
 }
 
@@ -318,10 +317,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	animation-delay: 0.1s;
 	animation-fill-mode: backwards;
 	border-radius: $radius-block-ui;
-	outline-color: transparent;
-	outline-style: solid;
-	outline-width: $border-width;
-	outline-offset: calc(-1 * $border-width);
 	bottom: 0;
 	content: "";
 	left: 0;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -310,6 +310,18 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 }
 
+@keyframes block-editor-is-editable__animation_reduce-motion {
+	0% {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+	}
+	99% {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+	}
+	100% {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0);
+	}
+}
+
 .is-root-container:not([inert]) .block-editor-block-list__block.is-reusable.is-selected .block-editor-block-list__block.has-editable-outline::after {
 	animation-name: block-editor-is-editable__animation;
 	animation-duration: 0.8s;
@@ -324,7 +336,12 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	position: absolute;
 	right: 0;
 	top: 0;
-	@include reduce-motion("animation");
+
+	// Unique reduced-motion affordance to ensure the effect is still visible when reduce motion is enabled.
+	@media (prefers-reduced-motion: reduce) {
+		animation-name: block-editor-is-editable__animation_reduce-motion;
+		animation-delay: 0s;
+	}
 }
 
 // Spotlight mode. Fade out blocks unless they contain a selected block.

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -304,11 +304,9 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 @keyframes block-editor-is-editable__animation {
 	from {
 		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.1);
-		outline-color: rgba(var(--wp-admin-theme-color--rgb), 0.5);
 	}
 	to {
 		background-color: rgba(var(--wp-admin-theme-color--rgb), 0);
-		outline-color: rgba(var(--wp-admin-theme-color--rgb), 0);
 	}
 }
 
@@ -319,10 +317,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	animation-delay: 0.1s;
 	animation-fill-mode: backwards;
 	border-radius: $radius-block-ui;
-	outline-color: transparent;
-	outline-style: solid;
-	outline-width: $border-width;
-	outline-offset: calc(-1 * $border-width);
 	bottom: 0;
 	content: "";
 	left: 0;

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -130,7 +130,11 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const hasBlockBindings = !! blockEditContext[ blockBindingsKey ];
 	const bindingsStyle =
 		hasBlockBindings && canBindBlock( name )
-			? { '--wp-admin-theme-color': 'var(--wp-block-synced-color)' }
+			? {
+					'--wp-admin-theme-color': 'var(--wp-block-synced-color)',
+					'--wp-admin-theme-color--rgb':
+						'var(--wp-block-synced-color--rgb)',
+			  }
 			: {};
 
 	// Ensures it warns only inside the `edit` implementation for the block.

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -23,7 +23,7 @@
 	z-index: z-index(".block-library-template-part__selection-search");
 }
 
-// Removed .is-outline-mode so colors take effect properly in the block editor.
+// We don't use .is-outline-mode in this case so colors take effect properly in the block editor.
 // Will be a better result when outlines are not shadows, but outlines, so we can target outline-color, not redefined the entire shadow.
 .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
 .block-editor-block-list__block:not(.remove-outline).is-reusable {

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -23,8 +23,10 @@
 	z-index: z-index(".block-library-template-part__selection-search");
 }
 
-.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
-.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-reusable {
+// Removed .is-outline-mode so colors take effect properly in the block editor.
+// Will be a better result when outlines are not shadows, but outlines, so we can target outline-color, not redefined the entire shadow.
+.block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
+.block-editor-block-list__block:not(.remove-outline).is-reusable {
 	&.is-highlighted::after,
 	&.is-selected::after {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -24,7 +24,7 @@
 }
 
 // We don't use .is-outline-mode in this case so colors take effect properly in the block editor.
-// Will be a better result when outlines are not shadows, but outlines, so we can target outline-color, not redefined the entire shadow.
+// Will be a better result when outlines are not shadows, but outlines, so we can target outline-color, not redefine the entire shadow.
 .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
 .block-editor-block-list__block:not(.remove-outline).is-reusable {
 	&.is-highlighted::after,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A piece of https://github.com/WordPress/gutenberg/pull/60286. 

Removes the previously implemented dotted border animation in lieu of a subtle background animation, to help indicate which blocks within the synced pattern are editable (have overrides). Too many outlines make it difficult to discern what is being communicated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a synced pattern, or create one. 
3. Edit the synced pattern to add overrides by renaming a heading or paragraph block. 
4. Go back to the page where you inserted the synced pattern.
5. See changes as you interact with blocks that are not editable within the synced pattern.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/1813435/ebbe39af-128d-4559-8a6d-78a27f8148ca

### After

https://github.com/WordPress/gutenberg/assets/1813435/b9400f38-b8b9-4e10-b77c-0f83680377a1

### Note

This effort scopes the effect only to synced patterns. Editable blocks within a template will not have this effect, or the previous outlines, as seen below:

https://github.com/WordPress/gutenberg/assets/1813435/02ab498b-9aec-40a4-af14-b14950d45e30

Related: https://github.com/WordPress/gutenberg/pull/57901 and https://github.com/WordPress/gutenberg/pull/58159



