### PR TITLE
Added @return after @global in php doc

### DIFF
--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -248,7 +248,7 @@ function gutenberg_add_global_styles_block_custom_css() {
  * Adds global style rules to the inline style for each block.
  *
  * @global WP_Styles $wp_styles
- * 
+ *
  * @return void
  */
 function gutenberg_add_global_styles_for_blocks() {

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -207,7 +207,7 @@ function gutenberg_get_global_styles_base_custom_css() {
  *
  * @since 6.6.0
  *
- *  @global WP_Styles $wp_styles
+ * @global WP_Styles $wp_styles
  */
 function gutenberg_add_global_styles_block_custom_css() {
 	global $wp_styles;
@@ -247,9 +247,9 @@ function gutenberg_add_global_styles_block_custom_css() {
 /**
  * Adds global style rules to the inline style for each block.
  *
- * @return void
- *
  * @global WP_Styles $wp_styles
+ * 
+ * @return void
  */
 function gutenberg_add_global_styles_for_blocks() {
 	global $wp_styles;


### PR DESCRIPTION
- Added @return after @global according to [PHP Doc Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)
- Removed Extra Space Before @global Documentation in Line 210

**Fixes:** https://github.com/WordPress/gutenberg/issues/60610