### PR TITLE
Revert "Make sure the CSS class id-dark-theme is added to the editor iframe body. (#60300)

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -141,13 +141,6 @@ function Iframe( {
 		function onLoad() {
 			const { contentDocument, ownerDocument } = node;
 			const { documentElement } = contentDocument;
-			// Get any CSS classes the iframe document body may initially have
-			// to re-apply them later together with the ones of the main document
-			// body. This is necessary for some CSS classes for example the
-			// `is-dark-theme` class added by useDarkThemeBodyClassName.
-			const initialIframeBodyClasses = Array.from(
-				contentDocument.body.classList
-			);
 			iFrameDocument = contentDocument;
 
 			documentElement.classList.add( 'block-editor-iframe__html' );
@@ -158,15 +151,12 @@ function Iframe( {
 			// be added in the editor too, which we'll somehow have to get from
 			// the server in the future (which will run the PHP filters).
 			setBodyClasses(
-				Array.from( ownerDocument.body.classList )
-					.concat( initialIframeBodyClasses )
-					.filter(
-						( name ) =>
-							name.startsWith( 'admin-color-' ) ||
-							name.startsWith( 'post-type-' ) ||
-							name === 'wp-embed-responsive' ||
-							name === 'is-dark-theme'
-					)
+				Array.from( ownerDocument.body.classList ).filter(
+					( name ) =>
+						name.startsWith( 'admin-color-' ) ||
+						name.startsWith( 'post-type-' ) ||
+						name === 'wp-embed-responsive'
+				)
 			);
 
 			contentDocument.dir = ownerDocument.dir;


### PR DESCRIPTION
## What?
This reverts commit a4ae81305699487f3fc1fad28620605cf879bca4.

## Why?
This commit broke the setting of editor styles in Safari - see https://github.com/WordPress/gutenberg/pull/60550#issuecomment-2044522891

## How?
Just reverts the commit for 18.1, and an alternative approach for keeping the `is-dark-theme` can be researched as a follow up 

## Testing Instructions

- Enable the zoomed out mode experiment
- In Safari run the site editor and try refreshing the page a number of times and make sure the following console error does not display and that zoomed out mode works as expected. 

<img width="1274" alt="Screenshot 2024-04-09 at 12 44 09 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/e9fa7a55-5114-4821-b5be-93f18875be10">
