### PR TITLE
Consolidate "bound block" color and "synced" colors

### DIFF
--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -5,4 +5,7 @@
 	@include admin-scheme(#007cba);
 	--wp-block-synced-color: #7a00df;
 	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
+	// This CSS variable is not used in Gutenberg project,
+	// but is maintained for backwards compatibility.
+	--wp-bound-block-color: var(--wp-block-synced-color);
 }

--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -5,5 +5,4 @@
 	@include admin-scheme(#007cba);
 	--wp-block-synced-color: #7a00df;
 	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
-	--wp-bound-block-color: #9747ff;
 }

--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/style.scss
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/style.scss
@@ -4,7 +4,7 @@
 	justify-content: center;
 	padding: 6px;
 	svg {
-		fill: var(--wp-bound-block-color);
+		fill: var(--wp-block-synced-color);
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -130,7 +130,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const hasBlockBindings = !! blockEditContext[ blockBindingsKey ];
 	const bindingsStyle =
 		hasBlockBindings && canBindBlock( name )
-			? { '--wp-admin-theme-color': 'var(--wp-bound-block-color)' }
+			? { '--wp-admin-theme-color': 'var(--wp-block-synced-color)' }
 			: {};
 
 	// Ensures it warns only inside the `edit` implementation for the block.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A piece of https://github.com/WordPress/gutenberg/pull/60286. 

Consolidate `--wp-bound-block-color` and `--wp-block-synced-color` into one variable. They're just slightly different purples, where it's not really necessary. Synced patterns use `--wp-block-synced-color` already, perhaps bindings should just use that too. https://github.com/WordPress/gutenberg/pull/60599 leans into `--wp-block-synced-color` for overrides as well. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a synced pattern with an overrides. 
3. Select a block with an override to see the applied changes. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-04-09 at 20 09 09](https://github.com/WordPress/gutenberg/assets/1813435/390c83ed-2e19-4742-ba85-3bd3219b78a2)|![CleanShot 2024-04-09 at 20 09 46](https://github.com/WordPress/gutenberg/assets/1813435/ed472f36-3bdd-4300-99b3-c8e48ec21541)|