### PR TITLE
Fix inserter pattern pagination focus loss

### DIFF
--- a/packages/block-editor/src/components/block-patterns-paging/index.js
+++ b/packages/block-editor/src/components/block-patterns-paging/index.js
@@ -45,6 +45,7 @@ export default function Pagination( {
 							onClick={ () => changePage( 1 ) }
 							disabled={ currentPage === 1 }
 							aria-label={ __( 'First page' ) }
+							__experimentalIsFocusable
 						>
 							<span>«</span>
 						</Button>
@@ -53,6 +54,7 @@ export default function Pagination( {
 							onClick={ () => changePage( currentPage - 1 ) }
 							disabled={ currentPage === 1 }
 							aria-label={ __( 'Previous page' ) }
+							__experimentalIsFocusable
 						>
 							<span>‹</span>
 						</Button>
@@ -75,6 +77,7 @@ export default function Pagination( {
 							onClick={ () => changePage( currentPage + 1 ) }
 							disabled={ currentPage === numPages }
 							aria-label={ __( 'Next page' ) }
+							__experimentalIsFocusable
 						>
 							<span>›</span>
 						</Button>
@@ -84,6 +87,7 @@ export default function Pagination( {
 							disabled={ currentPage === numPages }
 							aria-label={ __( 'Last page' ) }
 							size="default"
+							__experimentalIsFocusable
 						>
 							<span>»</span>
 						</Button>


### PR DESCRIPTION
## What?
Fixes #55043

Because the pagination buttons should remain focused when paginating, they should use `aria-disabled` instead of `disabled`.

## Why?
Applying `disabled` to a focused button causes a focus loss. Because the inserter sidebar is implemented as a dialog, this results in the sidebar closing (though it's strange that it only happens in some browsers).

## How?
Adds the `__experimentalIsFocusable` prop, which makes the `Button` component use `aria-disabled` instead of `disabled`. 

## Testing Instructions
Prerequisite: Use Safari (or firefox, where the issue has also been reported, though I personally couldn't reproduce)
1. Create a new post
2. Open the inserter sidebar
3. Switch to the patterns tab
4. Navigate to a category like 'Banners' or 'Featured' (which on a vanilla WordPress install has multiple pages of patterns)
5. Navigate to the pagination buttons after the list of patterns and go to the next page.

In this PR: the inserter sidebar should stay open and focus should remain on the button
In trunk: Focus is lost and the sidebar closes

## Screenshots or screencast <!-- if applicable -->
### Before

https://github.com/WordPress/gutenberg/assets/677833/63ef3edd-1e7b-4934-b1ac-85f7b0d66775

### After

https://github.com/WordPress/gutenberg/assets/677833/fe2c89c6-0fc1-4cc5-8158-bc155f02480e


