### PR TITLE
Fix sticking “Reset” option in `ToolsPanel`

### DIFF
--- a/packages/block-editor/src/components/dimensions-tool/width-height-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/width-height-tool.js
@@ -60,15 +60,13 @@ export default function WidthHeightTool( {
 	const height = value.height === 'auto' ? '' : value.height ?? '';
 
 	const onDimensionChange = ( dimension ) => ( nextDimension ) => {
-		// Readies the nextValue by omitting the dimension to be changed.
-		const { [ dimension ]: existingDimensionValue, ...nextValue } = value;
-		// Bails when both nextDimension and its existing value are falsy. This
-		// can occur when a `onDeselect` callback runs after the state has
-		// already updated. In such cases calling onChange would be redundant.
-		if ( ! nextDimension && ! existingDimensionValue ) return;
-
-		// Adds dimension only if non-falsy ('' or undefined may be passed).
-		if ( !! nextDimension ) nextValue[ dimension ] = nextDimension;
+		const nextValue = { ...value };
+		// Empty strings or undefined may be passed and both represent removing the value.
+		if ( ! nextDimension ) {
+			delete nextValue[ dimension ];
+		} else {
+			nextValue[ dimension ] = nextDimension;
+		}
 		onChange( nextValue );
 	};
 

--- a/packages/block-editor/src/components/dimensions-tool/width-height-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/width-height-tool.js
@@ -60,13 +60,15 @@ export default function WidthHeightTool( {
 	const height = value.height === 'auto' ? '' : value.height ?? '';
 
 	const onDimensionChange = ( dimension ) => ( nextDimension ) => {
-		const nextValue = { ...value };
-		// Empty strings or undefined may be passed and both represent removing the value.
-		if ( ! nextDimension ) {
-			delete nextValue[ dimension ];
-		} else {
-			nextValue[ dimension ] = nextDimension;
-		}
+		// Readies the nextValue by omitting the dimension to be changed.
+		const { [ dimension ]: existingDimensionValue, ...nextValue } = value;
+		// Bails when both nextDimension and its existing value are falsy. This
+		// can occur when a `onDeselect` callback runs after the state has
+		// already updated. In such cases calling onChange would be redundant.
+		if ( ! nextDimension && ! existingDimensionValue ) return;
+
+		// Adds dimension only if non-falsy ('' or undefined may be passed).
+		if ( !! nextDimension ) nextValue[ dimension ] = nextDimension;
 		onChange( nextValue );
 	};
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,10 @@
 -   `FormTokenField`: Hide label when not defined ([#61336](https://github.com/WordPress/gutenberg/pull/61336)).
 -   Upgraded the @types/react and @types/react-dom packages ([#60796](https://github.com/WordPress/gutenberg/pull/60796)).
 
+### Bug Fix
+
+-   `ToolsPanel`: Fix sticking “Reset” option ([#60621](https://github.com/WordPress/gutenberg/pull/60621)).
+
 ## 27.5.0 (2024-05-02)
 
 ### Enhancements

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -128,7 +128,9 @@ export function useToolsPanelItem(
 	// Notify the panel when an item's value has changed except for optional
 	// items without value because the item should not cause itself to hide.
 	useEffect( () => {
-		if ( ! isShownByDefault && ! isValueSet ) return;
+		if ( ! isShownByDefault && ! isValueSet ) {
+			return;
+		}
 
 		flagItemCustomization( isValueSet, label, menuGroup );
 	}, [

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -125,17 +125,11 @@ export function useToolsPanelItem(
 	const isRegistered = menuItems?.[ menuGroup ]?.[ label ] !== undefined;
 
 	const isValueSet = hasValue();
-	const wasValueSet = usePrevious( isValueSet );
-	const newValueSet = isValueSet && ! wasValueSet;
-
-	// Notify the panel when an item's value has been set.
-	useEffect( () => {
-		if ( ! newValueSet ) {
-			return;
-		}
-
-		flagItemCustomization( label, menuGroup );
-	}, [ newValueSet, menuGroup, label, flagItemCustomization ] );
+	// Notify the panel when an item's value has changed.
+	useEffect(
+		() => flagItemCustomization( isValueSet, label, menuGroup ),
+		[ isValueSet, menuGroup, label, flagItemCustomization ]
+	);
 
 	// Determine if the panel item's corresponding menu is being toggled and
 	// trigger appropriate callback if it is.

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -125,11 +125,19 @@ export function useToolsPanelItem(
 	const isRegistered = menuItems?.[ menuGroup ]?.[ label ] !== undefined;
 
 	const isValueSet = hasValue();
-	// Notify the panel when an item's value has changed.
-	useEffect(
-		() => flagItemCustomization( isValueSet, label, menuGroup ),
-		[ isValueSet, menuGroup, label, flagItemCustomization ]
-	);
+	// Notify the panel when an item's value has changed except for optional
+	// items without value because the item should not cause itself to hide.
+	useEffect( () => {
+		if ( ! isShownByDefault && ! isValueSet ) return;
+
+		flagItemCustomization( isValueSet, label, menuGroup );
+	}, [
+		isValueSet,
+		menuGroup,
+		label,
+		flagItemCustomization,
+		isShownByDefault,
+	] );
 
 	// Determine if the panel item's corresponding menu is being toggled and
 	// trigger appropriate callback if it is.

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -145,7 +145,7 @@ export function useToolsPanelItem(
 			onSelect?.();
 		}
 
-		if ( ! isMenuItemChecked && wasMenuItemChecked ) {
+		if ( ! isMenuItemChecked && isValueSet && wasMenuItemChecked ) {
 			onDeselect?.();
 		}
 	}, [

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -205,10 +205,9 @@ export function useToolsPanel(
 		} );
 	}, [ panelItems, setMenuItems, menuItemOrder ] );
 
-	// Force a menu item to be checked.
-	// This is intended for use with default panel items. They are displayed
-	// separately to optional items and have different display states,
-	// we need to update that when their value is customized.
+	// Updates the status of the panel’s menu items. For default items the
+	// value represents whether it differs from the default and for optional
+	// items whether the item is shown.
 	const flagItemCustomization = useCallback(
 		(
 			value: boolean,

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -210,13 +210,17 @@ export function useToolsPanel(
 	// separately to optional items and have different display states,
 	// we need to update that when their value is customized.
 	const flagItemCustomization = useCallback(
-		( label: string, group: ToolsPanelMenuItemKey = 'default' ) => {
+		(
+			value: boolean,
+			label: string,
+			group: ToolsPanelMenuItemKey = 'default'
+		) => {
 			setMenuItems( ( items ) => {
 				const newState = {
 					...items,
 					[ group ]: {
 						...items[ group ],
-						[ label ]: true,
+						[ label ]: value,
 					},
 				};
 				return newState;

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -176,6 +176,7 @@ export type ToolsPanelContext = {
 	registerResetAllFilter: ( filter: ResetAllFilter ) => void;
 	deregisterResetAllFilter: ( filter: ResetAllFilter ) => void;
 	flagItemCustomization: (
+		value: boolean,
 		label: string,
 		group?: ToolsPanelMenuItemKey
 	) => void;


### PR DESCRIPTION
## What?
Ensures the “Reset” action of tools panel’s menu items is present only when an item’s value is set.

## Why?
Currently once a panel item has had its value set the ”Reset” option becomes enabled but it gets stuck that way even if the original value has been restored. This doesn't cause much of a problem so fixing it could be described as UI/UX polish.

Further, this is extracted from a larger effort in another branch to ensure defaults of block supports are represented in the controls. It can work without these changes but the UI discrepancy is perhaps more glaring in such a context.

## How?

- Changes an effect to run anytime a panel item’s value changes and modifies the callback it triggers to accept the actual value (instead being hardcoded to `true`).

## Testing Instructions

### In the Editor
1. Go to Styles > Color
2. Pick a color for one of the elements
3. Activate the same picked color swatch to clear the picked value
4. Check the options menu and note that “Reset” is not available.

It's important to clear the value by using the same swatch as before. If you actually switch back to the original value by using its swatch then “Reset” will be enabled. This is a separate issue and fixing it also depends on these changes.

### In Storybook
1. Go to ToolsPanel
2. Enter a value in one of the example fields
3. Delete the value
4. Check the options menu and note that ”Reset” is not available.

### Testing Instructions for Keyboard
Not sure it’s required. The instructions above aren’t exclusively for pointing devices. I'll add more detailed instruction if need be.

## Screenshots or screencast <!-- if applicable -->
### Before

https://github.com/WordPress/gutenberg/assets/9000376/1415f27a-5933-48c6-b791-e1e167cf6d45

### After

https://github.com/WordPress/gutenberg/assets/9000376/c787ecaa-d515-485e-96de-a0cee390ee67
