### PR TITLE
Fix display of shortcut to add non breaking space in the post editor.

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -47,7 +47,7 @@ export const textFormattingShortcuts = [
 		),
 	},
 	{
-		keyCombination: { modifier: 'primaryShift', character: '\u00a0' },
+		keyCombination: { modifier: 'primaryShift', character: 'SPACE' },
 		description: __( 'Add non breaking space.' ),
 	},
 ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60624

Cc @t-hamano @ellatrix 

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes a typo that shows a wrong keyboard shortcut combination for the 'Add non breaking space' in the _post_ editor.
The UI is literally telling users to press the modifier keys _and a non breaking space_ to insert a non breaking space.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The UI should show correct keyboard shortcuts to users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue.
- Observe the correct keyboard shortcut combination is shown to users.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
