### PR TITLE
Update PublishPanel docs and internal usage to editor package

### DIFF
--- a/docs/reference-guides/slotfills/README.md
+++ b/docs/reference-guides/slotfills/README.md
@@ -99,8 +99,11 @@ The following SlotFills are available in the `edit-post` package. Please refer t
 -   [PluginBlockSettingsMenuItem](/docs/reference-guides/slotfills/plugin-block-settings-menu-item.md)
 -   [PluginDocumentSettingPanel](/docs/reference-guides/slotfills/plugin-document-setting-panel.md)
 -   [PluginMoreMenuItem](/docs/reference-guides/slotfills/plugin-more-menu-item.md)
--   [PluginPostPublishPanel](/docs/reference-guides/slotfills/plugin-post-publish-panel.md)
 -   [PluginPostStatusInfo](/docs/reference-guides/slotfills/plugin-post-status-info.md)
--   [PluginPrePublishPanel](/docs/reference-guides/slotfills/plugin-pre-publish-panel.md)
 -   [PluginSidebar](/docs/reference-guides/slotfills/plugin-sidebar.md)
 -   [PluginSidebarMoreMenuItem](/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md)
+
+The following SlotFills are available in the `editor` package. Please refer to the individual items below for usage and example details:
+
+-   [PluginPrePublishPanel](/docs/reference-guides/slotfills/plugin-pre-publish-panel.md)
+-   [PluginPostPublishPanel](/docs/reference-guides/slotfills/plugin-post-publish-panel.md)

--- a/docs/reference-guides/slotfills/plugin-post-publish-panel.md
+++ b/docs/reference-guides/slotfills/plugin-post-publish-panel.md
@@ -2,11 +2,15 @@
 
 This slot allows for injecting items into the bottom of the post-publish panel that appears after a post is published.
 
+<div class="callout callout-info">
+`PluginPostPublishPanel` was moved from the `@wordpress/edit-post` package to `@wordpress/editor` in Gutenberg 18.1 (to be included in WordPress 6.6). The deprecated export will be removed with WordPress 6.8.
+</div>
+
 ## Example
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { PluginPostPublishPanel } from '@wordpress/editor';
 
 const PluginPostPublishPanelTest = () => (
 	<PluginPostPublishPanel>

--- a/docs/reference-guides/slotfills/plugin-pre-publish-panel.md
+++ b/docs/reference-guides/slotfills/plugin-pre-publish-panel.md
@@ -2,11 +2,15 @@
 
 This slot allows for injecting items into the bottom of the pre-publish panel that appears to confirm publishing after the user clicks "Publish".
 
+<div class="callout callout-info">
+`PluginPrePublishPanel` was moved from the `@wordpress/edit-post` package to `@wordpress/editor` in Gutenberg 18.1 (to be included in WordPress 6.6). The deprecated export will be removed with WordPress 6.8.
+</div>
+
 ## Example
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/editor';
 
 const PluginPrePublishPanelTest = () => (
 	<PluginPrePublishPanel>

--- a/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
+++ b/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
@@ -11,9 +11,9 @@ import { blockDefault } from '@wordpress/icons';
 import CompactList from '../../components/compact-list';
 import { store as blockDirectoryStore } from '../../store';
 
-// We shouldn't import the edit-post package directly
-// because it would include the wp-edit-post in all pages loading the block-directory script.
-const { PluginPrePublishPanel } = window?.wp?.editPost ?? {};
+// We shouldn't import the editor package directly
+// because it would include the wp-editor in all pages loading the block-directory script.
+const { PluginPrePublishPanel } = window?.wp?.editor ?? {};
 
 export default function InstalledBlocksPrePublishPanel() {
 	const newBlockTypes = useSelect(

--- a/packages/e2e-tests/plugins/plugins-api/publish-panel.js
+++ b/packages/e2e-tests/plugins/plugins-api/publish-panel.js
@@ -3,8 +3,8 @@
 	const Fragment = wp.element.Fragment;
 	const __ = wp.i18n.__;
 	const registerPlugin = wp.plugins.registerPlugin;
-	const PluginPostPublishPanel = wp.editPost.PluginPostPublishPanel;
-	const PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;
+	const PluginPostPublishPanel = wp.editor.PluginPostPublishPanel;
+	const PluginPrePublishPanel = wp.editor.PluginPrePublishPanel;
 
 	function PanelContent() {
 		return el( 'p', {}, __( 'Here is the panel content!' ) );

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -524,7 +524,7 @@ _Usage_
 ```jsx
 // Using ESNext syntax
 import { __ } from '@wordpress/i18n';
-import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { PluginPostPublishPanel } from '@wordpress/editor';
 
 const MyPluginPostPublishPanel = () => (
 	<PluginPostPublishPanel
@@ -559,7 +559,7 @@ _Usage_
 ```jsx
 // Using ESNext syntax
 import { __ } from '@wordpress/i18n';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/editor';
 
 const MyPluginPrePublishPanel = () => (
 	<PluginPrePublishPanel

--- a/packages/editor/src/components/plugin-post-publish-panel/index.js
+++ b/packages/editor/src/components/plugin-post-publish-panel/index.js
@@ -21,7 +21,7 @@ const { Fill, Slot } = createSlotFill( 'PluginPostPublishPanel' );
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';
- * import { PluginPostPublishPanel } from '@wordpress/edit-post';
+ * import { PluginPostPublishPanel } from '@wordpress/editor';
  *
  * const MyPluginPostPublishPanel = () => (
  * 	<PluginPostPublishPanel

--- a/packages/editor/src/components/plugin-pre-publish-panel/index.js
+++ b/packages/editor/src/components/plugin-pre-publish-panel/index.js
@@ -24,7 +24,7 @@ const { Fill, Slot } = createSlotFill( 'PluginPrePublishPanel' );
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';
- * import { PluginPrePublishPanel } from '@wordpress/edit-post';
+ * import { PluginPrePublishPanel } from '@wordpress/editor';
  *
  * const MyPluginPrePublishPanel = () => (
  * 	<PluginPrePublishPanel


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This updates documentation to reflecht the changes form #60344

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
PluginPostPublishPanel and PluginPrePublishPanel where moved to `@wordpress/editor` (from `@wordpress/edit-post`). They are still available in the old package, but being deprecated there.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update example usage docs in those components/slot fills
- update slotfill reference docs with new location
- add notice that this change is only for gutenberg 18.1+ / wp 6.6+ - so not to confuse developers when looking at the docs now.
- change the internal use of those components/slots to the new package

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**Docs:**
nothing

**Internal usage**
The panel was used internally in the editor when installing a block directly in the editor and then publishing a post.
1. Create an empty post
2. Click the block inserter and search for a block which is not installed (e.g. [icon block](https://wordpress.org/plugins/icon-block/))
3. Install the block
4. Publish the post
5. The PrePublishPanel should show `Installed 1 Block`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
