### PR TITLE
Editor: Update post URL component

### DIFF
--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -97,6 +97,7 @@ export default function PostURL( { onClose } ) {
 							autoComplete="off"
 							spellCheck="false"
 							type="text"
+							className="editor-post-url__input"
 							onChange={ ( newValue ) => {
 								editPost( { slug: newValue } );
 								// When we delete the field the permalink gets
@@ -121,29 +122,34 @@ export default function PostURL( { onClose } ) {
 									setForceEmptyField( false );
 								}
 							} }
+							help={
+								<ExternalLink
+									className="editor-post-url__link"
+									href={ postLink }
+									target="_blank"
+								>
+									<span className="editor-post-url__link-prefix">
+										{ permalinkPrefix }
+									</span>
+									<span className="editor-post-url__link-slug">
+										{ postSlug }
+									</span>
+									<span className="editor-post-url__link-suffix">
+										{ permalinkSuffix }
+									</span>
+								</ExternalLink>
+							}
 						/>
 					) }
-					<ExternalLink
-						className="editor-post-url__link"
-						href={ postLink }
-						target="_blank"
-					>
-						{ isEditable ? (
-							<>
-								<span className="editor-post-url__link-prefix">
-									{ permalinkPrefix }
-								</span>
-								<span className="editor-post-url__link-slug">
-									{ postSlug }
-								</span>
-								<span className="editor-post-url__link-suffix">
-									{ permalinkSuffix }
-								</span>
-							</>
-						) : (
-							postLink
-						) }
-					</ExternalLink>
+					{ ! isEditable && (
+						<ExternalLink
+							className="editor-post-url__link"
+							href={ postLink }
+							target="_blank"
+						>
+							{ postLink }
+						</ExternalLink>
+					) }
 				</div>
 			</VStack>
 		</div>

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -64,16 +64,18 @@ export default function PostURL( { onClose } ) {
 				onClose={ onClose }
 			/>
 			<VStack spacing={ 3 }>
-				<div>
-					{ __( 'Customize the last part of the URL. ' ) }
-					<ExternalLink
-						href={ __(
-							'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
-						) }
-					>
-						{ __( 'Learn more.' ) }
-					</ExternalLink>
-				</div>
+				{ isEditable && (
+					<div>
+						{ __( 'Customize the last part of the URL. ' ) }
+						<ExternalLink
+							href={ __(
+								'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
+							) }
+						>
+							{ __( 'Learn more.' ) }
+						</ExternalLink>
+					</div>
+				) }
 				<div>
 					{ isEditable && (
 						<InputControl

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -60,7 +60,7 @@ export default function PostURL( { onClose } ) {
 	return (
 		<div className="editor-post-url">
 			<InspectorPopoverHeader
-				title={ __( 'Slug' ) }
+				title={ __( 'Link' ) }
 				onClose={ onClose }
 			/>
 			<VStack spacing={ 3 }>
@@ -91,7 +91,7 @@ export default function PostURL( { onClose } ) {
 									ref={ copyButtonRef }
 								/>
 							}
-							label={ __( 'Slug' ) }
+							label={ __( 'Link' ) }
 							hideLabelFromVision
 							value={ forceEmptyField ? '' : postSlug }
 							autoComplete="off"

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -65,9 +65,7 @@ export default function PostURL( { onClose } ) {
 			/>
 			<VStack spacing={ 3 }>
 				<div>
-					{ __(
-						'The slug forms the last part of the URL for a page. '
-					) }
+					{ __( 'Customize the last part of the URL. ' ) }
 					<ExternalLink
 						href={ __(
 							'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -6,122 +6,146 @@ import { safeDecodeURIComponent, cleanForSlug } from '@wordpress/url';
 import { useState } from '@wordpress/element';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { TextControl, ExternalLink } from '@wordpress/components';
+import {
+	ExternalLink,
+	Button,
+	__experimentalInputControl as InputControl,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { store as noticesStore } from '@wordpress/notices';
+import { copySmall } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
+import { useCopyToClipboard } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
+import { usePostURLLabel } from './label';
 import { store as editorStore } from '../../store';
 
 export default function PostURL( { onClose } ) {
-	const {
-		isEditable,
-		postSlug,
-		viewPostLabel,
-		postLink,
-		permalinkPrefix,
-		permalinkSuffix,
-	} = useSelect( ( select ) => {
-		const post = select( editorStore ).getCurrentPost();
-		const postTypeSlug = select( editorStore ).getCurrentPostType();
-		const postType = select( coreStore ).getPostType( postTypeSlug );
-		const permalinkParts = select( editorStore ).getPermalinkParts();
-		const hasPublishAction = post?._links?.[ 'wp:action-publish' ] ?? false;
+	const { isEditable, postSlug, postLink, permalinkPrefix, permalinkSuffix } =
+		useSelect( ( select ) => {
+			const post = select( editorStore ).getCurrentPost();
+			const postTypeSlug = select( editorStore ).getCurrentPostType();
+			const postType = select( coreStore ).getPostType( postTypeSlug );
+			const permalinkParts = select( editorStore ).getPermalinkParts();
+			const hasPublishAction =
+				post?._links?.[ 'wp:action-publish' ] ?? false;
 
-		return {
-			isEditable:
-				select( editorStore ).isPermalinkEditable() && hasPublishAction,
-			postSlug: safeDecodeURIComponent(
-				select( editorStore ).getEditedPostSlug()
-			),
-			viewPostLabel: postType?.labels.view_item,
-			postLink: post.link,
-			permalinkPrefix: permalinkParts?.prefix,
-			permalinkSuffix: permalinkParts?.suffix,
-		};
-	}, [] );
-
+			return {
+				isEditable:
+					select( editorStore ).isPermalinkEditable() &&
+					hasPublishAction,
+				postSlug: safeDecodeURIComponent(
+					select( editorStore ).getEditedPostSlug()
+				),
+				viewPostLabel: postType?.labels.view_item,
+				postLink: post.link,
+				permalinkPrefix: permalinkParts?.prefix,
+				permalinkSuffix: permalinkParts?.suffix,
+			};
+		}, [] );
 	const { editPost } = useDispatch( editorStore );
-
+	const { createNotice } = useDispatch( noticesStore );
 	const [ forceEmptyField, setForceEmptyField ] = useState( false );
-
+	const postUrlLabel = usePostURLLabel();
+	const copyButtonRef = useCopyToClipboard( postUrlLabel, () => {
+		createNotice( 'info', __( 'Copied URL to clipboard.' ), {
+			isDismissible: true,
+			type: 'snackbar',
+		} );
+	} );
 	return (
 		<div className="editor-post-url">
-			<InspectorPopoverHeader title={ __( 'URL' ) } onClose={ onClose } />
-			{ isEditable && (
-				<TextControl
-					__nextHasNoMarginBottom
-					label={ __( 'Permalink' ) }
-					value={ forceEmptyField ? '' : postSlug }
-					autoComplete="off"
-					spellCheck="false"
-					help={
-						<>
-							{ __( 'The last part of the URL.' ) }{ ' ' }
-							<ExternalLink
-								href={ __(
-									'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
-								) }
-							>
-								{ __( 'Learn more.' ) }
-							</ExternalLink>
-						</>
-					}
-					onChange={ ( newValue ) => {
-						editPost( { slug: newValue } );
-						// When we delete the field the permalink gets
-						// reverted to the original value.
-						// The forceEmptyField logic allows the user to have
-						// the field temporarily empty while typing.
-						if ( ! newValue ) {
-							if ( ! forceEmptyField ) {
-								setForceEmptyField( true );
-							}
-							return;
-						}
-						if ( forceEmptyField ) {
-							setForceEmptyField( false );
-						}
-					} }
-					onBlur={ ( event ) => {
-						editPost( {
-							slug: cleanForSlug( event.target.value ),
-						} );
-						if ( forceEmptyField ) {
-							setForceEmptyField( false );
-						}
-					} }
-				/>
-			) }
-			{ isEditable && (
-				<h3 className="editor-post-url__link-label">
-					{ viewPostLabel ?? __( 'View post' ) }
-				</h3>
-			) }
-			<p>
-				<ExternalLink
-					className="editor-post-url__link"
-					href={ postLink }
-					target="_blank"
-				>
-					{ isEditable ? (
-						<>
-							<span className="editor-post-url__link-prefix">
-								{ permalinkPrefix }
-							</span>
-							<span className="editor-post-url__link-slug">
-								{ postSlug }
-							</span>
-							<span className="editor-post-url__link-suffix">
-								{ permalinkSuffix }
-							</span>
-						</>
-					) : (
-						postLink
+			<InspectorPopoverHeader
+				title={ __( 'Slug' ) }
+				onClose={ onClose }
+			/>
+			<VStack spacing={ 3 }>
+				<div>
+					{ __(
+						'The slug forms the last part of the URL for a page. '
 					) }
-				</ExternalLink>
-			</p>
+					<ExternalLink
+						href={ __(
+							'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
+						) }
+					>
+						{ __( 'Learn more.' ) }
+					</ExternalLink>
+				</div>
+				<div>
+					{ isEditable && (
+						<InputControl
+							__next40pxDefaultSize
+							prefix={
+								<InputControlPrefixWrapper>
+									/
+								</InputControlPrefixWrapper>
+							}
+							suffix={
+								<Button
+									icon={ copySmall }
+									ref={ copyButtonRef }
+								/>
+							}
+							label={ __( 'Slug' ) }
+							hideLabelFromVision
+							value={ forceEmptyField ? '' : postSlug }
+							autoComplete="off"
+							spellCheck="false"
+							type="text"
+							onChange={ ( newValue ) => {
+								editPost( { slug: newValue } );
+								// When we delete the field the permalink gets
+								// reverted to the original value.
+								// The forceEmptyField logic allows the user to have
+								// the field temporarily empty while typing.
+								if ( ! newValue ) {
+									if ( ! forceEmptyField ) {
+										setForceEmptyField( true );
+									}
+									return;
+								}
+								if ( forceEmptyField ) {
+									setForceEmptyField( false );
+								}
+							} }
+							onBlur={ ( event ) => {
+								editPost( {
+									slug: cleanForSlug( event.target.value ),
+								} );
+								if ( forceEmptyField ) {
+									setForceEmptyField( false );
+								}
+							} }
+						/>
+					) }
+					<ExternalLink
+						className="editor-post-url__link"
+						href={ postLink }
+						target="_blank"
+					>
+						{ isEditable ? (
+							<>
+								<span className="editor-post-url__link-prefix">
+									{ permalinkPrefix }
+								</span>
+								<span className="editor-post-url__link-slug">
+									{ postSlug }
+								</span>
+								<span className="editor-post-url__link-suffix">
+									{ permalinkSuffix }
+								</span>
+							</>
+						) : (
+							postLink
+						) }
+					</ExternalLink>
+				</div>
+			</VStack>
 		</div>
 	);
 }

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -2,16 +2,18 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { safeDecodeURIComponent } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import PostURLCheck from './check';
 import PostURL from './index';
-import { usePostURLLabel } from './label';
 import PostPanelRow from '../post-panel-row';
+import { store as editorStore } from '../../store';
 
 export default function PostURLPanel() {
 	// Use internal state instead of a ref to make sure that the component
@@ -25,7 +27,7 @@ export default function PostURLPanel() {
 
 	return (
 		<PostURLCheck>
-			<PostPanelRow label={ __( 'URL' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow label={ __( 'Slug' ) } ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
 					className="editor-post-url__panel-dropdown"
@@ -44,18 +46,22 @@ export default function PostURLPanel() {
 }
 
 function PostURLToggle( { isOpen, onClick } ) {
-	const label = usePostURLLabel();
+	const slug = useSelect(
+		( select ) =>
+			safeDecodeURIComponent( select( editorStore ).getEditedPostSlug() ),
+		[]
+	);
 	return (
 		<Button
 			__next40pxDefaultSize
 			className="editor-post-url__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
-			// translators: %s: Current post URL.
-			aria-label={ sprintf( __( 'Change URL: %s' ), label ) }
+			// translators: %s: Current post slug.
+			aria-label={ sprintf( __( 'Change slug: %s' ), slug ) }
 			onClick={ onClick }
 		>
-			{ label }
+			{ slug }
 		</Button>
 	);
 }

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -27,7 +27,7 @@ export default function PostURLPanel() {
 
 	return (
 		<PostURLCheck>
-			<PostPanelRow label={ __( 'Slug' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow label={ __( 'Link' ) } ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
 					className="editor-post-url__panel-dropdown"
@@ -57,8 +57,8 @@ function PostURLToggle( { isOpen, onClick } ) {
 			className="editor-post-url__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
-			// translators: %s: Current post slug.
-			aria-label={ sprintf( __( 'Change slug: %s' ), slug ) }
+			// translators: %s: Current post link.
+			aria-label={ sprintf( __( 'Change link: %s' ), slug ) }
 			onClick={ onClick }
 		>
 			{ slug }

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -21,7 +21,14 @@ export default function PostURLPanel() {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 	// Memoize popoverProps to avoid returning a new object every time.
 	const popoverProps = useMemo(
-		() => ( { anchor: popoverAnchor, placement: 'bottom-end' } ),
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
 		[ popoverAnchor ]
 	);
 
@@ -47,10 +54,10 @@ export default function PostURLPanel() {
 
 function PostURLToggle( { isOpen, onClick } ) {
 	const slug = useSelect(
-		( select ) =>
-			safeDecodeURIComponent( select( editorStore ).getEditedPostSlug() ),
+		( select ) => select( editorStore ).getEditedPostSlug(),
 		[]
 	);
+	const decodedSlug = safeDecodeURIComponent( slug );
 	return (
 		<Button
 			__next40pxDefaultSize
@@ -58,10 +65,10 @@ function PostURLToggle( { isOpen, onClick } ) {
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			// translators: %s: Current post link.
-			aria-label={ sprintf( __( 'Change link: %s' ), slug ) }
+			aria-label={ sprintf( __( 'Change link: %s' ), decodedSlug ) }
 			onClick={ onClick }
 		>
-			{ slug }
+			{ decodedSlug }
 		</Button>
 	);
 }

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -17,16 +17,11 @@
 	margin: $grid-unit-10;
 }
 
-.editor-post-url__link-label {
-	font-size: $default-font-size;
-	font-weight: 400;
-	margin: 0;
-}
-
 /* rtl:begin:ignore */
 .editor-post-url__link {
 	direction: ltr;
 	word-break: break-word;
+	margin-top: $grid-unit-05;
 }
 /* rtl:end:ignore */
 

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -22,9 +22,16 @@
 	direction: ltr;
 	word-break: break-word;
 	margin-top: $grid-unit-05;
+	color: $gray-700;
 }
 /* rtl:end:ignore */
 
 .editor-post-url__link-slug {
 	font-weight: 600;
+}
+
+// TODO: This might indicate a need to update the InputControl itself, as
+// there is no way currently to control the padding when adding prefix/suffix.
+.editor-post-url__input input.components-input-control__input {
+	padding-inline-start: 0 !important;
 }

--- a/test/e2e/specs/editor/various/sidebar-permalink.spec.js
+++ b/test/e2e/specs/editor/various/sidebar-permalink.spec.js
@@ -34,7 +34,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change URL' } )
+			page.getByRole( 'button', { name: 'Change slug' } )
 		).toBeHidden();
 	} );
 
@@ -54,7 +54,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change URL' } )
+			page.getByRole( 'button', { name: 'Change slug' } )
 		).toBeHidden();
 	} );
 
@@ -75,7 +75,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change URL' } )
+			page.getByRole( 'button', { name: 'Change slug' } )
 		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/various/sidebar-permalink.spec.js
+++ b/test/e2e/specs/editor/various/sidebar-permalink.spec.js
@@ -34,7 +34,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change slug' } )
+			page.getByRole( 'button', { name: 'Change link' } )
 		).toBeHidden();
 	} );
 
@@ -54,7 +54,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change slug' } )
+			page.getByRole( 'button', { name: 'Change link' } )
 		).toBeHidden();
 	} );
 
@@ -75,7 +75,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change slug' } )
+			page.getByRole( 'button', { name: 'Change link' } )
 		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/60291

This PR updates the post url component that is used for updating the post's slug. Designs are from the linked issue: https://github.com/WordPress/gutenberg/issues/60291#issuecomment-2037258428
<!-- In a few words, what is the PR actually doing? -->



## Testing Instructions
1. Test the updated component to update the post's slug in both site and post editors
2. Verify no regression is introduced and everything works as before

## Screenshots or screencast <!-- if applicable -->
<img width="589" alt="Screenshot 2024-04-11 at 1 18 19 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/f85cc588-7acd-4207-9f95-c21d34a343fd">




