### PR TITLE
Upgrade Playwright to v1.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.6.0",
-				"@playwright/test": "1.42.1",
+				"@playwright/test": "1.43.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -6979,12 +6979,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-			"integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
+			"integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.42.1"
+				"playwright": "1.43.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -42214,12 +42214,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-			"integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
+			"integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.42.1"
+				"playwright-core": "1.43.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -42232,9 +42232,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-			"integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
+			"integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -55377,7 +55377,7 @@
 				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.42.1",
+				"@playwright/test": "^1.43.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -60722,12 +60722,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-			"integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
+			"integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.42.1"
+				"playwright": "1.43.0"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -88595,19 +88595,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-			"integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
+			"integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.42.1"
+				"playwright-core": "1.43.0"
 			}
 		},
 		"playwright-core": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-			"integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
+			"integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",
-		"@playwright/test": "1.42.1",
+		"@playwright/test": "1.43.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -91,7 +91,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.42.1",
+		"@playwright/test": "^1.43.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.43

## What's new?
https://github.com/microsoft/playwright/releases/tag/v1.43.0

## Testing Instructions
*  Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.
