### PR TITLE
Add duplicate post action

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -13,7 +13,7 @@ import {
 	useEffect,
 	useRef,
 } from '@wordpress/element';
-import { isRTL, __ } from '@wordpress/i18n';
+import { isRTL, __, sprintf } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import {
@@ -28,6 +28,7 @@ import {
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import { addQueryArgs } from '@wordpress/url';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -53,15 +54,6 @@ export const sidebars = {
 	document: 'edit-post/document',
 	block: 'edit-post/block',
 };
-
-function onActionPerformed( actionId, items ) {
-	if ( actionId === 'move-to-trash' ) {
-		const postType = items[ 0 ].type;
-		document.location.href = addQueryArgs( 'edit.php', {
-			post_type: postType,
-		} );
-	}
-}
 
 const SidebarContent = ( { tabName, keyboardShortcut, isEditingTemplate } ) => {
 	const tabListRef = useRef( null );
@@ -96,6 +88,56 @@ const SidebarContent = ( { tabName, keyboardShortcut, isEditingTemplate } ) => {
 			selectedTabElement?.focus();
 		}
 	}, [ tabName ] );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	const onActionPerformed = useCallback(
+		( actionId, items ) => {
+			switch ( actionId ) {
+				case 'move-to-trash':
+					{
+						const postType = items[ 0 ].type;
+						document.location.href = addQueryArgs( 'edit.php', {
+							post_type: postType,
+						} );
+					}
+					break;
+				case 'duplicate-post':
+					{
+						const newItem = items[ 0 ];
+						const title =
+							typeof newItem.title === 'string'
+								? newItem.title
+								: newItem.title?.rendered;
+						createSuccessNotice(
+							sprintf(
+								// translators: %s: Title of the created post e.g: "Post 1".
+								__( '"%s" successfully created.' ),
+								title
+							),
+							{
+								type: 'snackbar',
+								id: 'duplicate-post-action',
+								actions: [
+									{
+										label: __( 'Edit' ),
+										onClick: () => {
+											const postId = newItem.id;
+											document.location.href =
+												addQueryArgs( 'post.php', {
+													post: postId,
+													action: 'edit',
+												} );
+										},
+									},
+								],
+							}
+						);
+					}
+					break;
+			}
+		},
+		[ createSuccessNotice ]
+	);
 
 	return (
 		<PluginSidebar

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -195,6 +195,7 @@ const PAGE_ACTIONS = [
 	'restore',
 	'permanently-delete',
 	'view-post-revisions',
+	'duplicate-post',
 	'rename-post',
 	'move-to-trash',
 ];

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -56,13 +56,13 @@ export default function PagePanels() {
 			switch ( actionId ) {
 				case 'move-to-trash':
 					{
-				history.push( {
-					path: '/' + items[ 0 ].type,
-					postId: undefined,
-					postType: undefined,
-					canvas: 'view',
-				} );
-			}
+						history.push( {
+							path: '/' + items[ 0 ].type,
+							postId: undefined,
+							postType: undefined,
+							canvas: 'view',
+						} );
+					}
 					break;
 				case 'duplicate-post':
 					{
@@ -90,7 +90,7 @@ export default function PagePanels() {
 												postType: newItem.type,
 												canvas: 'edit',
 											} );
-		},
+										},
 									},
 								],
 							}

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { PanelBody } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	PluginDocumentSettingPanel,
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useCallback } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -48,11 +49,13 @@ export default function PagePanels() {
 				renderingMode: getRenderingMode(),
 			};
 		}, [] );
-
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const history = useHistory();
 	const onActionPerformed = useCallback(
 		( actionId, items ) => {
-			if ( actionId === 'move-to-trash' ) {
+			switch ( actionId ) {
+				case 'move-to-trash':
+					{
 				history.push( {
 					path: '/' + items[ 0 ].type,
 					postId: undefined,
@@ -60,8 +63,43 @@ export default function PagePanels() {
 					canvas: 'view',
 				} );
 			}
+					break;
+				case 'duplicate-post':
+					{
+						const newItem = items[ 0 ];
+						const title =
+							typeof newItem.title === 'string'
+								? newItem.title
+								: newItem.title?.rendered;
+						createSuccessNotice(
+							sprintf(
+								// translators: %s: Title of the created post e.g: "Post 1".
+								__( '"%s" successfully created.' ),
+								title
+							),
+							{
+								type: 'snackbar',
+								id: 'duplicate-post-action',
+								actions: [
+									{
+										label: __( 'Edit' ),
+										onClick: () => {
+											history.push( {
+												path: undefined,
+												postId: newItem.id,
+												postType: newItem.type,
+												canvas: 'edit',
+											} );
 		},
-		[ history ]
+									},
+								],
+							}
+						);
+					}
+					break;
+			}
+		},
+		[ history, createSuccessNotice ]
 	);
 
 	if ( ! hasResolved ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalVStack as VStack,
@@ -17,6 +17,7 @@ import { safeDecodeURIComponent, filterURLForDisplay } from '@wordpress/url';
 import { useEffect, useCallback } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ const { PostActions } = unlock( editorPrivateApis );
 export default function SidebarNavigationScreenPage( { backPath } ) {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const history = useHistory();
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const {
 		params: { postId },
 	} = useLocation();
@@ -83,16 +85,53 @@ export default function SidebarNavigationScreenPage( { backPath } ) {
 
 	const onActionPerformed = useCallback(
 		( actionId, items ) => {
-			if ( actionId === 'move-to-trash' ) {
-				history.push( {
-					path: '/' + items[ 0 ].type,
-					postId: undefined,
-					postType: undefined,
-					canvas: 'view',
-				} );
+			switch ( actionId ) {
+				case 'move-to-trash':
+					{
+						history.push( {
+							path: '/' + items[ 0 ].type,
+							postId: undefined,
+							postType: undefined,
+							canvas: 'view',
+						} );
+					}
+					break;
+				case 'duplicate-post':
+					{
+						const newItem = items[ 0 ];
+						const title =
+							typeof newItem.title === 'string'
+								? newItem.title
+								: newItem.title?.rendered;
+						createSuccessNotice(
+							sprintf(
+								// translators: %s: Title of the created post e.g: "Post 1".
+								__( '"%s" successfully created.' ),
+								title
+							),
+							{
+								type: 'snackbar',
+								id: 'duplicate-post-action',
+								actions: [
+									{
+										label: __( 'Edit' ),
+										onClick: () => {
+											history.push( {
+												path: undefined,
+												postId: newItem.id,
+												postType: newItem.type,
+												canvas: 'edit',
+											} );
+										},
+									},
+								],
+							}
+						);
+					}
+					break;
 			}
 		},
-		[ history ]
+		[ history, createSuccessNotice ]
 	);
 
 	const featureImageAltText = featuredMediaAltText

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -518,8 +518,7 @@ export const duplicatePostAction = {
 		);
 
 		const { saveEntityRecord } = useDispatch( coreStore );
-		const { createErrorNotice, createSuccessNotice } =
-			useDispatch( noticesStore );
+		const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 		async function createPage( event ) {
 			event.preventDefault();
@@ -558,11 +557,13 @@ export const duplicatePostAction = {
 						newItem.title?.rendered || title
 					),
 					{
+						id: 'duplicate-post-action',
 						type: 'snackbar',
 					}
 				);
+
 				if ( onActionPerformed ) {
-					onActionPerformed( items );
+					onActionPerformed( [ newItem ] );
 				}
 			} catch ( error ) {
 				const errorMessage =

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -509,7 +509,13 @@ export const duplicatePostAction = {
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ item ] = items;
 		const [ isCreatingPage, setIsCreatingPage ] = useState( false );
-		const [ title, setTitle ] = useState( getItemTitle( item ) );
+		const [ title, setTitle ] = useState(
+			sprintf(
+				/* translators: %s: Existing item title */
+				__( '%s (Copy)' ),
+				getItemTitle( item )
+			)
+		);
 
 		const { saveEntityRecord } = useDispatch( coreStore );
 		const { createErrorNotice, createSuccessNotice } =

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -6,7 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf, _x } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from '@wordpress/element';
 
@@ -500,6 +500,106 @@ const renamePostAction = {
 	},
 };
 
+export const duplicatePostAction = {
+	id: 'duplicate-post',
+	label: _x( 'Duplicate', 'action label' ),
+	isEligible( { status } ) {
+		return status !== 'trash';
+	},
+	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
+		const [ item ] = items;
+		const [ isCreatingPage, setIsCreatingPage ] = useState( false );
+		const [ title, setTitle ] = useState( getItemTitle( item ) );
+
+		const { saveEntityRecord } = useDispatch( coreStore );
+		const { createErrorNotice, createSuccessNotice } =
+			useDispatch( noticesStore );
+
+		async function createPage( event ) {
+			event.preventDefault();
+
+			if ( isCreatingPage ) {
+				return;
+			}
+			setIsCreatingPage( true );
+			try {
+				const newItem = await saveEntityRecord(
+					'postType',
+					item.type,
+					{
+						status: 'draft',
+						title,
+						slug: title || __( 'No title' ),
+						author: item.author,
+						comment_status: item.comment_status,
+						content: item.content.raw,
+						excerpt: item.excerpt.raw,
+						meta: item.meta,
+						parent: item.parent,
+						password: item.password,
+						template: item.template,
+						featured_media: item.featured_media,
+						menu_order: item.menu_order,
+						ping_status: item.ping_status,
+					},
+					{ throwOnError: true }
+				);
+
+				createSuccessNotice(
+					sprintf(
+						// translators: %s: Title of the created template e.g: "Category".
+						__( '"%s" successfully created.' ),
+						newItem.title?.rendered || title
+					),
+					{
+						type: 'snackbar',
+					}
+				);
+				if ( onActionPerformed ) {
+					onActionPerformed( items );
+				}
+			} catch ( error ) {
+				const errorMessage =
+					error.message && error.code !== 'unknown_error'
+						? error.message
+						: __( 'An error occurred while duplicating the page.' );
+
+				createErrorNotice( errorMessage, {
+					type: 'snackbar',
+				} );
+			} finally {
+				setIsCreatingPage( false );
+				closeModal();
+			}
+		}
+		return (
+			<form onSubmit={ createPage }>
+				<VStack spacing={ 3 }>
+					<TextControl
+						label={ __( 'Title' ) }
+						onChange={ setTitle }
+						placeholder={ __( 'No title' ) }
+						value={ title }
+					/>
+					<HStack spacing={ 2 } justify="end">
+						<Button variant="tertiary" onClick={ closeModal }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							type="submit"
+							isBusy={ isCreatingPage }
+							aria-disabled={ isCreatingPage }
+						>
+							{ _x( 'Duplicate', 'action label' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		);
+	},
+};
+
 const resetTemplateAction = {
 	id: 'reset-template',
 	label: __( 'Reset' ),
@@ -782,6 +882,7 @@ export function usePostActions( onActionPerformed, actionIds = null ) {
 				deleteTemplateAction,
 				permanentlyDeletePostAction,
 				postRevisionsAction,
+				duplicatePostAction,
 				renamePostAction,
 				renameTemplateAction,
 				trashPostAction,

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -518,7 +518,8 @@ export const duplicatePostAction = {
 		);
 
 		const { saveEntityRecord } = useDispatch( coreStore );
-		const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+		const { createSuccessNotice, createErrorNotice } =
+			useDispatch( noticesStore );
 
 		async function createPage( event ) {
 			event.preventDefault();

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -538,7 +538,10 @@ export const duplicatePostAction = {
 						slug: title || __( 'No title' ),
 						author: item.author,
 						comment_status: item.comment_status,
-						content: item.content.raw,
+						content:
+							typeof item.content === 'string'
+								? item.content
+								: item.content.raw,
 						excerpt: item.excerpt.raw,
 						meta: item.meta,
 						parent: item.parent,

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -34,9 +34,9 @@ const {
 const POST_ACTIONS_WHILE_EDITING = [
 	'view-post',
 	'view-post-revisions',
+	'duplicate-post',
 	'rename-post',
 	'move-to-trash',
-	'duplicate-post',
 ];
 
 export default function PostActions( { onActionPerformed, buttonProps } ) {

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -36,6 +36,7 @@ const POST_ACTIONS_WHILE_EDITING = [
 	'view-post-revisions',
 	'rename-post',
 	'move-to-trash',
+	'duplicate-post',
 ];
 
 export default function PostActions( { onActionPerformed, buttonProps } ) {

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -40,6 +40,7 @@ const POST_ACTIONS_WHILE_EDITING = [
 ];
 
 export default function PostActions( { onActionPerformed, buttonProps } ) {
+	const [ isActionsMenuOpen, setIsActionsMenuOpen ] = useState( false );
 	const { postType, item } = useSelect( ( select ) => {
 		const { getCurrentPostType, getCurrentPost } = select( editorStore );
 		return {
@@ -69,6 +70,7 @@ export default function PostActions( { onActionPerformed, buttonProps } ) {
 	}
 	return (
 		<DropdownMenu
+			open={ isActionsMenuOpen }
 			trigger={
 				<Button
 					size="small"
@@ -76,12 +78,22 @@ export default function PostActions( { onActionPerformed, buttonProps } ) {
 					label={ __( 'Actions' ) }
 					disabled={ ! actions.length }
 					className="editor-all-actions-button"
+					onClick={ () =>
+						setIsActionsMenuOpen( ! isActionsMenuOpen )
+					}
 					{ ...buttonProps }
 				/>
 			}
+			onOpenChange={ setIsActionsMenuOpen }
 			placement="bottom-end"
 		>
-			<ActionsDropdownMenuGroup actions={ actions } item={ item } />
+			<ActionsDropdownMenuGroup
+				actions={ actions }
+				item={ item }
+				onClose={ () => {
+					setIsActionsMenuOpen( false );
+				} }
+			/>
 		</DropdownMenu>
 	);
 }
@@ -104,7 +116,8 @@ function DropdownMenuItemTrigger( { action, onClick } ) {
 }
 
 // Copied as is from packages/dataviews/src/item-actions.js
-function ActionWithModal( { action, item, ActionTrigger } ) {
+// With an added onClose prop.
+function ActionWithModal( { action, item, ActionTrigger, onClose } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const actionTriggerProps = {
 		action,
@@ -127,7 +140,10 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 				>
 					<RenderModal
 						items={ [ item ] }
-						closeModal={ () => setIsModalOpen( false ) }
+						closeModal={ () => {
+							setIsModalOpen( false );
+							onClose();
+						} }
 					/>
 				</Modal>
 			) }
@@ -136,7 +152,8 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 }
 
 // Copied as is from packages/dataviews/src/item-actions.js
-function ActionsDropdownMenuGroup( { actions, item } ) {
+// With an added onClose prop.
+function ActionsDropdownMenuGroup( { actions, item, onClose } ) {
 	return (
 		<DropdownMenuGroup>
 			{ actions.map( ( action ) => {
@@ -147,6 +164,7 @@ function ActionsDropdownMenuGroup( { actions, item } ) {
 							action={ action }
 							item={ item }
 							ActionTrigger={ DropdownMenuItemTrigger }
+							onClose={ onClose }
 						/>
 					);
 				}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59689.
Adds the duplicate post-action.

@jameskoster After we duplicate a post when we are with the post opened in the editor should we navigate to the new post or keep the current post open?


## Testing Instructions
- Open a page in the post editor and site editor and verify there is an option to duplicate and it works.
- Open the pages (list) data views and verify the duplicate option is available and works.