### PR TITLE
Fix pattern titles

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -260,13 +260,16 @@
 
 	button.components-button.is-link {
 		text-decoration: none;
-		color: inherit;
 		font-weight: inherit;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
 		display: block;
 		width: 100%;
+		color: $gray-900;
+		&:hover {
+			color: var(--wp-admin-theme-color);
+		}
 	}
 }
 


### PR DESCRIPTION
## What?
Fix appearance of clickable pattern titles.

## Why?
A regression has snuck in somewhere that causes _clickable_ pattern titles to appear the same as _unclickable_ pattern titles.

## Trunk
<img width="622" alt="Screenshot 2024-04-10 at 19 19 25" src="https://github.com/WordPress/gutenberg/assets/846565/1a8f60f0-2554-4ae2-b2a1-cbc6275b0667">

## This branch
<img width="636" alt="Screenshot 2024-04-10 at 19 20 07" src="https://github.com/WordPress/gutenberg/assets/846565/5bdf6c36-e1c6-4358-9490-5a8dee5b7159">

## To test
* Open the patterns page in the site editor.
* Check that clickable pattern titles are dark gray (`$gray-900`), and `--wp-admin-theme-color` on hover.
* Check that unclickable pattern titles remain lighter gray (`$gray-700`).
* Check in both grid and table layouts.
* Compare with titles in the Pages and Templates data views and ensure there's consistency across.