### PR TITLE
Font Library: Fix modal scrollbar

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -181,7 +181,6 @@ function InstalledFonts() {
 							) ) }
 						</>
 					) }
-					<Spacer margin={ 16 } />
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/fontFamily">

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -1,3 +1,7 @@
+// Fixed height for the modal footer.
+// Ensures that the footer is always visible when the modal content is scrollable.
+$footer-height: 70px;
+
 .font-library-modal {
 	// @todo If a new prop is added to the Modal component that constrains
 	// the content width, we should use that prop instead of this style.
@@ -15,7 +19,7 @@
 
 	.components-modal__content {
 		padding-top: 0;
-		margin-bottom: 70px; // This should match the height of the footer
+		margin-bottom: $footer-height;
 	}
 
 	.font-library-modal__subtitle {
@@ -41,7 +45,7 @@
 		position: absolute;
 		bottom: $grid-unit-40;
 		width: 100%;
-		height: 70px; // This should match the margin-bottom of .components-modal__content
+		height: $footer-height;
 		background-color: $white;
 	}
 }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -15,6 +15,7 @@
 
 	.components-modal__content {
 		padding-top: 0;
+		margin-bottom: 70px; // This should match the height of the footer
 	}
 
 	.font-library-modal__subtitle {
@@ -40,6 +41,7 @@
 		position: absolute;
 		bottom: $grid-unit-40;
 		width: 100%;
+		height: 70px; // This should match the margin-bottom of .components-modal__content
 		background-color: $white;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improves the display of the Font Library modal's scrollbar to prevent it from disappearing behind the footer.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/WordPress/gutenberg/issues/54401.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This adjusts the CSS of the Font Library modal's content to add a bottom margin, which means it can take into account the height of the footer when displaying the scrollbar. I've also made the footer a fixed height so that these two measurements always match.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the Font Libary modal
2. Ensure there are enough fonts installed to increase the height of the content to cause a vertical scrollbar (add more fonts via the Install Fonts tab if necessary)
3. Scroll to the bottom of the modal content
4. Ensure that you can still see the scroll bar and its position at the bottom of the modal

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1645628/e86d37c7-061a-42a5-b641-da9f651e918c

