### PR TITLE
Only show block icon in toolbar for contentOnly blocks when block is a synced block

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -170,29 +170,33 @@ export function PrivateBlockToolbar( {
 				{ isUsingBindings && canBindBlock( blockName ) && (
 					<BlockBindingsIndicator />
 				) }
-				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
-					<div ref={ nodeRef } { ...showHoveredOrFocusedGestures }>
-						<ToolbarGroup className="block-editor-block-toolbar__block-controls">
-							<BlockSwitcher
-								clientIds={ blockClientIds }
-								disabled={ ! isDefaultEditingMode }
-							/>
-							{ isDefaultEditingMode && (
-								<>
-									{ ! isMultiToolbar && (
-										<BlockLockToolbar
-											clientId={ blockClientId }
+				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
+					( isDefaultEditingMode || isSynced ) && (
+						<div
+							ref={ nodeRef }
+							{ ...showHoveredOrFocusedGestures }
+						>
+							<ToolbarGroup className="block-editor-block-toolbar__block-controls">
+								<BlockSwitcher
+									clientIds={ blockClientIds }
+									disabled={ ! isDefaultEditingMode }
+								/>
+								{ isDefaultEditingMode && (
+									<>
+										{ ! isMultiToolbar && (
+											<BlockLockToolbar
+												clientId={ blockClientId }
+											/>
+										) }
+										<BlockMover
+											clientIds={ blockClientIds }
+											hideDragHandle={ hideDragHandle }
 										/>
-									) }
-									<BlockMover
-										clientIds={ blockClientIds }
-										hideDragHandle={ hideDragHandle }
-									/>
-								</>
-							) }
-						</ToolbarGroup>
-					</div>
-				) }
+									</>
+								) }
+							</ToolbarGroup>
+						</div>
+					) }
 				<Shuffle clientId={ blockClientId } />
 				{ shouldShowVisualToolbar && isMultiToolbar && (
 					<BlockGroupToolbar />


### PR DESCRIPTION
## What?
As part of https://github.com/WordPress/gutenberg/pull/60010 I changed `BlockToolbar` to show the block icon / block name on blocks that have a `contentOnly` editing mode, so that you can see the name of the template part when you've selected it.

This PR dials back that behaviour a little to only do this when the block is a synced block (reusable block or a pattern).

## Why?
The original change caused some unexpected behaviour for third parties that are using `contentOnly`.

https://github.com/woocommerce/woocommerce/issues/45908

Arguably this isn't really what `contentOnly` is for, but I don't mind simply dialing back the changes made in https://github.com/WordPress/gutenberg/pull/60010 since we only need the block icon to show on patterns.

## How?
Instead of always rendering `BlockSwitcher`, we render it if `isDefaultEditingMode || isSynced`. It's a partial reversion of the changes to `packages/block-editor/src/components/block-toolbar/index.js` in https://github.com/WordPress/gutenberg/pull/60010.

## Testing Instructions
1. Go to Appearance → Editor → Pages and create or edit page.
2. Select the header or footer.
3. The template part name should appear in the block toolbar.
4. Select the title block, content block, or featured image block.
5. No block icon should appear in the toolbar.