### PR TITLE
Pullquote: Reduce specificity of padding rule to avoid conflicts with global styles

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -1,5 +1,4 @@
 .wp-block-pullquote {
-	padding: 4em 0;
 	text-align: center; // Default text-alignment where the `textAlign` attribute value isn't specified.
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 	box-sizing: border-box;
@@ -36,9 +35,10 @@
 	}
 }
 
-// Lowest specificity to avoid overriding layout styles.
+// Lowest specificity to avoid overriding layout and global styles.
 :where(.wp-block-pullquote) {
 	margin: 0 0 1em 0;
+	padding: 4em 0;
 }
 
 // Ensure that we are reasonably specific to override theme defaults.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #60646

Reduce the specificity of the Pullquote block's default padding rules.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With global styles rules specificity being reduced as of https://github.com/WordPress/gutenberg/pull/60106, the default padding rule for the Pullquote wins out over padding rules set at the block level in `theme.json`. TT4 theme is a good example of a theme that provides its own padding values for this block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Include the Pullquote block's padding rules in the lower specificity `:where()` rule so that the global styles rules will win out. I believe the objective with this particular padding rule was for anything else to override it (i.e. theme styles or global styles), so hopefully this should be a fairly safe reduction. I've smoke tested with TT4, Twenty Twenty and a couple of other themes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With TT4 theme activate, confirm that on `trunk`, the issue in #60646 appears — there is too much padding on the block, and the global styles rules do not win out
2. Apply this PR and ensure that the theme's Pullquote padding rules win out
3. Test in the post and site editors, and on the site frontend
4. Test with a couple of other themes, including Classic themes to ensure there are no regressions

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="1273" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/ed846bf0-578a-47e0-95da-6d3a63f24e87"> | <img width="1273" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/d4ee017f-4a88-425f-ac59-d4a723d64e82"> |