### PR TITLE
List View: Support insert before/after keyboard shortcuts when focus is within the list view

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -68,8 +68,13 @@ function ListViewBlockSelectButton(
 		getBlocksByClientId,
 		canRemoveBlocks,
 	} = useSelect( blockEditorStore );
-	const { duplicateBlocks, multiSelect, removeBlocks } =
-		useDispatch( blockEditorStore );
+	const {
+		duplicateBlocks,
+		multiSelect,
+		removeBlocks,
+		insertAfterBlock,
+		insertBeforeBlock,
+	} = useDispatch( blockEditorStore );
 	const isMatch = useShortcutEventMatch();
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
@@ -189,6 +194,30 @@ function ListViewBlockSelectButton(
 					updateFocusAndSelection( updatedBlocks[ 0 ], false );
 				}
 			}
+		} else if ( isMatch( 'core/block-editor/insert-before', event ) ) {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+			event.preventDefault();
+
+			const { blocksToUpdate } = getBlocksToUpdate();
+			await insertBeforeBlock( blocksToUpdate[ 0 ] );
+			const newlySelectedBlocks = getSelectedBlockClientIds();
+
+			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
+			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
+		} else if ( isMatch( 'core/block-editor/insert-after', event ) ) {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+			event.preventDefault();
+
+			const { blocksToUpdate } = getBlocksToUpdate();
+			await insertAfterBlock( blocksToUpdate.at( -1 ) );
+			const newlySelectedBlocks = getSelectedBlockClientIds();
+
+			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
+			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
 		} else if ( isMatch( 'core/block-editor/select-all', event ) ) {
 			if ( event.defaultPrevented ) {
 				return;

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -496,7 +496,7 @@ test.describe( 'List View', () => {
 		).toBeFocused();
 	} );
 
-	test( 'should cut, copy, paste, select, duplicate, delete, and deselect blocks using keyboard', async ( {
+	test( 'should cut, copy, paste, select, duplicate, insert, delete, and deselect blocks using keyboard', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -663,8 +663,44 @@ test.describe( 'List View', () => {
 				{ name: 'core/file', focused: true },
 			] );
 
-		// Move focus to the first file block, and then delete it.
-		await page.keyboard.press( 'ArrowUp' );
+		// Test insert before.
+		await pageUtils.pressKeys( 'primaryAlt+t' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Inserting a block before should move selection and focus to the inserted block.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{ name: 'core/columns' },
+				{ name: 'core/file', selected: false },
+				{ name: 'core/paragraph', focused: true, selected: true },
+				{ name: 'core/file', selected: false },
+			] );
+
+		// Test insert after.
+		await pageUtils.pressKeys( 'primaryAlt+y' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Inserting a block before should move selection and focus to the inserted block.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{ name: 'core/columns' },
+				{ name: 'core/file', selected: false },
+				{ name: 'core/paragraph', focused: false, selected: false },
+				{ name: 'core/paragraph', focused: true, selected: true },
+				{ name: 'core/file', selected: false },
+			] );
+
+		// Remove the inserted blocks.
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.press( 'Delete' );
+
+		// Delete the first File block.
 		await page.keyboard.press( 'Delete' );
 		await expect
 			.poll(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/60099

Enable keyboard shortcuts for inserting before or after list view items when focus is within the list view. (The keyboard shortcuts are currently Option+CMD+T to insert before and Option+CMD+Y to insert after).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These keyboard shortcuts work when focus is within the editor canvas, and it's already supported in the list view via the block settings menu. If you're used to these keyboard shortcuts and have focus within the list view, it feels a little broken if the keyboard shortcuts don't work there. This brings consistency to these keyboard shortcuts.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add handling to the block select button for inserting before or after the current block focus. The logic here is similar to duplicating blocks: if we're focused within a selection, then we insert before or after the whole selection. If focus is outside a selection, we insert before/after the currently focused item.
* Once the block is inserted, we grab the selection again to set focus within the list view item. This preserves focus within the list view, which ensures a smoother experience when navigating via keyboard.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With this PR applied, open up the post or site editors and insert some blocks into the post or template
2. With the list view open, click a block twice to focus it within the list view (or Tab key your way there)
3. Press the keyboard shortcut to insert a block before the currently selected block (i.e. `Option+CMD+T`)
4. A block should be inserted, and selection and focus should be moved to it.
5. Press the keyboard shortcut to insert a block after the currently selected block (i.e. `Option+CMD+Y`)
6. A block should be inserted after, and selection and focus should be moved to it.
7. In a multiple-block selection (i.e. shift-select a range of blocks), then the keyboard shortcuts should insert before/after the entire selection.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/14988353/dd60570a-a1a6-4493-8953-8c04e67cc991