### PR TITLE
Add a Row control to grid layout in manual mode.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -471,6 +471,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				'selector'     => $selector,
 				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['columnCount'] . ', minmax(0, 1fr))' ),
 			);
+			if ( ! empty( $layout['rowCount'] ) ) {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'grid-template-rows' => 'repeat(' . $layout['rowCount'] . ', minmax(0, 1fr))' ),
+				);
+			}
 		} else {
 			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';
 

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -79,7 +79,7 @@ export default {
 					onChange={ onChange }
 				/>
 				{ layout?.columnCount ? (
-					<GridLayoutColumnsControl
+					<GridLayoutColumnsAndRowsControl
 						layout={ layout }
 						onChange={ onChange }
 						allowSizingOnChildren={ allowSizingOnChildren }
@@ -239,7 +239,7 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 }
 
 // Enables setting number of grid columns
-function GridLayoutColumnsControl( {
+function GridLayoutColumnsAndRowsControl( {
 	layout,
 	onChange,
 	allowSizingOnChildren,

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -104,7 +104,11 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
-		const { minimumColumnWidth = '12rem', columnCount = null } = layout;
+		const {
+			minimumColumnWidth = '12rem',
+			columnCount = null,
+			rowCount = null,
+		} = layout;
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
@@ -121,6 +125,11 @@ export default {
 			rules.push(
 				`grid-template-columns: repeat(${ columnCount }, minmax(0, 1fr))`
 			);
+			if ( rowCount ) {
+				rules.push(
+					`grid-template-rows: repeat(${ rowCount }, minmax(0, 1fr))`
+				);
+			}
 		} else if ( minimumColumnWidth ) {
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(min(${ minimumColumnWidth }, 100%), 1fr))`,
@@ -228,52 +237,92 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 
 // Enables setting number of grid columns
 function GridLayoutColumnsControl( { layout, onChange } ) {
-	const { columnCount = 3 } = layout;
+	const { columnCount = 3, rowCount = 3 } = layout;
 
 	return (
-		<fieldset>
-			<BaseControl.VisualLabel as="legend">
-				{ __( 'Columns' ) }
-			</BaseControl.VisualLabel>
-			<Flex gap={ 4 }>
-				<FlexItem isBlock>
-					<NumberControl
-						size={ '__unstable-large' }
-						onChange={ ( value ) => {
-							/**
-							 * If the input is cleared, avoid switching
-							 * back to "Auto" by setting a value of "1".
-							 */
-							const validValue = value !== '' ? value : '1';
-							onChange( {
-								...layout,
-								columnCount: validValue,
-							} );
-						} }
-						value={ columnCount }
-						min={ 1 }
-						label={ __( 'Columns' ) }
-						hideLabelFromVision
-					/>
-				</FlexItem>
-				<FlexItem isBlock>
-					<RangeControl
-						value={ parseInt( columnCount, 10 ) } // RangeControl can't deal with strings.
-						onChange={ ( value ) =>
-							onChange( {
-								...layout,
-								columnCount: value,
-							} )
-						}
-						min={ 1 }
-						max={ 16 }
-						withInputField={ false }
-						label={ __( 'Columns' ) }
-						hideLabelFromVision
-					/>
-				</FlexItem>
-			</Flex>
-		</fieldset>
+		<>
+			<fieldset>
+				<BaseControl.VisualLabel as="legend">
+					{ __( 'Columns' ) }
+				</BaseControl.VisualLabel>
+				<Flex gap={ 4 }>
+					<FlexItem isBlock>
+						<NumberControl
+							size={ '__unstable-large' }
+							onChange={ ( value ) => {
+								/**
+								 * If the input is cleared, avoid switching
+								 * back to "Auto" by setting a value of "1".
+								 */
+								const validValue = value !== '' ? value : '1';
+								onChange( {
+									...layout,
+									columnCount: validValue,
+								} );
+							} }
+							value={ columnCount }
+							min={ 1 }
+							label={ __( 'Columns' ) }
+							hideLabelFromVision
+						/>
+					</FlexItem>
+					<FlexItem isBlock>
+						<RangeControl
+							value={ parseInt( columnCount, 10 ) } // RangeControl can't deal with strings.
+							onChange={ ( value ) =>
+								onChange( {
+									...layout,
+									columnCount: value,
+								} )
+							}
+							min={ 1 }
+							max={ 16 }
+							withInputField={ false }
+							label={ __( 'Columns' ) }
+							hideLabelFromVision
+						/>
+					</FlexItem>
+				</Flex>
+			</fieldset>
+			<fieldset>
+				<BaseControl.VisualLabel as="legend">
+					{ __( 'Rows' ) }
+				</BaseControl.VisualLabel>
+				<Flex gap={ 4 }>
+					<FlexItem isBlock>
+						<NumberControl
+							size={ '__unstable-large' }
+							onChange={ ( value ) => {
+								onChange( {
+									...layout,
+									rowCount: value,
+								} );
+							} }
+							value={ rowCount }
+							min={ 1 }
+							label={ __( 'Rows' ) }
+							hideLabelFromVision
+						/>
+					</FlexItem>
+					<FlexItem isBlock>
+						<RangeControl
+							value={ parseInt( rowCount, 10 ) } // RangeControl can't deal with strings.
+							onChange={ ( value ) =>
+								onChange( {
+									...layout,
+									rowCount: value,
+								} )
+							}
+							min={ 1 }
+							max={ 16 }
+							withInputField={ false }
+							label={ __( 'Rows' ) }
+							hideLabelFromVision
+						/>
+					</FlexItem>
+				</Flex>
+			</fieldset>
+		</>
 	);
 }
 

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -69,7 +69,9 @@ export default {
 		layout = {},
 		onChange,
 		clientId,
+		layoutBlockSupport = {},
 	} ) {
+		const { allowSizingOnChildren = false } = layoutBlockSupport;
 		return (
 			<>
 				<GridLayoutTypeControl
@@ -80,6 +82,7 @@ export default {
 					<GridLayoutColumnsControl
 						layout={ layout }
 						onChange={ onChange }
+						allowSizingOnChildren={ allowSizingOnChildren }
 					/>
 				) : (
 					<GridLayoutMinimumWidthControl
@@ -236,7 +239,11 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 }
 
 // Enables setting number of grid columns
-function GridLayoutColumnsControl( { layout, onChange } ) {
+function GridLayoutColumnsControl( {
+	layout,
+	onChange,
+	allowSizingOnChildren,
+} ) {
 	const { columnCount = 3, rowCount = 3 } = layout;
 
 	return (
@@ -284,44 +291,46 @@ function GridLayoutColumnsControl( { layout, onChange } ) {
 					</FlexItem>
 				</Flex>
 			</fieldset>
-			<fieldset>
-				<BaseControl.VisualLabel as="legend">
-					{ __( 'Rows' ) }
-				</BaseControl.VisualLabel>
-				<Flex gap={ 4 }>
-					<FlexItem isBlock>
-						<NumberControl
-							size={ '__unstable-large' }
-							onChange={ ( value ) => {
-								onChange( {
-									...layout,
-									rowCount: value,
-								} );
-							} }
-							value={ rowCount }
-							min={ 1 }
-							label={ __( 'Rows' ) }
-							hideLabelFromVision
-						/>
-					</FlexItem>
-					<FlexItem isBlock>
-						<RangeControl
-							value={ parseInt( rowCount, 10 ) } // RangeControl can't deal with strings.
-							onChange={ ( value ) =>
-								onChange( {
-									...layout,
-									rowCount: value,
-								} )
-							}
-							min={ 1 }
-							max={ 16 }
-							withInputField={ false }
-							label={ __( 'Rows' ) }
-							hideLabelFromVision
-						/>
-					</FlexItem>
-				</Flex>
-			</fieldset>
+			{ allowSizingOnChildren && (
+				<fieldset>
+					<BaseControl.VisualLabel as="legend">
+						{ __( 'Rows' ) }
+					</BaseControl.VisualLabel>
+					<Flex gap={ 4 }>
+						<FlexItem isBlock>
+							<NumberControl
+								size={ '__unstable-large' }
+								onChange={ ( value ) => {
+									onChange( {
+										...layout,
+										rowCount: value,
+									} );
+								} }
+								value={ rowCount }
+								min={ 1 }
+								label={ __( 'Rows' ) }
+								hideLabelFromVision
+							/>
+						</FlexItem>
+						<FlexItem isBlock>
+							<RangeControl
+								value={ parseInt( rowCount, 10 ) } // RangeControl can't deal with strings.
+								onChange={ ( value ) =>
+									onChange( {
+										...layout,
+										rowCount: value,
+									} )
+								}
+								min={ 1 }
+								max={ 16 }
+								withInputField={ false }
+								label={ __( 'Rows' ) }
+								hideLabelFromVision
+							/>
+						</FlexItem>
+					</Flex>
+				</fieldset>
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -244,7 +244,7 @@ function GridLayoutColumnsControl( {
 	onChange,
 	allowSizingOnChildren,
 } ) {
-	const { columnCount = 3, rowCount = 3 } = layout;
+	const { columnCount = 3, rowCount } = layout;
 
 	return (
 		<>

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -291,46 +291,47 @@ function GridLayoutColumnsAndRowsControl( {
 					</FlexItem>
 				</Flex>
 			</fieldset>
-			{ allowSizingOnChildren && (
-				<fieldset>
-					<BaseControl.VisualLabel as="legend">
-						{ __( 'Rows' ) }
-					</BaseControl.VisualLabel>
-					<Flex gap={ 4 }>
-						<FlexItem isBlock>
-							<NumberControl
-								size={ '__unstable-large' }
-								onChange={ ( value ) => {
-									onChange( {
-										...layout,
-										rowCount: value,
-									} );
-								} }
-								value={ rowCount }
-								min={ 1 }
-								label={ __( 'Rows' ) }
-								hideLabelFromVision
-							/>
-						</FlexItem>
-						<FlexItem isBlock>
-							<RangeControl
-								value={ parseInt( rowCount, 10 ) } // RangeControl can't deal with strings.
-								onChange={ ( value ) =>
-									onChange( {
-										...layout,
-										rowCount: value,
-									} )
-								}
-								min={ 1 }
-								max={ 16 }
-								withInputField={ false }
-								label={ __( 'Rows' ) }
-								hideLabelFromVision
-							/>
-						</FlexItem>
-					</Flex>
-				</fieldset>
-			) }
+			{ allowSizingOnChildren &&
+				window.__experimentalEnableGridInteractivity && (
+					<fieldset>
+						<BaseControl.VisualLabel as="legend">
+							{ __( 'Rows' ) }
+						</BaseControl.VisualLabel>
+						<Flex gap={ 4 }>
+							<FlexItem isBlock>
+								<NumberControl
+									size={ '__unstable-large' }
+									onChange={ ( value ) => {
+										onChange( {
+											...layout,
+											rowCount: value,
+										} );
+									} }
+									value={ rowCount }
+									min={ 1 }
+									label={ __( 'Rows' ) }
+									hideLabelFromVision
+								/>
+							</FlexItem>
+							<FlexItem isBlock>
+								<RangeControl
+									value={ parseInt( rowCount, 10 ) } // RangeControl can't deal with strings.
+									onChange={ ( value ) =>
+										onChange( {
+											...layout,
+											rowCount: value,
+										} )
+									}
+									min={ 1 }
+									max={ 16 }
+									withInputField={ false }
+									label={ __( 'Rows' ) }
+									hideLabelFromVision
+								/>
+							</FlexItem>
+						</Flex>
+					</fieldset>
+				) }
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #57478.

Adds a "Row" control, identical to the existing "Column" one.  Setting a value in Row adds `grid-template-rows: repeat([row number], minmax(0, 1fr));` to the grid styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a post or template, add a Grid block and set it to Manual mode in the sidebar;
2. Play with changing the number of columns and rows.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="658" alt="Screenshot 2024-04-11 at 3 59 33 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/02ff8acd-eaab-418f-bb95-599f0df6419a">

