### PR TITLE
Do not render pattern aria description if not button is rendered

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -150,11 +150,6 @@ function Preview( { item, categoryId, viewType } ) {
 		ariaDescriptions.push( item.description );
 	}
 
-	if ( isNonUserPattern ) {
-		ariaDescriptions.push(
-			__( 'Theme & plugin patterns cannot be edited.' )
-		);
-	}
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const { onClick } = useLink( {
 		postType: item.type,
@@ -165,47 +160,46 @@ function Preview( { item, categoryId, viewType } ) {
 	} );
 
 	return (
-		<>
-			<div
-				className={ `page-patterns-preview-field is-viewtype-${ viewType }` }
-				style={ { backgroundColor } }
+		<div
+			className={ `page-patterns-preview-field is-viewtype-${ viewType }` }
+			style={ { backgroundColor } }
+		>
+			<PreviewWrapper
+				item={ item }
+				onClick={ onClick }
+				ariaDescribedBy={
+					ariaDescriptions.length
+						? ariaDescriptions
+								.map(
+									( _, index ) =>
+										`${ descriptionId }-${ index }`
+								)
+								.join( ' ' )
+						: undefined
+				}
 			>
-				<PreviewWrapper
-					item={ item }
-					onClick={ onClick }
-					ariaDescribedBy={
-						ariaDescriptions.length
-							? ariaDescriptions
-									.map(
-										( _, index ) =>
-											`${ descriptionId }-${ index }`
-									)
-									.join( ' ' )
-							: undefined
-					}
-				>
-					{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
-					{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
-					{ ! isEmpty && (
-						<Async>
-							<BlockPreview
-								blocks={ item.blocks }
-								viewportWidth={ item.viewportWidth }
-							/>
-						</Async>
-					) }
-				</PreviewWrapper>
-			</div>
-			{ ariaDescriptions.map( ( ariaDescription, index ) => (
-				<div
-					key={ index }
-					hidden
-					id={ `${ descriptionId }-${ index }` }
-				>
-					{ ariaDescription }
-				</div>
-			) ) }
-		</>
+				{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
+				{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
+				{ ! isEmpty && (
+					<Async>
+						<BlockPreview
+							blocks={ item.blocks }
+							viewportWidth={ item.viewportWidth }
+						/>
+					</Async>
+				) }
+			</PreviewWrapper>
+			{ ! isNonUserPattern &&
+				ariaDescriptions.map( ( ariaDescription, index ) => (
+					<div
+						key={ index }
+						hidden
+						id={ `${ descriptionId }-${ index }` }
+					>
+						{ ariaDescription }
+					</div>
+				) ) }
+		</div>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
@carolinan referring to the patterns list in site editor mentioned [here](https://github.com/WordPress/gutenberg/commit/7ebb55ca27e7bdf6275e73ff75de608158127533#r140714408):

>Hi, can you explain to me how a screen reader user can access this information?
I think there is a regression in this UI because while I can see the div with the descriptions in the markup,
the hidden attribute hides it from screen readers. Am I missing a way to access it? Neither the parent or the div that contains the description is focusable.

I'm not sure if I missed something from the original port of patterns list, but I used the same code from: https://github.com/WordPress/gutenberg/pull/58966/files#diff-8f4940d6721aa050133f42eb236d7078467fc399b0ea236139a750c17e6dde34L143. One difference though is that currently we do not always render a button and this PR fixes that, and doesn't render an aria description div when we do not render a button for the preview.

Besides that, I don't think the `hidden` attribute plays a role here, because it's announced for example in Firefox. I tried removing the attribute though while testing in Crome and it's not announced.  Maybe it's a voiceover issue like [this one](https://discussions.apple.com/thread/254083513)? 🤔 

I've tested with macOs.

So while the announcing is not solved for every OS, we could probably also land this one and handle it separately if we need to.

## Testing Instructions
1. When we don't have a user pattern, we shouldn't render the aria description div.


