### PR TITLE
Embed: Avoid retrying valid URLs

### DIFF
--- a/test/e2e/specs/editor/various/embedding.spec.js
+++ b/test/e2e/specs/editor/various/embedding.spec.js
@@ -194,7 +194,8 @@ test.describe( 'Embedding content', () => {
 		embedUtils,
 	} ) => {
 		await embedUtils.interceptRequests( {
-			'https://twitter.com/notnownikki/': MOCK_CANT_EMBED_RESPONSE,
+			'https://twitter.com/notnownikki/':
+				MOCK_BAD_EMBED_PROVIDER_RESPONSE,
 			'https://twitter.com/notnownikki': MOCK_EMBED_RICH_SUCCESS_RESPONSE,
 		} );
 		await embedUtils.insertEmbed( 'https://twitter.com/notnownikki/' );


### PR DESCRIPTION
## What?
Regression: https://github.com/WordPress/gutenberg/pull/58007#issuecomment-2048233573.

PR fixes the Embed block side-effect for retrying failing URL embeds without trailing slash. The fix prevents unnecessary retries for providers that support trailing slashes.

## Why?
The logic had a race condition, causing false runs in the side-effect logic.

When the URL is newly submitted and the `getEmbedPreview` starts the resolution:
* The `fetching` flag is `false`, waiting for meta selectors to return value.
* The `cannotEmbed` is `true`. The selector hasn't returned any info related to the previews.
* The `preview` is `undefined`. Same as above, the selector hasn't returned the value yet.

When all these conditions are met while the selector hasn't finished the resolution, the side effect logic runs and unnecessarily retries the URL.

## How?
Check if `getEmbedPreview` has resolved the initial URL before attempting the retry.

## Testing Instructions
1. Open a post or page.
2. Insert an Embed block.
3. Try embedding a URL that supports trailing slashes - `https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/`.
4. Confirm it's correctly embedded.
5. Confirm that the trailing slash hasn't been removed by editing the Embed URL.
6. Try embedding a new URL that doesn't support trailing slash - `https://twitter.com/WordPress/`.
7. Confirm it's correctly embedded after retrying without a trailing slash.

### Testing Instructions for Keyboard
Same.
