### PR TITLE
Patterns page: add edit & view revision actions to parts

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -439,17 +439,23 @@ export default function DataviewsPatterns() {
 		return filterSortAndPaginate( patterns, viewWithoutFilters, fields );
 	}, [ patterns, view, fields, type ] );
 
-	const actions = useMemo(
-		() => [
+	const actions = useMemo( () => {
+		if ( type === TEMPLATE_PART_POST_TYPE ) {
+			return [
+				renameAction,
+				duplicateTemplatePartAction,
+				resetAction,
+				deleteAction,
+			];
+		}
+		return [
 			renameAction,
 			duplicatePatternAction,
-			duplicateTemplatePartAction,
 			exportJSONaction,
 			resetAction,
 			deleteAction,
-		],
-		[]
-	);
+		];
+	}, [ type ] );
 	const onChangeView = useCallback(
 		( newView ) => {
 			if ( newView.type !== view.type ) {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -459,13 +459,17 @@ export default function DataviewsPatterns() {
 		},
 		[ history ]
 	);
-	const [ editAction ] = usePostActions( onActionPerformed, [ 'edit-post' ] );
+	const [ editAction, viewRevisionsAction ] = usePostActions(
+		onActionPerformed,
+		[ 'edit-post', 'view-post-revisions' ]
+	);
 	const actions = useMemo( () => {
 		if ( type === TEMPLATE_PART_POST_TYPE ) {
 			return [
 				editAction,
 				renameAction,
 				duplicateTemplatePartAction,
+				viewRevisionsAction,
 				resetAction,
 				deleteAction,
 			];
@@ -477,7 +481,7 @@ export default function DataviewsPatterns() {
 			resetAction,
 			deleteAction,
 		];
-	}, [ type, editAction ] );
+	}, [ type, editAction, viewRevisionsAction ] );
 	const onChangeView = useCallback(
 		( newView ) => {
 			if ( newView.type !== view.type ) {

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -40,6 +40,7 @@ const templatePartToPattern = ( templatePart ) => ( {
 	name: createTemplatePartId( templatePart.theme, templatePart.slug ),
 	title: decodeEntities( templatePart.title.rendered ),
 	type: templatePart.type,
+	_links: templatePart._links,
 	templatePart,
 } );
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/59659 https://github.com/WordPress/gutenberg/pull/60359

## What?

Add the `edit` and `viewRevision` actions to template parts in the patterns page.

<img width="1509" alt="Captura de ecrã 2024-04-11, às 11 29 43" src="https://github.com/WordPress/gutenberg/assets/583546/59125092-e8e3-4bfb-8abf-3cca4fdd36e5">


## Why?

These actions are available for Template Parts in the "Manage all template parts" screen. We aim to remove that screen, and one of the previous steps is to migrate all that behavior to the "Patterns" screen.

## How?

- a0709a072ca4fcf6cd8a354068202465cce7e6c3 Separate patterns & template parts actions.
- a0709a072ca4fcf6cd8a354068202465cce7e6c3 Add missing edit action.
- 0aa81bd4832994de48b829979e0a30cee4b2daf4 Add missing viewRevisions action.

## Testing Instructions

Visit the Patterns and go down to template parts. Verify that template parts have two new actions available (edit & view revisions) and they work as expected.

