### PR TITLE
Fix: Remove unused CSS code from the site editor.

### DIFF
--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -13,10 +13,3 @@
 	// This matches the logo padding
 	padding: 0 $grid-unit-15;
 }
-
-.edit-site-sidebar__footer {
-	border-top: 1px solid $gray-800;
-	flex-shrink: 0;
-	margin: 0 $canvas-padding;
-	padding: $canvas-padding 0;
-}


### PR DESCRIPTION
The className edit-site-sidebar__footer is not used anywhere on the code base, so all this CSS is useless and could be moved.

## Testing
Checked that the edit site sidebar including the publish section looks exactly as before.