### PR TITLE
Template parts: set backpath to patterns page

### DIFF
--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -35,7 +35,6 @@ import AddNewTemplate from '../add-new-template';
 import { useAddedBy } from './hooks';
 import {
 	TEMPLATE_POST_TYPE,
-	TEMPLATE_PART_POST_TYPE,
 	ENUMERATION_TYPE,
 	OPERATOR_IS_ANY,
 	LAYOUT_GRID,
@@ -102,11 +101,6 @@ function Title( { item, viewType } ) {
 			canvas: 'edit',
 		},
 	};
-	if ( item.type === TEMPLATE_PART_POST_TYPE ) {
-		linkProps.state = {
-			backPath: '/wp_template_part/all',
-		};
-	}
 	return (
 		<Link { ...linkProps }>
 			{ decodeEntities( item.title?.rendered ) || __( '(no title)' ) }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -52,7 +52,7 @@ function TemplatesList( { availableTemplates, onSelect } ) {
 
 const POST_TYPE_PATH = {
 	wp_template: '/wp_template',
-	wp_template_part: '/wp_template_part/all',
+	wp_template_part: '/patterns',
 };
 
 export default function TemplatePanel() {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -5,7 +5,6 @@ import { __experimentalUseNavigator as useNavigator } from '@wordpress/component
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
-import { getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -17,27 +16,18 @@ import usePatternDetails from './use-pattern-details';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import TemplateActions from '../template-actions';
-import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export default function SidebarNavigationScreenPattern() {
 	const navigator = useNavigator();
 	const {
 		params: { postType, postId },
 	} = navigator;
-	const { categoryType } = getQueryArgs( window.location.href );
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 
 	useInitEditedEntityFromURL();
 
 	const patternDetails = usePatternDetails( postType, postId );
-
-	// The absence of a category type in the query params for template parts
-	// indicates the user has arrived at the template part via the "manage all"
-	// page and the back button should return them to that list page.
-	const backPath =
-		! categoryType && postType === TEMPLATE_PART_POST_TYPE
-			? '/wp_template_part/all'
-			: '/patterns';
+	const backPath = '/patterns';
 
 	return (
 		<SidebarNavigationScreen

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -5,6 +5,7 @@ import { __experimentalUseNavigator as useNavigator } from '@wordpress/component
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
+import { getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -16,18 +17,27 @@ import usePatternDetails from './use-pattern-details';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import TemplateActions from '../template-actions';
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export default function SidebarNavigationScreenPattern() {
 	const navigator = useNavigator();
 	const {
 		params: { postType, postId },
 	} = navigator;
+	const { categoryType } = getQueryArgs( window.location.href );
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 
 	useInitEditedEntityFromURL();
 
 	const patternDetails = usePatternDetails( postType, postId );
-	const backPath = '/patterns';
+
+	// The absence of a category type in the query params for template parts
+	// indicates the user has arrived at the template part via the "manage all"
+	// page and the back button should return them to that list page.
+	const backPath =
+		! categoryType && postType === TEMPLATE_PART_POST_TYPE
+			? '/wp_template_part/all'
+			: '/patterns';
 
 	return (
 		<SidebarNavigationScreen

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -93,11 +93,6 @@ function useTemplateDetails( postType, postId ) {
 	return { title, description, content, footer };
 }
 
-const POST_TYPE_PATH = {
-	wp_template: '/wp_template',
-	wp_template_part: '/wp_template_part/all',
-};
-
 export default function SidebarNavigationScreenTemplate() {
 	const navigator = useNavigator();
 	const {
@@ -119,7 +114,7 @@ export default function SidebarNavigationScreenTemplate() {
 						postId={ postId }
 						toggleProps={ { as: SidebarButton } }
 						onRemove={ () => {
-							navigator.goTo( POST_TYPE_PATH[ postType ] );
+							navigator.goTo( postType );
 						} }
 					/>
 					<SidebarButton

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -114,7 +114,7 @@ export default function SidebarNavigationScreenTemplate() {
 						postId={ postId }
 						toggleProps={ { as: SidebarButton } }
 						onRemove={ () => {
-							navigator.goTo( postType );
+							navigator.goTo( '/' + postType );
 						} }
 					/>
 					<SidebarButton

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -154,9 +154,7 @@ function useManipulateDocumentCommands() {
 						decodeEntities( template.title )
 				  );
 		const path =
-			template.type === TEMPLATE_POST_TYPE
-				? '/wp_template'
-				: '/wp_template_part/all';
+			template.type === TEMPLATE_POST_TYPE ? '/wp_template' : '/patterns';
 		commands.push( {
 			name: 'core/remove-template',
 			label,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/59659 and https://github.com/WordPress/gutenberg/pull/60359

## What?

Sets the backpath to the Patterns page for all actions related to Template Parts:

- Details view sidebar: go back action.
- Details view sidebar: delete the custom part action.
- Editor sidebar: delete the custom part action.
- Command bar: delete the custom part action.

## Why?

We are trying to get rid of the "Manage all template parts" screen at https://github.com/WordPress/gutenberg/pull/60359. This is a preliminary step.

## How?

- c66a62efa99013d1ddf92fd5ea3bf039b43f59f4 Details view sidebar: on going back + on deleting the custom part action.
- cd580e738ebfcc263afbaa385e13f2ecec3c5fea Editor sidebar: on deleting the custom part.
- c09f5d25bd161489e1091ceb9b72d6a169fb0b1d Command bar: on deleting the custom part.
- 903762656e22294290a551a188ffe5e3ea5a3b73 Removes unnecessary backPath, as it is managed by the details page.
- 3084583dec6a147a8a517a27db67e7406d514db6 Removes unnecessary backPath, as the Templates sidebar is never loaded for parts.

## Testing Instructions

Details view sidebar: go back action — from the "Patterns" page.

- Visit the patterns page and then click on the "Header" category of the Template Parts group.
- Click one of the parts and visit the editor.
- Click the hub icon to get out of edit mode into the site editor.
- On the details view for the part, click on the back button.
- The expected result is that the Patterns page is loaded.

Details view sidebar: go back action — from the "Manage all parts" page.

- Visit the patterns page and then click on the "Manage all parts" link at the bottom.
- Click one of the parts and visit the editor.
- Click the hub icon to get out of edit mode into the site editor.
- On the details view for the part, click on the back button.
- The expected result is that the Patterns page is loaded. Before it'd load the "Manage all parts" page.

Details view sidebar: delete the custom part action.

- Visit the patterns page and create a custom part.
- Click the hub icon to get out of edit mode into the site editor.
- On the details view for the part, click on the "Actions" button, and then "Delete" action.
- The expected result is that the Patterns page is loaded. Before, it'd load the "Manage all parts" page.

Editor sidebar: delete the custom part action.

- Visit the patterns page and create a custom part.
- In the editor, open the Part sidebar and click "Actions", then select "Delete" action.
- The expected result is that the Patterns page is loaded. Before, it'd load the "Manage all parts" page.

Command bar: delete the custom part action.

- Visit the patterns page and create a custom part.
- In the editor, open the command bar (CTRL+k) and type "Delete template part: <custom title>".
- The expected result is that the Patterns page is loaded. Before, it'd load the "Manage all parts" page.
