### PR TITLE
Layout: Always add semantic classes

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -448,7 +448,9 @@ export const withLayoutStyles = createHigherOrderComponent(
 			return (
 				<BlockListBlock
 					{ ...props }
-					__unstableLayoutClassNames={ layoutClasses }
+					__unstableLayoutClassNames={
+						layoutClasses.length > 0 ? layoutClasses : undefined
+					}
 				/>
 			);
 		}

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -449,7 +449,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 				<BlockListBlock
 					{ ...props }
 					__unstableLayoutClassNames={
-						layoutClasses.length > 0 ? layoutClasses : undefined
+						blockSupportsLayout ? layoutClasses : undefined
 					}
 				/>
 			);

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -359,6 +359,7 @@ function BlockWithLayoutStyles( {
 	block: BlockListBlock,
 	props,
 	blockGapSupport,
+	layoutClasses,
 } ) {
 	const { name, attributes } = props;
 	const id = useInstanceId( BlockListBlock );
@@ -369,7 +370,6 @@ function BlockWithLayoutStyles( {
 		layout?.inherit || layout?.contentSize || layout?.wideSize
 			? { ...layout, type: 'constrained' }
 			: layout || defaultBlockLayout || {};
-	const layoutClasses = useLayoutClasses( attributes, name );
 
 	const { kebabCase } = unlock( componentsPrivateApis );
 	const selectorPrefix = `wp-container-${ kebabCase( name ) }-is-layout-`;
@@ -415,8 +415,9 @@ function BlockWithLayoutStyles( {
  */
 export const withLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const { clientId, name } = props;
+		const { clientId, name, attributes } = props;
 		const blockSupportsLayout = hasLayoutBlockSupport( name );
+		const layoutClasses = useLayoutClasses( attributes, name );
 		const extraProps = useSelect(
 			( select ) => {
 				// The callback returns early to avoid block editor subscription.
@@ -444,13 +445,19 @@ export const withLayoutStyles = createHigherOrderComponent(
 		);
 
 		if ( ! extraProps ) {
-			return <BlockListBlock { ...props } />;
+			return (
+				<BlockListBlock
+					{ ...props }
+					__unstableLayoutClassNames={ layoutClasses }
+				/>
+			);
 		}
 
 		return (
 			<BlockWithLayoutStyles
 				block={ BlockListBlock }
 				props={ props }
+				layoutClasses={ layoutClasses }
 				{ ...extraProps }
 			/>
 		);


### PR DESCRIPTION
## What?
Fixes #60569.

PR fixes a missing semantic layout classes regression in the editor.

## Why?
Matches behavior described in docs: https://developer.wordpress.org/block-editor/explanations/architecture/styles/#opting-out-of-generated-layout-styles.

## Notes
* The `useLayoutClasses` is a privately exported hook used in `ReusableBlockEdit` and `EditorCanvas`.
* I expect the store subscription numbers for non-layout blocks to remain the same. The hook subscribes to the store conditionally.

## Testing Instructions
1. Opt out from generating layout styles (see snippet below).
2. Add a Group block to a post. Enable the 'Inner blocks use content width' setting.
3. Preview the post. The rendered block includes `is-layout-constrained`.
4. Inspect the same block in the editor.
5. The semantic layout classes should be the same.

### Testing snippet
```php
add_action( 'after_setup_theme', function() {
	add_theme_support( 'disable-layout-styles' );
}, 100 );
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-11 at 16 29 48](https://github.com/WordPress/gutenberg/assets/240569/c33fd312-0992-4099-92b3-d029d77d9939)
