### PR TITLE
Fix layout of Data Views filter chip

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -706,8 +706,8 @@
 		border-radius: $grid-unit-20;
 		border: 1px solid transparent;
 		cursor: pointer;
-		padding: 0 $grid-unit-15;
-		height: $grid-unit-40;
+		padding: $grid-unit-10 $grid-unit-15;
+		min-height: $grid-unit-40;
 		background: $gray-100;
 		color: $gray-700;
 		position: relative;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes layout of data views filter chip to account for variable lengths of filter text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently a fixed height is applied to the chip which means that for filters which have a lot of text the UI looks broken as the text butts up against the edge of the chip. Instead there should be a nice spacing between the text and the edge of the chip.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Avoids relying on fixed height and instead requires a min height and uses veritcal padding to ensure spacing around text is maintained at all times.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open Site Editor
- Go to Pages
- Switch to `List` layout.
- Filter by "Draft" (there's a custom filter already in the left sidebar).
- Confirm layout of chip is as per `trunk` and text does not butt up against edge of the chip.
- Go to `Templates`
- Switch to `List` layout.
- Filter by your current Theme - i used TT4 as this has a lot of text.
- See that despite there being a lot of text in the filter the text does not butt up against the edge of the chip.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Trunk
<img width="2592" alt="Screen Shot 2024-04-11 at 14 09 29 (1)" src="https://github.com/WordPress/gutenberg/assets/444434/06e47899-f870-484b-a5a5-3d6465baa57c">



### This PR
<img width="2972" alt="Screen Shot 2024-04-11 at 14 06 03" src="https://github.com/WordPress/gutenberg/assets/444434/44c0679d-a13c-4036-9c51-4e31fdc5c728">
