### PR TITLE
Interactivity API: Allow async directive registration

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-function/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-function/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test/directive-function",
+	"title": "E2E Interactivity tests - directive function",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-function/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-function/render.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * HTML for testing the directive function.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+?>
+
+<div data-wp-interactive="directive-function">
+	<button
+		data-testid="async directive"
+		style="background-color:white"
+		data-wp-async-bg-color="state.colors"
+	>Click me!</button>
+
+	<button
+		data-testid="async directive with others"
+		style="background-color:white"
+		data-wp-async-bg-color="state.colors"
+		data-wp-context='{"count": 0}'
+		data-wp-text="context.count"
+		data-wp-on--click="actions.updateCount"
+	>0</button>
+
+	<button
+		data-testid="load async directive"
+		data-wp-on--click="actions.loadAsyncDirective"
+	>Load async directive</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-function/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-function/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-function/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-function/view.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext, useState, useCallback, privateApis } from '@wordpress/interactivity';
+
+const { directive } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
+
+store( 'directive-function', {
+	state: {
+		colors: [ "white", "magenta", "cyan", "yellow" ]
+	},
+	actions: {
+		updateCount: () => {
+			const context = getContext();
+			context.count += 1;
+		},
+		loadAsyncDirective: () => {
+			directive(
+				'async-bg-color',
+				( { directives: { 'async-bg-color': bgColor }, element, evaluate } ) => {
+					const [ index, setIndex ] = useState( 0 );
+					const entry = bgColor.find( ( { suffix } ) => suffix === 'default' );
+					const colors = evaluate( entry );
+
+					const clickHandler = useCallback(() => {
+						setIndex( ( index + 1 ) % colors.length );
+					}, [colors.length, index]);
+
+
+					// Use mouseup event so this doesn't interfere with `data-wp-on--click`.
+					element.props.onmouseup = clickHandler;
+					element.props.style = { backgroundColor: colors[index] };
+				}
+			);
+		}
+	},
+} );

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -321,7 +321,7 @@ const Directives = ( {
 	previousScope,
 }: DirectivesProps ) => {
 	// Initialize the priority levels in the first Directives component.
-	const [ currentPriorityLevel, ...nextPriorityLevels ] =
+	const [ currentPriorityLevel = [], ...nextPriorityLevels ] =
 		priorityLevels ?? getPriorityLevels( directives );
 
 	// Initialize the scope of this element. These scopes are different per each

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -11,6 +11,7 @@ import {
 } from 'preact';
 import { useRef, useCallback, useContext } from 'preact/hooks';
 import type { VNode, Context, RefObject } from 'preact';
+import { deepSignal } from 'deepsignal';
 
 /**
  * Internal dependencies
@@ -173,7 +174,9 @@ export const resetNamespace = () => {
 };
 
 // WordPress Directives.
-const directiveCallbacks: Record< string, DirectiveCallback > = {};
+const directiveCallbacks: Record< string, DirectiveCallback > = deepSignal(
+	{}
+);
 const directivePriorities: Record< string, number > = {};
 
 /**
@@ -312,11 +315,15 @@ const getPriorityLevels: GetPriorityLevels = ( directives ) => {
 // Component that wraps each priority level of directives of an element.
 const Directives = ( {
 	directives,
-	priorityLevels: [ currentPriorityLevel, ...nextPriorityLevels ],
+	priorityLevels,
 	element,
 	originalProps,
 	previousScope,
 }: DirectivesProps ) => {
+	// Initialize the priority levels in the first Directives component.
+	const [ currentPriorityLevel, ...nextPriorityLevels ] =
+		priorityLevels ?? getPriorityLevels( directives );
+
 	// Initialize the scope of this element. These scopes are different per each
 	// level because each level has a different context, but they share the same
 	// element ref, state and props.
@@ -373,16 +380,20 @@ options.vnode = ( vnode: VNode< any > ) => {
 	if ( vnode.props.__directives ) {
 		const props = vnode.props;
 		const directives = props.__directives;
-		if ( directives.key )
+		if ( directives.key ) {
 			vnode.key = directives.key.find(
 				( { suffix } ) => suffix === 'default'
 			).value;
+		}
+		// Remove known directives withouth callback.
+		[ 'interactive', 'key' ].forEach( ( d ) => {
+			delete directives[ d ];
+		} );
 		delete props.__directives;
-		const priorityLevels = getPriorityLevels( directives );
-		if ( priorityLevels.length > 0 ) {
+
+		if ( Object.keys( directives ).length > 0 ) {
 			vnode.props = {
 				directives,
-				priorityLevels,
 				originalProps: props,
 				type: vnode.type,
 				element: createElement( vnode.type as any, props ),

--- a/test/e2e/specs/interactivity/directive-function.spec.ts
+++ b/test/e2e/specs/interactivity/directive-function.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'directive function', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/directive-function' );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/directive-function' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'should support async directive registration', async ( { page } ) => {
+		const element = page.getByTestId( 'async directive' );
+		const button = page.getByTestId( 'load async directive' );
+
+		const colors = {
+			white: 'rgb(255, 255, 255)',
+			magenta: 'rgb(255, 0, 255)',
+			cyan: 'rgb(0, 255, 255)',
+			yellow: 'rgb(255, 255, 0)',
+		};
+
+		await expect( element ).toHaveCSS(
+			'background-color',
+			'rgb(255, 255, 255)'
+		);
+
+		// Clicking the element with the async directive changes the background,
+		// but it hasn't loaded yet. Nothing should happen.
+		await element.click( { clickCount: 3 } );
+		await expect( element ).toHaveCSS( 'background-color', colors.white );
+
+		// Load the async directive.
+		await button.click();
+
+		// The element should now change the background color when clicked.
+		await element.click();
+		await expect( element ).toHaveCSS( 'background-color', colors.magenta );
+		await element.click();
+		await expect( element ).toHaveCSS( 'background-color', colors.cyan );
+		await element.click();
+		await expect( element ).toHaveCSS( 'background-color', colors.yellow );
+		await element.click();
+		await expect( element ).toHaveCSS( 'background-color', colors.white );
+	} );
+
+	test( 'should support async directive along with other directives', async ( {
+		page,
+	} ) => {
+		const element = page.getByTestId( 'async directive with others' );
+		const button = page.getByTestId( 'load async directive' );
+
+		const colors = {
+			white: 'rgb(255, 255, 255)',
+			magenta: 'rgb(255, 0, 255)',
+			cyan: 'rgb(0, 255, 255)',
+			yellow: 'rgb(255, 255, 0)',
+		};
+
+		await expect( element ).toHaveText( '0' );
+		await expect( element ).toHaveCSS(
+			'background-color',
+			'rgb(255, 255, 255)'
+		);
+
+		// Clicking the element with the async directive changes the background,
+		// but it hasn't loaded yet. Only other directives should react.
+		await element.click( { clickCount: 3 } );
+		await expect( element ).toHaveText( '3' );
+		await expect( element ).toHaveCSS( 'background-color', colors.white );
+
+		// Load the async directive.
+		await button.click();
+
+		// The element should now change the background color when clicked.
+		await element.click();
+		await expect( element ).toHaveText( '4' );
+		await expect( element ).toHaveCSS( 'background-color', colors.magenta );
+		await element.click();
+		await expect( element ).toHaveText( '5' );
+		await expect( element ).toHaveCSS( 'background-color', colors.cyan );
+		await element.click();
+		await expect( element ).toHaveText( '6' );
+		await expect( element ).toHaveCSS( 'background-color', colors.yellow );
+		await element.click();
+		await expect( element ).toHaveText( '7' );
+		await expect( element ).toHaveCSS( 'background-color', colors.white );
+	} );
+} );


### PR DESCRIPTION
## What?

Allows new directives to be registered at any time, even after processing and rendering `data-wp-interactive` regions.

## Why?

This would be helpful with client-side navigation when some directives might not be needed on the initial page load. Also for custom directives that could get loaded from random files provided by extenders.

## How?

Creating a reactive registry with the directive callbacks.

## Testing Instructions

There are E2E tests, but this feature can be tested manually as well.

1. In a template you know contains interactive blocks, add a Custom HTML block with the following code:
   ```html
   <button
     style="background-color:white"
     data-wp-interactive="test/async-directive"
     data-wp-context='{ "colors": [ "white", "magenta", "cyan", "yellow" ] }'
     data-wp-bg-color="context.colors"
   >Click me!</button>
   ```
2. Visit a page with that template and ensure the added button appears.
3. Click it. Nothing should happen.
4. Open the dev tools and execute the following code in the console. It registers a directive named `bg-color`.
   ```js
   const { useState, useCallback, privateApis } = await import(
     "@wordpress/interactivity"
   );
   
   const { directive } = privateApis(
     "I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress."
   );
   
   directive(
     'bg-color',
     ( { directives: { 'bg-color': bgColor }, element, evaluate } ) => {
       const [ index, setIndex ] = useState( 0 );
       const entry = bgColor.find( ( { suffix } ) => suffix === 'default' );
       const colors = evaluate( entry );
   
       const clickHandler = useCallback(() => {
         setIndex( ( index + 1 ) % colors.length );
       }, [colors.length, index]);
   
   
       // Use mouseup event so this doesn't interfere with `data-wp-on--click`.
       element.props.onmouseup = clickHandler;
       element.props.style = { backgroundColor: colors[index] };
     }
   );
   ```
5. Click the button now. It should change the color.