### PR TITLE
Update: Hardcoded documentation link to a branch that does not exist

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -720,7 +720,7 @@ function getConfigurationValue( key ) {
 }
 ```
 
-When documenting a [function type](https://github.com/WordPress/gutenberg/blob/add/typescript-jsdoc-guidelines/docs/contributors/coding-guidelines.md#record-types), you must always include the `void` return value type, as otherwise the function is inferred to return a mixed ("any") value, not a void result.
+When documenting a [function type](#generic-types), you must always include the `void` return value type, as otherwise the function is inferred to return a mixed ("any") value, not a void result.
 
 ```js
 /**


### PR DESCRIPTION
The link https://github.com/WordPress/gutenberg/blob/add/typescript-jsdoc-guidelines/docs/contributors/coding-guidelines.md#record-types does not exist anymore as the branch was deleted and the section was renamed. This PR updates the link.