### PR TITLE
Editor: Add wordcount and reading time info in post card

### DIFF
--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -89,7 +89,7 @@ export default function PostActions( { onActionPerformed } ) {
 		<DropdownMenu
 			trigger={
 				<Button
-					size="compact"
+					size="small"
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
 					disabled={

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -75,9 +75,8 @@ export default function PostCardPanel( { className, actions } ) {
 			humanTimeDiff( modified )
 		);
 	const showPostContentInfo =
-		! [ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes(
-			postType
-		) && ! isPostsPage;
+		! isPostsPage &&
+		! [ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes( postType );
 	return (
 		<PanelBody>
 			<div
@@ -177,7 +176,7 @@ function PostContentInfo( { postContent } ) {
 	return (
 		<Text>
 			{ sprintf(
-				/* translators: 1: How many words a post has(eg. 30 words). 2: the number of minutes of read time(eg. 2 minutes read time) */
+				/* translators: 1: How many words a post has (e.g. 30 words). 2: the number of minutes of read time (e.g. 2 minutes read time) */
 				/* translators: %1s: is the number of minutes. */
 				'%1$s, %2$s.',
 				wordsCountText,

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -177,7 +177,7 @@ function PostContentInfo( { postContent } ) {
 		<Text>
 			{ sprintf(
 				/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
-				'%1$s, %2$s.',
+				__( '%1$s, %2$s.' ),
 				wordsCountText,
 				readingTimeText
 			) }

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -63,7 +63,7 @@ export default function PostCardPanel( { className, actions } ) {
 				area: _record?.area,
 			} ),
 			isPostsPage: +_id === siteSettings?.page_for_posts,
-			postContent: _record?.content?.rendered || _record?.content,
+			postContent: getEditedPostAttribute( 'content' ),
 		};
 	}, [] );
 	const description = templateInfo?.description;
@@ -144,43 +144,27 @@ function PostContentInfo( { postContent } ) {
 		return null;
 	}
 	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
-	const wordsCountText =
-		wordsCounted.toLocaleString() &&
-		( wordsCounted === 1
-			? __( '1 word' )
-			: sprintf(
-					// translators: %s: the number of words in the post.
-					_n( '%s word', '%s words', wordsCounted ),
-					wordsCounted.toLocaleString()
-			  ) );
-
-	const readingTimeText =
+	const wordsCountText = sprintf(
+		// translators: %s: the number of words in the post.
+		_n( '%s word', '%s words', wordsCounted ),
+		wordsCounted.toLocaleString()
+	);
+	const minutesText =
 		readingTime <= 1
-			? __( '1 minute read time' )
+			? __( '1 minute' )
 			: sprintf(
 					// translators: %s: the number of minutes to read the post.
-					_n(
-						'%s minute read time',
-						'%s minutes read time',
-						readingTime
-					),
+					_n( '%s minute', '%s minutes', readingTime ),
 					readingTime.toLocaleString()
 			  );
 	return (
 		<Text>
-			{ wordsCountText
-				? sprintf(
-						/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
-						__( '%1$s, %2$s.' ),
-						wordsCountText,
-						readingTimeText
-				  )
-				: sprintf(
-						/* translators: %s is a short phrase without any closing punctuation (e.g. "2 minutes read time"). Please translate only if you need a punctuation sign other than a period. */
-						__( '%s.' ),
-						wordsCountText,
-						readingTimeText
-				  ) }
+			{ sprintf(
+				/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
+				__( '%1$s, %2$s read time.' ),
+				wordsCountText,
+				minutesText
+			) }
 		</Text>
 	);
 }

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -165,7 +165,7 @@ function PostContentInfo( { postContent } ) {
 		readingTime <= 1
 			? __( '1 minute read time' )
 			: sprintf(
-					// translators: %s: the number of words in the post.
+					// translators: %s: the number of minutes to read the post.
 					_n(
 						'%s minute read time',
 						'%s minutes read time',
@@ -176,8 +176,7 @@ function PostContentInfo( { postContent } ) {
 	return (
 		<Text>
 			{ sprintf(
-				/* translators: 1: How many words a post has (e.g. 30 words). 2: the number of minutes of read time (e.g. 2 minutes read time) */
-				/* translators: %1s: is the number of minutes. */
+				/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
 				'%1$s, %2$s.',
 				wordsCountText,
 				readingTimeText

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -111,16 +111,12 @@ export default function PostCardPanel( { className, actions } ) {
 							spacing={ 2 }
 						>
 							{ description && <Text>{ description }</Text> }
-							<span>
-								{ showPostContentInfo && (
-									<PostContentInfo
-										postContent={ postContent }
-									/>
-								) }{ ' ' }
-								{ lastEditedText && (
-									<Text>{ lastEditedText }</Text>
-								) }
-							</span>
+							{ showPostContentInfo && (
+								<PostContentInfo postContent={ postContent } />
+							) }
+							{ lastEditedText && (
+								<Text>{ lastEditedText }</Text>
+							) }
 						</VStack>
 					) }
 					{ postType === TEMPLATE_POST_TYPE && <TemplateAreas /> }
@@ -148,19 +144,16 @@ function PostContentInfo( { postContent } ) {
 		return null;
 	}
 	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
-	let wordsCountText;
-	if ( ! wordsCounted.toLocaleString() ) {
-		wordsCountText = __( 'Unknown' );
-	} else {
-		wordsCountText =
-			wordsCounted === 1
-				? __( '1 word' )
-				: sprintf(
-						// translators: %s: the number of words in the post.
-						_n( '%s word', '%s words', wordsCounted ),
-						wordsCounted.toLocaleString()
-				  );
-	}
+	const wordsCountText =
+		wordsCounted.toLocaleString() &&
+		( wordsCounted === 1
+			? __( '1 word' )
+			: sprintf(
+					// translators: %s: the number of words in the post.
+					_n( '%s word', '%s words', wordsCounted ),
+					wordsCounted.toLocaleString()
+			  ) );
+
 	const readingTimeText =
 		readingTime <= 1
 			? __( '1 minute read time' )
@@ -175,12 +168,19 @@ function PostContentInfo( { postContent } ) {
 			  );
 	return (
 		<Text>
-			{ sprintf(
-				/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
-				__( '%1$s, %2$s.' ),
-				wordsCountText,
-				readingTimeText
-			) }
+			{ wordsCountText
+				? sprintf(
+						/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
+						__( '%1$s, %2$s.' ),
+						wordsCountText,
+						readingTimeText
+				  )
+				: sprintf(
+						/* translators: %s is a short phrase without any closing punctuation (e.g. "2 minutes read time"). Please translate only if you need a punctuation sign other than a period. */
+						__( '%s.' ),
+						wordsCountText,
+						readingTimeText
+				  ) }
 		</Text>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/59689

This PR add the wordcount and reading time info in post card, which are already part of the details view in site editor.


## Testing Instructions
1. Check the post card in both post and site editors and observe that reading time and wordcount info are properly displayed.



## Screenshots or screencast <!-- if applicable -->
<img width="280" alt="Screenshot 2024-04-11 at 15 44 42" src="https://github.com/WordPress/gutenberg/assets/846565/3692869b-6333-48cd-ba33-fcf706160313">
