### PR TITLE
Fix flaky Site Editor URL navigation e2e test

### DIFF
--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -12,59 +12,58 @@ test.describe( 'Site editor url navigation', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test.describe( 'Redirection after template and template part creation', () => {
-		test.afterEach( async ( { requestUtils } ) => {
-			await Promise.all( [
-				requestUtils.deleteAllPosts(),
-				requestUtils.deleteAllTemplates( 'wp_template' ),
-				requestUtils.deleteAllTemplates( 'wp_template_part' ),
-			] );
+	test.beforeEach( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPosts(),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllTemplates( 'wp_template_part' ),
+		] );
+	} );
+
+	test( 'Redirection after template creation', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.createPost( {
+			title: 'Demo',
+			content: 'Hello there!',
+			status: 'publish',
 		} );
-		test( 'Redirection after template creation', async ( {
-			admin,
-			page,
-			requestUtils,
-		} ) => {
-			await requestUtils.createPost( {
-				title: 'Demo',
-				status: 'publish',
-			} );
-			await admin.visitSiteEditor();
-			await page.click( 'role=button[name="Templates"]' );
-			await page.click( 'role=button[name="Add New Template"i]' );
-			await page
-				.getByRole( 'button', {
-					name: 'Single item: Post',
-				} )
-				.click();
-			await page
-				.getByRole( 'button', { name: 'For a specific item' } )
-				.click();
-			await page.getByRole( 'option', { name: 'Demo' } ).click();
-			await expect( page ).toHaveURL(
-				'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fsingle-post-demo&postType=wp_template&canvas=edit'
-			);
-		} );
-		test( 'Redirection after template part creation', async ( {
-			admin,
-			page,
-		} ) => {
-			await admin.visitSiteEditor();
-			await page.click( 'role=button[name="Patterns"i]' );
-			await page.click( 'role=button[name="Create pattern"i]' );
-			await page
-				.getByRole( 'menu', { name: 'Create pattern' } )
-				.getByRole( 'menuitem', { name: 'Create template part' } )
-				.click();
-			// Fill in a name in the dialog that pops up.
-			await page.type(
-				'role=dialog >> role=textbox[name="Name"i]',
-				'Demo'
-			);
-			await page.keyboard.press( 'Enter' );
-			await expect( page ).toHaveURL(
-				'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fdemo&postType=wp_template_part&canvas=edit'
-			);
-		} );
+
+		await admin.visitSiteEditor();
+		await page.click( 'role=button[name="Templates"]' );
+		await page.click( 'role=button[name="Add New Template"i]' );
+		await page
+			.getByRole( 'button', {
+				name: 'Single item: Post',
+			} )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'For a specific item' } )
+			.click();
+		await page.getByRole( 'option', { name: 'Demo' } ).click();
+		await expect( page ).toHaveURL(
+			'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fsingle-post-demo&postType=wp_template&canvas=edit'
+		);
+	} );
+
+	test( 'Redirection after template part creation', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		await page.click( 'role=button[name="Patterns"i]' );
+		await page.click( 'role=button[name="Create pattern"i]' );
+		await page
+			.getByRole( 'menu', { name: 'Create pattern' } )
+			.getByRole( 'menuitem', { name: 'Create template part' } )
+			.click();
+		// Fill in a name in the dialog that pops up.
+		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Demo' );
+		await page.keyboard.press( 'Enter' );
+		await expect( page ).toHaveURL(
+			'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fdemo&postType=wp_template_part&canvas=edit'
+		);
 	} );
 } );


### PR DESCRIPTION
## What?
PR fixes flaky 'Redirection after template creation' e2e tests.

## Why?
I noticed it failed a few times on GitHub, and then I could consistently reproduce it locally. The `Demo` test post wasn't available based on failure traces.

Recent failure report https://github.com/WordPress/gutenberg/actions/runs/8642543699

## How?
I tried a few things, but using `test.beforeEach` works without a problem. Though I'm not entirely sure why 😅

cc @kevin940726, @WunderBart

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/site-editor/site-editor-url-navigation.spec.js --ui
```
