### PR TITLE
Editor: Try animating inserter and category panels in zoom out

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -154,6 +154,7 @@ export default function Editor( { isLoading, onClick } ) {
 
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
+	const isZoomOutMode = blockEditorMode === 'zoom-out';
 	const showVisualEditor = isViewMode || editorMode === 'visual';
 	const shouldShowBlockBreadcrumbs =
 		! isDistractionFree &&
@@ -220,6 +221,7 @@ export default function Editor( { isLoading, onClick } ) {
 					{ isEditMode && <StartTemplateOptions /> }
 					<InterfaceSkeleton
 						isDistractionFree={ isDistractionFree }
+						isZoomOutMode={ isZoomOutMode }
 						enableRegionNavigation={ false }
 						className={ classnames(
 							'edit-site-editor__interface-skeleton',

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -25,6 +25,7 @@ import {
 import NavigableRegion from '../navigable-region';
 
 const SECONDARY_SIDEBAR_WIDTH = 350;
+const SECONDARY_SIDEBAR_DIALOG_WIDTH = 650;
 const ANIMATION_DURATION = 0.25;
 
 function useHTMLClass( className ) {
@@ -56,9 +57,16 @@ const secondarySidebarVariants = {
 	mobileOpen: { width: '100vw' },
 };
 
+const secondarySidebarDiaglogVariants = {
+	open: { width: SECONDARY_SIDEBAR_DIALOG_WIDTH },
+	closed: { width: 0 },
+	mobileOpen: { width: '100vw' },
+};
+
 function InterfaceSkeleton(
 	{
 		isDistractionFree,
+		isZoomOutMode,
 		footer,
 		header,
 		editorNotices,
@@ -78,12 +86,16 @@ function InterfaceSkeleton(
 ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const disableMotion = useReducedMotion();
+	const sidebarAnimationDuration = isZoomOutMode ? 0 : ANIMATION_DURATION;
 	const defaultTransition = {
 		type: 'tween',
-		duration: disableMotion ? 0 : ANIMATION_DURATION,
+		duration: disableMotion ? 0 : sidebarAnimationDuration,
 		ease: 'easeOut',
 	};
 	const navigateRegionsProps = useNavigateRegions( shortcuts );
+	const sidebarWidth = isZoomOutMode
+		? SECONDARY_SIDEBAR_DIALOG_WIDTH
+		: SECONDARY_SIDEBAR_WIDTH;
 	useHTMLClass( 'interface-interface-skeleton__html-container' );
 
 	const defaultLabels = {
@@ -165,7 +177,11 @@ function InterfaceSkeleton(
 									isMobileViewport ? 'mobileOpen' : 'open'
 								}
 								exit="closed"
-								variants={ secondarySidebarVariants }
+								variants={
+									isZoomOutMode
+										? secondarySidebarDiaglogVariants
+										: secondarySidebarVariants
+								}
 								transition={ defaultTransition }
 							>
 								<div
@@ -173,7 +189,7 @@ function InterfaceSkeleton(
 										position: 'absolute',
 										width: isMobileViewport
 											? '100vw'
-											: SECONDARY_SIDEBAR_WIDTH,
+											: sidebarWidth,
 										height: '100%',
 										right: 0,
 									} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A quick follow-up/exploration for #60665 to make zoom out work with the improved animated panels. It's not incredibly smooth, but perhaps helps finds a proper solution. 

Another exploration could be to animate the category panel independently. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. Open the pattens inserter, with a category. 
3. See changes. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1813435/a865e504-165d-4de0-8791-e9e593443964

