### PR TITLE
Tabs: Fallback to first enabled tab if no active tab Id

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 -   `ProgressBar`: Fix CSS variable with invalid value ([#60576](https://github.com/WordPress/gutenberg/pull/60576)).
 
+### Experimental
+
+-   `Tabs`: Fallback to first enabled tab if no active tab id ([#60681](https://github.com/WordPress/gutenberg/pull/60681)).
+
 ## 27.3.0 (2024-04-03)
 
 ### Bug Fix

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -154,6 +154,14 @@ function Tabs( {
 	}, [ isControlled, selectedTab, selectedTabId, setSelectedId ] );
 
 	useEffect( () => {
+		// If there is no active tab, fallback to place focus on the first enabled tab
+		// so there is always an active element
+		if ( selectedTabId === null && ! activeId && firstEnabledTab?.id ) {
+			setActiveId( firstEnabledTab.id );
+		}
+	}, [ selectedTabId, activeId, firstEnabledTab?.id, setActiveId ] );
+
+	useEffect( () => {
 		if ( ! isControlled ) {
 			return;
 		}
@@ -166,11 +174,6 @@ function Tabs( {
 				! focusedElement ||
 				! items.some( ( item ) => focusedElement === item.element )
 			) {
-				// If there is no focused or active tab, fallback to place focus on the first enabled tab
-				// so there is always an active element
-				if ( ! activeId && firstEnabledTab?.id ) {
-					setActiveId( firstEnabledTab.id );
-				}
 				return;
 			}
 
@@ -182,7 +185,7 @@ function Tabs( {
 				setActiveId( focusedElement.id );
 			}
 		} );
-	}, [ activeId, isControlled, items, setActiveId, firstEnabledTab ] );
+	}, [ activeId, isControlled, items, setActiveId ] );
 
 	const contextValue = useMemo(
 		() => ( {

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -166,7 +166,12 @@ function Tabs( {
 				! focusedElement ||
 				! items.some( ( item ) => focusedElement === item.element )
 			) {
-				return; // Return early if no tabs are focused.
+				// If there is no focused or active tab, fallback to place focus on the first enabled tab
+				// so there is always an active element
+				if ( ! activeId && firstEnabledTab?.id ) {
+					setActiveId( firstEnabledTab.id );
+				}
+				return;
 			}
 
 			// If, after ariakit re-computes the active tab, that tab doesn't match
@@ -177,7 +182,7 @@ function Tabs( {
 				setActiveId( focusedElement.id );
 			}
 		} );
-	}, [ activeId, isControlled, items, setActiveId ] );
+	}, [ activeId, isControlled, items, setActiveId, firstEnabledTab ] );
 
 	const contextValue = useMemo(
 		() => ( {

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -174,7 +174,7 @@ function Tabs( {
 				! focusedElement ||
 				! items.some( ( item ) => focusedElement === item.element )
 			) {
-				return;
+				return; // Return early if no tabs are focused.
 			}
 
 			// If, after ariakit re-computes the active tab, that tab doesn't match

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -242,6 +242,44 @@ describe( 'Tabs', () => {
 			await press.Tab();
 			expect( alphaButton ).toHaveFocus();
 		} );
+
+		it( 'should focus on the first enabled tab when pressing the Tab key if no tab is selected', async () => {
+			const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
+				tabObj.tabId === 'alpha'
+					? {
+							...tabObj,
+							tab: {
+								...tabObj.tab,
+								disabled: true,
+							},
+					  }
+					: tabObj
+			);
+
+			render(
+				<ControlledTabs
+					tabs={ TABS_WITH_ALPHA_DISABLED }
+					selectedTabId={ null }
+				/>
+			);
+
+			await sleep();
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', { name: 'Beta' } )
+			).toHaveFocus();
+
+			await press.ArrowRight();
+			expect(
+				await screen.findByRole( 'tab', { name: 'Gamma' } )
+			).toHaveFocus();
+
+			await press.Tab();
+			await press.ShiftTab();
+			expect(
+				await screen.findByRole( 'tab', { name: 'Gamma' } )
+			).toHaveFocus();
+		} );
 	} );
 
 	describe( 'Tab Attributes', () => {


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/60573. More context in https://github.com/WordPress/gutenberg/issues/52997#issuecomment-2035568332


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
If there is no selectedTabId, focus would be placed on the tab container which requires an arrow keypress to move focus to the first tab. This behavior isn't as user friendly as focus should be placed on a tab. To prevent focus on the wrapper, if no element is focused and there is no activeId, fallback to the first enabled tab.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Sometimes you don't want any tab pane selected by default. This was possible before, but the focus was set to the wrapping element, not the first tab. Also, we'd like a tab to always be selected rather than focus placed on the wrapping container.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Test the patterns inserter in https://github.com/WordPress/gutenberg/pull/60257.
- Open Block inserter (in post editor and in site editor)
- Select Pattern Tab
- Tab to patten categories panel
- Focus should be on first tab
- Use arrows to navigate between the patterns
- Select a pattern
- Tab into patterns panel
- Shift + Tab out
- Focus should be on the selected category
- Arrow between patterns and repeat switching between categories

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
