### PR TITLE
PHP unit test workflow: Try removing 7.0 and 7.1

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -147,8 +147,6 @@ jobs:
             fail-fast: true
             matrix:
                 php:
-                    - '7.0'
-                    - '7.1'
                     - '7.2'
                     - '7.3'
                     - '7.4'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Try removing PHP 7.0 and PHP 7.1 from the suite of PHP unit tests in the Github workflow.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As of https://github.com/WordPress/wordpress-develop/commit/d9523529879c270ffde4df1ea7a39cdff7240457 WordPress 6.6 will no longer support PHP 7.0 and 7.1. As a result, the PHP unit tests workflow is currently failing with the following error:

<img width="873" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/b111db4f-3d5b-4968-8243-583ddf3c791b">

`Your server is running PHP version 7.0.33 but WordPress 6.6-alpha-57985 requires at least 7.2.24.`

Since our tests appear to run WordPress trunk, in order to get them passing again, I think we should try removing PHP 7.0 + 7.1 from this list. If it's desirable to retain those workflows, then we'd need to get them working again but run a version of WordPress < 6.6 in order for them to pass.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove PHP 7.0 and 7.1 from the list of PHP versions in the PHP workflow

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See if the PHP workflow passes now.