### PR TITLE
Fix activating a theme in site editor when previewing

### DIFF
--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -150,9 +150,6 @@ export const saveDirtyEntities =
 				);
 			}
 		);
-		if ( ! entitiesToSave.length ) {
-			return;
-		}
 		close?.( entitiesToSave );
 		const siteItemsToSave = [];
 		const pendingSavedRecords = [];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/60650

There was a regression introduced here: https://github.com/WordPress/gutenberg/pull/60077 where you cannot activate a theme if no other changes have been made. In my original PR I had added an extra check to bail early, but it seems that was the cause of the regression when we need to activate a theme while previewing it in site editor.


## Testing Instructions

- Install a Block theme and navigate to the Live Preview by clicking `Live Preview` button
- Observe the activation of the theme is successful whether you have made other changes or not(test both cases)


### Tasks
- [ ] Write e2e test