### PR TITLE
Editor: Avoid text reflow during sidebar animation in the editor

### DIFF
--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -42,11 +42,9 @@ function ComplementaryAreaSlot( { scope, ...props } ) {
 	return <Slot name={ `ComplementaryArea/${ scope }` } { ...props } />;
 }
 
-const SIDEBAR_WIDTH = 280;
 const variants = {
-	open: { width: SIDEBAR_WIDTH },
-	closed: { width: 0 },
-	mobileOpen: { width: '100vw' },
+	open: { x: 0 },
+	closed: { x: '100%' },
 };
 
 function ComplementaryAreaFill( {
@@ -87,23 +85,15 @@ function ComplementaryAreaFill( {
 			<AnimatePresence initial={ false }>
 				{ ( previousIsActive || isActive ) && (
 					<motion.div
+						id={ id }
+						className={ className }
 						variants={ variants }
 						initial="closed"
-						animate={ isMobileViewport ? 'mobileOpen' : 'open' }
+						animate="open"
 						exit="closed"
 						transition={ transition }
 					>
-						<div
-							id={ id }
-							className={ className }
-							style={ {
-								width: isMobileViewport
-									? '100vw'
-									: SIDEBAR_WIDTH,
-							} }
-						>
-							{ children }
-						</div>
+						{ children }
 					</motion.div>
 				) }
 			</AnimatePresence>

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -1,6 +1,10 @@
 .interface-complementary-area {
 	background: $white;
 	color: $gray-900;
+	height: 100%;
+	@include break-medium() {
+		border-left: $border-width solid $gray-200;
+	}
 
 	@include break-small() {
 		-webkit-overflow-scrolling: touch;

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -13,19 +13,14 @@ import {
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import {
-	useMergeRefs,
-	useReducedMotion,
-	useViewportMatch,
-	useResizeObserver,
-} from '@wordpress/compose';
+import { useMergeRefs, useReducedMotion } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import NavigableRegion from '../navigable-region';
 
-const ANIMATION_DURATION = 0.25;
+const ANIMATION_DURATION = 0.3;
 
 function useHTMLClass( className ) {
 	useEffect( () => {
@@ -50,6 +45,11 @@ const headerVariants = {
 	distractionFreeInactive: { opacity: 1, transition: { delay: 0 } },
 };
 
+const secondarySidebarVariants = {
+	open: { x: 0 },
+	closed: { x: '-100%' },
+};
+
 function InterfaceSkeleton(
 	{
 		isDistractionFree,
@@ -70,9 +70,6 @@ function InterfaceSkeleton(
 	},
 	ref
 ) {
-	const [ secondarySidebarResizeListener, secondarySidebarSize ] =
-		useResizeObserver();
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const disableMotion = useReducedMotion();
 	const defaultTransition = {
 		type: 'tween',
@@ -157,26 +154,12 @@ function InterfaceSkeleton(
 								ariaLabel={ mergedLabels.secondarySidebar }
 								as={ motion.div }
 								initial="closed"
-								animate={
-									isMobileViewport ? 'mobileOpen' : 'open'
-								}
+								animate="open"
 								exit="closed"
-								variants={ {
-									open: { width: secondarySidebarSize.width },
-									closed: { width: 0 },
-									mobileOpen: { width: '100vw' },
-								} }
+								variants={ secondarySidebarVariants }
 								transition={ defaultTransition }
 							>
-								<div
-									style={ {
-										position: 'absolute',
-										width: 'fit-content',
-										height: '100%',
-										right: 0,
-									} }
-								>
-									{ secondarySidebarResizeListener }
+								<div className="interface-interface-skeleton__secondary-sidebar-inner">
 									{ secondarySidebar }
 								</div>
 							</NavigableRegion>

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -104,7 +104,6 @@ html.interface-interface-skeleton__html-container {
 	top: 0;
 	left: 0;
 	bottom: 0;
-	background: $white;
 	color: $gray-900;
 	width: auto; // Keep the sidebar width flexible.
 
@@ -123,10 +122,6 @@ html.interface-interface-skeleton__html-container {
 
 .interface-interface-skeleton__sidebar {
 	overflow: auto;
-
-	@include break-medium() {
-		border-left: $border-width solid $gray-200;
-	}
 }
 
 .interface-interface-skeleton__secondary-sidebar {
@@ -134,6 +129,11 @@ html.interface-interface-skeleton__html-container {
 	@include break-medium() {
 		border-right: $border-width solid $gray-200;
 	}
+}
+
+.interface-interface-skeleton__secondary-sidebar-inner {
+	background: #fff;
+	height: 100%;
 }
 
 .interface-interface-skeleton__header {


### PR DESCRIPTION
## What?

[Do not merge yet]

This PR explores a way to avoid text reflow (for performance reasons) when animating the sidebars in the post and site editors. An idea suggested by @jasmussen 

It turns out that the site editor already has some code in place to apply the right background outside of the iframe already. 
For now, the PR doesn't work entirely in the post editor, we'll need to figure out what is applying the background in the site editor and bringing that code to the post editor as well. We need to consider classic themes too.


## Testing Instructions

1- Open the site editor
2- Try opening and closing the different sidebars (left and right).
3- How does it feel?