### PR TITLE
DimensionControl: Fix story config

### DIFF
--- a/packages/components/src/dimension-control/stories/index.story.tsx
+++ b/packages/components/src/dimension-control/stories/index.story.tsx
@@ -29,10 +29,10 @@ export default {
 				mobile,
 			},
 		},
-		parameters: {
-			controls: { expanded: true },
-			docs: { canvas: { sourceState: 'shown' } },
-		},
+	},
+	parameters: {
+		controls: { expanded: true },
+		docs: { canvas: { sourceState: 'shown' } },
 	},
 } as Meta< typeof DimensionControl >;
 


### PR DESCRIPTION
## What?

Fixes the placement of the `parameters` config in the Storybook for `DimensionControl`.

## Why?

It was unintentionally placed as part of the `argTypes` config, causing a `parameters` prop to appear in the props table.

## Testing Instructions

In the Storybook docs for DimensionControl, the code snippet at the beginning should be shown by default as intended, and the `parameters` prop should be gone from the props table.
