### PR TITLE
Add e2e test for activating themes in site editor

### DIFF
--- a/test/e2e/specs/site-editor/activate-theme.spec.js
+++ b/test/e2e/specs/site-editor/activate-theme.spec.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function activateTheme( { page } ) {
+	await page.getByRole( 'button', { name: 'Activate Emptytheme' } ).click();
+	await page.getByRole( 'button', { name: 'Activate', exact: true } ).click();
+	await expect(
+		page.getByRole( 'button', { name: 'Dismiss this notice' } )
+	).toContainText( 'Site updated' );
+}
+
+test.describe( 'Activate theme', () => {
+	test.beforeEach( async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'themes.php' );
+		await page.getByLabel( 'Live Preview Emptytheme' ).click();
+	} );
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+	test( 'activate block theme when live previewing from sidebar save button', async ( {
+		admin,
+		page,
+	} ) => {
+		await activateTheme( { page } );
+		await admin.visitAdminPage( 'themes.php' );
+		await expect( page.getByLabel( 'Customize Emptytheme' ) ).toBeVisible();
+	} );
+	test( 'activate block theme when live previewing in edit mode', async ( {
+		editor,
+		admin,
+		page,
+	} ) => {
+		// Wait for the loading to complete.
+		await expect( page.locator( '.edit-site-canvas-loader' ) ).toHaveCount(
+			0
+		);
+		await editor.canvas.locator( 'body' ).click();
+		// Close the welcome guide.
+		await page.getByRole( 'button', { name: 'Get started' } ).click();
+		await activateTheme( { page } );
+		await admin.visitAdminPage( 'themes.php' );
+		await expect( page.getByLabel( 'Customize Emptytheme' ) ).toBeVisible();
+	} );
+} );

--- a/test/e2e/specs/site-editor/activate-theme.spec.js
+++ b/test/e2e/specs/site-editor/activate-theme.spec.js
@@ -3,14 +3,6 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-async function activateTheme( { page } ) {
-	await page.getByRole( 'button', { name: 'Activate Emptytheme' } ).click();
-	await page.getByRole( 'button', { name: 'Activate', exact: true } ).click();
-	await expect(
-		page.getByRole( 'button', { name: 'Dismiss this notice' } )
-	).toContainText( 'Site updated' );
-}
-
 test.describe( 'Activate theme', () => {
 	test.beforeEach( async ( { admin, page } ) => {
 		await admin.visitAdminPage( 'themes.php' );
@@ -23,7 +15,15 @@ test.describe( 'Activate theme', () => {
 		admin,
 		page,
 	} ) => {
-		await activateTheme( { page } );
+		await page
+			.getByRole( 'button', { name: 'Activate Emptytheme' } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Activate', exact: true } )
+			.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Dismiss this notice' } )
+		).toContainText( 'Site updated' );
 		await admin.visitAdminPage( 'themes.php' );
 		await expect( page.getByLabel( 'Customize Emptytheme' ) ).toBeVisible();
 	} );
@@ -37,9 +37,16 @@ test.describe( 'Activate theme', () => {
 			0
 		);
 		await editor.canvas.locator( 'body' ).click();
-		// Close the welcome guide.
-		await page.getByRole( 'button', { name: 'Get started' } ).click();
-		await activateTheme( { page } );
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Activate Emptytheme' } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Activate', exact: true } )
+			.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Dismiss this notice' } )
+		).toContainText( 'Site updated' );
 		await admin.visitAdminPage( 'themes.php' );
 		await expect( page.getByLabel( 'Customize Emptytheme' ) ).toBeVisible();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/60699

Just adds a couple of e2e tests for activating themes in site editor.
