### PR TITLE
Consolidate editor/canvas resize handles

### DIFF
--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -3,7 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
-import { VisuallyHidden } from '@wordpress/components';
+import {
+	VisuallyHidden,
+	Tooltip,
+	__unstableMotion as motion,
+} from '@wordpress/components';
 
 const DELTA_DISTANCE = 20; // The distance to resize per keydown in pixels.
 
@@ -28,18 +32,32 @@ export default function ResizeHandle( {
 		}
 	}
 
+	const resizeHandleVariants = {
+		active: {
+			opacity: 1,
+			scaleY: 1.3,
+		},
+	};
+
+	const resizableHandleHelpId = `resizable-editor__resize-help-${ direction }`;
+
 	return (
 		<>
-			<button
-				className={ `resizable-editor__drag-handle is-${ direction } is-variation-${ variation }` }
-				aria-label={ __( 'Drag to resize' ) }
-				aria-describedby={ `resizable-editor__resize-help-${ direction }` }
-				onKeyDown={ handleKeyDown }
-				type="button"
-			/>
-			<VisuallyHidden
-				id={ `resizable-editor__resize-help-${ direction }` }
-			>
+			<Tooltip text={ __( 'Drag to resize' ) }>
+				<motion.button
+					className={ `resizable-editor__drag-handle is-${ direction } is-variation-${ variation }` }
+					aria-label={ __( 'Drag to resize' ) }
+					aria-describedby={ resizableHandleHelpId }
+					onKeyDown={ handleKeyDown }
+					variants={ resizeHandleVariants }
+					whileFocus="active"
+					whileHover="active"
+					key="handle"
+					role="separator"
+					aria-orientation="vertical"
+				/>
+			</Tooltip>
+			<VisuallyHidden id={ resizableHandleHelpId }>
 				{ __( 'Use left and right arrow keys to resize the canvas.' ) }
 			</VisuallyHidden>
 		</>

--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -52,6 +52,7 @@ export default function ResizeHandle( {
 					variants={ resizeHandleVariants }
 					whileFocus="active"
 					whileHover="active"
+					whileTap="active"
 					key="handle"
 					role="separator"
 					aria-orientation="vertical"

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -106,22 +106,24 @@
 
 	&::after {
 		position: absolute;
-		top: $grid-unit-30;
+		top: $grid-unit-20;
 		left: $grid-unit-05;
 		right: 0;
-		bottom: $grid-unit-30;
+		bottom: $grid-unit-20;
 		content: "";
 		width: $grid-unit-05;
-		background: $gray-600;
+		background-color: rgba($gray-700, 0.4);
 		border-radius: $radius-block-ui;
 	}
 
 	&.is-left {
-		left: -$grid-unit-20;
+		// Subtract half of the handle width to properly center.
+		left: -$grid-unit-20 - ($grid-unit-05 / 2);
 	}
 
 	&.is-right {
-		right: -$grid-unit-20;
+		// Subtract half of the handle width to properly center.
+		right: -$grid-unit-20 - ($grid-unit-05 / 2);
 	}
 
 	&:hover,

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -125,15 +125,12 @@
 	}
 
 	&:hover,
+	&:focus,
 	&:active {
 		opacity: 1;
 		&::after {
 			background-color: var(--wp-admin-theme-color);
 		}
-	}
-
-	&:focus::after {
-		box-shadow: 0 0 0 1px $gray-800, 0 0 0 calc(var(--wp-admin-border-width-focus) + 1px) var(--wp-admin-theme-color);
 	}
 
 	&.is-variation-separator:focus::after {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -127,11 +127,8 @@
 	&:hover,
 	&:active {
 		opacity: 1;
-		&.is-variation-default::after {
-			background: $gray-400;
-		}
-		&.is-variation-separator::after {
-			background: var(--wp-admin-theme-color);
+		&::after {
+			background-color: var(--wp-admin-theme-color);
 		}
 	}
 

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -203,11 +203,11 @@ function ResizableFrame( {
 		},
 		visible: {
 			opacity: 1,
-			left: -16,
+			left: -14, // Account for the handle's width.
 		},
 		active: {
 			opacity: 1,
-			left: -16,
+			left: -14, // Account for the handle's width.
 			scaleY: 1.3,
 		},
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Consolidate the resize handles.

Fixes: https://github.com/WordPress/gutenberg/issues/60053 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To have the resize handles looking and working the same way in the different touchpoints, bringing a more cohesive experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Applying the same styles, relying on the admin theme accent, and adding the motion effect for the resize handle within the editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a site with Gutenberg and TT4
2. Open the site editor, check the resize handle for the site editor canvas.
3. Try editing the header template part, and check that the resize handle is consolidated.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/252415/02ae246d-7564-4466-922e-c7a7dcb69470



