### PR TITLE
Update list view spacing

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -64,7 +64,7 @@ const expanded = ( state, action ) => {
 	return state;
 };
 
-export const BLOCK_LIST_ITEM_HEIGHT = 36;
+export const BLOCK_LIST_ITEM_HEIGHT = 32;
 
 /** @typedef {import('react').ComponentType} ComponentType */
 /** @typedef {import('react').Ref<HTMLElement>} Ref */

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -156,13 +156,13 @@
 
 	&.is-displacement-up {
 		transition: transform 0.2s;
-		transform: translateY(-36px);
+		transform: translateY(-32px);
 		@include reduce-motion("transition");
 	}
 
 	&.is-displacement-down {
 		transition: transform 0.2s;
-		transform: translateY(36px);
+		transform: translateY(32px);
 		@include reduce-motion("transition");
 	}
 
@@ -172,20 +172,20 @@
 	// worth of space for the visual indicator of where a block will be placed when dropped.
 	&.is-after-dragged-blocks {
 		transition: transform 0.2s;
-		transform: translateY(calc(var(--wp-admin--list-view-dragged-items-height, 36px) * -1));
+		transform: translateY(calc(var(--wp-admin--list-view-dragged-items-height, 32px) * -1));
 		@include reduce-motion("transition");
 	}
 
 	&.is-after-dragged-blocks.is-displacement-up {
 		transition: transform 0.2s;
-		transform: translateY(calc(-36px + var(--wp-admin--list-view-dragged-items-height, 36px) * -1));
+		transform: translateY(calc(-32px + var(--wp-admin--list-view-dragged-items-height, 32px) * -1));
 		@include reduce-motion("transition");
 	}
 
 	&.is-after-dragged-blocks.is-displacement-down {
 		transition: transform 0.2s;
 		transform:
-			translateY(calc(36px + var(--wp-admin--list-view-dragged-items-height, 36px) *
+			translateY(calc(32px + var(--wp-admin--list-view-dragged-items-height, 32px) *
 			-1));
 		@include reduce-motion("transition");
 	}
@@ -204,14 +204,14 @@
 		z-index: -9999;
 	}
 
-	// List View renders a fixed number of items and relies on each item having a fixed height of 36px.
+	// List View renders a fixed number of items and relies on each item having a fixed height of 32px.
 	// If this value changes, we should also change the itemHeight value set in useFixedWindowList.
 	// See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
 	.block-editor-list-view-block-contents {
 		display: flex;
 		align-items: center;
 		width: 100%;
-		height: $button-size-compact;
+		height: $grid-unit-40;
 		padding: ($grid-unit-15 * 0.5) ($grid-unit-15 * 0.5) ($grid-unit-15 * 0.5) 0;
 		text-align: left;
 		border-radius: $radius-block-ui;
@@ -470,9 +470,7 @@ $block-navigation-max-indent: 8;
 }
 
 .block-editor-list-view-leaf[aria-level] .block-editor-list-view__expander {
-	margin-left:
-		($icon-size) * $block-navigation-max-indent + 4 *
-		($block-navigation-max-indent - 1);
+	margin-left: (20px) * ($block-navigation-max-indent);
 }
 
 // When updating the margin for each indentation level, the corresponding
@@ -534,7 +532,7 @@ svg {
 
 	.block-editor-list-view-drop-indicator__line {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-		height: 36px;
+		height: 32px;
 		border-radius: 4px;
 		overflow: hidden;
 	}
@@ -547,7 +545,7 @@ svg {
 .block-editor-list-view-placeholder {
 	padding: 0;
 	margin: 0;
-	height: 36px;
+	height: 32px;
 }
 
 .list-view-appender .block-editor-inserter__toggle {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -470,7 +470,7 @@ $block-navigation-max-indent: 8;
 }
 
 .block-editor-list-view-leaf[aria-level] .block-editor-list-view__expander {
-	margin-left: (20px) * ($block-navigation-max-indent);
+	margin-left: ($grid-unit-30) * ($block-navigation-max-indent);
 }
 
 // When updating the margin for each indentation level, the corresponding
@@ -480,7 +480,7 @@ $block-navigation-max-indent: 8;
 	.block-editor-list-view-leaf[aria-level="#{ $i + 1 }"]
 	.block-editor-list-view__expander {
 		@if $i - 1 >= 0 {
-			margin-left: (20px * $i);
+			margin-left: ($grid-unit-30 * $i);
 		} @else {
 			margin-left: 0;
 		}

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -446,9 +446,9 @@
 	}
 }
 
-// First level of indentation is aria-level 2, max indent is 7.
+// First level of indentation is aria-level 2, max indent is 8.
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
-$block-navigation-max-indent: 7;
+$block-navigation-max-indent: 8;
 
 .block-editor-list-view-draggable-chip {
 	opacity: 0.8;
@@ -471,7 +471,7 @@ $block-navigation-max-indent: 7;
 }
 
 .block-editor-list-view-leaf[aria-level] .block-editor-list-view__expander {
-	margin-left: ($grid-unit-30) * ($block-navigation-max-indent);
+	margin-left: ($grid-unit-30 * $block-navigation-max-indent) + (($grid-unit-05 * 0.5) * $block-navigation-max-indent);
 }
 
 // When updating the margin for each indentation level, the corresponding

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -277,7 +277,7 @@
 	}
 
 	.block-editor-block-icon {
-		margin-right: $grid-unit-05;
+		margin-right: $grid-unit-10;
 		flex: 0 0 $icon-size;
 	}
 
@@ -482,7 +482,7 @@ $block-navigation-max-indent: 8;
 	.block-editor-list-view-leaf[aria-level="#{ $i + 1 }"]
 	.block-editor-list-view__expander {
 		@if $i - 1 >= 0 {
-			margin-left: ($grid-unit-20 * $i);
+			margin-left: (20px * $i);
 		} @else {
 			margin-left: 0;
 		}

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -211,7 +211,7 @@
 		display: flex;
 		align-items: center;
 		width: 100%;
-		height: auto;
+		height: $button-size-compact;
 		padding: ($grid-unit-15 * 0.5) ($grid-unit-15 * 0.5) ($grid-unit-15 * 0.5) 0;
 		text-align: left;
 		border-radius: $radius-block-ui;
@@ -277,7 +277,7 @@
 	}
 
 	.block-editor-block-icon {
-		margin-right: $grid-unit-10;
+		margin-right: $grid-unit-05;
 		flex: 0 0 $icon-size;
 	}
 
@@ -475,12 +475,6 @@ $block-navigation-max-indent: 8;
 		($block-navigation-max-indent - 1);
 }
 
-.block-editor-list-view-leaf:not([aria-level="1"]) {
-	.block-editor-list-view__expander {
-		margin-right: 4px;
-	}
-}
-
 // When updating the margin for each indentation level, the corresponding
 // indentation in `use-list-view-drop-zone.js` must be updated as well
 // to ensure the drop zone is aligned with the indentation.
@@ -488,9 +482,9 @@ $block-navigation-max-indent: 8;
 	.block-editor-list-view-leaf[aria-level="#{ $i + 1 }"]
 	.block-editor-list-view__expander {
 		@if $i - 1 >= 0 {
-			margin-left: ($icon-size * $i) + 4 * ($i - 1);
+			margin-left: ($grid-unit-20 * $i);
 		} @else {
-			margin-left: ($icon-size * $i);
+			margin-left: 0;
 		}
 	}
 }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -212,7 +212,7 @@
 		align-items: center;
 		width: 100%;
 		height: $grid-unit-40;
-		padding: ($grid-unit-15 * 0.5) ($grid-unit-15 * 0.5) ($grid-unit-15 * 0.5) 0;
+		padding: ($grid-unit-15 * 0.5) $grid-unit-05 ($grid-unit-15 * 0.5) 0;
 		text-align: left;
 		border-radius: $radius-block-ui;
 		position: relative;
@@ -277,15 +277,14 @@
 	}
 
 	.block-editor-block-icon {
-		margin-right: $grid-unit-10;
+		margin-right: $grid-unit-10 * 0.5; // 6px.
 		flex: 0 0 $icon-size;
 	}
 
 	.block-editor-list-view-block__menu-cell,
 	.block-editor-list-view-block__mover-cell,
 	.block-editor-list-view-block__contents-cell {
-		padding-top: 0;
-		padding-bottom: 0;
+		padding: 0;
 	}
 
 	.block-editor-list-view-block__menu-cell,
@@ -316,7 +315,7 @@
 	}
 
 	.block-editor-list-view-block__menu-cell {
-		padding-right: $grid-unit-15 * 0.5; // 6px.
+		padding-right: $grid-unit-05;
 
 		.components-button.has-icon {
 			height: 24px;
@@ -379,8 +378,10 @@
 		}
 	}
 
-	.block-editor-list-view-block-select-button__label-wrapper {
-		min-width: 120px;
+	// Style lock and position icons in line with image previews.
+	.block-editor-list-view-block-select-button__label-wrapper svg {
+		left: $grid-unit-05 * 0.5; // 2px.
+		position: relative;
 	}
 
 	.block-editor-list-view-block-select-button__title {
@@ -464,7 +465,7 @@ $block-navigation-max-indent: 8;
 // Chevron container metrics.
 .block-editor-list-view__expander {
 	height: $icon-size;
-	margin-left: $grid-unit-05;
+	margin-right: $grid-unit-05 * 0.5; // Ensures chevron is spaced equally from left to right.
 	width: $icon-size;
 	cursor: pointer;
 }
@@ -480,7 +481,7 @@ $block-navigation-max-indent: 8;
 	.block-editor-list-view-leaf[aria-level="#{ $i + 1 }"]
 	.block-editor-list-view__expander {
 		@if $i - 1 >= 0 {
-			margin-left: ($grid-unit-30 * $i);
+			margin-left: ($grid-unit-30 * $i) + (($grid-unit-05 * 0.5) * $i); // Effectivly centers the expander below the parent's icon.
 		} @else {
 			margin-left: 0;
 		}

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -465,13 +465,12 @@ $block-navigation-max-indent: 8;
 // Chevron container metrics.
 .block-editor-list-view__expander {
 	height: $icon-size;
-	margin-right: $grid-unit-05 * 0.5; // Ensures chevron is spaced equally from left to right.
 	width: $icon-size;
 	cursor: pointer;
 }
 
 .block-editor-list-view-leaf[aria-level] .block-editor-list-view__expander {
-	margin-left: ($grid-unit-30 * $block-navigation-max-indent) + (($grid-unit-05 * 0.5) * $block-navigation-max-indent);
+	margin-left: ($grid-unit-30 * $block-navigation-max-indent);
 }
 
 // When updating the margin for each indentation level, the corresponding
@@ -481,7 +480,7 @@ $block-navigation-max-indent: 8;
 	.block-editor-list-view-leaf[aria-level="#{ $i + 1 }"]
 	.block-editor-list-view__expander {
 		@if $i - 1 >= 0 {
-			margin-left: ($grid-unit-30 * $i) + (($grid-unit-05 * 0.5) * $i); // Effectivly centers the expander below the parent's icon.
+			margin-left: ($grid-unit-30 * $i); // Effectivly centers the expander below the parent's icon.
 		} @else {
 			margin-left: 0;
 		}

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -446,9 +446,9 @@
 	}
 }
 
-// First level of indentation is aria-level 2, max indent is 8.
+// First level of indentation is aria-level 2, max indent is 7.
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
-$block-navigation-max-indent: 8;
+$block-navigation-max-indent: 7;
 
 .block-editor-list-view-draggable-chip {
 	opacity: 0.8;

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -62,7 +62,7 @@ import { store as blockEditorStore } from '../../store';
 
 // When the indentation level, the corresponding left margin in `style.scss`
 // must be updated as well to ensure the drop zone is aligned with the indentation.
-export const NESTING_LEVEL_INDENTATION = 28;
+export const NESTING_LEVEL_INDENTATION = 24;
 
 /**
  * Determines whether the user is positioning the dragged block to be

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -49,7 +49,7 @@
 	scrollbar-gutter: auto;
 
 	// The table cells use an extra pixels of space left and right. We compensate for that here.
-	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);
+	padding: $grid-unit-10;
 }
 
 .editor-list-view-sidebar__list-view-container {

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -49,7 +49,7 @@
 	scrollbar-gutter: auto;
 
 	// The table cells use an extra pixels of space left and right. We compensate for that here.
-	padding: $grid-unit-10;
+	padding: $grid-unit-05;
 }
 
 .editor-list-view-sidebar__list-view-container {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
* Reduce space between expander and icon
* Reduce indentation
* Reduce space between icon and block name
* Reduce row height from 36px to 32px, which is a standardised button size.

## Why?
With the site editor becoming more established since 6.5, it's not uncommon to find complex block structures when accounting for templates, template parts, and patterns. Given the current metrics, such structures often result in lots of scrolling around in list view, both vertically and horizontally. 

This PR seeks to reduce the likelihood of scrolling by reducing whitespace in the layout.

## Testing Instructions
* Open list view
* Observe new metrics :)

## Screenshots

| Trunk | This PR |
| --- | --- |
| <img width="349" alt="Screenshot 2024-04-12 at 16 37 46" src="https://github.com/WordPress/gutenberg/assets/846565/dea3a69f-a514-4475-8531-de7a090dd116"> | <img width="350" alt="Screenshot 2024-04-12 at 16 37 58" src="https://github.com/WordPress/gutenberg/assets/846565/2e52b219-e42f-4844-922e-1aa91b772339"> |
