### PR TITLE
Bump minimum required PHP version to 7.2.

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -157,7 +157,7 @@ jobs:
                 wordpress: [''] # Latest WordPress version.
                 include:
                     # Test with the previous WP version.
-                    - php: '7.0'
+                    - php: '7.2'
                       wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}
                     - php: '7.4'
                       wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.3
- * Requires PHP: 7.0
+ * Requires PHP: 7.2
  * Version: 18.2.0-rc.1
  * Author: Gutenberg Team
  * Text Domain: gutenberg

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,8 +2,8 @@
 <ruleset name="WordPress Coding Standards for Gutenberg Plugin">
 	<description>Sniffs for WordPress plugins, with minor modifications for Gutenberg</description>
 
-	<!-- Check for cross-version support for PHP 7.0 and higher. -->
-	<config name="testVersion" value="7.0-"/>
+	<!-- Check for cross-version support for PHP 7.2 and higher. -->
+	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
 	</rule>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

* Bumps the plugin's minimum PHP version from 7.0 to 7.2.
* Bumps PHPCS `testVersion` from `7.0-` to `7.2-`.
* Bumps the PHPUnit test `Test with previous WP version` from `php: 7.0` to `php: 7.2`.

Fixes https://github.com/WordPress/gutenberg/issues/60680.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

WordPress Core parity.

[WordPress 6.6.0's minimum supported PHP version is/will be 7.2](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Modifies the plugin header's `Requires PHP:` from `7.0` to `7.2`.

## Testing Instructions
1. Change your local test environment to PHP 7.0 (7.1) and WordPress 6.6-alpha.
2. Install and activate the Gutenberg 18.1.x plugin.
3. Open the `gutenberg.php` file, and in the file's DocBlock change `Requires PHP:` back to `7.2`.
Expected: Stays activated, bulk actions disabled, and a notice appears:
>This plugin does not work with your version of PHP. [Learn more about updating PHP](https://wordpress.org/support/update-php/).
4. Deactivate the plugin.
Expected: Bulk edit is disabled; `Cannot Activate` is displayed but not clickable; notice appears:
>This plugin does not work with your version of PHP. [Learn more about updating PHP](https://wordpress.org/support/update-php/).