### PR TITLE
Apply negative margins for alignfull children of blocks with custom padding set

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -292,32 +292,32 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'declarations' => array( 'max-width' => 'none' ),
 				)
 			);
+		}
 
-			if ( isset( $block_spacing ) ) {
-				$block_spacing_values = gutenberg_style_engine_get_styles(
-					array(
-						'spacing' => $block_spacing,
-					)
+		if ( isset( $block_spacing ) ) {
+			$block_spacing_values = gutenberg_style_engine_get_styles(
+				array(
+					'spacing' => $block_spacing,
+				)
+			);
+
+			/*
+			 * Handle negative margins for alignfull children of blocks with custom padding set.
+			 * They're added separately because padding might only be set on one side.
+			 */
+			if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
+				$padding_right   = $block_spacing_values['declarations']['padding-right'];
+				$layout_styles[] = array(
+					'selector'     => "$selector > .alignfull",
+					'declarations' => array( 'margin-right' => "calc($padding_right * -1)" ),
 				);
-
-				/*
-				 * Handle negative margins for alignfull children of blocks with custom padding set.
-				 * They're added separately because padding might only be set on one side.
-				 */
-				if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
-					$padding_right   = $block_spacing_values['declarations']['padding-right'];
-					$layout_styles[] = array(
-						'selector'     => "$selector > .alignfull",
-						'declarations' => array( 'margin-right' => "calc($padding_right * -1)" ),
-					);
-				}
-				if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
-					$padding_left    = $block_spacing_values['declarations']['padding-left'];
-					$layout_styles[] = array(
-						'selector'     => "$selector > .alignfull",
-						'declarations' => array( 'margin-left' => "calc($padding_left * -1)" ),
-					);
-				}
+			}
+			if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
+				$padding_left    = $block_spacing_values['declarations']['padding-left'];
+				$layout_styles[] = array(
+					'selector'     => "$selector > .alignfull",
+					'declarations' => array( 'margin-left' => "calc($padding_left * -1)" ),
+				);
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As part of the layout exploration from https://github.com/WordPress/gutenberg/issues/60308, I noticed that the negative margin applied to top-level fullwidth blocks of groups with custom padding was not being applied on the front-end. The result is overflowing content on the front-end of the site. I'm using [this gist](https://gist.github.com/richtabor/90df9a709815302fc1b322c6c68f3dc9) to test. 

## Why?
Currently if you place a fullwidth block inside another fullwidth block, the expectation is that it is also fullwidth—that's what's happening in the editor. 

That works fine, until that parent block has custom padding applied to it. Within the editor, the treatment is applied to appropriately negate the custom padding, but the corresponding treatment on the front-end was omitted from fullwidth blocks. 

## How?
I moved it out of the logic that was previously filtering it to $content or $wide align blocks only.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a group block. 
4. Give it a background color (so you can see the padding better). 
5. Set it to fullwidth.
6. Assign a padding value to it. 
7. Add an image to the group block. 
8. Set that image to fullwidth.
9. See that the image is fullwidth and there is no overflow scroll, in the editor or on the front-end.

## Visuals <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/1813435/4b80a6de-7396-428f-90fe-caf56b1df684

---

This also resolves the inconsistency between the editor and front-end of fullwidth > fullwidth blocks within constrained layouts: 

### Before (editor/front-end) 
![CleanShot 2024-04-12 at 16 21 32](https://github.com/WordPress/gutenberg/assets/1813435/1564fca4-7ea7-469f-9d93-55d1319d37b1)

### After (editor/front-end) 
![CleanShot 2024-04-12 at 16 22 52](https://github.com/WordPress/gutenberg/assets/1813435/a5ebe482-2d4b-4dbc-b6e5-31b98475195c)
