### PR TITLE
Block bindings: don't use hooks (with value setting example)

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -57,16 +57,3 @@ function gutenberg_menu() {
 	);
 }
 add_action( 'admin_menu', 'gutenberg_menu', 9 );
-
-register_meta(
-	'post',
-	'post_text_custom_field',
-	array(
-		'object_subtype' => 'post',
-		'show_in_rest' => true,
-		'single'       => true,
-		'type'         => 'string',
-		'default'	   => 'Post field value',
-		'revisions_enabled' => true
-	)
-);

--- a/lib/init.php
+++ b/lib/init.php
@@ -57,3 +57,16 @@ function gutenberg_menu() {
 	);
 }
 add_action( 'admin_menu', 'gutenberg_menu', 9 );
+
+register_meta(
+	'post',
+	'post_text_custom_field',
+	array(
+		'object_subtype' => 'post',
+		'show_in_rest' => true,
+		'single'       => true,
+		'type'         => 'string',
+		'default'	   => 'Post field value',
+		'revisions_enabled' => true
+	)
+);

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -112,6 +112,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 		const _setAttributes = useCallback(
 			( nextAttributes ) => {
+				const keptAttributes = { ...nextAttributes };
 				registry.batch( () => {
 					const bindings = Object.fromEntries(
 						Object.entries(
@@ -146,12 +147,12 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 									value,
 									args: bindings[ attributeKey ].args,
 								} );
-								delete nextAttributes[ attributeKey ];
+								delete keptAttributes[ attributeKey ];
 							}
 						}
 					}
 
-					setAttributes( nextAttributes );
+					setAttributes( keptAttributes );
 				} );
 			},
 			[

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -51,7 +51,8 @@ export function registerBlockBindingsSource( source ) {
 		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
 		sourceName: source.name,
 		sourceLabel: source.label,
-		useSource: source.useSource,
+		getValue: source.getValue,
+		setValue: source.setValue,
 		lockAttributesEditing: source.lockAttributesEditing,
 	};
 }

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -390,6 +390,8 @@ export function blockBindingsSources( state = {}, action ) {
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
 				useSource: action.useSource,
+				getValue: action.getValue,
+				setValue: action.setValue,
 				lockAttributesEditing: action.lockAttributesEditing ?? true,
 			},
 		};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I don't see much reason for the binding source API to be a hook. We can add use a simpler get function that selects data from the store and a set function dispatch the action. 

* Reduces the complexity: no local state is needed.
* Locks the API down to store/select dispatch, which will allow us to move add this function to the block-list/block selector/dispatch.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
