### PR TITLE
Block bindings: don't use hooks

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -1,12 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { getBlockType, store as blocksStore } from '@wordpress/blocks';
+import { store as blocksStore } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
-import { useLayoutEffect, useCallback, useState } from '@wordpress/element';
+import { useRegistry, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
-import { RichTextData } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -56,181 +55,134 @@ export function canBindAttribute( blockName, attributeName ) {
 	);
 }
 
-/**
- * This component is responsible for detecting and
- * propagating data changes from the source to the block.
- *
- * @param {Object}   props                   - The component props.
- * @param {string}   props.attrName          - The attribute name.
- * @param {Object}   props.blockProps        - The block props with bound attribute.
- * @param {Object}   props.source            - Source handler.
- * @param {Object}   props.args              - The arguments to pass to the source.
- * @param {Function} props.onPropValueChange - The function to call when the attribute value changes.
- * @return {null}                              Data-handling component. Render nothing.
- */
-const BindingConnector = ( {
-	args,
-	attrName,
-	blockProps,
-	source,
-	onPropValueChange,
-} ) => {
-	const { placeholder, value: propValue } = source.useSource(
-		blockProps,
-		args
-	);
+export const withBlockBindingSupport = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const registry = useRegistry();
 
-	const { name: blockName } = blockProps;
-	const attrValue = blockProps.attributes[ attrName ];
+		const boundAttributes = useSelect(
+			( select ) => {
+				const bindings = Object.fromEntries(
+					Object.entries(
+						props.attributes.metadata?.bindings || {}
+					).filter( ( [ attrName ] ) =>
+						canBindAttribute( props.name, attrName )
+					)
+				);
 
-	const updateBoundAttibute = useCallback(
-		( newAttrValue, prevAttrValue ) => {
-			/*
-			 * If the attribute is a RichTextData instance,
-			 * (core/paragraph, core/heading, core/button, etc.)
-			 * compare its HTML representation with the new value.
-			 *
-			 * To do: it looks like a workaround.
-			 * Consider improving the attribute and metadata fields types.
-			 */
-			if ( prevAttrValue instanceof RichTextData ) {
-				// Bail early if the Rich Text value is the same.
-				if ( prevAttrValue.toHTMLString() === newAttrValue ) {
+				if ( ! Object.keys( bindings ).length > 0 ) {
 					return;
 				}
 
-				/*
-				 * To preserve the value type,
-				 * convert the new value to a RichTextData instance.
-				 */
-				newAttrValue = RichTextData.fromHTMLString( newAttrValue );
-			}
+				const blockBindingsSources = unlock(
+					select( blocksStore )
+				).getAllBlockBindingsSources();
 
-			if ( prevAttrValue === newAttrValue ) {
-				return;
-			}
+				return Object.entries( bindings ).reduce(
+					( accu, [ attrName, boundAttribute ] ) => {
+						// Bail early if the block doesn't have a valid source handler.
+						const source =
+							blockBindingsSources[ boundAttribute.source ];
 
-			onPropValueChange( { [ attrName ]: newAttrValue } );
-		},
-		[ attrName, onPropValueChange ]
-	);
+						if ( ! source?.getValue ) {
+							return accu;
+						}
 
-	useLayoutEffect( () => {
-		if ( typeof propValue !== 'undefined' ) {
-			updateBoundAttibute( propValue, attrValue );
-		} else if ( placeholder ) {
-			/*
-			 * Placeholder fallback.
-			 * If the attribute is `src` or `href`,
-			 * a placeholder can't be used because it is not a valid url.
-			 * Adding this workaround until
-			 * attributes and metadata fields types are improved and include `url`.
-			 */
-			const htmlAttribute =
-				getBlockType( blockName ).attributes[ attrName ].attribute;
+						const args = {
+							registry,
+							context: props.context,
+							clientId: props.clientId,
+							attributeName: attrName,
+							args: boundAttribute.args,
+						};
 
-			if ( htmlAttribute === 'src' || htmlAttribute === 'href' ) {
-				updateBoundAttibute( null );
-				return;
-			}
+						accu[ attrName ] = source.getValue( args );
 
-			updateBoundAttibute( placeholder );
-		}
-	}, [
-		updateBoundAttibute,
-		propValue,
-		attrValue,
-		placeholder,
-		blockName,
-		attrName,
-	] );
+						if ( accu[ attrName ] === undefined ) {
+							if ( attrName === 'url' ) {
+								accu[ attrName ] = null;
+							} else {
+								accu[ attrName ] =
+									source.getPlaceholder?.( args );
+							}
+						}
 
-	return null;
-};
-
-/**
- * BlockBindingBridge acts like a component wrapper
- * that connects the bound attributes of a block
- * to the source handlers.
- * For this, it creates a BindingConnector for each bound attribute.
- *
- * @param {Object}   props                   - The component props.
- * @param {Object}   props.blockProps        - The BlockEdit props object.
- * @param {Object}   props.bindings          - The block bindings settings.
- * @param {Function} props.onPropValueChange - The function to call when the attribute value changes.
- * @return {null}                              Data-handling component. Render nothing.
- */
-function BlockBindingBridge( { blockProps, bindings, onPropValueChange } ) {
-	const blockBindingsSources = unlock(
-		useSelect( blocksStore )
-	).getAllBlockBindingsSources();
-
-	return (
-		<>
-			{ Object.entries( bindings ).map(
-				( [ attrName, boundAttribute ] ) => {
-					// Bail early if the block doesn't have a valid source handler.
-					const source =
-						blockBindingsSources[ boundAttribute.source ];
-					if ( ! source?.useSource ) {
-						return null;
-					}
-
-					return (
-						<BindingConnector
-							key={ attrName }
-							attrName={ attrName }
-							source={ source }
-							blockProps={ blockProps }
-							args={ boundAttribute.args }
-							onPropValueChange={ onPropValueChange }
-						/>
-					);
-				}
-			) }
-		</>
-	);
-}
-
-const withBlockBindingSupport = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		/*
-		 * Collect and update the bound attributes
-		 * in a separate state.
-		 */
-		const [ boundAttributes, setBoundAttributes ] = useState( {} );
-		const updateBoundAttributes = useCallback(
-			( newAttributes ) =>
-				setBoundAttributes( ( prev ) => ( {
-					...prev,
-					...newAttributes,
-				} ) ),
-			[]
+						return accu;
+					},
+					{}
+				);
+			},
+			[
+				props.attributes.metadata?.bindings,
+				props.name,
+				props.context,
+				props.clientId,
+				registry,
+			]
 		);
 
-		/*
-		 * Create binding object filtering
-		 * only the attributes that can be bound.
-		 */
-		const bindings = Object.fromEntries(
-			Object.entries( props.attributes.metadata?.bindings || {} ).filter(
-				( [ attrName ] ) => canBindAttribute( props.name, attrName )
-			)
+		const { setAttributes } = props;
+
+		const _setAttributes = useCallback(
+			( nextAttributes ) => {
+				const keptAttributes = { ...nextAttributes };
+				registry.batch( () => {
+					const bindings = Object.fromEntries(
+						Object.entries(
+							props.attributes.metadata?.bindings || {}
+						).filter( ( [ attrName ] ) =>
+							canBindAttribute( props.name, attrName )
+						)
+					);
+
+					if ( ! Object.keys( bindings ).length > 0 ) {
+						return setAttributes( nextAttributes );
+					}
+
+					const blockBindingsSources = unlock(
+						registry.select( blocksStore )
+					).getAllBlockBindingsSources();
+
+					for ( const [ attributeKey, value ] of Object.entries(
+						nextAttributes
+					) ) {
+						if ( bindings[ attributeKey ] ) {
+							const source =
+								blockBindingsSources[
+									bindings[ attributeKey ].source
+								];
+							if ( source?.setValue ) {
+								source.setValue( {
+									registry,
+									context: props.context,
+									clientId: props.clientId,
+									attributeName: attributeKey,
+									value,
+									args: bindings[ attributeKey ].args,
+								} );
+								delete keptAttributes[ attributeKey ];
+							}
+						}
+					}
+
+					setAttributes( keptAttributes );
+				} );
+			},
+			[
+				registry,
+				props.attributes.metadata?.bindings,
+				props.name,
+				props.context,
+				props.clientId,
+				setAttributes,
+			]
 		);
 
 		return (
 			<>
-				{ Object.keys( bindings ).length > 0 && (
-					<BlockBindingBridge
-						blockProps={ props }
-						bindings={ bindings }
-						onPropValueChange={ updateBoundAttributes }
-					/>
-				) }
-
 				<BlockEdit
 					{ ...props }
 					attributes={ { ...props.attributes, ...boundAttributes } }
+					setAttributes={ _setAttributes }
 				/>
 			</>
 		);

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -51,7 +51,9 @@ export function registerBlockBindingsSource( source ) {
 		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
 		sourceName: source.name,
 		sourceLabel: source.label,
-		useSource: source.useSource,
+		getValue: source.getValue,
+		setValue: source.setValue,
+		getPlaceholder: source.getPlaceholder,
 		lockAttributesEditing: source.lockAttributesEditing,
 	};
 }

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -390,6 +390,9 @@ export function blockBindingsSources( state = {}, action ) {
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
 				useSource: action.useSource,
+				getValue: action.getValue,
+				setValue: action.setValue,
+				getPlaceholder: action.getPlaceholder,
 				lockAttributesEditing: action.lockAttributesEditing ?? true,
 			},
 		};

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -389,7 +389,6 @@ export function blockBindingsSources( state = {}, action ) {
 			...state,
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
-				useSource: action.useSource,
 				getValue: action.getValue,
 				setValue: action.setValue,
 				getPlaceholder: action.getPlaceholder,

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
 import { _x } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
@@ -12,33 +12,17 @@ import { store as editorStore } from '../store';
 export default {
 	name: 'core/post-meta',
 	label: _x( 'Post Meta', 'block bindings source' ),
-	useSource( props, sourceAttributes ) {
-		const { getCurrentPostType } = useSelect( editorStore );
-		const { context } = props;
-		const { key: metaKey } = sourceAttributes;
+	getPlaceholder( { args } ) {
+		return args.key;
+	},
+	getValue( { registry, context, args } ) {
 		const postType = context.postType
 			? context.postType
-			: getCurrentPostType();
+			: registry.select( editorStore ).getCurrentPostType();
 
-		const [ meta, setMeta ] = useEntityProp(
-			'postType',
-			context.postType,
-			'meta',
-			context.postId
-		);
-
-		if ( postType === 'wp_template' ) {
-			return { placeholder: metaKey };
-		}
-		const metaValue = meta[ metaKey ];
-		const updateMetaValue = ( newValue ) => {
-			setMeta( { ...meta, [ metaKey ]: newValue } );
-		};
-
-		return {
-			placeholder: metaKey,
-			value: metaValue,
-			updateValue: updateMetaValue,
-		};
+		return registry
+			.select( coreDataStore )
+			.getEditedEntityRecord( 'postType', postType, context.postId )
+			.meta?.[ args.key ];
 	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I don't see much reason for the binding source API to be a hook. We can add use a simpler get function that selects data from the store and a set function dispatch the action. 

* Reduces the complexity: no local state is needed.
* Locks the API down to store/select dispatch, which will allow us to move add this function to the block-list/block selector/dispatch.

To see how setting the value works, see  #60725 and #60721.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
