### PR TITLE
Block bindings: allow editing post meta (new API)

### DIFF
--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -25,4 +25,17 @@ export default {
 			.getEditedEntityRecord( 'postType', postType, context.postId )
 			.meta?.[ args.key ];
 	},
+	setValue( { registry, context, args, value } ) {
+		const postType = context.postType
+			? context.postType
+			: registry.select( editorStore ).getCurrentPostType();
+		registry
+			.dispatch( coreDataStore )
+			.editEntityRecord( 'postType', postType, context.postId, {
+				meta: {
+					[ args.key ]: value,
+				},
+			} );
+	},
+	lockAttributesEditing: false,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR showcases the new API by enabling editing for post meta, see #60724 for the API change.

This is an alternative to #60719.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
