### PR TITLE
Latest Posts: Remove wrapper div and apply consistent class

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -431,7 +431,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 	const dateFormat = getSettings().formats.date;
 
 	return (
-		<div>
+		<>
 			{ inspectorControls }
 			<BlockControls>
 				<ToolbarGroup controls={ layoutControls } />
@@ -518,7 +518,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								<div className={ imageClasses }>
 									{ addLinkToFeaturedImage ? (
 										<a
-											className="wp-block-latest-posts__post-title"
 											href={ post.link }
 											rel="noreferrer noopener"
 											onClick={
@@ -533,6 +532,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								</div>
 							) }
 							<a
+								className="wp-block-latest-posts__post-title"
 								href={ post.link }
 								rel="noreferrer noopener"
 								dangerouslySetInnerHTML={
@@ -582,6 +582,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					);
 				} ) }
 			</ul>
-		</div>
+		</>
 	);
 }

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -157,7 +157,7 @@ function render_block_core_latest_posts( $attributes ) {
 					$trimmed_excerpt  = substr( $trimmed_excerpt, 0, -11 );
 					$trimmed_excerpt .= sprintf(
 						/* translators: 1: A URL to a post, 2: Hidden accessibility text: Post title */
-						__( '… <a href="%1$s" rel="noopener noreferrer">Read more<span class="screen-reader-text">: %2$s</span></a>' ),
+						__( '… <a class="wp-block-latest-posts__read-more" href="%1$s" rel="noopener noreferrer">Read more<span class="screen-reader-text">: %2$s</span></a>' ),
 						esc_url( $post_link ),
 						esc_html( $title )
 					);


### PR DESCRIPTION
Fixes #60692
Fixes #60540

## What?

This PR makes the following three changes to the Latest Posts block:

- Delete wrapper div in the editor
- Apply the class for the post title to the correct element in the editor
- Apply the class to Read More text in the front end

This should result in an exact match of the HTML in the editor and front end.

## Why?

> Delete wrapper div in the editor

This wrapper div was added by #28660. This fixes an issue where this block cannot be selected on page load. But I think this problem is no longer needed as it has been fixed by #28917, which is alternative to #28658.

> Apply the class for the post title to the correct element in the editor

This issue was reported in #60692.

> Apply the class to Read More text in the front end

The `wp-block-latest-posts__read-more` class that exists in the editor does not exist in the front end. This class is not used in the Gutenberg project, but I believe it is necessary for developers to write consistent CSS.

## Testing Instructions

> Delete wrapper div in the editor

Confirm that the problems reported with #28417 and #28536 do not occur.

- Insert a Laster Posts block and save the post.
- Reload the browser.
- Select the block.
- Confirm that the block is correctly selected and the block toolbar and block sidebar are displayed.

> Apply the class for the post title to the correct element in the editor
> Apply the class to Read More text in the front end

- Insert a Laster Posts block.
- Enable "Display featured image" and "Add link to featured image".
- Confirm that the HTML matches in the editor and front end.
