### PR TITLE
Change header height from 60px to 64px

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -97,7 +97,7 @@ $button-size: 36px;
 $button-size-next-default-40px: 40px; // transitionary variable for next default button size
 $button-size-small: 24px;
 $button-size-compact: 32px;
-$header-height: 60px;
+$header-height: 64px;
 $panel-header-height: $grid-unit-60;
 $nav-sidebar-width: 300px;
 $admin-bar-height: 32px;

--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -176,7 +176,8 @@
 
 .editor-collapsible-block-toolbar {
 	.block-editor-grid-item-mover__move-vertical-button-container {
-		// Move up a little to prevent the toolbar shift when focus is on the vertical movers.
+		// Reduce height and move up a little to prevent the toolbar
+		// shift when focus is on the vertical movers.
 		@include break-small() {
 			height: $grid-unit-50;
 			position: relative;

--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -180,7 +180,7 @@
 		@include break-small() {
 			height: $grid-unit-50;
 			position: relative;
-			top: -5px; // Should be -4px, but that causes scrolling when focus lands on the movers, in a 60px header.
+			top: #{$grid-unit-05 * -1};
 		}
 	}
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -373,7 +373,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-block-patterns-explorer {
 	&__sidebar {
 		position: absolute;
-		top: $header-height + $grid-unit-15;
+		top: $header-height + $grid-unit-10;
 		left: 0;
 		bottom: 0;
 		width: $sidebar-width;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -128,7 +128,7 @@
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
-	height: $header-height + $grid-unit-15;
+	height: $header-height + $grid-unit-10;
 	width: 100%;
 	z-index: z-index(".components-modal__header");
 	position: absolute;
@@ -175,7 +175,7 @@
 // Modal contents.
 .components-modal__content {
 	flex: 1;
-	margin-top: $header-height + $grid-unit-15;
+	margin-top: $header-height + $grid-unit-10;
 	// Small top padding required to avoid cutting off the visible outline when the first child element is focusable.
 	padding: $grid-unit-05 $grid-unit-40 $grid-unit-40;
 	overflow: auto;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -128,7 +128,7 @@
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
-	height: $header-height + $grid-unit-10;
+	height: $header-height + $grid-unit-10; // 72px
 	width: 100%;
 	z-index: z-index(".components-modal__header");
 	position: absolute;

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -63,8 +63,8 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	width: 60px;
-	height: 60px;
+	width: $header-height;
+	height: $header-height;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/packages/edit-widgets/src/components/error-boundary/style.scss
+++ b/packages/edit-widgets/src/components/error-boundary/style.scss
@@ -2,6 +2,6 @@
 	margin: auto;
 	max-width: 780px;
 	padding: 20px;
-	margin-top: 60px;
+	margin-top: $header-height;
 	box-shadow: $elevation-large;
 }

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -25,7 +25,7 @@
 		.block-editor-block-toolbar {
 			height: 100%;
 			// Push down so that buttons are centered vertically.
-			// It should be 14px (60px header height - 32px compact button height = 28 / 2),
+			// It should be 16px (64px header height - 32px compact button height = 32 / 2),
 			// but there is a -1px top-margin down the stack that affects this.
 			padding-top: math.div($header-height - $button-size-compact, 2) + 1;
 

--- a/packages/editor/src/components/collapsible-block-toolbar/style.scss
+++ b/packages/editor/src/components/collapsible-block-toolbar/style.scss
@@ -14,7 +14,7 @@
 	.block-editor-block-toolbar {
 		height: 100%;
 		// Push down so that buttons are centered vertically.
-		// It should be 14px (60px header height - 32px compact button height = 28 / 2),
+		// It should be 16px (64px header height - 32px compact button height = 32 / 2),
 		// but there is a -1px top-margin down the stack that affects this.
 		padding-top: math.div($header-height - $button-size-compact, 2) + 1;
 
@@ -67,7 +67,7 @@
 			&:not(.is-horizontal) .block-editor-block-mover__move-button-container {
 				height: $grid-unit-50;
 				position: relative;
-				top: -5px; // Should be -4px, but that causes scrolling when focus lands on the movers, in a 60px header.
+				top: #{$grid-unit-05 * -1};
 			}
 		}
 	}

--- a/packages/editor/src/components/collapsible-block-toolbar/style.scss
+++ b/packages/editor/src/components/collapsible-block-toolbar/style.scss
@@ -62,7 +62,8 @@
 			overflow: visible;
 		}
 
-		// Move up a little to prevent the toolbar shift when focus is on the vertical movers.
+		// Reduce height and move up a little to prevent the toolbar
+		// shift when focus is on the vertical movers.
 		@include break-small() {
 			&:not(.is-horizontal) .block-editor-block-mover__move-button-container {
 				height: $grid-unit-50;

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -3,7 +3,7 @@
 	margin: auto;
 	max-width: 780px;
 	padding: 1em;
-	margin-top: 60px;
+	margin-top: $header-height;
 	box-shadow: $elevation-large;
 	border: $border-width solid $gray-900;
 	border-radius: $radius-small;


### PR DESCRIPTION
Fixes #58293
Part of #46734

## What?

This PR changes the block editor header height from 60px to 64px. 

## Why?

As part of the unification of UI component sizes proposed in https://github.com/WordPress/gutenberg/issues/46734. [This comment](https://github.com/WordPress/gutenberg/pull/57444#issuecomment-1871881388) also suggests changing the header height to 64px.

## How?

Changed the value of the `$header-height` CSS variable from 60px to 64px. At the same time, I made adjustments to the areas affected by this change.

## Testing Instructions

We'll probably need to do extensive testing to make sure this change doesn't cause a 4px shift. I haven't found any issues in my testing, but if you have any concerns please let me know.

> [!NOTE]
> As reported in #55568, the `npm run dev` command does not detect changes to the `base-styles` package. So you need to run `npm run dev` again after checking out the branch.