### PR TITLE
Post Actions: Use small size button

### DIFF
--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -89,7 +89,7 @@ export default function PostActions( { onActionPerformed } ) {
 		<DropdownMenu
 			trigger={
 				<Button
-					size="compact"
+					size="small"
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
 					disabled={


### PR DESCRIPTION
Related to #60486

## What?

This PR changes the size of the post action component introduced in #60486 from 32px (compact) to 24px (small).

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/1aae6c20-2f9d-4558-97ef-3c243c599c44)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/ee5c5d1c-dced-43ec-956f-2a90210cba2f)


## Why?

Because the 24px size matches the template action's button size. Additionally, icon, page name, and action button are vertically aligned correctly.

![image](https://github.com/WordPress/gutenberg/assets/54422211/da426474-8d64-4899-b4f1-de953bfd7c11)

## Testing Instructions

- Open a new post/page.
- Open the sidebar and check the size of the action button.
