### PR TITLE
fix: add types to useSuspenseSelect

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -863,12 +863,12 @@ A variant of the `useSelect` hook that has the same API, but will throw a suspen
 
 _Parameters_
 
--   _mapSelect_ `Function`: Function called on every state change. The returned value is exposed to the component using this hook. The function receives the `registry.suspendSelect` method as the first argument and the `registry` as the second one.
+-   _mapSelect_ `T`: Function called on every state change. The returned value is exposed to the component using this hook. The function receives the `registry.suspendSelect` method as the first argument and the `registry` as the second one.
 -   _deps_ `Array`: A dependency array used to memoize the `mapSelect` so that the same `mapSelect` is invoked on every state change unless the dependencies change.
 
 _Returns_
 
--   `Object`: Data object returned by the `mapSelect` function.
+-   `ReturnType<T>`: Data object returned by the `mapSelect` function.
 
 ### withDispatch
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -859,7 +859,7 @@ _Returns_
 
 ### useSuspenseSelect
 
-A variant of the `useSelect` hook that has the same API, but will throw a suspense Promise if any of the called selectors is in an unresolved state.
+A variant of the `useSelect` hook that has the same API, but is a compatible Suspense-enabled data source.
 
 _Parameters_
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -20,9 +20,6 @@ import useAsyncMode from '../async-mode-provider/use-async-mode';
 const renderQueue = createQueue();
 
 /**
- * @typedef {import('react').SuspensePromiseError} SuspensePromiseError
- */
-/**
  * @typedef {import('../../types').StoreDescriptor<C>} StoreDescriptor
  * @template {import('../../types').AnyConfig} C
  */

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -20,6 +20,9 @@ import useAsyncMode from '../async-mode-provider/use-async-mode';
 const renderQueue = createQueue();
 
 /**
+ * @typedef {import('react').SuspensePromiseError} SuspensePromiseError
+ */
+/**
  * @typedef {import('../../types').StoreDescriptor<C>} StoreDescriptor
  * @template {import('../../types').AnyConfig} C
  */
@@ -319,8 +322,8 @@ export default function useSelect( mapSelect, deps ) {
 }
 
 /**
- * A variant of the `useSelect` hook that has the same API, but will throw a
- * suspense Promise if any of the called selectors is in an unresolved state.
+ * A variant of the `useSelect` hook that has the same API, but is a compatible
+ * Suspense-enabled data source.
  *
  * @template {MapSelect} T
  * @param {T}     mapSelect Function called on every state change. The
@@ -331,6 +334,9 @@ export default function useSelect( mapSelect, deps ) {
  * @param {Array} deps      A dependency array used to memoize the `mapSelect`
  *                          so that the same `mapSelect` is invoked on every
  *                          state change unless the dependencies change.
+ *
+ * @throws {Promise} A suspense Promise that is thrown if any of the called
+ * selectors is in an unresolved state.
  *
  * @return {ReturnType<T>} Data object returned by the `mapSelect` function.
  */

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -322,16 +322,17 @@ export default function useSelect( mapSelect, deps ) {
  * A variant of the `useSelect` hook that has the same API, but will throw a
  * suspense Promise if any of the called selectors is in an unresolved state.
  *
- * @param {Function} mapSelect Function called on every state change. The
- *                             returned value is exposed to the component
- *                             using this hook. The function receives the
- *                             `registry.suspendSelect` method as the first
- *                             argument and the `registry` as the second one.
- * @param {Array}    deps      A dependency array used to memoize the `mapSelect`
- *                             so that the same `mapSelect` is invoked on every
- *                             state change unless the dependencies change.
+ * @template {MapSelect} T
+ * @param {T}     mapSelect Function called on every state change. The
+ *                          returned value is exposed to the component
+ *                          using this hook. The function receives the
+ *                          `registry.suspendSelect` method as the first
+ *                          argument and the `registry` as the second one.
+ * @param {Array} deps      A dependency array used to memoize the `mapSelect`
+ *                          so that the same `mapSelect` is invoked on every
+ *                          state change unless the dependencies change.
  *
- * @return {Object} Data object returned by the `mapSelect` function.
+ * @return {ReturnType<T>} Data object returned by the `mapSelect` function.
  */
 export function useSuspenseSelect( mapSelect, deps ) {
 	return useMappingSelect( true, mapSelect, deps );


### PR DESCRIPTION
## What?
This PR improves the types of the `useSuspenseSelect` hook.

## Why?
The current typing of `useSuspenseSelect` is very basic, and does not use the existing types of `useSelect`. By using them we can provided better information about the returned data.

## How?
Using a generic `MapSelect` type for the argument and it's return type provide exact typings of the provided `select` function when using a typed data store object.
