### PR TITLE
Separator block: Reduce default border styles to avoid conflicts with global styles

### DIFF
--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -1,12 +1,4 @@
 .wp-block-separator {
-	border-top: 2px solid currentColor;
-	// Default, thin style, is stored in theme.scss so it can be opted out of
-
-	// Unset the left, right and bottom borders by default, otherwise some browsers will render them as "inset".
-	border-left: none;
-	border-right: none;
-	border-bottom: none;
-
 	// Dots style
 	&.is-style-dots {
 		// Override any background themes often set on the hr tag for this style.
@@ -27,4 +19,15 @@
 			font-family: serif;
 		}
 	}
+}
+
+// Lowest specificity to avoid overriding global styles.
+:where(.wp-block-separator) {
+	border-top: 2px solid currentColor;
+	// Default, thin style, is stored in theme.scss so it can be opted out of
+
+	// Unset the left, right and bottom borders by default, otherwise some browsers will render them as "inset".
+	border-left: none;
+	border-right: none;
+	border-bottom: none;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/60634, similar to #60649 

Reduce the specificity of the Separator block's default border rules.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With global styles rules specificity being reduced as of https://github.com/WordPress/gutenberg/pull/60106, the default border styles for the Separator block unintentionally override border rules set for the Separate block in `theme.json`. This is a slightly tricky issue as the Separator block has not _formally_ opted in to the Borer block support. However custom border rules are in use in TT4 so it's a good bug to address.

Because some themes might still depend on the higher specificity of the `theme.scss` rules, I've left them untouched. A good example would be a Classic theme that uses overly specific reset rules to set borders to `0` but that then opts in to `wp-block-styles` to receive the opinionated block styles. If we believe those rules should be lowered, too (the `theme.scss` ones for this block), I'd suggest looking at doing that in a separate PR potentially.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Wrap the Separator block's border styles in a `:where()` rule for consistency with global styles rules.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a base WP 6.5 installation, add a separator block to a post, page, or template, and confirm that in TT4, the separator block has a very thin style.
2. On GB trunk, confirm that the separator block is thicker than it should be.
3. Apply this PR, and confirm that the separator block looks as it does in WP 6.5.
4. Test in a range of themes (including Classic themes) that this PR does not introduce any regressions.

## Screenshots or screencast <!-- if applicable -->

### Before

The Separator block's `2px` rule overrides the `1px` from TT4:

![image](https://github.com/WordPress/gutenberg/assets/14988353/87e72fb6-0214-4c46-b444-09ce345733e8)

### After

TT4's `1px` rule overrides the Separator block's default styles:

![image](https://github.com/WordPress/gutenberg/assets/14988353/7ad58ce8-add6-4767-998d-c95017c3cc18)

Here's where TT4 sets its width:

https://github.com/WordPress/wordpress-develop/blob/f6747a384f56893aac4870979c71f02f72d2e624/src/wp-content/themes/twentytwentyfour/theme.json#L743