### PR TITLE
Fix translatable string in pagination modal

### DIFF
--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -43,7 +43,7 @@ export default function EnhancedPaginationModal( {
 	if ( hasBlocksFromPlugins ) {
 		notice =
 			__(
-				'Currently, avoiding full page reloads is not possible when non-interactive or non-clientNavigation compatible blocks from plugins are present inside the Query block.'
+				'Currently, avoiding full page reloads is not possible when non-interactive or non-client Navigation compatible blocks from plugins are present inside the Query block.'
 			) +
 			' ' +
 			notice;


### PR DESCRIPTION
Fixes a translatable string in the EnhancedPaginationModal component by separating words.

## Why

This is how translators see the current string in https://translate.wordpress.org

![image](https://github.com/WordPress/gutenberg/assets/583546/ff5cc218-0c14-49a4-92af-65320dec4ff3)

Props to @amieiro for reporting.