### PR TITLE
Interactivity: Ensure ignore directives are stable

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-ignore/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-ignore/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test/directive-ignore",
+	"title": "E2E Interactivity tests - directive ignore",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-ignore/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-ignore/render.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * HTML for testing the directive `data-wp-style`.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+
+wp_interactivity_state( 'directive-ignore', array( 'clicks' => 0 ) );
+?>
+
+<div
+	data-testid="block"
+	data-wp-interactive="directive-ignore"
+	data-wp-run="actions.run"
+	<?php
+		echo wp_interactivity_data_wp_context(
+			array(
+				'a'   => 'the letter a',
+				'b'   => 'the letter b',
+				'one' => 'the number one',
+				'two' => 'the number two',
+			)
+		);
+	?>
+>
+	<div data-wp-text="state.clicks" data-testid="counter"></div>
+
+	<div data-wp-ignore data-wp-text="context.two" data-testid="ignored">
+		<div data-testid="ignored-child" data-wp-text="context.a">No processing should occur here.</div>
+	</div>
+
+	<button data-testid="click-me" data-wp-on--click="actions.click" type="button">Click me</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-ignore/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-ignore/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-ignore/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-ignore/view.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+const { state } = store( 'directive-ignore', {
+	actions: {
+		run() {
+			getContext().one = '1';
+			getContext().two = '2';
+		},
+		click() {
+			state.clicks += 1;
+		},
+	},
+} );

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -221,6 +221,27 @@ const getGlobalEventDirective =
 			} );
 	};
 
+class IgnoredComponent extends Component {
+	shouldComponentUpdate() {
+		return false;
+	}
+
+	render( props ) {
+		const {
+			element: {
+				type: Type,
+				props: { innerHTML, ...rest },
+			},
+		} = props;
+		return (
+			<Type
+				dangerouslySetInnerHTML={ { __html: innerHTML } }
+				{ ...rest }
+			/>
+		);
+	}
+}
+
 export default () => {
 	// data-wp-context
 	directive(
@@ -440,29 +461,9 @@ export default () => {
 	} );
 
 	// data-wp-ignore
-	directive(
-		'ignore',
-		class extends Component {
-			shouldComponentUpdate() {
-				return false;
-			}
-
-			render( props ) {
-				const {
-					element: {
-						type: Type,
-						props: { innerHTML, ...rest },
-					},
-				} = props;
-				return (
-					<Type
-						dangerouslySetInnerHTML={ { __html: innerHTML } }
-						{ ...rest }
-					/>
-				);
-			}
-		}
-	);
+	directive( 'ignore', ( { element } ) => {
+		return <IgnoredComponent element={ element } />;
+	} );
 
 	// data-wp-text
 	directive( 'text', ( { directives: { text }, element, evaluate } ) => {

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { h as createElement } from 'preact';
+import { h as createElement, Component } from 'preact';
 import { useContext, useMemo, useRef } from 'preact/hooks';
 import { deepSignal, peek } from 'deepsignal';
 
@@ -442,20 +442,25 @@ export default () => {
 	// data-wp-ignore
 	directive(
 		'ignore',
-		( {
-			element: {
-				type: Type,
-				props: { innerHTML, ...rest },
-			},
-		} ) => {
-			// Preserve the initial inner HTML.
-			const cached = useMemo( () => innerHTML, [] );
-			return (
-				<Type
-					dangerouslySetInnerHTML={ { __html: cached } }
-					{ ...rest }
-				/>
-			);
+		class extends Component {
+			shouldComponentUpdate() {
+				return false;
+			}
+
+			render( props ) {
+				const {
+					element: {
+						type: Type,
+						props: { innerHTML, ...rest },
+					},
+				} = props;
+				return (
+					<Type
+						dangerouslySetInnerHTML={ { __html: innerHTML } }
+						{ ...rest }
+					/>
+				);
+			}
 		}
 	);
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -461,8 +461,8 @@ export default () => {
 	} );
 
 	// data-wp-ignore
-	directive( 'ignore', ( { element } ) => {
-		return <IgnoredComponent element={ element } />;
+	directive( 'ignore', ( props ) => {
+		return <IgnoredComponent { ...props } />;
 	} );
 
 	// data-wp-text

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -221,6 +221,9 @@ const getGlobalEventDirective =
 			} );
 	};
 
+/**
+ * @augments {Component<import('./hooks').DirectiveArgs>}
+ */
 class IgnoredComponent extends Component {
 	shouldComponentUpdate() {
 		return false;
@@ -461,8 +464,8 @@ export default () => {
 	} );
 
 	// data-wp-ignore
-	directive( 'ignore', ( props ) => {
-		return <IgnoredComponent { ...props } />;
+	directive( 'ignore', ( args ) => {
+		return <IgnoredComponent { ...args } />;
 	} );
 
 	// data-wp-text

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -24,7 +24,7 @@ interface DirectiveEntry {
 
 type DirectiveEntries = Record< string, DirectiveEntry[] >;
 
-interface DirectiveArgs {
+export interface DirectiveArgs {
 	/**
 	 * Object map with the defined directives of the element being evaluated.
 	 */
@@ -347,7 +347,7 @@ const Directives = ( {
 		);
 
 	const props = { ...originalProps, children };
-	const directiveArgs = {
+	const directiveArgs: DirectiveArgs = {
 		directives,
 		props,
 		element,

--- a/test/e2e/specs/interactivity/directive-each.spec.ts
+++ b/test/e2e/specs/interactivity/directive-each.spec.ts
@@ -18,7 +18,7 @@ test.describe( 'data-wp-each', () => {
 		await utils.deleteAllPosts();
 	} );
 
-	test( 'should use `item` as the defaul item name in the context', async ( {
+	test( 'should use `item` as the default item name in the context', async ( {
 		page,
 	} ) => {
 		const elements = page.getByTestId( 'letters' ).getByTestId( 'item' );

--- a/test/e2e/specs/interactivity/directive-ignore.spec.ts
+++ b/test/e2e/specs/interactivity/directive-ignore.spec.ts
@@ -18,7 +18,9 @@ test.describe( 'data-wp-ignore', () => {
 		await utils.deleteAllPosts();
 	} );
 
-	test( 'ignored directives should be stable', async ( { page } ) => {
+	test( 'ignored directives should never update the DOM', async ( {
+		page,
+	} ) => {
 		const block = page.getByTestId( 'block' );
 
 		const ignoredElement = await block

--- a/test/e2e/specs/interactivity/directive-ignore.spec.ts
+++ b/test/e2e/specs/interactivity/directive-ignore.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'data-wp-ignore', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/directive-ignore' );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/directive-ignore' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'ignored directives should be stable', async ( { page } ) => {
+		const block = page.getByTestId( 'block' );
+
+		const ignoredElement = await block
+			.getByTestId( 'ignored' )
+			.evaluate( ( el ) => el );
+		const ignoredChildElement = await block
+			.getByTestId( 'ignored-child' )
+			.evaluate( ( el ) => el );
+
+		await expect( block.getByTestId( 'ignored-child' ) ).toHaveText(
+			'No processing should occur here.'
+		);
+
+		await expect( block.getByTestId( 'counter' ) ).toHaveText( '0' );
+		await block.getByTestId( 'click-me' ).click();
+		await expect( block.getByTestId( 'counter' ) ).toHaveText( '1' );
+		expect( ignoredElement ).toBe(
+			await block.getByTestId( 'ignored' ).evaluate( ( el ) => el )
+		);
+		expect( ignoredChildElement ).toBe(
+			await block.getByTestId( 'ignored-child' ).evaluate( ( el ) => el )
+		);
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Ensure the ignore directive component is stable.

This requires https://github.com/WordPress/wordpress-develop/pull/6405 or the tests will likely fail. Currently, the server processes directives on tags with `data-wp-ignore` and their descendants.

## Why?

The `ignore` directive should render a completely stable component, it should provide a DOM element that can be used that will not be rerendered or otherwise changed during its lifecycle. This allows developers to use the rendered DOM to reliably attach other behaviors, such as mounting a React component.

It currently renders a component that updates if props change but leaves the `innerHTML` unchanged. It uses `useMemo` to do that, which is documented in react as an optimization that is usually stable, but not reliably so. Preact is less clear about this, but other mechanisms may be better to ensure the stability of the DOM, such defining `shouldComponentUpdate => false` as proposed.

## How?

Change the directive to a class Component with `shouldComponentUpdate(): false`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
