### PR TITLE
Site Editor: Support starter patterns

### DIFF
--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -45,6 +45,7 @@ const getMockedReusableBlock = ( id ) => ( {
 	title: { raw: `Reusable block - ${ id }` },
 	type: 'wp_block',
 	meta: { footnotes: '' },
+	wp_pattern_category: [],
 } );
 
 beforeAll( () => {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -56,7 +56,6 @@ import SettingsSidebar from '../sidebar/settings-sidebar';
 import MetaBoxes from '../meta-boxes';
 import WelcomeGuide from '../welcome-guide';
 import ActionsPanel from './actions-panel';
-import StartPageOptions from '../start-page-options';
 import { store as editPostStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import useCommonCommands from '../../hooks/commands/use-common-commands';
@@ -364,7 +363,6 @@ function Layout( { initialPost } ) {
 			<KeyboardShortcutHelpModal />
 			<WelcomeGuide />
 			<InitPatternModal />
-			<StartPageOptions />
 			<PluginArea onError={ onPluginAreaError } />
 			{ ! isDistractionFree && <SettingsSidebar /> }
 		</>

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -11,7 +11,6 @@
 @import "./components/text-editor/style.scss";
 @import "./components/visual-editor/style.scss";
 @import "./components/welcome-guide/style.scss";
-@import "./components/start-page-options/style.scss";
 
 /**
  * Animations

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -26,6 +26,7 @@ import NavigationBlockEditingMode from './navigation-block-editing-mode';
 import { useHideBlocksFromInserter } from './use-hide-blocks-from-inserter';
 import useCommands from '../commands';
 import BlockRemovalWarnings from '../block-removal-warnings';
+import StartPageOptions from '../start-page-options';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -267,6 +268,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 								<NavigationBlockEditingMode />
 							) }
 							<BlockRemovalWarnings />
+							<StartPageOptions />
 						</BlockEditorProviderComponent>
 					</BlockContextProvider>
 				</EntityProvider>

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -3,19 +3,19 @@
  */
 import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useEffect } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	__experimentalBlockPatternsList as BlockPatternsList,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useAsyncList } from '@wordpress/compose';
-import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import { store as editPostStore } from '../../store';
+import { store as editorStore } from '../../store';
 
 function useStartPatterns() {
 	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
@@ -23,11 +23,19 @@ function useStartPatterns() {
 	// the current post type is part of the postTypes declared.
 	const { blockPatternsWithPostContentBlockType, postType } = useSelect(
 		( select ) => {
-			const { getPatternsByBlockTypes } = select( blockEditorStore );
-			const { getCurrentPostType } = select( editorStore );
+			const { getPatternsByBlockTypes, getBlocksByName } =
+				select( blockEditorStore );
+			const { getCurrentPostType, getRenderingMode } =
+				select( editorStore );
+			const rootClientId =
+				getRenderingMode() === 'post-only'
+					? ''
+					: getBlocksByName( 'core/post-content' )?.[ 0 ];
 			return {
-				blockPatternsWithPostContentBlockType:
-					getPatternsByBlockTypes( 'core/post-content' ),
+				blockPatternsWithPostContentBlockType: getPatternsByBlockTypes(
+					'core/post-content',
+					rootClientId
+				),
 				postType: getCurrentPostType(),
 			};
 		},
@@ -49,13 +57,21 @@ function useStartPatterns() {
 
 function PatternSelection( { blockPatterns, onChoosePattern } ) {
 	const shownBlockPatterns = useAsyncList( blockPatterns );
-	const { resetEditorBlocks } = useDispatch( editorStore );
+	const { editEntityRecord } = useDispatch( coreStore );
+	const { postType, postId } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+
+		return {
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
+		};
+	}, [] );
 	return (
 		<BlockPatternsList
 			blockPatterns={ blockPatterns }
 			shownPatterns={ shownBlockPatterns }
 			onClickPattern={ ( _pattern, blocks ) => {
-				resetEditorBlocks( blocks );
+				editEntityRecord( 'postType', postType, postId, { blocks } );
 				onChoosePattern();
 			} }
 		/>
@@ -72,12 +88,11 @@ function StartPageOptionsModal( { onClose } ) {
 
 	return (
 		<Modal
-			className="edit-post-start-page-options__modal"
 			title={ __( 'Choose a pattern' ) }
 			isFullScreen
 			onRequestClose={ onClose }
 		>
-			<div className="edit-post-start-page-options__modal-content">
+			<div className="editor-start-page-options__modal-content">
 				<PatternSelection
 					blockPatterns={ startPatterns }
 					onChoosePattern={ onClose }
@@ -89,16 +104,25 @@ function StartPageOptionsModal( { onClose } ) {
 
 export default function StartPageOptions() {
 	const [ isClosed, setIsClosed ] = useState( false );
-	const shouldEnableModal = useSelect( ( select ) => {
-		const { isCleanNewPost, getRenderingMode } = select( editorStore );
-		const { isFeatureActive } = select( editPostStore );
+	const { shouldEnableModal, postType, postId } = useSelect( ( select ) => {
+		const {
+			isEditedPostDirty,
+			isEditedPostEmpty,
+			getCurrentPostType,
+			getCurrentPostId,
+		} = select( editorStore );
 
-		return (
-			getRenderingMode() === 'post-only' &&
-			! isFeatureActive( 'welcomeGuide' ) &&
-			isCleanNewPost()
-		);
+		return {
+			shouldEnableModal: ! isEditedPostDirty() && isEditedPostEmpty(),
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
+		};
 	}, [] );
+
+	useEffect( () => {
+		// Should reset the modal state when navigating to a new page/post.
+		setIsClosed( false );
+	}, [ postType, postId ] );
 
 	if ( ! shouldEnableModal || isClosed ) {
 		return null;

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -110,10 +110,13 @@ export default function StartPageOptions() {
 			isEditedPostEmpty,
 			getCurrentPostType,
 			getCurrentPostId,
+			getEditorSettings,
 		} = select( editorStore );
+		const { __unstableIsPreviewMode: isPreviewMode } = getEditorSettings();
 
 		return {
-			shouldEnableModal: ! isEditedPostDirty() && isEditedPostEmpty(),
+			shouldEnableModal:
+				! isPreviewMode && ! isEditedPostDirty() && isEditedPostEmpty(),
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
 		};

--- a/packages/editor/src/components/start-page-options/style.scss
+++ b/packages/editor/src/components/start-page-options/style.scss
@@ -1,5 +1,5 @@
 // 2 column masonry layout.
-.edit-post-start-page-options__modal-content .block-editor-block-patterns-list {
+.editor-start-page-options__modal-content .block-editor-block-patterns-list {
 	column-count: 2;
 	column-gap: $grid-unit-30;
 

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -30,5 +30,6 @@
 @import "./components/post-visibility/style.scss";
 @import "./components/post-trash/style.scss";
 @import "./components/preview-dropdown/style.scss";
+@import "./components/start-page-options/style.scss";
 @import "./components/table-of-contents/style.scss";
 @import "./components/template-areas/style.scss";


### PR DESCRIPTION
Alternative to #55117 
Fixes #55108

## What?

Adds the 'starter patterns' feature to the site editor for users creating a new page.

## Why?
The same feature is available in the post editor when creating a new page, so this provides parity.

## How?

It is slightly trickier in the site editor, as the pattern content needs to be inserted into the 'Content' block when in page editing mode. We can't check for an empty title as well because when creating a page in the site editor we fill the title first. So we're checking for "empty content" to show the modal rather than auto-draft status.

## Testing Instructions

1. Open the site editor
2. Select the 'Pages' option from the navigation
3. Select the 'Draft a new Page' (+ button) option
4. In the resulting modal, give your page a new then select 'Create draft' 
5. The page is created and the 'Choose a Pattern' modal should open
6. Select a pattern, the modal should close and the pattern is inserted into the post content block.
7. Navigate in the site editor to create a new page, the modal should show up again.

Test the modal in the post editor too.