### PR TITLE
Capitalize more occurrences of Navigation Menu

### DIFF
--- a/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
+++ b/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
@@ -11,7 +11,7 @@ function DeletedNavigationWarning( { onCreateNew } ) {
 		<Warning>
 			{ createInterpolateElement(
 				__(
-					'Navigation Menu has been deleted or is unavailable. <button>Create a new menu?</button>'
+					'Navigation Menu has been deleted or is unavailable. <button>Create a new Menu?</button>'
 				),
 				{
 					button: <Button onClick={ onCreateNew } variant="link" />,

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -202,7 +202,7 @@ function NavigationMenuSelector( {
 									! hasResolvedNavigationMenus
 								}
 							>
-								{ __( 'Create new menu' ) }
+								{ __( 'Create new Menu' ) }
 							</MenuItem>
 						</MenuGroup>
 					) }

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -191,7 +191,7 @@ describe( 'NavigationMenuSelector', () => {
 				expect( toolsGroup ).toBeInTheDocument();
 
 				const createMenuButton = screen.getByRole( 'menuitem', {
-					name: 'Create new menu',
+					name: 'Create new Menu',
 				} );
 
 				expect( createMenuButton ).toBeInTheDocument();
@@ -236,7 +236,7 @@ describe( 'NavigationMenuSelector', () => {
 				await user.click( toggleButton );
 
 				const createMenuButton = screen.getByRole( 'menuitem', {
-					name: 'Create new menu',
+					name: 'Create new Menu',
 				} );
 
 				await user.click( createMenuButton );
@@ -268,7 +268,7 @@ describe( 'NavigationMenuSelector', () => {
 
 				await user.click(
 					screen.getByRole( 'menuitem', {
-						name: 'Create new menu',
+						name: 'Create new Menu',
 					} )
 				);
 
@@ -293,7 +293,7 @@ describe( 'NavigationMenuSelector', () => {
 				// Check the "Create menu" button is disabled.
 				expect(
 					screen.queryByRole( 'menuitem', {
-						name: 'Create new menu',
+						name: 'Create new Menu',
 					} )
 				).toBeDisabled();
 
@@ -318,7 +318,7 @@ describe( 'NavigationMenuSelector', () => {
 				// Check the button is enabled again.
 				expect(
 					screen.queryByRole( 'menuitem', {
-						name: 'Create new menu',
+						name: 'Create new Menu',
 					} )
 				).toBeEnabled();
 			} );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-confirm-dialog.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-confirm-dialog.js
@@ -17,7 +17,7 @@ export default function DeleteConfirmDialog( { onClose, onConfirm } ) {
 			onCancel={ onClose }
 			confirmButtonText={ __( 'Delete' ) }
 		>
-			{ __( 'Are you sure you want to delete this Navigation menu?' ) }
+			{ __( 'Are you sure you want to delete this Navigation Menu?' ) }
 		</ConfirmDialog>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -36,7 +36,7 @@ function useDeleteNavigationMenu() {
 				}
 			);
 			createSuccessNotice(
-				__( 'Navigation menu successfully deleted.' ),
+				__( 'Navigation Menu successfully deleted.' ),
 				{
 					type: 'snackbar',
 				}
@@ -46,7 +46,7 @@ function useDeleteNavigationMenu() {
 			createErrorNotice(
 				sprintf(
 					/* translators: %s: error message describing why the navigation menu could not be deleted. */
-					__( `Unable to delete Navigation menu (%s).` ),
+					__( `Unable to delete Navigation Menu (%s).` ),
 					error?.message
 				),
 
@@ -107,7 +107,7 @@ function useSaveNavigationMenu() {
 					throwOnError: true,
 				}
 			);
-			createSuccessNotice( __( 'Renamed Navigation menu' ), {
+			createSuccessNotice( __( 'Renamed Navigation Menu' ), {
 				type: 'snackbar',
 			} );
 		} catch ( error ) {
@@ -117,7 +117,7 @@ function useSaveNavigationMenu() {
 			createErrorNotice(
 				sprintf(
 					/* translators: %s: error message describing why the navigation menu could not be renamed. */
-					__( `Unable to rename Navigation menu (%s).` ),
+					__( `Unable to rename Navigation Menu (%s).` ),
 					error?.message
 				),
 
@@ -162,7 +162,7 @@ function useDuplicateNavigationMenu() {
 			);
 
 			if ( savedRecord ) {
-				createSuccessNotice( __( 'Duplicated Navigation menu' ), {
+				createSuccessNotice( __( 'Duplicated Navigation Menu' ), {
 					type: 'snackbar',
 				} );
 				goTo( `/navigation/${ postType }/${ savedRecord.id }` );
@@ -171,7 +171,7 @@ function useDuplicateNavigationMenu() {
 			createErrorNotice(
 				sprintf(
 					/* translators: %s: error message describing why the navigation menu could not be deleted. */
-					__( `Unable to duplicate Navigation menu (%s).` ),
+					__( `Unable to duplicate Navigation Menu (%s).` ),
 					error?.message
 				),
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -143,7 +143,7 @@ export function SidebarNavigationScreenWrapper( {
 		<SidebarNavigationScreen
 			title={ title || __( 'Navigation' ) }
 			actions={ actions }
-			description={ description || __( 'Manage your Navigation menus.' ) }
+			description={ description || __( 'Manage your Navigation Menus.' ) }
 			content={ children }
 		/>
 	);

--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -560,13 +560,13 @@ test.describe( 'Navigation block - List view editing', () => {
 		await page.keyboard.press( 'ArrowUp' );
 
 		await expect(
-			page.getByRole( 'menuitem', { name: 'Create new menu' } )
+			page.getByRole( 'menuitem', { name: 'Create new Menu' } )
 		).toBeFocused();
 
 		await page.keyboard.press( 'Enter' );
 
 		await expect(
-			page.getByText( 'This navigation menu is empty.' )
+			page.getByText( 'This Navigation Menu is empty.' )
 		).toBeVisible();
 
 		// Move focus to the appender

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -309,7 +309,7 @@ test.describe( 'Navigation block', () => {
 		// Find the warning message
 		const warningMessage = editor.canvas
 			.getByRole( 'document', { name: 'Block: Navigation' } )
-			.getByText( 'Navigation menu has been deleted or is unavailable.' );
+			.getByText( 'Navigation Menu has been deleted or is unavailable.' );
 		await expect( warningMessage ).toBeVisible();
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow-up to https://github.com/WordPress/gutenberg/pull/60262
See https://github.com/WordPress/gutenberg/issues/59442

## What?
<!-- In a few words, what is the PR actually doing? -->
'Navigation Menu' and 'Menu' are WordPress features, according to WordPress conventions they should always be capitalized.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Capitalizes a few more occurrences of 'Navigation Menu' and 'Menu'.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A only check the tests pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
