### PR TITLE
Update: Reuse and unify template actions.

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -18,18 +18,18 @@ import { useAsyncList } from '@wordpress/compose';
 import { serialize } from '@wordpress/blocks';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../../store';
-import TemplateActions from '../../template-actions';
 import PluginTemplateSettingPanel from '../../plugin-template-setting-panel';
 import { useAvailablePatterns } from './hooks';
 import { TEMPLATE_PART_POST_TYPE } from '../../../utils/constants';
 import { unlock } from '../../../lock-unlock';
 
-const { PostCardPanel } = unlock( editorPrivateApis );
+const { PostCardPanel, PostActions } = unlock( editorPrivateApis );
 const { PatternOverridesPanel } = unlock( editorPrivateApis );
 const { useHistory } = unlock( routerPrivateApis );
 
@@ -49,11 +49,6 @@ function TemplatesList( { availableTemplates, onSelect } ) {
 		/>
 	);
 }
-
-const POST_TYPE_PATH = {
-	wp_template: '/wp_template',
-	wp_template_part: '/patterns',
-};
 
 export default function TemplatePanel() {
 	const { title, description, record, postType, postId } = useSelect(
@@ -81,6 +76,22 @@ export default function TemplatePanel() {
 		[]
 	);
 	const history = useHistory();
+	const onActionPerformed = useCallback(
+		( actionId, items ) => {
+			if ( actionId === 'delete-template' ) {
+				history.push( {
+					path:
+						items[ 0 ].type === TEMPLATE_PART_POST_TYPE
+							? '/' + TEMPLATE_PART_POST_TYPE + '/all'
+							: '/' + items[ 0 ].type,
+					postId: undefined,
+					postType: undefined,
+					canvas: 'view',
+				} );
+			}
+		},
+		[ history ]
+	);
 	const availablePatterns = useAvailablePatterns( record );
 	const { editEntityRecord } = useDispatch( coreStore );
 
@@ -100,17 +111,7 @@ export default function TemplatePanel() {
 			<PostCardPanel
 				className="edit-site-template-card"
 				actions={
-					<TemplateActions
-						postType={ postType }
-						postId={ postId }
-						className="edit-site-template-card__actions"
-						toggleProps={ { size: 'small' } }
-						onRemove={ () => {
-							history.push( {
-								path: POST_TYPE_PATH[ postType ],
-							} );
-						} }
-					/>
+					<PostActions onActionPerformed={ onActionPerformed } />
 				}
 			/>
 			<PluginTemplateSettingPanel.Slot />

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -6,6 +6,9 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { pencil } from '@wordpress/icons';
 import { Icon } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
+import { useCallback } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -18,9 +21,11 @@ import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 import SidebarButton from '../sidebar-button';
 import { useAddedBy } from '../page-templates-template-parts/hooks';
-import TemplateActions from '../template-actions';
 import HomeTemplateDetails from './home-template-details';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
+
+const { PostActions } = unlock( editorPrivateApis );
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
@@ -104,20 +109,25 @@ export default function SidebarNavigationScreenTemplate() {
 		postType,
 		postId
 	);
+	const onActionPerformed = useCallback(
+		( actionId, items ) => {
+			if ( actionId === 'delete-template' ) {
+				navigator.goTo(
+					items[ 0 ].type === TEMPLATE_PART_POST_TYPE
+						? '/' + TEMPLATE_PART_POST_TYPE + '/all'
+						: '/' + items[ 0 ].type
+				);
+			}
+		},
+		[ navigator ]
+	);
 
 	return (
 		<SidebarNavigationScreen
 			title={ title }
 			actions={
 				<>
-					<TemplateActions
-						postType={ postType }
-						postId={ postId }
-						toggleProps={ { as: SidebarButton } }
-						onRemove={ () => {
-							history.push( { path: '/' + postType } );
-						} }
-					/>
+					<PostActions onActionPerformed={ onActionPerformed } />
 					<SidebarButton
 						onClick={ () => setCanvasMode( 'edit' ) }
 						label={ __( 'Edit' ) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/index.js
@@ -112,14 +112,15 @@ export default function SidebarNavigationScreenTemplate() {
 	const onActionPerformed = useCallback(
 		( actionId, items ) => {
 			if ( actionId === 'delete-template' ) {
-				navigator.goTo(
-					items[ 0 ].type === TEMPLATE_PART_POST_TYPE
-						? '/' + TEMPLATE_PART_POST_TYPE + '/all'
-						: '/' + items[ 0 ].type
-				);
+				history.push( {
+					path:
+						items[ 0 ].type === TEMPLATE_PART_POST_TYPE
+							? '/' + TEMPLATE_PART_POST_TYPE + '/all'
+							: '/' + items[ 0 ],
+				} );
 			}
 		},
-		[ navigator ]
+		[ history ]
 	);
 
 	return (

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -35,7 +35,10 @@ const POST_ACTIONS_WHILE_EDITING = [
 	'view-post',
 	'view-post-revisions',
 	'rename-post',
+	'rename-template',
 	'move-to-trash',
+	'reset-template',
+	'delete-template',
 ];
 
 export default function PostActions( { onActionPerformed, buttonProps } ) {
@@ -51,13 +54,7 @@ export default function PostActions( { onActionPerformed, buttonProps } ) {
 		POST_ACTIONS_WHILE_EDITING
 	);
 
-	if (
-		[
-			TEMPLATE_POST_TYPE,
-			TEMPLATE_PART_POST_TYPE,
-			PATTERN_POST_TYPE,
-		].includes( postType )
-	) {
+	if ( PATTERN_POST_TYPE === postType ) {
 		return null;
 	}
 	return (

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -17,11 +17,7 @@ import { moreVertical } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
 import { usePostActions } from './actions';
 import { store as editorStore } from '../../store';
-import {
-	TEMPLATE_POST_TYPE,
-	TEMPLATE_PART_POST_TYPE,
-	PATTERN_POST_TYPE,
-} from '../../store/constants';
+import { PATTERN_POST_TYPE } from '../../store/constants';
 
 const {
 	DropdownMenuV2: DropdownMenu,

--- a/packages/editor/src/store/utils/is-template-revertable.js
+++ b/packages/editor/src/store/utils/is-template-revertable.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { TEMPLATE_ORIGINS } from '../constants';
+import {
+	TEMPLATE_ORIGINS,
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+} from '../constants';
 
 // Copy of the function from packages/edit-site/src/utils/is-template-revertable.js
 
@@ -12,7 +16,11 @@ import { TEMPLATE_ORIGINS } from '../constants';
  * @return {boolean} Whether the template is revertable.
  */
 export default function isTemplateRevertable( template ) {
-	if ( ! template ) {
+	if (
+		! template ||
+		( template.type !== TEMPLATE_POST_TYPE &&
+			template.type !== TEMPLATE_PART_POST_TYPE )
+	) {
 		return false;
 	}
 	/* eslint-disable camelcase */


### PR DESCRIPTION
Similar to https://github.com/WordPress/gutenberg/pull/60486.

Reuses the template actions across the post editor inspector, side editor inspector, details panel, and the dataviews.

## In progress
The handle of deleting a template that is associated with a page is not yet implemented.

## Screenshots

<img width="186" alt="Screenshot 2024-04-15 at 18 31 01" src="https://github.com/WordPress/gutenberg/assets/11271197/7f25f9bc-9f14-4374-8b05-62acaf2ff73f">
<img width="237" alt="Screenshot 2024-04-15 at 18 30 17" src="https://github.com/WordPress/gutenberg/assets/11271197/d9b6d656-fb2e-4115-953e-e4c72d84e7e6">
<img width="189" alt="Screenshot 2024-04-15 at 18 29 44" src="https://github.com/WordPress/gutenberg/assets/11271197/ed9590ca-f5da-41db-8701-22a59483cf1a">

## Testing Instructions
Create a custom template on the templates section.
Renamed the template using the edit site inspector sidebar.
Renamed the template using the details panel.
Tried to delete a template using both the edit site inspector sidebar and the details panel.
Added a change to a theme template and tried the reset action on both the edit site inspector sidebar and the details panel.
Associated a theme template with a change to a page, and verified I could reset the template on the edit post.
