### PR TITLE
Enhance block outlines and selection interactions

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/content.scss
+++ b/packages/block-editor/src/components/block-content-overlay/content.scss
@@ -1,38 +1,6 @@
 .block-editor-block-list__block.has-block-overlay {
 	cursor: default;
 
-	&::before {
-		content: "";
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		background: transparent;
-		border: none;
-		border-radius: $radius-block-ui;
-		z-index: z-index(".block-editor-block-list__block.has-block-overlay");
-	}
-
-	&:not(.is-multi-selected)::after {
-		content: none !important;
-	}
-
-	&:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
-	}
-
-	&.is-reusable:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before,
-	&.wp-block-template-part:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before {
-		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
-		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color) inset;
-	}
-
-	&.is-selected:not(.is-dragging-blocks)::before {
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
-	}
-
 	.block-editor-block-list__block {
 		pointer-events: none;
 	}

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -274,7 +274,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		}
 	}
 
-	&.is-hovered,
+	&.is-hovered:not(.is-selected),
 	&:not(.rich-text):not([contenteditable="true"]).is-selected {
 
 		&::after {

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -39,12 +39,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	position: relative;
 
 	// Block multi selection
-	// Apply a rounded radius to the entire block when multi selected, but with low specificity
-	// so explicit radii set by tools are preserved.
-	&:where(.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected)) {
-		border-radius: $radius-block-ui;
-	}
-
 	.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected) {
 		// Hide the native selection indicator, for the selection, and children.
 		&::selection,
@@ -64,7 +58,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 			left: 0;
 			background: var(--wp-admin-theme-color);
 			opacity: 0.4;
-			border-radius: $radius-block-ui;
 
 			// Animate.
 			animation: selection-overlay__fade-in-animation 0.1s ease-out;
@@ -77,7 +70,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 
 		// Don't show the highlight focus style when multi selected.
 		&.is-highlighted::after {
-			box-shadow: none;
+			outline-color: transparent;
 		}
 	}
 
@@ -99,17 +92,18 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 			position: absolute;
 			z-index: 1;
 			pointer-events: none;
-			top: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			left: $border-width;
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-			outline: 2px solid transparent; // This shows up in Windows High Contrast Mode.
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			outline-color: var(--wp-admin-theme-color);
+			outline-style: solid;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
 
 			// Show a light color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+				outline-color: $dark-theme-focus;
 			}
 		}
 	}
@@ -270,22 +264,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 }
 
-.is-outline-mode .block-editor-block-list__block {
-	&.is-hovered {
-		cursor: default;
-
-		&::after {
-			content: "";
-			position: absolute;
-			pointer-events: none;
-			top: $border-width;
-			left: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width;
-		}
-	}
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline) {
 
 	&.is-selected {
 		cursor: default;
@@ -293,17 +272,45 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		&.rich-text {
 			cursor: unset;
 		}
+	}
+
+	&.is-hovered,
+	&:not(.rich-text):not([contenteditable="true"]).is-selected {
 
 		&::after {
 			content: "";
 			position: absolute;
 			pointer-events: none;
-			top: $border-width;
-			left: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			outline-color: var(--wp-admin-theme-color);
+			outline-style: solid;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
+		}
+	}
+}
+
+// Colorize outlines for template parts and synced patterns (.is-reusable).
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-reusable {
+
+	&.is-hovered::after,
+	&.is-selected::after,
+	&.is-highlighted::after {
+		outline-color: var(--wp-block-synced-color);
+	}
+
+	&.block-editor-block-list__block:not([contenteditable]):focus {
+		&::after {
+			outline-color: var(--wp-block-synced-color);
+
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				outline-color: $dark-theme-focus;
+			}
 		}
 	}
 }
@@ -336,7 +343,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	animation-timing-function: ease-out;
 	animation-delay: 0.1s;
 	animation-fill-mode: backwards;
-	border-radius: $radius-block-ui;
 	bottom: 0;
 	content: "";
 	left: 0;
@@ -385,9 +391,16 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	z-index: z-index("{core/image aligned left or right} .wp-block");
 }
 
+// Increase width when zoomed out to match visually.
 body.is-zoomed-out {
 	display: flex;
 	flex-direction: column;
+
+	.is-outline-mode .block-editor-block-list__block:not(.remove-outline):not(.rich-text).is-selected::after,
+	.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-hovered:not(.is-selected)::after {
+		outline-width: calc(2 * var(--wp-admin-border-width-focus)); // Adjusted for the zoom scale.
+		outline-offset: calc(-2 * var(--wp-admin-border-width-focus));
+	}
 
 	> .is-root-container {
 		flex: 1;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -17,6 +17,19 @@
 	}
 }
 
+@mixin selectedOutline() {
+	content: "";
+	position: absolute;
+	pointer-events: none;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	outline-color: var(--wp-admin-theme-color);
+	outline-style: solid;
+	outline-width: var(--wp-admin-border-width-focus);
+	outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
+}
 
 // Hide selections on this element, otherwise Safari will include it stacked
 // under your actual selection.
@@ -88,18 +101,8 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		// We're using a pseudo element to overflow placeholder borders
 		// and any border inside the block itself.
 		&::after {
-			content: "";
-			position: absolute;
+			@include selectedOutline();
 			z-index: 1;
-			pointer-events: none;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			outline-color: var(--wp-admin-theme-color);
-			outline-style: solid;
-			outline-width: var(--wp-admin-border-width-focus);
-			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
 
 			// Show a light color for dark themes.
 			.is-dark-theme & {
@@ -278,17 +281,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	&:not(.rich-text):not([contenteditable="true"]).is-selected {
 
 		&::after {
-			content: "";
-			position: absolute;
-			pointer-events: none;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			outline-color: var(--wp-admin-theme-color);
-			outline-style: solid;
-			outline-width: var(--wp-admin-border-width-focus);
-			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
+			@include selectedOutline();
 		}
 	}
 }

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -16,17 +16,20 @@
 }
 
 .edit-post-visual-editor .block-editor-block-list__block:not(.remove-outline).is-reusable {
-	&.is-highlighted,
-	&.is-selected {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
+
+	&.is-hovered::after,
+	&.is-highlighted::after,
+	&.is-selected::after {
+		outline-color: var(--wp-block-synced-color);
 	}
 
 	&.block-editor-block-list__block:not([contenteditable]):focus {
 		&::after {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
+			outline-color: var(--wp-block-synced-color);
+
 			// Show a light color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+				outline-color: $dark-theme-focus;
 			}
 		}
 	}

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -17,7 +17,6 @@
 
 .edit-post-visual-editor .block-editor-block-list__block:not(.remove-outline).is-reusable {
 
-	&.is-hovered::after,
 	&.is-highlighted::after,
 	&.is-selected::after {
 		outline-color: var(--wp-block-synced-color);

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -27,7 +27,6 @@
 .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
 .block-editor-block-list__block:not(.remove-outline).is-reusable {
 
-	&.is-hovered::after,
 	&.is-highlighted::after,
 	&.is-selected::after {
 		outline-color: var(--wp-block-synced-color);

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -24,24 +24,22 @@
 }
 
 // We don't use .is-outline-mode in this case so colors take effect properly in the block editor.
-// Will be a better result when outlines are not shadows, but outlines, so we can target outline-color, not redefine the entire shadow.
 .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
 .block-editor-block-list__block:not(.remove-outline).is-reusable {
+
+	&.is-hovered::after,
 	&.is-highlighted::after,
 	&.is-selected::after {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
-	}
-
-	&.is-hovered::after {
-		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color);
+		outline-color: var(--wp-block-synced-color);
 	}
 
 	&.block-editor-block-list__block:not([contenteditable]):focus {
 		&::after {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
+			outline-color: var(--wp-block-synced-color);
+
 			// Show a light color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+				outline-color: $dark-theme-focus;
 			}
 		}
 	}

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -47,7 +47,6 @@
 		}
 
 		.edit-site-visual-editor__editor-canvas {
-			border-radius: $radius-block-ui;
 			max-height: 100%;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Originally explored as part of https://github.com/WordPress/gutenberg/pull/60286, cleans up the site editor's hover and selection outlines by: 
- Using outlines rather than shadows, for a simpler implementation across the experience.
- Using a consistent var(--wp-admin-border-width-focus) width for outlines.
- Not rendering outlines when selecting editable content/RichText, making text selection emulate the post editor. 
- Removing the template part hover overlay. 
- Removing border radius to reduce visual conflicts when against, or over, non-radii elements (images, fullwidth blocks, edge of the canvas, etc).
- Increasing the weight of the outlines when in zoom out mode to improve visibility. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. Hover and select blocks and synced patterns.
3. Do the same in the post editor.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-15 at 14 29 25](https://github.com/WordPress/gutenberg/assets/1813435/46e8d5de-d8b8-491c-a781-17623b398336)
![CleanShot 2024-04-15 at 14 30 59](https://github.com/WordPress/gutenberg/assets/1813435/1bfb0443-c1d0-4ef3-bea0-28d69d4bc9dc)
