### PR TITLE
Block Editor: Avoid errors when a block variation icon is an object

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -116,7 +116,9 @@ function VariationsToggleGroupControl( {
 				{ variations.map( ( variation ) => (
 					<ToggleGroupControlOptionIcon
 						key={ variation.name }
-						icon={ variation.icon }
+						icon={
+							<BlockIcon icon={ variation.icon } showColors />
+						}
 						value={ variation.name }
 						label={
 							selectedValue === variation.name


### PR DESCRIPTION
## What?
Fixes #60756.

PR prevents the editor from crashing when block variation is registered with an `icon` object.

```
Uncaught Error: Objects are invalid as a React child (found: object with keys {src, background, foreground}). If you meant to render a collection of children, use an array instead.
```

## Why?
Blocks and their variations can use `icon` objects.

## How?
Pass the `BlockIcon` instance to the `ToggleGroupControlOptionIcon` component. This matches behavior in `VariationsButtons`.

## Testing Instructions
1. Open a post or page.
2. Add a Group block variation that uses an `icon` object.
3. Add a Group block.
4. The variation icon should be correctly displayed, and the editor shouldn't crash.

### Testing Snippet
```js
const el = wp.element.createElement;
const SVG = wp.primitives.SVG;

const icon = el(SVG, {
    viewBox: '-144 -128 864 768'
}, el('path', {
    d: 'M59.6 160L95.2 80H200v80H59.6zM248 160V80H352.8l35.6 80H248zM48 208H358.6c22.3-10.3 47.2-16 73.4-16c5.4 0 10.7 .2 16 .7V176L384 32H64L0 176V432v48H48 296.2c-11.8-14.3-21.4-30.5-28.2-48H48V208zM576 368a144 144 0 1 0 -288 0 144 144 0 1 0 288 0zm-65.4-32l-11.3 11.3-72 72L416 430.6l-11.3-11.3-40-40L353.4 368 376 345.4l11.3 11.3L416 385.4l60.7-60.7L488 313.4 510.6 336z',
}));

wp.blocks.registerBlockVariation('core/group', {
    name: 'group-with-shadow',
    title: 'Group with Shadow',
    description: 'Adds a box-shadow to "Group" and their variations.',
    icon: {
        src: icon,
        background: '#ff0000',
        foreground: '#000',
    },
    attributes: {
        backgroundColor: 'base',
        className: 'has-box-shadow',
    },
    scope: ['inserter', 'transform'],
});

```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-16 at 08 34 44](https://github.com/WordPress/gutenberg/assets/240569/5cb7593b-a071-4e08-ac55-bbfb2502db48)
