### PR TITLE
NavigatorProvider: move the same-location check to the goTo function

### DIFF
--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -80,6 +80,13 @@ function goTo(
 		...restOptions
 	} = options;
 
+	const isNavigatingToSamePath =
+		locationHistory.length > 0 &&
+		locationHistory[ locationHistory.length - 1 ].path === path;
+	if ( isNavigatingToSamePath ) {
+		return locationHistory;
+	}
+
 	const isNavigatingToPreviousPath =
 		isBack &&
 		locationHistory.length > 1 &&
@@ -157,13 +164,6 @@ function routerReducer(
 			locationHistory = goBack( state );
 			break;
 		case 'goto':
-			if (
-				locationHistory.length &&
-				action.path ===
-					locationHistory[ locationHistory.length - 1 ].path
-			) {
-				break;
-			}
 			locationHistory = goTo( state, action.path, action.options );
 			break;
 		case 'gotoparent':


### PR DESCRIPTION
A tiny followup to #60561 that moves the new code to the `goTo` function. It maintains the structure of the reducer where all the work is done by the helper functions, and the reducer is just a command and control hub that assigns the work 🙂 