### PR TITLE
Update block-deprecation.md

### DIFF
--- a/docs/reference-guides/block-api/block-deprecation.md
+++ b/docs/reference-guides/block-api/block-deprecation.md
@@ -23,7 +23,7 @@ It is also important to note that if a deprecation's `save` method imports addit
 
 For blocks with multiple deprecations, it may be easier to save each deprecation to a constant with the version of the block it applies to, and then add each of these to the block's `deprecated` array. The deprecations in the array should be in reverse chronological order. This allows the block editor to attempt to apply the most recent and likely deprecations first, avoiding unnecessary and expensive processing.
 
-### Example:
+**Example**
 
 ```js
 const v1 = {};
@@ -59,7 +59,7 @@ Deprecations are defined on a block type as its `deprecated` property, an array 
 It's important to note that <code>attributes</code>, <code>supports</code>, and <code>save</code> are not automatically inherited from the current version, since they can impact parsing and serialization of a block, so they must be defined on the deprecated object in order to be processed during a migration.
 </div>
 
-### Example:
+**Example**
 
 ```js
 const { registerBlockType } = wp.blocks;
@@ -104,7 +104,7 @@ In the example above we updated the markup of the block to use a `div` instead o
 
 Sometimes, you need to update the attributes set to rename or modify old attributes.
 
-### Example:
+**Example**
 
 
 ```js
@@ -155,7 +155,7 @@ In the example above we updated the markup of the block to use a `div` instead o
 Situations may exist where when migrating the block we may need to add or remove innerBlocks.
 E.g: a block wants to migrate a title attribute to a paragraph innerBlock.
 
-### Example:
+**Example**
 
 ```js
 const { registerBlockType } = wp.blocks;


### PR DESCRIPTION
Remove "Examples" as headings to highlight meaningful headings on the article

cc: @ndiego 