### PR TITLE
Adjust allow pattern overrides UX flow

### DIFF
--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -5,6 +5,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
+	Text,
 	TextControl,
 	Modal,
 } from '@wordpress/components';
@@ -44,7 +45,6 @@ export function AllowOverridesModal( {
 		<Modal
 			title={ __( 'Enable overrides' ) }
 			onRequestClose={ onClose }
-			overlayClassName="block-editor-block-allow-overrides-modal"
 			focusOnMount="firstContentElement"
 			aria={ { describedby: descriptionId } }
 			size="small"
@@ -61,14 +61,11 @@ export function AllowOverridesModal( {
 				} }
 			>
 				<VStack spacing="6">
-					<p
-						id={ descriptionId }
-						className="block-editor-block-allow-overrides-modal__description"
-					>
+					<Text id={ descriptionId }>
 						{ __(
 							'Overrides are changes you make to a block within a synced pattern instance. Use overrides to customize a synced pattern instance to suit its new context. Name this block to specify an override.'
 						) }
-					</p>
+					</Text>
 					<TextControl
 						__nextHasNoMarginBottom
 						__next40pxDefaultSize
@@ -111,7 +108,6 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 		<Modal
 			title={ __( 'Disable overrides' ) }
 			onRequestClose={ onClose }
-			overlayClassName="block-editor-block-disallow-overrides-modal"
 			aria={ { describedby: descriptionId } }
 			size="small"
 		>
@@ -123,14 +119,11 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 				} }
 			>
 				<VStack spacing="6">
-					<p
-						id={ descriptionId }
-						className="block-editor-block-allow-overrides-modal__description"
-					>
+					<Text id={ descriptionId }>
 						{ __(
 							'Are you sure you want to disable overrides? Disabling overrides will revert all applied overrides for this block throughout instances of this pattern.'
 						) }
-					</p>
+					</Text>
 
 					<HStack justify="right">
 						<Button

--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -42,7 +42,7 @@ export function AllowOverridesModal( {
 
 	return (
 		<Modal
-			title={ __( 'Allow overrides' ) }
+			title={ __( 'Enable overrides' ) }
 			onRequestClose={ onClose }
 			overlayClassName="block-editor-block-allow-overrides-modal"
 			focusOnMount="firstContentElement"
@@ -60,18 +60,22 @@ export function AllowOverridesModal( {
 					handleSubmit();
 				} }
 			>
-				<p id={ descriptionId }>
-					{ __( 'Enter a custom name for this block.' ) }
-				</p>
-				<VStack spacing="3">
+				<VStack spacing="6">
+					<p
+						id={ descriptionId }
+						className="block-editor-block-allow-overrides-modal__description"
+					>
+						{ __(
+							'Overrides are changes you make to a block within a synced pattern instance. Use overrides to customize a synced pattern instance to suit its new context. Name this block to specify an override.'
+						) }
+					</p>
 					<TextControl
 						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 						value={ editedBlockName }
-						label={ __( 'Block name' ) }
-						hideLabelFromVision
+						label={ __( 'Name' ) }
 						help={ __(
-							'This name will be used to denote the override wherever the synced pattern is used. The name here will help people understand its purpose. E.g. if you\'re creating a recipe pattern, it can be "Recipe Title", "Recipe Description", etc.'
+							'For example, if you are creating a recipe pattern, you use "Recipe Title", "Recipe Description", etc.'
 						) }
 						placeholder={ placeholder }
 						onChange={ setEditedBlockName }
@@ -91,7 +95,7 @@ export function AllowOverridesModal( {
 							variant="primary"
 							type="submit"
 						>
-							{ __( 'Allow overrides' ) }
+							{ __( 'Enable overrides' ) }
 						</Button>
 					</HStack>
 				</VStack>
@@ -105,7 +109,7 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 
 	return (
 		<Modal
-			title={ __( 'Disallow overrides' ) }
+			title={ __( 'Disable overrides' ) }
 			onRequestClose={ onClose }
 			overlayClassName="block-editor-block-disallow-overrides-modal"
 			aria={ { describedby: descriptionId } }
@@ -118,29 +122,34 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 					onClose();
 				} }
 			>
-				<p id={ descriptionId }>
-					{ __(
-						'Are you sure you want to disallow the overrides? This could cause problems with content entered into instances of this pattern.'
-					) }
-				</p>
-
-				<HStack justify="right">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ onClose }
+				<VStack spacing="6">
+					<p
+						id={ descriptionId }
+						className="block-editor-block-allow-overrides-modal__description"
 					>
-						{ __( 'Cancel' ) }
-					</Button>
+						{ __(
+							'Are you sure you want to disable overrides? Disabling overrides will revert all applied overrides for this block throughout instances of this pattern.'
+						) }
+					</p>
 
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						type="submit"
-					>
-						{ __( 'Disallow overrides' ) }
-					</Button>
-				</HStack>
+					<HStack justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onClose }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							type="submit"
+						>
+							{ __( 'Disable overrides' ) }
+						</Button>
+					</HStack>
+				</VStack>
 			</form>
 		</Modal>
 	);

--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -5,7 +5,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
-	Text,
+	__experimentalText as Text,
 	TextControl,
 	Modal,
 } from '@wordpress/components';

--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -95,7 +95,7 @@ export function AllowOverridesModal( {
 							variant="primary"
 							type="submit"
 						>
-							{ __( 'Enable overrides' ) }
+							{ __( 'Enable' ) }
 						</Button>
 					</HStack>
 				</VStack>
@@ -146,7 +146,7 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 							variant="primary"
 							type="submit"
 						>
-							{ __( 'Disable overrides' ) }
+							{ __( 'Disable' ) }
 						</Button>
 					</HStack>
 				</VStack>

--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -12,25 +12,28 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState, useId } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
 
-export default function AllowOverridesModal( {
+export function AllowOverridesModal( {
 	placeholder,
+	initialName = '',
 	onClose,
 	onSave,
 } ) {
-	const [ editedBlockName, setEditedBlockName ] = useState( '' );
+	const [ editedBlockName, setEditedBlockName ] = useState( initialName );
 	const descriptionId = useId();
 
 	const isNameValid = !! editedBlockName.trim();
 
 	const handleSubmit = () => {
-		const message = sprintf(
-			/* translators: %s: new name/label for the block */
-			__( 'Block name changed to: "%s".' ),
-			editedBlockName
-		);
+		if ( editedBlockName !== initialName ) {
+			const message = sprintf(
+				/* translators: %s: new name/label for the block */
+				__( 'Block name changed to: "%s".' ),
+				editedBlockName
+			);
 
-		// Must be assertive to immediately announce change.
-		speak( message, 'assertive' );
+			// Must be assertive to immediately announce change.
+			speak( message, 'assertive' );
+		}
 		onSave( editedBlockName );
 
 		// Immediate close avoids ability to hit save multiple times.
@@ -88,10 +91,56 @@ export default function AllowOverridesModal( {
 							variant="primary"
 							type="submit"
 						>
-							{ __( 'Save' ) }
+							{ __( 'Allow overrides' ) }
 						</Button>
 					</HStack>
 				</VStack>
+			</form>
+		</Modal>
+	);
+}
+
+export function DisallowOverridesModal( { onClose, onSave } ) {
+	const descriptionId = useId();
+
+	return (
+		<Modal
+			title={ __( 'Disallow overrides' ) }
+			onRequestClose={ onClose }
+			overlayClassName="block-editor-block-disallow-overrides-modal"
+			aria={ { describedby: descriptionId } }
+			size="small"
+		>
+			<form
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					onSave();
+					onClose();
+				} }
+			>
+				<p id={ descriptionId }>
+					{ __(
+						'Are you sure you want to disallow the overrides? This could cause problems with content entered into instances of this pattern.'
+					) }
+				</p>
+
+				<HStack justify="right">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onClose }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						type="submit"
+					>
+						{ __( 'Disallow overrides' ) }
+					</Button>
+				</HStack>
 			</form>
 		</Modal>
 	);

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -105,6 +105,7 @@ function PatternOverridesControls( { attributes, name, setAttributes } ) {
 					) }
 				>
 					<Button
+						__next40pxDefaultSize
 						className="pattern-overrides-control__allow-overrides-button"
 						variant="secondary"
 						onClick={ () => {

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -101,7 +101,7 @@ function PatternOverridesControls( { attributes, name, setAttributes } ) {
 					id={ controlId }
 					label={ __( 'Overrides' ) }
 					help={ __(
-						'Allow attributes within this block to be overridden by pattern instances.'
+						'Allow changes to this block throughout instances of this pattern.'
 					) }
 				>
 					<Button
@@ -116,8 +116,8 @@ function PatternOverridesControls( { attributes, name, setAttributes } ) {
 						} }
 					>
 						{ allowOverrides
-							? __( 'Disallow overrides' )
-							: __( 'Allow overrides' ) }
+							? __( 'Disable overrides' )
+							: __( 'Enable overrides' ) }
 					</Button>
 				</BaseControl>
 			</InspectorControls>

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useState, useId, useRef, flushSync } from '@wordpress/element';
+import { useState, useId } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { ToggleControl, BaseControl, Button } from '@wordpress/components';
+import { BaseControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -13,7 +13,10 @@ import {
 	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
 	PATTERN_OVERRIDES_BINDING_SOURCE,
 } from '../constants';
-import AllowOverridesModal from './allow-overrides-modal';
+import {
+	AllowOverridesModal,
+	DisallowOverridesModal,
+} from './allow-overrides-modal';
 
 function removeBindings( bindings, syncedAttributes ) {
 	let updatedBindings = {};
@@ -47,8 +50,9 @@ function addBindings( bindings, syncedAttributes ) {
 
 function PatternOverridesControls( { attributes, name, setAttributes } ) {
 	const controlId = useId();
-	const toggleRef = useRef();
 	const [ showAllowOverridesModal, setShowAllowOverridesModal ] =
+		useState( false );
+	const [ showDisallowOverridesModal, setShowDisallowOverridesModal ] =
 		useState( false );
 
 	const syncedAttributes = PARTIAL_SYNCING_SUPPORTED_BLOCKS[ name ];
@@ -83,7 +87,12 @@ function PatternOverridesControls( { attributes, name, setAttributes } ) {
 	// Avoid overwriting other (e.g. meta) bindings.
 	if ( isConnectedToOtherSources ) return null;
 
-	const hasName = attributes.metadata?.name;
+	const hasName = !! attributes.metadata?.name;
+	const allowOverrides =
+		hasName &&
+		attributeSources.some(
+			( source ) => source === PATTERN_OVERRIDES_BINDING_SOURCE
+		);
 
 	return (
 		<>
@@ -95,40 +104,37 @@ function PatternOverridesControls( { attributes, name, setAttributes } ) {
 						'Allow attributes within this block to be overridden by pattern instances.'
 					) }
 				>
-					{ hasName ? (
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Allow overrides' ) }
-							checked={ attributeSources.some(
-								( source ) =>
-									source === PATTERN_OVERRIDES_BINDING_SOURCE
-							) }
-							onChange={ ( isChecked ) => {
-								updateBindings( isChecked );
-							} }
-							ref={ toggleRef }
-						/>
-					) : (
-						<Button
-							className="pattern-overrides-control__allow-overrides-button"
-							variant="secondary"
-							onClick={ () => setShowAllowOverridesModal( true ) }
-						>
-							{ __( 'Allow overrides' ) }
-						</Button>
-					) }
+					<Button
+						className="pattern-overrides-control__allow-overrides-button"
+						variant="secondary"
+						onClick={ () => {
+							if ( allowOverrides ) {
+								setShowDisallowOverridesModal( true );
+							} else {
+								setShowAllowOverridesModal( true );
+							}
+						} }
+					>
+						{ allowOverrides
+							? __( 'Disallow overrides' )
+							: __( 'Allow overrides' ) }
+					</Button>
 				</BaseControl>
 			</InspectorControls>
 
 			{ showAllowOverridesModal && (
 				<AllowOverridesModal
+					initialName={ attributes.metadata?.name }
 					onClose={ () => setShowAllowOverridesModal( false ) }
 					onSave={ ( newName ) => {
-						flushSync( () => {
-							updateBindings( true, newName );
-						} );
-						toggleRef.current?.focus();
+						updateBindings( true, newName );
 					} }
+				/>
+			) }
+			{ showDisallowOverridesModal && (
+				<DisallowOverridesModal
+					onClose={ () => setShowDisallowOverridesModal( false ) }
+					onSave={ () => updateBindings( false ) }
 				/>
 			) }
 		</>

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -43,3 +43,7 @@
 	width: 100%;
 	justify-content: center;
 }
+
+.block-editor-block-allow-overrides-modal__description {
+	margin: 0;
+}

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -44,6 +44,3 @@
 	justify-content: center;
 }
 
-.block-editor-block-allow-overrides-modal__description {
-	margin: 0;
-}

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -90,11 +90,11 @@ test.describe( 'Pattern Overrides', () => {
 				.getByRole( 'button', { name: 'Advanced' } )
 				.click();
 			await editorSettings
-				.getByRole( 'button', { name: 'Allow overrides' } )
+				.getByRole( 'button', { name: 'Enable overrides' } )
 				.click();
 			await page
-				.getByRole( 'dialog', { name: 'Allow overrides' } )
-				.getByRole( 'button', { name: 'Allow overrides' } )
+				.getByRole( 'dialog', { name: 'Enable overrides' } )
+				.getByRole( 'button', { name: 'Enable overrides' } )
 				.click();
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -90,8 +90,12 @@ test.describe( 'Pattern Overrides', () => {
 				.getByRole( 'button', { name: 'Advanced' } )
 				.click();
 			await editorSettings
-				.getByRole( 'checkbox', { name: 'Allow overrides' } )
-				.setChecked( true );
+				.getByRole( 'button', { name: 'Allow overrides' } )
+				.click();
+			await page
+				.getByRole( 'dialog', { name: 'Allow overrides' } )
+				.getByRole( 'button', { name: 'Allow overrides' } )
+				.click();
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -90,11 +90,11 @@ test.describe( 'Pattern Overrides', () => {
 				.getByRole( 'button', { name: 'Advanced' } )
 				.click();
 			await editorSettings
-				.getByRole( 'button', { name: 'Enable overrides' } )
+				.getByRole( 'button', { name: 'Enable' } )
 				.click();
 			await page
 				.getByRole( 'dialog', { name: 'Enable overrides' } )
-				.getByRole( 'button', { name: 'Enable overrides' } )
+				.getByRole( 'button', { name: 'Enable' } )
 				.click();
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -90,7 +90,7 @@ test.describe( 'Pattern Overrides', () => {
 				.getByRole( 'button', { name: 'Advanced' } )
 				.click();
 			await editorSettings
-				.getByRole( 'button', { name: 'Enable' } )
+				.getByRole( 'button', { name: 'Enable overrides' } )
 				.click();
 			await page
 				.getByRole( 'dialog', { name: 'Enable overrides' } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close #60760.

Refine the UX flow of the "allow overrides" button for Pattern Overrides. The wording is still TBD and can be changed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
So that the UX flow can just be buttons and modals.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a `DisallowOverridesModal`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a synced pattern with some blocks.
2. Allow overrides of the blocks in the advanced panel.
3. Enter the name of the block in the modal and hit "Allow overrides."
4. Test disallowing the overrides by clicking on the "Disallow overrides" button.
5. It should pop a modal up for confirmation.
6. Hit the "Allow overrides" button again, the initial name should be pre-populated in the modal.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/ca7e3976-1894-4dd0-a34d-dfc64c70cdd3

