### PR TITLE
Fix: Action button alignment on details panel.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -108,7 +108,10 @@ export default function SidebarNavigationScreenPage( { backPath } ) {
 			) }
 			actions={
 				<>
-					<PostActions onActionPerformed={ onActionPerformed } />
+					<PostActions
+						onActionPerformed={ onActionPerformed }
+						buttonProps={ { size: 'default' } }
+					/>
 					<SidebarButton
 						onClick={ () => setCanvasMode( 'edit' ) }
 						label={ __( 'Edit' ) }

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -39,7 +39,7 @@ const POST_ACTIONS_WHILE_EDITING = [
 	'move-to-trash',
 ];
 
-export default function PostActions( { onActionPerformed } ) {
+export default function PostActions( { onActionPerformed, buttonProps } ) {
 	const { postType, item } = useSelect( ( select ) => {
 		const { getCurrentPostType, getCurrentPost } = select( editorStore );
 		return {
@@ -88,6 +88,7 @@ export default function PostActions( { onActionPerformed } ) {
 						! primaryActions.length && ! secondaryActions.length
 					}
 					className="editor-all-actions-button"
+					{ ...buttonProps }
 				/>
 			}
 			placement="bottom-end"


### PR DESCRIPTION
This PR fixes an alignment issue on the actions button in the details panel.

Before:
<img width="231" alt="Screenshot 2024-04-16 at 10 55 36" src="https://github.com/WordPress/gutenberg/assets/11271197/e20581ab-e749-4dc1-9d5c-85c483b203a3">

After:
<img width="221" alt="Screenshot 2024-04-16 at 10 55 09" src="https://github.com/WordPress/gutenberg/assets/11271197/a24b0ac7-c3ba-43c4-9279-c85a8bb9d951">



## Testing Instructions
Verified that the page actions on the details panel still work as expected and the button is now aligned.
