### PR TITLE
Fix: remove unused css from page panels styles.

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -1,11 +1,3 @@
-.edit-site-page-card__actions {
-	flex-shrink: 0;
-}
-
-.edit-site-page-panels__swap-template__confirm-modal__actions {
-	margin-top: $grid-unit-30;
-}
-
 .edit-site-change-status__content {
 	.components-popover__content {
 		min-width: 320px;


### PR DESCRIPTION
When removing page actions for their unification we missed the removal of the styles for edit-site-page-card__actions selector.
While removing the selector I noticed the other selector right below it (edit-site-page-panels__swap-template__confirm-modal__actions) also was not used. So I also removed it in this PR.

## Testing
Tried to swap a template of a page on the site editor and verified things worked as expected.

