### PR TITLE
Patterns: add a "All Template Parts" section

### DIFF
--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -40,8 +40,10 @@ export default function PatternsHeader( {
 		const templatePartArea = templatePartAreas.find(
 			( area ) => area.area === categoryId
 		);
-		title = templatePartArea?.label;
-		description = templatePartArea?.description;
+		title = templatePartArea?.label || __( 'All Template Parts' );
+		description =
+			templatePartArea?.description ||
+			__( 'Includes every template part defined for any area.' );
 	} else if ( type === PATTERN_TYPES.theme ) {
 		patternCategory = patternCategories.find(
 			( category ) => category.name === categoryId

--- a/packages/edit-site/src/components/page-patterns/search-items.js
+++ b/packages/edit-site/src/components/page-patterns/search-items.js
@@ -16,6 +16,7 @@ const { extractWords, getNormalizedSearchTerms, normalizeString } = unlock(
  * Internal dependencies
  */
 import {
+	TEMPLATE_PART_ALL_AREAS_CATEGORY,
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,
 	PATTERN_TYPES,
@@ -48,6 +49,7 @@ const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
  */
 export const searchItems = ( items = [], searchInput = '', config = {} ) => {
 	const normalizedSearchTerms = getNormalizedSearchTerms( searchInput );
+
 	// Filter patterns by category: the default category indicates that all patterns will be shown.
 	const onlyFilterByCategory =
 		config.categoryId !== PATTERN_DEFAULT_CATEGORY &&
@@ -100,6 +102,7 @@ function getItemSearchRank( item, searchTerm, config ) {
 
 	let rank =
 		categoryId === PATTERN_DEFAULT_CATEGORY ||
+		categoryId === TEMPLATE_PART_ALL_AREAS_CATEGORY ||
 		( categoryId === PATTERN_USER_CATEGORY &&
 			item.type === PATTERN_TYPES.user ) ||
 		hasCategory( item, categoryId )

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -38,6 +38,22 @@ function TemplatePartGroup( { areas, currentArea, currentType } ) {
 				<Heading level={ 2 }>{ __( 'Template parts' ) }</Heading>
 			</div>
 			<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
+				<CategoryItem
+					key="all"
+					count={ Object.values( areas )
+						.map(
+							( { templateParts } ) => templateParts?.length || 0
+						)
+						.reduce( ( acc, val ) => acc + val, 0 ) }
+					icon={ getTemplatePartIcon() } /* no name, so it provides the fallback icon */
+					label={ __( 'All template parts' ) }
+					id={ 'all-parts' }
+					type={ TEMPLATE_PART_POST_TYPE }
+					isActive={
+						currentArea === 'all-parts' &&
+						currentType === TEMPLATE_PART_POST_TYPE
+					}
+				/>
 				{ Object.entries( areas ).map(
 					( [ area, { label, templateParts } ] ) => (
 						<CategoryItem

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -21,6 +21,7 @@ export const TEMPLATE_ORIGINS = {
 	plugin: 'plugin',
 };
 export const TEMPLATE_PART_AREA_DEFAULT_CATEGORY = 'uncategorized';
+export const TEMPLATE_PART_ALL_AREAS_CATEGORY = 'all-parts';
 
 // Patterns.
 export const {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/59659

## What?

Adds a "All Template Parts" section in sidebar.

<img width="1309" alt="Captura de ecrã 2024-04-16, às 12 47 22" src="https://github.com/WordPress/gutenberg/assets/583546/2df8b6d7-7260-48c0-bc86-92acec78020a">

## Why?

This is part of consolidating the index view for Patterns. While we are aiming to merge Patterns & Parts in a single category, it's unclear at this point what we can do for 6.5. 

We need to support hybrid themes (classic themes that declare support for parts) and these access patterns through the wp-admin screen but templates through the site-editor screen. Migrating them to only use site-editor is in the works https://github.com/WordPress/gutenberg/issues/52150

This is an intermediate step to unblock https://github.com/WordPress/gutenberg/pull/60689 and continue progress. How/whether Patters/Templates can be consolidated will be revisited in a later step.

## How?

- 49af1ebf123fae3fd484129da7e8c2e5b4e58c4a Sidebar: add "All template parts" section.
- ac9201bef7fe811318f72d141d63c4ee95bc8a24 Content: add header.
- ee7810720987112d2443a88e82606bac01ac2153 Content: display all template parts when categoryId is `all-parts`.

## Testing Instructions

Visit the Patterns screen and scroll down to the Parts section of the sidebar. Click on the "All template parts". The expected result is that all parts are visible.