### PR TITLE
Block API: try separate controls registration

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -13,6 +13,10 @@ import {
 	getBlockType,
 } from '@wordpress/blocks';
 import { useContext, useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { InspectorControls, BlockControls } from '../../components';
 
 /**
  * Internal dependencies
@@ -37,12 +41,31 @@ const Edit = ( props ) => {
 		return null;
 	}
 
+	const controls = [];
+
+	if ( blockType.attributeControls?.length > 0 ) {
+		for ( const control of blockType.attributeControls ) {
+			const Wrapper =
+				control.type === 'toolbar' ? BlockControls : InspectorControls;
+
+			controls.push(
+				<Wrapper group={ control.group } key={ control.key }>
+					<control.Control { ...props } />
+				</Wrapper>
+			);
+		}
+	}
+
 	// `edit` and `save` are functions or components describing the markup
 	// with which a block is displayed. If `blockType` is valid, assign
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
 
-	return <Component { ...props } />;
+	return [
+		<Component { ...props } key="content">
+			{ controls }
+		</Component>,
+	];
 };
 
 const EditWithFilters = withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -6,23 +6,9 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, _x, isRTL } from '@wordpress/i18n';
-import {
-	ToolbarButton,
-	ToggleControl,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
-import {
-	AlignmentControl,
-	BlockControls,
-	InspectorControls,
-	RichText,
-	useBlockProps,
-	useSettings,
-	useBlockEditingMode,
-} from '@wordpress/block-editor';
+import { __, isRTL } from '@wordpress/i18n';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { formatLtr } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -31,65 +17,8 @@ import { useOnEnter } from './use-enter';
 
 const name = 'core/paragraph';
 
-function ParagraphRTLControl( { direction, setDirection } ) {
-	return (
-		isRTL() && (
-			<ToolbarButton
-				icon={ formatLtr }
-				title={ _x( 'Left to right', 'editor button' ) }
-				isActive={ direction === 'ltr' }
-				onClick={ () => {
-					setDirection( direction === 'ltr' ? undefined : 'ltr' );
-				} }
-			/>
-		)
-	);
-}
-
 function hasDropCapDisabled( align ) {
 	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
-}
-
-function DropCapControl( { clientId, attributes, setAttributes } ) {
-	// Please do not add a useSelect call to the paragraph block unconditionally.
-	// Every useSelect added to a (frequently used) block will degrade load
-	// and type performance. By moving it within InspectorControls, the subscription is
-	// now only added for the selected block(s).
-	const [ isDropCapFeatureEnabled ] = useSettings( 'typography.dropCap' );
-
-	if ( ! isDropCapFeatureEnabled ) {
-		return null;
-	}
-
-	const { align, dropCap } = attributes;
-
-	let helpText;
-	if ( hasDropCapDisabled( align ) ) {
-		helpText = __( 'Not available for aligned text.' );
-	} else if ( dropCap ) {
-		helpText = __( 'Showing large initial letter.' );
-	} else {
-		helpText = __( 'Toggle to show a large initial letter.' );
-	}
-
-	return (
-		<ToolsPanelItem
-			hasValue={ () => !! dropCap }
-			label={ __( 'Drop cap' ) }
-			onDeselect={ () => setAttributes( { dropCap: undefined } ) }
-			resetAllFilter={ () => ( { dropCap: undefined } ) }
-			panelId={ clientId }
-		>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Drop cap' ) }
-				checked={ !! dropCap }
-				onChange={ () => setAttributes( { dropCap: ! dropCap } ) }
-				help={ helpText }
-				disabled={ hasDropCapDisabled( align ) ? true : false }
-			/>
-		</ToolsPanelItem>
-	);
 }
 
 function ParagraphBlock( {
@@ -109,81 +38,49 @@ function ParagraphBlock( {
 		} ),
 		style: { direction },
 	} );
-	const blockEditingMode = useBlockEditingMode();
-
 	return (
-		<>
-			{ blockEditingMode === 'default' && (
-				<BlockControls group="block">
-					<AlignmentControl
-						value={ align }
-						onChange={ ( newAlign ) =>
-							setAttributes( {
-								align: newAlign,
-								dropCap: hasDropCapDisabled( newAlign )
-									? false
-									: dropCap,
-							} )
-						}
-					/>
-					<ParagraphRTLControl
-						direction={ direction }
-						setDirection={ ( newDirection ) =>
-							setAttributes( { direction: newDirection } )
-						}
-					/>
-				</BlockControls>
-			) }
-			<InspectorControls group="typography">
-				<DropCapControl
-					clientId={ clientId }
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-				/>
-			</InspectorControls>
-			<RichText
-				identifier="content"
-				tagName="p"
-				{ ...blockProps }
-				value={ content }
-				onChange={ ( newContent ) =>
-					setAttributes( { content: newContent } )
+		<RichText
+			identifier="content"
+			tagName="p"
+			{ ...blockProps }
+			value={ content }
+			onChange={ ( newContent ) =>
+				setAttributes( { content: newContent } )
+			}
+			onSplit={ ( value, isOriginal ) => {
+				let newAttributes;
+
+				if ( isOriginal || value ) {
+					newAttributes = {
+						...attributes,
+						content: value,
+					};
 				}
-				onSplit={ ( value, isOriginal ) => {
-					let newAttributes;
 
-					if ( isOriginal || value ) {
-						newAttributes = {
-							...attributes,
-							content: value,
-						};
-					}
+				const block = createBlock( name, newAttributes );
 
-					const block = createBlock( name, newAttributes );
-
-					if ( isOriginal ) {
-						block.clientId = clientId;
-					}
-
-					return block;
-				} }
-				onMerge={ mergeBlocks }
-				onReplace={ onReplace }
-				onRemove={ onRemove }
-				aria-label={
-					RichText.isEmpty( content )
-						? __(
-								'Empty block; start writing or type forward slash to choose a block'
-						  )
-						: __( 'Block: Paragraph' )
+				if ( isOriginal ) {
+					block.clientId = clientId;
 				}
-				data-empty={ RichText.isEmpty( content ) }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
-				data-custom-placeholder={ placeholder ? true : undefined }
-				__unstableEmbedURLOnPaste
-				__unstableAllowPrefixTransformations
-			/>
-		</>
+
+				return block;
+			} }
+			onMerge={ mergeBlocks }
+			onReplace={ onReplace }
+			onRemove={ onRemove }
+			aria-label={
+				RichText.isEmpty( content )
+					? __(
+							'Empty block; start writing or type forward slash to choose a block'
+					  )
+					: __( 'Block: Paragraph' )
+			}
+			data-empty={ RichText.isEmpty( content ) }
+			placeholder={ placeholder || __( 'Type / to choose a block' ) }
+			data-custom-placeholder={ placeholder ? true : undefined }
+			__unstableEmbedURLOnPaste
+			__unstableAllowPrefixTransformations
+		/>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is just an idea to resolved the problem of disabling/omitting controls by attribute keys, for (but not limited to) block bindings. We could use this also for locking non content attributes, and it could also allow site admins to granularly control what block attribute controls can be used.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
