### PR TITLE
Pattern page: fix deps for `onActionPerformed` useCallback

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -451,7 +451,7 @@ export default function DataviewsPatterns() {
 				} );
 			}
 		},
-		[ history ]
+		[ history, categoryId, type ]
 	);
 	const [ editAction, viewRevisionsAction ] = usePostActions(
 		onActionPerformed,


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/60659/files#r1567313940