### PR TITLE
Chore: Fix: Wrong JSDOC for an action return.

### DIFF
--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -371,7 +371,7 @@ Resolves the template for a page and displays both. If no path is given, attempt
 
 _Returns_
 
--   `number`: The resolved template ID for the page route.
+-   `Object`: Action object.
 
 ### setTemplate
 

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -222,7 +222,7 @@ export function setEditedPostContext( context ) {
  *
  * @deprecated
  *
- * @return {number} The resolved template ID for the page route.
+ * @return {Object} Action object.
  */
 export function setPage() {
 	deprecated( "dispatch( 'core/edit-site' ).setPage", {


### PR DESCRIPTION
The JSDoc for action setPage wrongly specifies it returns a number while in fact, it returns an action object with nothing. This PR fixes the issue.
This PR follows what was done for setNavigationPanelActiveMenu which is also deprecated and returns an action object with nothing.