### PR TITLE
postcss-plugins-preset: Do not add IE 10-11 prefixes

### DIFF
--- a/packages/postcss-plugins-preset/CHANGELOG.md
+++ b/packages/postcss-plugins-preset/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Updated `autoprefixer` options to no longer add IE 10-11 prefixes for CSS grid properties
+
 ## 5.8.0 (2024-09-19)
 
 ## 5.7.0 (2024-09-05)

--- a/packages/postcss-plugins-preset/lib/index.js
+++ b/packages/postcss-plugins-preset/lib/index.js
@@ -1,1 +1,1 @@
-module.exports = [ require( 'autoprefixer' )( { grid: true } ) ];
+module.exports = [ require( 'autoprefixer' ) ];


### PR DESCRIPTION
## What?
Instructs autoprefixer to no longer add prefixes for IE 10-11 compatibility

## Why?
Support for IE 11 has been removed

## How?
Removes the `grid` option from the autoprefixer options (see https://github.com/postcss/autoprefixer?tab=readme-ov-file#options for docs)
