### PR TITLE
Restore classic auto margin rule to its previous specificity.

### DIFF
--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -2,7 +2,7 @@
 // Specificity is kept at this level as many classic themes output
 // rules like figure { margin: 0; } which would break centering.
 // These rules should also not apply to direct children of flex layout blocks.
-:where(.editor-styles-wrapper) :where(:not(.is-layout-flex, .is-layout-grid)) > .wp-block {
+.editor-styles-wrapper :where(:not(.is-layout-flex, .is-layout-grid)) > .wp-block {
 	margin-left: auto;
 	margin-right: auto;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes bug introduced in #60154 and reported [here](https://github.com/WordPress/gutenberg/pull/60228#issuecomment-2058263455). Themes relying on this rule for editor styles might have seen some inadvertent changes with the specificity reduction.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Check that Gallery and Quote blocks are properly centred in the editor on Twenty Twenty theme.
2. Check that editor styles remain unbroken for other classic themes.

Note: in testing this I noticed that the auto margin rule is causing a discrepancy between editor and front-end in the Details block on both Twenty Twenty and TT1, but that's likely due to those themes not having targeted styles for that block such as they do for older blocks like Columns. It remains an issue regardless of the specificity of this rule, so shouldn't be a blocker for this PR.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1163" alt="Screenshot 2024-04-17 at 2 39 58 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/e332fe49-dcf5-4e68-87f0-b4642ebaf800">
