### PR TITLE
DataViews: add actions to list layout

### DIFF
--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -128,16 +128,16 @@ export default function DataViews( {
 				/>
 			</HStack>
 			<ViewComponent
-				fields={ _fields }
-				view={ view }
-				onChangeView={ onChangeView }
 				actions={ actions }
 				data={ data }
+				fields={ _fields }
 				getItemId={ getItemId }
 				isLoading={ isLoading }
+				onChangeView={ onChangeView }
 				onSelectionChange={ onSetSelection }
 				selection={ selection }
 				setOpenedFilter={ setOpenedFilter }
+				view={ view }
 			/>
 			<Pagination
 				view={ view }

--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -47,14 +47,23 @@ function DropdownMenuItemTrigger( { action, onClick } ) {
 	);
 }
 
-export function ActionWithModal( {
-	action,
-	items,
-	ActionTrigger,
-	onActionStart,
-	onActionPerformed,
-	isBusy,
-} ) {
+export function ActionModal( { action, item, closeModal, onActionStart, onActionPerformed } ) {
+	return (
+		<Modal
+			title={ action.modalHeader || action.label }
+			__experimentalHideHeader={ !! action.hideModalHeader }
+			onRequestClose={ closeModal }
+			overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
+				action.id
+			) }` }
+		>
+			<action.RenderModal items={ [ item ] } closeModal={ closeModal } onActionStart={ onActionStart } onActionPerformed={ onActionPerformed }
+/>
+		</Modal>
+	);
+}
+
+function ActionWithModal( { action, item, ActionTrigger, onActionStart, onActionPerformed, isBusy } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const actionTriggerProps = {
 		action,
@@ -64,28 +73,17 @@ export function ActionWithModal( {
 		items,
 		isBusy,
 	};
-	const { RenderModal, hideModalHeader } = action;
 	return (
 		<>
 			<ActionTrigger { ...actionTriggerProps } />
 			{ isModalOpen && (
-				<Modal
-					title={ action.modalHeader || action.label }
-					__experimentalHideHeader={ !! hideModalHeader }
-					onRequestClose={ () => {
-						setIsModalOpen( false );
-					} }
-					overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
-						action.id
-					) }` }
-				>
-					<RenderModal
-						items={ items }
-						closeModal={ () => setIsModalOpen( false ) }
-						onActionStart={ onActionStart }
-						onActionPerformed={ onActionPerformed }
-					/>
-				</Modal>
+				<ActionModal
+					action={ action }
+					item={ item }
+					closeModal={ () => setIsModalOpen( false ) }
+					onActionStart={ onActionStart }
+					onActionPerformed={ onActionPerformed}
+				/>
 			) }
 		</>
 	);

--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -91,7 +91,7 @@ export function ActionWithModal( {
 	);
 }
 
-function ActionsDropdownMenuGroup( { actions, item } ) {
+export function ActionsDropdownMenuGroup( { actions, item } ) {
 	return (
 		<DropdownMenuGroup>
 			{ actions.map( ( action ) => {

--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -47,7 +47,13 @@ function DropdownMenuItemTrigger( { action, onClick } ) {
 	);
 }
 
-export function ActionModal( { action, item, closeModal, onActionStart, onActionPerformed } ) {
+export function ActionModal( {
+	action,
+	items,
+	closeModal,
+	onActionStart,
+	onActionPerformed,
+} ) {
 	return (
 		<Modal
 			title={ action.modalHeader || action.label }
@@ -57,13 +63,24 @@ export function ActionModal( { action, item, closeModal, onActionStart, onAction
 				action.id
 			) }` }
 		>
-			<action.RenderModal items={ [ item ] } closeModal={ closeModal } onActionStart={ onActionStart } onActionPerformed={ onActionPerformed }
-/>
+			<action.RenderModal
+				items={ items }
+				closeModal={ closeModal }
+				onActionStart={ onActionStart }
+				onActionPerformed={ onActionPerformed }
+			/>
 		</Modal>
 	);
 }
 
-function ActionWithModal( { action, item, ActionTrigger, onActionStart, onActionPerformed, isBusy } ) {
+export function ActionWithModal( {
+	action,
+	items,
+	ActionTrigger,
+	onActionStart,
+	onActionPerformed,
+	isBusy,
+} ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const actionTriggerProps = {
 		action,
@@ -79,10 +96,10 @@ function ActionWithModal( { action, item, ActionTrigger, onActionStart, onAction
 			{ isModalOpen && (
 				<ActionModal
 					action={ action }
-					item={ item }
+					items={ items }
 					closeModal={ () => setIsModalOpen( false ) }
 					onActionStart={ onActionStart }
-					onActionPerformed={ onActionPerformed}
+					onActionPerformed={ onActionPerformed }
 				/>
 			) }
 		</>

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -412,6 +412,10 @@
 			}
 		}
 
+		.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+			opacity: 0;
+		}
+
 		&:not(.is-selected) {
 			.dataviews-view-list__primary-field {
 				color: $gray-900;
@@ -425,8 +429,12 @@
 				.dataviews-view-list__fields {
 					color: var(--wp-admin-theme-color);
 				}
+				.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+					opacity: 1;
+				}
 			}
 		}
+
 	}
 
 	li.is-selected,

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -514,6 +514,10 @@
 		}
 	}
 
+	.dataviews-item-actions {
+		padding-right: $grid-unit-40;
+	}
+
 	& + .dataviews-pagination {
 		justify-content: space-between;
 	}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -416,6 +416,7 @@
 			opacity: 0;
 		}
 
+		&:focus-within,
 		&.is-hovered,
 		&:hover {
 			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -528,6 +528,7 @@
 	}
 
 	.dataviews-item-actions {
+		padding-top: $grid-unit-20;
 		padding-right: $grid-unit-40;
 	}
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -406,14 +406,8 @@
 			position: relative;
 			border-radius: $grid-unit-05;
 
-			&::after {
-				position: absolute;
-				content: "";
-				top: 100%;
-				left: $grid-unit-30;
-				right: $grid-unit-30;
-				background: $gray-100;
-				height: 1px;
+			> * {
+				width: 100%;
 			}
 		}
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -452,7 +452,7 @@
 	}
 
 	.dataviews-view-list__item {
-		padding: $grid-unit-20 $grid-unit-40;
+		padding: $grid-unit-20 0 $grid-unit-20 $grid-unit-40;
 		width: 100%;
 		scroll-margin: $grid-unit-10 0;
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -412,14 +412,14 @@
 			}
 		}
 
-		.dataviews-item-actions .components-button {
+		.dataviews-view-list__item-actions .components-button {
 			opacity: 0;
 		}
 
 		&.is-selected,
 		&.is-hovered,
 		&:focus-within {
-			.dataviews-item-actions .components-button {
+			.dataviews-view-list__item-actions .components-button {
 				opacity: 1;
 			}
 		}
@@ -527,7 +527,7 @@
 		}
 	}
 
-	.dataviews-item-actions {
+	.dataviews-view-list__item-actions {
 		padding-top: $grid-unit-20;
 		padding-right: $grid-unit-40;
 	}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -401,6 +401,7 @@
 	li {
 		margin: 0;
 		cursor: pointer;
+		border-top: 1px solid $gray-100;
 
 		.dataviews-view-list__item-wrapper {
 			position: relative;
@@ -446,7 +447,6 @@
 		padding: $grid-unit-20 $grid-unit-40;
 		width: 100%;
 		scroll-margin: $grid-unit-10 0;
-		border-top: 1px solid $gray-100;
 
 		&:focus-visible {
 			&::before {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -412,14 +412,14 @@
 			}
 		}
 
-		.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+		.dataviews-item-actions .components-button {
 			opacity: 0;
 		}
 
-		&:focus-within,
+		&.is-selected,
 		&.is-hovered,
-		&:hover {
-			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+		&:focus-within {
+			.dataviews-item-actions .components-button {
 				opacity: 1;
 			}
 		}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -416,6 +416,13 @@
 			opacity: 0;
 		}
 
+		&.is-hovered,
+		&:hover {
+			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+				opacity: 1;
+			}
+		}
+
 		&:not(.is-selected) {
 			.dataviews-view-list__primary-field {
 				color: $gray-900;
@@ -428,9 +435,6 @@
 				.dataviews-view-list__primary-field,
 				.dataviews-view-list__fields {
 					color: var(--wp-admin-theme-color);
-				}
-				.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
-					opacity: 1;
 				}
 			}
 		}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -406,8 +406,14 @@
 			position: relative;
 			border-radius: $grid-unit-05;
 
-			> * {
-				width: 100%;
+			&::after {
+				position: absolute;
+				content: "";
+				top: 100%;
+				left: $grid-unit-30;
+				right: $grid-unit-30;
+				background: $gray-100;
+				height: 1px;
 			}
 		}
 

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -175,14 +175,14 @@ function GridItem( {
 }
 
 export default function ViewGrid( {
+	actions,
 	data,
 	fields,
-	view,
-	actions,
-	isLoading,
 	getItemId,
-	selection,
+	isLoading,
 	onSelectionChange,
+	selection,
+	view,
 } ) {
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -191,7 +191,7 @@ function ListItem( {
 						</HStack>
 					</CompositeItem>
 				</div>
-				{ actions && (
+				{ actions?.length > 0 && (
 					<HStack
 						spacing={ 1 }
 						justify="flex-end"

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -9,6 +9,7 @@ import * as Ariakit from '@ariakit/react';
  */
 import { useInstanceId } from '@wordpress/compose';
 import {
+	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
@@ -17,6 +18,7 @@ import {
 } from '@wordpress/components';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -155,9 +157,13 @@ function ListItem( {
 							<CompositeItem
 								store={ store }
 								render={
-									<Ariakit.MenuButton>
-										Menu
-									</Ariakit.MenuButton>
+									<Button
+										size="compact"
+										icon={ moreVertical }
+										label={ __( 'Actions' ) }
+										disabled={ ! actions.length }
+										className="dataviews-all-actions-button"
+									/>
 								}
 							/>
 							<Ariakit.Menu>

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -8,9 +8,9 @@ import clsx from 'clsx';
  */
 import { useInstanceId } from '@wordpress/compose';
 import {
-	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	Button,
 	Modal,
 	privateApis as componentsPrivateApis,
 	Spinner,
@@ -19,8 +19,8 @@ import {
 import {
 	useCallback,
 	useEffect,
-	useRef,
 	useMemo,
+	useRef,
 	useState,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -40,15 +40,15 @@ import type {
 import { ActionsDropdownMenuGroup } from './item-actions';
 
 interface Action {
-	modalHeader: string;
-	hideModalHeader: any;
-	isDestructive: boolean | undefined;
-	isPrimary: boolean;
-	icon: any;
-	isEligible: any;
-	id: string;
-	label: string;
 	callback: ( items: Item[] ) => void;
+	hideModalHeader: any;
+	icon: any;
+	id: string;
+	isDestructive: boolean | undefined;
+	isEligible: any;
+	isPrimary: boolean;
+	label: string;
+	modalHeader: string;
 	RenderModal: any;
 }
 
@@ -77,21 +77,21 @@ interface ListViewItemProps {
 }
 
 const {
-	DropdownMenuV2: DropdownMenu,
+	useCompositeStoreV2: useCompositeStore,
 	CompositeV2: Composite,
 	CompositeItemV2: CompositeItem,
 	CompositeRowV2: CompositeRow,
-	useCompositeStoreV2: useCompositeStore,
+	DropdownMenuV2: DropdownMenu,
 	kebabCase,
 } = unlock( componentsPrivateApis );
 
 function ListItem( {
 	actions,
 	id,
-	item,
 	isSelected,
-	onSelect,
+	item,
 	mediaField,
+	onSelect,
 	primaryField,
 	store,
 	visibleFields,

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -221,40 +221,38 @@ function ListItem( {
 																true
 															)
 														}
-													>
-														{ isModalOpen && (
-															<Modal
-																title={
-																	action.modalHeader ||
-																	action.label
-																}
-																__experimentalHideHeader={
-																	!! action.hideModalHeader
-																}
-																onRequestClose={ () =>
-																	setIsModalOpen(
-																		false
-																	)
-																}
-																overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
-																	action.id
-																) }` }
-															>
-																<action.RenderModal
-																	items={ [
-																		item,
-																	] }
-																	closeModal={ () =>
-																		setIsModalOpen(
-																			false
-																		)
-																	}
-																/>
-															</Modal>
-														) }
-													</Button>
+													/>
 												}
-											/>
+											>
+												{ isModalOpen && (
+													<Modal
+														title={
+															action.modalHeader ||
+															action.label
+														}
+														__experimentalHideHeader={
+															!! action.hideModalHeader
+														}
+														onRequestClose={ () =>
+															setIsModalOpen(
+																false
+															)
+														}
+														overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
+															action.id
+														) }` }
+													>
+														<action.RenderModal
+															items={ [ item ] }
+															closeModal={ () =>
+																setIsModalOpen(
+																	false
+																)
+															}
+														/>
+													</Modal>
+												) }
+											</CompositeItem>
 										</div>
 									);
 								}

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -100,6 +100,14 @@ function ListItem( {
 	const labelId = `${ id }-label`;
 	const descriptionId = `${ id }-description`;
 
+	const [ isHovered, setIsHovered ] = useState( false );
+	const handleMouseEnter = () => {
+		setIsHovered( true );
+	};
+	const handleMouseLeave = () => {
+		setIsHovered( false );
+	};
+
 	useEffect( () => {
 		if ( isSelected ) {
 			itemRef.current?.scrollIntoView( {
@@ -134,7 +142,10 @@ function ListItem( {
 			role="row"
 			className={ clsx( {
 				'is-selected': isSelected,
+				'is-hovered': isHovered,
 			} ) }
+			onMouseEnter={ handleMouseEnter }
+			onMouseLeave={ handleMouseLeave }
 		>
 			<HStack className="dataviews-view-list__item-wrapper">
 				<div role="gridcell">

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -11,7 +11,6 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
-	Modal,
 	privateApis as componentsPrivateApis,
 	Spinner,
 	VisuallyHidden,
@@ -37,7 +36,7 @@ import type {
 	ViewList as ViewListType,
 } from './types';
 
-import { ActionsDropdownMenuGroup } from './item-actions';
+import { ActionsDropdownMenuGroup, ActionModal } from './item-actions';
 
 interface Action {
 	callback: ( items: Item[] ) => void;
@@ -82,7 +81,6 @@ const {
 	CompositeItemV2: CompositeItem,
 	CompositeRowV2: CompositeRow,
 	DropdownMenuV2: DropdownMenu,
-	kebabCase,
 } = unlock( componentsPrivateApis );
 
 function ListItem( {
@@ -236,32 +234,15 @@ function ListItem( {
 												}
 											>
 												{ isModalOpen && (
-													<Modal
-														title={
-															action.modalHeader ||
-															action.label
-														}
-														__experimentalHideHeader={
-															!! action.hideModalHeader
-														}
-														onRequestClose={ () =>
+													<ActionModal
+														action={ action }
+														item={ item }
+														closeModal={ () =>
 															setIsModalOpen(
 																false
 															)
 														}
-														overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
-															action.id
-														) }` }
-													>
-														<action.RenderModal
-															items={ [ item ] }
-															closeModal={ () =>
-																setIsModalOpen(
-																	false
-																)
-															}
-														/>
-													</Modal>
+													/>
 												) }
 											</CompositeItem>
 										</div>

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -343,6 +343,24 @@ export default function ViewList( props: ListViewProps ) {
 		defaultActiveId: getItemDomId( selectedItem ),
 	} );
 
+	// Manage focused item, when the active one is removed from the list.
+	const isActiveIdInList = store.useState(
+		( state: { items: any[]; activeId: any } ) =>
+			state.items.some(
+				( item: { id: any } ) => item.id === state.activeId
+			)
+	);
+	useEffect( () => {
+		if ( ! isActiveIdInList ) {
+			// Prefer going down, except if there is no item below (last item), then go up (last item in list).
+			if ( store.down() ) {
+				store.move( store.down() );
+			} else if ( store.up() ) {
+				store.move( store.up() );
+			}
+		}
+	}, [ isActiveIdInList ] );
+
 	const hasData = data?.length;
 	if ( ! hasData ) {
 		return (

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -2,15 +2,15 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import * as Ariakit from '@ariakit/react';
 
 /**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
 import {
-	__experimentalHStack as HStack,
+	__experimentalHStack as HStack,		
 	__experimentalVStack as VStack,
-	privateApis as componentsPrivateApis,
 	Spinner,
 	VisuallyHidden,
 } from '@wordpress/components';
@@ -20,7 +20,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { unlock } from './lock-unlock';
 import type {
 	Data,
 	Item,
@@ -48,16 +47,9 @@ interface ListViewItemProps {
 	mediaField?: NormalizedField;
 	onSelect: ( item: Item ) => void;
 	primaryField?: NormalizedField;
+	store: any;
 	visibleFields: NormalizedField[];
 }
-import ItemActions from './item-actions';
-
-const {
-	useCompositeStoreV2: useCompositeStore,
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	CompositeRowV2: CompositeRow,
-} = unlock( componentsPrivateApis );
 
 function ListItem( {
 	actions,
@@ -67,6 +59,7 @@ function ListItem( {
 	onSelect,
 	mediaField,
 	primaryField,
+	store,
 	visibleFields,
 }: ListViewItemProps ) {
 	const itemRef = useRef< HTMLElement >( null );
@@ -84,8 +77,7 @@ function ListItem( {
 	}, [ isSelected ] );
 
 	return (
-		<CompositeRow
-			ref={ itemRef }
+		<Ariakit.CompositeRow
 			render={ <li /> }
 			role="row"
 			className={ clsx( {
@@ -94,7 +86,8 @@ function ListItem( {
 		>
 			<HStack className="dataviews-view-list__item-wrapper">
 				<div role="gridcell">
-					<CompositeItem
+					<Ariakit.CompositeItem
+						store={ store }
 						render={ <div /> }
 						role="button"
 						id={ id }
@@ -144,27 +137,27 @@ function ListItem( {
 								</div>
 							</VStack>
 						</HStack>
-					</CompositeItem>
+					</Ariakit.CompositeItem>
 				</div>
 				{ actions && (
 					<div role="gridcell">
-						<CompositeItem
-							// To be able to pass ItemActions directly, it should pass the incoming props to the underlying element:
-							// https://ariakit.org/guide/composition#custom-components-must-be-open-for-extension
-							render={ ( props: { actions: []; item: Item } ) => (
-								<ItemActions
-									actions={ props.actions }
-									item={ props.item }
-									isCompact
-								/>
-							) }
-							item={ item }
-							actions={ actions }
-						/>
+						<Ariakit.MenuProvider>
+							<Ariakit.CompositeItem
+								store={ store }
+								render={
+									<Ariakit.MenuButton>
+										Menu
+									</Ariakit.MenuButton>
+								}
+							/>
+							<Ariakit.Menu>
+								<Ariakit.MenuItem>Hello</Ariakit.MenuItem>
+							</Ariakit.Menu>
+						</Ariakit.MenuProvider>
 					</div>
 				) }
 			</HStack>
-		</CompositeRow>
+		</Ariakit.CompositeRow>
 	);
 }
 
@@ -209,7 +202,7 @@ export default function ViewList( props: ListViewProps ) {
 		[ baseId, getItemId ]
 	);
 
-	const store = useCompositeStore( {
+	const store = Ariakit.useCompositeStore( {
 		defaultActiveId: getItemDomId( selectedItem ),
 	} );
 
@@ -230,7 +223,7 @@ export default function ViewList( props: ListViewProps ) {
 	}
 
 	return (
-		<Composite
+		<Ariakit.Composite
 			id={ baseId }
 			render={ <ul /> }
 			className="dataviews-view-list"
@@ -249,10 +242,11 @@ export default function ViewList( props: ListViewProps ) {
 						onSelect={ onSelect }
 						mediaField={ mediaField }
 						primaryField={ primaryField }
+						store={ store }
 						visibleFields={ visibleFields }
 					/>
 				);
 			} ) }
-		</Composite>
+		</Ariakit.Composite>
 	);
 }

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -145,7 +145,10 @@ function ListItem( {
 			onMouseEnter={ handleMouseEnter }
 			onMouseLeave={ handleMouseLeave }
 		>
-			<HStack className="dataviews-view-list__item-wrapper">
+			<HStack
+				className="dataviews-view-list__item-wrapper"
+				alignment="top"
+			>
 				<div role="gridcell">
 					<CompositeItem
 						store={ store }

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -209,7 +209,7 @@ function ListItem( {
 					<HStack
 						spacing={ 1 }
 						justify="flex-end"
-						className="dataviews-item-actions"
+						className="dataviews-view-list__item-actions"
 						style={ {
 							flexShrink: '0',
 							width: 'auto',
@@ -280,7 +280,6 @@ function ListItem( {
 												icon={ moreVertical }
 												label={ __( 'Actions' ) }
 												disabled={ ! actions.length }
-												className="dataviews-all-actions-button"
 												onKeyDown={ ( event: {
 													key: string;
 													preventDefault: () => void;

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -279,6 +279,30 @@ function ListItem( {
 												label={ __( 'Actions' ) }
 												disabled={ ! actions.length }
 												className="dataviews-all-actions-button"
+												onKeyDown={ ( event: {
+													key: string;
+													preventDefault: () => any;
+												} ) => {
+													if (
+														event.key ===
+														'ArrowDown'
+													) {
+														// Prevent the default behaviour (open dropdown menu) and go down.
+														event.preventDefault();
+														store.move(
+															store.down()
+														);
+													}
+													if (
+														event.key === 'ArrowUp'
+													) {
+														// Prevent the default behavior (open dropdown menu) and go up.
+														event.preventDefault();
+														store.move(
+															store.up()
+														);
+													}
+												} }
 											/>
 										}
 									/>

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -116,7 +116,7 @@ function ListItem( {
 		}
 	}, [ isSelected ] );
 
-	const { primaryActions, eligibleActions } = useMemo( () => {
+	const { primaryAction, eligibleActions } = useMemo( () => {
 		// If an action is eligible for all items, doesn't need
 		// to provide the `isEligible` function.
 		const _eligibleActions = actions.filter(
@@ -126,7 +126,7 @@ function ListItem( {
 			( action ) => action.isPrimary && !! action.icon
 		);
 		return {
-			primaryActions: _primaryActions,
+			primaryAction: _primaryActions?.[ 0 ],
 			eligibleActions: _eligibleActions,
 		};
 	}, [ actions, item ] );
@@ -210,67 +210,58 @@ function ListItem( {
 							width: 'auto',
 						} }
 					>
-						{ !! primaryActions.length &&
-							primaryActions.map( ( action ) => {
-								if ( !! action.RenderModal ) {
-									return (
-										<div role="gridcell">
-											<CompositeItem
-												store={ store }
-												render={
-													<Button
-														label={ action.label }
-														icon={ action.icon }
-														isDestructive={
-															action.isDestructive
-														}
-														size="compact"
-														onClick={ () =>
-															setIsModalOpen(
-																true
-															)
-														}
-													/>
-												}
-											>
-												{ isModalOpen && (
-													<ActionModal
-														action={ action }
-														item={ item }
-														closeModal={ () =>
-															setIsModalOpen(
-																false
-															)
-														}
-													/>
-												) }
-											</CompositeItem>
-										</div>
-									);
-								}
-								return (
-									<div role="gridcell" key={ action.id }>
-										<CompositeItem
-											store={ store }
-											render={
-												<Button
-													label={ action.label }
-													icon={ action.icon }
-													isDestructive={
-														action.isDestructive
-													}
-													size="compact"
-													onClick={ () =>
-														action.callback( [
-															item,
-														] )
-													}
-												/>
+						{ primaryAction && !! primaryAction.RenderModal && (
+							<div role="gridcell">
+								<CompositeItem
+									store={ store }
+									render={
+										<Button
+											label={ primaryAction.label }
+											icon={ primaryAction.icon }
+											isDestructive={
+												primaryAction.isDestructive
+											}
+											size="compact"
+											onClick={ () =>
+												setIsModalOpen( true )
 											}
 										/>
-									</div>
-								);
-							} ) }
+									}
+								>
+									{ isModalOpen && (
+										<ActionModal
+											action={ primaryAction }
+											item={ item }
+											closeModal={ () =>
+												setIsModalOpen( false )
+											}
+										/>
+									) }
+								</CompositeItem>
+							</div>
+						) }
+						{ primaryAction && ! primaryAction.RenderModal && (
+							<div role="gridcell" key={ primaryAction.id }>
+								<CompositeItem
+									store={ store }
+									render={
+										<Button
+											label={ primaryAction.label }
+											icon={ primaryAction.icon }
+											isDestructive={
+												primaryAction.isDestructive
+											}
+											size="compact"
+											onClick={ () =>
+												primaryAction.callback( [
+													item,
+												] )
+											}
+										/>
+									}
+								/>
+							</div>
+						) }
 						<div role="gridcell">
 							<DropdownMenu
 								trigger={

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -9,8 +9,9 @@ import * as Ariakit from '@ariakit/react';
  */
 import { useInstanceId } from '@wordpress/compose';
 import {
-	__experimentalHStack as HStack,		
+	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	privateApis as componentsPrivateApis,
 	Spinner,
 	VisuallyHidden,
 } from '@wordpress/components';
@@ -20,6 +21,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { unlock } from './lock-unlock';
 import type {
 	Data,
 	Item,
@@ -51,6 +53,13 @@ interface ListViewItemProps {
 	visibleFields: NormalizedField[];
 }
 
+const {
+	CompositeV2: Composite,
+	CompositeItemV2: CompositeItem,
+	CompositeRowV2: CompositeRow,
+	useCompositeStoreV2: useCompositeStore,
+} = unlock( componentsPrivateApis );
+
 function ListItem( {
 	actions,
 	id,
@@ -77,7 +86,8 @@ function ListItem( {
 	}, [ isSelected ] );
 
 	return (
-		<Ariakit.CompositeRow
+		<CompositeRow
+			ref={ itemRef }
 			render={ <li /> }
 			role="row"
 			className={ clsx( {
@@ -86,7 +96,7 @@ function ListItem( {
 		>
 			<HStack className="dataviews-view-list__item-wrapper">
 				<div role="gridcell">
-					<Ariakit.CompositeItem
+					<CompositeItem
 						store={ store }
 						render={ <div /> }
 						role="button"
@@ -137,12 +147,12 @@ function ListItem( {
 								</div>
 							</VStack>
 						</HStack>
-					</Ariakit.CompositeItem>
+					</CompositeItem>
 				</div>
 				{ actions && (
 					<div role="gridcell">
 						<Ariakit.MenuProvider>
-							<Ariakit.CompositeItem
+							<CompositeItem
 								store={ store }
 								render={
 									<Ariakit.MenuButton>
@@ -157,7 +167,7 @@ function ListItem( {
 					</div>
 				) }
 			</HStack>
-		</Ariakit.CompositeRow>
+		</CompositeRow>
 	);
 }
 
@@ -202,7 +212,7 @@ export default function ViewList( props: ListViewProps ) {
 		[ baseId, getItemId ]
 	);
 
-	const store = Ariakit.useCompositeStore( {
+	const store = useCompositeStore( {
 		defaultActiveId: getItemDomId( selectedItem ),
 	} );
 
@@ -223,7 +233,7 @@ export default function ViewList( props: ListViewProps ) {
 	}
 
 	return (
-		<Ariakit.Composite
+		<Composite
 			id={ baseId }
 			render={ <ul /> }
 			className="dataviews-view-list"
@@ -247,6 +257,6 @@ export default function ViewList( props: ListViewProps ) {
 					/>
 				);
 			} ) }
-		</Ariakit.Composite>
+		</Composite>
 	);
 }

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -11,11 +11,18 @@ import {
 	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	Modal,
 	privateApis as componentsPrivateApis,
 	Spinner,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { useCallback, useEffect, useRef, useMemo } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 
@@ -33,6 +40,8 @@ import type {
 import { ActionsDropdownMenuGroup } from './item-actions';
 
 interface Action {
+	modalHeader: string;
+	hideModalHeader: any;
 	isDestructive: boolean | undefined;
 	isPrimary: boolean;
 	icon: any;
@@ -73,6 +82,7 @@ const {
 	CompositeItemV2: CompositeItem,
 	CompositeRowV2: CompositeRow,
 	useCompositeStoreV2: useCompositeStore,
+	kebabCase,
 } = unlock( componentsPrivateApis );
 
 function ListItem( {
@@ -114,6 +124,8 @@ function ListItem( {
 			eligibleActions: _eligibleActions,
 		};
 	}, [ actions, item ] );
+
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	return (
 		<CompositeRow
@@ -191,32 +203,61 @@ function ListItem( {
 					>
 						{ !! primaryActions.length &&
 							primaryActions.map( ( action ) => {
-								// TODO: make keyboard layout work.
-								// if (!!action.RenderModal) {
-								// 	return (
-								// 		<div role="gridcell">
-								// 			<CompositeItem
-								// 				store={store}
-								// 				render={<ActionWithModal
-								// 					key={action.id}
-								// 					action={action}
-								// 					item={item}
-								// 					ActionTrigger={({ action, onClick }: { action: Action, onClick: () => void }) => {
-								// 						return (
-								// 							<Button
-								// 								label={action.label}
-								// 								icon={action.icon}
-								// 								isDestructive={action.isDestructive}
-								// 								size="compact"
-								// 								onClick={onClick}
-								// 							/>
-								// 						);
-								// 					}}
-								// 				/>}
-								// 			/>
-								// 		</div>
-								// 	);
-								// }
+								if ( !! action.RenderModal ) {
+									return (
+										<div role="gridcell">
+											<CompositeItem
+												store={ store }
+												render={
+													<Button
+														label={ action.label }
+														icon={ action.icon }
+														isDestructive={
+															action.isDestructive
+														}
+														size="compact"
+														onClick={ () =>
+															setIsModalOpen(
+																true
+															)
+														}
+													>
+														{ isModalOpen && (
+															<Modal
+																title={
+																	action.modalHeader ||
+																	action.label
+																}
+																__experimentalHideHeader={
+																	!! action.hideModalHeader
+																}
+																onRequestClose={ () =>
+																	setIsModalOpen(
+																		false
+																	)
+																}
+																overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
+																	action.id
+																) }` }
+															>
+																<action.RenderModal
+																	items={ [
+																		item,
+																	] }
+																	closeModal={ () =>
+																		setIsModalOpen(
+																			false
+																		)
+																	}
+																/>
+															</Modal>
+														) }
+													</Button>
+												}
+											/>
+										</div>
+									);
+								}
 								return (
 									<div role="gridcell" key={ action.id }>
 										<CompositeItem

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -30,10 +30,13 @@ import type {
 	ViewList as ViewListType,
 } from './types';
 
+import { ActionsDropdownMenuGroup } from './item-actions';
+
 interface Action {
 	id: string;
 	label: string;
 	callback: ( items: Item[] ) => void;
+	RenderModal: any;
 }
 
 interface ListViewProps {
@@ -62,9 +65,6 @@ interface ListViewItemProps {
 
 const {
 	DropdownMenuV2: DropdownMenu,
-	DropdownMenuGroupV2: DropdownMenuGroup,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
 	CompositeV2: Composite,
 	CompositeItemV2: CompositeItem,
 	CompositeRowV2: CompositeRow,
@@ -179,23 +179,10 @@ function ListItem( {
 							}
 							placement="bottom-end"
 						>
-							<DropdownMenuGroup>
-								{ actions.map( ( action: Action ) => {
-									return (
-										<DropdownMenuItem
-											key={ action.id }
-											action={ action }
-											onClick={ () =>
-												action.callback( [ item ] )
-											}
-										>
-											<DropdownMenuItemLabel>
-												{ action.label }
-											</DropdownMenuItemLabel>
-										</DropdownMenuItem>
-									);
-								} ) }
-							</DropdownMenuGroup>
+							<ActionsDropdownMenuGroup
+								actions={ actions }
+								item={ item }
+							/>
 						</DropdownMenu>
 					</div>
 				) }

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -2,6 +2,9 @@
  * External dependencies
  */
 import clsx from 'clsx';
+// Import CompositeStore type, which is not exported from @wordpress/components.
+// eslint-disable-next-line no-restricted-imports
+import type { CompositeStore } from '@ariakit/react';
 
 /**
  * WordPress dependencies
@@ -40,15 +43,14 @@ import { ActionsDropdownMenuGroup, ActionModal } from './item-actions';
 
 interface Action {
 	callback: ( items: Item[] ) => void;
-	hideModalHeader: any;
 	icon: any;
 	id: string;
 	isDestructive: boolean | undefined;
-	isEligible: any;
-	isPrimary: boolean;
+	isEligible: ( item: Item ) => boolean | undefined;
+	isPrimary: boolean | undefined;
 	label: string;
 	modalHeader: string;
-	RenderModal: any;
+	RenderModal: ( props: any ) => JSX.Element;
 }
 
 interface ListViewProps {
@@ -71,7 +73,7 @@ interface ListViewItemProps {
 	mediaField?: NormalizedField;
 	onSelect: ( item: Item ) => void;
 	primaryField?: NormalizedField;
-	store: any;
+	store: CompositeStore;
 	visibleFields: NormalizedField[];
 }
 
@@ -281,7 +283,7 @@ function ListItem( {
 												className="dataviews-all-actions-button"
 												onKeyDown={ ( event: {
 													key: string;
-													preventDefault: () => any;
+													preventDefault: () => void;
 												} ) => {
 													if (
 														event.key ===

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -147,21 +147,23 @@ function ListItem( {
 						</HStack>
 					</CompositeItem>
 				</div>
-				<div role="gridcell">
-					<CompositeItem
-						// To be able to pass ItemActions directly, it should pass the incoming props to the underlying element:
-						// https://ariakit.org/guide/composition#custom-components-must-be-open-for-extension
-						render={ ( props ) => (
-							<ItemActions
-								actions={ props.actions }
-								item={ props.item }
-								isCompact
-							/>
-						) }
-						item={ item }
-						actions={ actions }
-					/>
-				</div>
+				{ actions && (
+					<div role="gridcell">
+						<CompositeItem
+							// To be able to pass ItemActions directly, it should pass the incoming props to the underlying element:
+							// https://ariakit.org/guide/composition#custom-components-must-be-open-for-extension
+							render={ ( props ) => (
+								<ItemActions
+									actions={ props.actions }
+									item={ props.item }
+									isCompact
+								/>
+							) }
+							item={ item }
+							actions={ actions }
+						/>
+					</div>
+				) }
 			</HStack>
 		</CompositeRow>
 	);

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -234,10 +234,12 @@ function ListItem( {
 									{ isModalOpen && (
 										<ActionModal
 											action={ primaryAction }
-											item={ item }
+											items={ [ item ] }
 											closeModal={ () =>
 												setIsModalOpen( false )
 											}
+											onActionStart={ () => {} }
+											onActionPerformed={ () => {} }
 										/>
 									) }
 								</CompositeItem>

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -152,13 +152,12 @@ export default function ViewList( props: ListViewProps ) {
 		data,
 		fields,
 		getItemId,
-		id: preferredId,
 		isLoading,
 		onSelectionChange,
 		selection,
 		view,
 	} = props;
-	const baseId = useInstanceId( ViewList, 'view-list', preferredId );
+	const baseId = useInstanceId( ViewList, 'view-list' );
 	const selectedItem = data?.findLast( ( item ) =>
 		selection.includes( item.id )
 	);

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -21,7 +21,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
-<<<<<<< HEAD:packages/dataviews/src/view-list.tsx
 import type {
 	Data,
 	Item,
@@ -30,28 +29,28 @@ import type {
 } from './types';
 
 interface ListViewProps {
-	view: ViewListType;
-	fields: NormalizedField[];
+	actions: [];
 	data: Data;
-	isLoading: boolean;
+	fields: NormalizedField[];
 	getItemId: ( item: Item ) => string;
+	id: string;
+	isLoading: boolean;
 	onSelectionChange: ( selection: Item[] ) => void;
 	selection: Item[];
-	id: string;
+	view: ViewListType;
 }
 
 interface ListViewItemProps {
+	actions: [];
 	id?: string;
-	item: Item;
 	isSelected: boolean;
-	onSelect: ( item: Item ) => void;
+	item: Item;
 	mediaField?: NormalizedField;
+	onSelect: ( item: Item ) => void;
 	primaryField?: NormalizedField;
 	visibleFields: NormalizedField[];
 }
-=======
 import ItemActions from './item-actions';
->>>>>>> c2605916bd (Use actions in the ListItem):packages/dataviews/src/view-list.js
 
 const {
 	useCompositeStoreV2: useCompositeStore,
@@ -152,7 +151,7 @@ function ListItem( {
 						<CompositeItem
 							// To be able to pass ItemActions directly, it should pass the incoming props to the underlying element:
 							// https://ariakit.org/guide/composition#custom-components-must-be-open-for-extension
-							render={ ( props ) => (
+							render={ ( props: { actions: []; item: Item } ) => (
 								<ItemActions
 									actions={ props.actions }
 									item={ props.item }

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import * as Ariakit from '@ariakit/react';
 
 /**
  * WordPress dependencies
@@ -31,8 +30,14 @@ import type {
 	ViewList as ViewListType,
 } from './types';
 
+interface Action {
+	id: string;
+	label: string;
+	callback: ( items: Item[] ) => void;
+}
+
 interface ListViewProps {
-	actions: [];
+	actions: Action[];
 	data: Data;
 	fields: NormalizedField[];
 	getItemId: ( item: Item ) => string;
@@ -44,7 +49,7 @@ interface ListViewProps {
 }
 
 interface ListViewItemProps {
-	actions: [];
+	actions: Action[];
 	id?: string;
 	isSelected: boolean;
 	item: Item;
@@ -56,6 +61,10 @@ interface ListViewItemProps {
 }
 
 const {
+	DropdownMenuV2: DropdownMenu,
+	DropdownMenuGroupV2: DropdownMenuGroup,
+	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
 	CompositeV2: Composite,
 	CompositeItemV2: CompositeItem,
 	CompositeRowV2: CompositeRow,
@@ -153,23 +162,41 @@ function ListItem( {
 				</div>
 				{ actions && (
 					<div role="gridcell">
-						<Ariakit.MenuProvider>
-							<CompositeItem
-								store={ store }
-								render={
-									<Button
-										size="compact"
-										icon={ moreVertical }
-										label={ __( 'Actions' ) }
-										disabled={ ! actions.length }
-										className="dataviews-all-actions-button"
-									/>
-								}
-							/>
-							<Ariakit.Menu>
-								<Ariakit.MenuItem>Hello</Ariakit.MenuItem>
-							</Ariakit.Menu>
-						</Ariakit.MenuProvider>
+						<DropdownMenu
+							trigger={
+								<CompositeItem
+									store={ store }
+									render={
+										<Button
+											size="compact"
+											icon={ moreVertical }
+											label={ __( 'Actions' ) }
+											disabled={ ! actions.length }
+											className="dataviews-all-actions-button"
+										/>
+									}
+								/>
+							}
+							placement="bottom-end"
+						>
+							<DropdownMenuGroup>
+								{ actions.map( ( action: Action ) => {
+									return (
+										<DropdownMenuItem
+											key={ action.id }
+											action={ action }
+											onClick={ () =>
+												action.callback( [ item ] )
+											}
+										>
+											<DropdownMenuItemLabel>
+												{ action.label }
+											</DropdownMenuItemLabel>
+										</DropdownMenuItem>
+									);
+								} ) }
+							</DropdownMenuGroup>
+						</DropdownMenu>
 					</div>
 				) }
 			</HStack>

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -149,14 +149,14 @@ function ListItem( {
 
 export default function ViewList( props: ListViewProps ) {
 	const {
-		view,
-		fields,
 		data,
-		isLoading,
+		fields,
 		getItemId,
+		id: preferredId,
+		isLoading,
 		onSelectionChange,
 		selection,
-		id: preferredId,
+		view,
 	} = props;
 	const baseId = useInstanceId( ViewList, 'view-list', preferredId );
 	const selectedItem = data?.findLast( ( item ) =>

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -21,6 +21,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
+<<<<<<< HEAD:packages/dataviews/src/view-list.tsx
 import type {
 	Data,
 	Item,
@@ -48,6 +49,9 @@ interface ListViewItemProps {
 	primaryField?: NormalizedField;
 	visibleFields: NormalizedField[];
 }
+=======
+import ItemActions from './item-actions';
+>>>>>>> c2605916bd (Use actions in the ListItem):packages/dataviews/src/view-list.js
 
 const {
 	useCompositeStoreV2: useCompositeStore,
@@ -57,6 +61,7 @@ const {
 } = unlock( componentsPrivateApis );
 
 function ListItem( {
+	actions,
 	id,
 	item,
 	isSelected,
@@ -142,6 +147,21 @@ function ListItem( {
 						</HStack>
 					</CompositeItem>
 				</div>
+				<div role="gridcell">
+					<CompositeItem
+						// To be able to pass ItemActions directly, it should pass the incoming props to the underlying element:
+						// https://ariakit.org/guide/composition#custom-components-must-be-open-for-extension
+						render={ ( props ) => (
+							<ItemActions
+								actions={ props.actions }
+								item={ props.item }
+								isCompact
+							/>
+						) }
+						item={ item }
+						actions={ actions }
+					/>
+				</div>
 			</HStack>
 		</CompositeRow>
 	);
@@ -149,6 +169,7 @@ function ListItem( {
 
 export default function ViewList( props: ListViewProps ) {
 	const {
+		actions,
 		data,
 		fields,
 		getItemId,
@@ -221,6 +242,7 @@ export default function ViewList( props: ListViewProps ) {
 					<ListItem
 						key={ id }
 						id={ id }
+						actions={ actions }
 						item={ item }
 						isSelected={ item === selectedItem }
 						onSelect={ onSelect }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -362,16 +362,16 @@ function TableRow( {
 }
 
 function ViewTable( {
-	view,
-	onChangeView,
-	fields,
 	actions,
 	data,
+	fields,
 	getItemId,
 	isLoading = false,
-	selection,
+	onChangeView,
 	onSelectionChange,
+	selection,
 	setOpenedFilter,
+	view,
 } ) {
 	const headerMenuRefs = useRef( new Map() );
 	const headerMenuToFocusRef = useRef();


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59659 and https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/59637
Fixes https://github.com/WordPress/gutenberg/issues/61555

## What?

This PR adds support for actions in list layout, which is only enabled for Pages and Templates as of now:

| Pages | Templates |
| --- | --- |
| <img width="1512" alt="Captura de ecrã 2024-05-10, às 11 49 29" src="https://github.com/WordPress/gutenberg/assets/583546/53bca771-e1b7-422e-af97-e8864027c615"> |  <img width="1512" alt="Captura de ecrã 2024-05-10, às 11 49 23" src="https://github.com/WordPress/gutenberg/assets/583546/f0f264c3-61cc-407b-b788-2781aec6cc24"> |

This PR also enables two-dimensional arrow-key navigation:

https://github.com/WordPress/gutenberg/assets/583546/81c24287-3f53-4744-bbc6-efd7948e0e2f

## Why?

We want to make them available. See https://github.com/WordPress/gutenberg/issues/59659

## How?

- Pass the existing `actions` prop that any other layout is using to the list view layout.
- Add two-dimensional arrow navigation to the list items, so users can use right/left arrow keys to move between the element and its actions.

## Testing Instructions

- Go to a page with list view (Pages or Templates) and verify the actions are present.
- Navigate via keyboard to verify that it works as expected:
  - The item list is a single tab stop.
  - You can vertically through the list via up/down arrow keys.
  - You can move horizontally within a single item via right/left arrow keys.
