### PR TITLE
Editor: Use hook instead of HoC in 'ThemeSupportCheck'

### DIFF
--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -9,12 +9,14 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editorStore } from '../../store';
 
-export function ThemeSupportCheck( {
-	themeSupports,
-	children,
-	postType,
-	supportKeys,
-} ) {
+export default function ThemeSupportCheck( { children, supportKeys } ) {
+	const { postType, themeSupports } = useSelect( ( select ) => {
+		return {
+			postType: select( editorStore ).getEditedPostAttribute( 'type' ),
+			themeSupports: select( coreStore ).getThemeSupports(),
+		};
+	}, [] );
+
 	const isSupported = (
 		Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ]
 	).some( ( key ) => {
@@ -35,12 +37,3 @@ export function ThemeSupportCheck( {
 
 	return children;
 }
-
-export default withSelect( ( select ) => {
-	const { getThemeSupports } = select( coreStore );
-	const { getEditedPostAttribute } = select( editorStore );
-	return {
-		postType: getEditedPostAttribute( 'type' ),
-		themeSupports: getThemeSupports(),
-	};
-} )( ThemeSupportCheck );

--- a/packages/editor/src/components/theme-support-check/test/index.js
+++ b/packages/editor/src/components/theme-support-check/test/index.js
@@ -4,26 +4,37 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { ThemeSupportCheck } from '../index';
+import ThemeSupportCheck from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+
+function setupUseSelectMock( themeSupports = {}, postType = 'post' ) {
+	useSelect.mockImplementation( ( cb ) => {
+		return cb( () => ( {
+			getEditedPostAttribute: () => postType,
+			getThemeSupports: () => themeSupports,
+		} ) );
+	} );
+}
 
 describe( 'ThemeSupportCheck', () => {
 	it( "should not render if there's no support check provided", () => {
+		setupUseSelectMock( { 'post-thumbnails': true } );
 		render( <ThemeSupportCheck>foobar</ThemeSupportCheck> );
 		expect( screen.queryByText( 'foobar' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if post-thumbnails are supported', () => {
-		const themeSupports = {
-			'post-thumbnails': true,
-		};
-		const supportKeys = 'post-thumbnails';
+		setupUseSelectMock( { 'post-thumbnails': true } );
 		render(
-			<ThemeSupportCheck
-				supportKeys={ supportKeys }
-				themeSupports={ themeSupports }
-			>
+			<ThemeSupportCheck supportKeys="post-thumbnails">
 				foobar
 			</ThemeSupportCheck>
 		);
@@ -31,16 +42,14 @@ describe( 'ThemeSupportCheck', () => {
 	} );
 
 	it( 'should render if post-thumbnails are supported for the post type', () => {
-		const themeSupports = {
-			'post-thumbnails': [ 'post' ],
-		};
-		const supportKeys = 'post-thumbnails';
+		setupUseSelectMock(
+			{
+				'post-thumbnails': [ 'post' ],
+			},
+			'post'
+		);
 		render(
-			<ThemeSupportCheck
-				supportKeys={ supportKeys }
-				postType={ 'post' }
-				themeSupports={ themeSupports }
-			>
+			<ThemeSupportCheck supportKeys="post-thumbnails">
 				foobar
 			</ThemeSupportCheck>
 		);
@@ -48,16 +57,14 @@ describe( 'ThemeSupportCheck', () => {
 	} );
 
 	it( "should not render if post-thumbnails aren't supported for the post type", () => {
-		const themeSupports = {
-			'post-thumbnails': [ 'post' ],
-		};
-		const supportKeys = 'post-thumbnails';
+		setupUseSelectMock(
+			{
+				'post-thumbnails': [ 'post' ],
+			},
+			'page'
+		);
 		render(
-			<ThemeSupportCheck
-				supportKeys={ supportKeys }
-				postType={ 'page' }
-				themeSupports={ themeSupports }
-			>
+			<ThemeSupportCheck supportKeys="post-thumbnails">
 				foobar
 			</ThemeSupportCheck>
 		);
@@ -65,16 +72,14 @@ describe( 'ThemeSupportCheck', () => {
 	} );
 
 	it( 'should not render if post-thumbnails is limited and false is passed for postType', () => {
-		const themeSupports = {
-			'post-thumbnails': [ 'post' ],
-		};
-		const supportKeys = 'post-thumbnails';
+		setupUseSelectMock(
+			{
+				'post-thumbnails': [ 'post' ],
+			},
+			false
+		);
 		render(
-			<ThemeSupportCheck
-				supportKeys={ supportKeys }
-				postType={ false }
-				themeSupports={ themeSupports }
-			>
+			<ThemeSupportCheck supportKeys="post-thumbnails">
 				foobar
 			</ThemeSupportCheck>
 		);
@@ -82,15 +87,11 @@ describe( 'ThemeSupportCheck', () => {
 	} );
 
 	it( "should not render if theme doesn't support post-thumbnails", () => {
-		const themeSupports = {
+		setupUseSelectMock( {
 			'post-thumbnails': false,
-		};
-		const supportKeys = 'post-thumbnails';
+		} );
 		render(
-			<ThemeSupportCheck
-				supportKeys={ supportKeys }
-				themeSupports={ themeSupports }
-			>
+			<ThemeSupportCheck supportKeys="post-thumbnails">
 				foobar
 			</ThemeSupportCheck>
 		);


### PR DESCRIPTION
## What?
PR updates the `ThemeSupportCheck` component to use data hooks instead of HoCs.

## Why?
A micro-optimization makes the rendered component tree smaller.

Similar to #53235.

## Testing Instructions
1. Using TT4 theme.
2. Open a post
3. Confirm that the post thumbnail component is displayed as before in the document settings sidebar.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-17 at 13 44 20](https://github.com/WordPress/gutenberg/assets/240569/bfe029c3-f378-4b82-ae86-1c1dbcfa7ece)