### PR TITLE
Respect reduced motion when engaging zoom out mode

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -487,8 +487,9 @@ body.is-zoomed-out {
 }
 
 .block-editor-iframe__html {
-	transition: all 0.3s;
 	transform-origin: top center;
+	transition: all 0.3s;
+	@include reduce-motion("transition");
 }
 
 .block-editor-iframe__html[style*="scale"] {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Respect reduce motion setting when engaging zoom out mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Consistent behaviour, plus the UI animation for scaling the entire canvas is quite a lot for those who prefer reduced motion.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the existing mixing for the transform.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Turn on your system wide reduce motion accessibility setting
2. Enable the zoom out experiment
3. Visit the site editor
4. Edit a page
5. Engage zoom out from the icon in the editor header
6. Notice no animation

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
