### PR TITLE
Fix: Don't allow selection of template parts that the user doesn't have the privileges to edit

### DIFF
--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -3,6 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 import { useEffect } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
@@ -10,7 +11,6 @@ const CONTENT_ONLY_BLOCKS = applyFilters( 'editor.postContentBlockTypes', [
 	'core/post-title',
 	'core/post-featured-image',
 	'core/post-content',
-	'core/template-part',
 ] );
 
 /**
@@ -21,6 +21,14 @@ export default function DisableNonPageContentBlocks() {
 	const contentOnlyIds = useSelect( ( select ) => {
 		const { getBlocksByName, getBlockParents, getBlockName } =
 			select( blockEditorStore );
+
+		const canEditTemplate =
+			select( coreStore ).canUser( 'create', 'templates' ) ?? false;
+
+		if ( canEditTemplate ) {
+			CONTENT_ONLY_BLOCKS.push( 'core/template-part' );
+		}
+
 		return getBlocksByName( CONTENT_ONLY_BLOCKS ).filter( ( clientId ) =>
 			getBlockParents( clientId ).every( ( parentClientId ) => {
 				const parentBlockName = getBlockName( parentClientId );

--- a/packages/editor/src/components/provider/test/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/test/disable-non-page-content-blocks.js
@@ -40,34 +40,44 @@ describe( 'DisableNonPageContentBlocks', () => {
 			type: 'UNSET_BLOCK_EDITING_MODE',
 		} ) );
 
-		const registry = createRegistry( {
-			'core/block-editor': {
-				reducer: () => {},
-				selectors: {
-					getBlocksByName( state, blockNames ) {
-						return Object.keys( testBlocks ).filter( ( clientId ) =>
-							blockNames.includes( testBlocks[ clientId ] )
-						);
-					},
-					getBlockParents( state, clientId ) {
-						return clientId.slice( 0, -1 ).split( '' );
-					},
-					getBlockName( state, clientId ) {
-						return testBlocks[ clientId ];
-					},
-					getBlockOrder( state, rootClientId ) {
-						return Object.keys( testBlocks ).filter(
-							( clientId ) =>
-								clientId.startsWith( rootClientId ) &&
-								clientId !== rootClientId
-						);
-					},
+		const registry = createRegistry();
+
+		registry.registerStore( 'core/block-editor', {
+			reducer: () => {},
+			selectors: {
+				getBlocksByName( state, blockNames ) {
+					return Object.keys( testBlocks ).filter( ( clientId ) =>
+						blockNames.includes( testBlocks[ clientId ] )
+					);
 				},
-				actions: {
-					setBlockEditingMode,
-					unsetBlockEditingMode,
+				getBlockParents( state, clientId ) {
+					return clientId.slice( 0, -1 ).split( '' );
+				},
+				getBlockName( state, clientId ) {
+					return testBlocks[ clientId ];
+				},
+				getBlockOrder( state, rootClientId ) {
+					return Object.keys( testBlocks ).filter(
+						( clientId ) =>
+							clientId.startsWith( rootClientId ) &&
+							clientId !== rootClientId
+					);
 				},
 			},
+			actions: {
+				setBlockEditingMode,
+				unsetBlockEditingMode,
+			},
+		} );
+
+		registry.registerStore( 'core', {
+			reducer: () => {},
+			selectors: {
+				canUser() {
+					return true;
+				},
+			},
+			actions: {},
 		} );
 
 		const { unmount } = render(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove the ability to select the core template part whilst editing the content of a post for users who don't have the privileges to edit the template part.

This was split out from #60447 as per @noisysocks [request](https://github.com/WordPress/gutenberg/pull/60447/files#r1556853779) :) 


**Before**

https://github.com/WordPress/gutenberg/assets/20684594/f320920c-cf8e-48f8-8a2d-4cad8b5e6cda


**After**

https://github.com/WordPress/gutenberg/assets/20684594/0207d6b5-c325-47a2-9b4f-3160cabad741


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it is confusing to allow the selection of a block that doesn't allow you to do anything with it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We are adding a check whether the current user is able to edit a template part before we add the `core/template-part` to the list of blocks that can be selected in the content-only locked mode. 
