### PR TITLE
DataViews: make the experiment about custom views

### DIFF
--- a/lib/experimental/data-views.php
+++ b/lib/experimental/data-views.php
@@ -10,7 +10,7 @@
  */
 function _gutenberg_register_data_views_post_type() {
 	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-	if ( empty( $gutenberg_experiments ) || ! array_key_exists( 'gutenberg-dataviews', $gutenberg_experiments ) ) {
+	if ( empty( $gutenberg_experiments ) || ! array_key_exists( 'gutenberg-custom-dataviews', $gutenberg_experiments ) ) {
 		return;
 	}
 	register_post_type(

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -16,7 +16,7 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-zoomed-out-view', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomedOutView = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-dataviews', $gutenberg_experiments ) ) {
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-custom-dataviews', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalCustomViews = true', 'before' );
 	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-color-randomizer', $gutenberg_experiments ) ) {

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -17,7 +17,7 @@ function gutenberg_enable_experiments() {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomedOutView = true', 'before' );
 	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-dataviews', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalAdminViews = true', 'before' );
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalCustomViews = true', 'before' );
 	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-color-randomizer', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableColorRandomizer = true', 'before' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -69,12 +69,12 @@ function gutenberg_initialize_experiments_settings() {
 
 	add_settings_field(
 		'gutenberg-custom-dataviews',
-		__( 'New admin views', 'gutenberg' ),
+		__( 'Custom dataviews', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Test the new views for different entities like pages.', 'gutenberg' ),
+			'label' => __( 'Test the custom dataviews in the pages page.', 'gutenberg' ),
 			'id'    => 'gutenberg-custom-dataviews',
 		)
 	);

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -68,14 +68,14 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-dataviews',
+		'gutenberg-custom-dataviews',
 		__( 'New admin views', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
 			'label' => __( 'Test the new views for different entities like pages.', 'gutenberg' ),
-			'id'    => 'gutenberg-dataviews',
+			'id'    => 'gutenberg-custom-dataviews',
 		)
 	);
 

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -48,7 +48,7 @@ export default function DataViewsSidebarContent() {
 					);
 				} ) }
 			</ItemGroup>
-			{ window?.__experimentalAdminViews && (
+			{ window?.__experimentalCustomViews && (
 				<CustomDataViewsList
 					activeView={ activeView }
 					type={ type }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Renames the "dataviews" experiment to be a "custom dataviews" experiment.

## Why?

All of the DataViews work is now stable apart from the "custom dataviews".

## How?

- [Rename __experimentalAdminViews to __experimentalCustomViews](https://github.com/WordPress/gutenberg/commit/d69f5b08800b1a13634c414a3db1d3218a00e89d)
- [Rename gutenberg-dataviews to gutenberg-custom-dataviews](https://github.com/WordPress/gutenberg/commit/952c7c1aba481536fc43a11c9123ca12a229aebe)
- [Update text for experiment](https://github.com/WordPress/gutenberg/commit/80b68adccae18434c0bc26055e50ada9ecf5888d)

## Testing Instructions

Go to "Gutenberg > Experiments" and enable/disable it. When it's enabled, if you visit the Pages page, you should see the "Custom Views" in the sidebar. If it's not, they'll not be displayed.
