### PR TITLE
Chore: Simplify some CSS margin rules.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/style.scss
@@ -34,9 +34,8 @@
 }
 
 .edit-site-sidebar-navigation-screen-page__modified {
-	margin: 0 0 $grid-unit-20 0;
+	margin: 0 0 $grid-unit-20 $grid-unit-20;
 	color: $gray-600;
-	margin-left: $grid-unit-20;
 	.components-text {
 		color: $gray-600;
 	}

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -33,9 +33,8 @@
 }
 
 .edit-site-sidebar-navigation-screen__meta {
-	margin: 0 0 $grid-unit-20 0;
+	margin: 0 0 $grid-unit-20 $grid-unit-20;
 	color: $gray-400;
-	margin-left: $grid-unit-20;
 	.components-text {
 		color: $gray-400;
 	}


### PR DESCRIPTION
Replaces the two rules: "margin: 0 0 $grid-unit-20 0; margin-left: $grid-unit-20;" with just one margin: 0 0 $grid-unit-20 $grid-unit-20;.