### PR TITLE
Update: Reference editor scope instead of edit-site, edit-post on interface package docs

### DIFF
--- a/packages/interface/src/components/complementary-area-more-menu-item/README.md
+++ b/packages/interface/src/components/complementary-area-more-menu-item/README.md
@@ -5,7 +5,7 @@ Props not referenced here are passed to the component used to render the menu it
 
 ### scope
 
-The scope of the complementary area e.g: "core/edit-post", "core/edit-site", "myplugin/custom-screen-a",
+The scope of the complementary area e.g: "core", "myplugin/custom-screen-a",
 
 -   Type: `String`
 -   Required: Yes

--- a/packages/interface/src/components/complementary-area-toggle/README.md
+++ b/packages/interface/src/components/complementary-area-toggle/README.md
@@ -6,7 +6,7 @@
 
 ### scope
 
-The scope of the complementary area e.g: "core/edit-post", "core/edit-site", "myplugin/custom-screen-a",
+The scope of the complementary area e.g: "core", "myplugin/custom-screen-a",
 
 -   Type: `String`
 -   Required: Yes

--- a/packages/interface/src/components/complementary-area/README.md
+++ b/packages/interface/src/components/complementary-area/README.md
@@ -79,7 +79,7 @@ A className passed to the panel that contains the contents of the sidebar.
 
 ### scope
 
-The scope of the complementary area e.g: "core/edit-post", "core/edit-site", "myplugin/custom-screen-a",
+The scope of the complementary area e.g: "core", "myplugin/custom-screen-a",
 
 -   Type: `String`
 -   Required: Yes
@@ -114,7 +114,7 @@ A slot that renders the currently active ComplementaryArea.
 
 ### scope
 
-The scope of the complementary area e.g: "core/edit-post", "core/edit-site", "myplugin/custom-screen-a",
+The scope of the complementary area e.g: "core", "myplugin/custom-screen-a",
 
 -   Type: `String`
 -   Required: Yes

--- a/packages/interface/src/components/pinned-items/README.md
+++ b/packages/interface/src/components/pinned-items/README.md
@@ -15,7 +15,7 @@ The content to be displayed for the pinned items. Most of the time, a button wit
 
 ### scope
 
-The scope of the pinned items area e.g: "core/edit-post", "core/edit-site", "myplugin/custom-screen-a",
+The scope of the pinned items area e.g: "core", "myplugin/custom-screen-a",
 
 -   Type: `String`
 -   Required: Yes
@@ -28,7 +28,7 @@ A slot that renders the pinned items.
 
 ### scope
 
-The scope of the pinned items area e.g: "core/edit-post", "core/edit-site", "myplugin/custom-screen-a",
+The scope of the pinned items area e.g: "core", "myplugin/custom-screen-a",
 
 -   Type: `String`
 -   Required: Yes


### PR DESCRIPTION
Fixes a detail I missed while reviewing https://github.com/WordPress/gutenberg/pull/60778. It updates the documentation of some artifacts to reference the new editor scope instead of edit-site and edit-post that we were using before.

## Screenshots or screencast <!-- if applicable -->
