### PR TITLE
DataViews: Fix typing in combobox filter

### DIFF
--- a/packages/dataviews/src/search-widget.js
+++ b/packages/dataviews/src/search-widget.js
@@ -39,6 +39,7 @@ function normalizeSearchInput( input = '' ) {
 	return removeAccents( input.trim().toLowerCase() );
 }
 
+const EMPTY_ARRAY = [];
 const getCurrentValue = ( filterDefinition, currentFilter ) => {
 	if ( filterDefinition.singleSelection ) {
 		return currentFilter?.value;
@@ -52,7 +53,7 @@ const getCurrentValue = ( filterDefinition, currentFilter ) => {
 		return [ currentFilter.value ];
 	}
 
-	return [];
+	return EMPTY_ARRAY;
 };
 
 const getNewValue = ( filterDefinition, currentFilter, value ) => {

--- a/packages/dataviews/src/search-widget.js
+++ b/packages/dataviews/src/search-widget.js
@@ -190,7 +190,6 @@ function ComboboxList( { view, filter, onChangeView } ) {
 		( _filter ) => _filter.field === filter.field
 	);
 	const currentValue = getCurrentValue( filter, currentFilter );
-	const [ selectedValues, setSelectedValues ] = useState( currentValue );
 	const matches = useMemo( () => {
 		const normalizedSearch = normalizeSearchInput( deferredSearchValue );
 		return filter.elements.filter( ( item ) =>
@@ -199,9 +198,9 @@ function ComboboxList( { view, filter, onChangeView } ) {
 	}, [ filter.elements, deferredSearchValue ] );
 	return (
 		<Ariakit.ComboboxProvider
-			selectedValue={ selectedValues }
+			value={ searchValue }
+			selectedValue={ currentValue }
 			setSelectedValue={ ( value ) => {
-				setSelectedValues( value );
 				const newFilters = currentFilter
 					? [
 							...view.filters.map( ( _filter ) => {

--- a/packages/dataviews/src/search-widget.js
+++ b/packages/dataviews/src/search-widget.js
@@ -199,6 +199,7 @@ function ComboboxList( { view, filter, onChangeView } ) {
 	}, [ filter.elements, deferredSearchValue ] );
 	return (
 		<Ariakit.ComboboxProvider
+			resetValueOnSelect={ false }
 			selectedValue={ currentValue }
 			setSelectedValue={ ( value ) => {
 				const newFilters = currentFilter

--- a/packages/dataviews/src/search-widget.js
+++ b/packages/dataviews/src/search-widget.js
@@ -190,6 +190,7 @@ function ComboboxList( { view, filter, onChangeView } ) {
 		( _filter ) => _filter.field === filter.field
 	);
 	const currentValue = getCurrentValue( filter, currentFilter );
+	const [ selectedValues, setSelectedValues ] = useState( currentValue );
 	const matches = useMemo( () => {
 		const normalizedSearch = normalizeSearchInput( deferredSearchValue );
 		return filter.elements.filter( ( item ) =>
@@ -198,9 +199,9 @@ function ComboboxList( { view, filter, onChangeView } ) {
 	}, [ filter.elements, deferredSearchValue ] );
 	return (
 		<Ariakit.ComboboxProvider
-			value={ searchValue }
-			selectedValue={ currentValue }
+			selectedValue={ selectedValues }
 			setSelectedValue={ ( value ) => {
+				setSelectedValues( value );
 				const newFilters = currentFilter
 					? [
 							...view.filters.map( ( _filter ) => {

--- a/packages/dataviews/src/search-widget.js
+++ b/packages/dataviews/src/search-widget.js
@@ -199,7 +199,6 @@ function ComboboxList( { view, filter, onChangeView } ) {
 	}, [ filter.elements, deferredSearchValue ] );
 	return (
 		<Ariakit.ComboboxProvider
-			value={ searchValue }
 			selectedValue={ currentValue }
 			setSelectedValue={ ( value ) => {
 				const newFilters = currentFilter

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -263,7 +263,7 @@ export default function PagePages() {
 	} = useEntityRecords( 'postType', postType, queryArgs );
 
 	const { records: authors, isResolving: isLoadingAuthors } =
-		useEntityRecords( 'root', 'user' );
+		useEntityRecords( 'root', 'user', { per_page: -1 } );
 
 	const paginationInfo = useMemo(
 		() => ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

In Data Views filters when we have more than 10 available options we render a combobox. There was a regression introduced [here](https://github.com/WordPress/gutenberg/pull/59610), where you couldn't type in the combobox and filter the options.

## How

- https://github.com/WordPress/gutenberg/pull/60819/commits/5dc89c5292d2c5d86e0bf92ff2926d7252f4516a Do not return a new reference every time when it's empty.
- https://github.com/WordPress/gutenberg/pull/60819/commits/012af57e00dc072af8ed819f0d46a5507e0d29b0 Ensure the author list displays all authors, not just 10.

## Testing Instructions
1. With either having more than 10 authors or updating [this line](https://github.com/WordPress/gutenberg/blob/trunk/packages/dataviews/src/search-widget.js#L293) in code in order to render the combobox with fewer options
2. Go to pages list in site editor and test the `author` combobox filter
3. Ensure everything else regarding the filters work as expected, as before.

