### PR TITLE
Site Editor: Close the editor sidebar by default

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
@@ -21,6 +21,7 @@ export default function DefaultSidebar( {
 	header,
 	headerClassName,
 	panelClassName,
+	isActiveByDefault,
 } ) {
 	return (
 		<>
@@ -35,6 +36,7 @@ export default function DefaultSidebar( {
 				header={ header }
 				headerClassName={ headerClassName }
 				panelClassName={ panelClassName }
+				isActiveByDefault={ isActiveByDefault }
 			>
 				{ children }
 			</ComplementaryArea>

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -83,6 +83,7 @@ const FillContents = ( { tabName, isEditingPage, supportsGlobalStyles } ) => {
 				// margin to the panel.
 				// see https://github.com/WordPress/gutenberg/pull/55360#pullrequestreview-1737671049
 				className="edit-site-sidebar__panel"
+				isActiveByDefault
 			>
 				<Tabs.Context.Provider value={ tabsContextValue }>
 					<Tabs.TabPanel

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -14,7 +14,6 @@ import {
 	PluginMoreMenuItem,
 	PluginSidebar,
 	store as editorStore,
-	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -28,9 +27,6 @@ import {
 import './hooks';
 import { store as editSiteStore } from './store';
 import App from './components/app';
-import { unlock } from './lock-unlock';
-
-const { interfaceStore } = unlock( editorPrivateApis );
 
 /**
  * Initializes the site editor screen.
@@ -77,11 +73,6 @@ export function initializeEditor( id, settings ) {
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 	} );
-
-	dispatch( interfaceStore ).setDefaultComplementaryArea(
-		'core',
-		'edit-site/template'
-	);
 
 	dispatch( editSiteStore ).updateSettings( settings );
 

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -124,15 +124,25 @@ test.describe( 'Site Editor Performance', () => {
 				postType: 'page',
 			} );
 
-			// Run the test with the sidebar closed
-			await page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Close Settings' } )
-				.click();
-
 			// Enter edit mode (second click is needed for the legacy edit mode).
 			const canvas = await perfUtils.getCanvas();
 			await canvas.locator( 'body' ).click();
+
+			// Run the test with the sidebar closed
+			const toggleSidebarButton = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', {
+					name: 'Settings',
+					disabled: false,
+				} );
+			const isClosed =
+				( await toggleSidebarButton.getAttribute(
+					'aria-expanded'
+				) ) === 'false';
+			if ( ! isClosed ) {
+				await toggleSidebarButton.click();
+			}
+
 			await canvas
 				.getByRole( 'document', { name: /Block:( Post)? Content/ } )
 				.click();

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -117,12 +117,18 @@ test.describe( 'Site Editor Performance', () => {
 			draftId = await perfUtils.saveDraft();
 		} );
 
-		test( 'Run the test', async ( { admin, perfUtils, metrics } ) => {
+		test( 'Run the test', async ( { admin, perfUtils, metrics, page } ) => {
 			// Go to the test draft.
 			await admin.visitSiteEditor( {
 				postId: draftId,
 				postType: 'page',
 			} );
+
+			// Run the test with the sidebar closed
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Close Settings' } )
+				.click();
 
 			// Enter edit mode (second click is needed for the legacy edit mode).
 			const canvas = await perfUtils.getCanvas();


### PR DESCRIPTION
## What?

After #60778 was merged, the sidebar in the site editor became "open" by default and it used to be closed. This resulted in the performance "typing" test running with sidebar closed which resulted in showing a performance regression (there wasn't any).

This PR marks the sidebar as closed by default like it used to be.
