### PR TITLE
Fix: Use core instead of core/editor on normalizeComplementaryAreaScope.

### DIFF
--- a/packages/interface/src/store/deprecated.js
+++ b/packages/interface/src/store/deprecated.js
@@ -7,10 +7,10 @@ export function normalizeComplementaryAreaScope( scope ) {
 	if ( [ 'core/edit-post', 'core/edit-site' ].includes( scope ) ) {
 		deprecated( `${ scope } interface scope`, {
 			alternative:
-				'Use the core/editor interface scope instead. core/edit-post and core/edit-site are merging.',
+				'Use the core interface scope instead. core/edit-post and core/edit-site are merging.',
 			version: '6.6',
 		} );
-		return 'core/editor';
+		return 'core';
 	}
 
 	return scope;


### PR DESCRIPTION
I think during the iterations on PR https://github.com/WordPress/gutenberg/pull/60778 we missed the change of "core/editor" to "core".
cc: @youknowriad 