### PR TITLE
Fixes a link to the getEntityRecord documentation.

### DIFF
--- a/docs/how-to-guides/data-basics/3-building-an-edit-form.md
+++ b/docs/how-to-guides/data-basics/3-building-an-edit-form.md
@@ -120,7 +120,7 @@ Great! We now have a basic user interface to work with.
 
 We want the `EditPageForm` to display the title of the currently edited page. You may have noticed that it doesn't receive a `page` prop, only `pageId`. That's okay. Gutenberg Data allows us to easily access entity records from any component.
 
-In this case, we need to use the [`getEntityRecord`](/docs/reference-guides/data/data-core/#getentityrecord) selector. The list of records is already available thanks to the `getEntityRecords` call in `MyFirstApp`, so there won't even be any additional HTTP requests involved – we'll get the cached record right away.
+In this case, we need to use the [`getEntityRecord`](/docs/reference-guides/data/data-core.md#getentityrecord) selector. The list of records is already available thanks to the `getEntityRecords` call in `MyFirstApp`, so there won't even be any additional HTTP requests involved – we'll get the cached record right away.
 
 Here's how you can try it in your browser's dev tools:
 


### PR DESCRIPTION
The link /docs/reference-guides/data/data-core/#getentityrecord is invalid and does not work. It links to a folder named data-core instead of to a file data-core.md as it should.


## Testing Instructions
Verified the link https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/data/data-core.md#getentityrecord works.
