### PR TITLE
Block Bindings: rely on broader context instead of requiring direct block context

### DIFF
--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -51,6 +51,7 @@ export function registerBlockBindingsSource( source ) {
 		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
 		sourceName: source.name,
 		sourceLabel: source.label,
+		usesContext: source.usesContext,
 		getValue: source.getValue,
 		setValue: source.setValue,
 		getPlaceholder: source.getPlaceholder,

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -376,6 +376,7 @@ export function blockBindingsSources( state = {}, action ) {
 			...state,
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
+				usesContext: action.usesContext,
 				getValue: action.getValue,
 				setValue: action.setValue,
 				getPlaceholder: action.getPlaceholder,

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -12,6 +12,7 @@ import { store as editorStore } from '../store';
 export default {
 	name: 'core/post-meta',
 	label: _x( 'Post Meta', 'block bindings source' ),
+	usesContext: [ 'postId', 'postType' ],
 	getPlaceholder( { args } ) {
 		return args.key;
 	},


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR removes the need for bound block to have the context that a binding needs. Instead we can look at the broader context. I've opted to require a binding source to declare the context it needs, just to avoid passing all context down to the callbacks (not absolutely required though). This is very similar to how a block needs to declare what context it needs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Block bindings shouldn't have to affect the block registration, instead we can add the right context just in time.

I could see Bits work similarly: it can declare what context it needs without requiring the parent block to consume the context as well.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
