### PR TITLE
Drop patterns and blocks between sections only in zoom out mode

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -215,7 +215,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			const parentClientId = getBlockRootClientId( clientId );
 			const [ defaultLayout ] = getBlockSettings( clientId, 'layout' );
 
-			// in zoom out mode, we want to disable the drop zone for the sections.
+			// In zoom out mode, we want to disable the drop zone for the sections.
 			// The inner blocks belonging to the section drop zone is
 			// already disabled by the blocks themselves being disabled.
 			let _isDropZoneDisabled = blockEditingMode === 'disabled';

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -216,7 +216,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			const [ defaultLayout ] = getBlockSettings( clientId, 'layout' );
 
 			// in zoom out mode, we want to disable the drop zone for the sections.
-			// the inner blocks belonging to the section drop zone is
+			// The inner blocks belonging to the section drop zone is
 			// already disabled by the blocks themselves being disabled.
 			let _isDropZoneDisabled = blockEditingMode === 'disabled';
 			if ( __unstableGetEditorMode() === 'zoom-out' ) {

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -217,7 +217,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 
 			// in zoom out mode, we want to disable the drop zone for the sections.
 			// the inner blocks belonging to the section drop zone is
-			// already disabled by the blocks themselves being disabled
+			// already disabled by the blocks themselves being disabled.
 			let _isDropZoneDisabled = blockEditingMode === 'disabled';
 			if ( __unstableGetEditorMode() === 'zoom-out' ) {
 				const { sectionRootClientId } = unlock( getSettings() );

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -204,6 +204,8 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getBlockEditingMode,
 				getBlockSettings,
 				isDragging,
+				getSettings,
+				getBlockOrder,
 			} = unlock( select( blockEditorStore ) );
 			const { hasBlockSupport, getBlockType } = select( blocksStore );
 			const blockName = getBlockName( clientId );
@@ -212,6 +214,17 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			const blockEditingMode = getBlockEditingMode( clientId );
 			const parentClientId = getBlockRootClientId( clientId );
 			const [ defaultLayout ] = getBlockSettings( clientId, 'layout' );
+
+			// in zoom out mode, we want to disable the drop zone for the sections.
+			// the inner blocks belonging to the section drop zone is
+			// already disabled by the blocks themselves being disabled
+			let _isDropZoneDisabled = blockEditingMode === 'disabled';
+			if ( __unstableGetEditorMode() === 'zoom-out' ) {
+				const { sectionRootClientId } = unlock( getSettings() );
+				const sectionsClientIds = getBlockOrder( sectionRootClientId );
+				_isDropZoneDisabled = sectionsClientIds?.includes( clientId );
+			}
+
 			return {
 				__experimentalCaptureToolbars: hasBlockSupport(
 					blockName,
@@ -228,7 +241,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				blockType: getBlockType( blockName ),
 				parentLock: getTemplateLock( parentClientId ),
 				parentClientId,
-				isDropZoneDisabled: blockEditingMode === 'disabled',
+				isDropZoneDisabled: _isDropZoneDisabled,
 				defaultLayout,
 			};
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When zoom out mode is engaged the dragging operations from the inserter need to only allow dropping in between whatever we consider sections (1st children of the detected section root).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To avoid a bad experience considering the scaled down visuals, and the fact that once something is created via drag and drop inside a section it won't be selectable, because only sections are selectable, not their contents.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Disable the drop zone in zoom out mode for the section containers.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a template
2. Add some full width patterns
3. Group them all
4. Make the top group have a `main` tag
5. Engage zoom out mode
6. Try to drag a pattern or a block into the canvas
7. _Notice it can only be dropped in between sections_

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

**Before / Trunk**

https://github.com/WordPress/gutenberg/assets/107534/a1295e85-7a64-4971-80dd-d764647fcf72


**After / This PR**

https://github.com/WordPress/gutenberg/assets/107534/44d5003f-ba56-44e0-bc8f-6cfd718007f7



