### PR TITLE
Fix the removePropertyFromObject function throws an error if the object is null

### DIFF
--- a/packages/edit-site/src/hooks/use-theme-style-variations/test/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/test/use-theme-style-variations-by-property.js
@@ -1079,6 +1079,10 @@ describe( 'removePropertyFromObject', () => {
 		expect( removePropertyFromObject( object, 'color' ) ).toEqual( object );
 	} );
 
+	it( 'should return with null', () => {
+		expect( removePropertyFromObject( null, 'color' ) ).toEqual( null );
+	} );
+
 	it( 'should remove the specified property from the object', () => {
 		expect(
 			removePropertyFromObject(

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -28,7 +28,11 @@ export function removePropertyFromObject( object, property ) {
 		return object;
 	}
 
-	if ( typeof object !== 'object' || ! Object.keys( object ).length ) {
+	if (
+		typeof object !== 'object' ||
+		! object ||
+		! Object.keys( object ).length
+	) {
 		return object;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Prevent the `removePropertyFromObject` from throwing an error if the object is null. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes https://github.com/WordPress/gutenberg/issues/60830.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Return early before calling the `Object.keys` function if the object is null

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to `Styles > Blocks`
2. Pick a block, e.g.: Image
3. Scroll to the Border section, and click the `Unlink sides` icon to split the border
4. Change any side and save
5. Go to either `Styles > Typography` or `Styles > Colors`
6. The error shows

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
