### PR TITLE
Blocks: Merge variations bootstrapped from a server with the client definitions

### DIFF
--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -402,13 +402,19 @@ describe( 'blocks', () => {
 			const blockName = 'core/test-block-with-merged-settings';
 			unstable__bootstrapServerSideBlockDefinitions( {
 				[ blockName ]: {
-					variations: [ { name: 'foo', label: 'Foo' } ],
+					variations: [
+						{ name: 'foo', label: 'Foo' },
+						{ name: 'baz', label: 'Baz', description: 'Testing' },
+					],
 				},
 			} );
 
 			const blockType = {
 				title: 'block settings merge',
-				variations: [ { name: 'bar', label: 'Bar' } ],
+				variations: [
+					{ name: 'bar', label: 'Bar' },
+					{ name: 'baz', label: 'Baz', icon: 'layout' },
+				],
 			};
 			registerBlockType( blockName, blockType );
 			expect( getBlockType( blockName ) ).toEqual( {
@@ -425,6 +431,12 @@ describe( 'blocks', () => {
 				styles: [],
 				variations: [
 					{ name: 'foo', label: 'Foo' },
+					{
+						description: 'Testing',
+						name: 'baz',
+						label: 'Baz',
+						icon: 'layout',
+					},
 					{ name: 'bar', label: 'Bar' },
 				],
 				blockHooks: {},

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -398,6 +398,39 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		it( 'should merge settings provided by server and client', () => {
+			const blockName = 'core/test-block-with-merged-settings';
+			unstable__bootstrapServerSideBlockDefinitions( {
+				[ blockName ]: {
+					variations: [ { name: 'foo', label: 'Foo' } ],
+				},
+			} );
+
+			const blockType = {
+				title: 'block settings merge',
+				variations: [ { name: 'bar', label: 'Bar' } ],
+			};
+			registerBlockType( blockName, blockType );
+			expect( getBlockType( blockName ) ).toEqual( {
+				name: blockName,
+				save: expect.any( Function ),
+				title: 'block settings merge',
+				icon: { src: BLOCK_ICON_DEFAULT },
+				attributes: {},
+				providesContext: {},
+				usesContext: [],
+				keywords: [],
+				selectors: {},
+				supports: {},
+				styles: [],
+				variations: [
+					{ name: 'foo', label: 'Foo' },
+					{ name: 'bar', label: 'Bar' },
+				],
+				blockHooks: {},
+			} );
+		} );
+
 		// This test can be removed once the polyfill for blockHooks gets removed.
 		it( 'should polyfill blockHooks using metadata on the client when not set on the server', () => {
 			const blockName = 'tests/hooked-block';

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -34,6 +34,37 @@ const LEGACY_CATEGORY_MAPPING = {
 };
 
 /**
+ * Merge block variations bootstrapped from the server and client.
+ *
+ * When a variation is registered in both places, its properties are merged.
+ *
+ * @param {Array} bootstrappedVariations - A block type variations from the server.
+ * @param {Array} clientVariations       - A block type variations from the client.
+ * @return {Array} The merged array of block variations.
+ */
+function mergeBlockVariations(
+	bootstrappedVariations = [],
+	clientVariations = []
+) {
+	const result = [ ...bootstrappedVariations ];
+
+	clientVariations.forEach( ( clientVariation ) => {
+		const index = result.findIndex(
+			( bootstrappedVariation ) =>
+				bootstrappedVariation.name === clientVariation.name
+		);
+
+		if ( index !== -1 ) {
+			result[ index ] = { ...result[ index ], ...clientVariation };
+		} else {
+			result.push( clientVariation );
+		}
+	} );
+
+	return result;
+}
+
+/**
  * Takes the unprocessed block type settings, merges them with block type metadata
  * and applies all the existing filters for the registered block type.
  * Next, it validates all the settings and performs additional processing to the block type definition.
@@ -47,6 +78,7 @@ export const processBlockType =
 	( name, blockSettings ) =>
 	( { select } ) => {
 		const bootstrappedBlockType = select.getBootstrappedBlockType( name );
+
 		const blockType = {
 			name,
 			icon: BLOCK_ICON_DEFAULT,
@@ -61,10 +93,10 @@ export const processBlockType =
 			save: () => null,
 			...bootstrappedBlockType,
 			...blockSettings,
-			variations: [
-				...( bootstrappedBlockType?.variations || [] ),
-				...( blockSettings?.variations || [] ),
-			],
+			variations: mergeBlockVariations(
+				bootstrappedBlockType?.variations,
+				blockSettings?.variations
+			),
 		};
 
 		const settings = applyFilters(

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -46,6 +46,7 @@ const LEGACY_CATEGORY_MAPPING = {
 export const processBlockType =
 	( name, blockSettings ) =>
 	( { select } ) => {
+		const bootstrappedBlockType = select.getBootstrappedBlockType( name );
 		const blockType = {
 			name,
 			icon: BLOCK_ICON_DEFAULT,
@@ -56,11 +57,14 @@ export const processBlockType =
 			selectors: {},
 			supports: {},
 			styles: [],
-			variations: [],
 			blockHooks: {},
 			save: () => null,
-			...select.getBootstrappedBlockType( name ),
+			...bootstrappedBlockType,
 			...blockSettings,
+			variations: [
+				...( bootstrappedBlockType?.variations || [] ),
+				...( blockSettings?.variations || [] ),
+			],
 		};
 
 		const settings = applyFilters(


### PR DESCRIPTION
## What?
Resolves #60298.

PR updates the block type processing logic (`processBlockType`) to merge the `variations` settings provided by the server and client.

## Why?
Some block settings like `variations` should be merged.

## Testing Instructions
1. Add block variation to a Group using a PHP snippet.
2. Open a post or page.
3. The "Test Group Variation" should be visible in the inserter.

### Testing variation
```php
add_filter( 'get_block_type_variations', function( $variations, $block_type ) {
	if ( 'core/group' === $block_type->name ) {
		$variations[] = array(
			'name'  => 'group-test-variation',
			'title' => 'Test Group Variation',
			'icon'  => 'layout',
			'scope' => [ 'inserter' ],
		);
	}

	return $variations;
}, 10, 2 );
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-18 at 09 28 48](https://github.com/WordPress/gutenberg/assets/240569/b4c7f4a2-cc65-4e86-959a-8798a7f9ed06)