### PR TITLE
Patterns data view: Remove icons in favor of dedicated sync status field

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -26,14 +26,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import {
-	Icon,
-	header,
-	footer,
-	symbolFilled as uncategorized,
-	symbol,
-	lockSmall,
-} from '@wordpress/icons';
+import { Icon, lockSmall } from '@wordpress/icons';
 import { usePrevious } from '@wordpress/compose';
 import { useEntityRecords } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
@@ -76,7 +69,6 @@ const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 const { usePostActions } = unlock( editorPrivateApis );
 const { useHistory } = unlock( routerPrivateApis );
 
-const templatePartIcons = { header, footer, uncategorized };
 const EMPTY_ARRAY = [];
 const defaultConfigPerViewType = {
 	[ LAYOUT_TABLE ]: {
@@ -93,7 +85,7 @@ const DEFAULT_VIEW = {
 	search: '',
 	page: 1,
 	perPage: 20,
-	hiddenFields: [ 'sync-status' ],
+	hiddenFields: [],
 	layout: {
 		...defaultConfigPerViewType[ LAYOUT_GRID ],
 	},
@@ -242,9 +234,7 @@ function Author( { item, viewType } ) {
 
 function Title( { item, categoryId } ) {
 	const isUserPattern = item.type === PATTERN_TYPES.user;
-	const isNonUserPattern = item.type === PATTERN_TYPES.theme;
 	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
-	let itemIcon;
 	const { onClick } = useLink( {
 		postType: item.type,
 		postId: isUserPattern ? item.id : item.name,
@@ -252,12 +242,6 @@ function Title( { item, categoryId } ) {
 		categoryType: isTemplatePart ? item.type : PATTERN_TYPES.theme,
 		canvas: 'edit',
 	} );
-	if ( ! isUserPattern && templatePartIcons[ categoryId ] ) {
-		itemIcon = templatePartIcons[ categoryId ];
-	} else {
-		itemIcon =
-			item.syncStatus === PATTERN_SYNC_TYPES.full ? symbol : undefined;
-	}
 	return (
 		<HStack alignment="center" justify="flex-start" spacing={ 2 }>
 			<Flex
@@ -280,19 +264,6 @@ function Title( { item, categoryId } ) {
 					</Button>
 				) }
 			</Flex>
-			{ itemIcon && ! isNonUserPattern && (
-				<Tooltip
-					placement="top"
-					text={ __(
-						'Editing this pattern will also update anywhere it is used'
-					) }
-				>
-					<Icon
-						className="edit-site-patterns__pattern-icon"
-						icon={ itemIcon }
-					/>
-				</Tooltip>
-			) }
 			{ item.type === PATTERN_TYPES.theme && (
 				<Tooltip
 					placement="top"


### PR DESCRIPTION
## What?
Remove the icons used to indicate sync status. Make the dedicated `sync-status` field visible by default.

## Why?
1. The icons are a legacy artefact from the pre-data-views patterns page.
2. They essentially do the exact same job as the dedicated field, without any of the benefits (filtering, visibility toggling, etc).
3. The icon positioning in table layout doesn't look great.
4. The `area` based icons for template parts only appear when you're already browsing a specific category (e.g. "Headers"), making their utility minimal.

## Testing Instructions
1. Navigate to the Patterns page.
2. Click through the template part categories observing no `area`-based icons.
3. Click through pattern categories and observe that the sync status field is visible.

### Before

| Template part | Pattern |
| --- | --- |
| <img width="291" alt="Screenshot 2024-04-17 at 17 46 07" src="https://github.com/WordPress/gutenberg/assets/846565/9bd32207-65e0-4c61-a4c8-265d9925a804"> | <img width="293" alt="Screenshot 2024-04-17 at 17 46 25" src="https://github.com/WordPress/gutenberg/assets/846565/2d4196da-18f4-491f-8e5f-c746e0897372"> |



### After

| Template part | Pattern |
| --- | --- |
| <img width="289" alt="Screenshot 2024-04-17 at 17 50 54" src="https://github.com/WordPress/gutenberg/assets/846565/45e5d9d3-9c48-4d5d-bade-07485ca68774"> | <img width="292" alt="Screenshot 2024-04-17 at 17 50 41" src="https://github.com/WordPress/gutenberg/assets/846565/9b5f88ae-a695-4251-b287-e3b444b165fd"> |

