### PR TITLE
Data Views: Simplify visually hidden label

### DIFF
--- a/packages/dataviews/src/single-selection-checkbox.js
+++ b/packages/dataviews/src/single-selection-checkbox.js
@@ -32,7 +32,7 @@ export default function SingleSelectionCheckbox( {
 		<CheckboxControl
 			className="dataviews-view-table-selection-checkbox"
 			__nextHasNoMarginBottom
-			label={ selectionLabel }
+			aria-label={ selectionLabel }
 			aria-disabled={ disabled }
 			checked={ isSelected }
 			onChange={ () => {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -536,17 +536,6 @@
 	}
 
 	line-height: 0;
-	label {
-		position: absolute;
-		width: 1px;
-		height: 1px;
-		padding: 0;
-		margin: -1px;
-		overflow: hidden;
-		clip: rect(0, 0, 0, 0);
-		white-space: nowrap;
-		border: 0;
-	}
 }
 
 .dataviews-filters__custom-menu-radio-item-prefix {

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -218,7 +218,9 @@ function BulkSelectionCheckbox( {
 					onSelectionChange( selectableItems );
 				}
 			} }
-			label={ areAllSelected ? __( 'Deselect all' ) : __( 'Select all' ) }
+			aria-label={
+				areAllSelected ? __( 'Deselect all' ) : __( 'Select all' )
+			}
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Keep the checkbox labels in Data Views visually hidden without a CSS override.

## Why?

I noticed this when reviewing another PR and later realized this was already possible via props.

## Testing Instructions

The checkboxes in the Data Views table layout should still look the same and be accessibly labeled.

## Screenshots

<img width="673" alt="Checkbox having a correct aria-label in the devtools inspector" src="https://github.com/WordPress/gutenberg/assets/555336/9f97f9b7-a044-4272-967d-36abaf090224">

