### PR TITLE
List View: Fix stuck dragging mode in UI in Firefox when dealing with deeply nested lists

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -556,9 +556,14 @@ export default function useListViewDropZone( {
 	const ref = useDropZone( {
 		dropZoneElement,
 		onDrop( event ) {
+			throttled.cancel();
 			if ( target ) {
 				onBlockDrop( event );
 			}
+			// Use `undefined` value to indicate that the drag has concluded.
+			// This allows styling rules that are active only when a user is
+			// dragging to be removed.
+			setTarget( undefined );
 		},
 		onDragLeave() {
 			throttled.cancel();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #49563

Fix an issue where sometimes in Firefox, after dragging and dropping within the list view, the list view would become stuck in a dragging-like state, so there would be an unexpected additional whitespace between some list view items, with the drop indicator displaying when it shouldn't.

Kudos @diggeddy for raising the issue in https://github.com/WordPress/gutenberg/issues/49563#issuecomment-2041066293

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It seems that (for some reason) in Firefox, the order or presence of the `onDragEnd` callback firing correctly and clearing out the throttled drag callback and target state is unreliable. I couldn't ascertain whether this is due to a browser issue, Gutenberg code, or a combination of the two. However, for now, a fix appears to be to also add the `throttled.cancel()` and target clearing code to the `onDrop` callback. Nothing bad should happen if these are called too frequently when dropping a list item, but it is a problem if they're not called correctly, as can be seen in the before / after videos below.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the List View's drop zone / drag and drop handlers, add the following to the `onDrop` callback:

* A call to `throttled.cancel` to cancel out any scheduled call to update the drop target
* Clear out the target state (explicitly set to `undefined`) so that any styling rules that are active while a target is present are removed

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* In Firefox, add a very deeply nested set of Group blocks to a post or template.
* Go to drag a container block up and down the list.
* On `trunk`, sometimes, it's possible to get stuck in a state where the list view drop indicator is still visible after dropping, and there is an unexpected space between some list view items.
* With this PR applied, that should not occur.
* Double check with a few different browsers that this change doesn't introduce any regressions.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/67a95cd3-1e46-417b-8f7e-4f391b03b8ec

### After

https://github.com/WordPress/gutenberg/assets/14988353/a1b261ee-0ce0-41c7-a7c9-872678c25088