### PR TITLE
Blocks: Remove client-side polyfill for 'selectors'

### DIFF
--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -398,43 +398,6 @@ describe( 'blocks', () => {
 			} );
 		} );
 
-		// This can be removed once polyfill adding selectors has been removed.
-		it( 'should apply selectors on the client when not set on the server', () => {
-			const blockName = 'core/test-block-with-selectors';
-			unstable__bootstrapServerSideBlockDefinitions( {
-				[ blockName ]: {
-					category: 'widgets',
-				},
-			} );
-			unstable__bootstrapServerSideBlockDefinitions( {
-				[ blockName ]: {
-					selectors: { root: '.wp-block-custom-selector' },
-					category: 'ignored',
-				},
-			} );
-
-			const blockType = {
-				title: 'block title',
-			};
-			registerBlockType( blockName, blockType );
-			expect( getBlockType( blockName ) ).toEqual( {
-				name: blockName,
-				save: expect.any( Function ),
-				title: 'block title',
-				category: 'widgets',
-				icon: { src: BLOCK_ICON_DEFAULT },
-				attributes: {},
-				providesContext: {},
-				usesContext: [],
-				keywords: [],
-				selectors: { root: '.wp-block-custom-selector' },
-				supports: {},
-				styles: [],
-				variations: [],
-				blockHooks: {},
-			} );
-		} );
-
 		// This test can be removed once the polyfill for blockHooks gets removed.
 		it( 'should polyfill blockHooks using metadata on the client when not set on the server', () => {
 			const blockName = 'tests/hooked-block';

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -66,19 +66,6 @@ function bootstrappedBlockTypes( state = {}, action ) {
 			// Don't overwrite if already set. It covers the case when metadata
 			// was initialized from the server.
 			if ( serverDefinition ) {
-				// The `selectors` prop is not yet included in the server provided
-				// definitions and needs to be polyfilled. This can be removed when the
-				// minimum supported WordPress is >= 6.3.
-				if (
-					serverDefinition.selectors === undefined &&
-					blockType.selectors
-				) {
-					newDefinition = {
-						...serverDefinition,
-						selectors: blockType.selectors,
-					};
-				}
-
 				// The `blockHooks` prop is not yet included in the server provided
 				// definitions and needs to be polyfilled. This can be removed when the
 				// minimum supported WordPress is >= 6.4.


### PR DESCRIPTION
## What
PR removes client-side polyfill for the block's `selectors` settings. The plugin requires WP 6.3 and higher — #56464.

## Testing Instructions
1. Set a duotone filter globally for images via the Site Editor.
2. Open a post or page.
3. Add the image block and select an image.
4. A Duotone filter should be applied.

### Testing Instructions for Keyboard
Same.
