### PR TITLE
Sidebar slide animation: replace motion.div with CSS animation

### DIFF
--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -1,8 +1,11 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { __unstableMotion as motion } from '@wordpress/components';
-import { useReducedMotion } from '@wordpress/compose';
 import {
 	useCallback,
 	createContext,
@@ -13,23 +16,6 @@ import {
 import { focus } from '@wordpress/dom';
 
 export const SidebarNavigationContext = createContext( () => {} );
-
-function getAnim( direction ) {
-	switch ( direction ) {
-		case 'back':
-			return {
-				initial: { opacity: 0, x: '-50px' },
-				animate: { opacity: 1, x: '0' },
-			};
-		case 'forward':
-			return {
-				initial: { opacity: 0, x: '50px' },
-				animate: { opacity: 1, x: '0' },
-			};
-		default:
-			return { initial: false, animate: false };
-	}
-}
 
 export default function SidebarContent( { routeKey, children } ) {
 	const [ navState, setNavState ] = useState( {
@@ -62,22 +48,21 @@ export default function SidebarContent( { routeKey, children } ) {
 		elementToFocus?.focus();
 	}, [ navState ] );
 
-	const disableMotion = useReducedMotion();
-	const { initial, animate } = getAnim( navState.direction );
+	const wrapperCls = classnames( 'edit-site-sidebar__screen-wrapper', {
+		'slide-from-left': navState.direction === 'back',
+		'slide-from-right': navState.direction === 'forward',
+	} );
 
 	return (
 		<SidebarNavigationContext.Provider value={ navigate }>
 			<div className="edit-site-sidebar__content">
-				<motion.div
+				<div
 					ref={ wrapperRef }
 					key={ routeKey }
-					className="edit-site-sidebar__screen-wrapper"
-					initial={ ! disableMotion && initial }
-					animate={ ! disableMotion && animate }
-					transition={ { duration: 0.14 } }
+					className={ wrapperCls }
 				>
 					{ children }
-				</motion.div>
+				</div>
 			</div>
 		</SidebarNavigationContext.Provider>
 	);

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -3,6 +3,28 @@
 	overflow-y: auto;
 }
 
+@keyframes slide-from-right {
+	from {
+		transform: translateX(50px);
+		opacity: 0;
+	}
+	to {
+		transform: none;
+		opacity: 1;
+	}
+}
+
+@keyframes slide-from-left {
+	from {
+		transform: translateX(-50px);
+		opacity: 0;
+	}
+	to {
+		transform: none;
+		opacity: 1;
+	}
+}
+
 .edit-site-sidebar__screen-wrapper {
 	overflow-x: auto;
 	@include custom-scrollbars-on-hover(transparent, $gray-700);
@@ -14,4 +36,22 @@
 
 	// This matches the logo padding
 	padding: 0 $grid-unit-15;
+
+	// Animation
+	animation-duration: 0.14s;
+	animation-timing-function: ease-in-out;
+	will-change: transform, opacity;
+
+	@media ( prefers-reduced-motion: reduce ) {
+		animation-duration: 0s;
+	}
+
+	&.slide-from-left {
+		animation-name: slide-from-left;
+	}
+
+	&.slide-from-right {
+		animation-name: slide-from-right;
+	}
+
 }


### PR DESCRIPTION
Followup to #60466 that replaces the `motion.div` animation with a more performant CSS animation.

**How to test:**
Navigate back and forth in the Site Editor sidebar and verify that screens slide in either from left of from right, depending on the direction of the navigation:

<img width="363" alt="Screenshot 2024-04-18 at 9 39 40" src="https://github.com/WordPress/gutenberg/assets/664258/4af45b07-dfff-409f-ac32-e849b8db2a78">

Verify that no animation is done when the browser prefers reduced motion. Can be set in Chrome devtools in the Rendering tab:

<img width="821" alt="Screenshot 2024-04-18 at 9 41 32" src="https://github.com/WordPress/gutenberg/assets/664258/f0dcb8e1-3847-46b4-872d-0c207fb53291">

Also verify that the direction is correct in an RTL language like Hebrew. With CSS animations, this is handled "automatically" because the `rtlcss` plugin changes `translateX(-50x)` to `translate(50px)` in the RTL stylesheet. `motion.div` or Emotion need special JS code for this, but with plain SCSS this is not needed.