### PR TITLE
Router: load proper sidebar for `/wp_template`

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -108,9 +108,7 @@ export default function useLayoutAreas() {
 		return {
 			key: 'templates-list',
 			areas: {
-				sidebar: postId ? (
-					<SidebarNavigationScreenTemplate />
-				) : (
+				sidebar: (
 					<SidebarNavigationScreenTemplatesBrowse postType="wp_template" />
 				),
 				content: (


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/60466#issuecomment-2063298864

## What

Loads the proper sidebar for the `/wp_template` path when coming back from the editor.

## How

[637b898](https://github.com/WordPress/gutenberg/pull/60850/commits/637b8980bdb5aa08afa5e75bd478dc1f28d7918f) Removes the `postId` conditional.

## Test

1. go to templates index screen
2. go to the editor for one template
3. click the hub: the expected result is that it opens the template details
4. click back button: the expected result is that it shows the same sidebar for the template index screen as step 1
5. click back again: the expected result is that is goes back to the site editor root

