### PR TITLE
Fix: Remove unused CSS for TemplatePartHint.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -126,25 +126,6 @@
 	border-top: 1px solid $gray-800;
 }
 
-.edit-site-sidebar__notice {
-	background: $gray-800;
-	color: $gray-300;
-	margin: $grid-unit-30 0;
-	&.is-dismissible {
-		padding-right: $grid-unit-10;
-	}
-
-	.components-notice__dismiss:not(:disabled):not([aria-disabled="true"]) {
-		color: $gray-400;
-	}
-
-	.components-notice__dismiss:not(:disabled):not([aria-disabled="true"]):focus,
-	.components-notice__dismiss:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):active,
-	.components-notice__dismiss:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):hover {
-		color: $white;
-	}
-}
-
 /* In general style overrides are discouraged.
  * This is a temporary solution to override the InputControl component's styles.
  * The `Theme` component will potentially be the more appropriate approach


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/59092.

On https://github.com/WordPress/gutenberg/pull/52395 a component named TemplatePartHint was added.
On https://github.com/WordPress/gutenberg/pull/59092 the component and its usage was removed, but that PR did not remove the CSS for that component which became unused. This PR fixes the issue.