### PR TITLE
Editor: Fix post status label styles for low-capability users

### DIFF
--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -28,7 +28,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { store as editorStore } from '../../store';
 import { Icon, chevronDownSmall } from '@wordpress/icons';
 
-function PostStatusLabel() {
+function PostStatusLabel( { canEdit } ) {
 	const status = useSelect(
 		( select ) => select( editorStore ).getEditedPostAttribute( 'status' ),
 		[]
@@ -56,10 +56,11 @@ function PostStatusLabel() {
 		<Text
 			className={ classnames( 'editor-post-status-label', {
 				[ ` has-status-${ status }` ]: !! status,
+				'has-icon': canEdit,
 			} ) }
 		>
 			{ statusLabel }
-			<Icon icon={ chevronDownSmall } />
+			{ canEdit && <Icon icon={ chevronDownSmall } /> }
 		</Text>
 	);
 }
@@ -206,7 +207,11 @@ export default function PostStatus() {
 	};
 
 	if ( ! canEdit ) {
-		return <PostStatusLabel />;
+		return (
+			<div className="editor-post-status">
+				<PostStatusLabel />
+			</div>
+		);
 	}
 
 	return (
@@ -221,7 +226,7 @@ export default function PostStatus() {
 					className="editor-post-status-trigger"
 					onClick={ onToggle }
 				>
-					<PostStatusLabel />
+					<PostStatusLabel canEdit={ canEdit } />
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (

--- a/packages/editor/src/components/post-status/style.scss
+++ b/packages/editor/src/components/post-status/style.scss
@@ -17,12 +17,12 @@
 		align-items: center;
 		color: $gray-900;
 
-		&:hover {
-			background: rgba($gray-900, 0.08);
-		}
-
 		&.has-icon {
 			padding: 0 $grid-unit-10 0 $grid-unit-15;
+
+			&:hover {
+				background: rgba($gray-900, 0.08);
+			}
 		}
 
 		&.has-status-publish,

--- a/packages/editor/src/components/post-status/style.scss
+++ b/packages/editor/src/components/post-status/style.scss
@@ -11,7 +11,7 @@
 	.editor-post-status-label {
 		border-radius: $grid-unit-20;
 		display: inline-flex;
-		padding: 0 $grid-unit-10 0 $grid-unit-15;
+		padding: 0 $grid-unit-15 0 $grid-unit-15;
 		background: rgba($gray-900, 0.04);
 		height: $button-size-compact;
 		align-items: center;
@@ -19,6 +19,10 @@
 
 		&:hover {
 			background: rgba($gray-900, 0.08);
+		}
+
+		&.has-icon {
+			padding: 0 $grid-unit-10 0 $grid-unit-15;
 		}
 
 		&.has-status-publish,


### PR DESCRIPTION
## What?
PR fixes post-status label styles for low-capability users when the dropdown isn't displayed, and the editor just displays the status.

## Why?
It looked broken :) 

## Testing Instructions
1. Create a test user with a Contributor role and logic with it.
2. Create a post.
3. Confirm that the post status label is correctly displayed.
4. Repeat the test with the admin user.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|--------|--------|
| ![CleanShot 2024-04-18 at 15 03 50](https://github.com/WordPress/gutenberg/assets/240569/2bb750ef-a0ba-40bf-a6be-4a110bf253d1) | ![CleanShot 2024-04-18 at 15 02 45](https://github.com/WordPress/gutenberg/assets/240569/fa0a82b9-e7a5-4225-bad4-fa3f4837269f) | 


