### PR TITLE
Zoom Out: Insert patterns at the end of the root section

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1445,12 +1445,18 @@ export const __unstableSetEditorMode =
 				const sectionClientIds =
 					select.getBlockOrder( sectionRootClientId );
 				if ( sectionClientIds ) {
-					const parents = select.getBlockParents(
-						firstSelectedClientId
-					);
-					const firstSectionClientId = parents.find( ( parent ) =>
-						sectionClientIds.includes( parent )
-					);
+					let firstSectionClientId =
+						sectionClientIds[ sectionClientIds.length - 1 ];
+
+					if ( firstSelectedClientId ) {
+						const parents = select.getBlockParents(
+							firstSelectedClientId
+						);
+						firstSectionClientId = parents.find( ( parent ) =>
+							sectionClientIds.includes( parent )
+						);
+					}
+
 					dispatch.selectBlock( firstSectionClientId );
 				}
 			} else if ( firstSelectedClientId ) {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1454,9 +1454,9 @@ export const __unstableSetEditorMode =
 						);
 						dispatch.selectBlock( firstSectionClientId );
 					} else {
-						const lastChildSectionClientId =
+						const lastSectionClientId =
 							sectionClientIds[ sectionClientIds.length - 1 ];
-						dispatch.selectBlock( lastChildSectionClientId );
+						dispatch.selectBlock( lastSectionClientId );
 					}
 				}
 			} else if ( firstSelectedClientId ) {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1445,19 +1445,19 @@ export const __unstableSetEditorMode =
 				const sectionClientIds =
 					select.getBlockOrder( sectionRootClientId );
 				if ( sectionClientIds ) {
-					let firstSectionClientId =
-						sectionClientIds[ sectionClientIds.length - 1 ];
-
 					if ( firstSelectedClientId ) {
 						const parents = select.getBlockParents(
 							firstSelectedClientId
 						);
-						firstSectionClientId = parents.find( ( parent ) =>
+						const firstSectionClientId = parents.find( ( parent ) =>
 							sectionClientIds.includes( parent )
 						);
+						dispatch.selectBlock( firstSectionClientId );
+					} else {
+						const lastChildSectionClientId =
+							sectionClientIds[ sectionClientIds.length - 1 ];
+						dispatch.selectBlock( lastChildSectionClientId );
 					}
-
-					dispatch.selectBlock( firstSectionClientId );
 				}
 			} else if ( firstSelectedClientId ) {
 				const rootClientId = select.getBlockHierarchyRootClientId(

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1438,6 +1438,8 @@ export const __unstableSetEditorMode =
 		// When switching to zoom-out mode, we need to select the parent section
 		if ( mode === 'zoom-out' ) {
 			const firstSelectedClientId = select.getBlockSelectionStart();
+			const allBlocks = select.getBlocks();
+
 			const { sectionRootClientId } = unlock(
 				registry.select( STORE_NAME ).getSettings()
 			);
@@ -1464,6 +1466,10 @@ export const __unstableSetEditorMode =
 					firstSelectedClientId
 				);
 				dispatch.selectBlock( rootClientId );
+			} else {
+				// If there's no block selected and no sectionRootClientId, select the last root block.
+				const lastRootBlock = allBlocks[ allBlocks.length - 1 ];
+				dispatch.selectBlock( lastRootBlock?.clientId );
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When zoom out mode is invoked, but there is no block selected, the pattern inserter doesn't work. This automatically selects the last block in the root section so that when patterns are inserted in zoom out mode, they are added after the last pattern in the section root.

## Why?
When zoom out mode is invoked, but there is no block selected, the pattern inserter doesn't work.

## How?
If there is no block selected we automatically select the last block in the section root.

## Testing Instructions
1. Open the Site Editor
2. Do not select a block
3. Open the inserter in the top toolbar
4. Select the patterns tab
5. Select a pattern category
6. Confirm that the last block inside the section root is selected
7. Select a pattern
8. Confirm that the block is inserted at the end of the section root

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/275961/273d730e-6797-45f3-825e-488ecb384a50

## Note
We should also scroll to the selected block but that should be a different PR.