### PR TITLE
Editor: Do not render publish time and post status panels in design post types

### DIFF
--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -4,6 +4,7 @@
 import { Button, Dropdown } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,9 +13,27 @@ import PostScheduleCheck from './check';
 import PostScheduleForm from './index';
 import { usePostScheduleLabel } from './label';
 import PostPanelRow from '../post-panel-row';
+import { store as editorStore } from '../../store';
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+} from '../../store/constants';
+
+const DESIGN_POST_TYPES = [
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+];
 
 export default function PostSchedulePanel() {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	const postType = useSelect(
+		( select ) => select( editorStore ).getCurrentPostType(),
+		[]
+	);
 	// Memoize popoverProps to avoid returning a new object every time.
 	const popoverProps = useMemo(
 		() => ( {
@@ -29,6 +48,9 @@ export default function PostSchedulePanel() {
 
 	const label = usePostScheduleLabel();
 	const fullLabel = usePostScheduleLabel( { full: true } );
+	if ( DESIGN_POST_TYPES.includes( postType ) ) {
+		return null;
+	}
 
 	return (
 		<PostScheduleCheck>

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -25,6 +25,12 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+} from '../../store/constants';
 import { store as editorStore } from '../../store';
 import { Icon, chevronDownSmall } from '@wordpress/icons';
 
@@ -123,6 +129,13 @@ const STATUS_OPTIONS = [
 	},
 ];
 
+const DESIGN_POST_TYPES = [
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+];
+
 export default function PostStatus() {
 	const { status, date, password, postId, postType, canEdit } = useSelect(
 		( select ) => {
@@ -166,6 +179,18 @@ export default function PostStatus() {
 		[ popoverAnchor ]
 	);
 
+	if ( DESIGN_POST_TYPES.includes( postType ) ) {
+		return null;
+	}
+
+	if ( ! canEdit ) {
+		return (
+			<div className="editor-post-status">
+				<PostStatusLabel />
+			</div>
+		);
+	}
+
 	const updatePost = ( {
 		status: newStatus = status,
 		password: newPassword = password,
@@ -205,14 +230,6 @@ export default function PostStatus() {
 			password: newPassword,
 		} );
 	};
-
-	if ( ! canEdit ) {
-		return (
-			<div className="editor-post-status">
-				<PostStatusLabel />
-			</div>
-		);
-	}
 
 	return (
 		<Dropdown

--- a/packages/editor/src/store/constants.js
+++ b/packages/editor/src/store/constants.js
@@ -21,6 +21,7 @@ export const AUTOSAVE_PROPERTIES = [ 'title', 'excerpt', 'content' ];
 export const TEMPLATE_POST_TYPE = 'wp_template';
 export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
 export const PATTERN_POST_TYPE = 'wp_block';
+export const NAVIGATION_POST_TYPE = 'wp_navigation';
 export const TEMPLATE_ORIGINS = {
 	custom: 'custom',
 	theme: 'theme',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
With the unification efforts of the editors (post and site) we expose some information in some post types (patterns, templates, template parts) that don't make much sense and might have unexpected results and lead to confusion. 

Examples are:
1. Publish date panel while we expect them to be published. So if you update the date to a future date, it can result in the pattern not being rendered in the front end.
2. Post status panel which can have the same effects if we switch to draft, etc..

Below is trunk:

![Screenshot 2024-04-17 at 16 19 51](https://github.com/WordPress/gutenberg/assets/16275880/188a536e-182b-4c6e-87d7-9a7c19009591)


## Testing Instructions
1. While editing 'design' entities like a pattern, template part, etc.., publish date and post status panels should not be rendered.
4. Everything else should work as before.


