### PR TITLE
Prevents delete key from undoing automatic changes

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
+++ b/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
-import { BACKSPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
+import { BACKSPACE, ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -20,11 +20,7 @@ export function useUndoAutomaticChange() {
 				return;
 			}
 
-			if (
-				keyCode !== DELETE &&
-				keyCode !== BACKSPACE &&
-				keyCode !== ESCAPE
-			) {
+			if ( keyCode !== BACKSPACE && keyCode !== ESCAPE ) {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

_Created during **Yoast Contributor Day** on Thursday 18 April 2024._

## What?
This PR prevents the delete key (<kbd>del</kbd>) from undoing automatic changes, for example through transforms based on prefixes. 

## Why?
As per #35388, after an automatic transformation from one block to the other, we want the delete key to have the standard behaviour: deleting the character after the caret. 

## How?
This PR removes the delete button from the list of characters that undoes an automatic change, leaving the backspace and the escape button. Note that with this PR, next to automatic transforms through prefixes (e.g. `> ` to quote, `-` to list), also other actions regarded as automatic changes will no longer be undoable through the delete button (which I think makes sense). 

## Testing Instructions
To confirm the behaviour for the delete button: 
1. Create a new post.
2. Insert some text in a paragraph block. 
3. Prepend `> ` to the text.
4. Confirm that the paragraph block transforms into a quote block. 
5. Press the delete button (<kbd>del</kbd>, or <kbd>fn</kbd> + <kbd>backspace</kbd> on Mac).
6. Confirm that the character after the caret is removed. 

To confirm the behaviour for the backspace/escape button: 
1. Create a new post.
2. Insert some text in a paragraph block. 
3. Prepend `> ` to the text.
4. Confirm that the paragraph block transforms into a quote block. 
5. Press the backspace button.
6. Confirm that the block transformation is undone. 

### Testing Instructions for Keyboard
In a new post: 
1. Insert some text (e.g. type `Hello World`).
2. Move the caret to the beginning of the text (by using the left arrow, or a keyboard shortcut like <kbd>⌘</kbd><kbd><-</kbd>).
3. Type `> `.
4. Type <kbd>del</kbd>.
6. Confirm that the character after the caret is removed. 

## Screenshots or screencast
See the bug report for a screencast. 

Fixes #35388 
