### PR TITLE
Adds additional check to make sure the show_in_rest parameter is present before it is manipulated

### DIFF
--- a/lib/compat/wordpress-6.6/option.php
+++ b/lib/compat/wordpress-6.6/option.php
@@ -26,9 +26,9 @@ function gutenberg_update_initial_settings( $args, $defaults, $option_group, $op
 		$args['label'] = $settings_label_map[ $option_name ];
 	}
 
-	// Don't update schema when label isn't provided.
-	if ( ! isset( $args['label'] ) ) {
-		return $args;
+	// Don't update schema when label or show_in_rest isn't provided.
+	if ( ! isset( $args['label']) || ! isset( $args['show_in_rest'] ) )  {
+		//return $args;
 	}
 
 	$schema = array( 'title' => $args['label'] );


### PR DESCRIPTION
…<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This pr makes sure that it is checked that show_in_rest is present before it is manipulated and shows a notice for plugins using `register_setting` without specifying `show_in_rest`.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This solves https://github.com/WordPress/gutenberg/issues/60859
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I have added an additional isset check.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Install Gutenberg latest version and & Yoast SEO
2. Go to Yoast SEO->Settings
3. Confirm that you don't get a Warning:  Undefined array key "show_in_rest" warning
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
