### PR TITLE
Fix PHP notice triggered by 'gutenberg_update_initial_settings'

### DIFF
--- a/lib/compat/wordpress-6.6/option.php
+++ b/lib/compat/wordpress-6.6/option.php
@@ -26,6 +26,11 @@ function gutenberg_update_initial_settings( $args, $defaults, $option_group, $op
 		$args['label'] = $settings_label_map[ $option_name ];
 	}
 
+	// Don't update schema when a setting isn't exposed via REST API.
+	if ( ! isset( $args['show_in_rest'] ) ) {
+		return $args;
+	}
+
 	// Don't update schema when label isn't provided.
 	if ( ! isset( $args['label'] ) ) {
 		return $args;


### PR DESCRIPTION
## What?
Fixes #60859.

PR updates logic in the `gutenberg_update_initial_settings` filter callback to bail out early when the setting isn't exposed via REST API.

## Testing Instructions
1. Register a setting without `show_in_rest`.
2. Load the testing site.
3. Confirm that the following warning isn't displayed or logged - `PHP Warning:  Undefined array key "show_in_rest"`

## Example setting
```php
add_action( 'init', function() {
	register_setting(
		'general',
		'foo_my_setting',
		array(
			'type'              => 'string',
			'label'             => 'My Setting',
			'description'       => 'This is a custom setting.',
		)
	);
} );
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
