### PR TITLE
Fix: Action order is different from inspector and dataviews.

### DIFF
--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useMemo, useState, Fragment, Children } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	privateApis as componentsPrivateApis,
@@ -28,7 +28,6 @@ const {
 	DropdownMenuGroupV2: DropdownMenuGroup,
 	DropdownMenuItemV2: DropdownMenuItem,
 	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 	kebabCase,
 } = unlock( componentsPrivateApis );
 
@@ -52,22 +51,6 @@ export default function PostActions( { onActionPerformed, buttonProps } ) {
 		POST_ACTIONS_WHILE_EDITING
 	);
 
-	const { primaryActions, secondaryActions } = useMemo( () => {
-		return actions.reduce(
-			( accumulator, action ) => {
-				if ( action.isEligible && ! action.isEligible( item ) ) {
-					return accumulator;
-				}
-				if ( action.isPrimary ) {
-					accumulator.primaryActions.push( action );
-				} else {
-					accumulator.secondaryActions.push( action );
-				}
-				return accumulator;
-			},
-			{ primaryActions: [], secondaryActions: [] }
-		);
-	}, [ actions, item ] );
 	if (
 		[
 			TEMPLATE_POST_TYPE,
@@ -84,29 +67,14 @@ export default function PostActions( { onActionPerformed, buttonProps } ) {
 					size="small"
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
-					disabled={
-						! primaryActions.length && ! secondaryActions.length
-					}
+					disabled={ ! actions.length }
 					className="editor-all-actions-button"
 					{ ...buttonProps }
 				/>
 			}
 			placement="bottom-end"
 		>
-			<WithDropDownMenuSeparators>
-				{ !! primaryActions.length && (
-					<ActionsDropdownMenuGroup
-						actions={ primaryActions }
-						item={ item }
-					/>
-				) }
-				{ !! secondaryActions.length && (
-					<ActionsDropdownMenuGroup
-						actions={ secondaryActions }
-						item={ item }
-					/>
-				) }
-			</WithDropDownMenuSeparators>
+			<ActionsDropdownMenuGroup actions={ actions } item={ item } />
 		</DropdownMenu>
 	);
 }
@@ -158,18 +126,6 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 			) }
 		</>
 	);
-}
-
-// Copied as is from packages/dataviews/src/view-table.js
-function WithDropDownMenuSeparators( { children } ) {
-	return Children.toArray( children )
-		.filter( Boolean )
-		.map( ( child, i ) => (
-			<Fragment key={ i }>
-				{ i > 0 && <DropdownMenuSeparator /> }
-				{ child }
-			</Fragment>
-		) );
 }
 
 // Copied as is from packages/dataviews/src/item-actions.js


### PR DESCRIPTION
Fixes an issue raised by @jameskoster at:
https://github.com/WordPress/gutenberg/pull/60637#issuecomment-2049224623

> As a separate note, the actions menu in the Inspector should match the one in the Table (minus the 'Edit' action), currently they're mismatched:



## Testing Instructions
- Open a page and verify the actions in the post card panel are as shown bellow.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="284" alt="Screenshot 2024-04-11 at 09 47 46" src="https://github.com/WordPress/gutenberg/assets/846565/8f83ac39-07b8-41fd-97ef-6a3274f67d18">

After:
<img width="188" alt="Screenshot 2024-04-18 at 18 23 50" src="https://github.com/WordPress/gutenberg/assets/11271197/c4a29958-aba4-486b-b386-1fe44977204b">

