### PR TITLE
Fix pattern preview focus styles

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -50,9 +50,7 @@
 		&:hover,
 		&:focus {
 			.block-editor-block-preview__container {
-				box-shadow:
-					0 0 0 2px var(--wp-block-synced-color),
-					0 15px 25px rgb(0 0 0 / 7%);
+				box-shadow: 0 0 0 2px var(--wp-block-synced-color);
 			}
 		}
 	}

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -49,29 +49,27 @@
 	z-index: 1;
 }
 
-// Restrict these shadows to the context of the inspector.
-.interface-interface-skeleton__sidebar {
-	.block-editor-block-patterns-list__list-item {
-		.block-editor-block-preview__container {
-			box-shadow: 0 0 $border-width rgba($black, 0.1);
-		}
-		&:hover {
-			.block-editor-block-preview__container {
-				box-shadow: 0 0 0 2px $gray-900;
-			}
-		}
-	}
-}
-
 // Restrict these shadows to the context of the inserter.
 .editor-inserter-sidebar {
-	.block-editor-block-patterns-list__list-item {
+	.block-editor-block-patterns-list__item {
 		.block-editor-block-preview__container {
 			box-shadow: 0 15px 25px rgb(0 0 0 / 7%);
 		}
+		&:focus,
 		&:hover {
 			.block-editor-block-preview__container {
 				box-shadow: 0 0 0 2px $gray-900, 0 15px 25px rgb(0 0 0 / 7%);
+			}
+		}
+
+		&.block-editor-block-patterns-list__list-item-synced {
+			&:hover,
+			&:focus {
+				.block-editor-block-preview__container {
+					box-shadow:
+						0 0 0 2px var(--wp-block-synced-color),
+						0 15px 25px rgb(0 0 0 / 7%);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/60211

The focus styles for the pattern previews were missing. This refactors to have a default focus style that works as a base for the pattern previews and then overrides it for the pattern inserter since it uses a large soft shadow for the previews too.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds focus styles for pattern previews.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
a11y


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open main inserter
- Switch to patterns tab
- Click pattern category
- Check hover and focus styles are present on pattern previews
- Also check that synced patterns have a purple outline on focus/hover
- On the site editor, select a template part like Header
- Open the right settings sidebar
- Switch to Block tab
- Design section should show patterns
- Focus/hover them to check for outlines
- There should not be the larger soft drop shadow
