### PR TITLE
Documentation: Add `AutosaveMonitor` component JSDoc and populate `README` with auto-gen docs

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -128,7 +128,13 @@ Example:
 
 ### AutosaveMonitor
 
-Undocumented declaration.
+AutosaveMonitor component. Monitors the changes made to the edited post and triggers autosave if necessary.
+
+_Usage_
+
+```jsx
+<AutosaveMonitor interval={ 30000 } />
+```
 
 ### BlockAlignmentToolbar
 

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -91,6 +91,15 @@ export class AutosaveMonitor extends Component {
 	}
 }
 
+/**
+ * AutosaveMonitor component.
+ * Monitors the changes made to the edited post and triggers autosave if necessary.
+ *
+ * @example
+ * ```jsx
+ * <AutosaveMonitor interval={30000} />
+ * ```
+ */
 export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const { getReferenceByDistinctEdits } = select( coreStore );


### PR DESCRIPTION
## What?
Adding documentation for `AutosaveMonitor` component. Addresses one item on https://github.com/WordPress/gutenberg/issues/60358

**Aside:** I've discussed with @ntsekouras and I would like to utilize https://github.com/WordPress/gutenberg/issues/60358 for an upcoming WP Engine Contributor Day, and I'm hoping that if we get a solid PR process then I can create instructions for contributors to replicate my PR process and we can complete the entire Task List of items noted in https://github.com/WordPress/gutenberg/issues/60358

## Why?
There are a great number of APIs in the editor package that are lacking documentation. We aim to address this one-by-one. See https://github.com/WordPress/gutenberg/issues/60358 for a full checklist. This is just the first item on the list 😉 

## How?
Add a JSDoc comment to the `AutosaveMonitor` component and run `npm run docs:build` to populate the `README` with the newly added documents.
