### PR TITLE
Components: Remove "experimental" designation

### DIFF
--- a/packages/components/src/alignment-matrix-control/README.md
+++ b/packages/components/src/alignment-matrix-control/README.md
@@ -1,16 +1,12 @@
 # AlignmentMatrixControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 AlignmentMatrixControl components enable adjustments to horizontal and vertical alignments for UI.
 
 ## Usage
 
 ```jsx
 import { useState } from 'react';
-import { __experimentalAlignmentMatrixControl as AlignmentMatrixControl } from '@wordpress/components';
+import { AlignmentMatrixControl } from '@wordpress/components';
 
 const Example = () => {
 	const [ alignment, setAlignment ] = useState( 'center center' );

--- a/packages/components/src/alignment-matrix-control/index.tsx
+++ b/packages/components/src/alignment-matrix-control/index.tsx
@@ -25,7 +25,7 @@ import type { AlignmentMatrixControlProps } from './types';
  * AlignmentMatrixControl components enable adjustments to horizontal and vertical alignments for UI.
  *
  * ```jsx
- * import { __experimentalAlignmentMatrixControl as AlignmentMatrixControl } from '@wordpress/components';
+ * import { AlignmentMatrixControl } from '@wordpress/components';
  * import { useState } from '@wordpress/element';
  *
  * const Example = () => {

--- a/packages/components/src/alignment-matrix-control/stories/index.story.tsx
+++ b/packages/components/src/alignment-matrix-control/stories/index.story.tsx
@@ -17,7 +17,7 @@ import { HStack } from '../../h-stack';
 import type { AlignmentMatrixControlProps } from '../types';
 
 const meta: Meta< typeof AlignmentMatrixControl > = {
-	title: 'Components (Experimental)/AlignmentMatrixControl',
+	title: 'Components/AlignmentMatrixControl',
 	component: AlignmentMatrixControl,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -1,10 +1,5 @@
 # BorderBoxControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-<br />
-
 This component provides users with the ability to configure a single "flat"
 border or separate borders per side.
 
@@ -28,7 +23,7 @@ show "Mixed" placeholder text.
 
 ```jsx
 import { useState } from 'react';
-import { __experimentalBorderBoxControl as BorderBoxControl } from '@wordpress/components';
+import { BorderBoxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const colors = [

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -162,7 +162,7 @@ const UnconnectedBorderBoxControl = (
  * view's width input would show "Mixed" placeholder text.
  *
  * ```jsx
- * import { __experimentalBorderBoxControl as BorderBoxControl } from '@wordpress/components';
+ * import { BorderBoxControl } from '@wordpress/components';
  * import { __ } from '@wordpress/i18n';
  *
  * const colors = [

--- a/packages/components/src/border-box-control/stories/index.story.tsx
+++ b/packages/components/src/border-box-control/stories/index.story.tsx
@@ -16,7 +16,7 @@ import Button from '../../button';
 import { BorderBoxControl } from '../';
 
 const meta: Meta< typeof BorderBoxControl > = {
-	title: 'Components (Experimental)/BorderBoxControl',
+	title: 'Components/BorderBoxControl',
 	component: BorderBoxControl,
 	argTypes: {
 		onChange: { action: 'onChange' },

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -1,9 +1,5 @@
 #  BorderControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-<br />
 This component provides control over a border's color, style, and width.
 
 ## Development guidelines
@@ -21,7 +17,7 @@ a "shape" abstraction.
 
 ```jsx
 import { useState } from 'react';
-import { __experimentalBorderControl as BorderControl } from '@wordpress/components';
+import { BorderControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const colors = [

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -134,7 +134,7 @@ const UnconnectedBorderControl = (
  * a "shape" abstraction.
  *
  * ```jsx
- * import { __experimentalBorderControl as BorderControl } from '@wordpress/components';
+ * import { BorderControl } from '@wordpress/components';
  * import { __ } from '@wordpress/i18n';
  *
  * const colors = [

--- a/packages/components/src/border-control/stories/index.story.tsx
+++ b/packages/components/src/border-control/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { BorderControl } from '..';
 import type { Border } from '../types';
 
 const meta: Meta< typeof BorderControl > = {
-	title: 'Components (Experimental)/BorderControl',
+	title: 'Components/BorderControl',
 	component: BorderControl,
 	argTypes: {
 		onChange: {

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -1,16 +1,12 @@
 # BoxControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 BoxControl components let users set values for Top, Right, Bottom, and Left. This can be used as an input control for values like `padding` or `margin`.
 
 ## Usage
 
 ```jsx
 import { useState } from 'react';
-import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
+import { BoxControl } from '@wordpress/components';
 
 const Example = () => {
 	const [ values, setValues ] = useState( {

--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -51,7 +51,7 @@ function useUniqueId( idProp?: string ) {
  * This can be used as an input control for values like `padding` or `margin`.
  *
  * ```jsx
- * import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
+ * import { BoxControl } from '@wordpress/components';
  * import { useState } from '@wordpress/element';
  *
  * const Example = () => {

--- a/packages/components/src/box-control/stories/index.story.tsx
+++ b/packages/components/src/box-control/stories/index.story.tsx
@@ -14,7 +14,7 @@ import { useState } from '@wordpress/element';
 import BoxControl from '../';
 
 const meta: Meta< typeof BoxControl > = {
-	title: 'Components (Experimental)/BoxControl',
+	title: 'Components/BoxControl',
 	component: BoxControl,
 	argTypes: {
 		values: { control: { type: null } },

--- a/packages/components/src/card/card/README.md
+++ b/packages/components/src/card/card/README.md
@@ -13,7 +13,7 @@ import {
 	CardBody,
 	CardFooter,
 	__experimentalText as Text,
-	__experimentalHeading as Heading,
+	Heading,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/card/card/README.md
+++ b/packages/components/src/card/card/README.md
@@ -12,7 +12,7 @@ import {
 	CardHeader,
 	CardBody,
 	CardFooter,
-	__experimentalText as Text,
+	Text,
 	Heading,
 } from '@wordpress/components';
 

--- a/packages/components/src/card/card/component.tsx
+++ b/packages/components/src/card/card/component.tsx
@@ -86,7 +86,7 @@ function UnconnectedCard(
  *   CardBody,
  *   CardFooter,
  *   __experimentalText as Text,
- *   __experimentalHeading as Heading,
+ *   Heading,
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/card/card/component.tsx
+++ b/packages/components/src/card/card/component.tsx
@@ -85,7 +85,7 @@ function UnconnectedCard(
  *   CardHeader,
  *   CardBody,
  *   CardFooter,
- *   __experimentalText as Text,
+ *   Text,
  *   Heading,
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/confirm-dialog/README.md
+++ b/packages/components/src/confirm-dialog/README.md
@@ -1,9 +1,5 @@
 # `ConfirmDialog`
 
-<div class="callout callout-alert">
-This feature is still experimental. "Experimental" means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `ConfirmDialog` is built of top of [`Modal`](/packages/components/src/modal/README.md) and displays a confirmation dialog, with _confirm_ and _cancel_ buttons.
 
 The dialog is confirmed by clicking the _confirm_ button or by pressing the `Enter` key. It is cancelled (closed) by clicking the _cancel_ button, by pressing the `ESC` key, or by clicking outside the dialog focus (i.e, the overlay).
@@ -23,7 +19,7 @@ Allows the component to be used standalone, just by declaring it as part of anot
 Activating this mode is as simple as omitting the `isOpen` prop. The only mandatory prop, in this case, is the `onConfirm` callback. The message is passed as the `children`. You can pass any JSX you'd like, which allows to further format the message or include sub-component if you'd like:
 
 ```jsx
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { ConfirmDialog } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -44,7 +40,7 @@ Let the parent component control when the dialog is open/closed. It's activated 
 
 ```jsx
 import { useState } from 'react';
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { ConfirmDialog } from '@wordpress/components';
 
 function Example() {
 	const [ isOpen, setIsOpen ] = useState( true );

--- a/packages/components/src/confirm-dialog/component.tsx
+++ b/packages/components/src/confirm-dialog/component.tsx
@@ -138,7 +138,7 @@ const UnconnectedConfirmDialog = (
  * Activating this mode is as simple as omitting the `isOpen` prop. The only mandatory prop, in this case, is the `onConfirm` callback. The message is passed as the `children`. You can pass any JSX you'd like, which allows to further format the message or include sub-component if you'd like:
  *
  * ```jsx
- * import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+ * import { ConfirmDialog } from '@wordpress/components';
  *
  * function Example() {
  * 	return (
@@ -158,7 +158,7 @@ const UnconnectedConfirmDialog = (
  * -   You'll want to update the state that controls `isOpen` by updating it from the `onCancel` and `onConfirm` callbacks.
  *
  *```jsx
- * import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+ * import { ConfirmDialog } from '@wordpress/components';
  * import { useState } from '@wordpress/element';
  *
  * function Example() {

--- a/packages/components/src/confirm-dialog/stories/index.story.tsx
+++ b/packages/components/src/confirm-dialog/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { ConfirmDialog } from '../component';
 
 const meta: Meta< typeof ConfirmDialog > = {
 	component: ConfirmDialog,
-	title: 'Components (Experimental)/ConfirmDialog',
+	title: 'Components/ConfirmDialog',
 	argTypes: {
 		isOpen: {
 			control: { type: null },

--- a/packages/components/src/custom-select-control-v2/stories/legacy.story.tsx
+++ b/packages/components/src/custom-select-control-v2/stories/legacy.story.tsx
@@ -15,7 +15,7 @@ import CustomSelectControl from '../legacy-component';
 import * as V1Story from '../../custom-select-control/stories/index.story';
 
 const meta: Meta< typeof CustomSelectControl > = {
-	title: 'Components (Experimental)/CustomSelectControl v2/Legacy',
+	title: 'Components/CustomSelectControl v2/Legacy',
 	component: CustomSelectControl,
 	argTypes: {
 		onChange: { control: { type: null } },

--- a/packages/components/src/dimension-control/README.md
+++ b/packages/components/src/dimension-control/README.md
@@ -1,16 +1,12 @@
 # DimensionControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `DimensionControl` is a component designed to provide a UI to control spacing and/or dimensions.
 
 ## Usage
 
 ```jsx
 import { useState } from 'react';
-import { __experimentalDimensionControl as DimensionControl } from '@wordpress/components';
+import { DimensionControl } from '@wordpress/components';
 
 export default function MyCustomDimensionControl() {
 	const [ paddingSize, setPaddingSize ] = useState( '' );

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -23,7 +23,7 @@ import type { SelectControlSingleSelectionProps } from '../select-control/types'
  * This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
  *
  * ```jsx
- * import { __experimentalDimensionControl as DimensionControl } from '@wordpress/components';
+ * import { DimensionControl } from '@wordpress/components';
  * import { useState } from '@wordpress/element';
  *
  * export default function MyCustomDimensionControl() {

--- a/packages/components/src/dimension-control/stories/index.story.tsx
+++ b/packages/components/src/dimension-control/stories/index.story.tsx
@@ -15,7 +15,7 @@ import { desktop, tablet, mobile } from '@wordpress/icons';
 
 export default {
 	component: DimensionControl,
-	title: 'Components (Experimental)/DimensionControl',
+	title: 'Components/DimensionControl',
 	argTypes: {
 		onChange: { action: 'onChange' },
 		value: { control: { type: null } },

--- a/packages/components/src/divider/README.md
+++ b/packages/components/src/divider/README.md
@@ -1,16 +1,12 @@
 # Divider
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Divider` is a layout component that separates groups of related content.
 
 ## Usage
 
 ```jsx
 import {
-	__experimentalDivider as Divider,
+	Divider,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from `@wordpress/components`;

--- a/packages/components/src/divider/README.md
+++ b/packages/components/src/divider/README.md
@@ -7,7 +7,7 @@
 ```jsx
 import {
 	Divider,
-	__experimentalText as Text,
+	Text,
 	__experimentalVStack as VStack,
 } from `@wordpress/components`;
 

--- a/packages/components/src/divider/README.md
+++ b/packages/components/src/divider/README.md
@@ -8,7 +8,7 @@
 import {
 	Divider,
 	Text,
-	__experimentalVStack as VStack,
+	VStack,
 } from `@wordpress/components`;
 
 function Example() {

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -33,7 +33,7 @@ function UnconnectedDivider(
  *
  * ```js
  * import {
- * 		__experimentalDivider as Divider,
+ * 		Divider,
  * 		__experimentalText as Text,
  * 		__experimentalVStack as VStack,
  * } from `@wordpress/components`;

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -34,7 +34,7 @@ function UnconnectedDivider(
  * ```js
  * import {
  * 		Divider,
- * 		__experimentalText as Text,
+ * 		Text,
  * 		__experimentalVStack as VStack,
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -35,7 +35,7 @@ function UnconnectedDivider(
  * import {
  * 		Divider,
  * 		Text,
- * 		__experimentalVStack as VStack,
+ * 		VStack,
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/divider/stories/index.story.tsx
+++ b/packages/components/src/divider/stories/index.story.tsx
@@ -12,7 +12,7 @@ import { Flex } from '../../flex';
 
 const meta: Meta< typeof Divider > = {
 	component: Divider,
-	title: 'Components (Experimental)/Divider',
+	title: 'Components/Divider',
 	argTypes: {
 		margin: {
 			control: { type: 'text' },

--- a/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
@@ -32,7 +32,7 @@ import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { ContextSystemProvider } from '../../context';
 
 const meta: Meta< typeof DropdownMenu > = {
-	title: 'Components (Experimental)/DropdownMenu V2',
+	title: 'Components/DropdownMenu V2',
 	component: DropdownMenu,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170

--- a/packages/components/src/elevation/README.md
+++ b/packages/components/src/elevation/README.md
@@ -1,9 +1,5 @@
 # Elevation
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Elevation` is a core component that renders shadow, using the component system's shadow system.
 
 ## Usage
@@ -12,7 +8,7 @@ The shadow effect is generated using the `value` prop.
 
 ```jsx
 import {
-	__experimentalElevation as Elevation,
+	Elevation,
 	__experimentalSurface as Surface,
 	__experimentalText as Text,
 } from '@wordpress/components';
@@ -75,7 +71,7 @@ Size of the shadow, based on the Style system's elevation system. The `value` de
 In the example below, `isInteractive` is activated to give a better sense of depth.
 
 ```jsx
-import { __experimentalElevation as Elevation } from '@wordpress/components';
+import { Elevation } from '@wordpress/components';
 
 function Example() {
 	return (

--- a/packages/components/src/elevation/README.md
+++ b/packages/components/src/elevation/README.md
@@ -9,7 +9,7 @@ The shadow effect is generated using the `value` prop.
 ```jsx
 import {
 	Elevation,
-	__experimentalSurface as Surface,
+	Surface,
 	__experimentalText as Text,
 } from '@wordpress/components';
 

--- a/packages/components/src/elevation/README.md
+++ b/packages/components/src/elevation/README.md
@@ -10,7 +10,7 @@ The shadow effect is generated using the `value` prop.
 import {
 	Elevation,
 	Surface,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/elevation/component.tsx
+++ b/packages/components/src/elevation/component.tsx
@@ -29,7 +29,7 @@ function UnconnectedElevation(
  *
  * ```jsx
  * import {
- *	__experimentalElevation as Elevation,
+ *	Elevation,
  *	__experimentalSurface as Surface,
  *	__experimentalText as Text,
  * } from '@wordpress/components';

--- a/packages/components/src/elevation/component.tsx
+++ b/packages/components/src/elevation/component.tsx
@@ -31,7 +31,7 @@ function UnconnectedElevation(
  * import {
  *	Elevation,
  *	Surface,
- *	__experimentalText as Text,
+ *	Text,
  * } from '@wordpress/components';
  *
  * function Example() {

--- a/packages/components/src/elevation/component.tsx
+++ b/packages/components/src/elevation/component.tsx
@@ -30,7 +30,7 @@ function UnconnectedElevation(
  * ```jsx
  * import {
  *	Elevation,
- *	__experimentalSurface as Surface,
+ *	Surface,
  *	__experimentalText as Text,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/elevation/stories/index.story.tsx
+++ b/packages/components/src/elevation/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { Elevation } from '..';
 
 const meta: Meta< typeof Elevation > = {
 	component: Elevation,
-	title: 'Components (Experimental)/Elevation',
+	title: 'Components/Elevation',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		borderRadius: { control: { type: 'text' } },

--- a/packages/components/src/grid/README.md
+++ b/packages/components/src/grid/README.md
@@ -1,16 +1,12 @@
 # Grid
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Grid` is a primitive layout component that can arrange content in a grid configuration.
 
 ## Usage
 
 ```jsx
 import {
-	__experimentalGrid as Grid,
+	Grid,
 	__experimentalText as Text,
 } from '@wordpress/components';
 

--- a/packages/components/src/grid/README.md
+++ b/packages/components/src/grid/README.md
@@ -7,7 +7,7 @@
 ```jsx
 import {
 	Grid,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/grid/component.tsx
+++ b/packages/components/src/grid/component.tsx
@@ -26,7 +26,7 @@ function UnconnectedGrid(
  *
  * ```jsx
  * import {
- * 	__experimentalGrid as Grid,
+ * 	Grid,
  * 	__experimentalText as Text
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/grid/component.tsx
+++ b/packages/components/src/grid/component.tsx
@@ -27,7 +27,7 @@ function UnconnectedGrid(
  * ```jsx
  * import {
  * 	Grid,
- * 	__experimentalText as Text
+ * 	Text
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/grid/stories/index.story.tsx
+++ b/packages/components/src/grid/stories/index.story.tsx
@@ -11,7 +11,7 @@ import { Grid } from '..';
 
 const meta: Meta< typeof Grid > = {
 	component: Grid,
-	title: 'Components (Experimental)/Grid',
+	title: 'Components/Grid',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		align: { control: { type: 'text' } },

--- a/packages/components/src/h-stack/README.md
+++ b/packages/components/src/h-stack/README.md
@@ -1,9 +1,5 @@
 # HStack
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `HStack` (Horizontal Stack) arranges child elements in a horizontal line.
 
 ## Usage
@@ -12,7 +8,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalHStack as HStack,
+	HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
 
@@ -85,7 +81,7 @@ When a `Spacer` is used within an `HStack`, the `Spacer` adaptively expands to t
 
 ```jsx
 import {
-	__experimentalHStack as HStack,
+	HStack,
 	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
 } from '@wordpress/components';
@@ -107,7 +103,7 @@ function Example() {
 
 ```jsx
 import {
-	__experimentalHStack as HStack,
+	HStack,
 	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
 } from '@wordpress/components';

--- a/packages/components/src/h-stack/README.md
+++ b/packages/components/src/h-stack/README.md
@@ -82,7 +82,7 @@ When a `Spacer` is used within an `HStack`, the `Spacer` adaptively expands to t
 ```jsx
 import {
 	HStack,
-	__experimentalSpacer as Spacer,
+	Spacer,
 	__experimentalText as Text,
 } from '@wordpress/components';
 
@@ -104,7 +104,7 @@ function Example() {
 ```jsx
 import {
 	HStack,
-	__experimentalSpacer as Spacer,
+	Spacer,
 	__experimentalText as Text,
 } from '@wordpress/components';
 

--- a/packages/components/src/h-stack/README.md
+++ b/packages/components/src/h-stack/README.md
@@ -9,7 +9,7 @@
 ```jsx
 import {
 	HStack,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {
@@ -83,7 +83,7 @@ When a `Spacer` is used within an `HStack`, the `Spacer` adaptively expands to t
 import {
 	HStack,
 	Spacer,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {
@@ -105,7 +105,7 @@ function Example() {
 import {
 	HStack,
 	Spacer,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/h-stack/component.tsx
+++ b/packages/components/src/h-stack/component.tsx
@@ -23,7 +23,7 @@ function UnconnectedHStack(
  *
  * ```jsx
  * import {
- * 	__experimentalHStack as HStack,
+ * 	HStack,
  * 	__experimentalText as Text,
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/h-stack/component.tsx
+++ b/packages/components/src/h-stack/component.tsx
@@ -24,7 +24,7 @@ function UnconnectedHStack(
  * ```jsx
  * import {
  * 	HStack,
- * 	__experimentalText as Text,
+ * 	Text,
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/h-stack/stories/index.story.tsx
+++ b/packages/components/src/h-stack/stories/index.story.tsx
@@ -42,7 +42,7 @@ const JUSTIFICATIONS = {
 
 const meta: Meta< typeof HStack > = {
 	component: HStack,
-	title: 'Components (Experimental)/HStack',
+	title: 'Components/HStack',
 	argTypes: {
 		as: {
 			control: { type: null },

--- a/packages/components/src/heading/README.md
+++ b/packages/components/src/heading/README.md
@@ -1,15 +1,11 @@
 # Heading
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Heading` renders headings and titles using the library's typography system.
 
 ## Usage
 
 ```jsx
-import { __experimentalHeading as Heading } from '@wordpress/components';
+import { Heading } from '@wordpress/components';
 
 function Example() {
 	return <Heading>Code is Poetry</Heading>;

--- a/packages/components/src/heading/component.tsx
+++ b/packages/components/src/heading/component.tsx
@@ -25,7 +25,7 @@ function UnconnectedHeading(
  * `Heading` renders headings and titles using the library's typography system.
  *
  * ```jsx
- * import { __experimentalHeading as Heading } from "@wordpress/components";
+ * import { Heading } from "@wordpress/components";
  *
  * function Example() {
  *   return <Heading>Code is Poetry</Heading>;

--- a/packages/components/src/heading/stories/index.story.tsx
+++ b/packages/components/src/heading/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { Heading } from '..';
 
 const meta: Meta< typeof Heading > = {
 	component: Heading,
-	title: 'Components (Experimental)/Heading',
+	title: 'Components/Heading',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		color: { control: { type: 'color' } },

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -12,7 +12,13 @@ export {
 } from '@wordpress/primitives';
 
 // Components.
-export { default as __experimentalAlignmentMatrixControl } from './alignment-matrix-control';
+export {
+	/**
+	 * @deprecated Import `AlignmentMatrixControl` instead.
+	 */
+	default as __experimentalAlignmentMatrixControl,
+	AlignmentMatrixControl,
+} from './alignment-matrix-control';
 export {
 	default as Animate,
 	getAnimateClassName as __unstableGetAnimateClassName,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -101,7 +101,13 @@ export {
 } from './dimension-control';
 export { default as Disabled } from './disabled';
 export { DisclosureContent as __unstableDisclosureContent } from './disclosure';
-export { Divider as __experimentalDivider } from './divider';
+export {
+	/**
+	 * @deprecated Import `Divider` instead.
+	 */
+	Divider as __experimentalDivider,
+	Divider,
+} from './divider';
 export { default as Draggable } from './draggable';
 export { default as DropZone } from './drop-zone';
 export { default as DropZoneProvider } from './drop-zone/provider';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -142,7 +142,13 @@ export {
 export { default as Guide } from './guide';
 export { default as GuidePage } from './guide/page';
 export { Heading as __experimentalHeading } from './heading';
-export { HStack as __experimentalHStack } from './h-stack';
+export {
+	/**
+	 * @deprecated Import `HStack` instead.
+	 */
+	HStack as __experimentalHStack,
+	HStack,
+} from './h-stack';
 export { default as Icon } from './icon';
 export type { IconType } from './icon';
 export { default as IconButton } from './button/deprecated';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -92,7 +92,13 @@ export {
 export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
-export { default as __experimentalDimensionControl } from './dimension-control';
+export {
+	/**
+	 * @deprecated Import `DimensionControl` instead.
+	 */
+	default as __experimentalDimensionControl,
+	DimensionControl,
+} from './dimension-control';
 export { default as Disabled } from './disabled';
 export { DisclosureContent as __unstableDisclosureContent } from './disclosure';
 export { Divider as __experimentalDivider } from './divider';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -82,7 +82,13 @@ export {
 	CompositeItem as __unstableCompositeItem,
 	useCompositeState as __unstableUseCompositeState,
 } from './composite';
-export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
+export {
+	/**
+	 * @deprecated Import `ConfirmDialog` instead.
+	 */
+	ConfirmDialog as __experimentalConfirmDialog,
+	ConfirmDialog,
+} from './confirm-dialog';
 export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -325,10 +325,26 @@ export {
 } from './tools-panel';
 export { default as Tooltip } from './tooltip';
 export {
+	/**
+	 * @deprecated Import `TreeGrid` instead.
+	 */
 	default as __experimentalTreeGrid,
+	/**
+	 * @deprecated Import `TreeGridRow` instead.
+	 */
 	TreeGridRow as __experimentalTreeGridRow,
+	/**
+	 * @deprecated Import `TreeGridCell` instead.
+	 */
 	TreeGridCell as __experimentalTreeGridCell,
+	/**
+	 * @deprecated Import `TreeGridItem` instead.
+	 */
 	TreeGridItem as __experimentalTreeGridItem,
+	default as TreeGrid,
+	TreeGridRow,
+	TreeGridCell,
+	TreeGridItem,
 } from './tree-grid';
 export { default as TreeSelect } from './tree-select';
 export { Truncate as __experimentalTruncate } from './truncate';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -115,7 +115,13 @@ export { default as Dropdown } from './dropdown';
 export { default as __experimentalDropdownContentWrapper } from './dropdown/dropdown-content-wrapper';
 export { default as DropdownMenu } from './dropdown-menu';
 export { DuotoneSwatch, DuotonePicker } from './duotone-picker';
-export { Elevation as __experimentalElevation } from './elevation';
+export {
+	/**
+	 * @deprecated Import `Elevation` instead.
+	 */
+	Elevation as __experimentalElevation,
+	Elevation,
+} from './elevation';
 export { default as ExternalLink } from './external-link';
 export { Flex, FlexBlock, FlexItem } from './flex';
 export { default as FocalPointPicker } from './focal-point-picker';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -52,8 +52,12 @@ export {
 	BorderControl,
 } from './border-control';
 export {
+	/**
+	 * @deprecated Import `BoxControl` instead.
+	 */
 	default as __experimentalBoxControl,
 	applyValueToSides as __experimentalApplyValueToSides,
+	default as BoxControl,
 } from './box-control';
 export { default as Button } from './button';
 export { default as ButtonGroup } from './button-group';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -269,7 +269,13 @@ export {
 	Surface,
 } from './surface';
 export { default as TabPanel } from './tab-panel';
-export { Text as __experimentalText } from './text';
+export {
+	/**
+	 * @deprecated Import `Text` instead.
+	 */
+	Text as __experimentalText,
+	Text,
+} from './text';
 export { default as TextControl } from './text-control';
 export { default as TextareaControl } from './textarea-control';
 export { default as TextHighlight } from './text-highlight';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -35,10 +35,14 @@ export {
 } from './autocomplete';
 export { default as BaseControl, useBaseControlProps } from './base-control';
 export {
+	/**
+	 * @deprecated Import `BorderBoxControl` instead.
+	 */
 	BorderBoxControl as __experimentalBorderBoxControl,
 	hasSplitBorders as __experimentalHasSplitBorders,
 	isDefinedBorder as __experimentalIsDefinedBorder,
 	isEmptyBorder as __experimentalIsEmptyBorder,
+	BorderBoxControl,
 } from './border-box-control';
 export { BorderControl as __experimentalBorderControl } from './border-control';
 export {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -162,7 +162,13 @@ export {
 	ItemGroup as __experimentalItemGroup,
 	Item as __experimentalItem,
 } from './item-group';
-export { default as __experimentalInputControl } from './input-control';
+export {
+	/**
+	 * @deprecated Import `InputControl` instead.
+	 */
+	default as __experimentalInputControl,
+	InputControl,
+} from './input-control';
 export { default as __experimentalInputControlPrefixWrapper } from './input-control/input-prefix-wrapper';
 export { default as __experimentalInputControlSuffixWrapper } from './input-control/input-suffix-wrapper';
 export { default as KeyboardShortcuts } from './keyboard-shortcuts';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -363,7 +363,13 @@ export {
 	parseQuantityAndUnitFromRawValue as __experimentalParseQuantityAndUnitFromRawValue,
 	UnitControl,
 } from './unit-control';
-export { View as __experimentalView } from './view';
+export {
+	/**
+	 * @deprecated Import `View` instead.
+	 */
+	View as __experimentalView,
+	View,
+} from './view';
 export { VisuallyHidden } from './visually-hidden';
 export {
 	/**

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -246,8 +246,20 @@ export { default as SearchControl } from './search-control';
 export { default as SelectControl } from './select-control';
 export { default as Snackbar } from './snackbar';
 export { default as SnackbarList } from './snackbar/list';
-export { Spacer as __experimentalSpacer } from './spacer';
-export { Scrollable as __experimentalScrollable } from './scrollable';
+export {
+	/**
+	 * @deprecated Import `Spacer` instead.
+	 */
+	Spacer as __experimentalSpacer,
+	Spacer,
+} from './spacer';
+export {
+	/**
+	 * @deprecated Import `Scrollable` instead.
+	 */
+	Scrollable as __experimentalScrollable,
+	Scrollable,
+} from './scrollable';
 export { default as Spinner } from './spinner';
 export { Surface as __experimentalSurface } from './surface';
 export { default as TabPanel } from './tab-panel';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -388,7 +388,13 @@ export {
 	useSlotFills as __experimentalUseSlotFills,
 } from './slot-fill';
 export { default as __experimentalStyleProvider } from './style-provider';
-export { ZStack as __experimentalZStack } from './z-stack';
+export {
+	/**
+	 * @deprecated Import `ZStack` instead.
+	 */
+	ZStack as __experimentalZStack,
+	ZStack,
+} from './z-stack';
 
 // Higher-Order Components.
 export {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -261,7 +261,13 @@ export {
 	Scrollable,
 } from './scrollable';
 export { default as Spinner } from './spinner';
-export { Surface as __experimentalSurface } from './surface';
+export {
+	/**
+	 * @deprecated Import `Surface` instead.
+	 */
+	Surface as __experimentalSurface,
+	Surface,
+} from './surface';
 export { default as TabPanel } from './tab-panel';
 export { Text as __experimentalText } from './text';
 export { default as TextControl } from './text-control';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -282,9 +282,21 @@ export { default as TextHighlight } from './text-highlight';
 export { default as Tip } from './tip';
 export { default as ToggleControl } from './toggle-control';
 export {
+	/**
+	 * @deprecated Import `ToggleGroupControl` instead.
+	 */
 	ToggleGroupControl as __experimentalToggleGroupControl,
+	/**
+	 * @deprecated Import `ToggleGroupControlOption` instead.
+	 */
 	ToggleGroupControlOption as __experimentalToggleGroupControlOption,
+	/**
+	 * @deprecated Import `ToggleGroupControlOptionIcon` instead.
+	 */
 	ToggleGroupControlOptionIcon as __experimentalToggleGroupControlOptionIcon,
+	ToggleGroupControl,
+	ToggleGroupControlOption,
+	ToggleGroupControlOptionIcon,
 } from './toggle-group-control';
 export {
 	Toolbar,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -141,7 +141,13 @@ export {
 } from './grid';
 export { default as Guide } from './guide';
 export { default as GuidePage } from './guide/page';
-export { Heading as __experimentalHeading } from './heading';
+export {
+	/**
+	 * @deprecated Import `Heading` instead.
+	 */
+	Heading as __experimentalHeading,
+	Heading,
+} from './heading';
 export {
 	/**
 	 * @deprecated Import `HStack` instead.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -365,7 +365,13 @@ export {
 } from './unit-control';
 export { View as __experimentalView } from './view';
 export { VisuallyHidden } from './visually-hidden';
-export { VStack as __experimentalVStack } from './v-stack';
+export {
+	/**
+	 * @deprecated Import `VStack` instead.
+	 */
+	VStack as __experimentalVStack,
+	VStack,
+} from './v-stack';
 export { default as IsolatedEventContainer } from './isolated-event-container';
 export {
 	createSlotFill,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -188,12 +188,36 @@ export { default as __experimentalNavigationGroup } from './navigation/group';
 export { default as __experimentalNavigationItem } from './navigation/item';
 export { default as __experimentalNavigationMenu } from './navigation/menu';
 export {
+	/**
+	 * @deprecated Import `NavigatorProvider` instead.
+	 */
 	NavigatorProvider as __experimentalNavigatorProvider,
+	/**
+	 * @deprecated Import `NavigatorScreen` instead.
+	 */
 	NavigatorScreen as __experimentalNavigatorScreen,
+	/**
+	 * @deprecated Import `NavigatorButton` instead.
+	 */
 	NavigatorButton as __experimentalNavigatorButton,
+	/**
+	 * @deprecated Import `NavigatorBackButton` instead.
+	 */
 	NavigatorBackButton as __experimentalNavigatorBackButton,
+	/**
+	 * @deprecated Import `NavigatorToParentButton` instead.
+	 */
 	NavigatorToParentButton as __experimentalNavigatorToParentButton,
+	/**
+	 * @deprecated Import `useNavigator` instead.
+	 */
 	useNavigator as __experimentalUseNavigator,
+	NavigatorProvider,
+	NavigatorScreen,
+	NavigatorButton,
+	NavigatorBackButton,
+	NavigatorToParentButton,
+	useNavigator,
 } from './navigator';
 export { default as Notice } from './notice';
 export { default as __experimentalNumberControl } from './number-control';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -220,7 +220,13 @@ export {
 	useNavigator,
 } from './navigator';
 export { default as Notice } from './notice';
-export { default as __experimentalNumberControl } from './number-control';
+export {
+	/**
+	 * @deprecated Import `NumberControl` instead.
+	 */
+	default as __experimentalNumberControl,
+	NumberControl,
+} from './number-control';
 export { default as NoticeList } from './notice/list';
 export { default as Panel } from './panel';
 export { default as PanelBody } from './panel/body';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -307,9 +307,21 @@ export {
 	ToolbarItem,
 } from './toolbar';
 export {
+	/**
+	 * @deprecated Import `ToolsPanel` instead.
+	 */
 	ToolsPanel as __experimentalToolsPanel,
+	/**
+	 * @deprecated Import `ToolsPanelItem` instead.
+	 */
 	ToolsPanelItem as __experimentalToolsPanelItem,
+	/**
+	 * @deprecated Import `ToolsPanelContext` instead.
+	 */
 	ToolsPanelContext as __experimentalToolsPanelContext,
+	ToolsPanel,
+	ToolsPanelItem,
+	ToolsPanelContext,
 } from './tools-panel';
 export { default as Tooltip } from './tooltip';
 export {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -159,8 +159,12 @@ export { default as Icon } from './icon';
 export type { IconType } from './icon';
 export { default as IconButton } from './button/deprecated';
 export {
+	/**
+	 * @deprecated Import `ItemGroup` instead.
+	 */
 	ItemGroup as __experimentalItemGroup,
 	Item as __experimentalItem,
+	ItemGroup,
 } from './item-group';
 export {
 	/**

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -347,7 +347,13 @@ export {
 	TreeGridItem,
 } from './tree-grid';
 export { default as TreeSelect } from './tree-select';
-export { Truncate as __experimentalTruncate } from './truncate';
+export {
+	/**
+	 * @deprecated Import `Truncate` instead.
+	 */
+	Truncate as __experimentalTruncate,
+	Truncate,
+} from './truncate';
 export {
 	default as __experimentalUnitControl,
 	useCustomUnits as __experimentalUseCustomUnits,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -355,9 +355,13 @@ export {
 	Truncate,
 } from './truncate';
 export {
+	/**
+	 * @deprecated Import `UnitControl` instead.
+	 */
 	default as __experimentalUnitControl,
 	useCustomUnits as __experimentalUseCustomUnits,
 	parseQuantityAndUnitFromRawValue as __experimentalParseQuantityAndUnitFromRawValue,
+	UnitControl,
 } from './unit-control';
 export { View as __experimentalView } from './view';
 export { VisuallyHidden } from './visually-hidden';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -44,7 +44,13 @@ export {
 	isEmptyBorder as __experimentalIsEmptyBorder,
 	BorderBoxControl,
 } from './border-box-control';
-export { BorderControl as __experimentalBorderControl } from './border-control';
+export {
+	/**
+	 * @deprecated Import `BorderControl` instead.
+	 */
+	BorderControl as __experimentalBorderControl,
+	BorderControl,
+} from './border-control';
 export {
 	default as __experimentalBoxControl,
 	applyValueToSides as __experimentalApplyValueToSides,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -132,7 +132,13 @@ export { default as FormToggle } from './form-toggle';
 export { default as FormTokenField } from './form-token-field';
 export { default as GradientPicker } from './gradient-picker';
 export { default as CustomGradientPicker } from './custom-gradient-picker';
-export { Grid as __experimentalGrid } from './grid';
+export {
+	/**
+	 * @deprecated Import `Grid` instead.
+	 */
+	Grid as __experimentalGrid,
+	Grid,
+} from './grid';
 export { default as Guide } from './guide';
 export { default as GuidePage } from './guide/page';
 export { Heading as __experimentalHeading } from './heading';

--- a/packages/components/src/input-control/README.md
+++ b/packages/components/src/input-control/README.md
@@ -1,15 +1,11 @@
 # InputControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 InputControl components let users enter and edit text. This is an experimental component intended to (in time) merge with or replace [TextControl](../text-control).
 
 ## Usage
 
 ```js
-import { __experimentalInputControl as InputControl } from '@wordpress/components';
+import { InputControl } from '@wordpress/components';
 import { useState } from 'react';
 
 const Example = () => {

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -120,7 +120,7 @@ export function UnforwardedInputControl(
  * intended to (in time) merge with or replace `TextControl`.
  *
  * ```jsx
- * import { __experimentalInputControl as InputControl } from '@wordpress/components';
+ * import { InputControl } from '@wordpress/components';
  * import { useState } from 'react';
  *
  * const Example = () => {

--- a/packages/components/src/input-control/input-prefix-wrapper.tsx
+++ b/packages/components/src/input-control/input-prefix-wrapper.tsx
@@ -28,7 +28,7 @@ function UnconnectedInputControlPrefixWrapper(
  *
  * ```jsx
  * import {
- *   __experimentalInputControl as InputControl,
+ *   InputControl,
  *   __experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/input-control/input-suffix-wrapper.tsx
+++ b/packages/components/src/input-control/input-suffix-wrapper.tsx
@@ -28,7 +28,7 @@ function UnconnectedInputControlSuffixWrapper(
  *
  * ```jsx
  * import {
- *   __experimentalInputControl as InputControl,
+ *   InputControl,
  *   __experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/input-control/stories/index.story.tsx
+++ b/packages/components/src/input-control/stories/index.story.tsx
@@ -11,7 +11,7 @@ import { InputControlPrefixWrapper } from '../input-prefix-wrapper';
 import { InputControlSuffixWrapper } from '../input-suffix-wrapper';
 
 const meta: Meta< typeof InputControl > = {
-	title: 'Components (Experimental)/InputControl',
+	title: 'Components/InputControl',
 	component: InputControl,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { InputControlPrefixWrapper, InputControlSuffixWrapper },

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -130,7 +130,7 @@ export interface InputBaseProps extends BaseProps, FlexProps {
 	 *
 	 * @example
 	 * import {
-	 *   __experimentalInputControl as InputControl,
+	 *   InputControl,
 	 *   __experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	 * } from '@wordpress/components';
 	 *
@@ -148,7 +148,7 @@ export interface InputBaseProps extends BaseProps, FlexProps {
 	 *
 	 * @example
 	 * import {
-	 *   __experimentalInputControl as InputControl,
+	 *   InputControl,
 	 *   __experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 	 * } from '@wordpress/components';
 	 *

--- a/packages/components/src/item-group/item-group/README.md
+++ b/packages/components/src/item-group/item-group/README.md
@@ -1,9 +1,5 @@
 # `ItemGroup`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `ItemGroup` displays a list of `Item`s grouped and styled together.
 
 ## Usage
@@ -12,7 +8,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalItemGroup as ItemGroup,
+	ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
 
@@ -66,7 +62,7 @@ In the following example, the `<Item />` will render with a size of `small`:
 
 ```jsx
 import {
-	__experimentalItemGroup as ItemGroup,
+	ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
 

--- a/packages/components/src/item-group/item-group/component.tsx
+++ b/packages/components/src/item-group/item-group/component.tsx
@@ -46,7 +46,7 @@ function UnconnectedItemGroup(
  *
  * ```jsx
  * import {
- *   __experimentalItemGroup as ItemGroup,
+ *   ItemGroup,
  *   __experimentalItem as Item,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/item-group/item/README.md
+++ b/packages/components/src/item-group/item/README.md
@@ -1,9 +1,5 @@
 # `Item`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Item` is used in combination with `ItemGroup` to display a list of items grouped and styled together.
 
 ## Usage
@@ -12,7 +8,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalItemGroup as ItemGroup,
+	ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
 
@@ -50,7 +46,7 @@ In the following example, the `<Item />` will render with a size of `small`:
 
 ```jsx
 import {
-	__experimentalItemGroup as ItemGroup,
+	ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
 

--- a/packages/components/src/item-group/item/component.tsx
+++ b/packages/components/src/item-group/item/component.tsx
@@ -31,7 +31,7 @@ function UnconnectedItem(
  *
  * ```jsx
  * import {
- *   __experimentalItemGroup as ItemGroup,
+ *   ItemGroup,
  *   __experimentalItem as Item,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/item-group/stories/index.story.tsx
+++ b/packages/components/src/item-group/stories/index.story.tsx
@@ -15,7 +15,7 @@ const meta: Meta< typeof ItemGroup > = {
 	component: ItemGroup,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { Item },
-	title: 'Components (Experimental)/ItemGroup',
+	title: 'Components/ItemGroup',
 	argTypes: {
 		as: { control: { type: null } },
 		children: { control: { type: null } },

--- a/packages/components/src/navigator/navigator-back-button/README.md
+++ b/packages/components/src/navigator/navigator-back-button/README.md
@@ -1,9 +1,5 @@
 # `NavigatorBackButton`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorBackButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage

--- a/packages/components/src/navigator/navigator-back-button/component.tsx
+++ b/packages/components/src/navigator/navigator-back-button/component.tsx
@@ -30,10 +30,10 @@ function UnconnectedNavigatorBackButton(
  * @example
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorBackButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-button/README.md
+++ b/packages/components/src/navigator/navigator-button/README.md
@@ -1,9 +1,5 @@
 # `NavigatorButton`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage

--- a/packages/components/src/navigator/navigator-button/component.tsx
+++ b/packages/components/src/navigator/navigator-button/component.tsx
@@ -29,10 +29,10 @@ function UnconnectedNavigatorButton(
  * @example
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorBackButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-provider/README.md
+++ b/packages/components/src/navigator/navigator-provider/README.md
@@ -1,19 +1,15 @@
 # `NavigatorProvider`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorProvider` component allows rendering nested views/panels/menus (via the [`NavigatorScreen` component](/packages/components/src/navigator/navigator-screen/README.md)) and navigate between these different states (via the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md), [`NavigatorToParentButton`](/packages/components/src/navigator/navigator-to-parent-button/README.md) and [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components or the `useNavigator` hook). The Global Styles sidebar is an example of this.
 
 ## Usage
 
 ```jsx
 import {
-  __experimentalNavigatorProvider as NavigatorProvider,
-  __experimentalNavigatorScreen as NavigatorScreen,
-  __experimentalNavigatorButton as NavigatorButton,
-  __experimentalNavigatorToParentButton as NavigatorToParentButton,
+  NavigatorProvider,
+  NavigatorScreen,
+  NavigatorButton,
+  NavigatorToParentButton,
 } from '@wordpress/components';
 
 const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -274,10 +274,10 @@ function UnconnectedNavigatorProvider(
  *
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorBackButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-screen/README.md
+++ b/packages/components/src/navigator/navigator-screen/README.md
@@ -1,9 +1,5 @@
 # `NavigatorScreen`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorScreen` component represents a single view/screen/panel and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) and the [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -147,10 +147,10 @@ function UnconnectedNavigatorScreen(
  * @example
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorBackButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-to-parent-button/README.md
+++ b/packages/components/src/navigator/navigator-to-parent-button/README.md
@@ -1,9 +1,5 @@
 # `NavigatorToParentButton`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorToParentButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -33,10 +33,10 @@ function UnconnectedNavigatorToParentButton(
  * @example
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorToParentButton as NavigatorToParentButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorToParentButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -23,7 +23,7 @@ const meta: Meta< typeof NavigatorProvider > = {
 	component: NavigatorProvider,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { NavigatorScreen, NavigatorButton, NavigatorBackButton },
-	title: 'Components (Experimental)/Navigator',
+	title: 'Components/Navigator',
 	argTypes: {
 		as: { control: { type: null } },
 		children: { control: { type: null } },

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -1,15 +1,11 @@
 # NumberControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 NumberControl is an enhanced HTML [`input[type="number]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) element.
 
 ## Usage
 
 ```jsx
-import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
+import { NumberControl } from '@wordpress/components';
 
 const Example = () => {
 	const [ value, setValue ] = useState( 10 );

--- a/packages/components/src/number-control/stories/index.story.tsx
+++ b/packages/components/src/number-control/stories/index.story.tsx
@@ -14,7 +14,7 @@ import { useState } from '@wordpress/element';
 import NumberControl from '..';
 
 const meta: Meta< typeof NumberControl > = {
-	title: 'Components (Experimental)/NumberControl',
+	title: 'Components/NumberControl',
 	component: NumberControl,
 	argTypes: {
 		onChange: { action: 'onChange' },

--- a/packages/components/src/progress-bar/stories/index.story.tsx
+++ b/packages/components/src/progress-bar/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { ProgressBar } from '..';
 
 const meta: Meta< typeof ProgressBar > = {
 	component: ProgressBar,
-	title: 'Components (Experimental)/ProgressBar',
+	title: 'Components/ProgressBar',
 	argTypes: {
 		value: { control: { type: 'number', min: 0, max: 100, step: 1 } },
 	},

--- a/packages/components/src/scrollable/README.md
+++ b/packages/components/src/scrollable/README.md
@@ -1,15 +1,11 @@
 # Scrollable
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Scrollable` is a layout component that content in a scrollable container.
 
 ## Usage
 
 ```jsx
-import { __experimentalScrollable as Scrollable } from '@wordpress/components';
+import { Scrollable } from '@wordpress/components';
 
 function Example() {
 	return (

--- a/packages/components/src/scrollable/component.tsx
+++ b/packages/components/src/scrollable/component.tsx
@@ -25,7 +25,7 @@ function UnconnectedScrollable(
  * `Scrollable` is a layout component that content in a scrollable container.
  *
  * ```jsx
- * import { __experimentalScrollable as Scrollable } from `@wordpress/components`;
+ * import { Scrollable } from `@wordpress/components`;
  *
  * function Example() {
  * 	return (

--- a/packages/components/src/scrollable/stories/index.story.tsx
+++ b/packages/components/src/scrollable/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { Scrollable } from '..';
 
 const meta: Meta< typeof Scrollable > = {
 	component: Scrollable,
-	title: 'Components (Experimental)/Scrollable',
+	title: 'Components/Scrollable',
 	argTypes: {
 		as: {
 			control: { type: 'text' },

--- a/packages/components/src/spacer/README.md
+++ b/packages/components/src/spacer/README.md
@@ -13,7 +13,7 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	__experimentalSpacer as Spacer,
-	__experimentalHeading as Heading,
+	Heading,
 	__experimentalView as View,
 } from '@wordpress/components';
 

--- a/packages/components/src/spacer/README.md
+++ b/packages/components/src/spacer/README.md
@@ -1,9 +1,5 @@
 # Spacer
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Spacer` is a primitive layout component that providers inner (`padding`) or outer (`margin`) space in-between components. It can also be used to adaptively provide space within an `HStack` or `VStack`.
 
 ## Usage
@@ -12,7 +8,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalSpacer as Spacer,
+	Spacer,
 	Heading,
 	__experimentalView as View,
 } from '@wordpress/components';

--- a/packages/components/src/spacer/README.md
+++ b/packages/components/src/spacer/README.md
@@ -10,7 +10,7 @@
 import {
 	Spacer,
 	Heading,
-	__experimentalView as View,
+	View,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/spacer/stories/index.story.tsx
+++ b/packages/components/src/spacer/stories/index.story.tsx
@@ -31,7 +31,7 @@ const controls = [
 
 const meta: Meta< typeof Spacer > = {
 	component: Spacer,
-	title: 'Components (Experimental)/Spacer',
+	title: 'Components/Spacer',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		children: {

--- a/packages/components/src/surface/README.md
+++ b/packages/components/src/surface/README.md
@@ -1,9 +1,5 @@
 # Surface
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Surface` is a core component that renders a primary background color.
 
 ## Usage
@@ -12,7 +8,7 @@ In the example below, notice how the `Surface` renders in white (or dark gray if
 
 ```jsx
 import {
-	__experimentalSurface as Surface,
+	Surface,
 	__experimentalText as Text,
 } from '@wordpress/components';
 

--- a/packages/components/src/surface/README.md
+++ b/packages/components/src/surface/README.md
@@ -9,7 +9,7 @@ In the example below, notice how the `Surface` renders in white (or dark gray if
 ```jsx
 import {
 	Surface,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/surface/component.tsx
+++ b/packages/components/src/surface/component.tsx
@@ -28,7 +28,7 @@ function UnconnectedSurface(
  *
  * ```jsx
  * import {
- *	__experimentalSurface as Surface,
+ *	Surface,
  *	__experimentalText as Text,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/surface/component.tsx
+++ b/packages/components/src/surface/component.tsx
@@ -29,7 +29,7 @@ function UnconnectedSurface(
  * ```jsx
  * import {
  *	Surface,
- *	__experimentalText as Text,
+ *	Text,
  * } from '@wordpress/components';
  *
  * function Example() {

--- a/packages/components/src/surface/stories/index.story.tsx
+++ b/packages/components/src/surface/stories/index.story.tsx
@@ -11,7 +11,7 @@ import { Text } from '../../text';
 
 const meta: Meta< typeof Surface > = {
 	component: Surface,
-	title: 'Components (Experimental)/Surface',
+	title: 'Components/Surface',
 	argTypes: {
 		children: { control: { type: null } },
 		as: { control: { type: 'text' } },

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -18,7 +18,7 @@ import DropdownMenu from '../../dropdown-menu';
 import Button from '../../button';
 
 const meta: Meta< typeof Tabs > = {
-	title: 'Components (Experimental)/Tabs',
+	title: 'Components/Tabs',
 	component: Tabs,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170

--- a/packages/components/src/text/README.md
+++ b/packages/components/src/text/README.md
@@ -11,7 +11,7 @@ This feature is still experimental. “Experimental” means this is an early im
 `Text` can be used to render any text-content, like an HTML `p` or `span`.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return <Text>Code is Poetry</Text>;
@@ -27,7 +27,7 @@ function Example() {
 Automatically calculate the appropriate line-height value for contents that render text and Control elements (e.g. `TextInput`).
 
 ```jsx
-import { __experimentalText as Text, TextInput } from '@wordpress/components';
+import { Text, TextInput } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -46,7 +46,7 @@ function Example() {
 Adjusts the text alignment.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -111,7 +111,7 @@ Array of search words. String search terms are automatically cast to RegExps unl
 Letters or words within `Text` can be highlighted using `highlightWords`.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -165,7 +165,7 @@ Clamps the text content to the specifiec `numberOfLines`, adding the `ellipsis` 
 The `Text` color can be adapted to a background color for optimal readability. `optimizeReadabilityFor` can accept CSS variables, in addition to standard CSS color values (e.g. Hex, RGB, HSL, etc...).
 
 ```jsx
-import { __experimentalText as Text, View } from '@wordpress/components';
+import { Text, View } from '@wordpress/components';
 
 function Example() {
 	const backgroundColor = 'blue';
@@ -187,7 +187,7 @@ function Example() {
 Adjusts text size based on the typography system. `Text` can render a wide range of font sizes, which are automatically calculated and adapted to the typography system. The `size` value can be a system preset, a `number`, or a custom unit value (`string`) such as `30em`.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return <Text size="largeTitle">Code is Poetry</Text>;
@@ -203,7 +203,7 @@ Enables text truncation. When `truncate` is set, we are able to truncate the lon
 Note: text truncation won't work if the `isBlock` property is set to `true`
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -231,7 +231,7 @@ Uppercases the text content.
 Adjusts style variation of the text.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return <Text variant="muted">Code is Poetry</Text>;

--- a/packages/components/src/text/component.tsx
+++ b/packages/components/src/text/component.tsx
@@ -29,7 +29,7 @@ function UnconnectedText(
  * @example
  *
  * ```jsx
- * import { __experimentalText as Text } from `@wordpress/components`;
+ * import { Text } from `@wordpress/components`;
  *
  * function Example() {
  * 	return <Text>Code is Poetry</Text>;

--- a/packages/components/src/text/stories/index.story.tsx
+++ b/packages/components/src/text/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { Text } from '../component';
 
 const meta: Meta< typeof Text > = {
 	component: Text,
-	title: 'Components (Experimental)/Text',
+	title: 'Components/Text',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		color: { control: { type: 'color' } },

--- a/packages/components/src/theme/stories/index.story.tsx
+++ b/packages/components/src/theme/stories/index.story.tsx
@@ -13,7 +13,7 @@ import { HStack } from '../../h-stack';
 
 const meta: Meta< typeof Theme > = {
 	component: Theme,
-	title: 'Components (Experimental)/Theme',
+	title: 'Components/Theme',
 	argTypes: {
 		accent: { control: { type: 'color' } },
 		background: { control: { type: 'color' } },

--- a/packages/components/src/toggle-group-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof ToggleGroupControl > = {
 	component: ToggleGroupControl,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { ToggleGroupControlOption, ToggleGroupControlOptionIcon },
-	title: 'Components (Experimental)/ToggleGroupControl',
+	title: 'Components/ToggleGroupControl',
 	argTypes: {
 		help: { control: { type: 'text' } },
 		onChange: { action: 'onChange' },

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -184,8 +184,8 @@ function ToggleGroupControlOptionBase(
  * @example
  * ```jsx
  * import {
- *   __experimentalToggleGroupControl as ToggleGroupControl,
- *   __experimentalToggleGroupControlOptionBase as ToggleGroupControlOptionBase,
+ *   ToggleGroupControl,
+ *   ToggleGroupControlOptionBase,
  * } from '@wordpress/components';
  *
  * function Example() {

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/README.md
@@ -1,17 +1,13 @@
 # `ToggleGroupControlOptionIcon`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `ToggleGroupControlOptionIcon` is a form component which is meant to be used as a child of [`ToggleGroupControl`](/packages/components/src/toggle-group-control/toggle-group-control/README.md) and displays an icon.
 
 ## Usage
 
 ```js
 import {
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+	ToggleGroupControl,
+	ToggleGroupControlOptionIcon,
 } from '@wordpress/components';
 import { formatLowercase, formatUppercase } from '@wordpress/icons';
 

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
@@ -45,8 +45,8 @@ function UnforwardedToggleGroupControlOptionIcon(
  * ```jsx
  *
  * import {
- *	__experimentalToggleGroupControl as ToggleGroupControl,
- *	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+ *	ToggleGroupControl,
+ *	ToggleGroupControlOptionIcon,
  * from '@wordpress/components';
  * import { formatLowercase, formatUppercase } from '@wordpress/icons';
  *

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
@@ -1,9 +1,5 @@
 # `ToggleGroupControlOption`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `ToggleGroupControlOption` is a form component and is meant to be used as a child of [`ToggleGroupControl`](/packages/components/src/toggle-group-control/toggle-group-control/README.md).
 
 
@@ -11,8 +7,8 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```js
 import {
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	ToggleGroupControl,
+	ToggleGroupControlOption,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -42,8 +42,8 @@ function UnforwardedToggleGroupControlOption(
  *
  * ```jsx
  * import {
- *   __experimentalToggleGroupControl as ToggleGroupControl,
- *   __experimentalToggleGroupControlOption as ToggleGroupControlOption,
+ *   ToggleGroupControl,
+ *   ToggleGroupControlOption,
  * } from '@wordpress/components';
  *
  * function Example() {

--- a/packages/components/src/toggle-group-control/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control/README.md
@@ -1,9 +1,5 @@
 # `ToggleGroupControl`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `ToggleGroupControl` is a form component that lets users choose options represented in horizontal segments. To render options for this control use [`ToggleGroupControlOption`](/packages/components/src/toggle-group-control/toggle-group-control-option/README.md) component.
 
 This component is intended for selecting a single persistent value from a set of options, similar to a how a radio button group would work. If you simply want a toggle to switch between views, use a [`TabPanel`](/packages/components/src/tab-panel/README.md) instead.
@@ -14,8 +10,8 @@ Only use this control when you know for sure the labels of items inside won't wr
 
 ```js
 import {
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	ToggleGroupControl,
+	ToggleGroupControlOption,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -111,8 +111,8 @@ function UnconnectedToggleGroupControl(
  *
  * ```jsx
  * import {
- *   __experimentalToggleGroupControl as ToggleGroupControl,
- *   __experimentalToggleGroupControlOption as ToggleGroupControlOption,
+ *   ToggleGroupControl,
+ *   ToggleGroupControlOption,
  * } from '@wordpress/components';
  *
  * function Example() {

--- a/packages/components/src/tools-panel/stories/index.story.tsx
+++ b/packages/components/src/tools-panel/stories/index.story.tsx
@@ -26,7 +26,7 @@ import UnitControl from '../../unit-control';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 
 const meta: Meta< typeof ToolsPanel > = {
-	title: 'Components (Experimental)/ToolsPanel',
+	title: 'Components/ToolsPanel',
 	component: ToolsPanel,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { ToolsPanelItem },

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -60,7 +60,7 @@ import styled from '@emotion/styled';
  * WordPress dependencies
  */
 import {
-	__experimentalBoxControl as BoxControl,
+	BoxControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUnitControl as UnitControl,

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -1,10 +1,5 @@
 # ToolsPanel
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early
-implementation subject to drastic and breaking changes.
-</div>
-<br />
 These panels provide progressive discovery options for their children. For
 example the controls provided via block supports.
 
@@ -61,8 +56,8 @@ import styled from '@emotion/styled';
  */
 import {
 	BoxControl,
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
+	ToolsPanel,
+	ToolsPanelItem,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -58,7 +58,7 @@ import {
 	BoxControl,
 	ToolsPanel,
 	ToolsPanelItem,
-	__experimentalUnitControl as UnitControl,
+	UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -53,8 +53,8 @@ const UnconnectedToolsPanel = (
  * ```jsx
  * import { __ } from '@wordpress/i18n';
  * import {
- *   __experimentalToolsPanel as ToolsPanel,
- *   __experimentalToolsPanelItem as ToolsPanelItem,
+ *   ToolsPanel,
+ *   ToolsPanelItem,
  *   __experimentalUnitControl as UnitControl
  * } from '@wordpress/components';
  *

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -55,7 +55,7 @@ const UnconnectedToolsPanel = (
  * import {
  *   ToolsPanel,
  *   ToolsPanelItem,
- *   __experimentalUnitControl as UnitControl
+ *   UnitControl
  * } from '@wordpress/components';
  *
  * function Example() {

--- a/packages/components/src/tree-grid/stories/index.story.tsx
+++ b/packages/components/src/tree-grid/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { Button } from '../../button';
 import InputControl from '../../input-control';
 
 const meta: Meta< typeof TreeGrid > = {
-	title: 'Components (Experimental)/TreeGrid',
+	title: 'Components/TreeGrid',
 	component: TreeGrid,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { TreeGridRow, TreeGridCell },

--- a/packages/components/src/truncate/README.md
+++ b/packages/components/src/truncate/README.md
@@ -1,15 +1,11 @@
 # Truncate
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Truncate` is a typography primitive that trims text content. For almost all cases, it is recommended that `Text`, `Heading`, or `Subheading` is used to render text content. However, `Truncate` is available for custom implementations.
 
 ## Usage
 
 ```jsx
-import { __experimentalTruncate as Truncate } from '@wordpress/components';
+import { Truncate } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -66,7 +62,7 @@ Clamps the text content to the specified `numberOfLines`, adding an ellipsis at 
 -   Default: `0`
 
 ```jsx
-import { __experimentalTruncate as Truncate } from '@wordpress/components';
+import { Truncate } from '@wordpress/components';
 
 function Example() {
 	return (

--- a/packages/components/src/truncate/component.tsx
+++ b/packages/components/src/truncate/component.tsx
@@ -28,7 +28,7 @@ function UnconnectedTruncate(
  * available for custom implementations.
  *
  * ```jsx
- * import { __experimentalTruncate as Truncate } from `@wordpress/components`;
+ * import { Truncate } from `@wordpress/components`;
  *
  * function Example() {
  * 	return (

--- a/packages/components/src/truncate/stories/index.story.tsx
+++ b/packages/components/src/truncate/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { Truncate } from '..';
 
 const meta: Meta< typeof Truncate > = {
 	component: Truncate,
-	title: 'Components (Experimental)/Truncate',
+	title: 'Components/Truncate',
 	argTypes: {
 		children: { control: { type: 'text' } },
 		as: { control: { type: 'text' } },

--- a/packages/components/src/unit-control/README.md
+++ b/packages/components/src/unit-control/README.md
@@ -10,7 +10,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import { useState } from 'react';
-import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import { UnitControl } from '@wordpress/components';
 
 const Example = () => {
 	const [ value, setValue ] = useState( '10px' );
@@ -116,7 +116,7 @@ Example:
 
 ```jsx
 import { useState } from 'react';
-import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import { UnitControl } from '@wordpress/components';
 
 const Example = () => {
 	const [ value, setValue ] = useState( '10px' );

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -235,7 +235,7 @@ function UnforwardedUnitControl(
  *
  *
  * ```jsx
- * import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+ * import { UnitControl } from '@wordpress/components';
  * import { useState } from '@wordpress/element';
  *
  * const Example = () => {

--- a/packages/components/src/unit-control/stories/index.story.tsx
+++ b/packages/components/src/unit-control/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { CSS_UNITS } from '../utils';
 
 const meta: Meta< typeof UnitControl > = {
 	component: UnitControl,
-	title: 'Components (Experimental)/UnitControl',
+	title: 'Components/UnitControl',
 	argTypes: {
 		__unstableInputWidth: { control: { type: 'text' } },
 		__unstableStateReducer: { control: { type: null } },

--- a/packages/components/src/v-stack/README.md
+++ b/packages/components/src/v-stack/README.md
@@ -73,7 +73,7 @@ When a `Spacer` is used within an `VStack`, the `Spacer` adaptively expands to t
 
 ```jsx
 import {
-	__experimentalSpacer as Spacer,
+	Spacer,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -95,7 +95,7 @@ function Example() {
 
 ```jsx
 import {
-	__experimentalSpacer as Spacer,
+	Spacer,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';

--- a/packages/components/src/v-stack/README.md
+++ b/packages/components/src/v-stack/README.md
@@ -13,7 +13,7 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	Text,
-	__experimentalVStack as VStack,
+	VStack,
 } from '@wordpress/components';
 
 function Example() {
@@ -75,7 +75,7 @@ When a `Spacer` is used within an `VStack`, the `Spacer` adaptively expands to t
 import {
 	Spacer,
 	Text,
-	__experimentalVStack as VStack,
+	VStack,
 } from '@wordpress/components';
 
 function Example() {
@@ -97,7 +97,7 @@ function Example() {
 import {
 	Spacer,
 	Text,
-	__experimentalVStack as VStack,
+	VStack,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/v-stack/README.md
+++ b/packages/components/src/v-stack/README.md
@@ -12,7 +12,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalText as Text,
+	Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
@@ -74,7 +74,7 @@ When a `Spacer` is used within an `VStack`, the `Spacer` adaptively expands to t
 ```jsx
 import {
 	Spacer,
-	__experimentalText as Text,
+	Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
@@ -96,7 +96,7 @@ function Example() {
 ```jsx
 import {
 	Spacer,
-	__experimentalText as Text,
+	Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 

--- a/packages/components/src/v-stack/component.tsx
+++ b/packages/components/src/v-stack/component.tsx
@@ -29,7 +29,7 @@ function UnconnectedVStack(
  *
  * ```jsx
  * import {
- * 	__experimentalText as Text,
+ * 	Text,
  * 	__experimentalVStack as VStack,
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/v-stack/component.tsx
+++ b/packages/components/src/v-stack/component.tsx
@@ -30,7 +30,7 @@ function UnconnectedVStack(
  * ```jsx
  * import {
  * 	Text,
- * 	__experimentalVStack as VStack,
+ * 	VStack,
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/v-stack/stories/index.story.tsx
+++ b/packages/components/src/v-stack/stories/index.story.tsx
@@ -25,7 +25,7 @@ const ALIGNMENTS = {
 
 const meta: Meta< typeof VStack > = {
 	component: VStack,
-	title: 'Components (Experimental)/VStack',
+	title: 'Components/VStack',
 	argTypes: {
 		alignment: {
 			control: { type: 'select' },

--- a/packages/components/src/view/README.md
+++ b/packages/components/src/view/README.md
@@ -12,7 +12,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalText as Text,
+	Text,
 	__experimentalView as View,
 } from '@wordpress/components';
 

--- a/packages/components/src/view/README.md
+++ b/packages/components/src/view/README.md
@@ -13,7 +13,7 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	Text,
-	__experimentalView as View,
+	View,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/view/stories/index.story.tsx
+++ b/packages/components/src/view/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { View } from '..';
 
 const meta: Meta< typeof View > = {
 	component: View,
-	title: 'Components (Experimental)/View',
+	title: 'Components/View',
 	argTypes: {
 		as: { control: { type: null } },
 		children: { control: { type: 'text' } },

--- a/packages/components/src/z-stack/README.md
+++ b/packages/components/src/z-stack/README.md
@@ -9,7 +9,7 @@ This feature is still experimental. “Experimental” means this is an early im
 `ZStack` allows you to stack things along the Z-axis.
 
 ```jsx
-import { __experimentalZStack as ZStack } from '@wordpress/components';
+import { ZStack } from '@wordpress/components';
 
 function Example() {
 	return (

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -68,7 +68,7 @@ function UnconnectedZStack(
  * `ZStack` allows you to stack things along the Z-axis.
  *
  * ```jsx
- * import { __experimentalZStack as ZStack } from '@wordpress/components';
+ * import { ZStack } from '@wordpress/components';
  *
  * function Example() {
  *   return (

--- a/packages/components/src/z-stack/stories/index.story.tsx
+++ b/packages/components/src/z-stack/stories/index.story.tsx
@@ -13,7 +13,7 @@ import { ZStack } from '..';
 
 const meta: Meta< typeof ZStack > = {
 	component: ZStack,
-	title: 'Components (Experimental)/ZStack',
+	title: 'Components/ZStack',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		children: { control: { type: null } },

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,9 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [
+			'navigation',
+			'alignmentmatrixcontrol',
+		];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -21,6 +21,7 @@
 			'scrollable',
 			'spacer',
 			'surface',
+			'text',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -24,6 +24,7 @@
 			'text',
 			'togglegroupcontrol',
 			'toolspanel',
+			'treegrid',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -18,6 +18,7 @@
 			'navigator',
 			'numbercontrol',
 			'progressbar',
+			'scrollable',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -14,6 +14,7 @@
 			'hstack',
 			'heading',
 			'inputcontrol',
+			'itemgroup',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -4,6 +4,7 @@
 			'navigation',
 			'alignmentmatrixcontrol',
 			'borderboxcontrol',
+			'bordercontrol',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -20,6 +20,7 @@
 			'progressbar',
 			'scrollable',
 			'spacer',
+			'surface',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -3,6 +3,7 @@
 		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [
 			'navigation',
 			'alignmentmatrixcontrol',
+			'borderboxcontrol',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -29,6 +29,7 @@
 			'unitcontrol',
 			'tabs',
 			'vstack',
+			'view',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -23,6 +23,7 @@
 			'surface',
 			'text',
 			'togglegroupcontrol',
+			'toolspanel',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -12,6 +12,7 @@
 			'elevation',
 			'grid',
 			'hstack',
+			'heading',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -11,6 +11,7 @@
 			'divider',
 			'elevation',
 			'grid',
+			'hstack',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -33,6 +33,7 @@
 			'zstack',
 			'dropdownmenu-v2',
 			'theme',
+			'customselectcontrol-v2',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -25,6 +25,7 @@
 			'togglegroupcontrol',
 			'toolspanel',
 			'treegrid',
+			'truncate',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -31,6 +31,7 @@
 			'vstack',
 			'view',
 			'zstack',
+			'dropdownmenu-v2',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -26,6 +26,8 @@
 			'toolspanel',
 			'treegrid',
 			'truncate',
+			'unitcontrol',
+			'tabs',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -5,6 +5,7 @@
 			'alignmentmatrixcontrol',
 			'borderboxcontrol',
 			'bordercontrol',
+			'boxcontrol',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -9,6 +9,7 @@
 			'confirmdialog',
 			'dimensioncontrol',
 			'divider',
+			'elevation',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -6,6 +6,7 @@
 			'borderboxcontrol',
 			'bordercontrol',
 			'boxcontrol',
+			'confirmdialog',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -17,6 +17,7 @@
 			'itemgroup',
 			'navigator',
 			'numbercontrol',
+			'progressbar',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -19,6 +19,7 @@
 			'numbercontrol',
 			'progressbar',
 			'scrollable',
+			'spacer',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -28,6 +28,7 @@
 			'truncate',
 			'unitcontrol',
 			'tabs',
+			'vstack',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -7,6 +7,7 @@
 			'bordercontrol',
 			'boxcontrol',
 			'confirmdialog',
+			'dimensioncontrol',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -32,6 +32,7 @@
 			'view',
 			'zstack',
 			'dropdownmenu-v2',
+			'theme',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -8,6 +8,7 @@
 			'boxcontrol',
 			'confirmdialog',
 			'dimensioncontrol',
+			'divider',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -30,6 +30,7 @@
 			'tabs',
 			'vstack',
 			'view',
+			'zstack',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -16,6 +16,7 @@
 			'inputcontrol',
 			'itemgroup',
 			'navigator',
+			'numbercontrol',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -10,6 +10,7 @@
 			'dimensioncontrol',
 			'divider',
 			'elevation',
+			'grid',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -22,6 +22,7 @@
 			'spacer',
 			'surface',
 			'text',
+			'togglegroupcontrol',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -13,6 +13,7 @@
 			'grid',
 			'hstack',
 			'heading',
+			'inputcontrol',
 		];
 		const REDIRECTS = [
 			{

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -15,6 +15,7 @@
 			'heading',
 			'inputcontrol',
 			'itemgroup',
+			'navigator',
 		];
 		const REDIRECTS = [
 			{


### PR DESCRIPTION
> [!NOTE]
> Closed in favor of splitting commits into individual PRs. See the [issue](https://github.com/WordPress/gutenberg/issues/59418) for a complete list.

Solves: https://github.com/WordPress/gutenberg/issues/59418.
Follow-up to the first draft: https://github.com/WordPress/gutenberg/pull/60837.

## What?

Remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. Read more in the related issue. 

## How?

For each `__experimental` component:

1) Exports it from components without the `__experimental` prefix;
2) Keep the old `__experimental` alias export for backwards compatibility;
3) Add a deprecation annotation above the old alias;
4) Change all the code snippets in docs to reference the new non-experimental import (changing the actual imports across the Gutenberg app will be done in other follow-up(s));
5) Add the component id to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old `experimental` story paths are redirected to the new one.

**TODO:**
- [ ] Discuss code smells 👃🏻 
- [ ] Add changelog entry(ies) about the removal the `__experimental` prefix. Perhaps `Components: Remove "experimental" designation for <component>` for each component would be the best changelog entry, semantically?

## Testing Instructions

* All checks should pass;
* Unit tests and E2Es should pass;


