### PR TITLE
Site Editor: fallback to url when site title is empty

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -23,6 +23,7 @@ import { memo } from '@wordpress/element';
 import { search, external } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
+import { filterURLForDisplay } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -44,13 +45,16 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 				getSite,
 				getUnstableBase, // Site index.
 			} = select( coreStore );
-
+			const _site = getSite();
 			return {
 				canvasMode: getCanvasMode(),
 				dashboardLink:
 					getSettings().__experimentalDashboardLink || 'index.php',
 				homeUrl: getUnstableBase()?.home,
-				siteTitle: getSite()?.title,
+				siteTitle:
+					! _site?.title && !! _site?.url
+						? filterURLForDisplay( _site?.url )
+						: _site?.title,
 			};
 		},
 		[]


### PR DESCRIPTION

## What?

In the Site Editor sidebar, fallback to the site URL where no site title is set.

Fixes https://github.com/WordPress/gutenberg/issues/60765


## Why?
When the site title is empty, nothing will be shown in the header.

See the screenshots on the issue https://github.com/WordPress/gutenberg/issues/60765

## How?

Fallback to the site url.

## Testing Instructions

1. Fire up this branch and head over to the Site Editor.
2. In a template that contains a Site Title block, clear the site title and save.
3. Return to the Site Editor left-hand sidebar. 
4. Check that the site's URL without the trailing `http(s)://(www).` is displayed.
5. Thank you!



## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/6458278/3176ee8a-11f6-4cd6-94e5-4147a904d28e



