### PR TITLE
Typography Panel: Use simple labels

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -346,7 +346,7 @@ export default function TypographyPanel( {
 		>
 			{ hasFontFamilyEnabled && (
 				<ToolsPanelItem
-					label={ __( 'Font family' ) }
+					label={ __( 'Font' ) }
 					hasValue={ hasFontFamily }
 					onDeselect={ resetFontFamily }
 					isShownByDefault={ defaultControls.fontFamily }
@@ -363,7 +363,7 @@ export default function TypographyPanel( {
 			) }
 			{ hasFontSizeEnabled && (
 				<ToolsPanelItem
-					label={ __( 'Font size' ) }
+					label={ __( 'Size' ) }
 					hasValue={ hasFontSize }
 					onDeselect={ resetFontSize }
 					isShownByDefault={ defaultControls.fontSize }
@@ -440,14 +440,14 @@ export default function TypographyPanel( {
 			{ hasTextColumnsControl && (
 				<ToolsPanelItem
 					className="single-column"
-					label={ __( 'Text columns' ) }
+					label={ __( 'Columns' ) }
 					hasValue={ hasTextColumns }
 					onDeselect={ resetTextColumns }
 					isShownByDefault={ defaultControls.textColumns }
 					panelId={ panelId }
 				>
 					<NumberControl
-						label={ __( 'Text columns' ) }
+						label={ __( 'Columns' ) }
 						max={ MAX_TEXT_COLUMNS }
 						min={ MIN_TEXT_COLUMNS }
 						onChange={ setTextColumns }
@@ -461,7 +461,7 @@ export default function TypographyPanel( {
 			{ hasTextDecorationControl && (
 				<ToolsPanelItem
 					className="single-column"
-					label={ __( 'Text decoration' ) }
+					label={ __( 'Decoration' ) }
 					hasValue={ hasTextDecoration }
 					onDeselect={ resetTextDecoration }
 					isShownByDefault={ defaultControls.textDecoration }
@@ -478,7 +478,7 @@ export default function TypographyPanel( {
 			{ hasWritingModeControl && (
 				<ToolsPanelItem
 					className="single-column"
-					label={ __( 'Text orientation' ) }
+					label={ __( 'Orientation' ) }
 					hasValue={ hasWritingMode }
 					onDeselect={ resetWritingMode }
 					isShownByDefault={ defaultControls.writingMode }

--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -179,7 +179,7 @@ test.describe( 'Font Size Picker', () => {
 <!-- /wp:paragraph -->` );
 
 			await page.click( 'role=button[name="Typography options"i]' );
-			await page.click( 'role=menuitem[name="Reset Font size"i]' );
+			await page.click( 'role=menuitem[name="Reset Size"i]' );
 			await page.keyboard.press( 'Escape' ); // Close the menu
 
 			await expect.poll( editor.getEditedPostContent )
@@ -266,7 +266,7 @@ test.describe( 'Font Size Picker', () => {
 <!-- /wp:paragraph -->` );
 
 			await page.click( 'role=button[name="Typography options"i]' );
-			await page.click( 'role=menuitem[name="Reset Font size"i]' );
+			await page.click( 'role=menuitem[name="Reset Size"i]' );
 			await page.keyboard.press( 'Escape' ); // Close the menu
 
 			await expect.poll( editor.getEditedPostContent )


### PR DESCRIPTION
Fixes #60547

## What?

This PR simplifies the labels of the tools panel popover in the Typography panel. This should perfectly match the label in the actual UIs.

## Why?

Mismatches between option names and actual control labels confuse users.

## How?

I use the simple label that received the most feedback in #60547. As mentioned in [this comment](https://github.com/WordPress/gutenberg/issues/60547#issuecomment-2047794264), the context of typography already exists, so there seems to be no problem from an accessibility perspective.

## Testing Instructions

There are currently no blocks that support textColumn, which is part of the typography support, so add the code below somewhere in `gutenberg.php` to temporarily add textColumn support to the paragraph block.

```php
function custom_register_block_type_args( $args, $block_type ) {
	if ( 'core/paragraph' !== $block_type ) {
		return $args;
	}
	$args['supports']['typography']['textColumns'] = true;
	return $args;
}
add_filter( 'register_block_type_args', 'custom_register_block_type_args', 10, 2 );

function custom_wp_theme_json_data_default( $theme_json ) {
	$new_data = array(
		'version'  => 2,
		'settings' => array(
			'typography' => array(
				'textColumns' => true,
			),
		),
	);
	return $theme_json->update_with( $new_data );
}
add_filter( 'wp_theme_json_data_default', 'custom_wp_theme_json_data_default' );
```

- Insert a paragraph block into your post and check out the Typography panel.
- Also check out the global styles Typography panel.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/4691ff29-6f80-433a-8b17-2cfaae9b46a9) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/a6bf77b2-27a9-402b-9652-b70c12150b2e) | 
