### PR TITLE
Editor: Do not show scrollbars when closing sidebars

### DIFF
--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -92,6 +92,7 @@ function ComplementaryAreaFill( {
 						animate={ isMobileViewport ? 'mobileOpen' : 'open' }
 						exit="closed"
 						transition={ transition }
+						className="interface-complementary-area__fill"
 					>
 						<div
 							id={ id }

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -1,6 +1,8 @@
 .interface-complementary-area {
 	background: $white;
 	color: $gray-900;
+	height: 100%;
+	overflow: auto;
 
 	@include break-small() {
 		-webkit-overflow-scrolling: touch;
@@ -71,4 +73,8 @@
 		bottom: 10px;
 		left: auto;
 	}
+}
+
+.interface-complementary-area__fill {
+	height: 100%;
 }

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -122,7 +122,7 @@ html.interface-interface-skeleton__html-container {
 }
 
 .interface-interface-skeleton__sidebar {
-	overflow: auto;
+	overflow: hidden;
 
 	@include break-medium() {
 		border-left: $border-width solid $gray-200;


### PR DESCRIPTION
## What?

In #60561 we added an animation to the opening/closing of the editor sidebars. It causes a small issue where the scrollbar is shown during the animation (when the width of the content of the sidebar exceeds its size). This PR tweaks the CSS a bit to avoid this.

## Testing Instructions

1- Open the post editor (or site editor)
2- Make sure you have "scrollbars visible" in your OS config
3- Check that the scrollbars don't show up during the animation.