### PR TITLE
Fix link control link preview when it displays long URLs.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Bug Fix
 
--   `Truncate`: Fix link control link preview when it displays long URLs ([#60576](https://github.com/WordPress/gutenberg/pull/60890)).
+-   `Truncate`: Fix link control link preview when it displays long URLs ([#60890](https://github.com/WordPress/gutenberg/pull/60890)).
 
 -   `ProgressBar`: Fix CSS variable with invalid value ([#60576](https://github.com/WordPress/gutenberg/pull/60576)).
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Bug Fix
 
+-   `Truncate`: Fix link control link preview when it displays long URLs ([#60576](https://github.com/WordPress/gutenberg/pull/60890)).
+
 -   `ProgressBar`: Fix CSS variable with invalid value ([#60576](https://github.com/WordPress/gutenberg/pull/60576)).
 
 ### Experimental

--- a/packages/components/src/truncate/hook.ts
+++ b/packages/components/src/truncate/hook.ts
@@ -53,7 +53,11 @@ export default function useTruncate(
 		!! childrenAsText && ellipsizeMode === TRUNCATE_TYPE.auto;
 
 	const classes = useMemo( () => {
+		// The `word-break: break-all` property first makes sure a text line
+		// breaks even when it contains 'unbreakable' content such as long URLs.
+		// See https://github.com/WordPress/gutenberg/issues/60860.
 		const truncateLines = css`
+			word-break: break-all;
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: ${ numberOfLines };
 			display: -webkit-box;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60860

## What?
<!-- In a few words, what is the PR actually doing? -->
The link control 'link preview' layout breaks when it displays long URLs. When this happens, the buttons in the link control are pushed to the right and aren't visible due to the hidden overflow. As such, the important UI controls aren't operable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The layout breaks making some controls impossible to use.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The `Truncate` is expected to truncate long text lines in the link preview. It does so by using the CSS property `-webkit-line-clamp`. However:
- The `-webkit-line-clamp` property works when some text breaks in two or more lines and _then_ it limites the displayed lines to the specified value.
- As such, a line needs to break in more lines first for the `-webkit-line-clamp` property to have any effect.
- Long URLs are treated as 'unbreakable' text by browsers.
- The addition of the `word-break: break-all` CSS property  makes sure that _any text_ including long URLs break into more lines so that `-webkit-line-clamp` works as expected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Repeat the reproduction instructions from the issue https://github.com/WordPress/gutenberg/issues/60860
- Observe long URls in the link preview are truncated.
- Observe the buttons 'Edit link', 'Remove link', and 'Copy link' are visible

## Screenshots or screencast <!-- if applicable -->

Before:

![image](https://github.com/WordPress/gutenberg/assets/1682452/7b01db15-adda-4035-9f4c-f38c0a929ab3)

After:

![Screenshot 2024-04-19 at 10 14 48](https://github.com/WordPress/gutenberg/assets/1682452/e5afa390-aea1-439d-baba-0e2dc2089e2f)

