### PR TITLE
ComboboxControl: Simplify string normalization

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   `Navigator`: Navigation to the active path doesn't create a new location history ([#60561](https://github.com/WordPress/gutenberg/pull/60561))
 -   `FormToggle`: Forwards ref to input ([#60234](https://github.com/WordPress/gutenberg/pull/60234)).
 -   `ToggleControl`: Forwards ref to FormToggle ([#60234](https://github.com/WordPress/gutenberg/pull/60234)).
+-   `ComboboxControl`: Simplify string normalization ([#60893](https://github.com/WordPress/gutenberg/pull/60893)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `SlotFill`: fixed missing `getServerSnapshot` parameter in slot map ([#60943](https://github.com/WordPress/gutenberg/pull/60943)).
 
+### Enhancements
+
+-   `ComboboxControl`: Simplify string normalization ([#60893](https://github.com/WordPress/gutenberg/pull/60893)).
+
 ## 27.4.0 (2024-04-19)
 
 ### Deprecation
@@ -21,7 +25,6 @@
 -   `Navigator`: Navigation to the active path doesn't create a new location history ([#60561](https://github.com/WordPress/gutenberg/pull/60561))
 -   `FormToggle`: Forwards ref to input ([#60234](https://github.com/WordPress/gutenberg/pull/60234)).
 -   `ToggleControl`: Forwards ref to FormToggle ([#60234](https://github.com/WordPress/gutenberg/pull/60234)).
--   `ComboboxControl`: Simplify string normalization ([#60893](https://github.com/WordPress/gutenberg/pull/60893)).
 
 ### Bug Fix
 

--- a/packages/components/src/utils/strings.ts
+++ b/packages/components/src/utils/strings.ts
@@ -6,64 +6,22 @@ import { paramCase } from 'change-case';
 
 const ALL_UNICODE_DASH_CHARACTERS = new RegExp(
 	`[${ [
-		// - (hyphen-minus)
-		'\u002d',
 		// ~ (tilde)
 		'\u007e',
 		// ­ (soft hyphen)
 		'\u00ad',
-		// ֊ (armenian hyphen)
-		'\u058a',
-		// ־ (hebrew punctuation maqaf)
-		'\u05be',
-		// ᐀ (canadian syllabics hyphen)
-		'\u1400',
-		// ᠆ (mongolian todo soft hyphen)
-		'\u1806',
-		// ‐ (hyphen)
-		'\u2010',
-		// non-breaking hyphen)
-		'\u2011',
-		// ‒ (figure dash)
-		'\u2012',
-		// – (en dash)
-		'\u2013',
-		// — (em dash)
-		'\u2014',
-		// ― (horizontal bar)
-		'\u2015',
 		// ⁓ (swung dash)
 		'\u2053',
-		// superscript minus)
+		// ⁻ (superscript minus)
 		'\u207b',
-		// subscript minus)
+		// ₋ (subscript minus)
 		'\u208b',
 		// − (minus sign)
 		'\u2212',
-		// ⸗ (double oblique hyphen)
-		'\u2e17',
-		// ⸺ (two-em dash)
-		'\u2e3a',
-		// ⸻ (three-em dash)
-		'\u2e3b',
-		// 〜 (wave dash)
-		'\u301c',
-		// 〰 (wavy dash)
-		'\u3030',
-		// ゠ (katakana-hiragana double hyphen)
-		'\u30a0',
-		// ︱ (presentation form for vertical em dash)
-		'\ufe31',
-		// ︲ (presentation form for vertical en dash)
-		'\ufe32',
-		// ﹘ (small em dash)
-		'\ufe58',
-		// ﹣ (small hyphen-minus)
-		'\ufe63',
-		// － (fullwidth hyphen-minus)
-		'\uff0d',
+		// any other Unicode dash character
+		'\\p{Pd}',
 	].join( '' ) }]`,
-	'g'
+	'gu'
 );
 
 export const normalizeTextString = ( value: string ): string => {

--- a/packages/components/src/utils/strings.ts
+++ b/packages/components/src/utils/strings.ts
@@ -4,6 +4,16 @@
 import removeAccents from 'remove-accents';
 import { paramCase } from 'change-case';
 
+/**
+ * All unicode characters that we consider "dash-like":
+ * - `\u007e`: ~ (tilde)
+ * - `\u00ad`: ­ (soft hyphen)
+ * - `\u2053`: ⁓ (swung dash)
+ * - `\u207b`: ⁻ (superscript minus)
+ * - `\u208b`: ₋ (subscript minus)
+ * - `\u2212`: − (minus sign)
+ * - `\\p{Pd}`: any other Unicode dash character
+ */
 const ALL_UNICODE_DASH_CHARACTERS = new RegExp(
 	/[\u007e\u00ad\u2053\u207b\u208b\u2212\p{Pd}]/gu
 );

--- a/packages/components/src/utils/strings.ts
+++ b/packages/components/src/utils/strings.ts
@@ -5,23 +5,7 @@ import removeAccents from 'remove-accents';
 import { paramCase } from 'change-case';
 
 const ALL_UNICODE_DASH_CHARACTERS = new RegExp(
-	`[${ [
-		// ~ (tilde)
-		'\u007e',
-		// ­ (soft hyphen)
-		'\u00ad',
-		// ⁓ (swung dash)
-		'\u2053',
-		// ⁻ (superscript minus)
-		'\u207b',
-		// ₋ (subscript minus)
-		'\u208b',
-		// − (minus sign)
-		'\u2212',
-		// any other Unicode dash character
-		'\\p{Pd}',
-	].join( '' ) }]`,
-	'gu'
+	/[\u007e\u00ad\u2053\u207b\u208b\u2212\p{Pd}]/gu
 );
 
 export const normalizeTextString = ( value: string ): string => {

--- a/packages/components/src/utils/test/strings.js
+++ b/packages/components/src/utils/test/strings.js
@@ -106,5 +106,67 @@ describe( 'normalizeTextString', () => {
 		expect( normalizeTextString( 'foo⸻bar' ) ).toBe( 'foo-bar' );
 		expect( normalizeTextString( 'foo゠bar' ) ).toBe( 'foo-bar' );
 		expect( normalizeTextString( 'foo－bar' ) ).toBe( 'foo-bar' );
+
+		const dashCharacters = [
+			// - (hyphen-minus)
+			'\u002d',
+			// ~ (tilde)
+			'\u007e',
+			// ­ (soft hyphen)
+			'\u00ad',
+			// ֊ (armenian hyphen)
+			'\u058a',
+			// ־ (hebrew punctuation maqaf)
+			'\u05be',
+			// ᐀ (canadian syllabics hyphen)
+			'\u1400',
+			// ᠆ (mongolian todo soft hyphen)
+			'\u1806',
+			// ‐ (hyphen)
+			'\u2010',
+			// non-breaking hyphen)
+			'\u2011',
+			// ‒ (figure dash)
+			'\u2012',
+			// – (en dash)
+			'\u2013',
+			// — (em dash)
+			'\u2014',
+			// ― (horizontal bar)
+			'\u2015',
+			// ⁓ (swung dash)
+			'\u2053',
+			// superscript minus)
+			'\u207b',
+			// subscript minus)
+			'\u208b',
+			// − (minus sign)
+			'\u2212',
+			// ⸗ (double oblique hyphen)
+			'\u2e17',
+			// ⸺ (two-em dash)
+			'\u2e3a',
+			// ⸻ (three-em dash)
+			'\u2e3b',
+			// 〜 (wave dash)
+			'\u301c',
+			// 〰 (wavy dash)
+			'\u3030',
+			// ゠ (katakana-hiragana double hyphen)
+			'\u30a0',
+			// ︱ (presentation form for vertical em dash)
+			'\ufe31',
+			// ︲ (presentation form for vertical en dash)
+			'\ufe32',
+			// ﹘ (small em dash)
+			'\ufe58',
+			// ﹣ (small hyphen-minus)
+			'\ufe63',
+			// － (fullwidth hyphen-minus)
+			'\uff0d',
+		];
+		expect( normalizeTextString( dashCharacters.join( '' ) ) ).toBe(
+			'-'.repeat( dashCharacters.length )
+		);
 	} );
 } );

--- a/packages/components/src/utils/test/strings.js
+++ b/packages/components/src/utils/test/strings.js
@@ -136,9 +136,9 @@ describe( 'normalizeTextString', () => {
 			'\u2015',
 			// ⁓ (swung dash)
 			'\u2053',
-			// superscript minus)
+			// ⁻ (superscript minus)
 			'\u207b',
-			// subscript minus)
+			// ₋ (subscript minus)
 			'\u208b',
 			// − (minus sign)
 			'\u2212',


### PR DESCRIPTION
## What?
This PR simplifies the string normalization, performed on the user input of `ComboboxControl`.

## Why?
For simplicity, brevity, and better coverage of dash characters that we might have missed. 

## How?
We're using the dash punctuation character class `\p{Pd}` that covers the most explicitly listed characters. 

We're also moving all original characters to the unit test to ensure clarity, full backward compatibility, and better documentation that sets the right expectations.

## Testing Instructions
All tests should still pass.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None