### PR TITLE
Block embed: use dedicated attribute to save the embed ratio instead of using custom classes (#39616)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -264,7 +264,7 @@ Add a block that displays content pulled from other sites, like Twitter or YouTu
 -	**Name:** core/embed
 -	**Category:** embed
 -	**Supports:** align, interactivity (clientNavigation), spacing (margin)
--	**Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
+-	**Attributes:** allowResponsive, aspectRatio, caption, previewable, providerNameSlug, responsive, type, url
 
 ## File
 

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -38,6 +38,10 @@
 			"type": "boolean",
 			"default": true,
 			"__experimentalRole": "content"
+		},
+		"aspectRatio": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/embed/deprecated.js
+++ b/packages/block-library/src/embed/deprecated.js
@@ -4,21 +4,55 @@
 import classnames from 'classnames';
 
 /**
- * Internal dependencies
- */
-import metadata from './block.json';
-
-/**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	__experimentalGetElementClassName,
+} from '@wordpress/block-editor';
 
-const { attributes: blockAttributes } = metadata;
+/**
+ * Internal dependencies
+ */
+import { hasAspectRatioClass, removeAspectRatioClasses } from './util';
+import { ASPECT_RATIOS } from './constants';
 
-// In #41140 support was added to global styles for caption elements which added a `wp-element-caption` classname
-// to the embed figcaption element.
-const v2 = {
-	attributes: blockAttributes,
+const v3 = {
+	attributes: {
+		url: {
+			type: 'string',
+			__experimentalRole: 'content',
+		},
+		caption: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'figcaption',
+			__experimentalRole: 'content',
+		},
+		type: {
+			type: 'string',
+			__experimentalRole: 'content',
+		},
+		providerNameSlug: {
+			type: 'string',
+			__experimentalRole: 'content',
+		},
+		allowResponsive: {
+			type: 'boolean',
+			default: true,
+		},
+		responsive: {
+			type: 'boolean',
+			default: false,
+			__experimentalRole: 'content',
+		},
+		previewable: {
+			type: 'boolean',
+			default: true,
+			__experimentalRole: 'content',
+		},
+	},
 	save( { attributes } ) {
 		const { url, caption, type, providerNameSlug } = attributes;
 
@@ -38,15 +72,132 @@ const v2 = {
 					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
 				</div>
 				{ ! RichText.isEmpty( caption ) && (
-					<RichText.Content tagName="figcaption" value={ caption } />
+					<RichText.Content
+						className={ __experimentalGetElementClassName(
+							'caption'
+						) }
+						tagName="figcaption"
+						value={ caption }
+					/>
 				) }
 			</figure>
 		);
 	},
+	isEligible: ( attributes ) => {
+		return (
+			attributes.className && hasAspectRatioClass( attributes.className )
+		);
+	},
+	migrate: ( attributes ) => {
+		const { className: existingClassname } = attributes;
+
+		const aspectRatioFromBlockClassname = ASPECT_RATIOS.find(
+			( { className } ) => {
+				return existingClassname.includes( className );
+			}
+		);
+
+		return {
+			...attributes,
+			className: removeAspectRatioClasses( existingClassname ),
+			aspectRatio: aspectRatioFromBlockClassname
+				? aspectRatioFromBlockClassname.ratio
+				: '',
+		};
+	},
+};
+
+// In #41140 support was added to global styles for caption elements which added a `wp-element-caption` classname
+// to the embed figcaption element.
+const v2 = {
+	attributes: {
+		url: {
+			type: 'string',
+		},
+		caption: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'figcaption',
+		},
+		type: {
+			type: 'string',
+		},
+		providerNameSlug: {
+			type: 'string',
+		},
+		allowResponsive: {
+			type: 'boolean',
+			default: true,
+		},
+		responsive: {
+			type: 'boolean',
+			default: false,
+		},
+		previewable: {
+			type: 'boolean',
+			default: true,
+		},
+		save( { attributes } ) {
+			const { url, caption, type, providerNameSlug } = attributes;
+
+			if ( ! url ) {
+				return null;
+			}
+
+			const className = classnames( 'wp-block-embed', {
+				[ `is-type-${ type }` ]: type,
+				[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,
+				[ `wp-block-embed-${ providerNameSlug }` ]: providerNameSlug,
+			} );
+
+			return (
+				<figure { ...useBlockProps.save( { className } ) }>
+					<div className="wp-block-embed__wrapper">
+						{
+							`\n${ url }\n` /* URL needs to be on its own line. */
+						}
+					</div>
+					{ ! RichText.isEmpty( caption ) && (
+						<RichText.Content
+							tagName="figcaption"
+							value={ caption }
+						/>
+					) }
+				</figure>
+			);
+		},
+	},
 };
 
 const v1 = {
-	attributes: blockAttributes,
+	attributes: {
+		url: {
+			type: 'string',
+		},
+		caption: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'figcaption',
+		},
+		type: {
+			type: 'string',
+		},
+		providerNameSlug: {
+			type: 'string',
+		},
+		allowResponsive: {
+			type: 'boolean',
+			default: true,
+		},
+		responsive: {
+			type: 'boolean',
+			default: false,
+		},
+		previewable: {
+			type: 'boolean',
+			default: true,
+		},
+	},
 	save( { attributes: { url, caption, type, providerNameSlug } } ) {
 		if ( ! url ) {
 			return null;
@@ -67,7 +218,6 @@ const v1 = {
 		);
 	},
 };
-
-const deprecated = [ v2, v1 ];
+const deprecated = [ v3, v2, v1 ];
 
 export default deprecated;

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -3,11 +3,11 @@
  */
 import {
 	createUpgradedEmbedBlock,
-	getClassNames,
-	removeAspectRatioClasses,
 	fallback,
 	getEmbedInfoByProvider,
 	getMergedAttributesWithPreview,
+	calculateEmbedRatio,
+	getClassNames,
 } from './util';
 import EmbedControls from './embed-controls';
 import { embedContentIcon } from './icons';
@@ -112,17 +112,13 @@ const EmbedEdit = ( props ) => {
 		);
 
 	const toggleResponsive = () => {
-		const { allowResponsive, className } = attributes;
+		const { allowResponsive } = attributes;
 		const { html } = preview;
 		const newAllowResponsive = ! allowResponsive;
 
 		setAttributes( {
 			allowResponsive: newAllowResponsive,
-			className: getClassNames(
-				html,
-				className,
-				responsive && newAllowResponsive
-			),
+			aspectRatio: newAllowResponsive ? calculateEmbedRatio( html ) : '',
 		} );
 	};
 
@@ -202,14 +198,8 @@ const EmbedEdit = ( props ) => {
 							event.preventDefault();
 						}
 
-						// If the embed URL was changed, we need to reset the aspect ratio class.
-						// To do this we have to remove the existing ratio class so it can be recalculated.
-						const blockClass = removeAspectRatioClasses(
-							attributes.className
-						);
-
 						setIsEditingURL( false );
-						setAttributes( { url, className: blockClass } );
+						setAttributes( { url, aspectRatio: '' } );
 					} }
 					value={ url }
 					cannotEmbed={ cannotEmbed }
@@ -236,8 +226,13 @@ const EmbedEdit = ( props ) => {
 		type,
 		allowResponsive,
 		className: classFromPreview,
+		aspectRatio,
 	} = getMergedAttributes();
-	const className = classnames( classFromPreview, props.className );
+	const className = getClassNames(
+		classnames( classFromPreview, props.className ),
+		aspectRatio,
+		allowResponsive
+	);
 
 	return (
 		<>

--- a/packages/block-library/src/embed/edit.native.js
+++ b/packages/block-library/src/embed/edit.native.js
@@ -3,11 +3,10 @@
  */
 import {
 	createUpgradedEmbedBlock,
-	getClassNames,
-	removeAspectRatioClasses,
 	fallback,
 	getEmbedInfoByProvider,
 	getMergedAttributesWithPreview,
+	calculateEmbedRatio,
 } from './util';
 import EmbedControls from './embed-controls';
 import { embedContentIcon } from './icons';
@@ -136,17 +135,13 @@ const EmbedEdit = ( props ) => {
 		);
 
 	const toggleResponsive = () => {
-		const { allowResponsive, className } = attributes;
+		const { allowResponsive } = attributes;
 		const { html } = preview;
 		const newAllowResponsive = ! allowResponsive;
 
 		setAttributes( {
 			allowResponsive: newAllowResponsive,
-			className: getClassNames(
-				html,
-				className,
-				responsive && newAllowResponsive
-			),
+			aspectRatio: newAllowResponsive ? calculateEmbedRatio( html ) : '',
 		} );
 	};
 
@@ -203,13 +198,9 @@ const EmbedEdit = ( props ) => {
 
 	const onEditURL = useCallback(
 		( value ) => {
-			// If the embed URL was changed, we need to reset the aspect ratio class.
-			// To do this we have to remove the existing ratio class so it can be recalculated.
+			// Reset the aspect ratio
 			if ( attributes.url !== value ) {
-				const blockClass = removeAspectRatioClasses(
-					attributes.className
-				);
-				setAttributes( { className: blockClass } );
+				setAttributes( { aspectRation: '' } );
 			}
 
 			// The order of the following calls is important, we need to update the URL attribute before changing `isEditingURL`,

--- a/packages/block-library/src/embed/save.js
+++ b/packages/block-library/src/embed/save.js
@@ -12,17 +12,29 @@ import {
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import { ASPECT_RATIOS } from './constants';
+
 export default function save( { attributes } ) {
-	const { url, caption, type, providerNameSlug } = attributes;
+	const { url, caption, type, providerNameSlug, aspectRatio } = attributes;
 
 	if ( ! url ) {
 		return null;
 	}
 
+	const ratioData = ASPECT_RATIOS.find(
+		( element ) => element.ratio === aspectRatio
+	);
+	const aspectRatioClassname = ratioData ? ratioData.className : false;
+
 	const className = classnames( 'wp-block-embed', {
 		[ `is-type-${ type }` ]: type,
 		[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,
 		[ `wp-block-embed-${ providerNameSlug }` ]: providerNameSlug,
+		[ `${ aspectRatioClassname }` ]: aspectRatioClassname,
+		'wp-has-aspect-ratio': aspectRatioClassname,
 	} );
 
 	return (

--- a/packages/block-library/src/embed/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.native.js.snap
@@ -49,7 +49,7 @@ https://twitter.com/notnownikki
 `;
 
 exports[`Embed block create by pasting URL creates embed block when pasting URL in paragraph block 1`] = `
-"<!-- wp:embed {"url":"https://www.youtube.com/watch?v=lXMskKTw3Bc","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+"<!-- wp:embed {"url":"https://www.youtube.com/watch?v=lXMskKTw3Bc","type":"video","providerNameSlug":"youtube","responsive":true,"aspectRatio":"1.78"} -->
 <figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
 https://www.youtube.com/watch?v=lXMskKTw3Bc
 </div></figure>
@@ -95,7 +95,7 @@ https://twitter.com/notnownikki
 `;
 
 exports[`Embed block edit URL replaces URL 1`] = `
-"<!-- wp:embed {"url":"https://www.youtube.com/watch?v=lXMskKTw3Bc","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+"<!-- wp:embed {"url":"https://www.youtube.com/watch?v=lXMskKTw3Bc","type":"video","providerNameSlug":"youtube","responsive":true,"aspectRatio":"1.78"} -->
 <figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
 https://www.youtube.com/watch?v=lXMskKTw3Bc
 </div></figure>

--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -18,6 +18,7 @@ import {
 	getEmbedInfoByProvider,
 	removeAspectRatioClasses,
 	hasAspectRatioClass,
+	calculateEmbedRatio,
 } from '../util';
 import { embedInstagramIcon } from '../icons';
 import variations from '../variations';
@@ -56,47 +57,47 @@ describe( 'utils', () => {
 			expect( findMoreSuitableBlock( unknownURL ) ).toBeUndefined();
 		} );
 	} );
-	describe( 'getClassNames', () => {
-		it( 'should return aspect ratio class names for iframes with width and height', () => {
+	describe( 'calculateEmbedRatio', () => {
+		it( 'should return aspect ratio for iframes with width and height', () => {
 			const html = '<iframe height="9" width="16"></iframe>';
+			const expected = '1.78';
+			expect( calculateEmbedRatio( html ) ).toEqual( expected );
+		} );
+	} );
+	describe( 'getClassNames', () => {
+		it( 'should return aspect ratio class names', () => {
 			const expected = 'wp-embed-aspect-16-9 wp-has-aspect-ratio';
-			expect( getClassNames( html ) ).toEqual( expected );
+			expect( getClassNames( '', '1.78', true ) ).toEqual( expected );
 		} );
 
 		it( 'should not return aspect ratio class names if we do not allow responsive', () => {
-			const html = '<iframe height="9" width="16"></iframe>';
 			const expected = '';
-			expect( getClassNames( html, '', false ) ).toEqual( expected );
+			expect( getClassNames( '', '1.78', false ) ).toEqual( expected );
 		} );
 
-		it( 'should preserve exsiting class names when removing responsive classes', () => {
-			const html = '<iframe height="9" width="16"></iframe>';
+		it( 'should preserve existing class names when removing responsive classes', () => {
 			const expected = 'lovely';
 			expect(
 				getClassNames(
-					html,
 					'lovely wp-embed-aspect-16-9 wp-has-aspect-ratio',
+					'1.78',
 					false
 				)
 			).toEqual( expected );
 		} );
 
 		it( 'should return the same falsy value as passed for existing classes when no new classes are added', () => {
-			const html = '<iframe></iframe>';
 			const expected = undefined;
-			expect( getClassNames( html, undefined, false ) ).toEqual(
-				expected
-			);
+			expect( getClassNames( undefined, false ) ).toEqual( expected );
 		} );
 
 		it( 'should preserve existing classes and replace aspect ratio related classes with the current embed preview', () => {
-			const html = '<iframe height="3" width="4"></iframe>';
 			const expected =
 				'wp-block-embed wp-embed-aspect-4-3 wp-has-aspect-ratio';
 			expect(
 				getClassNames(
-					html,
 					'wp-block-embed wp-embed-aspect-16-9 wp-has-aspect-ratio',
+					'1.33',
 					true
 				)
 			).toEqual( expected );

--- a/test/integration/fixtures/blocks/core__embed.json
+++ b/test/integration/fixtures/blocks/core__embed.json
@@ -7,7 +7,8 @@
 			"caption": "Embedded content from an example URL",
 			"allowResponsive": true,
 			"responsive": false,
-			"previewable": true
+			"previewable": true,
+			"aspectRatio": ""
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__embed__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-2.json
@@ -1,13 +1,14 @@
 [
 	{
 		"name": "core/embed",
-		"isValid": true,
+		"isValid": false,
 		"attributes": {
 			"url": "https://example.com/",
 			"caption": "Embedded content from an example URL",
 			"allowResponsive": true,
 			"responsive": false,
-			"previewable": true
+			"previewable": true,
+			"aspectRatio": ""
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__embed__deprecated-2.serialized.html
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-2.serialized.html
@@ -1,5 +1,8 @@
 <!-- wp:embed {"url":"https://example.com/"} -->
-<figure class="wp-block-embed"><div class="wp-block-embed__wrapper">
-https://example.com/
-</div><figcaption class="wp-element-caption">Embedded content from an example URL</figcaption></figure>
+<figure class="wp-block-embed">
+    <div class="wp-block-embed__wrapper">
+        https://example.com/
+    </div>
+    <figcaption>Embedded content from an example URL</figcaption>
+</figure>
 <!-- /wp:embed -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR change the way custom CSS classes for the aspect ratio are managed for the block embed.

## Why?
When a block embed is transformed to a paragraph, the custom CSS classes for the aspect ratio were not removed.

## How?
This is an alternative approach of #44947. This PR go a step further by adding a new attribute to store the aspect ratio and dynamically add the aspect ratio CSS classes to the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post
2. Paste an embeddable link (eg. https://www.youtube.com/watch?v=S1Z9OHXME7E)
3. The field "Additional CSS Classes"  in the "Advanced" panel should be empty
4. Publish the post
5. Go to the frontend
6.  Inspect the block, the `class` attribute should contain the classes `wp-embed-aspect-16-9 wp-has-aspect-ratio`
