### PR TITLE
CustomSelectControlV2: Support disabled in item types

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   Deprecate `reduceMotion` util ([#60839](https://github.com/WordPress/gutenberg/pull/60839)).
 -   `InputBase`: Simplify management of focus styles. Affects all components based on `InputControl` (e.g. `SearchControl`, `NumberControl`, `UnitControl`), as well as `SelectControl`, `CustomSelectControl`, and `TreeSelect` ([#60226](https://github.com/WordPress/gutenberg/pull/60226)).
 -   Removed dependency on `valtio`, replaced its usage in `SlotFill` with a custom object [#60879](https://github.com/WordPress/gutenberg/pull/60879)).
+-   `CustomSelectControlV2`: Support disabled in item types ([#60896](https://github.com/WordPress/gutenberg/pull/60896)).
 
 ## 27.3.0 (2024-04-03)
 

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -190,6 +190,7 @@ export type CustomSelectItemProps = {
 	/**
 	 * If true, the item will be disabled.
 	 *
+	 * You will need to add your own styles (e.g. reduced opacity) to visually show that they are disabled.
 	 * @default false
 	 */
 	disabled?: boolean;

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -187,4 +187,10 @@ export type CustomSelectItemProps = {
 	 * used if left `undefined`.
 	 */
 	children?: React.ReactNode;
+	/**
+	 * If true, the item will be disabled.
+	 *
+	 * @default false
+	 */
+	disabled?: boolean;
 };


### PR DESCRIPTION
## What?
This PR adds support for `disabled` items in `CustomSelectControlV2` types. 

## Why?

`CustomSelectControlV2` currently supports [setting items to be disabled](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#advanced_select_with_multiple_features) since [Ariakit supports it too](https://ariakit.org/components/select). However, the item types don't reflect that.

Related: https://github.com/WordPress/gutenberg/issues/55023

## How?
We're adding `disabled` as an expected prop by the `CustomSelectControlV2.Item` types.

## Testing Instructions
Add a `disabled` to one of the items in the `CustomSelectControlV2` storybook and verify it doesn't trigger a TS error.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
