### PR TITLE
Editor: Unify the region navigation keyboard shortcuts

### DIFF
--- a/docs/reference-guides/data/data-core-keyboard-shortcuts.md
+++ b/docs/reference-guides/data/data-core-keyboard-shortcuts.md
@@ -22,7 +22,7 @@ const ExampleComponent = () => {
 	const allShortcutKeyCombinations = useSelect(
 		( select ) =>
 			select( keyboardShortcutsStore ).getAllShortcutKeyCombinations(
-				'core/edit-post/next-region'
+				'core/editor/next-region'
 			),
 		[]
 	);
@@ -77,7 +77,7 @@ const ExampleComponent = () => {
 	const allShortcutRawKeyCombinations = useSelect(
 		( select ) =>
 			select( keyboardShortcutsStore ).getAllShortcutRawKeyCombinations(
-				'core/edit-post/next-region'
+				'core/editor/next-region'
 			),
 		[]
 	);
@@ -168,7 +168,7 @@ const ExampleComponent = () => {
 	const shortcutAliases = useSelect(
 		( select ) =>
 			select( keyboardShortcutsStore ).getShortcutAliases(
-				'core/edit-post/next-region'
+				'core/editor/next-region'
 			),
 		[]
 	);
@@ -219,7 +219,7 @@ const ExampleComponent = () => {
 	const shortcutDescription = useSelect(
 		( select ) =>
 			select( keyboardShortcutsStore ).getShortcutDescription(
-				'core/edit-post/next-region'
+				'core/editor/next-region'
 			),
 		[]
 	);
@@ -256,7 +256,7 @@ const ExampleComponent = () => {
 	const { character, modifier } = useSelect(
 		( select ) =>
 			select( keyboardShortcutsStore ).getShortcutKeyCombination(
-				'core/edit-post/next-region'
+				'core/editor/next-region'
 			),
 		[]
 	);
@@ -302,16 +302,16 @@ const ExampleComponent = () => {
 	const { display, raw, ariaLabel } = useSelect( ( select ) => {
 		return {
 			display: select( keyboardShortcutsStore ).getShortcutRepresentation(
-				'core/edit-post/next-region'
+				'core/editor/next-region'
 			),
 			raw: select( keyboardShortcutsStore ).getShortcutRepresentation(
-				'core/edit-post/next-region',
+				'core/editor/next-region',
 				'raw'
 			),
 			ariaLabel: select(
 				keyboardShortcutsStore
 			).getShortcutRepresentation(
-				'core/edit-post/next-region',
+				'core/editor/next-region',
 				'ariaLabel'
 			),
 		};
@@ -410,13 +410,13 @@ const ExampleComponent = () => {
 	const { unregisterShortcut } = useDispatch( keyboardShortcutsStore );
 
 	useEffect( () => {
-		unregisterShortcut( 'core/edit-post/next-region' );
+		unregisterShortcut( 'core/editor/next-region' );
 	}, [] );
 
 	const shortcut = useSelect(
 		( select ) =>
 			select( keyboardShortcutsStore ).getShortcutKeyCombination(
-				'core/edit-post/next-region'
+				'core/editor/next-region'
 			),
 		[]
 	);

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -28,42 +28,6 @@ function KeyboardShortcuts() {
 				character: 'f',
 			},
 		} );
-
-		registerShortcut( {
-			name: 'core/edit-post/next-region',
-			category: 'global',
-			description: __( 'Navigate to the next part of the editor.' ),
-			keyCombination: {
-				modifier: 'ctrl',
-				character: '`',
-			},
-			aliases: [
-				{
-					modifier: 'access',
-					character: 'n',
-				},
-			],
-		} );
-
-		registerShortcut( {
-			name: 'core/edit-post/previous-region',
-			category: 'global',
-			description: __( 'Navigate to the previous part of the editor.' ),
-			keyCombination: {
-				modifier: 'ctrlShift',
-				character: '`',
-			},
-			aliases: [
-				{
-					modifier: 'access',
-					character: 'p',
-				},
-				{
-					modifier: 'ctrlShift',
-					character: '~',
-				},
-			],
-		} );
 	}, [] );
 
 	useShortcut( 'core/edit-post/toggle-fullscreen', () => {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -182,10 +182,10 @@ function Layout( { initialPost } ) {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			previousShortcut: select(
 				keyboardShortcutsStore
-			).getAllShortcutKeyCombinations( 'core/edit-post/previous-region' ),
+			).getAllShortcutKeyCombinations( 'core/editor/previous-region' ),
 			nextShortcut: select(
 				keyboardShortcutsStore
-			).getAllShortcutKeyCombinations( 'core/edit-post/next-region' ),
+			).getAllShortcutKeyCombinations( 'core/editor/next-region' ),
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),

--- a/packages/edit-site/src/components/keyboard-shortcuts/register.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/register.js
@@ -19,42 +19,6 @@ function KeyboardShortcutsRegister() {
 				character: 's',
 			},
 		} );
-
-		registerShortcut( {
-			name: 'core/edit-site/next-region',
-			category: 'global',
-			description: __( 'Navigate to the next part of the editor.' ),
-			keyCombination: {
-				modifier: 'ctrl',
-				character: '`',
-			},
-			aliases: [
-				{
-					modifier: 'access',
-					character: 'n',
-				},
-			],
-		} );
-
-		registerShortcut( {
-			name: 'core/edit-site/previous-region',
-			category: 'global',
-			description: __( 'Navigate to the previous part of the editor.' ),
-			keyCombination: {
-				modifier: 'ctrlShift',
-				character: '`',
-			},
-			aliases: [
-				{
-					modifier: 'access',
-					character: 'p',
-				},
-				{
-					modifier: 'ctrlShift',
-					character: '~',
-				},
-			],
-		} );
 	}, [ registerShortcut ] );
 
 	return null;

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -86,10 +86,10 @@ export default function Layout() {
 		return {
 			canvasMode: getCanvasMode(),
 			previousShortcut: getAllShortcutKeyCombinations(
-				'core/edit-site/previous-region'
+				'core/editor/previous-region'
 			),
 			nextShortcut: getAllShortcutKeyCombinations(
-				'core/edit-site/next-region'
+				'core/editor/next-region'
 			),
 			hasFixedToolbar: select( preferencesStore ).get(
 				'core',

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -103,6 +103,42 @@ function EditorKeyboardShortcutsRegister() {
 				character: 'h',
 			},
 		} );
+
+		registerShortcut( {
+			name: 'core/editor/next-region',
+			category: 'global',
+			description: __( 'Navigate to the next part of the editor.' ),
+			keyCombination: {
+				modifier: 'ctrl',
+				character: '`',
+			},
+			aliases: [
+				{
+					modifier: 'access',
+					character: 'n',
+				},
+			],
+		} );
+
+		registerShortcut( {
+			name: 'core/editor/previous-region',
+			category: 'global',
+			description: __( 'Navigate to the previous part of the editor.' ),
+			keyCombination: {
+				modifier: 'ctrlShift',
+				character: '`',
+			},
+			aliases: [
+				{
+					modifier: 'access',
+					character: 'p',
+				},
+				{
+					modifier: 'ctrlShift',
+					character: '~',
+				},
+			],
+		} );
 	}, [ registerShortcut ] );
 
 	return <BlockEditorKeyboardShortcuts.Register />;

--- a/packages/keyboard-shortcuts/src/store/actions.js
+++ b/packages/keyboard-shortcuts/src/store/actions.js
@@ -100,13 +100,13 @@ export function registerShortcut( {
  *     const { unregisterShortcut } = useDispatch( keyboardShortcutsStore );
  *
  *     useEffect( () => {
- *         unregisterShortcut( 'core/edit-post/next-region' );
+ *         unregisterShortcut( 'core/editor/next-region' );
  *     }, [] );
  *
  *     const shortcut = useSelect(
  *         ( select ) =>
  *             select( keyboardShortcutsStore ).getShortcutKeyCombination(
- *                 'core/edit-post/next-region'
+ *                 'core/editor/next-region'
  *             ),
  *         []
  *     );

--- a/packages/keyboard-shortcuts/src/store/selectors.js
+++ b/packages/keyboard-shortcuts/src/store/selectors.js
@@ -71,7 +71,7 @@ function getKeyCombinationRepresentation( shortcut, representation ) {
  *     const {character, modifier} = useSelect(
  *         ( select ) =>
  *             select( keyboardShortcutsStore ).getShortcutKeyCombination(
- *                 'core/edit-post/next-region'
+ *                 'core/editor/next-region'
  *             ),
  *         []
  *     );
@@ -117,9 +117,9 @@ export function getShortcutKeyCombination( state, name ) {
  *     const {display, raw, ariaLabel} = useSelect(
  *         ( select ) =>{
  *             return {
- *                 display: select( keyboardShortcutsStore ).getShortcutRepresentation('core/edit-post/next-region' ),
- *                 raw: select( keyboardShortcutsStore ).getShortcutRepresentation('core/edit-post/next-region','raw' ),
- *                 ariaLabel: select( keyboardShortcutsStore ).getShortcutRepresentation('core/edit-post/next-region', 'ariaLabel')
+ *                 display: select( keyboardShortcutsStore ).getShortcutRepresentation('core/editor/next-region' ),
+ *                 raw: select( keyboardShortcutsStore ).getShortcutRepresentation('core/editor/next-region','raw' ),
+ *                 ariaLabel: select( keyboardShortcutsStore ).getShortcutRepresentation('core/editor/next-region', 'ariaLabel')
  *             }
  *         },
  *         []
@@ -161,7 +161,7 @@ export function getShortcutRepresentation(
  * const ExampleComponent = () => {
  *     const shortcutDescription = useSelect(
  *         ( select ) =>
- *             select( keyboardShortcutsStore ).getShortcutDescription( 'core/edit-post/next-region' ),
+ *             select( keyboardShortcutsStore ).getShortcutDescription( 'core/editor/next-region' ),
  *         []
  *     );
  *
@@ -194,7 +194,7 @@ export function getShortcutDescription( state, name ) {
  *     const shortcutAliases = useSelect(
  *         ( select ) =>
  *             select( keyboardShortcutsStore ).getShortcutAliases(
- *                 'core/edit-post/next-region'
+ *                 'core/editor/next-region'
  *             ),
  *         []
  *     );
@@ -247,7 +247,7 @@ export function getShortcutAliases( state, name ) {
  *     const allShortcutKeyCombinations = useSelect(
  *         ( select ) =>
  *             select( keyboardShortcutsStore ).getAllShortcutKeyCombinations(
- *                 'core/edit-post/next-region'
+ *                 'core/editor/next-region'
  *             ),
  *         []
  *     );
@@ -307,7 +307,7 @@ export const getAllShortcutKeyCombinations = createSelector(
  *     const allShortcutRawKeyCombinations = useSelect(
  *         ( select ) =>
  *             select( keyboardShortcutsStore ).getAllShortcutRawKeyCombinations(
- *                 'core/edit-post/next-region'
+ *                 'core/editor/next-region'
  *             ),
  *         []
  *     );


### PR DESCRIPTION
Related #52632

## What?

This unifies the region navigation keyboard shortcuts between the post and site editors. We register these shortcuts in the editor package for now.

## Testing Instructions

1- You can use `ctrl + option + n` to navigate editor regions in both post and site editors.
