### PR TITLE
Make the zoom out inserters work for sections inside the section root

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -10,11 +10,15 @@ import { useEffect, useState } from '@wordpress/element';
 import BlockPopoverInbetween from '../block-popover/inbetween';
 import { store as blockEditorStore } from '../../store';
 import Inserter from '../inserter';
+import { unlock } from '../../lock-unlock';
 
 function ZoomOutModeInserters( { __unstableContentRef } ) {
 	const [ isReady, setIsReady ] = useState( false );
 	const blockOrder = useSelect( ( select ) => {
-		return select( blockEditorStore ).getBlockOrder();
+		const { sectionRootClientId } = unlock(
+			select( blockEditorStore ).getSettings()
+		);
+		return select( blockEditorStore ).getBlockOrder( sectionRootClientId );
 	}, [] );
 
 	// Defer the initial rendering to avoid the jumps due to the animation.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In zoom out mode there were some inserters appearing between top level blocks and this PR makes them appear back.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We changed how zoom out finds top level blocks by introducing the concept of section root, and the block inserters were not aware of this, looking always for the root element.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Get the top blocks from the section root, whatever that is.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable zoom out experiment
2. Go to a template
3. Engage zoom out
4. **Notice inserters**

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


N/A