### PR TITLE
Notices: Fix snackbar placement 

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -244,7 +244,8 @@ function Layout( { initialPost } ) {
 		'has-metaboxes': hasActiveMetaboxes,
 		'is-distraction-free': isDistractionFree && isWideViewport,
 		'is-entity-save-view-open': !! entitiesSavedStatesCallback,
-		'has-block-breadcrumbs': hasBlockBreadcrumbs,
+		'has-block-breadcrumbs':
+			hasBlockBreadcrumbs && ( ! isDistractionFree || ! isWideViewport ),
 	} );
 
 	const secondarySidebarLabel = isListViewOpened

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -245,7 +245,7 @@ function Layout( { initialPost } ) {
 		'is-distraction-free': isDistractionFree && isWideViewport,
 		'is-entity-save-view-open': !! entitiesSavedStatesCallback,
 		'has-block-breadcrumbs':
-			hasBlockBreadcrumbs && ( ! isDistractionFree || ! isWideViewport ),
+			hasBlockBreadcrumbs && ! isDistractionFree && isWideViewport,
 	} );
 
 	const secondarySidebarLabel = isListViewOpened

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -158,6 +158,7 @@ function Layout( { initialPost } ) {
 		showMetaBoxes,
 		documentLabel,
 		hasHistory,
+		hasBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
@@ -192,6 +193,7 @@ function Layout( { initialPost } ) {
 			hasBlockSelected:
 				!! select( blockEditorStore ).getBlockSelectionStart(),
 			hasHistory: !! getEditorSettings().onNavigateToPreviousEntityRecord,
+			hasBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 		};
 	}, [] );
 
@@ -242,6 +244,7 @@ function Layout( { initialPost } ) {
 		'has-metaboxes': hasActiveMetaboxes,
 		'is-distraction-free': isDistractionFree && isWideViewport,
 		'is-entity-save-view-open': !! entitiesSavedStatesCallback,
+		'has-block-breadcrumbs': hasBlockBreadcrumbs,
 	} );
 
 	const secondarySidebarLabel = isListViewOpened

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -19,7 +19,7 @@
 }
 
 // Adjust the position of the notices when breadcrumbs are present
-.has-block-breadcrumbs:not(.is-distraction-free) {
+.has-block-breadcrumbs {
 	.components-editor-notices__snackbar {
 		bottom: 40px;
 	}

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -7,14 +7,21 @@
 .edit-post-layout .components-editor-notices__snackbar {
 	position: fixed;
 	right: 0;
-	bottom: 40px;
+	bottom: 16px;
 	padding-left: 16px;
 	padding-right: 16px;
 }
 
 .is-distraction-free {
 	.components-editor-notices__snackbar {
-		bottom: 20px;
+		bottom: 16px;
+	}
+}
+
+// Adjust the position of the notices when breadcrumbs are present
+.has-block-breadcrumbs:not(.is-distraction-free) {
+	.components-editor-notices__snackbar {
+		bottom: 40px;
 	}
 }
 

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -23,7 +23,7 @@
 }
 
 // Adjust the position of the notices when breadcrumbs are present
-.edit-site .has-block-breadcrumbs.is-full-canvas:not(.is-distraction-free) .components-editor-notices__snackbar {
+.edit-site .has-block-breadcrumbs.is-full-canvas .components-editor-notices__snackbar {
 	bottom: 40px;
 }
 

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -22,11 +22,16 @@
 	justify-content: center;
 }
 
+// Adjust the position of the notices when breadcrumbs are present
+.edit-site .has-block-breadcrumbs.is-full-canvas:not(.is-distraction-free) .components-editor-notices__snackbar {
+	bottom: 40px;
+}
+
 // Adjust the position of the notices
 .edit-site .components-editor-notices__snackbar {
 	position: absolute;
 	right: 0;
-	bottom: 40px;
+	bottom: 16px;
 	padding-left: 16px;
 	padding-right: 16px;
 }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -187,7 +187,9 @@ export default function Layout() {
 						'has-fixed-toolbar': hasFixedToolbar,
 						'is-block-toolbar-visible': hasBlockSelected,
 						'is-zoom-out': isZoomOutMode,
-						'has-block-breadcrumbs': hasBlockBreadcrumbs,
+						'has-block-breadcrumbs':
+							hasBlockBreadcrumbs &&
+							( ! isDistractionFree || canvasMode !== 'edit' ),
 					}
 				) }
 			>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -189,7 +189,8 @@ export default function Layout() {
 						'is-zoom-out': isZoomOutMode,
 						'has-block-breadcrumbs':
 							hasBlockBreadcrumbs &&
-							( ! isDistractionFree || canvasMode !== 'edit' ),
+							! isDistractionFree &&
+							canvasMode === 'edit',
 					}
 				) }
 			>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -78,6 +78,7 @@ export default function Layout() {
 		canvasMode,
 		previousShortcut,
 		nextShortcut,
+		hasBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
 		const { getAllShortcutKeyCombinations } = select(
 			keyboardShortcutsStore
@@ -98,6 +99,10 @@ export default function Layout() {
 			isDistractionFree: select( preferencesStore ).get(
 				'core',
 				'distractionFree'
+			),
+			hasBlockBreadcrumbs: select( preferencesStore ).get(
+				'core',
+				'showBlockBreadcrumbs'
 			),
 			isZoomOutMode:
 				select( blockEditorStore ).__unstableGetEditorMode() ===
@@ -182,6 +187,7 @@ export default function Layout() {
 						'has-fixed-toolbar': hasFixedToolbar,
 						'is-block-toolbar-visible': hasBlockSelected,
 						'is-zoom-out': isZoomOutMode,
+						'has-block-breadcrumbs': hasBlockBreadcrumbs,
 					}
 				) }
 			>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix snackbar placement for distraction-free, and when blocks breadcrumbs is not enabled.

Fixes https://github.com/WordPress/gutenberg/issues/53198

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When the editor was in distraction-free mode, or when the blocks breadcrumbs were disabled

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding a class to the wrapper when the editor has block breadcrumbs enabled, and playing with CSS. I went with a bottom of 16px to follow the other paddings applied to the snackbar, and because the computed height of the blocks breadcrumb is 24px.

## Testing Instructions

**Site Editor**

1. Open the site editor (Appearance > Editor)
2. Make any change to your site. Check the positioning of the snackbar.
3. Try with distraction free, and toggling the "Show block breadcrumbs" preference. Confirm the positioning of the snackbar is ok.
4. Exit the editing mode, confirm the positioning is also ok.

**Post/Page editor**

1. Create a page or a post.
2. Make any change to the page/post. Check the positioning of the snackbar.
3. Try with distraction free, and toggling the "Show block breadcrumbs" preference. Confirm the positioning of the snackbar is ok.
4. Exit the editing mode, confirm the positioning is also ok.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/252415/2160f019-8229-40b8-957b-3e09f99d1cbe

