### PR TITLE
Share variant context between components

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -34,6 +34,7 @@ import {
 } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -58,6 +59,7 @@ import { POST_TYPE_LABELS, TEMPLATE_POST_TYPE } from '../../utils/constants';
 import SiteEditorCanvas from '../block-editor/site-editor-canvas';
 import TemplatePartConverter from '../template-part-converter';
 import { useSpecificEditorSettings } from '../block-editor/use-site-editor-settings';
+import { PrivateHeaderAnimationContext } from '../layout/animation';
 
 const {
 	ExperimentalEditorProvider: EditorProvider,
@@ -147,7 +149,7 @@ export default function Editor( { isLoading, onClick } ) {
 			postTypeLabel: getPostTypeLabel(),
 		};
 	}, [] );
-
+	const headerAnimationVariant = useContext( PrivateHeaderAnimationContext );
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
 	const showVisualEditor = isViewMode || editorMode === 'visual';
@@ -192,6 +194,8 @@ export default function Editor( { isLoading, onClick } ) {
 		( ( postWithTemplate && !! contextPost && !! editedPost ) ||
 			( ! postWithTemplate && !! editedPost ) );
 
+	// const headerAnimationControls = useAnimateHeader( { variant: false } );
+
 	return (
 		<>
 			{ ! isReady ? <CanvasLoader id={ loadingProgressId } /> : null }
@@ -223,6 +227,7 @@ export default function Editor( { isLoading, onClick } ) {
 								'show-icon-labels': showIconLabels,
 							}
 						) }
+						headerAnimationVariant={ headerAnimationVariant }
 						header={
 							<AnimatePresence initial={ false }>
 								{ canvasMode === 'edit' && (
@@ -230,11 +235,29 @@ export default function Editor( { isLoading, onClick } ) {
 										initial={ {
 											marginTop: -60,
 										} }
-										animate={ {
-											marginTop: 0,
-										} }
 										exit={ {
 											marginTop: -60,
+										} }
+										variants={ {
+											isDistractionFree: {
+												marginTop: -60,
+												opacity: 0,
+												transition: {
+													type: 'tween',
+													delay: 0.8,
+													delayChildren: 0.8,
+												}, // How long to wait before the header exits
+											},
+											isDistractionFreeHovering: {
+												marginTop: 0,
+												opacity: 1,
+												transition: {
+													type: 'tween',
+													delay: 0.2,
+													delayChildren: 0.2,
+												}, // How long to wait before the header shows
+											},
+											edit: { marginTop: 0 },
 										} }
 										transition={ {
 											type: 'tween',
@@ -246,6 +269,7 @@ export default function Editor( { isLoading, onClick } ) {
 													: ANIMATION_DURATION,
 											ease: [ 0.6, 0, 0.4, 1 ],
 										} }
+										animate={ headerAnimationVariant }
 									>
 										<Header />
 									</motion.div>

--- a/packages/edit-site/src/components/layout/animation.js
+++ b/packages/edit-site/src/components/layout/animation.js
@@ -6,7 +6,14 @@ import { Controller, easings } from '@react-spring/web';
 /**
  * WordPress dependencies
  */
-import { useLayoutEffect, useMemo, useRef } from '@wordpress/element';
+import {
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	createContext,
+} from '@wordpress/element';
+
+export const PrivateHeaderAnimationContext = createContext( 'view' );
 
 function getAbsolutePosition( element ) {
 	return {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -267,6 +267,7 @@
 		position: absolute;
 		top: 0;
 		z-index: z-index(".edit-site-layout__hub");
+		pointer-events: all;
 	}
 }
 

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -41,15 +41,6 @@ function useHTMLClass( className ) {
 	}, [ className ] );
 }
 
-const headerVariants = {
-	hidden: { opacity: 0 },
-	hover: {
-		opacity: 1,
-		transition: { type: 'tween', delay: 0.2, delayChildren: 0.2 },
-	},
-	distractionFreeInactive: { opacity: 1, transition: { delay: 0 } },
-};
-
 function InterfaceSkeleton(
 	{
 		isDistractionFree,
@@ -67,6 +58,7 @@ function InterfaceSkeleton(
 		// Todo: does this need to be a prop.
 		// Can we use a dependency to keyboard-shortcuts directly?
 		shortcuts,
+		headerAnimationVariant,
 	},
 	ref
 ) {
@@ -119,22 +111,19 @@ function InterfaceSkeleton(
 						as={ motion.div }
 						className="interface-interface-skeleton__header"
 						aria-label={ mergedLabels.header }
-						initial={
-							isDistractionFree
-								? 'hidden'
-								: 'distractionFreeInactive'
-						}
-						whileHover={
-							isDistractionFree
-								? 'hover'
-								: 'distractionFreeInactive'
-						}
-						animate={
-							isDistractionFree
-								? 'hidden'
-								: 'distractionFreeInactive'
-						}
-						variants={ headerVariants }
+						variants={ {
+							isDistractionFree: { opacity: 0 },
+							isDistractionFreeHovering: {
+								opacity: 1,
+								transition: {
+									type: 'tween',
+									delay: 0.2,
+									delayChildren: 0.2,
+								},
+							},
+							view: { opacity: 1, transition: { delay: 0 } },
+						} }
+						animate={ headerAnimationVariant }
 						transition={
 							isDistractionFree
 								? { type: 'tween', delay: 0.8 }


### PR DESCRIPTION
Allow a trigger element to set the context of the header animation state and share it between components.

- Known issues: Post editor distraction free mode is broken (would need to read from this context)
- Can't click on elements within the header of distraction free mode because the trigger area is covering the elements beneath it.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
