### PR TITLE
Removed Extra Space Before Since

### DIFF
--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -12,7 +12,7 @@
 /**
  * Class used for interacting with block bindings sources.
  *
- *  @since 6.5.0
+ * @since 6.5.0
  */
 if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 	final class WP_Block_Bindings_Registry {


### PR DESCRIPTION
**Fixes**: https://github.com/WordPress/gutenberg/issues/60917