### PR TITLE
Return an empty object when no fallback templates are found (wp/v2/templates/lookup)

### DIFF
--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
@@ -113,11 +113,8 @@ class Gutenberg_REST_Templates_Controller_6_6 extends Gutenberg_REST_Templates_C
 			array_shift( $hierarchy );
 		} while ( ! empty( $hierarchy ) && empty( $fallback_template->content ) );
 
-		if ( ! $fallback_template ) {
-			return new WP_Error( 'rest_template_not_found', __( 'No fallback templates exist for that slug.', 'default' ), array( 'status' => 404 ) );
-		}
-
-		$response = $this->prepare_item_for_response( $fallback_template, $request );
+		// To maintain original behavior, return an empty object rather than a 404 error when no template is found.
+		$response = $fallback_template ? $this->prepare_item_for_response( $fallback_template, $request ) : new stdClass();
 
 		return rest_ensure_response( $response );
 	}

--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
@@ -113,6 +113,10 @@ class Gutenberg_REST_Templates_Controller_6_6 extends Gutenberg_REST_Templates_C
 			array_shift( $hierarchy );
 		} while ( ! empty( $hierarchy ) && empty( $fallback_template->content ) );
 
+		if ( ! $fallback_template ) {
+			return new WP_Error( 'rest_template_not_found', __( 'No fallback templates exist for that slug.', 'default' ), array( 'status' => 404 ) );
+		}
+
 		$response = $this->prepare_item_for_response( $fallback_template, $request );
 
 		return rest_ensure_response( $response );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -712,7 +712,8 @@ export const getDefaultTemplateId =
 		const template = await apiFetch( {
 			path: addQueryArgs( '/wp/v2/templates/lookup', query ),
 		} );
-		if ( template ) {
+		// Endpoint may return an empty object if no template is found.
+		if ( template?.id ) {
 			dispatch.receiveDefaultTemplateId( query, template.id );
 		}
 	};

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -609,10 +609,13 @@ export const getEditedPostTemplate = createRegistrySelector(
 		const defaultTemplateId = select( coreStore ).getDefaultTemplateId( {
 			slug: slugToCheck,
 		} );
-		return select( coreStore ).getEditedEntityRecord(
-			'postType',
-			'wp_template',
-			defaultTemplateId
-		);
+
+		return defaultTemplateId
+			? select( coreStore ).getEditedEntityRecord(
+					'postType',
+					'wp_template',
+					defaultTemplateId
+			  )
+			: null;
 	}
 );


### PR DESCRIPTION
## What?

When a classic theme uses a theme.json file, it may not have any block templates available. This change modifies the `wp/v2/templates/lookup` to return an empty object when no fallback templates available, rather than an object full of empty properties, to avoid PHP errors being triggered.

Fixes https://core.trac.wordpress.org/ticket/60909
Fixes https://github.com/WordPress/gutenberg/issues/60974

Companion wordpress-develop PR: https://github.com/WordPress/wordpress-develop/pull/6420

## Why?

- Prevents returning a object with all null properties in the response
- Prevents several PHP warnings in the error log

## Testing Instructions

- Activate a classic theme, such as twentyeleven
- Add a theme.json file to the theme with minimal content (e.g. `{ "version": 2 }`)
- Load a page in the editor
- You should see a request to `/wp-json/wp/v2/templates/lookup` respond with an empty object in the browser network tab
- There should not be any PHP warnings in the error log
