### PR TITLE
(experiment)(wip) Components: Abstract/namespace all related `Navigator` components in the root component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -93,10 +93,11 @@
 ### Internal
 
 -   `FontSizerPicker`: Improve docs for default units ([#60996](https://github.com/WordPress/gutenberg/pull/60996)).
+
 ### Deprecation
 
 -   `Navigator`: Remove "experimental" designation ([#60927](https://github.com/WordPress/gutenberg/pull/60927)).
--   `Navigator`: Group all related children as properties in the root component `NavigatorProvider` and add a `Navigator` alias for it ([#59182](https://github.com/WordPress/gutenberg/pull/59182)).
+-   `Navigator`: Group all related children as properties in the root component `NavigatorProvider` and add a `Navigator` alias for it ([#60926](https://github.com/WordPress/gutenberg/pull/60926)).
 
 ## 27.4.0 (2024-04-19)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -93,6 +93,9 @@
 ### Internal
 
 -   `FontSizerPicker`: Improve docs for default units ([#60996](https://github.com/WordPress/gutenberg/pull/60996)).
+### Deprecation
+
+-   `Navigator`: Remove "experimental" designation ([#60927](https://github.com/WordPress/gutenberg/pull/60927)).
 
 ## 27.4.0 (2024-04-19)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -96,6 +96,7 @@
 ### Deprecation
 
 -   `Navigator`: Remove "experimental" designation ([#60927](https://github.com/WordPress/gutenberg/pull/60927)).
+-   `Navigator`: Rename the root provider to `Navigator` and grouped all related components under this namespace ([#59182](https://github.com/WordPress/gutenberg/pull/59182)).
 
 ## 27.4.0 (2024-04-19)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -96,7 +96,7 @@
 ### Deprecation
 
 -   `Navigator`: Remove "experimental" designation ([#60927](https://github.com/WordPress/gutenberg/pull/60927)).
--   `Navigator`: Rename the root provider to `Navigator` and grouped all related components under this namespace ([#59182](https://github.com/WordPress/gutenberg/pull/59182)).
+-   `Navigator`: Group all related children as properties in the root component `NavigatorProvider` and add a `Navigator` alias for it ([#59182](https://github.com/WordPress/gutenberg/pull/59182)).
 
 ## 27.4.0 (2024-04-19)
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -116,12 +116,36 @@ export { default as __experimentalNavigationGroup } from './navigation/group';
 export { default as __experimentalNavigationItem } from './navigation/item';
 export { default as __experimentalNavigationMenu } from './navigation/menu';
 export {
+	/**
+	 * @deprecated Import `NavigatorProvider` instead.
+	 */
 	NavigatorProvider as __experimentalNavigatorProvider,
+	/**
+	 * @deprecated Import `NavigatorScreen` instead.
+	 */
 	NavigatorScreen as __experimentalNavigatorScreen,
+	/**
+	 * @deprecated Import `NavigatorButton` instead.
+	 */
 	NavigatorButton as __experimentalNavigatorButton,
+	/**
+	 * @deprecated Import `NavigatorBackButton` instead.
+	 */
 	NavigatorBackButton as __experimentalNavigatorBackButton,
+	/**
+	 * @deprecated Import `NavigatorToParentButton` instead.
+	 */
 	NavigatorToParentButton as __experimentalNavigatorToParentButton,
+	/**
+	 * @deprecated Import `useNavigator` instead.
+	 */
 	useNavigator as __experimentalUseNavigator,
+	NavigatorProvider,
+	NavigatorScreen,
+	NavigatorButton,
+	NavigatorBackButton,
+	NavigatorToParentButton,
+	useNavigator,
 } from './navigator';
 export { default as Notice } from './notice';
 export { default as __experimentalNumberControl } from './number-control';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -139,9 +139,10 @@ export {
 	/**
 	 * @deprecated Import `useNavigator` instead.
 	 */
-	NavigatorProvider,
-	Navigator,
 	useNavigator as __experimentalUseNavigator,
+	NavigatorProvider,
+	Navigator, // alias for `NavigatorProvider`
+	useNavigator,
 } from './navigator';
 export { default as Notice } from './notice';
 export { default as __experimentalNumberControl } from './number-control';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -117,35 +117,31 @@ export { default as __experimentalNavigationItem } from './navigation/item';
 export { default as __experimentalNavigationMenu } from './navigation/menu';
 export {
 	/**
-	 * @deprecated Import `NavigatorProvider` instead.
+	 * @deprecated Import `Navigator` instead.
 	 */
 	NavigatorProvider as __experimentalNavigatorProvider,
 	/**
-	 * @deprecated Import `NavigatorScreen` instead.
+	 * @deprecated Import `Navigator` and use `Navigator.Screen instead.
 	 */
 	NavigatorScreen as __experimentalNavigatorScreen,
 	/**
-	 * @deprecated Import `NavigatorButton` instead.
+	 * @deprecated Import `Navigator` and use `Navigator.Button` instead.
 	 */
 	NavigatorButton as __experimentalNavigatorButton,
 	/**
-	 * @deprecated Import `NavigatorBackButton` instead.
+	 * @deprecated Import `Navigator` and use `Navigator.BackButton` instead.
 	 */
 	NavigatorBackButton as __experimentalNavigatorBackButton,
 	/**
-	 * @deprecated Import `NavigatorToParentButton` instead.
+	 * @deprecated Import `Navigator` and use `Navigator.ToParentButton` instead.
 	 */
 	NavigatorToParentButton as __experimentalNavigatorToParentButton,
 	/**
 	 * @deprecated Import `useNavigator` instead.
 	 */
-	useNavigator as __experimentalUseNavigator,
 	NavigatorProvider,
-	NavigatorScreen,
-	NavigatorButton,
-	NavigatorBackButton,
-	NavigatorToParentButton,
-	useNavigator,
+	Navigator,
+	useNavigator as __experimentalUseNavigator,
 } from './navigator';
 export { default as Notice } from './notice';
 export { default as __experimentalNumberControl } from './number-control';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -117,11 +117,11 @@ export { default as __experimentalNavigationItem } from './navigation/item';
 export { default as __experimentalNavigationMenu } from './navigation/menu';
 export {
 	/**
-	 * @deprecated Import `Navigator` instead.
+	 * @deprecated Import `Navigator` and use `Navigator.Root` instead..
 	 */
 	NavigatorProvider as __experimentalNavigatorProvider,
 	/**
-	 * @deprecated Import `Navigator` and use `Navigator.Screen instead.
+	 * @deprecated Import `Navigator` and use `Navigator.Screen` instead.
 	 */
 	NavigatorScreen as __experimentalNavigatorScreen,
 	/**
@@ -140,8 +140,7 @@ export {
 	 * @deprecated Import `useNavigator` instead.
 	 */
 	useNavigator as __experimentalUseNavigator,
-	NavigatorProvider,
-	Navigator, // alias for `NavigatorProvider`
+	Navigator,
 	useNavigator,
 } from './navigator';
 export { default as Notice } from './notice';

--- a/packages/components/src/navigator/index.ts
+++ b/packages/components/src/navigator/index.ts
@@ -1,4 +1,7 @@
-export { NavigatorProvider } from './navigator-provider';
+export {
+	NavigatorProvider,
+	NavigatorProvider as Navigator,
+} from './navigator-provider';
 export { NavigatorScreen } from './navigator-screen';
 export { NavigatorButton } from './navigator-button';
 export { NavigatorBackButton } from './navigator-back-button';

--- a/packages/components/src/navigator/index.ts
+++ b/packages/components/src/navigator/index.ts
@@ -1,9 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { NavigatorProvider } from './navigator-provider';
+import { NavigatorScreen } from './navigator-screen';
+import { NavigatorButton } from './navigator-button';
+import { NavigatorBackButton } from './navigator-back-button';
+import { NavigatorToParentButton } from './navigator-to-parent-button';
+
 export {
 	NavigatorProvider,
-	NavigatorProvider as Navigator,
-} from './navigator-provider';
-export { NavigatorScreen } from './navigator-screen';
-export { NavigatorButton } from './navigator-button';
-export { NavigatorBackButton } from './navigator-back-button';
-export { NavigatorToParentButton } from './navigator-to-parent-button';
+	NavigatorScreen,
+	NavigatorButton,
+	NavigatorBackButton,
+	NavigatorToParentButton,
+};
 export { default as useNavigator } from './use-navigator';
+
+export const Navigator = {
+	Root: NavigatorProvider,
+	Screen: NavigatorScreen,
+	Button: NavigatorButton,
+	BackButton: NavigatorBackButton,
+	ToParentButton: NavigatorToParentButton,
+};

--- a/packages/components/src/navigator/navigator-back-button/README.md
+++ b/packages/components/src/navigator/navigator-back-button/README.md
@@ -1,6 +1,6 @@
-# `NavigatorBackButton`
+# `Navigator.BackButton`
 
-The `NavigatorBackButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
+The `Navigator.BackButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md) (also aliased as `Navigator`), the [`Navigator.Screen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`Navigator.Button`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage
 
@@ -8,4 +8,4 @@ Refer to [the `NavigatorProvider` component](/packages/components/src/navigator/
 
 ### Inherited props
 
-`NavigatorBackButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.
+`Navigator.BackButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.

--- a/packages/components/src/navigator/navigator-back-button/README.md
+++ b/packages/components/src/navigator/navigator-back-button/README.md
@@ -1,9 +1,5 @@
 # `NavigatorBackButton`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorBackButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage

--- a/packages/components/src/navigator/navigator-back-button/component.tsx
+++ b/packages/components/src/navigator/navigator-back-button/component.tsx
@@ -57,7 +57,7 @@ function UnconnectedNavigatorBackButton(
  */
 export const NavigatorBackButton = contextConnect(
 	UnconnectedNavigatorBackButton,
-	'NavigatorBackButton'
+	'Navigator.BackButton'
 );
 
 export default NavigatorBackButton;

--- a/packages/components/src/navigator/navigator-back-button/component.tsx
+++ b/packages/components/src/navigator/navigator-back-button/component.tsx
@@ -22,36 +22,33 @@ function UnconnectedNavigatorBackButton(
 }
 
 /**
- * The `NavigatorBackButton` component can be used to navigate to a screen and
- * should be used in combination with the `NavigatorProvider`, the
- * `NavigatorScreen` and the `NavigatorButton` components (or the `useNavigator`
+ * The `Navigator.BackButton` component can be used to navigate to a screen and
+ * should be used in combination with the `NavigatorProvider` (alias `Navigator`), the
+ * `Navigator.Screen` and the `Navigator.Button` components (or the `useNavigator`
  * hook).
  *
  * @example
  * ```jsx
  * import {
- *   NavigatorProvider,
- *   NavigatorScreen,
- *   NavigatorButton,
- *   NavigatorBackButton,
+ *   Navigator,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <NavigatorProvider initialPath="/">
- *     <NavigatorScreen path="/">
+ *   <Navigator.Provider initialPath="/">
+ *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
- *        <NavigatorButton path="/child">
+ *        <Navigator.Button path="/child">
  *          Navigate to child screen.
- *       </NavigatorButton>
- *     </NavigatorScreen>
+ *       </Navigator.Button>
+ *     </Navigator.Screen>
  *
- *     <NavigatorScreen path="/child">
+ *     <Navigator.Screen path="/child">
  *       <p>This is the child screen.</p>
- *       <NavigatorBackButton>
+ *       <Navigator.BackButton>
  *         Go back
- *       </NavigatorBackButton>
- *     </NavigatorScreen>
- *   </NavigatorProvider>
+ *       </Navigator.BackButton>
+ *     </Navigator.Screen>
+ *   </Navigator>
  * );
  * ```
  */

--- a/packages/components/src/navigator/navigator-back-button/component.tsx
+++ b/packages/components/src/navigator/navigator-back-button/component.tsx
@@ -23,8 +23,8 @@ function UnconnectedNavigatorBackButton(
 
 /**
  * The `Navigator.BackButton` component can be used to navigate to a screen and
- * should be used in combination with the `NavigatorProvider` (alias `Navigator`), the
- * `Navigator.Screen` and the `Navigator.Button` components (or the `useNavigator`
+ * should be used in combination with the `NavigatorProvider` (also aliased as `Navigator`),
+ * the `Navigator.Screen` and the `Navigator.Button` components (or the `useNavigator`
  * hook).
  *
  * @example
@@ -34,7 +34,7 @@ function UnconnectedNavigatorBackButton(
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <Navigator.Provider initialPath="/">
+ *   <Navigator initialPath="/">
  *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
  *        <Navigator.Button path="/child">

--- a/packages/components/src/navigator/navigator-back-button/component.tsx
+++ b/packages/components/src/navigator/navigator-back-button/component.tsx
@@ -30,10 +30,10 @@ function UnconnectedNavigatorBackButton(
  * @example
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorBackButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-back-button/component.tsx
+++ b/packages/components/src/navigator/navigator-back-button/component.tsx
@@ -34,7 +34,7 @@ function UnconnectedNavigatorBackButton(
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <Navigator initialPath="/">
+ *   <Navigator.Root initialPath="/">
  *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
  *        <Navigator.Button path="/child">
@@ -48,7 +48,7 @@ function UnconnectedNavigatorBackButton(
  *         Go back
  *       </Navigator.BackButton>
  *     </Navigator.Screen>
- *   </Navigator>
+ *   </Navigator.Root>
  * );
  * ```
  */

--- a/packages/components/src/navigator/navigator-button/README.md
+++ b/packages/components/src/navigator/navigator-button/README.md
@@ -1,9 +1,5 @@
 # `NavigatorButton`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage

--- a/packages/components/src/navigator/navigator-button/README.md
+++ b/packages/components/src/navigator/navigator-button/README.md
@@ -1,6 +1,6 @@
-# `NavigatorButton`
+# `Navigator.Button`
 
-The `NavigatorButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components (or the `useNavigator` hook).
+The `Navigator.Button` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md) (also aliased as `Navigator`), the [`Navigator.Screen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`Navigator.BackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage
 
@@ -31,4 +31,4 @@ The path of the screen to navigate to. The value of this prop needs to be [a val
 
 ### Inherited props
 
-`NavigatorButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.
+`Navigator.Button` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.

--- a/packages/components/src/navigator/navigator-button/component.tsx
+++ b/packages/components/src/navigator/navigator-button/component.tsx
@@ -22,35 +22,32 @@ function UnconnectedNavigatorButton(
 }
 
 /**
- * The `NavigatorButton` component can be used to navigate to a screen and should
- * be used in combination with the `NavigatorProvider`, the `NavigatorScreen`
- * and the `NavigatorBackButton` components (or the `useNavigator` hook).
+ * The `Navigator.Button` component can be used to navigate to a screen and should
+ * be used in combination with the `NavigatorProvider` (alias `Navigator`), the
+ * `Navigator.Screen` and the `Navigator.BackButton` components (or the `useNavigator` hook).
  *
  * @example
  * ```jsx
  * import {
- *   NavigatorProvider,
- *   NavigatorScreen,
- *   NavigatorButton,
- *   NavigatorBackButton,
+ *   Navigator,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <NavigatorProvider initialPath="/">
- *     <NavigatorScreen path="/">
+ *   <Navigator initialPath="/">
+ *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
- *        <NavigatorButton path="/child">
+ *        <Navigator.Button path="/child">
  *          Navigate to child screen.
- *       </NavigatorButton>
- *     </NavigatorScreen>
+ *       </Navigator.Button>
+ *     </Navigator.Screen>
  *
- *     <NavigatorScreen path="/child">
+ *     <Navigator.Screen path="/child">
  *       <p>This is the child screen.</p>
- *       <NavigatorBackButton>
+ *       <Navigator.BackButton>
  *         Go back
- *       </NavigatorBackButton>
- *     </NavigatorScreen>
- *   </NavigatorProvider>
+ *       </Navigator.BackButton>
+ *     </Navigator.Screen>
+ *   </Navigator>
  * );
  * ```
  */

--- a/packages/components/src/navigator/navigator-button/component.tsx
+++ b/packages/components/src/navigator/navigator-button/component.tsx
@@ -56,7 +56,7 @@ function UnconnectedNavigatorButton(
  */
 export const NavigatorButton = contextConnect(
 	UnconnectedNavigatorButton,
-	'NavigatorButton'
+	'Navigator.Button'
 );
 
 export default NavigatorButton;

--- a/packages/components/src/navigator/navigator-button/component.tsx
+++ b/packages/components/src/navigator/navigator-button/component.tsx
@@ -29,10 +29,10 @@ function UnconnectedNavigatorButton(
  * @example
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorBackButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-button/component.tsx
+++ b/packages/components/src/navigator/navigator-button/component.tsx
@@ -23,7 +23,7 @@ function UnconnectedNavigatorButton(
 
 /**
  * The `Navigator.Button` component can be used to navigate to a screen and should
- * be used in combination with the `NavigatorProvider` (alias `Navigator`), the
+ * be used in combination with the `NavigatorProvider` (also aliased as `Navigator`), the
  * `Navigator.Screen` and the `Navigator.BackButton` components (or the `useNavigator` hook).
  *
  * @example

--- a/packages/components/src/navigator/navigator-button/component.tsx
+++ b/packages/components/src/navigator/navigator-button/component.tsx
@@ -33,7 +33,7 @@ function UnconnectedNavigatorButton(
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <Navigator initialPath="/">
+ *   <Navigator.Root initialPath="/">
  *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
  *        <Navigator.Button path="/child">
@@ -47,7 +47,7 @@ function UnconnectedNavigatorButton(
  *         Go back
  *       </Navigator.BackButton>
  *     </Navigator.Screen>
- *   </Navigator>
+ *   </Navigator.Root>
  * );
  * ```
  */

--- a/packages/components/src/navigator/navigator-provider/README.md
+++ b/packages/components/src/navigator/navigator-provider/README.md
@@ -1,19 +1,15 @@
 # `NavigatorProvider`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorProvider` component allows rendering nested views/panels/menus (via the [`NavigatorScreen` component](/packages/components/src/navigator/navigator-screen/README.md)) and navigate between these different states (via the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md), [`NavigatorToParentButton`](/packages/components/src/navigator/navigator-to-parent-button/README.md) and [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components or the `useNavigator` hook). The Global Styles sidebar is an example of this.
 
 ## Usage
 
 ```jsx
 import {
-  __experimentalNavigatorProvider as NavigatorProvider,
-  __experimentalNavigatorScreen as NavigatorScreen,
-  __experimentalNavigatorButton as NavigatorButton,
-  __experimentalNavigatorToParentButton as NavigatorToParentButton,
+  NavigatorProvider,
+  NavigatorScreen,
+  NavigatorButton,
+  NavigatorToParentButton,
 } from '@wordpress/components';
 
 const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-provider/README.md
+++ b/packages/components/src/navigator/navigator-provider/README.md
@@ -1,33 +1,30 @@
 # `NavigatorProvider`
 
-The `NavigatorProvider` component allows rendering nested views/panels/menus (via the [`NavigatorScreen` component](/packages/components/src/navigator/navigator-screen/README.md)) and navigate between these different states (via the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md), [`NavigatorToParentButton`](/packages/components/src/navigator/navigator-to-parent-button/README.md) and [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components or the `useNavigator` hook). The Global Styles sidebar is an example of this.
+The `NavigatorProvider` (also aliased as `Navigator`) component allows rendering nested views/panels/menus (via the [`Navigator.Screen` component](/packages/components/src/navigator/navigator-screen/README.md)) and navigate between these different states (via the [`Navigator.Button`](/packages/components/src/navigator/navigator-button/README.md), [`Navigator.ToParentButton`](/packages/components/src/navigator/navigator-to-parent-button/README.md) and [`Navigator.BackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components or the `useNavigator` hook). The Global Styles sidebar is an example of this.
 
 ## Usage
 
 ```jsx
 import {
-  NavigatorProvider,
-  NavigatorScreen,
-  NavigatorButton,
-  NavigatorToParentButton,
+  Navigator,
 } from '@wordpress/components';
 
 const MyNavigation = () => (
-  <NavigatorProvider initialPath="/">
-    <NavigatorScreen path="/">
+  <Navigator initialPath="/">
+    <Navigator.Screen path="/">
       <p>This is the home screen.</p>
-       <NavigatorButton path="/child">
+       <Navigator.Button path="/child">
          Navigate to child screen.
-      </NavigatorButton>
-    </NavigatorScreen>
+      </Navigator.Button>
+    </Navigator.Screen>
 
-    <NavigatorScreen path="/child">
+    <Navigator.Screen path="/child">
       <p>This is the child screen.</p>
-      <NavigatorToParentButton>
+      <Navigator.ToParentButton>
         Go back
-      </NavigatorToParentButton>
-    </NavigatorScreen>
-  </NavigatorProvider>
+      </Navigator.ToParentButton>
+    </Navigator.Screen>
+  </Navigator>
 );
 ```
 **Important note**

--- a/packages/components/src/navigator/navigator-provider/README.md
+++ b/packages/components/src/navigator/navigator-provider/README.md
@@ -5,36 +5,34 @@ The `NavigatorProvider` (also aliased as `Navigator`) component allows rendering
 ## Usage
 
 ```jsx
-import {
-  Navigator,
-} from '@wordpress/components';
+import { Navigator } from '@wordpress/components';
 
 const MyNavigation = () => (
-  <Navigator initialPath="/">
-    <Navigator.Screen path="/">
-      <p>This is the home screen.</p>
-       <Navigator.Button path="/child">
-         Navigate to child screen.
-      </Navigator.Button>
-    </Navigator.Screen>
+	<Navigator.Root initialPath="/">
+		<Navigator.Screen path="/">
+			<p>This is the home screen.</p>
+			<Navigator.Button path="/child">
+				Navigate to child screen.
+			</Navigator.Button>
+		</Navigator.Screen>
 
-    <Navigator.Screen path="/child">
-      <p>This is the child screen.</p>
-      <Navigator.ToParentButton>
-        Go back
-      </Navigator.ToParentButton>
-    </Navigator.Screen>
-  </Navigator>
+		<Navigator.Screen path="/child">
+			<p>This is the child screen.</p>
+			<Navigator.ToParentButton>Go back</Navigator.ToParentButton>
+		</Navigator.Screen>
+	</Navigator.Root>
 );
 ```
+
 **Important note**
 
 Parent/child navigation only works if the path you define are hierarchical, following a URL-like scheme where each path segment is separated by the `/` character.
 For example:
-- `/` is the root of all paths. There should always be a screen with `path="/"`.
-- `/parent/child` is a child of `/parent`.
-- `/parent/child/grand-child` is a child of `/parent/child`.
-- `/parent/:param` is a child of `/parent` as well.
+
+-   `/` is the root of all paths. There should always be a screen with `path="/"`.
+-   `/parent/child` is a child of `/parent`.
+-   `/parent/child/grand-child` is a child of `/parent/child`.
+-   `/parent/:param` is a child of `/parent` as well.
 
 ## Props
 
@@ -58,8 +56,8 @@ The `goTo` function allows navigating to a given path. The second argument can a
 
 The available options are:
 
-- `focusTargetSelector`: `string`. An optional property used to specify the CSS selector used to restore focus on the matching element when navigating back.
-- `isBack`: `boolean`. An optional property used to specify whether the navigation should be considered as backwards (thus enabling focus restoration when possible, and causing the animation to be backwards too)
+-   `focusTargetSelector`: `string`. An optional property used to specify the CSS selector used to restore focus on the matching element when navigating back.
+-   `isBack`: `boolean`. An optional property used to specify whether the navigation should be considered as backwards (thus enabling focus restoration when possible, and causing the animation to be backwards too)
 
 ### `goToParent`: `() => void;`
 
@@ -77,9 +75,9 @@ The `goBack` function allows navigating to the previous path.
 
 The `location` object represent the current location, and has a few properties:
 
-- `path`: `string`. The path associated to the location.
-- `isBack`: `boolean`. A flag that is `true` when the current location was reached by navigating backwards in the location stack.
-- `isInitial`: `boolean`. A flag that is `true` only for the first (root) location in the location stack.
+-   `path`: `string`. The path associated to the location.
+-   `isBack`: `boolean`. A flag that is `true` when the current location was reached by navigating backwards in the location stack.
+-   `isInitial`: `boolean`. A flag that is `true` only for the first (root) location in the location stack.
 
 ### `params`: `Record< string, string | string[] >`
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -271,35 +271,32 @@ function UnconnectedNavigatorProvider(
 }
 
 /**
- * The `NavigatorProvider` component allows rendering nested views/panels/menus
- * (via the `NavigatorScreen` component and navigate between these different
- * view (via the `NavigatorButton` and `NavigatorBackButton` components or the
- * `useNavigator` hook).
+ * The `NavigatorProvider` component (alias `Navigator`) allows rendering nested
+ * views/panels/menus (via the `Navigator.Screen` component and navigate between
+ * these different view (via the `Navigator.Button` and `Navigator.BackButton`
+ * components or the `useNavigator` hook).
  *
  * ```jsx
  * import {
- *   NavigatorProvider,
- *   NavigatorScreen,
- *   NavigatorButton,
- *   NavigatorBackButton,
+ *   Navigator,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <NavigatorProvider initialPath="/">
- *     <NavigatorScreen path="/">
+ *   <Navigator initialPath="/">
+ *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
- *        <NavigatorButton path="/child">
+ *        <Navigator.Button path="/child">
  *          Navigate to child screen.
- *       </NavigatorButton>
- *     </NavigatorScreen>
+ *       </Navigator.Button>
+ *     </Navigator.Screen>
  *
- *     <NavigatorScreen path="/child">
+ *     <Navigator.Screen path="/child">
  *       <p>This is the child screen.</p>
- *       <NavigatorBackButton>
+ *       <Navigator.BackButton>
  *         Go back
- *       </NavigatorBackButton>
- *     </NavigatorScreen>
- *   </NavigatorProvider>
+ *       </Navigator.BackButton>
+ *     </Navigator.Screen>
+ *   </Navigator>
  * );
  * ```
  */

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -27,6 +27,10 @@ import type {
 	Screen,
 	NavigateToParentOptions,
 } from '../types';
+import { NavigatorBackButton } from '../navigator-back-button';
+import { NavigatorScreen } from '../navigator-screen';
+import { NavigatorButton } from '../navigator-button';
+import { NavigatorToParentButton } from '../navigator-to-parent-button';
 
 type MatchedPath = ReturnType< typeof patternMatch >;
 
@@ -299,9 +303,28 @@ function UnconnectedNavigatorProvider(
  * );
  * ```
  */
-export const NavigatorProvider = contextConnect(
+
+type NavigatorProviderComponent< C > = C & {
+	// Define the function signature with props and a ref
+	Screen: typeof NavigatorScreen;
+	Button: typeof NavigatorButton;
+	BackButton: typeof NavigatorBackButton;
+	ToParentButton: typeof NavigatorToParentButton;
+};
+
+const Provider = contextConnect(
 	UnconnectedNavigatorProvider,
 	'NavigatorProvider'
 );
 
+const NavigatorProvider = Provider as NavigatorProviderComponent<
+	typeof Provider
+>;
+
+NavigatorProvider.Screen = NavigatorScreen;
+NavigatorProvider.Button = NavigatorButton;
+NavigatorProvider.BackButton = NavigatorBackButton;
+NavigatorProvider.ToParentButton = NavigatorToParentButton;
+
+export { NavigatorProvider };
 export default NavigatorProvider;

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -271,9 +271,9 @@ function UnconnectedNavigatorProvider(
 }
 
 /**
- * The `NavigatorProvider` component (alias `Navigator`) allows rendering nested
- * views/panels/menus (via the `Navigator.Screen` component and navigate between
- * these different view (via the `Navigator.Button` and `Navigator.BackButton`
+ * The `NavigatorProvider` component (also aliased as `Navigator`) allows rendering
+ * nested views/panels/menus (via the `Navigator.Screen` component and navigate
+ * between these different view (via the `Navigator.Button` and `Navigator.BackButton`
  * components or the `useNavigator` hook).
  *
  * ```jsx

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -274,10 +274,10 @@ function UnconnectedNavigatorProvider(
  *
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorBackButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -271,9 +271,9 @@ function UnconnectedNavigatorProvider(
 }
 
 /**
- * The `NavigatorProvider` component (also aliased as `Navigator`) allows rendering
- * nested views/panels/menus (via the `Navigator.Screen` component and navigate
- * between these different view (via the `Navigator.Button` and `Navigator.BackButton`
+ * The `Navigator.Root` allows rendering nested views/panels/menus
+ * (via the `Navigator.Screen` component) and navigate between these
+ * different views (via the `Navigator.Button` and `Navigator.BackButton`
  * components or the `useNavigator` hook).
  *
  * ```jsx
@@ -282,7 +282,7 @@ function UnconnectedNavigatorProvider(
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <Navigator initialPath="/">
+ *   <Navigator.Root> initialPath="/">
  *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
  *        <Navigator.Button path="/child">
@@ -296,32 +296,12 @@ function UnconnectedNavigatorProvider(
  *         Go back
  *       </Navigator.BackButton>
  *     </Navigator.Screen>
- *   </Navigator>
+ *   </Navigator.Root>
  * );
  * ```
  */
-
-type NavigatorProviderComponent< C > = C & {
-	// Define the function signature with props and a ref
-	Screen: typeof NavigatorScreen;
-	Button: typeof NavigatorButton;
-	BackButton: typeof NavigatorBackButton;
-	ToParentButton: typeof NavigatorToParentButton;
-};
-
-const Provider = contextConnect(
+export const NavigatorProvider = contextConnect(
 	UnconnectedNavigatorProvider,
 	'NavigatorProvider'
 );
-
-const NavigatorProvider = Provider as NavigatorProviderComponent<
-	typeof Provider
->;
-
-NavigatorProvider.Screen = NavigatorScreen;
-NavigatorProvider.Button = NavigatorButton;
-NavigatorProvider.BackButton = NavigatorBackButton;
-NavigatorProvider.ToParentButton = NavigatorToParentButton;
-
-export { NavigatorProvider };
 export default NavigatorProvider;

--- a/packages/components/src/navigator/navigator-screen/README.md
+++ b/packages/components/src/navigator/navigator-screen/README.md
@@ -1,9 +1,5 @@
 # `NavigatorScreen`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorScreen` component represents a single view/screen/panel and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) and the [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage

--- a/packages/components/src/navigator/navigator-screen/README.md
+++ b/packages/components/src/navigator/navigator-screen/README.md
@@ -1,6 +1,6 @@
-# `NavigatorScreen`
+# `Navigator.Screen`
 
-The `NavigatorScreen` component represents a single view/screen/panel and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) and the [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components (or the `useNavigator` hook).
+The `Navigator.Screen` component represents a single view/screen/panel and should be used in combination with the [`Navigator.Provider`](/packages/components/src/navigator/navigator-provider/README.md) (also aliased as `Navigator`), the [`Navigator.Button`](/packages/components/src/navigator/navigator-button/README.md) and the [`NavigatorBackButton`](/packages/components/src/navigator/navigator-back-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage
 

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -147,10 +147,10 @@ function UnconnectedNavigatorScreen(
  * @example
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorBackButton as NavigatorBackButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorBackButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -140,8 +140,8 @@ function UnconnectedNavigatorScreen(
 
 /**
  * The `Navigator.Screen` component represents a single view/screen/panel and
- * should be used in combination with the `NavigatorProvider` (alias `Navigator`), the
- * `Navigator.Button` and the `Navigator.BackButton` components (or the `useNavigator`
+ * should be used in combination with the `NavigatorProvider` (also aliased as `Navigator`),
+ * the `Navigator.Button` and the `Navigator.BackButton` components (or the `useNavigator`
  * hook).
  *
  * @example

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -174,7 +174,7 @@ function UnconnectedNavigatorScreen(
  */
 export const NavigatorScreen = contextConnect(
 	UnconnectedNavigatorScreen,
-	'NavigatorScreen'
+	'Navigator.Screen'
 );
 
 export default NavigatorScreen;

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -139,36 +139,33 @@ function UnconnectedNavigatorScreen(
 }
 
 /**
- * The `NavigatorScreen` component represents a single view/screen/panel and
- * should be used in combination with the `NavigatorProvider`, the
- * `NavigatorButton` and the `NavigatorBackButton` components (or the `useNavigator`
+ * The `Navigator.Screen` component represents a single view/screen/panel and
+ * should be used in combination with the `NavigatorProvider` (alias `Navigator`), the
+ * `Navigator.Button` and the `Navigator.BackButton` components (or the `useNavigator`
  * hook).
  *
  * @example
  * ```jsx
  * import {
- *   NavigatorProvider,
- *   NavigatorScreen,
- *   NavigatorButton,
- *   NavigatorBackButton,
+ *   Navigator,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <NavigatorProvider initialPath="/">
- *     <NavigatorScreen path="/">
+ *   <Navigator initialPath="/">
+ *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
- *        <NavigatorButton path="/child">
+ *        <Navigator.Button path="/child">
  *          Navigate to child screen.
- *       </NavigatorButton>
- *     </NavigatorScreen>
+ *       </Navigator.Button>
+ *     </Navigator.Screen>
  *
- *     <NavigatorScreen path="/child">
+ *     <Navigator.Screen path="/child">
  *       <p>This is the child screen.</p>
- *       <NavigatorBackButton>
+ *       <Navigator.BackButton>
  *         Go back
- *       </NavigatorBackButton>
- *     </NavigatorScreen>
- *   </NavigatorProvider>
+ *       </Navigator.BackButton>
+ *     </Navigator.Screen>
+ *   </Navigator>
  * );
  * ```
  */

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -151,7 +151,7 @@ function UnconnectedNavigatorScreen(
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <Navigator initialPath="/">
+ *   <Navigator.Root initialPath="/">
  *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
  *        <Navigator.Button path="/child">
@@ -165,7 +165,7 @@ function UnconnectedNavigatorScreen(
  *         Go back
  *       </Navigator.BackButton>
  *     </Navigator.Screen>
- *   </Navigator>
+ *   </Navigator.Root>
  * );
  * ```
  */

--- a/packages/components/src/navigator/navigator-to-parent-button/README.md
+++ b/packages/components/src/navigator/navigator-to-parent-button/README.md
@@ -1,6 +1,6 @@
-# `NavigatorToParentButton`
+# `Navigator.ToParentButton`
 
-The `NavigatorToParentButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
+The `Navigator.ToParentButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md) (also aliased as `Navigator`), the [`Navigator.Screen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`Navigator.Button`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage
 
@@ -8,4 +8,4 @@ Refer to [the `NavigatorProvider` component](/packages/components/src/navigator/
 
 ### Inherited props
 
-`NavigatorToParentButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.
+`Navigator.ToParentButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.

--- a/packages/components/src/navigator/navigator-to-parent-button/README.md
+++ b/packages/components/src/navigator/navigator-to-parent-button/README.md
@@ -1,9 +1,5 @@
 # `NavigatorToParentButton`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 The `NavigatorToParentButton` component can be used to navigate to a screen and should be used in combination with the [`NavigatorProvider`](/packages/components/src/navigator/navigator-provider/README.md), the [`NavigatorScreen`](/packages/components/src/navigator/navigator-screen/README.md) and the [`NavigatorButton`](/packages/components/src/navigator/navigator-button/README.md) components (or the `useNavigator` hook).
 
 ## Usage

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -26,8 +26,8 @@ function UnconnectedNavigatorToParentButton(
 
 /*
  * The `Navigator.ToParentButton` component can be used to navigate to a screen and
- * should be used in combination with the `NavigatorProvider` (alias `Navigator`), the
- * `Navigator.Screen` and the `Navigator.Button` components (or the `useNavigator`
+ * should be used in combination with the `NavigatorProvider` (also aliased as `Navigator`),
+ * the `Navigator.Screen` and the `Navigator.Button` components (or the `useNavigator`
  * hook).
  *
  * @example

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -60,7 +60,7 @@ function UnconnectedNavigatorToParentButton(
  */
 export const NavigatorToParentButton = contextConnect(
 	UnconnectedNavigatorToParentButton,
-	'NavigatorToParentButton'
+	'Navigator.ToParentButton'
 );
 
 export default NavigatorToParentButton;

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -33,10 +33,10 @@ function UnconnectedNavigatorToParentButton(
  * @example
  * ```jsx
  * import {
- *   __experimentalNavigatorProvider as NavigatorProvider,
- *   __experimentalNavigatorScreen as NavigatorScreen,
- *   __experimentalNavigatorButton as NavigatorButton,
- *   __experimentalNavigatorToParentButton as NavigatorToParentButton,
+ *   NavigatorProvider,
+ *   NavigatorScreen,
+ *   NavigatorButton,
+ *   NavigatorToParentButton,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -25,36 +25,33 @@ function UnconnectedNavigatorToParentButton(
 }
 
 /*
- * The `NavigatorToParentButton` component can be used to navigate to a screen and
- * should be used in combination with the `NavigatorProvider`, the
- * `NavigatorScreen` and the `NavigatorButton` components (or the `useNavigator`
+ * The `Navigator.ToParentButton` component can be used to navigate to a screen and
+ * should be used in combination with the `NavigatorProvider` (alias `Navigator`), the
+ * `Navigator.Screen` and the `Navigator.Button` components (or the `useNavigator`
  * hook).
  *
  * @example
  * ```jsx
  * import {
- *   NavigatorProvider,
- *   NavigatorScreen,
- *   NavigatorButton,
- *   NavigatorToParentButton,
+ *   Navigator,
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <NavigatorProvider initialPath="/">
- *     <NavigatorScreen path="/">
+ *   <Navigator initialPath="/">
+ *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
- *        <NavigatorButton path="/child">
+ *        <Navigator.Button path="/child">
  *          Navigate to child screen.
- *       </NavigatorButton>
- *     </NavigatorScreen>
+ *       </Navigator.Button>
+ *     </Navigator.Screen>
  *
- *     <NavigatorScreen path="/child">
+ *     <Navigator.Screen path="/child">
  *       <p>This is the child screen.</p>
- *       <NavigatorToParentButton>
+ *       <Navigator.ToParentButton>
  *         Go to parent
- *       </NavigatorToParentButton>
- *     </NavigatorScreen>
- *   </NavigatorProvider>
+ *       </Navigator.ToParentButton>
+ *     </Navigator.Screen>
+ *   </Navigator>
  * );
  * ```
  */

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -37,7 +37,7 @@ function UnconnectedNavigatorToParentButton(
  * } from '@wordpress/components';
  *
  * const MyNavigation = () => (
- *   <Navigator initialPath="/">
+ *   <Navigator.Root initialPath="/">
  *     <Navigator.Screen path="/">
  *       <p>This is the home screen.</p>
  *        <Navigator.Button path="/child">
@@ -51,7 +51,7 @@ function UnconnectedNavigatorToParentButton(
  *         Go to parent
  *       </Navigator.ToParentButton>
  *     </Navigator.Screen>
- *   </Navigator>
+ *   </Navigator.Root>
  * );
  * ```
  */

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -12,10 +12,16 @@ import { VStack } from '../../v-stack';
 import Dropdown from '../../dropdown';
 import { Navigator, useNavigator } from '..';
 
-const meta: Meta< typeof NavigatorProvider > = {
-	component: NavigatorProvider,
-	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-	subcomponents: { NavigatorScreen, NavigatorButton, NavigatorBackButton },
+const meta: Meta< typeof Navigator > = {
+	component: Navigator,
+	subcomponents: {
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'Navigator.Screen': Navigator.Screen,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'Navigator.Button': Navigator.Button,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'Navigator.BackButton': Navigator.BackButton,
+	},
 	title: 'Components/Navigator',
 	argTypes: {
 		as: { control: { type: null } },
@@ -29,10 +35,7 @@ const meta: Meta< typeof NavigatorProvider > = {
 };
 export default meta;
 
-const Template: StoryFn< typeof NavigatorProvider > = ( {
-	style,
-	...props
-} ) => (
+const Template: StoryFn< typeof Navigator > = ( { style, ...props } ) => (
 	<Navigator
 		style={ { ...style, height: '100vh', maxHeight: '450px' } }
 		{ ...props }
@@ -43,24 +46,24 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 					<p>This is the home screen.</p>
 
 					<VStack alignment="left">
-						<NavigatorButton variant="secondary" path="/child">
+						<Navigator.Button variant="secondary" path="/child">
 							Navigate to child screen.
-						</NavigatorButton>
+						</Navigator.Button>
 
-						<NavigatorButton
+						<Navigator.Button
 							variant="secondary"
 							path="/overflow-child"
 						>
 							Navigate to screen with horizontal overflow.
-						</NavigatorButton>
+						</Navigator.Button>
 
-						<NavigatorButton variant="secondary" path="/stickies">
+						<Navigator.Button variant="secondary" path="/stickies">
 							Navigate to screen with sticky content.
-						</NavigatorButton>
+						</Navigator.Button>
 
-						<NavigatorButton variant="secondary" path="/product/1">
+						<Navigator.Button variant="secondary" path="/product/1">
 							Navigate to product screen with id 1.
-						</NavigatorButton>
+						</Navigator.Button>
 
 						<Dropdown
 							renderToggle={ ( {
@@ -95,19 +98,19 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 			<Card>
 				<CardBody>
 					<p>This is the child screen.</p>
-					<NavigatorBackButton variant="secondary">
+					<Navigator.BackButton variant="secondary">
 						Go back
-					</NavigatorBackButton>
+					</Navigator.BackButton>
 				</CardBody>
 			</Card>
 		</Navigator.Screen>
 
-		<NavigatorScreen path="/overflow-child">
+		<Navigator.Screen path="/overflow-child">
 			<Card>
 				<CardBody>
-					<NavigatorBackButton variant="secondary">
+					<Navigator.BackButton variant="secondary">
 						Go back
-					</NavigatorBackButton>
+					</Navigator.BackButton>
 					<div
 						style={ {
 							display: 'inline-block',
@@ -126,14 +129,14 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 					</div>
 				</CardBody>
 			</Card>
-		</NavigatorScreen>
+		</Navigator.Screen>
 
-		<NavigatorScreen path="/stickies">
+		<Navigator.Screen path="/stickies">
 			<Card>
 				<CardHeader style={ getStickyStyles( { zIndex: 2 } ) }>
-					<NavigatorBackButton variant="secondary">
+					<Navigator.BackButton variant="secondary">
 						Go back
-					</NavigatorBackButton>
+					</Navigator.BackButton>
 				</CardHeader>
 				<CardBody>
 					<div
@@ -165,7 +168,7 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 					<Button variant="primary">Primary noop</Button>
 				</CardFooter>
 			</Card>
-		</NavigatorScreen>
+		</Navigator.Screen>
 
 		<Navigator.Screen path="/product/:id">
 			<ProductDetails />
@@ -173,7 +176,7 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 	</Navigator>
 );
 
-export const Default: StoryFn< typeof NavigatorProvider > = Template.bind( {} );
+export const Default: StoryFn< typeof Navigator > = Template.bind( {} );
 Default.args = {
 	initialPath: '/',
 };
@@ -227,7 +230,7 @@ function ProductDetails() {
 	);
 }
 
-const NestedNavigatorTemplate: StoryFn< typeof NavigatorProvider > = ( {
+const NestedNavigatorTemplate: StoryFn< typeof Navigator > = ( {
 	style,
 	...props
 } ) => (
@@ -238,12 +241,12 @@ const NestedNavigatorTemplate: StoryFn< typeof NavigatorProvider > = ( {
 		<Navigator.Screen path="/">
 			<Card>
 				<CardBody>
-					<NavigatorButton variant="secondary" path="/child1">
+					<Navigator.Button variant="secondary" path="/child1">
 						Go to first child.
-					</NavigatorButton>
-					<NavigatorButton variant="secondary" path="/child2">
+					</Navigator.Button>
+					<Navigator.Button variant="secondary" path="/child2">
 						Go to second child.
-					</NavigatorButton>
+					</Navigator.Button>
 				</CardBody>
 			</Card>
 		</Navigator.Screen>
@@ -251,9 +254,9 @@ const NestedNavigatorTemplate: StoryFn< typeof NavigatorProvider > = ( {
 			<Card>
 				<CardBody>
 					This is the first child
-					<NavigatorToParentButton variant="secondary">
+					<Navigator.ToParentButton variant="secondary">
 						Go back to parent
-					</NavigatorToParentButton>
+					</Navigator.ToParentButton>
 				</CardBody>
 			</Card>
 		</Navigator.Screen>
@@ -310,7 +313,7 @@ const NavigatorButtonWithSkipFocus = ( {
 	);
 };
 
-export const SkipFocus: StoryFn< typeof NavigatorProvider > = ( args ) => {
+export const SkipFocus: StoryFn< typeof Navigator > = ( args ) => {
 	return <Navigator { ...args } />;
 };
 SkipFocus.args = {

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -10,14 +10,7 @@ import Button from '../../button';
 import { Card, CardBody, CardFooter, CardHeader } from '../../card';
 import { VStack } from '../../v-stack';
 import Dropdown from '../../dropdown';
-import {
-	NavigatorProvider,
-	NavigatorScreen,
-	NavigatorButton,
-	NavigatorBackButton,
-	NavigatorToParentButton,
-	useNavigator,
-} from '..';
+import { Navigator, useNavigator } from '..';
 
 const meta: Meta< typeof NavigatorProvider > = {
 	component: NavigatorProvider,
@@ -40,11 +33,11 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 	style,
 	...props
 } ) => (
-	<NavigatorProvider
+	<Navigator
 		style={ { ...style, height: '100vh', maxHeight: '450px' } }
 		{ ...props }
 	>
-		<NavigatorScreen path="/">
+		<Navigator.Screen path="/">
 			<Card>
 				<CardBody>
 					<p>This is the home screen.</p>
@@ -96,9 +89,9 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 					</VStack>
 				</CardBody>
 			</Card>
-		</NavigatorScreen>
+		</Navigator.Screen>
 
-		<NavigatorScreen path="/child">
+		<Navigator.Screen path="/child">
 			<Card>
 				<CardBody>
 					<p>This is the child screen.</p>
@@ -107,7 +100,7 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 					</NavigatorBackButton>
 				</CardBody>
 			</Card>
-		</NavigatorScreen>
+		</Navigator.Screen>
 
 		<NavigatorScreen path="/overflow-child">
 			<Card>
@@ -174,10 +167,10 @@ const Template: StoryFn< typeof NavigatorProvider > = ( {
 			</Card>
 		</NavigatorScreen>
 
-		<NavigatorScreen path="/product/:id">
+		<Navigator.Screen path="/product/:id">
 			<ProductDetails />
-		</NavigatorScreen>
-	</NavigatorProvider>
+		</Navigator.Screen>
+	</Navigator>
 );
 
 export const Default: StoryFn< typeof NavigatorProvider > = Template.bind( {} );
@@ -225,9 +218,9 @@ function ProductDetails() {
 	return (
 		<Card>
 			<CardBody>
-				<NavigatorBackButton variant="secondary">
+				<Navigator.BackButton variant="secondary">
 					Go back
-				</NavigatorBackButton>
+				</Navigator.BackButton>
 				<p>This is the screen for the product with id: { params.id }</p>
 			</CardBody>
 		</Card>
@@ -238,11 +231,11 @@ const NestedNavigatorTemplate: StoryFn< typeof NavigatorProvider > = ( {
 	style,
 	...props
 } ) => (
-	<NavigatorProvider
+	<Navigator
 		style={ { ...style, height: '100vh', maxHeight: '450px' } }
 		{ ...props }
 	>
-		<NavigatorScreen path="/">
+		<Navigator.Screen path="/">
 			<Card>
 				<CardBody>
 					<NavigatorButton variant="secondary" path="/child1">
@@ -253,8 +246,8 @@ const NestedNavigatorTemplate: StoryFn< typeof NavigatorProvider > = ( {
 					</NavigatorButton>
 				</CardBody>
 			</Card>
-		</NavigatorScreen>
-		<NavigatorScreen path="/child1">
+		</Navigator.Screen>
+		<Navigator.Screen path="/child1">
 			<Card>
 				<CardBody>
 					This is the first child
@@ -263,37 +256,37 @@ const NestedNavigatorTemplate: StoryFn< typeof NavigatorProvider > = ( {
 					</NavigatorToParentButton>
 				</CardBody>
 			</Card>
-		</NavigatorScreen>
-		<NavigatorScreen path="/child2">
+		</Navigator.Screen>
+		<Navigator.Screen path="/child2">
 			<Card>
 				<CardBody>
 					This is the second child
-					<NavigatorToParentButton variant="secondary">
+					<Navigator.ToParentButton variant="secondary">
 						Go back to parent
-					</NavigatorToParentButton>
-					<NavigatorButton
+					</Navigator.ToParentButton>
+					<Navigator.Button
 						variant="secondary"
 						path="/child2/grandchild"
 					>
 						Go to grand child.
-					</NavigatorButton>
+					</Navigator.Button>
 				</CardBody>
 			</Card>
-		</NavigatorScreen>
-		<NavigatorScreen path="/child2/grandchild">
+		</Navigator.Screen>
+		<Navigator.Screen path="/child2/grandchild">
 			<Card>
 				<CardBody>
 					This is the grand child
-					<NavigatorToParentButton variant="secondary">
+					<Navigator.ToParentButton variant="secondary">
 						Go back to parent
-					</NavigatorToParentButton>
+					</Navigator.ToParentButton>
 				</CardBody>
 			</Card>
-		</NavigatorScreen>
-	</NavigatorProvider>
+		</Navigator.Screen>
+	</Navigator>
 );
 
-export const NestedNavigator: StoryFn< typeof NavigatorProvider > =
+export const NestedNavigator: StoryFn< typeof Navigator > =
 	NestedNavigatorTemplate.bind( {} );
 NestedNavigator.args = {
 	initialPath: '/child2/grandchild',
@@ -303,7 +296,7 @@ const NavigatorButtonWithSkipFocus = ( {
 	path,
 	onClick,
 	...props
-}: React.ComponentProps< typeof NavigatorButton > ) => {
+}: React.ComponentProps< typeof Navigator.Button > ) => {
 	const { goTo } = useNavigator();
 
 	return (
@@ -318,7 +311,7 @@ const NavigatorButtonWithSkipFocus = ( {
 };
 
 export const SkipFocus: StoryFn< typeof NavigatorProvider > = ( args ) => {
-	return <NavigatorProvider { ...args } />;
+	return <Navigator { ...args } />;
 };
 SkipFocus.args = {
 	initialPath: '/',
@@ -330,28 +323,28 @@ SkipFocus.args = {
 					border: '1px solid black',
 				} }
 			>
-				<NavigatorScreen
+				<Navigator.Screen
 					path="/"
 					style={ {
 						height: '100%',
 					} }
 				>
 					<h1>Home screen</h1>
-					<NavigatorButton variant="secondary" path="/child">
+					<Navigator.Button variant="secondary" path="/child">
 						Go to child screen.
-					</NavigatorButton>
-				</NavigatorScreen>
-				<NavigatorScreen
+					</Navigator.Button>
+				</Navigator.Screen>
+				<Navigator.Screen
 					path="/child"
 					style={ {
 						height: '100%',
 					} }
 				>
 					<h2>Child screen</h2>
-					<NavigatorToParentButton variant="secondary">
+					<Navigator.ToParentButton variant="secondary">
 						Go to parent screen.
-					</NavigatorToParentButton>
-				</NavigatorScreen>
+					</Navigator.ToParentButton>
+				</Navigator.Screen>
 			</div>
 
 			<NavigatorButtonWithSkipFocus

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -23,7 +23,7 @@ const meta: Meta< typeof NavigatorProvider > = {
 	component: NavigatorProvider,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { NavigatorScreen, NavigatorButton, NavigatorBackButton },
-	title: 'Components (Experimental)/Navigator',
+	title: 'Components/Navigator',
 	argTypes: {
 		as: { control: { type: null } },
 		children: { control: { type: null } },

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -12,8 +12,8 @@ import { VStack } from '../../v-stack';
 import Dropdown from '../../dropdown';
 import { Navigator, useNavigator } from '..';
 
-const meta: Meta< typeof Navigator > = {
-	component: Navigator,
+const meta: Meta< typeof Navigator.Root > = {
+	component: Navigator.Root,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 		'Navigator.Screen': Navigator.Screen,
@@ -35,8 +35,8 @@ const meta: Meta< typeof Navigator > = {
 };
 export default meta;
 
-const Template: StoryFn< typeof Navigator > = ( { style, ...props } ) => (
-	<Navigator
+const Template: StoryFn< typeof Navigator.Root > = ( { style, ...props } ) => (
+	<Navigator.Root
 		style={ { ...style, height: '100vh', maxHeight: '450px' } }
 		{ ...props }
 	>
@@ -173,10 +173,10 @@ const Template: StoryFn< typeof Navigator > = ( { style, ...props } ) => (
 		<Navigator.Screen path="/product/:id">
 			<ProductDetails />
 		</Navigator.Screen>
-	</Navigator>
+	</Navigator.Root>
 );
 
-export const Default: StoryFn< typeof Navigator > = Template.bind( {} );
+export const Default: StoryFn< typeof Navigator.Root > = Template.bind( {} );
 Default.args = {
 	initialPath: '/',
 };
@@ -230,11 +230,11 @@ function ProductDetails() {
 	);
 }
 
-const NestedNavigatorTemplate: StoryFn< typeof Navigator > = ( {
+const NestedNavigatorTemplate: StoryFn< typeof Navigator.Root > = ( {
 	style,
 	...props
 } ) => (
-	<Navigator
+	<Navigator.Root
 		style={ { ...style, height: '100vh', maxHeight: '450px' } }
 		{ ...props }
 	>
@@ -286,10 +286,10 @@ const NestedNavigatorTemplate: StoryFn< typeof Navigator > = ( {
 				</CardBody>
 			</Card>
 		</Navigator.Screen>
-	</Navigator>
+	</Navigator.Root>
 );
 
-export const NestedNavigator: StoryFn< typeof Navigator > =
+export const NestedNavigator: StoryFn< typeof Navigator.Root > =
 	NestedNavigatorTemplate.bind( {} );
 NestedNavigator.args = {
 	initialPath: '/child2/grandchild',
@@ -313,8 +313,8 @@ const NavigatorButtonWithSkipFocus = ( {
 	);
 };
 
-export const SkipFocus: StoryFn< typeof Navigator > = ( args ) => {
-	return <Navigator { ...args } />;
+export const SkipFocus: StoryFn< typeof Navigator.Root > = ( args ) => {
+	return <Navigator.Root { ...args } />;
 };
 SkipFocus.args = {
 	initialPath: '/',

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -14,14 +14,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Button from '../../button';
-import {
-	NavigatorProvider,
-	NavigatorScreen,
-	NavigatorButton,
-	NavigatorBackButton,
-	NavigatorToParentButton,
-	useNavigator,
-} from '..';
+import { Navigator, useNavigator } from '..';
 import type { NavigateOptions } from '../types';
 
 const INVALID_HTML_ATTRIBUTE = {
@@ -76,11 +69,11 @@ function CustomNavigatorButton( {
 	path,
 	onClick,
 	...props
-}: Omit< ComponentPropsWithoutRef< typeof NavigatorButton >, 'onClick' > & {
+}: Omit< ComponentPropsWithoutRef< typeof Navigator.Button >, 'onClick' > & {
 	onClick?: CustomTestOnClickHandler;
 } ) {
 	return (
-		<NavigatorButton
+		<Navigator.Button
 			onClick={ () => {
 				// Used to spy on the values passed to `navigator.goTo`.
 				onClick?.( { type: 'goTo', path } );
@@ -95,7 +88,7 @@ function CustomNavigatorGoToBackButton( {
 	path,
 	onClick,
 	...props
-}: Omit< ComponentPropsWithoutRef< typeof NavigatorButton >, 'onClick' > & {
+}: Omit< ComponentPropsWithoutRef< typeof Navigator.Button >, 'onClick' > & {
 	onClick?: CustomTestOnClickHandler;
 } ) {
 	const { goTo } = useNavigator();
@@ -115,7 +108,7 @@ function CustomNavigatorGoToSkipFocusButton( {
 	path,
 	onClick,
 	...props
-}: Omit< ComponentPropsWithoutRef< typeof NavigatorButton >, 'onClick' > & {
+}: Omit< ComponentPropsWithoutRef< typeof Navigator.Button >, 'onClick' > & {
 	onClick?: CustomTestOnClickHandler;
 } ) {
 	const { goTo } = useNavigator();
@@ -134,11 +127,14 @@ function CustomNavigatorGoToSkipFocusButton( {
 function CustomNavigatorBackButton( {
 	onClick,
 	...props
-}: Omit< ComponentPropsWithoutRef< typeof NavigatorBackButton >, 'onClick' > & {
+}: Omit<
+	ComponentPropsWithoutRef< typeof Navigator.BackButton >,
+	'onClick'
+> & {
 	onClick?: CustomTestOnClickHandler;
 } ) {
 	return (
-		<NavigatorBackButton
+		<Navigator.BackButton
 			onClick={ () => {
 				// Used to spy on the values passed to `navigator.goBack`.
 				onClick?.( { type: 'goBack' } );
@@ -151,11 +147,14 @@ function CustomNavigatorBackButton( {
 function CustomNavigatorToParentButton( {
 	onClick,
 	...props
-}: Omit< ComponentPropsWithoutRef< typeof NavigatorBackButton >, 'onClick' > & {
+}: Omit<
+	ComponentPropsWithoutRef< typeof Navigator.BackButton >,
+	'onClick'
+> & {
 	onClick?: CustomTestOnClickHandler;
 } ) {
 	return (
-		<NavigatorToParentButton
+		<Navigator.ToParentButton
 			onClick={ () => {
 				// Used to spy on the values passed to `navigator.goBack`.
 				onClick?.( { type: 'goToParent' } );
@@ -173,13 +172,13 @@ const ProductScreen = ( {
 	const { params } = useNavigator();
 
 	return (
-		<NavigatorScreen path={ PATHS.PRODUCT_PATTERN }>
+		<Navigator.Screen path={ PATHS.PRODUCT_PATTERN }>
 			<p>{ SCREEN_TEXT.product }</p>
 			<p>Product ID is { params.productId }</p>
 			<CustomNavigatorBackButton onClick={ onBackButtonClick }>
 				{ BUTTON_TEXT.back }
 			</CustomNavigatorBackButton>
-		</NavigatorScreen>
+		</Navigator.Screen>
 	);
 };
 
@@ -194,8 +193,8 @@ const MyNavigation = ( {
 	const [ outerInputValue, setOuterInputValue ] = useState( '' );
 	return (
 		<>
-			<NavigatorProvider initialPath={ initialPath }>
-				<NavigatorScreen path={ PATHS.HOME }>
+			<Navigator initialPath={ initialPath }>
+				<Navigator.Screen path={ PATHS.HOME }>
 					<p>{ SCREEN_TEXT.home }</p>
 					{ /*
 					 * A button useful to test focus restoration. This button is the first
@@ -233,9 +232,9 @@ const MyNavigation = ( {
 					>
 						{ BUTTON_TEXT.toInvalidHtmlPathScreen }
 					</CustomNavigatorButton>
-				</NavigatorScreen>
+				</Navigator.Screen>
 
-				<NavigatorScreen path={ PATHS.CHILD }>
+				<Navigator.Screen path={ PATHS.CHILD }>
 					<p>{ SCREEN_TEXT.child }</p>
 					{ /*
 					 * A button useful to test focus restoration. This button is the first
@@ -265,30 +264,30 @@ const MyNavigation = ( {
 						} }
 						value={ innerInputValue }
 					/>
-				</NavigatorScreen>
+				</Navigator.Screen>
 
-				<NavigatorScreen path={ PATHS.NESTED }>
+				<Navigator.Screen path={ PATHS.NESTED }>
 					<p>{ SCREEN_TEXT.nested }</p>
 					<CustomNavigatorBackButton
 						onClick={ onNavigatorButtonClick }
 					>
 						{ BUTTON_TEXT.back }
 					</CustomNavigatorBackButton>
-				</NavigatorScreen>
+				</Navigator.Screen>
 
 				<ProductScreen onBackButtonClick={ onNavigatorButtonClick } />
 
-				<NavigatorScreen path={ PATHS.INVALID_HTML_ATTRIBUTE }>
+				<Navigator.Screen path={ PATHS.INVALID_HTML_ATTRIBUTE }>
 					<p>{ SCREEN_TEXT.invalidHtmlPath }</p>
 					<CustomNavigatorBackButton
 						onClick={ onNavigatorButtonClick }
 					>
 						{ BUTTON_TEXT.back }
 					</CustomNavigatorBackButton>
-				</NavigatorScreen>
+				</Navigator.Screen>
 
-				{ /* A `NavigatorScreen` with `path={ PATHS.NOT_FOUND }` is purposefully not included. */ }
-			</NavigatorProvider>
+				{ /* A `Navigator.Screen` with `path={ PATHS.NOT_FOUND }` is purposefully not included. */ }
+			</Navigator>
 
 			<label htmlFor="test-input-outer">Outer input</label>
 			<input
@@ -313,8 +312,8 @@ const MyHierarchicalNavigation = ( {
 } ) => {
 	return (
 		<>
-			<NavigatorProvider initialPath={ initialPath }>
-				<NavigatorScreen path={ PATHS.HOME }>
+			<Navigator initialPath={ initialPath }>
+				<Navigator.Screen path={ PATHS.HOME }>
 					<p>{ SCREEN_TEXT.home }</p>
 					{ /*
 					 * A button useful to test focus restoration. This button is the first
@@ -328,9 +327,9 @@ const MyHierarchicalNavigation = ( {
 					>
 						{ BUTTON_TEXT.toChildScreen }
 					</CustomNavigatorButton>
-				</NavigatorScreen>
+				</Navigator.Screen>
 
-				<NavigatorScreen path={ PATHS.CHILD }>
+				<Navigator.Screen path={ PATHS.CHILD }>
 					<p>{ SCREEN_TEXT.child }</p>
 					{ /*
 					 * A button useful to test focus restoration. This button is the first
@@ -349,9 +348,9 @@ const MyHierarchicalNavigation = ( {
 					>
 						{ BUTTON_TEXT.back }
 					</CustomNavigatorToParentButton>
-				</NavigatorScreen>
+				</Navigator.Screen>
 
-				<NavigatorScreen path={ PATHS.NESTED }>
+				<Navigator.Screen path={ PATHS.NESTED }>
 					<p>{ SCREEN_TEXT.nested }</p>
 					<CustomNavigatorToParentButton
 						onClick={ onNavigatorButtonClick }
@@ -364,14 +363,14 @@ const MyHierarchicalNavigation = ( {
 					>
 						{ BUTTON_TEXT.backUsingGoTo }
 					</CustomNavigatorGoToBackButton>
-				</NavigatorScreen>
+				</Navigator.Screen>
 				<CustomNavigatorGoToSkipFocusButton
 					path={ PATHS.NESTED }
 					onClick={ onNavigatorButtonClick }
 				>
 					{ BUTTON_TEXT.goToWithSkipFocus }
 				</CustomNavigatorGoToSkipFocusButton>
-			</NavigatorProvider>
+			</Navigator>
 		</>
 	);
 };

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -193,7 +193,7 @@ const MyNavigation = ( {
 	const [ outerInputValue, setOuterInputValue ] = useState( '' );
 	return (
 		<>
-			<Navigator initialPath={ initialPath }>
+			<Navigator.Root initialPath={ initialPath }>
 				<Navigator.Screen path={ PATHS.HOME }>
 					<p>{ SCREEN_TEXT.home }</p>
 					{ /*
@@ -287,7 +287,7 @@ const MyNavigation = ( {
 				</Navigator.Screen>
 
 				{ /* A `Navigator.Screen` with `path={ PATHS.NOT_FOUND }` is purposefully not included. */ }
-			</Navigator>
+			</Navigator.Root>
 
 			<label htmlFor="test-input-outer">Outer input</label>
 			<input
@@ -312,7 +312,7 @@ const MyHierarchicalNavigation = ( {
 } ) => {
 	return (
 		<>
-			<Navigator initialPath={ initialPath }>
+			<Navigator.Root initialPath={ initialPath }>
 				<Navigator.Screen path={ PATHS.HOME }>
 					<p>{ SCREEN_TEXT.home }</p>
 					{ /*
@@ -370,7 +370,7 @@ const MyHierarchicalNavigation = ( {
 				>
 					{ BUTTON_TEXT.goToWithSkipFocus }
 				</CustomNavigatorGoToSkipFocusButton>
-			</Navigator>
+			</Navigator.Root>
 		</>
 	);
 };

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -5,6 +5,7 @@
 			'customselectcontrol-v2',
 			'theme',
 			'progressbar',
+			'navigator',
 		];
 		const REDIRECTS = [
 			{


### PR DESCRIPTION
- Follow-up to: https://github.com/WordPress/gutenberg/pull/60927
- Based on the discussion in https://github.com/WordPress/gutenberg/pull/60884#discussion_r1572458464.

## What / How

Namespace all children sub-components in the root `NavigatorProvider`component. Also, export a `Navigator` alias for `NavigatorProvider` to make it more semantically sound. Keep exporting all individual components as-is for backwards compatibility. 

## Why

Closely related (children) components always used together should ideally be namespaced into the root parent component. This provides a cleaner API that's easier to use and understand.

TODO:
- [x] Fix types and make TS happy :)
- [x] Update the test
- [x] Update description
- [ ] Any other API changes we should make as part of this changeset?
- [ ] Discuss tree-shaking consequences and/or if it's relevant in this case.
- [ ] Naming of the root provider component: discuss keeping it as `Navigator` (abstract away the provider part from the name, to simplify) or as `NavigatorProvider` or both.