### PR TITLE
Docs: Fix import statement of PluginMoreMenuItem

### DIFF
--- a/docs/reference-guides/slotfills/plugin-more-menu-item.md
+++ b/docs/reference-guides/slotfills/plugin-more-menu-item.md
@@ -6,7 +6,7 @@ This slot will add a new item to the More Tools & Options section.
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginMoreMenuItem } from '@wordpress/edit-post';
+import { PluginMoreMenuItem } from '@wordpress/editor';
 import { image } from '@wordpress/icons';
 
 const MyButtonMoreMenuItemTest = () => (


### PR DESCRIPTION
## What?

This PR fixes the import statement of `PluginMoreMenuItem`.
<!-- In a few words, what is the PR actually doing? -->

## Why?

#60778 moved `PluginMoreMenuItem` from `@wordpress/edit-post` and `@wordpress/edit-site` to `@wordpress/editor`.

## How?

As far as I can tell, this is the only document that needs to be fixed.