### PR TITLE
Add documentation for EditorHistoryRedo and EditorHistoryUndo

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -251,7 +251,7 @@ Renders the redo button for the editor history.
 _Parameters_
 
 -   _props_ `Object`: - Props.
--   _ref_ `Ref`: - Reference with the element.
+-   _ref_ `Ref`: - Forwarded ref.
 
 _Returns_
 
@@ -264,7 +264,7 @@ Renders the undo button for the editor history.
 _Parameters_
 
 -   _props_ `Object`: - Props.
--   _ref_ `Ref`: - Reference with the element.
+-   _ref_ `Ref`: - Forwarded ref.
 
 _Returns_
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -246,7 +246,7 @@ Undocumented declaration.
 
 ### EditorHistoryRedo
 
-Component to Renders the redo button for the editor history.
+Renders the redo button for the editor history.
 
 _Parameters_
 
@@ -259,7 +259,7 @@ _Returns_
 
 ### EditorHistoryUndo
 
-Component to Renders the undo button for the editor history.
+Renders the undo button for the editor history.
 
 _Parameters_
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -246,11 +246,29 @@ Undocumented declaration.
 
 ### EditorHistoryRedo
 
-Undocumented declaration.
+Component to Renders the redo button for the editor history.
+
+_Parameters_
+
+-   _props_ `Object`: Props.
+-   _ref_ `Ref`: Reference with the element.
+
+_Returns_
+
+-   `Component`: The component to be rendered.
 
 ### EditorHistoryUndo
 
-Undocumented declaration.
+Component to Renders the undo button for the editor history.
+
+_Parameters_
+
+-   _props_ `Object`: Props.
+-   _ref_ `Ref`: Reference with the element.
+
+_Returns_
+
+-   `Component`: The component to be rendered.
 
 ### EditorKeyboardShortcuts
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -250,8 +250,8 @@ Component to Renders the redo button for the editor history.
 
 _Parameters_
 
--   _props_ `Object`: Props.
--   _ref_ `Ref`: Reference with the element.
+-   _props_ `Object`: - Props.
+-   _ref_ `Ref`: - Reference with the element.
 
 _Returns_
 
@@ -263,8 +263,8 @@ Component to Renders the undo button for the editor history.
 
 _Parameters_
 
--   _props_ `Object`: Props.
--   _ref_ `Ref`: Reference with the element.
+-   _props_ `Object`: - Props.
+-   _ref_ `Ref`: - Reference with the element.
 
 _Returns_
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -246,29 +246,11 @@ Undocumented declaration.
 
 ### EditorHistoryRedo
 
-Component to Renders the redo button for the editor history.
-
-_Parameters_
-
--   _props_ `Object`: Props.
--   _ref_ `Ref`: Reference with the element.
-
-_Returns_
-
--   `Component`: The component to be rendered.
+Undocumented declaration.
 
 ### EditorHistoryUndo
 
-Component to Renders the undo button for the editor history.
-
-_Parameters_
-
--   _props_ `Object`: Props.
--   _ref_ `Ref`: Reference with the element.
-
-_Returns_
-
--   `Component`: The component to be rendered.
+Undocumented declaration.
 
 ### EditorKeyboardShortcuts
 

--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -47,7 +47,7 @@ function EditorHistoryRedo( props, ref ) {
  * Renders the redo button for the editor history.
  *
  * @param {Object} props - Props.
- * @param {Ref}    ref   - Reference with the element.
+ * @param {Ref}    ref   - Forwarded ref.
  *
  * @return {Component} The component to be rendered.
  */

--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -13,16 +13,6 @@ import { forwardRef } from '@wordpress/element';
  */
 import { store as editorStore } from '../../store';
 
-/** @typedef {import('react').Ref<HTMLElement>} Ref */
-
-/**
- * Component to Renders the redo button for the editor history.
- *
- * @param {Object} props - Props.
- * @param {Ref}    ref   - Reference with the element.
- *
- * @return {Component} The component to be rendered.
- */
 function EditorHistoryRedo( props, ref ) {
 	const shortcut = isAppleOS()
 		? displayShortcut.primaryShift( 'z' )
@@ -51,4 +41,14 @@ function EditorHistoryRedo( props, ref ) {
 	);
 }
 
+/** @typedef {import('react').Ref<HTMLElement>} Ref */
+
+/**
+ * Renders the redo button for the editor history.
+ *
+ * @param {Object} props - Props.
+ * @param {Ref}    ref   - Reference with the element.
+ *
+ * @return {Component} The component to be rendered.
+ */
 export default forwardRef( EditorHistoryRedo );

--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -21,7 +21,7 @@ import { store as editorStore } from '../../store';
  * @param {Object} props - Props.
  * @param {Ref}    ref   - Reference with the element.
  *
- * @return {Element} The component to be rendered.
+ * @return {Component} The component to be rendered.
  */
 function EditorHistoryRedo( props, ref ) {
 	const shortcut = isAppleOS()

--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -13,6 +13,16 @@ import { forwardRef } from '@wordpress/element';
  */
 import { store as editorStore } from '../../store';
 
+/** @typedef {import('react').Ref<HTMLElement>} Ref */
+
+/**
+ * Component to Renders the redo button for the editor history.
+ *
+ * @param {Object} props - Props.
+ * @param {Ref}    ref   - Reference with the element.
+ *
+ * @return {Element} The component to be rendered.
+ */
 function EditorHistoryRedo( props, ref ) {
 	const shortcut = isAppleOS()
 		? displayShortcut.primaryShift( 'z' )

--- a/packages/editor/src/components/editor-history/undo.js
+++ b/packages/editor/src/components/editor-history/undo.js
@@ -43,7 +43,7 @@ function EditorHistoryUndo( props, ref ) {
  * Renders the undo button for the editor history.
  *
  * @param {Object} props - Props.
- * @param {Ref}    ref   - Reference with the element.
+ * @param {Ref}    ref   - Forwarded ref.
  *
  * @return {Component} The component to be rendered.
  */

--- a/packages/editor/src/components/editor-history/undo.js
+++ b/packages/editor/src/components/editor-history/undo.js
@@ -13,16 +13,6 @@ import { forwardRef } from '@wordpress/element';
  */
 import { store as editorStore } from '../../store';
 
-/** @typedef {import('react').Ref<HTMLElement>} Ref */
-
-/**
- * Component to Renders the undo button for the editor history.
- *
- * @param {Object} props - Props.
- * @param {Ref}    ref   - Reference with the element.
- *
- * @return {Component} The component to be rendered.
- */
 function EditorHistoryUndo( props, ref ) {
 	const hasUndo = useSelect(
 		( select ) => select( editorStore ).hasEditorUndo(),
@@ -47,4 +37,14 @@ function EditorHistoryUndo( props, ref ) {
 	);
 }
 
+/** @typedef {import('react').Ref<HTMLElement>} Ref */
+
+/**
+ * Renders the undo button for the editor history.
+ *
+ * @param {Object} props - Props.
+ * @param {Ref}    ref   - Reference with the element.
+ *
+ * @return {Component} The component to be rendered.
+ */
 export default forwardRef( EditorHistoryUndo );

--- a/packages/editor/src/components/editor-history/undo.js
+++ b/packages/editor/src/components/editor-history/undo.js
@@ -13,6 +13,16 @@ import { forwardRef } from '@wordpress/element';
  */
 import { store as editorStore } from '../../store';
 
+/** @typedef {import('react').Ref<HTMLElement>} Ref */
+
+/**
+ * Component to Renders the undo button for the editor history.
+ *
+ * @param {Object} props - Props.
+ * @param {Ref}    ref   - Reference with the element.
+ *
+ * @return {Element} The component to be rendered.
+ */
 function EditorHistoryUndo( props, ref ) {
 	const hasUndo = useSelect(
 		( select ) => select( editorStore ).hasEditorUndo(),

--- a/packages/editor/src/components/editor-history/undo.js
+++ b/packages/editor/src/components/editor-history/undo.js
@@ -21,7 +21,7 @@ import { store as editorStore } from '../../store';
  * @param {Object} props - Props.
  * @param {Ref}    ref   - Reference with the element.
  *
- * @return {Element} The component to be rendered.
+ * @return {Component} The component to be rendered.
  */
 function EditorHistoryUndo( props, ref ) {
 	const hasUndo = useSelect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/60358

<!-- In a few words, what is the PR actually doing? -->
Added documentation in the readme for `EditorHistoryRedo` and `EditorHistoryUndo` components and also on components itself. 