### PR TITLE
Template lock: batch block disabling

### DIFF
--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
@@ -18,6 +18,8 @@ const CONTENT_ONLY_BLOCKS = applyFilters( 'editor.postContentBlockTypes', [
  * page content to be edited.
  */
 export default function DisableNonPageContentBlocks() {
+	// Note that there are two separate subscription because the result for each
+	// returns a new array.
 	const contentOnlyIds = useSelect( ( select ) => {
 		const { getBlocksByName, getBlockParents, getBlockName } =
 			select( blockEditorStore );
@@ -33,7 +35,6 @@ export default function DisableNonPageContentBlocks() {
 			} )
 		);
 	}, [] );
-
 	const disabledIds = useSelect( ( select ) => {
 		const { getBlocksByName, getBlockOrder } = select( blockEditorStore );
 		return getBlocksByName( [ 'core/template-part' ] ).flatMap(
@@ -41,33 +42,34 @@ export default function DisableNonPageContentBlocks() {
 		);
 	}, [] );
 
-	const { setBlockEditingMode, unsetBlockEditingMode } =
-		useDispatch( blockEditorStore );
+	const registry = useRegistry();
 
 	useEffect( () => {
-		setBlockEditingMode( '', 'disabled' );
-		for ( const clientId of contentOnlyIds ) {
-			setBlockEditingMode( clientId, 'contentOnly' );
-		}
-		for ( const clientId of disabledIds ) {
-			setBlockEditingMode( clientId, 'disabled' );
-		}
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
 
-		return () => {
-			unsetBlockEditingMode( '' );
+		registry.batch( () => {
+			setBlockEditingMode( '', 'disabled' );
 			for ( const clientId of contentOnlyIds ) {
-				unsetBlockEditingMode( clientId );
+				setBlockEditingMode( clientId, 'contentOnly' );
 			}
 			for ( const clientId of disabledIds ) {
-				unsetBlockEditingMode( clientId );
+				setBlockEditingMode( clientId, 'disabled' );
 			}
+		} );
+
+		return () => {
+			registry.batch( () => {
+				unsetBlockEditingMode( '' );
+				for ( const clientId of contentOnlyIds ) {
+					unsetBlockEditingMode( clientId );
+				}
+				for ( const clientId of disabledIds ) {
+					unsetBlockEditingMode( clientId );
+				}
+			} );
 		};
-	}, [
-		contentOnlyIds,
-		disabledIds,
-		setBlockEditingMode,
-		unsetBlockEditingMode,
-	] );
+	}, [ contentOnlyIds, disabledIds, registry ] );
 
 	return null;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I saw this pass by in #60010 and later in the graph: we should be batching these actions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
