### PR TITLE
Fix usages of uSES with missing getServerSnapshot

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `SlotFill`: fixed missing `getServerSnapshot` parameter in slot map.
+
 ## 27.4.0 (2024-04-19)
 
 ### Deprecation

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
--   `SlotFill`: fixed missing `getServerSnapshot` parameter in slot map.
+-   `SlotFill`: fixed missing `getServerSnapshot` parameter in slot map ([#60943](https://github.com/WordPress/gutenberg/pull/60943)).
 
 ## 27.4.0 (2024-04-19)
 

--- a/packages/components/src/slot-fill/bubbles-virtually/observable-map.ts
+++ b/packages/components/src/slot-fill/bubbles-virtually/observable-map.ts
@@ -75,5 +75,5 @@ export function useObservableValue< K, V >(
 		],
 		[ map, name ]
 	);
-	return useSyncExternalStore( subscribe, getValue );
+	return useSyncExternalStore( subscribe, getValue, getValue );
 }

--- a/packages/plugins/src/components/plugin-area/index.tsx
+++ b/packages/plugins/src/components/plugin-area/index.tsx
@@ -113,7 +113,11 @@ function PluginArea( {
 		};
 	}, [ scope ] );
 
-	const plugins = useSyncExternalStore( store.subscribe, store.getValue );
+	const plugins = useSyncExternalStore(
+		store.subscribe,
+		store.getValue,
+		store.getValue
+	);
 
 	return (
 		<div style={ { display: 'none' } }>


### PR DESCRIPTION
Fixes #60924. The `useSyncExternalStore` call that I introduced in #60879 was missing the third `getServerSnapshot` parameter used in SSR mode. That triggered an error:
```
Internal error: Error: Missing getServerSnapshot, which is required for server-rendered content.
```

I also found another instance of the same bug in the `PluginArea` component.