### PR TITLE
Don't show appender at all inside sections on zoom-out mode

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -204,11 +204,10 @@ function Items( {
 					visibleBlocks: __unstableGetVisibleBlocks(),
 					shouldRenderAppender:
 						hasAppender &&
+						__unstableGetEditorMode() !== 'zoom-out' &&
 						( hasCustomAppender
 							? ! getTemplateLock( rootClientId ) &&
-							  getBlockEditingMode( rootClientId ) !==
-									'disabled' &&
-							  __unstableGetEditorMode() !== 'zoom-out'
+							  getBlockEditingMode( rootClientId ) !== 'disabled'
 							: rootClientId === selectedBlockClientId ||
 							  ( ! rootClientId &&
 									! selectedBlockClientId &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes the black appender inside sections on zoom-out mode

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We don't want to insert inside the sections at all

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By changing the condition that shows or hides the custom appender inside block-list

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- With the zoom out experiment on, click on zoom-out mode
- Select a section, you shouldn't see the black apender, just the blue ones in between sections

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="1115" alt="Screenshot 2024-04-22 at 12 38 26" src="https://github.com/WordPress/gutenberg/assets/3593343/98ee31d5-4683-46d5-8d63-e8952761df1a">

After:

<img width="1070" alt="Screenshot 2024-04-22 at 12 36 47" src="https://github.com/WordPress/gutenberg/assets/3593343/e655c647-c9ce-4121-b6c9-e8d23f1fdae2">