### PR TITLE
Calculate and report quartiles in performance results

### DIFF
--- a/bin/log-performance-results.js
+++ b/bin/log-performance-results.js
@@ -50,7 +50,7 @@ const data = new TextEncoder().encode(
 						performanceResults[ index ][ hash ] ?? {}
 					).map( ( [ key, value ] ) => [
 						metricsPrefix + key,
-						value,
+						typeof value === 'object' ? value.q50 : value,
 					] )
 				),
 			};
@@ -64,7 +64,7 @@ const data = new TextEncoder().encode(
 							performanceResults[ index ][ baseHash ] ?? {}
 						).map( ( [ key, value ] ) => [
 							metricsPrefix + key,
-							value,
+							typeof value === 'object' ? value.q50 : value,
 						] )
 					),
 				};

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -146,7 +146,7 @@ function formatValue( metric, value ) {
 function printStats( m, s ) {
 	const pp = fixed( ( 100 * ( s.q75 - s.q50 ) ) / s.q50 );
 	const mp = fixed( ( 100 * ( s.q50 - s.q25 ) ) / s.q50 );
-	return `${ formatValue( m, s.q50 ) } ms (±${ pp }/${ mp }%)`;
+	return `${ formatValue( m, s.q50 ) } +${ pp }% -${ mp }% (${ s.cnt })`;
 }
 
 /**

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -20,7 +20,7 @@ const config = require( '../config' );
 
 const ARTIFACTS_PATH =
 	process.env.WP_ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
-const RESULTS_FILE_SUFFIX = '.performance-results.json';
+const RESULTS_FILE_SUFFIX = '.performance-results.raw.json';
 
 /**
  * @typedef WPPerformanceCommandOptions
@@ -56,24 +56,97 @@ function sanitizeBranchName( branch ) {
 }
 
 /**
- * Computes the median number from an array numbers.
- *
- * @param {number[]} array
- *
- * @return {number|undefined} Median value or undefined if array empty.
+ * @param {number} number
  */
-function median( array ) {
-	if ( ! array || ! array.length ) {
+function fixed( number ) {
+	return Math.round( number * 100 ) / 100;
+}
+
+/**
+ * @param {number[]} array
+ */
+function quartiles( array ) {
+	const numbers = array.slice().sort( ( a, b ) => a - b );
+
+	/**
+	 * @param {number} offset
+	 * @param {number} length
+	 */
+	function med( offset, length ) {
+		if ( length % 2 === 0 ) {
+			// even length, average of two middle numbers
+			return (
+				( numbers[ offset + length / 2 - 1 ] +
+					numbers[ offset + length / 2 ] ) /
+				2
+			);
+		}
+
+		// odd length, exact middle point
+		return numbers[ offset + ( length - 1 ) / 2 ];
+	}
+
+	const q50 = med( 0, numbers.length );
+
+	let q25, q75;
+	if ( numbers.length % 2 === 0 ) {
+		// medians of two exact halves
+		const mid = numbers.length / 2;
+		q25 = med( 0, mid );
+		q75 = med( mid, mid );
+	} else {
+		// quartiles are average of medians of the smaller and bigger slice
+		const midl = ( numbers.length - 1 ) / 2;
+		const midh = ( numbers.length + 1 ) / 2;
+		q25 = ( med( 0, midl ) + med( 0, midh ) ) / 2;
+		q75 = ( med( midl, midh ) + med( midh, midl ) ) / 2;
+	}
+	return { q25, q50, q75 };
+}
+
+/**
+ * @param {number[]|undefined} values
+ */
+function stats( values ) {
+	if ( ! values || values.length === 0 ) {
 		return undefined;
 	}
+	const { q25, q50, q75 } = quartiles( values );
+	const cnt = values.length;
+	return {
+		q25: fixed( q25 ),
+		q50: fixed( q50 ),
+		q75: fixed( q75 ),
+		cnt,
+	};
+}
 
-	const numbers = [ ...array ].sort( ( a, b ) => a - b );
-	const middleIndex = Math.floor( numbers.length / 2 );
-
-	if ( numbers.length % 2 === 0 ) {
-		return ( numbers[ middleIndex - 1 ] + numbers[ middleIndex ] ) / 2;
+/**
+ * Nicely formats a given value.
+ *
+ * @param {string} metric Metric.
+ * @param {number} value
+ */
+function formatValue( metric, value ) {
+	if ( 'wpMemoryUsage' === metric ) {
+		return `${ ( value / Math.pow( 10, 6 ) ).toFixed( 2 ) } MB`;
 	}
-	return numbers[ middleIndex ];
+
+	if ( 'wpDbQueries' === metric ) {
+		return value.toString();
+	}
+
+	return `${ value } ms`;
+}
+
+/**
+ * @param {string}                 m
+ * @param {Record<string, number>} s
+ */
+function printStats( m, s ) {
+	const pp = fixed( ( 100 * ( s.q75 - s.q50 ) ) / s.q50 );
+	const mp = fixed( ( 100 * ( s.q50 - s.q25 ) ) / s.q50 );
+	return `${ formatValue( m, s.q50 ) } ms (±${ pp }/${ mp }%)`;
 }
 
 /**
@@ -149,24 +222,6 @@ function formatAsMarkdownTable( rows ) {
 	}
 
 	return result;
-}
-
-/**
- * Nicely formats a given value.
- *
- * @param {string} metric Metric.
- * @param {number} value
- */
-function formatValue( metric, value ) {
-	if ( 'wpMemoryUsage' === metric ) {
-		return `${ ( value / Math.pow( 10, 6 ) ).toFixed( 2 ) } MB`;
-	}
-
-	if ( 'wpDbQueries' === metric ) {
-		return value.toString();
-	}
-
-	return `${ value } ms`;
 }
 
 /**
@@ -439,7 +494,7 @@ async function runPerformanceTests( branches, options ) {
 	const resultFiles = getFilesFromDir( ARTIFACTS_PATH ).filter( ( file ) =>
 		file.endsWith( RESULTS_FILE_SUFFIX )
 	);
-	/** @type {Record<string,Record<string, Record<string, number>>>} */
+	/** @type {Record<string,Record<string, Record<string, Record<string, number>>>>} */
 	const results = {};
 
 	// Calculate medians from all rounds.
@@ -464,11 +519,11 @@ async function runPerformanceTests( branches, options ) {
 			results[ testSuite ][ branch ] = {};
 
 			for ( const metric of metrics ) {
-				const values = resultsRounds
-					.map( ( round ) => round[ metric ] )
-					.filter( ( value ) => typeof value === 'number' );
+				const values = resultsRounds.flatMap(
+					( round ) => round[ metric ] ?? []
+				);
 
-				const value = median( values );
+				const value = stats( values );
 				if ( value !== undefined ) {
 					results[ testSuite ][ branch ][ metric ] = value;
 				}
@@ -506,45 +561,50 @@ async function runPerformanceTests( branches, options ) {
 		logAtIndent( 0, formats.success( testSuite ) );
 
 		// Invert the results so we can display them in a table.
-		/** @type {Record<string, Record<string, string>>} */
+		/** @type {Record<string, Record<string, Record<string, number>>>} */
 		const invertedResult = {};
 		for ( const [ branch, metrics ] of Object.entries(
 			results[ testSuite ]
 		) ) {
 			for ( const [ metric, value ] of Object.entries( metrics ) ) {
 				invertedResult[ metric ] = invertedResult[ metric ] || {};
-				invertedResult[ metric ][ branch ] = formatValue(
-					metric,
-					value
-				);
+				invertedResult[ metric ][ branch ] = value;
 			}
 		}
 
-		if ( branches.length === 2 ) {
-			const [ branch1, branch2 ] = branches;
-			for ( const metric in invertedResult ) {
-				const value1 = parseFloat(
-					invertedResult[ metric ][ branch1 ]
+		/** @type {Record<string, Record<string, string>>} */
+		const printedResult = {};
+		for ( const [ metric, branch ] of Object.entries( invertedResult ) ) {
+			printedResult[ metric ] = {};
+			for ( const [ branchName, data ] of Object.entries( branch ) ) {
+				printedResult[ metric ][ branchName ] = printStats(
+					metric,
+					data
 				);
-				const value2 = parseFloat(
-					invertedResult[ metric ][ branch2 ]
+			}
+
+			if ( branches.length === 2 ) {
+				const [ branch1, branch2 ] = branches;
+				const value1 = branch[ branch1 ].q50;
+				const value2 = branch[ branch2 ].q50;
+				const percentageChange = fixed(
+					( ( value1 - value2 ) / value2 ) * 100
 				);
-				const percentageChange = ( ( value1 - value2 ) / value2 ) * 100;
-				invertedResult[ metric ][
+				printedResult[ metric ][
 					'% Change'
-				] = `${ percentageChange.toFixed( 2 ) }%`;
+				] = `${ percentageChange }%`;
 			}
 		}
 
 		// Print the results.
-		console.table( invertedResult );
+		console.table( printedResult );
 
 		// Use yet another structure to generate a Markdown table.
 
 		const rows = [];
 
 		for ( const [ metric, resultBranches ] of Object.entries(
-			invertedResult
+			printedResult
 		) ) {
 			/**
 			 * @type {Record< string, string >}

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -146,7 +146,7 @@ function formatValue( metric, value ) {
 function printStats( m, s ) {
 	const pp = fixed( ( 100 * ( s.q75 - s.q50 ) ) / s.q50 );
 	const mp = fixed( ( 100 * ( s.q50 - s.q25 ) ) / s.q50 );
-	return `${ formatValue( m, s.q50 ) } +${ pp }% -${ mp }% (${ s.cnt })`;
+	return `${ formatValue( m, s.q50 ) } +${ pp }% -${ mp }%`;
 }
 
 /**

--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -43,54 +43,43 @@ export interface WPRawPerformanceResults {
 	wpDbQueries: number[];
 }
 
+type PerformanceStats = {
+	q25: number;
+	q50: number;
+	q75: number;
+	out: number[]; // outliers
+	cnt: number; // number of data points
+};
+
 export interface WPPerformanceResults {
-	timeToFirstByte?: number;
-	timeToFirstByteV?: number;
-	largestContentfulPaint?: number;
-	largestContentfulPaintV?: number;
-	lcpMinusTtfb?: number;
-	lcpMinusTtfbV?: number;
-	serverResponse?: number;
-	serverResponseV?: number;
-	firstPaint?: number;
-	firstPaintV?: number;
-	domContentLoaded?: number;
-	domContentLoadedV?: number;
-	loaded?: number;
-	loadedV?: number;
-	firstContentfulPaint?: number;
-	firstContentfulPaintV?: number;
-	firstBlock?: number;
-	firstBlockV?: number;
-	type?: number;
-	typeV?: number;
-	typeWithoutInspector?: number;
-	typeWithoutInspectorV?: number;
-	typeWithTopToolbar?: number;
-	typeWithTopToolbarV?: number;
-	typeContainer?: number;
-	typeContainerV?: number;
-	focus?: number;
-	focusV?: number;
-	inserterOpen?: number;
-	inserterOpenV?: number;
-	inserterSearch?: number;
-	inserterSearchV?: number;
-	inserterHover?: number;
-	inserterHoverV?: number;
-	loadPatterns?: number;
-	loadPatternsV?: number;
-	listViewOpen?: number;
-	listViewOpenV?: number;
-	navigate?: number;
-	wpBeforeTemplate?: number;
-	wpTemplate?: number;
-	wpTotal?: number;
-	wpMemoryUsage?: number;
-	wpDbQueries?: number;
+	timeToFirstByte?: PerformanceStats;
+	largestContentfulPaint?: PerformanceStats;
+	lcpMinusTtfb?: PerformanceStats;
+	serverResponse?: PerformanceStats;
+	firstPaint?: PerformanceStats;
+	domContentLoaded?: PerformanceStats;
+	loaded?: PerformanceStats;
+	firstContentfulPaint?: PerformanceStats;
+	firstBlock?: PerformanceStats;
+	type?: PerformanceStats;
+	typeWithoutInspector?: PerformanceStats;
+	typeWithTopToolbar?: PerformanceStats;
+	typeContainer?: PerformanceStats;
+	focus?: PerformanceStats;
+	inserterOpen?: PerformanceStats;
+	inserterSearch?: PerformanceStats;
+	inserterHover?: PerformanceStats;
+	loadPatterns?: PerformanceStats;
+	listViewOpen?: PerformanceStats;
+	navigate?: PerformanceStats;
+	wpBeforeTemplate?: PerformanceStats;
+	wpTemplate?: PerformanceStats;
+	wpTotal?: PerformanceStats;
+	wpMemoryUsage?: PerformanceStats;
+	wpDbQueries?: PerformanceStats;
 }
 
-function stats( values: number[] ) {
+function stats( values: number[] ): PerformanceStats | undefined {
 	if ( ! values || values.length === 0 ) {
 		return undefined;
 	}
@@ -112,9 +101,8 @@ function stats( values: number[] ) {
 /**
  * Curate the raw performance results.
  *
- * @param {WPRawPerformanceResults} results
- *
- * @return {WPPerformanceResults} Curated Performance results.
+ * @param results Raw results.
+ * @return Curated statistics for the results.
  */
 export function curateResults(
 	results: WPRawPerformanceResults

--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -13,7 +13,7 @@ import type {
 /**
  * Internal dependencies
  */
-import { average, median, round } from '../utils';
+import { average, median, variance, round } from '../utils';
 
 export interface WPRawPerformanceResults {
 	timeToFirstByte: number[];
@@ -45,24 +45,43 @@ export interface WPRawPerformanceResults {
 
 export interface WPPerformanceResults {
 	timeToFirstByte?: number;
+	timeToFirstByteV?: number;
 	largestContentfulPaint?: number;
+	largestContentfulPaintV?: number;
 	lcpMinusTtfb?: number;
+	lcpMinusTtfbV?: number;
 	serverResponse?: number;
+	serverResponseV?: number;
 	firstPaint?: number;
+	firstPaintV?: number;
 	domContentLoaded?: number;
+	domContentLoadedV?: number;
 	loaded?: number;
+	loadedV?: number;
 	firstContentfulPaint?: number;
+	firstContentfulPaintV?: number;
 	firstBlock?: number;
+	firstBlockV?: number;
 	type?: number;
+	typeV?: number;
 	typeWithoutInspector?: number;
+	typeWithoutInspectorV?: number;
 	typeWithTopToolbar?: number;
+	typeWithTopToolbarV?: number;
 	typeContainer?: number;
+	typeContainerV?: number;
 	focus?: number;
+	focusV?: number;
 	inserterOpen?: number;
+	inserterOpenV?: number;
 	inserterSearch?: number;
+	inserterSearchV?: number;
 	inserterHover?: number;
+	inserterHoverV?: number;
 	loadPatterns?: number;
+	loadPatternsV?: number;
 	listViewOpen?: number;
+	listViewOpenV?: number;
 	navigate?: number;
 	wpBeforeTemplate?: number;
 	wpTemplate?: number;
@@ -82,24 +101,42 @@ export function curateResults(
 	results: WPRawPerformanceResults
 ): WPPerformanceResults {
 	const output = {
-		timeToFirstByte: median( results.timeToFirstByte ),
-		largestContentfulPaint: median( results.largestContentfulPaint ),
-		lcpMinusTtfb: median( results.lcpMinusTtfb ),
-		serverResponse: median( results.serverResponse ),
-		firstPaint: median( results.firstPaint ),
-		domContentLoaded: median( results.domContentLoaded ),
-		loaded: median( results.loaded ),
-		firstContentfulPaint: median( results.firstContentfulPaint ),
-		firstBlock: median( results.firstBlock ),
+		timeToFirstByte: average( results.timeToFirstByte ),
+		timeToFirstByteV: variance( results.timeToFirstByte ),
+		largestContentfulPaint: average( results.largestContentfulPaint ),
+		largestContentfulPaintV: variance( results.largestContentfulPaint ),
+		lcpMinusTtfb: average( results.lcpMinusTtfb ),
+		lcpMinusTtfbV: variance( results.lcpMinusTtfb ),
+		serverResponse: average( results.serverResponse ),
+		serverResponseV: variance( results.serverResponse ),
+		firstPaint: average( results.firstPaint ),
+		firstPaintV: variance( results.firstPaint ),
+		domContentLoaded: average( results.domContentLoaded ),
+		domContentLoadedV: variance( results.domContentLoaded ),
+		loaded: average( results.loaded ),
+		loadedV: variance( results.loaded ),
+		firstContentfulPaint: average( results.firstContentfulPaint ),
+		firstContentfulPaintV: variance( results.firstContentfulPaint ),
+		firstBlock: average( results.firstBlock ),
+		firstBlockV: variance( results.firstBlock ),
 		type: average( results.type ),
+		typeV: variance( results.type ),
 		typeWithoutInspector: average( results.typeWithoutInspector ),
+		typeWithoutInspectorV: variance( results.typeWithoutInspector ),
 		typeWithTopToolbar: average( results.typeWithTopToolbar ),
+		typeWithTopToolbarV: variance( results.typeWithTopToolbar ),
 		typeContainer: average( results.typeContainer ),
+		typeContainerV: variance( results.typeContainer ),
 		focus: average( results.focus ),
+		focusV: variance( results.focus ),
 		inserterOpen: average( results.inserterOpen ),
+		inserterOpenV: variance( results.inserterOpen ),
 		inserterSearch: average( results.inserterSearch ),
+		inserterSearchV: variance( results.inserterSearch ),
 		inserterHover: average( results.inserterHover ),
+		inserterHoverV: variance( results.inserterHover ),
 		loadPatterns: average( results.loadPatterns ),
+		loadPatternsV: variance( results.loadPatterns ),
 		listViewOpen: average( results.listViewOpen ),
 		navigate: median( results.navigate ),
 		wpBeforeTemplate: median( results.wpBeforeTemplate ),

--- a/test/performance/utils.js
+++ b/test/performance/utils.js
@@ -19,6 +19,15 @@ export function average( array ) {
 	return sum( array ) / array.length;
 }
 
+export function variance( array ) {
+	if ( ! array || ! array.length ) return undefined;
+
+	return Math.sqrt(
+		sum( array.map( ( x ) => x ** 2 ) ) / array.length -
+			( sum( array ) / array.length ) ** 2
+	);
+}
+
 export function median( array ) {
 	if ( ! array || ! array.length ) {
 		return undefined;

--- a/test/performance/utils.js
+++ b/test/performance/utils.js
@@ -79,6 +79,20 @@ export function quartiles( array ) {
 	return { q25, q50, q75 };
 }
 
+export function stats( values ) {
+	if ( ! values || values.length === 0 ) {
+		return undefined;
+	}
+	const { q25, q50, q75 } = quartiles( values );
+	const cnt = values.length;
+	return {
+		q25: round( q25 ),
+		q50: round( q50 ),
+		q75: round( q75 ),
+		cnt,
+	};
+}
+
 export function minimum( array ) {
 	if ( ! array || ! array.length ) {
 		return undefined;

--- a/test/performance/utils.js
+++ b/test/performance/utils.js
@@ -20,7 +20,9 @@ export function average( array ) {
 }
 
 export function variance( array ) {
-	if ( ! array || ! array.length ) return undefined;
+	if ( ! array || ! array.length ) {
+		return undefined;
+	}
 
 	return Math.sqrt(
 		sum( array.map( ( x ) => x ** 2 ) ) / array.length -
@@ -40,6 +42,41 @@ export function median( array ) {
 		return ( numbers[ middleIndex - 1 ] + numbers[ middleIndex ] ) / 2;
 	}
 	return numbers[ middleIndex ];
+}
+
+export function quartiles( array ) {
+	const numbers = array.slice().sort( ( a, b ) => a - b );
+
+	function med( offset, length ) {
+		if ( length % 2 === 0 ) {
+			// even length, average of two middle numbers
+			return (
+				( numbers[ offset + length / 2 - 1 ] +
+					numbers[ offset + length / 2 ] ) /
+				2
+			);
+		}
+
+		// odd length, exact middle point
+		return numbers[ offset + ( length - 1 ) / 2 ];
+	}
+
+	const q50 = med( 0, numbers.length );
+
+	let q25, q75;
+	if ( numbers.length % 2 === 0 ) {
+		// medians of two exact halves
+		const mid = numbers.length / 2;
+		q25 = med( 0, mid );
+		q75 = med( mid, mid );
+	} else {
+		// quartiles are average of medians of the smaller and bigger slice
+		const midl = ( numbers.length - 1 ) / 2;
+		const midh = ( numbers.length + 1 ) / 2;
+		q25 = ( med( 0, midl ) + med( 0, midh ) ) / 2;
+		q75 = ( med( midl, midh ) + med( midh, midl ) ) / 2;
+	}
+	return { q25, q50, q75 };
 }
 
 export function minimum( array ) {


### PR DESCRIPTION
Inspired by #60509, I'm adding a calculation of 25% and 75% quartiles of the measurements. Each measurement is a set of 10+ samples, so let's extract more data than a single number, i.e., the average or the median.

Knowing the quartiles gives us some idea about the variance, i.e., the error of the measurements. Knowing that is important for determining if a change in a metric in a given PR is significant or not.

Also using medians consistently everywhere instead of averages. Medians are more stable in presence of outliers, i.e., measurements where the process fails in a big way, i.e., the error is larger than a gaussian noise.

Let's see how it works.