### PR TITLE
Avoid unnecessary heading level and paragraph transform via keyboard shortcuts

### DIFF
--- a/packages/block-library/src/block-keyboard-shortcuts/index.js
+++ b/packages/block-library/src/block-keyboard-shortcuts/index.js
@@ -19,17 +19,34 @@ function BlockKeyboardShortcuts() {
 
 	const handleTransformHeadingAndParagraph = ( event, level ) => {
 		event.preventDefault();
-		const destinationBlockName =
-			level === 0 ? 'core/paragraph' : 'core/heading';
+
 		const currentClientId = getSelectedBlockClientId();
 		if ( currentClientId === null ) {
 			return;
 		}
+
 		const blockName = getBlockName( currentClientId );
-		if ( blockName !== 'core/paragraph' && blockName !== 'core/heading' ) {
+		const isParagraph = blockName === 'core/paragraph';
+		const isHeading = blockName === 'core/heading';
+
+		if ( ! isParagraph && ! isHeading ) {
 			return;
 		}
+
+		const destinationBlockName =
+			level === 0 ? 'core/paragraph' : 'core/heading';
+
 		const attributes = getBlockAttributes( currentClientId );
+
+		// Avoid unnecessary block transform when attempting to transform to
+		// the same block type and/or same level.
+		if (
+			( isParagraph && level === 0 ) ||
+			( isHeading && attributes.level === level )
+		) {
+			return;
+		}
+
 		const textAlign =
 			blockName === 'core/paragraph' ? 'align' : 'textAlign';
 		const destinationTextAlign =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60949

## What?
<!-- In a few words, what is the PR actually doing? -->
When using keybaord shortcuts to change Heading level or transforming to - from Paragraph, the block transform runs even when the Heading already has the destination level or the Paragraph is already... a Paragraph.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Running code to transform a block to the same block type / level is unnecessary and should be avoided.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check the type of transform triggered via keyboard shorcuts and returns early when the transform is not necessary.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post and add a Heading block with level 2.
- Select the Heading block.
- Press Control + Option + 2 (macOS).
- Observe there is no flickering in the block inspector (the settings panel). This is a sign the unnecessary transform didn't run.
- Repeat with all the other heading levels 1-6.
- Select a Paragraph block.
- Press Control + Option + 0 or Press Control + Option + 7 (macOS).
- Observe there is no flickering in the block inspector.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
