### PR TITLE
Update block-transforms.md Using transforms with createBlocksFromInne…

### DIFF
--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -88,6 +88,42 @@ transforms: {
 },
 ```
 
+**Example: create InnerBlocks from a template**
+
+A single block can be transformed with the addition of InnerBlocks created from a template. Example, a single block used to generate an event listing in a specific format or for a custom post type can be transformed to use the Query Loop block.
+
+```js
+transforms: {
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/query' ],
+            transform: ( attributes ) => {
+		const queryAttributes = {"queryId":0,"query":{"perPage":20,"pages":0,"offset":0,"postType":"mycustomtype","order":"asc","author":"","search":"","exclude":[],"sticky":"","inherit":false},"namespace":"mycustomtype/loop"};
+		const template = [
+		['core/post-template',{"layout":{"type":"grid","columnCount":2}},
+			[ [ 'core/post-title',  {"isLink":true}  ],
+			[ 'core/post-featured-image' ],
+			[ 'mycustomtype/customblock' ]] ,
+			[ 'core/query-pagination' ],
+			[ 'core/query-no-results', {}, [['core/paragraph', {"content": "No events found."}] ]],
+		];
+		const innerBlocks = createBlocksFromInnerBlocksTemplate( template );
+                return createBlock(
+                    'core/query',
+                    queryAttributes,
+                    innerBlocks
+                );
+            },
+        },
+    ],
+},
+```
+
+In this example, a namespace is included in the queryAttributes so the core/query will inherit the custom controls for a block variation (See [Variations](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/).Otherwise, that should be omitted.
+
+Like createBlock, createBlocksFromInnerBlocksTemplate is imported from [`wp-blocks` package](/packages/blocks/README.md#createBlock). Its function is to convert a template in array format to an array of block objects.
+
 ### Enter
 
 This type of transformations support the _from_ direction, allowing blocks to be created from some content introduced by the user. They're applied in a new block line after the user has introduced some content and hit the ENTER key.


### PR DESCRIPTION
The documentation covers the case of converting one block that includes InnerBlocks to another block with InnerBlocks. Suggest explaining how to create an InnerBlocks template from code. Example: creating a single block that outputs database content to a Query Loop with an InnerBlocks template.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adding an additional example to the Transforms page for single block -> multiple block transformations

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Using createBlocksFromInnerBlocksTemplate makes this type of transformation possible but is not documented in this context.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Providing an abstracted description of a solution I used for my own plugin. (blog post)[https://davidfcarr.com/transforming-a-single-wordpress-block-into-a-block-variation-with-innerblocks/]

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add the sample code to a block registration definition.
Test that the transformation is displayed in the Transform To UI and that it works.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A

[Type] Developer Documentation 