### PR TITLE
FIX[#60958]: Code Editor background height

### DIFF
--- a/packages/edit-site/src/components/code-editor/style.scss
+++ b/packages/edit-site/src/components/code-editor/style.scss
@@ -1,7 +1,6 @@
 .edit-site-code-editor {
 	position: relative;
 	width: 100%;
-	min-height: 100%;
 	background-color: $white;
 
 	&__body {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix issue #60958 

## How?
Remove `min-height: 100%;` in .edit-site-code-editor class

