### PR TITLE
Add PluginDocumentSettingPanel in template inspector controls

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -126,19 +126,15 @@ const SidebarContent = ( { tabName, keyboardShortcut, isEditingTemplate } ) => {
 							/>
 						}
 					/>
-					{ ! isEditingTemplate && (
-						<>
-							<PostStatus />
-							<PluginDocumentSettingPanel.Slot />
-							<PostLastRevisionPanel />
-							<PostTaxonomiesPanel />
-							<PostExcerptPanel />
-							<PostDiscussionPanel />
-							<PageAttributesPanel />
-							<PatternOverridesPanel />
-							<MetaBoxes location="side" />
-						</>
-					) }
+					{ ! isEditingTemplate && <PostStatus /> }
+					<PluginDocumentSettingPanel.Slot />
+					<PostLastRevisionPanel />
+					<PostTaxonomiesPanel />
+					<PostExcerptPanel />
+					<PostDiscussionPanel />
+					<PageAttributesPanel />
+					<PatternOverridesPanel />
+					{ ! isEditingTemplate && <MetaBoxes location="side" /> }
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
 					<BlockInspector />

--- a/packages/edit-site/src/components/plugin-template-setting-panel/index.js
+++ b/packages/edit-site/src/components/plugin-template-setting-panel/index.js
@@ -8,10 +8,16 @@
 import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 import { createSlotFill } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 
 const { Fill, Slot } = createSlotFill( 'PluginTemplateSettingPanel' );
 
 const PluginTemplateSettingPanel = ( { children } ) => {
+	deprecated( 'wp.editSite.PluginTemplateSettingPanel', {
+		since: '6.6',
+		version: '6.8',
+		alternative: 'wp.editor.PluginDocumentSettingPanel',
+	} );
 	const isCurrentEntityTemplate = useSelect(
 		( select ) =>
 			select( editorStore ).getCurrentPostType() === 'wp_template',
@@ -28,6 +34,8 @@ PluginTemplateSettingPanel.Slot = Slot;
 /**
  * Renders items in the Template Sidebar below the main information
  * like the Template Card.
+ *
+ * @deprecated since 6.6. Use `wp.editor.PluginDocumentSettingPanel` instead.
  *
  * @example
  * ```jsx

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -11,7 +11,14 @@ import { useCallback, useContext, useEffect, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
-import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import {
+	PageAttributesPanel,
+	PostDiscussionPanel,
+	PostExcerptPanel,
+	PostLastRevisionPanel,
+	PostTaxonomiesPanel,
+	privateApis as editorPrivateApis,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -25,7 +32,7 @@ import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { Tabs } = unlock( componentsPrivateApis );
-const { interfaceStore, useAutoSwitchEditorSidebars } =
+const { interfaceStore, useAutoSwitchEditorSidebars, PatternOverridesPanel } =
 	unlock( editorPrivateApis );
 const { Slot: InspectorSlot, Fill: InspectorFill } = createSlotFill(
 	'EditSiteSidebarInspector'
@@ -91,6 +98,12 @@ const FillContents = ( { tabName, isEditingPage, supportsGlobalStyles } ) => {
 						focusable={ false }
 					>
 						{ isEditingPage ? <PagePanels /> : <TemplatePanel /> }
+						<PostLastRevisionPanel />
+						<PostTaxonomiesPanel />
+						<PostExcerptPanel />
+						<PostDiscussionPanel />
+						<PageAttributesPanel />
+						<PatternOverridesPanel />
 					</Tabs.TabPanel>
 					<Tabs.TabPanel tabId="edit-post/block" focusable={ false }>
 						<InspectorSlot bubblesVirtually />

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -6,12 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
-	PageAttributesPanel,
 	PluginDocumentSettingPanel,
-	PostDiscussionPanel,
-	PostExcerptPanel,
-	PostLastRevisionPanel,
-	PostTaxonomiesPanel,
 	store as editorStore,
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
@@ -95,11 +90,6 @@ export default function PagePanels() {
 					<PageContent />
 				</PanelBody>
 			) }
-			<PostLastRevisionPanel />
-			<PostTaxonomiesPanel />
-			<PostExcerptPanel />
-			<PostDiscussionPanel />
-			<PageAttributesPanel />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -4,11 +4,6 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import {
-	PageAttributesPanel,
-	PostDiscussionPanel,
-	PostExcerptPanel,
-	PostLastRevisionPanel,
-	PostTaxonomiesPanel,
 	PluginDocumentSettingPanel,
 	privateApis as editorPrivateApis,
 	store as editorStore,
@@ -31,7 +26,6 @@ import { TEMPLATE_PART_POST_TYPE } from '../../../utils/constants';
 import { unlock } from '../../../lock-unlock';
 
 const { PostCardPanel } = unlock( editorPrivateApis );
-const { PatternOverridesPanel } = unlock( editorPrivateApis );
 const { useHistory } = unlock( routerPrivateApis );
 
 function TemplatesList( { availableTemplates, onSelect } ) {
@@ -135,12 +129,6 @@ export default function TemplatePanel() {
 					/>
 				</PanelBody>
 			) }
-			<PostLastRevisionPanel />
-			<PostTaxonomiesPanel />
-			<PostExcerptPanel />
-			<PostDiscussionPanel />
-			<PageAttributesPanel />
-			<PatternOverridesPanel />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -9,6 +9,7 @@ import {
 	PostExcerptPanel,
 	PostLastRevisionPanel,
 	PostTaxonomiesPanel,
+	PluginDocumentSettingPanel,
 	privateApis as editorPrivateApis,
 	store as editorStore,
 } from '@wordpress/editor';
@@ -114,6 +115,7 @@ export default function TemplatePanel() {
 				}
 			/>
 			<PluginTemplateSettingPanel.Slot />
+			<PluginDocumentSettingPanel.Slot />
 			{ availablePatterns?.length > 0 && (
 				<PanelBody
 					title={ __( 'Transform into:' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR moves some panels around in order to be rendered for both posts and templates. That was already the case for most panels in site editor. The main addition is that `PluginDocumentSettingPanel` is also rendered for templates too, so extenders can use this slot in this case.


Additionally in this [PR](https://github.com/WordPress/gutenberg/pull/50257), but with the unification effort it has been [suggested](https://github.com/WordPress/gutenberg/pull/50257#issuecomment-2009381915) that we could use `PluginDocumentSettingPanel ` instead.

Technically we cannot use internally `PluginDocumentSettingPanel ` slot, because it checks if the panel is opened, which is false by default and that results in not showing the contents. The other difference is that this slot didn't render the PanelBody whereas PluginDocumentSettingPanel does. So we soft deprecates the PluginTemplateSettingPanel.



## Testing Instructions
PluginDocumentSettingPanel should also work for templates