### PR TITLE
Update Node.js requirement in create-block docs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53694,8 +53694,8 @@
 				"wp-create-block": "index.js"
 			},
 			"engines": {
-				"node": ">=14",
-				"npm": ">=6.14.4"
+				"node": ">=18",
+				"npm": ">=10.5.0"
 			}
 		},
 		"packages/create-block-tutorial-template": {

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -19,7 +19,7 @@ $ npm start
 The `slug` provided (`todo-list` in the example) defines the folder name for the scaffolded plugin and the internal block name. The WordPress plugin generated must [be installed manually](https://wordpress.org/documentation/article/manage-plugins/#manual-plugin-installation-1).
 
 
-_(requires `node` version `16.9.0` or above, and `npm` version `6.14.4` or above)_
+_(requires `node` version `18.0.0` or above, and `npm` version `10.5.0` or above)_
 
 
 > [Watch a video introduction to create-block on Learn.wordpress.org](https://learn.wordpress.org/tutorial/using-the-create-block-tool/)

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -19,7 +19,7 @@ $ npm start
 The `slug` provided (`todo-list` in the example) defines the folder name for the scaffolded plugin and the internal block name. The WordPress plugin generated must [be installed manually](https://wordpress.org/documentation/article/manage-plugins/#manual-plugin-installation-1).
 
 
-_(requires `node` version `14.0.0` or above, and `npm` version `6.14.4` or above)_
+_(requires `node` version `16.9.0` or above, and `npm` version `6.14.4` or above)_
 
 
 > [Watch a video introduction to create-block on Learn.wordpress.org](https://learn.wordpress.org/tutorial/using-the-create-block-tool/)

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -20,8 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14",
-		"npm": ">=6.14.4"
+		"node": ">=18",
+		"npm": ">=10.5.0"
 	},
 	"files": [
 		"lib"


### PR DESCRIPTION
## What?

Updates minimum required Node.js version from 14.0.0 to 16.9.0:

## Why?

The build currently fails with:

```
[webpack-cli] TypeError: Object.hasOwn is not a function
    at getBlockJsonScriptFields (.../node_modules/@wordpress/scripts/utils/block-json.js:28:15)
    at .../node_modules/@wordpress/scripts/utils/config.js:253:9
```

Object.hasOwn [was introduced](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#browser_compatibility) in Node.js 16.9.0.