### PR TITLE
Navigation: Remove unnecessary `__experimentalStyle`

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -137,15 +137,6 @@
 				"type": "flex"
 			}
 		},
-		"__experimentalStyle": {
-			"elements": {
-				"link": {
-					"color": {
-						"text": "inherit"
-					}
-				}
-			}
-		},
 		"interactivity": true,
 		"renaming": false
 	},


### PR DESCRIPTION
Closes #59142
Rleated to #51710, #52579

## What?

This PR removes unnecessary `__experimentalStyle` from the Navigation menu.

## Why?

From what I've researched, this is an accidental regression caused by the timing of two PRs being merged.

Below are the PRs related to this issue and the dates and times they were merged.

- #51710
  - Merged date: Jul 13, 2023, 11:23 PM GMT+9
  - `__experimentalStyle` has been removed to the `block.json` ([Source](https://github.com/WordPress/gutenberg/pull/51710/files#diff-554049ef85f1660a9ba54b7ee492d7d347a5244a9aa4a7d3fb75ab24015c2f29L126-L134))
- #52579
  - Merged date: Jul 14, 2023, 2:36 AM GMT+9
  - `__experimentalStyle` has been re-added to the `block.json`. ([Source](https://github.com/WordPress/gutenberg/pull/52579/files#diff-554049ef85f1660a9ba54b7ee492d7d347a5244a9aa4a7d3fb75ab24015c2f29R126-R134))

As you can see, the times when the two PRs were merged are very close. Perhaps the latter PR did not include the former PR, so `__experimentalStyle` was added unintentionally.

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Since the stylesheet already exists, there will be no side effects of deleting it. As shown below, `color: inherit;` should still be applied to links in the navigation block.

| trunk | This PR |
|--------|--------|
| ![trunk](https://github.com/WordPress/gutenberg/assets/54422211/91676059-6c14-4a31-a0d4-0a754338ab80) | ![this_pr](https://github.com/WordPress/gutenberg/assets/54422211/2d3c4eeb-030c-491b-b26e-c206622e589b) | 