### PR TITLE
Inserter: Bail early when a user has no permission to upload media

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -127,23 +127,31 @@ export function MediaPreview( { media, onClick, category } ) {
 	);
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
-	const mediaUpload = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
-		[]
-	);
+	const { getSettings } = useSelect( blockEditorStore );
+
 	const onMediaInsert = useCallback(
 		( previewBlock ) => {
 			// Prevent multiple uploads when we're in the process of inserting.
 			if ( isInserting ) {
 				return;
 			}
+
+			const settings = getSettings();
 			const clonedBlock = cloneBlock( previewBlock );
 			const { id, url, caption } = clonedBlock.attributes;
+
+			// User has no permission to upload media.
+			if ( ! id && ! settings.mediaUpload ) {
+				setShowExternalUploadModal( true );
+				return;
+			}
+
 			// Media item already exists in library, so just insert it.
 			if ( !! id ) {
 				onClick( clonedBlock );
 				return;
 			}
+
 			setIsInserting( true );
 			// Media item does not exist in library, so try to upload it.
 			// Fist fetch the image data. This may fail if the image host
@@ -154,7 +162,7 @@ export function MediaPreview( { media, onClick, category } ) {
 				.fetch( url )
 				.then( ( response ) => response.blob() )
 				.then( ( blob ) => {
-					mediaUpload( {
+					settings.mediaUpload( {
 						filesList: [ blob ],
 						additionalData: { caption },
 						onFileChange( [ img ] ) {
@@ -189,10 +197,10 @@ export function MediaPreview( { media, onClick, category } ) {
 		},
 		[
 			isInserting,
+			getSettings,
 			onClick,
-			mediaUpload,
-			createErrorNotice,
 			createSuccessNotice,
+			createErrorNotice,
 		]
 	);
 


### PR DESCRIPTION
## What?
PR updates logic flow in the `onMediaInsert` callback to display the modal early when inserting an external image, and the user has no permission to upload the media.

I've also updated the component to get settings on-demand instead of creating a store subscription and added a few more extra spaces to let [the code breathe](https://freek.dev/2206-code-that-breathes).

## Why?
It prevents making an unnecessary `GET` request to fetch image data. Previously, fetching would error at the upload step due to `settings.mediaUpload` being `undefined` and trigger the modal.

## Testing Instructions
1. Login as a test user with a Contributor role.
2. Create a new post.
3. Open the Inserter > Media > Openverse.
4. Try inserting an image.
5. The "Extranal image" notice modal should be displayed.
6. Repeat the same steps with the Admin user.
7. The modal shouldn't be displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-23 at 11 47 02](https://github.com/WordPress/gutenberg/assets/240569/390afd2a-04cf-4168-a397-901e44f19076)