### PR TITLE
Box Control: fix issue with negative values

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -17,7 +17,7 @@ import {
 	__experimentalView as View,
 } from '@wordpress/components';
 import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
-import { useCallback, Platform } from '@wordpress/element';
+import { useCallback, useState, Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -248,6 +248,10 @@ export default function DimensionsPanel( {
 		],
 	} );
 
+	//Minimum Margin Value
+	const minimumMargin = -Infinity;
+	const [ minMarginValue, setMinMarginValue ] = useState( minimumMargin );
+
 	// Content Size
 	const showContentSizeControl =
 		useHasContentSize( settings ) && includeLayoutControls;
@@ -435,6 +439,25 @@ export default function DimensionsPanel( {
 
 	const onMouseLeaveControls = () => onVisualize( false );
 
+	const inputProps = {
+		min: minMarginValue,
+		onDragStart: ( dragProps ) => {
+			const { target } = dragProps;
+			if ( target.value < 0 ) {
+				setMinMarginValue( 0 );
+			}
+		},
+		onDrag: ( dragProps ) => {
+			const { target } = dragProps;
+			if ( target.value < 0 ) {
+				setMinMarginValue( 0 );
+			}
+		},
+		onDragEnd: () => {
+			setMinMarginValue( minimumMargin );
+		},
+	};
+
 	return (
 		<Wrapper
 			resetAllFilter={ resetAllFilter }
@@ -561,7 +584,7 @@ export default function DimensionsPanel( {
 						<BoxControl
 							values={ marginValues }
 							onChange={ setMarginValues }
-							inputProps={ { min: -Infinity } }
+							inputProps={ inputProps }
 							label={ __( 'Margin' ) }
 							sides={ marginSides }
 							units={ units }

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -442,6 +442,7 @@ export default function DimensionsPanel( {
 	const inputProps = {
 		min: minMarginValue,
 		onDragStart: () => {
+			//Reset to 0 in case the value was negative.
 			setMinMarginValue( 0 );
 		},
 		onDragEnd: () => {

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -561,7 +561,7 @@ export default function DimensionsPanel( {
 						<BoxControl
 							values={ marginValues }
 							onChange={ setMarginValues }
-							min={ -Infinity }
+							inputProps={ { min: -Infinity } }
 							label={ __( 'Margin' ) }
 							sides={ marginSides }
 							units={ units }

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -441,17 +441,8 @@ export default function DimensionsPanel( {
 
 	const inputProps = {
 		min: minMarginValue,
-		onDragStart: ( dragProps ) => {
-			const { target } = dragProps;
-			if ( target.value < 0 ) {
-				setMinMarginValue( 0 );
-			}
-		},
-		onDrag: ( dragProps ) => {
-			const { target } = dragProps;
-			if ( target.value < 0 ) {
-				setMinMarginValue( 0 );
-			}
+		onDragStart: () => {
+			setMinMarginValue( 0 );
 		},
 		onDragEnd: () => {
 			setMinMarginValue( minimumMargin );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).
--   `BoxControl`: Allow negative values for margin controls ([#60347](https://github.com/WordPress/gutenberg/pull/60347)).
 -   `View`: Fix prop types ([#60919](https://github.com/WordPress/gutenberg/pull/60919)).
 
 ### Bug Fix

--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -34,6 +34,10 @@ import type {
 	BoxControlValue,
 } from './types';
 
+const defaultInputProps = {
+	min: 0,
+};
+
 const noop = () => {};
 
 function useUniqueId( idProp?: string ) {
@@ -70,6 +74,7 @@ function useUniqueId( idProp?: string ) {
 function BoxControl( {
 	__next40pxDefaultSize = false,
 	id: idProp,
+	inputProps = defaultInputProps,
 	onChange = noop,
 	label = __( 'Box Control' ),
 	values: valuesProp,
@@ -80,7 +85,6 @@ function BoxControl( {
 	resetValues = DEFAULT_VALUES,
 	onMouseOver,
 	onMouseOut,
-	...inputProps
 }: BoxControlProps ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
@@ -136,11 +140,8 @@ function BoxControl( {
 		setIsDirty( false );
 	};
 
-	const min = 'min' in inputProps ? inputProps.min : 0;
-	const newInputProps = { ...inputProps, min };
-
 	const inputControlProps = {
-		newInputProps,
+		...inputProps,
 		onChange: handleOnChange,
 		onFocus: handleOnFocus,
 		isLinked,

--- a/packages/components/src/box-control/input-controls.tsx
+++ b/packages/components/src/box-control/input-controls.tsx
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -29,8 +28,6 @@ export default function BoxInputControls( {
 	sides,
 	...props
 }: BoxControlInputControlProps ) {
-	const minimumCustomValue = props.min;
-	const [ minValue, setMinValue ] = useState( minimumCustomValue );
 	const generatedId = useInstanceId( BoxInputControls, 'box-control-input' );
 
 	const createHandleOnFocus =
@@ -103,9 +100,6 @@ export default function BoxInputControls( {
 					? parsedUnit
 					: selectedUnits[ side ];
 
-				const isNegativeValue =
-					parsedQuantity !== undefined && parsedQuantity < 0;
-
 				const inputId = [ generatedId, side ].join( '-' );
 
 				return (
@@ -121,7 +115,6 @@ export default function BoxInputControls( {
 								value={ [ parsedQuantity, computedUnit ].join(
 									''
 								) }
-								min={ minValue }
 								onChange={ ( nextValue, extra ) =>
 									handleOnValueChange(
 										side,
@@ -133,19 +126,6 @@ export default function BoxInputControls( {
 									side
 								) }
 								onFocus={ createHandleOnFocus( side ) }
-								onDragStart={ () => {
-									if ( isNegativeValue ) {
-										setMinValue( 0 );
-									}
-								} }
-								onDrag={ () => {
-									if ( isNegativeValue ) {
-										setMinValue( 0 );
-									}
-								} }
-								onDragEnd={ () => {
-									setMinValue( minimumCustomValue );
-								} }
 								label={ LABELS[ side ] }
 								hideLabelFromVision
 							/>

--- a/packages/components/src/box-control/test/index.tsx
+++ b/packages/components/src/box-control/test/index.tsx
@@ -80,6 +80,28 @@ describe( 'BoxControl', () => {
 			expect( input ).toHaveValue( '50' );
 			expect( screen.getByRole( 'slider' ) ).toHaveValue( '50' );
 		} );
+
+		it( 'should render the number input with a default min value of 0', () => {
+			render( <BoxControl onChange={ () => {} } /> );
+
+			const input = screen.getByRole( 'textbox', { name: 'All sides' } );
+
+			expect( input ).toHaveAttribute( 'min', '0' );
+		} );
+
+		it( 'should pass down `inputProps` to the underlying number input', () => {
+			render(
+				<BoxControl
+					onChange={ () => {} }
+					inputProps={ { min: 10, max: 50 } }
+				/>
+			);
+
+			const input = screen.getByRole( 'textbox', { name: 'All sides' } );
+
+			expect( input ).toHaveAttribute( 'min', '10' );
+			expect( input ).toHaveAttribute( 'max', '50' );
+		} );
 	} );
 
 	describe( 'Reset', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Merging https://github.com/WordPress/gutenberg/pull/60347 broke the Box Control component, not allowing for `inputProps` to be passed. It also made the changes directly into the component, instead of only in the instance where the changes are needed. This aims to fix both things.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It was a bug, we don't want to break the component usage :D

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We added unit tests to cover the failure and moved the changes to the dimensions panels, where we need the drag control and to happen and setting the min value instead of directly in the component

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
https://github.com/WordPress/gutenberg/pull/60347 testing instructions should still be valid


