### PR TITLE
lint-staged-typecheck: don't run TSC when no TS project is affected

### DIFF
--- a/bin/packages/lint-staged-typecheck.js
+++ b/bin/packages/lint-staged-typecheck.js
@@ -28,9 +28,11 @@ const changedPackages = [
 	fs.existsSync( path.join( packageRoot, 'tsconfig.json' ) )
 );
 
-try {
-	execa.sync( tscPath, [ '--build', ...changedPackages ] );
-} catch ( err ) {
-	console.error( err.stdout );
-	process.exitCode = 1;
+if ( changedPackages.length > 0 ) {
+	try {
+		execa.sync( tscPath, [ '--build', ...changedPackages ] );
+	} catch ( err ) {
+		console.error( err.stdout );
+		process.exitCode = 1;
+	}
 }


### PR DESCRIPTION
The `lint-staged-typecheck` script that's run in a precommit hook determines a set of changed packages and runs `tsc` on a list of the changed package directories.

However, when the list of changed packages is empty, because there's no `tsconfig.json` in any affected directory, it runs a redundant `tsc --build` command which typechecks the entire project.

This PR fixes that so no `tsc --build` is run.

**How to test:** Modify a file in `packages/edit-site` (which doesn't have a `tsconfig.json` and try to commit.
- before this PR, you'd see a `lint-staged-typecheck` task running for quite some time.
- after this PR, the commit is much faster
