### PR TITLE
useMatchMedia: cache queries

### DIFF
--- a/packages/compose/src/hooks/use-media-query/index.js
+++ b/packages/compose/src/hooks/use-media-query/index.js
@@ -16,15 +16,17 @@ function getMediaQueryList( query ) {
 		return null;
 	}
 
-	if ( matchMediaCache.has( query ) ) {
-		return matchMediaCache.get( query );
+	let match = matchMediaCache.get( query );
+
+	if ( match ) {
+		return match;
 	}
 
 	if (
 		typeof window !== 'undefined' &&
 		typeof window.matchMedia === 'function'
 	) {
-		const match = window.matchMedia( query );
+		match = window.matchMedia( query );
 		matchMediaCache.set( query, match );
 		return match;
 	}

--- a/packages/compose/src/hooks/use-media-query/index.js
+++ b/packages/compose/src/hooks/use-media-query/index.js
@@ -3,6 +3,8 @@
  */
 import { useMemo, useSyncExternalStore } from '@wordpress/element';
 
+const matchMediaCache = new Map();
+
 /**
  * A new MediaQueryList object for the media query
  *
@@ -10,12 +12,21 @@ import { useMemo, useSyncExternalStore } from '@wordpress/element';
  * @return {MediaQueryList|null} A new object for the media query
  */
 function getMediaQueryList( query ) {
+	if ( ! query ) {
+		return null;
+	}
+
+	if ( matchMediaCache.has( query ) ) {
+		return matchMediaCache.get( query );
+	}
+
 	if (
-		query &&
 		typeof window !== 'undefined' &&
 		typeof window.matchMedia === 'function'
 	) {
-		return window.matchMedia( query );
+		const match = window.matchMedia( query );
+		matchMediaCache.set( query, match );
+		return match;
 	}
 
 	return null;

--- a/packages/compose/src/hooks/use-media-query/test/index.js
+++ b/packages/compose/src/hooks/use-media-query/test/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { act, render } from '@testing-library/react';
-import { matchMedia, setMedia, cleanup } from 'mock-match-media';
+import { matchMedia, setMedia } from 'mock-match-media';
 
 /**
  * Internal dependencies
@@ -26,10 +26,11 @@ describe( 'useMediaQuery', () => {
 	} );
 
 	afterEach( () => {
-		cleanup();
+		// Do not clean up, this will break our cache. Browsers also do not
+		// reset media queries.
 	} );
 
-	it( 'should return true when query matches', async () => {
+	it( 'should return true when the query matches', async () => {
 		const { container } = render(
 			<TestComponent query="(min-width: 782px)" />
 		);
@@ -53,7 +54,7 @@ describe( 'useMediaQuery', () => {
 		expect( container ).toHaveTextContent( 'useMediaQuery: false' );
 	} );
 
-	it( 'should return false when the query does not matches', async () => {
+	it( 'should return false when the query does not match', async () => {
 		const { container } = render(
 			<TestComponent query="(max-width: 782px)" />
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

As seen in #60546 (among others, such as #57133), `matchMedia` is the most expensive part of these media queries. Let's cache it. Usually the number of different media queries is very small, so I wouldn't worry about the cache getting out of hand.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
