### PR TITLE
Select last section if parent section doesn't exist

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1446,6 +1446,8 @@ export const __unstableSetEditorMode =
 			if ( sectionRootClientId ) {
 				const sectionClientIds =
 					select.getBlockOrder( sectionRootClientId );
+				const lastSectionClientId =
+					sectionClientIds[ sectionClientIds.length - 1 ];
 				if ( sectionClientIds ) {
 					if ( firstSelectedClientId ) {
 						const parents = select.getBlockParents(
@@ -1457,13 +1459,9 @@ export const __unstableSetEditorMode =
 						if ( firstSectionClientId ) {
 							dispatch.selectBlock( firstSectionClientId );
 						} else {
-							const lastSectionClientId =
-								sectionClientIds[ sectionClientIds.length - 1 ];
 							dispatch.selectBlock( lastSectionClientId );
 						}
 					} else {
-						const lastSectionClientId =
-							sectionClientIds[ sectionClientIds.length - 1 ];
 						dispatch.selectBlock( lastSectionClientId );
 					}
 				}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1454,7 +1454,13 @@ export const __unstableSetEditorMode =
 						const firstSectionClientId = parents.find( ( parent ) =>
 							sectionClientIds.includes( parent )
 						);
-						dispatch.selectBlock( firstSectionClientId );
+						if ( firstSectionClientId ) {
+							dispatch.selectBlock( firstSectionClientId );
+						} else {
+							const lastSectionClientId =
+								sectionClientIds[ sectionClientIds.length - 1 ];
+							dispatch.selectBlock( lastSectionClientId );
+						}
 					} else {
 						const lastSectionClientId =
 							sectionClientIds[ sectionClientIds.length - 1 ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #60972

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Selecting a category from the inserter patterns tab puts the editor in zoom out mode. Since in zoom out mode block selection is disabled and we default to "section" selection, we need to manage what is selected.

There is some logic to decide what to select in `__unstableSetEditorMode` which is an action in the block editor store, so when zoom out is activated:

- if there is a section root
  - **if there is a block selected, select the parent section**
  - if there is no block selection, select the last section
- if there is no section root
  - if there is a selected block, select the root parent
- finally,
  - select the "last root block" (*)

The bug in #60972 happens because we didn't consider that a selected block may have an undefined parent section (the root block doesn't).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Fixes `__unstableSetEditorMode` to also select the last section, if the currently selected block does not have a valid parent section.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

0. Create a template with several patterns grouped in a group block whose tag is set to `main`
1. Open main Block Inserter
2. Click Pattern Tab
3. Click a Pattern Category
4. Click Block Tab
5. Click Pattern Tab
6. Click Pattern Category
7. **It should work as expected**

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

n/a

## Screenshots or screencast <!-- if applicable -->

n/a

(*) "last root block", we expect that in a template we'd have a list of patterns or other grouped blocks, so if they're not in a `main` group they're considered sections themselves.