### PR TITLE
Editor: Optimize some of the post-support panels

### DIFF
--- a/packages/editor/src/components/page-attributes/panel.js
+++ b/packages/editor/src/components/page-attributes/panel.js
@@ -17,7 +17,7 @@ import PageAttributesParent from './parent';
 
 const PANEL_NAME = 'page-attributes';
 
-export function PageAttributesPanel() {
+function AttributesPanel() {
 	const { isEnabled, isOpened, postType } = useSelect( ( select ) => {
 		const {
 			getEditedPostAttribute,
@@ -38,25 +38,24 @@ export function PageAttributesPanel() {
 		return null;
 	}
 
-	const onTogglePanel = ( ...args ) =>
-		toggleEditorPanelOpened( PANEL_NAME, ...args );
-
 	return (
-		<PageAttributesCheck>
-			<PanelBody
-				title={
-					postType?.labels?.attributes ?? __( 'Page attributes' )
-				}
-				opened={ isOpened }
-				onToggle={ onTogglePanel }
-			>
-				<PageAttributesParent />
-				<PanelRow>
-					<PageAttributesOrder />
-				</PanelRow>
-			</PanelBody>
-		</PageAttributesCheck>
+		<PanelBody
+			title={ postType?.labels?.attributes ?? __( 'Page attributes' ) }
+			opened={ isOpened }
+			onToggle={ () => toggleEditorPanelOpened( PANEL_NAME ) }
+		>
+			<PageAttributesParent />
+			<PanelRow>
+				<PageAttributesOrder />
+			</PanelRow>
+		</PanelBody>
 	);
 }
 
-export default PageAttributesPanel;
+export default function PageAttributesPanel() {
+	return (
+		<PageAttributesCheck>
+			<AttributesPanel />
+		</PageAttributesCheck>
+	);
+}

--- a/packages/editor/src/components/post-discussion/panel.js
+++ b/packages/editor/src/components/post-discussion/panel.js
@@ -15,7 +15,7 @@ import PostPingbacks from '../post-pingbacks';
 
 const PANEL_NAME = 'discussion-panel';
 
-function PostDiscussionPanel() {
+function DiscussionPanel() {
 	const { isEnabled, isOpened } = useSelect( ( select ) => {
 		const { isEditorPanelEnabled, isEditorPanelOpened } =
 			select( editorStore );
@@ -32,26 +32,30 @@ function PostDiscussionPanel() {
 	}
 
 	return (
-		<PostTypeSupportCheck supportKeys={ [ 'comments', 'trackbacks' ] }>
-			<PanelBody
-				title={ __( 'Discussion' ) }
-				opened={ isOpened }
-				onToggle={ () => toggleEditorPanelOpened( PANEL_NAME ) }
-			>
-				<PostTypeSupportCheck supportKeys="comments">
-					<PanelRow>
-						<PostComments />
-					</PanelRow>
-				</PostTypeSupportCheck>
+		<PanelBody
+			title={ __( 'Discussion' ) }
+			opened={ isOpened }
+			onToggle={ () => toggleEditorPanelOpened( PANEL_NAME ) }
+		>
+			<PostTypeSupportCheck supportKeys="comments">
+				<PanelRow>
+					<PostComments />
+				</PanelRow>
+			</PostTypeSupportCheck>
 
-				<PostTypeSupportCheck supportKeys="trackbacks">
-					<PanelRow>
-						<PostPingbacks />
-					</PanelRow>
-				</PostTypeSupportCheck>
-			</PanelBody>
-		</PostTypeSupportCheck>
+			<PostTypeSupportCheck supportKeys="trackbacks">
+				<PanelRow>
+					<PostPingbacks />
+				</PanelRow>
+			</PostTypeSupportCheck>
+		</PanelBody>
 	);
 }
 
-export default PostDiscussionPanel;
+export default function PostDiscussionPanel() {
+	return (
+		<PostTypeSupportCheck supportKeys={ [ 'comments', 'trackbacks' ] }>
+			<DiscussionPanel />
+		</PostTypeSupportCheck>
+	);
+}

--- a/packages/editor/src/components/post-excerpt/panel.js
+++ b/packages/editor/src/components/post-excerpt/panel.js
@@ -18,7 +18,7 @@ import { store as editorStore } from '../../store';
  */
 const PANEL_NAME = 'post-excerpt';
 
-export default function PostExcerptPanel() {
+function ExcerptPanel() {
 	const { isOpened, isEnabled } = useSelect( ( select ) => {
 		const { isEditorPanelOpened, isEditorPanelEnabled } =
 			select( editorStore );
@@ -37,21 +37,27 @@ export default function PostExcerptPanel() {
 	}
 
 	return (
+		<PanelBody
+			title={ __( 'Excerpt' ) }
+			opened={ isOpened }
+			onToggle={ toggleExcerptPanel }
+		>
+			<PluginPostExcerpt.Slot>
+				{ ( fills ) => (
+					<>
+						<PostExcerptForm />
+						{ fills }
+					</>
+				) }
+			</PluginPostExcerpt.Slot>
+		</PanelBody>
+	);
+}
+
+export default function PostExcerptPanel() {
+	return (
 		<PostExcerptCheck>
-			<PanelBody
-				title={ __( 'Excerpt' ) }
-				opened={ isOpened }
-				onToggle={ toggleExcerptPanel }
-			>
-				<PluginPostExcerpt.Slot>
-					{ ( fills ) => (
-						<>
-							<PostExcerptForm />
-							{ fills }
-						</>
-					) }
-				</PluginPostExcerpt.Slot>
-			</PanelBody>
+			<ExcerptPanel />
 		</PostExcerptCheck>
 	);
 }


### PR DESCRIPTION
## What?
This micro-optimization of the "Discussion," "Excerpt," and "Page Attributes" panel components avoids creating unnecessary store subscriptions when the post type doesn't support a feature.

## Why?
When a post type doesn't support a panel/feature, no panel-related code needs to be initiated.

## How?
Extract general panel logic into separate components, passing it to the "check" components as `children`.

## Testing Instructions
1. Open a post.
2. Confirm that the "Discussion" and "Excerpt" panels are visible.
3. Confirm you can toggle or disable the panel from the Preferences modal.
4. Open a page.
5. Confirm that the "Page Attribute" panel is visible.
6. It can be toggled or disabled from the Preferences modal.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-23 at 18 01 51](https://github.com/WordPress/gutenberg/assets/240569/7df7348c-6f71-43be-905a-d31c19a2ded7)
