### PR TITLE
Zoomed Out View: Don't close the inserter

### DIFF
--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -5,10 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
 import { closeSmall } from '@wordpress/icons';
-import {
-	useViewportMatch,
-	__experimentalUseDialog as useDialog,
-} from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -34,19 +31,10 @@ export default function InserterSidebar( {
 	const { setIsInserterOpened } = useDispatch( editorStore );
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: () => setIsInserterOpened( false ),
-		focusOnMount: true,
-	} );
-
 	const libraryRef = useRef();
 
 	return (
-		<div
-			ref={ inserterDialogRef }
-			{ ...inserterDialogProps }
-			className="editor-inserter-sidebar"
-		>
+		<div className="editor-inserter-sidebar">
 			<div className="editor-inserter-sidebar__header">
 				<Button
 					className="editor-inserter-sidebar__close-button"

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -628,7 +628,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.click();
 		await page.getByRole( 'option', { name: 'More', exact: true } ).click();
 
-		// Moving focus to the More block should close the inserter.
+		// Moving focus to the More block should not close the inserter.
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Read more' } )
 			.fill( 'More' );
@@ -636,7 +636,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			page.getByRole( 'region', {
 				name: 'Block Library',
 			} )
-		).toBeHidden();
+		).toBeVisible();
 	} );
 
 	test( 'shows block preview when hovering over block in inserter', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make the inserter not a dialog anymore so that it doesn't close when we focus outside of it.

## Why?
The other sidebar panels don't operate as dialogs, so this brings consistency with them

## How?
Just remove the `useDialog` hook from the component.


## Testing Instructions
1. Open the block inserter
2. Insert a block/pattern
3. Check that the inserter panel stays open

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/275961/6bcfbc7d-02cf-4d69-9593-6024a7bb59cc
