### PR TITLE
Experiment: Run block bindings logic for any block in the editor

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -31,8 +31,8 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-page-client-side-navigation' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalFullPageClientSideNavigation = true', 'before' );
 	}
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-allow-any-block-to-use-block-bindings' ) ) {
-		wp_add_inline_script( 'wp-block-library', 'window.__experimentalBlockBindingsInAnyBlock = true', 'before' );
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-expose-block-bindings-editor-apis' ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalBlockBindingsEditorAPIs = { allowAnyBlock: true }', 'before' );
 	}
 }
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -31,6 +31,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-page-client-side-navigation' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalFullPageClientSideNavigation = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-allow-any-block-to-use-block-bindings' ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalBlockBindingsInAnyBlock = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -140,14 +140,14 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-allow-any-block-to-use-block-bindings',
-		__( 'Allow block bindings in any block', 'gutenberg' ),
+		'gutenberg-expose-block-bindings-editor-apis',
+		__( 'Expose block bindings editor APIs', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Allow any block to use block bindings API in the editor', 'gutenberg' ),
-			'id'    => 'gutenberg-allow-any-block-to-use-block-bindings',
+			'label' => __( 'Expose block bindings editor APIs, including supporting any block. Server support should be handled independtenly of this experiment', 'gutenberg' ),
+			'id'    => 'gutenberg-expose-block-bindings-editor-apis',
 		)
 	);
 

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -139,6 +139,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-allow-any-block-to-use-block-bindings',
+		__( 'Allow block bindings in any block', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Allow any block to use block bindings API in the editor', 'gutenberg' ),
+			'id'    => 'gutenberg-allow-any-block-to-use-block-bindings',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -38,7 +38,7 @@ const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
  */
 export function canBindBlock( blockName ) {
 	return (
-		window.__experimentalBlockBindingsInAnyBlock ||
+		window.__experimentalBlockBindingsEditorAPIs?.allowAnyBlock ||
 		blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS
 	);
 }
@@ -53,7 +53,7 @@ export function canBindBlock( blockName ) {
  */
 export function canBindAttribute( blockName, attributeName ) {
 	return (
-		window.__experimentalBlockBindingsInAnyBlock ||
+		window.__experimentalBlockBindingsEditorAPIs?.allowAnyBlock ||
 		( canBindBlock( blockName ) &&
 			BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].includes(
 				attributeName

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -37,7 +37,10 @@ const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
  * @return {boolean} Whether it is possible to bind the block to sources.
  */
 export function canBindBlock( blockName ) {
-	return blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS;
+	return (
+		window.__experimentalBlockBindingsInAnyBlock ||
+		blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS
+	);
 }
 
 /**
@@ -50,8 +53,11 @@ export function canBindBlock( blockName ) {
  */
 export function canBindAttribute( blockName, attributeName ) {
 	return (
-		canBindBlock( blockName ) &&
-		BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].includes( attributeName )
+		window.__experimentalBlockBindingsInAnyBlock ||
+		( canBindBlock( blockName ) &&
+			BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].includes(
+				attributeName
+			) )
 	);
 }
 

--- a/packages/editor/src/bindings/index.js
+++ b/packages/editor/src/bindings/index.js
@@ -16,3 +16,8 @@ registerBlockBindingsSource( postMeta );
 if ( process.env.IS_GUTENBERG_PLUGIN ) {
 	registerBlockBindingsSource( patternOverrides );
 }
+
+if ( window.__experimentalBlockBindingsEditorAPIs ) {
+	window.__experimentalBlockBindingsEditorAPIs.registerBlockBindingsSource =
+		registerBlockBindingsSource;
+}


### PR DESCRIPTION
## What?
Create a new Gutenberg experimental setting to run block bindings logic in the editor in any block.

## Why?
Right now, the block bindings API is limited to a list of core blocks because we can't ensure the server logic will work as expected. However, this limitation doesn't exist in the editor. For that reason, it could make sense to have this possibility to start exploring how it could work and allow users/plugins to use the API in other blocks at their own risk.

## How?

Add a new `window.__experimentalBlockBindingsInAnyBlock` property when the experiment is enabled and read that from the editor hook.
