### PR TITLE
Remove unnecessary `usesContext` from paragraph block

### DIFF
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -7,7 +7,6 @@
 	"description": "Start with the basic building block of all narrative.",
 	"keywords": [ "text" ],
 	"textdomain": "default",
-	"usesContext": [ "postId" ],
 	"attributes": {
 		"align": {
 			"type": "string"


### PR DESCRIPTION
## What?
Remove unnecessary `usesContext` from paragraph block.

## Why?
It doesn't seem to be used at all in the paragraph block.

If I am not mistaken, this was introduced as part of the first experiment of connecting blocks and custom fields: [link](https://github.com/WordPress/gutenberg/pull/53247). However, it was finally implemented using [another solution](https://github.com/WordPress/gutenberg/pull/58554), and it seems we didn't remove it.

## How?
Just remove it from the `block.json.`

## Testing Instructions
Tests should pass.
