### PR TITLE
Interactivity API: Allow multiple event handlers for the same type with `data-wp-on-document` and `data-wp-on-window`.

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/render.php
@@ -24,4 +24,8 @@
 			<p data-wp-text="state.counter" data-testid="counter">0</p>
 		</div>
 	</div>
+	<div data-wp-on-document--keydown="actions.keydownHandler" data-wp-on-document--keydown--second="actions.keydownSecondHandler">
+		<p data-wp-text="state.keydownHandler" data-testid="keydownHandler">no</p>
+		<p data-wp-text="state.keydownSecondHandler" data-testid="keydownSecondHandler">no</p>
+	</div>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/view.js
@@ -25,6 +25,8 @@ const { state } = store( 'directive-on-document', {
 		counter: 0,
 		isVisible: true,
 		isEventAttached: 'no',
+		keydownHandler: 'no',
+		keydownSecondHandler: 'no',
 	},
 	callbacks: {
 		keydownHandler() {
@@ -39,5 +41,11 @@ const { state } = store( 'directive-on-document', {
 			state.isEventAttached = 'no';
 			state.isVisible = ! state.isVisible;
 		},
+		keydownHandler: () => {
+			state.keydownHandler = 'yes';
+		},
+		keydownSecondHandler: () => {
+			state.keydownSecondHandler = 'yes';
+		}
 	}
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/render.php
@@ -21,4 +21,8 @@
 			<p data-wp-text="state.counter" data-testid="counter">0</p>
 		</div>
 	</div>
+	<div data-wp-on-window--resize="actions.resizeHandler" data-wp-on-window--resize--second="actions.resizeSecondHandler">
+		<p data-wp-text="state.resizeHandler" data-testid="resizeHandler">no</p>
+		<p data-wp-text="state.resizeSecondHandler" data-testid="resizeSecondHandler">no</p>
+	</div>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/view.js
@@ -25,6 +25,8 @@ const { state } = store( 'directive-on-window', {
 		counter: 0,
 		isVisible: true,
 		isEventAttached: 'no',
+		resizeHandler: 'no',
+		resizeSecondHandler: 'no',
 	},
 	callbacks: {
 		resizeHandler() {
@@ -39,5 +41,11 @@ const { state } = store( 'directive-on-window', {
 			state.isEventAttached = 'no';
 			state.isVisible = ! state.isVisible;
 		},
+		resizeHandler: () => {
+			state.resizeHandler = 'yes';
+		},
+		resizeSecondHandler: () => {
+			state.resizeSecondHandler = 'yes';
+		}
 	}
 } );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-	Allow multiple event handlers for the same type with `data-wp-on-document` and `data-wp-on-window`. ([#61009](https://github.com/WordPress/gutenberg/pull/61009))
+
 ## 5.6.0 (2024-05-02)
 
 ## 5.5.0 (2024-04-19)

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -207,24 +207,17 @@ const cssStringToObject = ( val ) => {
  */
 const getGlobalEventDirective = ( type ) => {
 	return ( { directives, evaluate } ) => {
-		const events = new Map();
 		directives[ `on-${ type }` ]
 			.filter( ( { suffix } ) => suffix !== 'default' )
 			.forEach( ( entry ) => {
-				const event = entry.suffix.split( '--' )[ 0 ];
-				if ( ! events.has( event ) ) events.set( event, new Set() );
-				events.get( event ).add( entry );
-			} );
-		events.forEach( ( entries, eventType ) => {
-			entries.forEach( ( entry ) => {
+				const event = entry.suffix.split( '--', 1 )[ 0 ];
 				useInit( () => {
-					const cb = ( event ) => evaluate( entry, event );
+					const cb = () => evaluate( entry, event );
 					const globalVar = type === 'window' ? window : document;
-					globalVar.addEventListener( eventType, cb );
-					return () => globalVar.removeEventListener( eventType, cb );
+					globalVar.addEventListener( event, cb );
+					return () => globalVar.removeEventListener( event, cb );
 				}, [] );
 			} );
-		} );
 	};
 };
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -212,7 +212,7 @@ const getGlobalEventDirective = ( type ) => {
 			.forEach( ( entry ) => {
 				const event = entry.suffix.split( '--', 1 )[ 0 ];
 				useInit( () => {
-					const cb = () => evaluate( entry, event );
+					const cb = ( cbEvent ) => evaluate( entry, cbEvent );
 					const globalVar = type === 'window' ? window : document;
 					globalVar.addEventListener( event, cb );
 					return () => globalVar.removeEventListener( event, cb );

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -210,12 +210,12 @@ const getGlobalEventDirective = ( type ) => {
 		directives[ `on-${ type }` ]
 			.filter( ( { suffix } ) => suffix !== 'default' )
 			.forEach( ( entry ) => {
-				const event = entry.suffix.split( '--', 1 )[ 0 ];
+				const eventName = entry.suffix.split( '--', 1 )[ 0 ];
 				useInit( () => {
-					const cb = ( cbEvent ) => evaluate( entry, cbEvent );
+					const cb = ( event ) => evaluate( entry, event );
 					const globalVar = type === 'window' ? window : document;
-					globalVar.addEventListener( event, cb );
-					return () => globalVar.removeEventListener( event, cb );
+					globalVar.addEventListener( eventName, cb );
+					return () => globalVar.removeEventListener( eventName, cb );
 				}, [] );
 			} );
 	};

--- a/test/e2e/specs/interactivity/directive-on-document.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-document.spec.ts
@@ -65,4 +65,25 @@ test.describe( 'data-wp-on-document', () => {
 		await page.keyboard.press( 'ArrowDown' );
 		await expect( counter ).toHaveText( '2' );
 	} );
+	test( 'should work with multiple event handlers on the same event type', async ( {
+		page,
+	} ) => {
+		const keydownHandler = page.getByTestId( 'keydownHandler' );
+		const keydownSecondHandler = page.getByTestId( 'keydownSecondHandler' );
+
+		// Initial value.
+		await expect( keydownHandler ).toHaveText( 'no' );
+		await expect( keydownSecondHandler ).toHaveText( 'no' );
+
+		// Make sure the event listener is attached.
+		await page
+			.getByTestId( 'isEventAttached' )
+			.filter( { hasText: 'yes' } )
+			.waitFor();
+
+		// This keyboard press should increase the counter.
+		await page.keyboard.press( 'ArrowDown' );
+		await expect( keydownHandler ).toHaveText( 'yes' );
+		await expect( keydownSecondHandler ).toHaveText( 'yes' );
+	} );
 } );

--- a/test/e2e/specs/interactivity/directive-on-window.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-window.spec.ts
@@ -65,4 +65,25 @@ test.describe( 'data-wp-on-window', () => {
 		await page.setViewportSize( { width: 200, height: 600 } );
 		await expect( counter ).toHaveText( '2' );
 	} );
+	test( 'should work with multiple event handlers on the same event type', async ( {
+		page,
+	} ) => {
+		const resizeHandler = page.getByTestId( 'resizeHandler' );
+		const resizeSecondHandler = page.getByTestId( 'resizeSecondHandler' );
+
+		// Initial value.
+		await expect( resizeHandler ).toHaveText( 'no' );
+		await expect( resizeSecondHandler ).toHaveText( 'no' );
+
+		// Make sure the event listener is attached.
+		await page
+			.getByTestId( 'isEventAttached' )
+			.filter( { hasText: 'yes' } )
+			.waitFor();
+
+		// This keyboard press should increase the counter.
+		await page.setViewportSize( { width: 600, height: 600 } );
+		await expect( resizeHandler ).toHaveText( 'yes' );
+		await expect( resizeSecondHandler ).toHaveText( 'yes' );
+	} );
 } );


### PR DESCRIPTION
## What?

Fixes #60683 by allowing multiple `data-wp-on-document` and `data-wp-on-window` events in the same element.

This PR allows declaring multiple event listeners with `data-wp-on-window` and `data-wp-on-document` for the same event type in the same element. Example:

```html
<div
  data-wp-on-window--resize="actions.setResized"
  data-wp-on-window--resize--one="actions.resizeHandler"
>Resize your browser</button>
```

```html
<div
  data-wp-on-document--scroll="actions.setScroll"
  data-wp-on-document--scroll--one="actions.scrollHandler"
>Scroll in your browser</button>
```


The syntax is the same as the rest of the directives (i.e., a unique ID is appended at the end of the directive name).

## Why?

This could be considered a bug fix. The limitation of the number of event handlers that can be registered (only one per element & event type) affects the extensibility of interactive blocks, as well as the reuse of code (e.g., store callbacks).

In addition, all other directives already allow this syntax for the same reason.

## How?

The directive internally groups all the event handlers with the same type and assigns a function to the corresponding `on-document-${event}` `on-window-${event}` or property in the element that runs all the event handlers consecutively.

This fix has some limitations that could be addressed later on:

- The order in which the callbacks run is the same they appear inside the `directives.on-window` or `directives.on-dom`  entries array that the `data-wp-on-document` and `data-wp-on-window` directives function receive. That depends on the order they appear in the HTML, which is not guaranteed.

## Testing Instructions

I've added a couple of E2E tests that should pass.
