### PR TITLE
Setup Node action - Set arch for key value

### DIFF
--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -28,7 +28,7 @@ runs:
           uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
           with:
               path: '**/node_modules'
-              key: node_modules-${{ runner.os }}-${{ steps.node-version.outputs.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+              key: node_modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.node-version.outputs.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
 
         - name: Install npm dependencies
           if: ${{ steps.cache-node_modules.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## What?
This PR updates the `key` used for the cache key for the `node_module` dependencies.

## Why?
Currently the React Native E2E tests are failing, they use the Mac OS runner that appears to have been updated recently.

```
lerna ERR! Error: Cannot find module '@nx/nx-darwin-x64'
lerna ERR! Require stack:
lerna ERR! - /Users/runner/work/gutenberg/gutenberg/node_modules/nx/src/native/index.js
lerna ERR! - /Users/runner/work/gutenberg/gutenberg/node_modules/nx/src/project-graph/utils/retrieve-workspace-files.js
lerna ERR! - /Users/runner/work/gutenberg/gutenberg/node_modules/nx/src/utils/nx-plugin.js
lerna ERR! - /Users/runner/work/gutenberg/gutenberg/node_modules/nx/src/config/workspaces.js
lerna ERR! - /Users/runner/work/gutenberg/gutenberg/node_modules/nx/src/config/configuration.js
lerna ERR! - /Users/runner/work/gutenberg/gutenberg/node_modules/nx/src/daemon/client/client.js
lerna ERR! - /Users/runner/work/gutenberg/gutenberg/node_modules/lerna/dist/index.js
lerna ERR! - /Users/runner/work/gutenberg/gutenberg/node_modules/lerna/dist/cli.js
lerna ERR!     at Module._resolveFilename (node:internal/modules/cjs/loader:1143:15)
lerna ERR!     at Module._load (node:internal/modules/cjs/loader:984:27)
```

## How?
By including the architecture the runner image is running so it doesn't bring a stored cached that was built for a different architecture/environment.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A