### PR TITLE
Core data: properly forward entity resolvers

### DIFF
--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -70,8 +70,9 @@ beforeEach( () => {
 	// Mock media fetch requests
 	setupApiFetch( [ FETCH_MEDIA ] );
 
-	// Invalidate `getMedia` resolutions to allow requesting to the API the same media id
-	dispatch( coreStore ).invalidateResolutionForStoreSelector( 'getMedia' );
+	// Invalidate `getMedia` resolutions to allow requesting to the API the same
+	// media id
+	dispatch( coreStore ).invalidateResolutionForStore();
 } );
 
 afterEach( () => {

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -43,6 +43,10 @@ const entitySelectors = entitiesConfig.reduce( ( result, entity ) => {
 
 const entityResolvers = entitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name, plural } = entity;
+	// We forward the resolver using resolveSelect, which will first check if
+	// the destination resolver is already resolved, thus avoiding duplicate
+	// requests. See `mapResolveSelectors` in
+	// packages/data/src/redux-store/index.js.
 	result[ getMethodName( kind, name ) ] =
 		( key, query ) =>
 		async ( { resolveSelect } ) => {
@@ -50,8 +54,7 @@ const entityResolvers = entitiesConfig.reduce( ( result, entity ) => {
 		};
 
 	if ( plural ) {
-		const pluralMethodName = getMethodName( kind, plural, 'get' );
-		result[ pluralMethodName ] =
+		result[ getMethodName( kind, plural, 'get' ) ] =
 			( query ) =>
 			async ( { resolveSelect } ) => {
 				await resolveSelect.getEntityRecords( kind, name, query );

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import {
+	createReduxStore,
+	register,
+	createRegistrySelector,
+} from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -31,27 +35,17 @@ const entitiesConfig = [
 
 const entitySelectors = entitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name, plural } = entity;
-	result[ getMethodName( kind, name ) ] = ( state, key, query ) =>
-		selectors.getEntityRecord( state, kind, name, key, query );
-
-	if ( plural ) {
-		result[ getMethodName( kind, plural, 'get' ) ] = ( state, query ) =>
-			selectors.getEntityRecords( state, kind, name, query );
-	}
-	return result;
-}, {} );
-
-const entityResolvers = entitiesConfig.reduce( ( result, entity ) => {
-	const { kind, name, plural } = entity;
-	result[ getMethodName( kind, name ) ] = ( key, query ) =>
-		resolvers.getEntityRecord( kind, name, key, query );
+	result[ getMethodName( kind, name ) ] = createRegistrySelector(
+		( select ) => ( state, key, query ) =>
+			select( STORE_NAME ).getEntityRecord( kind, name, key, query )
+	);
 
 	if ( plural ) {
 		const pluralMethodName = getMethodName( kind, plural, 'get' );
-		result[ pluralMethodName ] = ( ...args ) =>
-			resolvers.getEntityRecords( kind, name, ...args );
-		result[ pluralMethodName ].shouldInvalidate = ( action ) =>
-			resolvers.getEntityRecords.shouldInvalidate( action, kind, name );
+		result[ pluralMethodName ] = createRegistrySelector(
+			( select ) => ( state, query ) =>
+				select( STORE_NAME ).getEntityRecords( kind, name, query )
+		);
 	}
 	return result;
 }, {} );
@@ -69,7 +63,7 @@ const storeConfig = () => ( {
 	reducer,
 	actions: { ...actions, ...entityActions, ...createLocksActions() },
 	selectors: { ...selectors, ...entitySelectors },
-	resolvers: { ...resolvers, ...entityResolvers },
+	resolvers,
 } );
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently the dynamically entity resolver "shortcuts" are not really properly forwarded: is the `core` package these will be seen as separate resolvers altogether with and will be cached separately.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For example: `getSite()` and `getEntityRecord( 'root', 'site' )` should be equivalent, but they will each trigger a separate REST request.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We should avoid creating new resolvers for these shortcuts and instead rely on `createRegistrySelector`, so that the underlying resolver is called instead of a wrapper resolver.

Edit: it seems like this breaks `resolveSelect`: when trying to resolve a normal selector, it will just return the initial value without awaiting the result. Not sure how we can fix that. Maybe declare aliases and let the `data` package handle aliasing instead?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Load a page in the site editor, and you'll see two GET requests to the `/v2/settings` endpoint in the network tab. With this PR, there should only be one.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
