### PR TITLE
Components: Assess stabilization of `Elevation`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `Elevation`: Remove "experimental" designation ([#61017](https://github.com/WordPress/gutenberg/pull/61017)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/elevation/README.md
+++ b/packages/components/src/elevation/README.md
@@ -1,9 +1,5 @@
 # Elevation
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Elevation` is a core component that renders shadow, using the component system's shadow system.
 
 ## Usage
@@ -12,7 +8,7 @@ The shadow effect is generated using the `value` prop.
 
 ```jsx
 import {
-	__experimentalElevation as Elevation,
+	Elevation,
 	__experimentalSurface as Surface,
 	__experimentalText as Text,
 } from '@wordpress/components';
@@ -75,7 +71,7 @@ Size of the shadow, based on the Style system's elevation system. The `value` de
 In the example below, `isInteractive` is activated to give a better sense of depth.
 
 ```jsx
-import { __experimentalElevation as Elevation } from '@wordpress/components';
+import { Elevation } from '@wordpress/components';
 
 function Example() {
 	return (

--- a/packages/components/src/elevation/component.tsx
+++ b/packages/components/src/elevation/component.tsx
@@ -29,7 +29,7 @@ function UnconnectedElevation(
  *
  * ```jsx
  * import {
- *	__experimentalElevation as Elevation,
+ *	Elevation,
  *	__experimentalSurface as Surface,
  *	__experimentalText as Text,
  * } from '@wordpress/components';

--- a/packages/components/src/elevation/stories/index.story.tsx
+++ b/packages/components/src/elevation/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { Elevation } from '..';
 
 const meta: Meta< typeof Elevation > = {
 	component: Elevation,
-	title: 'Components (Experimental)/Elevation',
+	title: 'Components/Elevation',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		borderRadius: { control: { type: 'text' } },

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -77,7 +77,13 @@ export { default as Dropdown } from './dropdown';
 export { default as __experimentalDropdownContentWrapper } from './dropdown/dropdown-content-wrapper';
 export { default as DropdownMenu } from './dropdown-menu';
 export { DuotoneSwatch, DuotonePicker } from './duotone-picker';
-export { Elevation as __experimentalElevation } from './elevation';
+export {
+	/**
+	 * @deprecated Import `Elevation` instead.
+	 */
+	Elevation as __experimentalElevation,
+	Elevation,
+} from './elevation';
 export { default as ExternalLink } from './external-link';
 export { Flex, FlexBlock, FlexItem } from './flex';
 export { default as FocalPointPicker } from './focal-point-picker';

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,9 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [
+			'navigation',
+			'elevation',
+		];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.