### PR TITLE
Components: Assess stabilization of `Grid`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `Grid`: Remove "experimental" designation ([#61018](https://github.com/WordPress/gutenberg/pull/61018)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/grid/README.md
+++ b/packages/components/src/grid/README.md
@@ -1,16 +1,12 @@
 # Grid
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Grid` is a primitive layout component that can arrange content in a grid configuration.
 
 ## Usage
 
 ```jsx
 import {
-	__experimentalGrid as Grid,
+	Grid,
 	__experimentalText as Text,
 } from '@wordpress/components';
 

--- a/packages/components/src/grid/component.tsx
+++ b/packages/components/src/grid/component.tsx
@@ -26,7 +26,7 @@ function UnconnectedGrid(
  *
  * ```jsx
  * import {
- * 	__experimentalGrid as Grid,
+ * 	Grid,
  * 	__experimentalText as Text
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/grid/stories/index.story.tsx
+++ b/packages/components/src/grid/stories/index.story.tsx
@@ -11,7 +11,7 @@ import { Grid } from '..';
 
 const meta: Meta< typeof Grid > = {
 	component: Grid,
-	title: 'Components (Experimental)/Grid',
+	title: 'Components/Grid',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		align: { control: { type: 'text' } },

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -88,7 +88,13 @@ export { default as FormToggle } from './form-toggle';
 export { default as FormTokenField } from './form-token-field';
 export { default as GradientPicker } from './gradient-picker';
 export { default as CustomGradientPicker } from './custom-gradient-picker';
-export { Grid as __experimentalGrid } from './grid';
+export {
+	/**
+	 * @deprecated Import `Grid` instead.
+	 */
+	Grid as __experimentalGrid,
+	Grid,
+} from './grid';
 export { default as Guide } from './guide';
 export { default as GuidePage } from './guide/page';
 export { Heading as __experimentalHeading } from './heading';

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,6 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation', 'grid' ];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.