### PR TITLE
Components: Assess stabilization of `Heading`

### DIFF
--- a/packages/components/src/card/card/README.md
+++ b/packages/components/src/card/card/README.md
@@ -13,7 +13,7 @@ import {
 	CardBody,
 	CardFooter,
 	__experimentalText as Text,
-	__experimentalHeading as Heading,
+	Heading,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/card/card/component.tsx
+++ b/packages/components/src/card/card/component.tsx
@@ -86,7 +86,7 @@ function UnconnectedCard(
  *   CardBody,
  *   CardFooter,
  *   __experimentalText as Text,
- *   __experimentalHeading as Heading,
+ *   Heading,
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/heading/README.md
+++ b/packages/components/src/heading/README.md
@@ -1,15 +1,11 @@
 # Heading
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Heading` renders headings and titles using the library's typography system.
 
 ## Usage
 
 ```jsx
-import { __experimentalHeading as Heading } from '@wordpress/components';
+import { Heading } from '@wordpress/components';
 
 function Example() {
 	return <Heading>Code is Poetry</Heading>;

--- a/packages/components/src/heading/component.tsx
+++ b/packages/components/src/heading/component.tsx
@@ -25,7 +25,7 @@ function UnconnectedHeading(
  * `Heading` renders headings and titles using the library's typography system.
  *
  * ```jsx
- * import { __experimentalHeading as Heading } from "@wordpress/components";
+ * import { Heading } from "@wordpress/components";
  *
  * function Example() {
  *   return <Heading>Code is Poetry</Heading>;

--- a/packages/components/src/heading/stories/index.story.tsx
+++ b/packages/components/src/heading/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { Heading } from '..';
 
 const meta: Meta< typeof Heading > = {
 	component: Heading,
-	title: 'Components (Experimental)/Heading',
+	title: 'Components/Heading',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		color: { control: { type: 'color' } },

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -91,7 +91,13 @@ export { default as CustomGradientPicker } from './custom-gradient-picker';
 export { Grid as __experimentalGrid } from './grid';
 export { default as Guide } from './guide';
 export { default as GuidePage } from './guide/page';
-export { Heading as __experimentalHeading } from './heading';
+export {
+	/**
+	 * @deprecated Import `Heading` instead.
+	 */
+	Heading as __experimentalHeading,
+	Heading,
+} from './heading';
 export { HStack as __experimentalHStack } from './h-stack';
 export { default as Icon } from './icon';
 export type { IconType } from './icon';

--- a/packages/components/src/spacer/README.md
+++ b/packages/components/src/spacer/README.md
@@ -13,7 +13,7 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	__experimentalSpacer as Spacer,
-	__experimentalHeading as Heading,
+	Heading,
 	__experimentalView as View,
 } from '@wordpress/components';
 

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,6 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation', 'heading' ];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.