### PR TITLE
Docs: handle "oneOf" in theme.json schema doc generation

### DIFF
--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -150,13 +150,17 @@ const getSettingsPropertiesMarkup = ( struct ) => {
 			}
 
 			if ( ! ps ) {
-				ps = props[ key ].oneOf.map( ( item ) =>
-					item?.type === 'object' && item?.properties
-						? keys( getPropertiesFromArray( item ) )
-								.sort()
-								.join( ', ' )
-						: ''
-				);
+				ps = props[ key ].oneOf
+					.map( ( item ) =>
+						item?.type === 'object' && item?.properties
+							? '_{' +
+							  keys( getPropertiesFromArray( item ) )
+									.sort()
+									.join( ', ' ) +
+							  '}_'
+							: ''
+					)
+					.join( ' ' );
 			}
 		}
 

--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -127,16 +127,40 @@ const getSettingsPropertiesMarkup = ( struct ) => {
 	}
 
 	let markup = '| Property  | Type   | Default | Props  |\n';
-	markup += '| ---       | ---    | ---    |---   |\n';
+	markup += '| ---    | ---    | ---    |---   |\n';
 	ks.forEach( ( key ) => {
 		const def = 'default' in props[ key ] ? props[ key ].default : '';
-		const ps =
+		let type = props[ key ].type || '';
+		let ps =
 			props[ key ].type === 'array'
 				? keys( getPropertiesFromArray( props[ key ].items ) )
 						.sort()
 						.join( ', ' )
 				: '';
-		markup += `| ${ key } | ${ props[ key ].type } | ${ def } | ${ ps } |\n`;
+
+		/*
+		 * Handle`oneOf` type definitions - extract the type and properties.
+		 * See: https://json-schema.org/understanding-json-schema/reference/combining#oneOf
+		 */
+		if ( props[ key ].oneOf && Array.isArray( props[ key ].oneOf ) ) {
+			if ( ! type ) {
+				type = props[ key ].oneOf
+					.map( ( item ) => item.type )
+					.join( ', ' );
+			}
+
+			if ( ! ps ) {
+				ps = props[ key ].oneOf.map( ( item ) =>
+					item?.type === 'object' && item?.properties
+						? keys( getPropertiesFromArray( item ) )
+								.sort()
+								.join( ', ' )
+						: ''
+				);
+			}
+		}
+
+		markup += `| ${ key } | ${ type } | ${ def } | ${ ps } |\n`;
 	} );
 
 	return markup;

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -58,7 +58,7 @@ Please note that when using this setting, `styles.spacing.padding` should always
 Settings related to borders.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | color | boolean | false |  |
 | radius | boolean | false |  |
 | style | boolean | false |  |
@@ -71,7 +71,7 @@ Settings related to borders.
 Settings related to shadows.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | defaultPresets | boolean | true |  |
 | presets | array |  | name, shadow, slug |
 
@@ -82,7 +82,7 @@ Settings related to shadows.
 Settings related to colors.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | background | boolean | true |  |
 | custom | boolean | true |  |
 | customDuotone | boolean | true |  |
@@ -106,7 +106,7 @@ Settings related to colors.
 Settings related to background.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | backgroundImage | boolean | false |  |
 | backgroundSize | boolean | false |  |
 
@@ -117,7 +117,7 @@ Settings related to background.
 Settings related to dimensions.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | aspectRatio | boolean | false |  |
 | minHeight | boolean | false |  |
 
@@ -128,7 +128,7 @@ Settings related to dimensions.
 Settings related to layout.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | contentSize | string |  |  |
 | wideSize | string |  |  |
 | allowEditing | boolean | true |  |
@@ -141,7 +141,7 @@ Settings related to layout.
 Settings related to the lightbox.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | enabled | boolean |  |  |
 | allowEditing | boolean |  |  |
 
@@ -152,7 +152,7 @@ Settings related to the lightbox.
 Settings related to position.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | sticky | boolean | false |  |
 
 ---
@@ -162,8 +162,8 @@ Settings related to position.
 Settings related to spacing.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| blockGap | undefined | null |  |
+| ---    | ---    | ---    |---   |
+| blockGap | boolean, null | null | , |
 | margin | boolean | false |  |
 | padding | boolean | false |  |
 | units | array | px,em,rem,vh,vw,% |  |
@@ -178,11 +178,11 @@ Settings related to spacing.
 Settings related to typography.
 
 | Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
+| ---    | ---    | ---    |---   |
 | customFontSize | boolean | true |  |
 | fontStyle | boolean | true |  |
 | fontWeight | boolean | true |  |
-| fluid | undefined | false |  |
+| fluid | object, boolean | false | maxViewportWidth, minFontSize, minViewportWidth, |
 | letterSpacing | boolean | true |  |
 | lineHeight | boolean | false |  |
 | textAlign | boolean | true |  |

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -163,7 +163,7 @@ Settings related to spacing.
 
 | Property  | Type   | Default | Props  |
 | ---    | ---    | ---    |---   |
-| blockGap | boolean, null | null | , |
+| blockGap | boolean, null | null |   |
 | margin | boolean | false |  |
 | padding | boolean | false |  |
 | units | array | px,em,rem,vh,vw,% |  |
@@ -182,7 +182,7 @@ Settings related to typography.
 | customFontSize | boolean | true |  |
 | fontStyle | boolean | true |  |
 | fontWeight | boolean | true |  |
-| fluid | object, boolean | false | maxViewportWidth, minFontSize, minViewportWidth, |
+| fluid | object, boolean | false | _{maxViewportWidth, minFontSize, minViewportWidth}_  |
 | letterSpacing | boolean | true |  |
 | lineHeight | boolean | false |  |
 | textAlign | boolean | true |  |


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When generating theme.json docs, handle "oneOf" multiple types.

Props to @t-hamano and @carolinan for discovering this over in https://github.com/WordPress/gutenberg/pull/60980

## Why?
To properly document theme.json schema multiple types.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Run `npm run docs:build` locally, and or check out [docs/reference-guides/theme-json-reference/theme-json-living.md](https://github.com/WordPress/gutenberg/blob/83ad94fcb6c6d311cc7bdc99e3c4c0119da8a94f/docs/reference-guides/theme-json-reference/theme-json-living.md) in this branch

<img width="846" alt="Screenshot 2024-04-24 at 3 17 28 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/76769317-9480-4251-a046-8c1c09c13428">



