### PR TITLE
Group: Remove hard-coded Group block example styles

### DIFF
--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -22,14 +22,6 @@ export { metadata, name };
 export const settings = {
 	icon,
 	example: {
-		attributes: {
-			style: {
-				color: {
-					text: '#000000',
-					background: '#ffffff',
-				},
-			},
-		},
 		innerBlocks: [
 			{
 				name: 'core/paragraph',


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/57908

_**Note: The changes in this PR are being split out from https://github.com/WordPress/gutenberg/pull/57908 to make that more manageable**_

## What?

Removes hardcoded style attributes from the Group block example.

## Why?

The hardcoded styles are applied inline which interferes with providing accurate previews for block style variations.


## Testing Instructions

1. Load the editor
2. Add a paragraph block
3. Hover over the Group block transform and make sure the Group block preview displays ok

