### PR TITLE
Block Styles: Add extended version of register block style functions

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -77,3 +77,46 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 		add_filter( 'render_block', $callback, 10, 2 );
 	}
 }
+
+/*
+ * WP_Block_Styles_Registry was marked as `final` in core so it cannot be
+ * updated via Gutenberg to allow registration of a style across multiple
+ * block types as well as with an optional style object. This function will
+ * support the desired functionality until the styles registry can be updated
+ * in core.
+ */
+if ( ! function_exists( 'gutenberg_register_block_style' ) ) {
+	/**
+	 * Registers a new block style for one or more block types.
+	 *
+	 * @param string|array $block_name       Block type name including namespace or array of namespaced block type names.
+	 * @param array        $style_properties Array containing the properties of the style name, label,
+	 *                                       style_handle (name of the stylesheet to be enqueued),
+	 *                                       inline_style (string containing the CSS to be added),
+	 *                                       style_data (theme.json-like object to generate CSS from).
+	 *
+	 * @return bool True if all block styles were registered with success and false otherwise.
+	 */
+	function gutenberg_register_block_style( $block_name, $style_properties ) {
+		if ( ! is_string( $block_name ) && ! is_array( $block_name ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Block name must be a string or array.', 'gutenberg' ),
+				'6.6.0'
+			);
+
+			return false;
+		}
+
+		$block_names = is_string( $block_name ) ? array( $block_name ) : $block_name;
+		$result      = true;
+
+		foreach ( $block_names as $name ) {
+			if ( ! WP_Block_Styles_Registry::get_instance()->register( $name, $style_properties ) ) {
+				$result = false;
+			}
+		}
+
+		return $result;
+	}
+}

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -507,7 +507,7 @@ _Parameters_
 
 ### registerBlockStyle
 
-Registers a new block style for the given block.
+Registers a new block style for the given block types.
 
 For more information on connecting the styles with CSS [the official documentation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/#styles).
 
@@ -536,7 +536,7 @@ const ExampleComponent = () => {
 
 _Parameters_
 
--   _blockName_ `string`: Name of block (example: “core/latest-posts”).
+-   _blockNames_ `string|Array`: Name of blocks e.g. “core/latest-posts” or `["core/group", "core/columns"]`.
 -   _styleVariation_ `Object`: Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
 
 ### registerBlockType

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -611,13 +611,13 @@ export const hasChildBlocksWithInserterSupport = ( blockName ) => {
 };
 
 /**
- * Registers a new block style for the given block.
+ * Registers a new block style for the given block types.
  *
  * For more information on connecting the styles with CSS
  * [the official documentation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/#styles).
  *
- * @param {string} blockName      Name of block (example: “core/latest-posts”).
- * @param {Object} styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
+ * @param {string|Array} blockNames     Name of blocks e.g. “core/latest-posts” or `["core/group", "core/columns"]`.
+ * @param {Object}       styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
  *
  * @example
  * ```js
@@ -642,8 +642,8 @@ export const hasChildBlocksWithInserterSupport = ( blockName ) => {
  * };
  * ```
  */
-export const registerBlockStyle = ( blockName, styleVariation ) => {
-	dispatch( blocksStore ).addBlockStyles( blockName, styleVariation );
+export const registerBlockStyle = ( blockNames, styleVariation ) => {
+	dispatch( blocksStore ).addBlockStyles( blockNames, styleVariation );
 };
 
 /**

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -98,18 +98,18 @@ export function removeBlockTypes( names ) {
  * Returns an action object used in signalling that new block styles have been added.
  * Ignored from documentation as the recommended usage for this action through registerBlockStyle from @wordpress/blocks.
  *
- * @param {string}       blockName Block name.
- * @param {Array|Object} styles    Block style object or array of block style objects.
+ * @param {string|Array} blockNames Block names to register new styles for.
+ * @param {Array|Object} styles     Block style object or array of block style objects.
  *
  * @ignore
  *
  * @return {Object} Action object.
  */
-export function addBlockStyles( blockName, styles ) {
+export function addBlockStyles( blockNames, styles ) {
 	return {
 		type: 'ADD_BLOCK_STYLES',
 		styles: Array.isArray( styles ) ? styles : [ styles ],
-		blockName,
+		blockNames: Array.isArray( blockNames ) ? blockNames : [ blockNames ],
 	};
 }
 

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -201,13 +201,14 @@ export function blockStyles( state = {}, action ) {
 				),
 			};
 		case 'ADD_BLOCK_STYLES':
-			return {
-				...state,
-				[ action.blockName ]: getUniqueItemsByName( [
-					...( state[ action.blockName ] ?? [] ),
+			const updatedStyles = {};
+			action.blockNames.forEach( ( blockName ) => {
+				updatedStyles[ blockName ] = getUniqueItemsByName( [
+					...( state[ blockName ] ?? [] ),
 					...action.styles,
-				] ),
-			};
+				] );
+			} );
+			return { ...state, ...updatedStyles };
 		case 'REMOVE_BLOCK_STYLES':
 			return {
 				...state,

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -108,12 +108,12 @@ describe( 'blockStyles', () => {
 		expect( blockStyles( undefined, {} ) ).toEqual( {} );
 	} );
 
-	it( 'should add a new block styles', () => {
+	it( 'should add new block styles for a single block type', () => {
 		const original = deepFreeze( {} );
 
 		let state = blockStyles( original, {
 			type: 'ADD_BLOCK_STYLES',
-			blockName,
+			blockNames: [ blockName ],
 			styles: [ { name: 'fancy' } ],
 		} );
 
@@ -123,12 +123,38 @@ describe( 'blockStyles', () => {
 
 		state = blockStyles( state, {
 			type: 'ADD_BLOCK_STYLES',
-			blockName,
+			blockNames: [ blockName ],
 			styles: [ { name: 'lightbox' } ],
 		} );
 
 		expect( state ).toEqual( {
 			[ blockName ]: [ { name: 'fancy' }, { name: 'lightbox' } ],
+		} );
+	} );
+
+	it( 'should add block styles for array of block types', () => {
+		const original = deepFreeze( {} );
+
+		let state = blockStyles( original, {
+			type: 'ADD_BLOCK_STYLES',
+			blockNames: [ 'core/group', 'core/columns' ],
+			styles: [ { name: 'dark' } ],
+		} );
+
+		expect( state ).toEqual( {
+			'core/group': [ { name: 'dark' } ],
+			'core/columns': [ { name: 'dark' } ],
+		} );
+
+		state = blockStyles( state, {
+			type: 'ADD_BLOCK_STYLES',
+			blockNames: [ 'core/group' ],
+			styles: [ { name: 'light' } ],
+		} );
+
+		expect( state ).toEqual( {
+			'core/group': [ { name: 'dark' }, { name: 'light' } ],
+			'core/columns': [ { name: 'dark' } ],
 		} );
 	} );
 

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -113,7 +113,7 @@ describe( 'blockStyles', () => {
 
 		let state = blockStyles( original, {
 			type: 'ADD_BLOCK_STYLES',
-			blockNames: blockName,
+			blockNames: [ blockName ],
 			styles: [ { name: 'fancy' } ],
 		} );
 
@@ -123,7 +123,7 @@ describe( 'blockStyles', () => {
 
 		state = blockStyles( state, {
 			type: 'ADD_BLOCK_STYLES',
-			blockNames: blockName,
+			blockNames: [ blockName ],
 			styles: [ { name: 'lightbox' } ],
 		} );
 

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -10,6 +10,7 @@ import {
 	addBlockVariations,
 	addBlockTypes,
 	removeBlockVariations,
+	addBlockStyles,
 } from '../actions';
 import {
 	unprocessedBlockTypes,
@@ -111,21 +112,19 @@ describe( 'blockStyles', () => {
 	it( 'should add new block styles for a single block type', () => {
 		const original = deepFreeze( {} );
 
-		let state = blockStyles( original, {
-			type: 'ADD_BLOCK_STYLES',
-			blockNames: [ blockName ],
-			styles: [ { name: 'fancy' } ],
-		} );
+		let state = blockStyles(
+			original,
+			addBlockStyles( blockName, [ { name: 'fancy' } ] )
+		);
 
 		expect( state ).toEqual( {
 			[ blockName ]: [ { name: 'fancy' } ],
 		} );
 
-		state = blockStyles( state, {
-			type: 'ADD_BLOCK_STYLES',
-			blockNames: [ blockName ],
-			styles: [ { name: 'lightbox' } ],
-		} );
+		state = blockStyles(
+			state,
+			addBlockStyles( blockName, [ { name: 'lightbox' } ] )
+		);
 
 		expect( state ).toEqual( {
 			[ blockName ]: [ { name: 'fancy' }, { name: 'lightbox' } ],
@@ -135,22 +134,23 @@ describe( 'blockStyles', () => {
 	it( 'should add block styles for array of block types', () => {
 		const original = deepFreeze( {} );
 
-		let state = blockStyles( original, {
-			type: 'ADD_BLOCK_STYLES',
-			blockNames: [ 'core/group', 'core/columns' ],
-			styles: [ { name: 'dark' } ],
-		} );
+		let state = blockStyles(
+			original,
+			addBlockStyles(
+				[ 'core/group', 'core/columns' ],
+				[ { name: 'dark' } ]
+			)
+		);
 
 		expect( state ).toEqual( {
 			'core/group': [ { name: 'dark' } ],
 			'core/columns': [ { name: 'dark' } ],
 		} );
 
-		state = blockStyles( state, {
-			type: 'ADD_BLOCK_STYLES',
-			blockNames: [ 'core/group' ],
-			styles: [ { name: 'light' } ],
-		} );
+		state = blockStyles(
+			state,
+			addBlockStyles( [ 'core/group' ], [ { name: 'light' } ] )
+		);
 
 		expect( state ).toEqual( {
 			'core/group': [ { name: 'dark' }, { name: 'light' } ],

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -113,7 +113,7 @@ describe( 'blockStyles', () => {
 
 		let state = blockStyles( original, {
 			type: 'ADD_BLOCK_STYLES',
-			blockNames: [ blockName ],
+			blockNames: blockName,
 			styles: [ { name: 'fancy' } ],
 		} );
 
@@ -123,7 +123,7 @@ describe( 'blockStyles', () => {
 
 		state = blockStyles( state, {
 			type: 'ADD_BLOCK_STYLES',
-			blockNames: [ blockName ],
+			blockNames: blockName,
 			styles: [ { name: 'lightbox' } ],
 		} );
 

--- a/phpunit/blocks/register-block-style-test.php
+++ b/phpunit/blocks/register-block-style-test.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Tests for `gutenberg_register_block_style`.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Tests for Gutenberg's extended block style registration function.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Register_Block_Style extends WP_UnitTestCase {
+	/**
+	 * Tests `gutenberg_register_block_style` registers block style
+	 * across multiple block types.
+	 */
+	public function test_gutenberg_register_block_style() {
+		$block_types      = array( 'core/group', 'core/columns', 'core/cover' );
+		$style_properties = array(
+			'name'  => 'fancy',
+			'label' => 'Fancy',
+		);
+
+		gutenberg_register_block_style( $block_types, $style_properties );
+		$registry = WP_Block_Styles_Registry::get_instance();
+
+		$this->assertTrue( $registry->is_registered( 'core/group', 'fancy' ) );
+		$this->assertTrue( $registry->is_registered( 'core/columns', 'fancy' ) );
+		$this->assertTrue( $registry->is_registered( 'core/cover', 'fancy' ) );
+	}
+}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/57908

_**Note: The changes in this PR are being split out from https://github.com/WordPress/gutenberg/pull/57908 to make that more manageable**_

## What?

The `WP_Block_Styles_Registry` class was marked `final` so it can't be extended in Gutenberg to allow block styles to be registered across multiple block types or with a style data object.

This PR adds a global function, `gutenberg_register_block_style`, that will allow Gutenberg to support the extended block style registration until it is in Core and that version of WordPress is the minimum supported by Gutenberg.

Additionally, the JS `registerBlockStyle` function has been updated to match i.e. you can pass it an array of block types to register the block style for.

## Why?

The planned [section styling](https://github.com/WordPress/gutenberg/issues/57537) feature requires the ability to share block style variations across block types.

It is desired to allow registration of such block styles through both theme.json and the existing `register_block_style` PHP function. The proposed function here helps make this possible until `register_block_style` can be updated in core.

## Testing Instructions

1. Register custom block style by adding the snippet below to your theme's functions.php file
2. In the editor, add a group and column block to the post
3. Select each block and make sure the custom block style is present in the inspector's Styles panel

```php
gutenberg_register_block_style(
	array( 'core/group', 'core/columns' ),
	array(
		'name'       => 'purple',
		'label'      => __( 'Purple' ),
		'style_data' => array(
			'color' => array(
				'background' => '#aa00aa',
				'text'       => '#330033',
			),
		),
	)
);
```

4. Test JS registration of block styles, passing either `string` block name or `array` of block names

```js
wp.blocks.registerBlockStyle( 'core/image', {
	name: 'framed',
	label: 'Framed',
} );

wp.blocks.registerBlockStyle( ['core/group', 'core/columns'], {
	name: 'fancy',
	label: 'Fancy',
} );
```


## Screenshot

<img width="293" alt="Screenshot 2024-04-24 at 5 31 56 PM" src="https://github.com/WordPress/gutenberg/assets/60436221/44b4c2ef-01c9-4b7f-bfe1-45b5b73042fe">
