### PR TITLE
Global Styles: Add scoping of feature level selectors for custom block style variations

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1200,7 +1200,7 @@ class WP_Theme_JSON_Gutenberg {
 				$node['selector'] = static::scope_selector( $options['scope'], $node['selector'] );
 			}
 			foreach ( $style_nodes as &$node ) {
-				$node['selector'] = static::scope_selector( $options['scope'], $node['selector'] );
+				$node = static::scope_style_node_selectors( $options['scope'], $node );
 			}
 			unset( $node );
 		}
@@ -4038,5 +4038,38 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		return implode( ',', $result );
+	}
+
+	/**
+	 * Scopes the selectors for a given style node. This includes the primary
+	 * selector, i.e. `$node['selector']`, as well as any custom selectors for
+	 * features and subfeatures, e.g. `$node['selectors']['border']` etc.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @param string $scope Selector to scope to.
+	 * @param array  $node  Style node with selectors to scope.
+	 *
+	 * @return array Node with updated selectors.
+	 */
+	protected static function scope_style_node_selectors( $scope, $node ) {
+		$node['selector'] = static::scope_selector( $scope, $node['selector'] );
+
+		if ( empty( $node['selectors'] ) ) {
+			return $node;
+		}
+
+		foreach ( $node['selectors'] as $feature => $selector ) {
+			if ( is_string( $selector ) ) {
+				$node['selectors'][ $feature ] = static::scope_selector( $scope, $selector );
+			}
+			if ( is_array( $selector ) ) {
+				foreach ( $selector as $subfeature => $subfeature_selector ) {
+					$node['selectors'][ $feature ][ $subfeature ] = static::scope_selector( $scope, $subfeature_selector );
+				}
+			}
+		}
+
+		return $node;
 	}
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1857,6 +1857,39 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Scopes the selectors for a given style node. This includes the primary
+	 * selector, i.e. `$node['selector']`, as well as any custom selectors for
+	 * features and subfeatures, e.g. `$node['selectors']['border']` etc.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @param string $scope Selector to scope to.
+	 * @param array  $node  Style node with selectors to scope.
+	 *
+	 * @return array Node with updated selectors.
+	 */
+	protected static function scope_style_node_selectors( $scope, $node ) {
+		$node['selector'] = static::scope_selector( $scope, $node['selector'] );
+
+		if ( empty( $node['selectors'] ) ) {
+			return $node;
+		}
+
+		foreach ( $node['selectors'] as $feature => $selector ) {
+			if ( is_string( $selector ) ) {
+				$node['selectors'][ $feature ] = static::scope_selector( $scope, $selector );
+			}
+			if ( is_array( $selector ) ) {
+				foreach ( $selector as $subfeature => $subfeature_selector ) {
+					$node['selectors'][ $feature ][ $subfeature ] = static::scope_selector( $scope, $subfeature_selector );
+				}
+			}
+		}
+
+		return $node;
+	}
+
+	/**
 	 * Gets preset values keyed by slugs based on settings and metadata.
 	 *
 	 * <code>
@@ -4038,38 +4071,5 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		return implode( ',', $result );
-	}
-
-	/**
-	 * Scopes the selectors for a given style node. This includes the primary
-	 * selector, i.e. `$node['selector']`, as well as any custom selectors for
-	 * features and subfeatures, e.g. `$node['selectors']['border']` etc.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param string $scope Selector to scope to.
-	 * @param array  $node  Style node with selectors to scope.
-	 *
-	 * @return array Node with updated selectors.
-	 */
-	protected static function scope_style_node_selectors( $scope, $node ) {
-		$node['selector'] = static::scope_selector( $scope, $node['selector'] );
-
-		if ( empty( $node['selectors'] ) ) {
-			return $node;
-		}
-
-		foreach ( $node['selectors'] as $feature => $selector ) {
-			if ( is_string( $selector ) ) {
-				$node['selectors'][ $feature ] = static::scope_selector( $scope, $selector );
-			}
-			if ( is_array( $selector ) ) {
-				foreach ( $selector as $subfeature => $subfeature_selector ) {
-					$node['selectors'][ $feature ][ $subfeature ] = static::scope_selector( $scope, $subfeature_selector );
-				}
-			}
-		}
-
-		return $node;
 	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5357,4 +5357,49 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests the correct scoping of selectors for a style node.
+	 */
+	public function test_scope_style_node_selectors() {
+		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
+
+		$func = $theme_json->getMethod( 'scope_style_node_selectors' );
+		$func->setAccessible( true );
+
+		$node = array(
+			'name'      => 'core/image',
+			'path'      => array( 'styles', 'blocks', 'core/image' ),
+			'selector'  => '.wp-block-image',
+			'selectors' => array(
+				'root'       => '.wp-block-image',
+				'border'     => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+				'typography' => array(
+					'textDecoration' => '.wp-block-image caption',
+				),
+				'filter'     => array(
+					'duotone' => '.wp-block-image img, .wp-block-image .components-placeholder',
+				),
+			),
+		);
+
+		$actual   = $func->invoke( null, '.custom-scope', $node );
+		$expected = array(
+			'name'      => 'core/image',
+			'path'      => array( 'styles', 'blocks', 'core/image' ),
+			'selector'  => '.custom-scope .wp-block-image',
+			'selectors' => array(
+				'root'       => '.custom-scope .wp-block-image',
+				'border'     => '.custom-scope .wp-block-image img, .custom-scope .wp-block-image .wp-block-image__crop-area, .custom-scope .wp-block-image .components-placeholder',
+				'typography' => array(
+					'textDecoration' => '.custom-scope .wp-block-image caption',
+				),
+				'filter'     => array(
+					'duotone' => '.custom-scope .wp-block-image img, .custom-scope .wp-block-image .components-placeholder',
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $actual );
+	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/57908

_**Note: The changes in this PR are being split out from https://github.com/WordPress/gutenberg/pull/57908 to make that more manageable**_

## What?

Ensures that feature-level selectors for block style variations are correctly scoped when generating a theme.json stylesheet.

_Important: Currently, only block styles registered via block.json on core blocks are supported through theme.json. This means the supported blocks and their block styles don't currently leverage feature-level selectors. The issue this PR addresses would only surface once custom block style variations can be defined via theme.json in #57908._

## Why?

To ensure that once custom block style variations being registered via theme.json are supported, the resulting CSS selectors are correct.


## Testing Instructions

- There should be no change to existing core block style variations that can be styled via Global Styles e.g. Image rounded
- `npm run test:unit:php:base -- --filter WP_Theme_JSON_Gutenberg_Test`

