### PR TITLE
Fix inserter position and size on mobile

### DIFF
--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -171,7 +171,9 @@ function InterfaceSkeleton(
 								<div
 									style={ {
 										position: 'absolute',
-										width: 'fit-content',
+										width: isMobileViewport
+											? '100vw'
+											: 'fit-content',
 										height: '100%',
 										right: 0,
 									} }

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -43,6 +43,7 @@ html.interface-interface-skeleton__html-container {
 @include editor-left(".interface-interface-skeleton");
 
 .interface-interface-skeleton__body {
+	position: relative;
 	flex-grow: 1;
 	display: flex;
 


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/60693#issuecomment-2069767123

## What?

We've added animations to the inserter sidebar but caused some small regression in small viewports. 
The inserter was not full width and was covering the header.
This PR fixes both of these issues.

## Testing Instructions

On a small viewport, open the inserter and check the width and the position of the inserter. It should match this screenshot.

<img width="577" alt="Screenshot 2024-04-24 at 9 39 32 AM" src="https://github.com/WordPress/gutenberg/assets/272444/aba324a7-7679-484c-a3e5-1f67056cb08c">
