### PR TITLE
Blocks: Add a warning when registering variation without a name

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -723,6 +723,10 @@ export const getBlockVariations = ( blockName, scope ) => {
  * ```
  */
 export const registerBlockVariation = ( blockName, variation ) => {
+	if ( typeof variation.name !== 'string' ) {
+		console.warn( 'Variation names must be unique strings.' );
+	}
+
 	dispatch( blocksStore ).addBlockVariations( blockName, variation );
 };
 

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -13,6 +13,7 @@ import { select, dispatch } from '@wordpress/data';
 import {
 	registerBlockType,
 	registerBlockCollection,
+	registerBlockVariation,
 	unregisterBlockCollection,
 	unregisterBlockType,
 	setFreeformContentHandlerName,
@@ -26,6 +27,7 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getBlockSupport,
+	getBlockVariations,
 	hasBlockSupport,
 	isReusableBlock,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
@@ -1408,6 +1410,26 @@ describe( 'blocks', () => {
 		it( 'should return false for other blocks', () => {
 			const block = { name: 'core/paragraph' };
 			expect( isReusableBlock( block ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'registerBlockVariation', () => {
+		it( 'should warn when registering block variation without a name', () => {
+			registerBlockType( 'core/variation-block', defaultBlockSettings );
+			registerBlockVariation( 'core/variation-block', {
+				title: 'Variation Title',
+				description: 'Variation description',
+			} );
+
+			expect( console ).toHaveWarnedWith(
+				'Variation names must be unique strings.'
+			);
+			expect( getBlockVariations( 'core/variation-block' ) ).toEqual( [
+				{
+					title: 'Variation Title',
+					description: 'Variation description',
+				},
+			] );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
This is a follow-up to #60832.

PR adds a warning to block the variation registration method when the variation name is missing. The registrar's behavior remains the same.

## Why?
The block variations must have a unique name to work correctly in the block editor.

## How
The method is the soft version of the `registerBlockType` function validation. 

## Testing Instructions
1. Open a post or page.
2. Run the test snippet in the DevTools console.
3. Confirm that the warning is logged.

### Test snippet

```js
wp.blocks.registerBlockVariation( 'core/embed', { title: 'My Custom Embed', attributes: { providerNameSlug: 'custom' } } );
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-24 at 13 02 27](https://github.com/WordPress/gutenberg/assets/240569/d096c72b-8acb-4fa8-94f6-59186fe777b4)
