### PR TITLE
Editor: Sort style overrides by block client ids

### DIFF
--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -72,7 +72,6 @@ function EditorStyles( { styles, scope } ) {
 		( select ) => unlock( select( blockEditorStore ) ).getStyleOverrides(),
 		[]
 	);
-
 	const [ transformedStyles, transformedSvgs ] = useMemo( () => {
 		const _styles = Object.values( styles ?? [] );
 

--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -68,32 +68,15 @@ function useDarkThemeBodyClassName( styles, scope ) {
 }
 
 function EditorStyles( { styles, scope } ) {
-	const { overrides, clientIds } = useSelect(
-		( select ) => ( {
-			overrides: unlock( select( blockEditorStore ) ).getStyleOverrides(),
-			clientIds: select( blockEditorStore ).getClientIdsWithDescendants(),
-		} ),
+	const overrides = useSelect(
+		( select ) => unlock( select( blockEditorStore ) ).getStyleOverrides(),
 		[]
 	);
 
 	const [ transformedStyles, transformedSvgs ] = useMemo( () => {
-		const clientIdMap = clientIds.reduce( ( acc, clientId, index ) => {
-			acc[ clientId ] = index;
-			return acc;
-		}, {} );
-
-		// Sort overrides to match the order of blocks they relate to.
-		// This is useful to maintain the correct CSS cascade order for
-		// nested block style variations.
-		const sortedOverrides = [ ...overrides ].sort( ( a, b ) => {
-			const aIndex = clientIdMap[ a[ 1 ].clientId ] ?? -1;
-			const bIndex = clientIdMap[ b[ 1 ].clientId ] ?? -1;
-			return aIndex - bIndex;
-		} );
-
 		const _styles = Object.values( styles ?? [] );
 
-		for ( const [ id, override ] of sortedOverrides ) {
+		for ( const [ id, override ] of overrides ) {
 			const index = _styles.findIndex( ( { id: _id } ) => id === _id );
 			const overrideWithId = { ...override, id };
 			if ( index === -1 ) {
@@ -113,7 +96,7 @@ function EditorStyles( { styles, scope } ) {
 				.map( ( style ) => style.assets )
 				.join( '' ),
 		];
-	}, [ styles, overrides, scope, clientIds ] );
+	}, [ styles, overrides, scope ] );
 
 	return (
 		<>

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -135,7 +135,13 @@ export function shouldSkipSerialization(
 
 const pendingStyleOverrides = new WeakMap();
 
-export function useStyleOverride( { id, css, assets, __unstableType } = {} ) {
+export function useStyleOverride( {
+	id,
+	css,
+	assets,
+	__unstableType,
+	clientId,
+} = {} ) {
 	const { setStyleOverride, deleteStyleOverride } = unlock(
 		useDispatch( blockEditorStore )
 	);
@@ -151,6 +157,7 @@ export function useStyleOverride( { id, css, assets, __unstableType } = {} ) {
 			css,
 			assets,
 			__unstableType,
+			clientId,
 		};
 		// Batch updates to style overrides to avoid triggering cascading renders
 		// for each style override block included in a tree and optimize initial render.
@@ -187,6 +194,7 @@ export function useStyleOverride( { id, css, assets, __unstableType } = {} ) {
 	}, [
 		id,
 		css,
+		clientId,
 		assets,
 		__unstableType,
 		fallbackId,

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -181,7 +181,7 @@ export function getOpenedBlockSettingsMenu( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {Map} A map of style IDs to style overrides.
+ * @return {Array} An array of style ID to style override pairs.
  */
 export const getStyleOverrides = createSelector(
 	( state ) => {
@@ -191,9 +191,16 @@ export const getStyleOverrides = createSelector(
 			return acc;
 		}, {} );
 
-		return [ ...state.styleOverrides ].sort( ( a, b ) => {
-			const aIndex = clientIdMap[ a[ 1 ].clientId ] ?? -1;
-			const bIndex = clientIdMap[ b[ 1 ].clientId ] ?? -1;
+		return [ ...state.styleOverrides ].sort( ( overrideA, overrideB ) => {
+			// Once the overrides Map is spread to an array, the first element
+			// is the key, while the second is the override itself including
+			// the clientId to sort by.
+			const [ , { clientId: clientIdA } ] = overrideA;
+			const [ , { clientId: clientIdB } ] = overrideB;
+
+			const aIndex = clientIdMap[ clientIdA ] ?? -1;
+			const bIndex = clientIdMap[ clientIdB ] ?? -1;
+
 			return aIndex - bIndex;
 		} );
 	},


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/57908
- https://github.com/WordPress/gutenberg/pull/60940

_**Note: The changes in this PR are being split out from https://github.com/WordPress/gutenberg/pull/57908 to make that more manageable**_

## What?

- Adds the ability to assign a block's `clientId` to editor style overrides
- Sorts style overrides by the order of blocks based on `clientId`

## Why?

The extended block style variations feature in #57908 relies on being able to generate styles for individual applications of block style variations and having those styles in the order of blocks. Without this ability, block style variations can't reliably be nested.

