### PR TITLE
Site editor: load post earlier

### DIFF
--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -34,42 +34,62 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 		postsPageId,
 		url,
 		frontPageTemplateId,
-	} = useSelect( ( select ) => {
-		const { getSite, getUnstableBase, getEntityRecords } =
-			select( coreDataStore );
-		const siteData = getSite();
-		const base = getUnstableBase();
-		const templates = getEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
-			per_page: -1,
-		} );
-		const _homepageId =
-			siteData?.show_on_front === 'page' &&
-			[ 'number', 'string' ].includes( typeof siteData.page_on_front ) &&
-			!! +siteData.page_on_front // We also need to check if it's not zero(`0`).
-				? siteData.page_on_front.toString()
-				: null;
-		const _postsPageId =
-			siteData?.show_on_front === 'page' &&
-			[ 'number', 'string' ].includes( typeof siteData.page_for_posts )
-				? siteData.page_for_posts.toString()
-				: null;
-		let _frontPageTemplateId;
-		if ( templates ) {
-			const frontPageTemplate = templates.find(
-				( t ) => t.slug === 'front-page'
+		editedEntity,
+	} = useSelect(
+		( select ) => {
+			const {
+				getSite,
+				getUnstableBase,
+				getEditedEntityRecord,
+				getEntityRecords,
+			} = select( coreDataStore );
+			const siteData = getSite();
+			const base = getUnstableBase();
+			const templates = getEntityRecords(
+				'postType',
+				TEMPLATE_POST_TYPE,
+				{
+					per_page: -1,
+				}
 			);
-			_frontPageTemplateId = frontPageTemplate
-				? frontPageTemplate.id
-				: false;
-		}
-		return {
-			hasLoadedAllDependencies: !! base && !! siteData,
-			homepageId: _homepageId,
-			postsPageId: _postsPageId,
-			url: base?.home,
-			frontPageTemplateId: _frontPageTemplateId,
-		};
-	}, [] );
+			const _homepageId =
+				siteData?.show_on_front === 'page' &&
+				[ 'number', 'string' ].includes(
+					typeof siteData.page_on_front
+				) &&
+				!! +siteData.page_on_front // We also need to check if it's not zero(`0`).
+					? siteData.page_on_front.toString()
+					: null;
+			const _postsPageId =
+				siteData?.show_on_front === 'page' &&
+				[ 'number', 'string' ].includes(
+					typeof siteData.page_for_posts
+				)
+					? siteData.page_for_posts.toString()
+					: null;
+			let _frontPageTemplateId;
+			if ( templates ) {
+				const frontPageTemplate = templates.find(
+					( t ) => t.slug === 'front-page'
+				);
+				_frontPageTemplateId = frontPageTemplate
+					? frontPageTemplate.id
+					: false;
+			}
+			return {
+				hasLoadedAllDependencies: !! base && !! siteData,
+				homepageId: _homepageId,
+				postsPageId: _postsPageId,
+				url: base?.home,
+				frontPageTemplateId: _frontPageTemplateId,
+				editedEntity:
+					postType && postId
+						? getEditedEntityRecord( 'postType', postType, postId )
+						: undefined,
+			};
+		},
+		[ postType, postId ]
+	);
 
 	/**
 	 * This is a hook that recreates the logic to resolve a template for a given WordPress postID postTypeId
@@ -86,7 +106,6 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 			}
 
 			const {
-				getEditedEntityRecord,
 				getEntityRecords,
 				getDefaultTemplateId,
 				__experimentalGetTemplateForLink,
@@ -112,11 +131,6 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 					}
 				}
 
-				const editedEntity = getEditedEntityRecord(
-					'postType',
-					postTypeToResolve,
-					postIdToResolve
-				);
 				if ( ! editedEntity ) {
 					return undefined;
 				}
@@ -198,6 +212,7 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 			postType,
 			path,
 			frontPageTemplateId,
+			editedEntity,
 		]
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

[without whitespace](https://github.com/WordPress/gutenberg/pull/61046/files?diff=split&w=1)

## What?
<!-- In a few words, what is the PR actually doing? -->

We're currently waiting to request the post for the server until site settings etc. are loaded, but there's no reason to delay this when we already have the post ID (from the URL).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Loading resources in parallel should speed up site editor loading.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
