### PR TITLE
Editor: No need to memorize callback in 'SwapTemplateButton'

### DIFF
--- a/packages/editor/src/components/post-template/swap-template-button.js
+++ b/packages/editor/src/components/post-template/swap-template-button.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useState, useCallback } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { MenuItem, Modal } from '@wordpress/components';
@@ -18,9 +18,6 @@ import { useAvailableTemplates, useEditedPostContext } from './hooks';
 
 export default function SwapTemplateButton( { onClick } ) {
 	const [ showModal, setShowModal ] = useState( false );
-	const onClose = useCallback( () => {
-		setShowModal( false );
-	}, [] );
 	const { postType, postId } = useEditedPostContext();
 	const availableTemplates = useAvailableTemplates( postType );
 	const { editEntityRecord } = useDispatch( coreStore );
@@ -35,7 +32,7 @@ export default function SwapTemplateButton( { onClick } ) {
 			{ template: template.name },
 			{ undoIgnore: true }
 		);
-		onClose(); // Close the template suggestions modal first.
+		setShowModal( false ); // Close the template suggestions modal first.
 		onClick();
 	};
 	return (
@@ -46,7 +43,7 @@ export default function SwapTemplateButton( { onClick } ) {
 			{ showModal && (
 				<Modal
 					title={ __( 'Choose a template' ) }
-					onRequestClose={ onClose }
+					onRequestClose={ () => setShowModal( false ) }
 					overlayClassName="editor-post-template__swap-template-modal"
 					isFullScreen
 				>


### PR DESCRIPTION
## What?
PR removes unnecessary callback memoization in the `SwapTemplateButton` component.

Story: I was looking into #61031 and noticed the memoization.

## Why?
The callback isn't passed to an effect, memoized component or another memoized callback.

## How?
I just inlined the `setState` calls.

## Testing Instructions
1. Open a post or page.
2. Confirm 'Swap

### Testing Instructions for Keyboard
Same.
