### PR TITLE
ListViewBlock: Combine 'useSelect' hooks, part two

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -82,25 +82,26 @@ function ListViewBlock( {
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 
-	const { block, blockName, blockEditingMode } = useSelect(
-		( select ) => {
-			const { getBlock, getBlockName, getBlockEditingMode } =
-				select( blockEditorStore );
+	const { block, blockName, blockEditingMode, allowRightClickOverrides } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlock,
+					getBlockName,
+					getBlockEditingMode,
+					getSettings,
+				} = select( blockEditorStore );
 
-			return {
-				block: getBlock( clientId ),
-				blockName: getBlockName( clientId ),
-				blockEditingMode: getBlockEditingMode( clientId ),
-			};
-		},
-		[ clientId ]
-	);
-
-	const allowRightClickOverrides = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().allowRightClickOverrides,
-		[]
-	);
+				return {
+					block: getBlock( clientId ),
+					blockName: getBlockName( clientId ),
+					blockEditingMode: getBlockEditingMode( clientId ),
+					allowRightClickOverrides:
+						getSettings().allowRightClickOverrides,
+				};
+			},
+			[ clientId ]
+		);
 
 	const showBlockActions =
 		// When a block hides its toolbar it also hides the block settings menu,


### PR DESCRIPTION
## What?
PR moves the `allowRightClickOverrides` setting selection into the existing `mapSelect`.

## Why?
Reduces the number of store subscriptions to the active `core/block-editor` store

## Testing Instructions
1. Open a post or page. 
2. Add a few blocks.
3. Open the List View.
4. Confirm that the right mouse click on the list view block item opens the block options dropdown.
5. Disable setting via Preferences modal.
6. Repeat the 4th step. It should revert to native browser behavior.

### Testing Instructions for Keyboard
Same.
