### PR TITLE
Components: Assess stabilization of `ItemGroup`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `ItemGroup`: Remove "experimental" designation ([#61060](https://github.com/WordPress/gutenberg/pull/61060)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -97,8 +97,12 @@ export { default as Icon } from './icon';
 export type { IconType } from './icon';
 export { default as IconButton } from './button/deprecated';
 export {
+	/**
+	 * @deprecated Import `ItemGroup` instead.
+	 */
 	ItemGroup as __experimentalItemGroup,
 	Item as __experimentalItem,
+	ItemGroup,
 } from './item-group';
 export { default as __experimentalInputControl } from './input-control';
 export { default as __experimentalInputControlPrefixWrapper } from './input-control/input-prefix-wrapper';

--- a/packages/components/src/item-group/item-group/README.md
+++ b/packages/components/src/item-group/item-group/README.md
@@ -1,9 +1,5 @@
 # `ItemGroup`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `ItemGroup` displays a list of `Item`s grouped and styled together.
 
 ## Usage
@@ -12,7 +8,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalItemGroup as ItemGroup,
+	ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
 
@@ -66,7 +62,7 @@ In the following example, the `<Item />` will render with a size of `small`:
 
 ```jsx
 import {
-	__experimentalItemGroup as ItemGroup,
+	ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
 

--- a/packages/components/src/item-group/item-group/component.tsx
+++ b/packages/components/src/item-group/item-group/component.tsx
@@ -46,7 +46,7 @@ function UnconnectedItemGroup(
  *
  * ```jsx
  * import {
- *   __experimentalItemGroup as ItemGroup,
+ *   ItemGroup,
  *   __experimentalItem as Item,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/item-group/item/README.md
+++ b/packages/components/src/item-group/item/README.md
@@ -1,9 +1,5 @@
 # `Item`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Item` is used in combination with `ItemGroup` to display a list of items grouped and styled together.
 
 ## Usage
@@ -12,7 +8,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalItemGroup as ItemGroup,
+	ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
 
@@ -50,7 +46,7 @@ In the following example, the `<Item />` will render with a size of `small`:
 
 ```jsx
 import {
-	__experimentalItemGroup as ItemGroup,
+	ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
 

--- a/packages/components/src/item-group/item/component.tsx
+++ b/packages/components/src/item-group/item/component.tsx
@@ -31,7 +31,7 @@ function UnconnectedItem(
  *
  * ```jsx
  * import {
- *   __experimentalItemGroup as ItemGroup,
+ *   ItemGroup,
  *   __experimentalItem as Item,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/item-group/stories/index.story.tsx
+++ b/packages/components/src/item-group/stories/index.story.tsx
@@ -15,7 +15,7 @@ const meta: Meta< typeof ItemGroup > = {
 	component: ItemGroup,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { Item },
-	title: 'Components (Experimental)/ItemGroup',
+	title: 'Components/ItemGroup',
 	argTypes: {
 		as: { control: { type: null } },
 		children: { control: { type: null } },

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,9 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [
+			'navigation',
+			'itemgroup',
+		];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.



