### PR TITLE
Components: Assess stabilization of `Scrollable`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `Scrollable`: Remove "experimental" designation ([#61063](https://github.com/WordPress/gutenberg/pull/61063)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -144,8 +144,20 @@ export { default as SearchControl } from './search-control';
 export { default as SelectControl } from './select-control';
 export { default as Snackbar } from './snackbar';
 export { default as SnackbarList } from './snackbar/list';
-export { Spacer as __experimentalSpacer } from './spacer';
-export { Scrollable as __experimentalScrollable } from './scrollable';
+export {
+	/**
+	 * @deprecated Import `Spacer` instead.
+	 */
+	Spacer as __experimentalSpacer,
+	Spacer,
+} from './spacer';
+export {
+	/**
+	 * @deprecated Import `Scrollable` instead.
+	 */
+	Scrollable as __experimentalScrollable,
+	Scrollable,
+} from './scrollable';
 export { default as Spinner } from './spinner';
 export { Surface as __experimentalSurface } from './surface';
 export { default as TabPanel } from './tab-panel';

--- a/packages/components/src/scrollable/README.md
+++ b/packages/components/src/scrollable/README.md
@@ -1,15 +1,11 @@
 # Scrollable
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Scrollable` is a layout component that content in a scrollable container.
 
 ## Usage
 
 ```jsx
-import { __experimentalScrollable as Scrollable } from '@wordpress/components';
+import { Scrollable } from '@wordpress/components';
 
 function Example() {
 	return (

--- a/packages/components/src/scrollable/component.tsx
+++ b/packages/components/src/scrollable/component.tsx
@@ -25,7 +25,7 @@ function UnconnectedScrollable(
  * `Scrollable` is a layout component that content in a scrollable container.
  *
  * ```jsx
- * import { __experimentalScrollable as Scrollable } from `@wordpress/components`;
+ * import { Scrollable } from `@wordpress/components`;
  *
  * function Example() {
  * 	return (

--- a/packages/components/src/scrollable/stories/index.story.tsx
+++ b/packages/components/src/scrollable/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { Scrollable } from '..';
 
 const meta: Meta< typeof Scrollable > = {
 	component: Scrollable,
-	title: 'Components (Experimental)/Scrollable',
+	title: 'Components/Scrollable',
 	argTypes: {
 		as: {
 			control: { type: 'text' },

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,9 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [
+			'navigation',
+			'scrollable',
+		];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.



