### PR TITLE
Components: Assess stabilization of `Surface`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `Surface`: Remove "experimental" designation ([#61065](https://github.com/WordPress/gutenberg/pull/61065)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/elevation/README.md
+++ b/packages/components/src/elevation/README.md
@@ -13,7 +13,7 @@ The shadow effect is generated using the `value` prop.
 ```jsx
 import {
 	__experimentalElevation as Elevation,
-	__experimentalSurface as Surface,
+	Surface,
 	__experimentalText as Text,
 } from '@wordpress/components';
 

--- a/packages/components/src/elevation/component.tsx
+++ b/packages/components/src/elevation/component.tsx
@@ -30,7 +30,7 @@ function UnconnectedElevation(
  * ```jsx
  * import {
  *	__experimentalElevation as Elevation,
- *	__experimentalSurface as Surface,
+ *	Surface,
  *	__experimentalText as Text,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -147,7 +147,13 @@ export { default as SnackbarList } from './snackbar/list';
 export { Spacer as __experimentalSpacer } from './spacer';
 export { Scrollable as __experimentalScrollable } from './scrollable';
 export { default as Spinner } from './spinner';
-export { Surface as __experimentalSurface } from './surface';
+export {
+	/**
+	 * @deprecated Import `Surface` instead.
+	 */
+	Surface as __experimentalSurface,
+	Surface,
+} from './surface';
 export { default as TabPanel } from './tab-panel';
 export { Text as __experimentalText } from './text';
 export { default as TextControl } from './text-control';

--- a/packages/components/src/surface/README.md
+++ b/packages/components/src/surface/README.md
@@ -1,9 +1,5 @@
 # Surface
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Surface` is a core component that renders a primary background color.
 
 ## Usage
@@ -12,7 +8,7 @@ In the example below, notice how the `Surface` renders in white (or dark gray if
 
 ```jsx
 import {
-	__experimentalSurface as Surface,
+	Surface,
 	__experimentalText as Text,
 } from '@wordpress/components';
 

--- a/packages/components/src/surface/component.tsx
+++ b/packages/components/src/surface/component.tsx
@@ -28,7 +28,7 @@ function UnconnectedSurface(
  *
  * ```jsx
  * import {
- *	__experimentalSurface as Surface,
+ *	Surface,
  *	__experimentalText as Text,
  * } from '@wordpress/components';
  *

--- a/packages/components/src/surface/stories/index.story.tsx
+++ b/packages/components/src/surface/stories/index.story.tsx
@@ -11,7 +11,7 @@ import { Text } from '../../text';
 
 const meta: Meta< typeof Surface > = {
 	component: Surface,
-	title: 'Components (Experimental)/Surface',
+	title: 'Components/Surface',
 	argTypes: {
 		children: { control: { type: null } },
 		as: { control: { type: 'text' } },

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,6 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation', 'surface' ];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.



