### PR TITLE
Components: Assess stabilization of `Text`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `Text`: Remove "experimental" designation ([#61066](https://github.com/WordPress/gutenberg/pull/61066)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/card/card/README.md
+++ b/packages/components/src/card/card/README.md
@@ -12,7 +12,7 @@ import {
 	CardHeader,
 	CardBody,
 	CardFooter,
-	__experimentalText as Text,
+	Text,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
 

--- a/packages/components/src/card/card/component.tsx
+++ b/packages/components/src/card/card/component.tsx
@@ -85,7 +85,7 @@ function UnconnectedCard(
  *   CardHeader,
  *   CardBody,
  *   CardFooter,
- *   __experimentalText as Text,
+ *   Text,
  *   __experimentalHeading as Heading,
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/divider/README.md
+++ b/packages/components/src/divider/README.md
@@ -11,7 +11,7 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	__experimentalDivider as Divider,
-	__experimentalText as Text,
+	Text,
 	__experimentalVStack as VStack,
 } from `@wordpress/components`;
 

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -34,7 +34,7 @@ function UnconnectedDivider(
  * ```js
  * import {
  * 		__experimentalDivider as Divider,
- * 		__experimentalText as Text,
+ * 		Text,
  * 		__experimentalVStack as VStack,
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/elevation/README.md
+++ b/packages/components/src/elevation/README.md
@@ -14,7 +14,7 @@ The shadow effect is generated using the `value` prop.
 import {
 	__experimentalElevation as Elevation,
 	__experimentalSurface as Surface,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/elevation/component.tsx
+++ b/packages/components/src/elevation/component.tsx
@@ -31,7 +31,7 @@ function UnconnectedElevation(
  * import {
  *	__experimentalElevation as Elevation,
  *	__experimentalSurface as Surface,
- *	__experimentalText as Text,
+ *	Text,
  * } from '@wordpress/components';
  *
  * function Example() {

--- a/packages/components/src/grid/README.md
+++ b/packages/components/src/grid/README.md
@@ -11,7 +11,7 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	__experimentalGrid as Grid,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/grid/component.tsx
+++ b/packages/components/src/grid/component.tsx
@@ -27,7 +27,7 @@ function UnconnectedGrid(
  * ```jsx
  * import {
  * 	__experimentalGrid as Grid,
- * 	__experimentalText as Text
+ * 	Text
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/h-stack/README.md
+++ b/packages/components/src/h-stack/README.md
@@ -13,7 +13,7 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	__experimentalHStack as HStack,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {
@@ -87,7 +87,7 @@ When a `Spacer` is used within an `HStack`, the `Spacer` adaptively expands to t
 import {
 	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {
@@ -109,7 +109,7 @@ function Example() {
 import {
 	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/h-stack/component.tsx
+++ b/packages/components/src/h-stack/component.tsx
@@ -24,7 +24,7 @@ function UnconnectedHStack(
  * ```jsx
  * import {
  * 	__experimentalHStack as HStack,
- * 	__experimentalText as Text,
+ * 	Text,
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -149,7 +149,13 @@ export { Scrollable as __experimentalScrollable } from './scrollable';
 export { default as Spinner } from './spinner';
 export { Surface as __experimentalSurface } from './surface';
 export { default as TabPanel } from './tab-panel';
-export { Text as __experimentalText } from './text';
+export {
+	/**
+	 * @deprecated Import `Text` instead.
+	 */
+	Text as __experimentalText,
+	Text,
+} from './text';
 export { default as TextControl } from './text-control';
 export { default as TextareaControl } from './textarea-control';
 export { default as TextHighlight } from './text-highlight';

--- a/packages/components/src/surface/README.md
+++ b/packages/components/src/surface/README.md
@@ -13,7 +13,7 @@ In the example below, notice how the `Surface` renders in white (or dark gray if
 ```jsx
 import {
 	__experimentalSurface as Surface,
-	__experimentalText as Text,
+	Text,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/surface/component.tsx
+++ b/packages/components/src/surface/component.tsx
@@ -29,7 +29,7 @@ function UnconnectedSurface(
  * ```jsx
  * import {
  *	__experimentalSurface as Surface,
- *	__experimentalText as Text,
+ *	Text,
  * } from '@wordpress/components';
  *
  * function Example() {

--- a/packages/components/src/text/README.md
+++ b/packages/components/src/text/README.md
@@ -1,9 +1,5 @@
 # Text
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 `Text` is a core component that renders text in the library, using the library's typography system.
 
 ## Usage
@@ -11,7 +7,7 @@ This feature is still experimental. “Experimental” means this is an early im
 `Text` can be used to render any text-content, like an HTML `p` or `span`.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return <Text>Code is Poetry</Text>;
@@ -27,7 +23,7 @@ function Example() {
 Automatically calculate the appropriate line-height value for contents that render text and Control elements (e.g. `TextInput`).
 
 ```jsx
-import { __experimentalText as Text, TextInput } from '@wordpress/components';
+import { Text, TextInput } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -46,7 +42,7 @@ function Example() {
 Adjusts the text alignment.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -111,7 +107,7 @@ Array of search words. String search terms are automatically cast to RegExps unl
 Letters or words within `Text` can be highlighted using `highlightWords`.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -165,7 +161,7 @@ Clamps the text content to the specifiec `numberOfLines`, adding the `ellipsis` 
 The `Text` color can be adapted to a background color for optimal readability. `optimizeReadabilityFor` can accept CSS variables, in addition to standard CSS color values (e.g. Hex, RGB, HSL, etc...).
 
 ```jsx
-import { __experimentalText as Text, View } from '@wordpress/components';
+import { Text, View } from '@wordpress/components';
 
 function Example() {
 	const backgroundColor = 'blue';
@@ -187,7 +183,7 @@ function Example() {
 Adjusts text size based on the typography system. `Text` can render a wide range of font sizes, which are automatically calculated and adapted to the typography system. The `size` value can be a system preset, a `number`, or a custom unit value (`string`) such as `30em`.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return <Text size="largeTitle">Code is Poetry</Text>;
@@ -203,7 +199,7 @@ Enables text truncation. When `truncate` is set, we are able to truncate the lon
 Note: text truncation won't work if the `isBlock` property is set to `true`
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return (
@@ -231,7 +227,7 @@ Uppercases the text content.
 Adjusts style variation of the text.
 
 ```jsx
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@wordpress/components';
 
 function Example() {
 	return <Text variant="muted">Code is Poetry</Text>;

--- a/packages/components/src/text/component.tsx
+++ b/packages/components/src/text/component.tsx
@@ -29,7 +29,7 @@ function UnconnectedText(
  * @example
  *
  * ```jsx
- * import { __experimentalText as Text } from `@wordpress/components`;
+ * import { Text } from `@wordpress/components`;
  *
  * function Example() {
  * 	return <Text>Code is Poetry</Text>;

--- a/packages/components/src/text/stories/index.story.tsx
+++ b/packages/components/src/text/stories/index.story.tsx
@@ -10,7 +10,7 @@ import { Text } from '../component';
 
 const meta: Meta< typeof Text > = {
 	component: Text,
-	title: 'Components (Experimental)/Text',
+	title: 'Components/Text',
 	argTypes: {
 		as: { control: { type: 'text' } },
 		color: { control: { type: 'color' } },

--- a/packages/components/src/v-stack/README.md
+++ b/packages/components/src/v-stack/README.md
@@ -12,7 +12,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalText as Text,
+	Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
@@ -74,7 +74,7 @@ When a `Spacer` is used within an `VStack`, the `Spacer` adaptively expands to t
 ```jsx
 import {
 	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
+	Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
@@ -96,7 +96,7 @@ function Example() {
 ```jsx
 import {
 	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
+	Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 

--- a/packages/components/src/v-stack/component.tsx
+++ b/packages/components/src/v-stack/component.tsx
@@ -29,7 +29,7 @@ function UnconnectedVStack(
  *
  * ```jsx
  * import {
- * 	__experimentalText as Text,
+ * 	Text,
  * 	__experimentalVStack as VStack,
  * } from `@wordpress/components`;
  *

--- a/packages/components/src/view/README.md
+++ b/packages/components/src/view/README.md
@@ -12,7 +12,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import {
-	__experimentalText as Text,
+	Text,
 	__experimentalView as View,
 } from '@wordpress/components';
 

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,6 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation', 'text' ];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.



