### PR TITLE
Components: Assess stabilization of `ToolsPanel`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `ToolsPanel`: Remove "experimental" designation ([#61068](https://github.com/WordPress/gutenberg/pull/61068)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -169,9 +169,21 @@ export {
 	ToolbarItem,
 } from './toolbar';
 export {
+	/**
+	 * @deprecated Import `ToolsPanel` instead.
+	 */
 	ToolsPanel as __experimentalToolsPanel,
+	/**
+	 * @deprecated Import `ToolsPanelItem` instead.
+	 */
 	ToolsPanelItem as __experimentalToolsPanelItem,
+	/**
+	 * @deprecated Import `ToolsPanelContext` instead.
+	 */
 	ToolsPanelContext as __experimentalToolsPanelContext,
+	ToolsPanel,
+	ToolsPanelItem,
+	ToolsPanelContext,
 } from './tools-panel';
 export { default as Tooltip } from './tooltip';
 export {

--- a/packages/components/src/tools-panel/stories/index.story.tsx
+++ b/packages/components/src/tools-panel/stories/index.story.tsx
@@ -26,7 +26,7 @@ import UnitControl from '../../unit-control';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 
 const meta: Meta< typeof ToolsPanel > = {
-	title: 'Components (Experimental)/ToolsPanel',
+	title: 'Components/ToolsPanel',
 	component: ToolsPanel,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { ToolsPanelItem },

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -1,10 +1,5 @@
 # ToolsPanel
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early
-implementation subject to drastic and breaking changes.
-</div>
-<br />
 These panels provide progressive discovery options for their children. For
 example the controls provided via block supports.
 
@@ -61,7 +56,7 @@ import styled from '@emotion/styled';
  */
 import {
 	__experimentalBoxControl as BoxControl,
-	__experimentalToolsPanel as ToolsPanel,
+	ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -53,8 +53,8 @@ const UnconnectedToolsPanel = (
  * ```jsx
  * import { __ } from '@wordpress/i18n';
  * import {
- *   __experimentalToolsPanel as ToolsPanel,
- *   __experimentalToolsPanelItem as ToolsPanelItem,
+ *   ToolsPanel,
+ *   ToolsPanelItem,
  *   __experimentalUnitControl as UnitControl
  * } from '@wordpress/components';
  *

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,9 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [
+			'navigation',
+			'toolspanel',
+		];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.



