### PR TITLE
Components: Assess stabilization of `TreeGrid`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `TreeGrid`: Remove "experimental" designation ([#61069](https://github.com/WordPress/gutenberg/pull/61069)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -175,10 +175,26 @@ export {
 } from './tools-panel';
 export { default as Tooltip } from './tooltip';
 export {
+	/**
+	 * @deprecated Import `TreeGrid` instead.
+	 */
 	default as __experimentalTreeGrid,
+	/**
+	 * @deprecated Import `TreeGridRow` instead.
+	 */
 	TreeGridRow as __experimentalTreeGridRow,
+	/**
+	 * @deprecated Import `TreeGridCell` instead.
+	 */
 	TreeGridCell as __experimentalTreeGridCell,
+	/**
+	 * @deprecated Import `TreeGridItem` instead.
+	 */
 	TreeGridItem as __experimentalTreeGridItem,
+	default as TreeGrid,
+	TreeGridRow,
+	TreeGridCell,
+	TreeGridItem,
 } from './tree-grid';
 export { default as TreeSelect } from './tree-select';
 export { Truncate as __experimentalTruncate } from './truncate';

--- a/packages/components/src/tree-grid/stories/index.story.tsx
+++ b/packages/components/src/tree-grid/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { Button } from '../../button';
 import InputControl from '../../input-control';
 
 const meta: Meta< typeof TreeGrid > = {
-	title: 'Components (Experimental)/TreeGrid',
+	title: 'Components/TreeGrid',
 	component: TreeGrid,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { TreeGridRow, TreeGridCell },

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,6 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation', 'treegrid' ];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.



