### PR TITLE
Components: Assess stabilization of `VStack`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `VStack`: Remove "experimental" designation ([#61073](https://github.com/WordPress/gutenberg/pull/61073)).
+
 ### Enhancements
 
 -   `InputControl`: Add a password visibility toggle story ([#60898](https://github.com/WordPress/gutenberg/pull/60898)).

--- a/packages/components/src/divider/README.md
+++ b/packages/components/src/divider/README.md
@@ -12,7 +12,7 @@ This feature is still experimental. “Experimental” means this is an early im
 import {
 	__experimentalDivider as Divider,
 	__experimentalText as Text,
-	__experimentalVStack as VStack,
+	VStack,
 } from `@wordpress/components`;
 
 function Example() {

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -35,7 +35,7 @@ function UnconnectedDivider(
  * import {
  * 		__experimentalDivider as Divider,
  * 		__experimentalText as Text,
- * 		__experimentalVStack as VStack,
+ * 		VStack,
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -189,7 +189,13 @@ export {
 } from './unit-control';
 export { View as __experimentalView } from './view';
 export { VisuallyHidden } from './visually-hidden';
-export { VStack as __experimentalVStack } from './v-stack';
+export {
+	/**
+	 * @deprecated Import `VStack` instead.
+	 */
+	VStack as __experimentalVStack,
+	VStack,
+} from './v-stack';
 export { default as IsolatedEventContainer } from './isolated-event-container';
 export {
 	createSlotFill,

--- a/packages/components/src/v-stack/README.md
+++ b/packages/components/src/v-stack/README.md
@@ -13,7 +13,7 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	__experimentalText as Text,
-	__experimentalVStack as VStack,
+	VStack,
 } from '@wordpress/components';
 
 function Example() {
@@ -75,7 +75,7 @@ When a `Spacer` is used within an `VStack`, the `Spacer` adaptively expands to t
 import {
 	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
-	__experimentalVStack as VStack,
+	VStack,
 } from '@wordpress/components';
 
 function Example() {
@@ -97,7 +97,7 @@ function Example() {
 import {
 	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
-	__experimentalVStack as VStack,
+	VStack,
 } from '@wordpress/components';
 
 function Example() {

--- a/packages/components/src/v-stack/component.tsx
+++ b/packages/components/src/v-stack/component.tsx
@@ -30,7 +30,7 @@ function UnconnectedVStack(
  * ```jsx
  * import {
  * 	__experimentalText as Text,
- * 	__experimentalVStack as VStack,
+ * 	VStack,
  * } from `@wordpress/components`;
  *
  * function Example() {

--- a/packages/components/src/v-stack/stories/index.story.tsx
+++ b/packages/components/src/v-stack/stories/index.story.tsx
@@ -25,7 +25,7 @@ const ALIGNMENTS = {
 
 const meta: Meta< typeof VStack > = {
 	component: VStack,
-	title: 'Components (Experimental)/VStack',
+	title: 'Components/VStack',
 	argTypes: {
 		alignment: {
 			control: { type: 'select' },

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -1,6 +1,6 @@
 <script>
 	( function redirectIfStoryMoved() {
-		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation' ];
+		const PREVIOUSLY_EXPERIMENTAL_COMPONENTS = [ 'navigation', 'vstack' ];
 		const REDIRECTS = [
 			{
 				from: /\/components-deprecated-/,


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/59418.

## What?

This is part of a [larger effort](https://github.com/WordPress/gutenberg/issues/59418) to remove `__experimental` prefix from all "experimental" components, effectively promoting them to regular stable components. See the related issue for more context.

## Why?

The strategy of prefixing exports with `__experimental` has become deprecated after the introduction of private APIs. 

## How?

1. Export it from components without the `__experimental` prefix;
1. Keep the old `__experimental` export for backwards compatibility;
1. Change all imports of the old `__experimental` in GB and components to the one without the prefix (including in storybook stories). Also, update the docs to refer to the new unprefixed component;
1. Add the component storybook `id` (get it from the storybook URL) to the `PREVIOUSLY_EXPERIMENTAL_COMPONENTS` const array in `manager-head.html` so that old experimental story paths are redirected to the new one;
1. Add a changelog for the change.



