### PR TITLE
Editor: Avoid triggering the start page modal on unsaved pages

### DIFF
--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -11,6 +11,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useAsyncList } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
+import { __unstableSerializeAndClean } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -71,7 +72,11 @@ function PatternSelection( { blockPatterns, onChoosePattern } ) {
 			blockPatterns={ blockPatterns }
 			shownPatterns={ shownBlockPatterns }
 			onClickPattern={ ( _pattern, blocks ) => {
-				editEntityRecord( 'postType', postType, postId, { blocks } );
+				editEntityRecord( 'postType', postType, postId, {
+					blocks,
+					content: ( { blocks: blocksForSerialization = [] } ) =>
+						__unstableSerializeAndClean( blocksForSerialization ),
+				} );
 				onChoosePattern();
 			} }
 		/>


### PR DESCRIPTION
Fixes a bug raised here https://github.com/WordPress/gutenberg/pull/60745#issuecomment-2075108716

## What?

When we create a new page in the site editor, we're shown a modal to pick a starter content. If we pick some content and immediately navigate out of the page in the site editor with the unsaved changes, when we come back to the page, it was still considered "empty" which cause the modal to appear again even if the page was not really empty.

## How?

It turns out that `editEntityRecod( { blocks } )` is not enough to change the return value of the over optimized `isEmptyEditedPost`. It seems that every time we call editEntityRecord with blocks, we're supposed to also call it with a function edit for the "content" to ensure that the save mechanism knows how to persist the blocks into content on save.

## Testing Instructions

1- Create a new page in the site editor
2- Choose a starter content in the modal
3- Click the site icon to leave the editor page
4- Click the preview frame again to go back to the editor
5- You shouldn't see the starter options modal again.
