### PR TITLE
Remove unnecessary period in template block selection notice

### DIFF
--- a/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
@@ -82,7 +82,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 			onCancel={ () => setIsDialogOpen( false ) }
 		>
 			{ __(
-				'You’ve tried to select a block that is part of a template, which may be used on other posts and pages. Would you like to edit the template?.'
+				'You’ve tried to select a block that is part of a template, which may be used on other posts and pages. Would you like to edit the template?'
 			) }
 		</ConfirmDialog>
 	);


### PR DESCRIPTION
Fixes a bug raised here https://github.com/WordPress/gutenberg/issues/61053

## What?
A unnecessary point at the end of the sentence.

You’ve tried to select a block that is part of a template, which may be used on other posts and pages. Would you like to edit the template?->.<-

