### PR TITLE
Site Editor: preload always required settings

### DIFF
--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -35,17 +35,6 @@ function gutenberg_block_editor_preload_paths_6_6( $paths ) {
 	$paths[] = '/wp/v2/settings';
 	$paths[] = array( '/wp/v2/templates', 'OPTIONS' );
 	$paths[] = '/wp/v2/types?context=edit';
-	$paths[] = '/?_fields=' . urlencode( implode( ',', [
-		'description',
-		'gmt_offset',
-		'home',
-		'name',
-		'site_icon',
-		'site_icon_url',
-		'site_logo',
-		'timezone_string',
-		'url',
-	] ) );
 	return $paths;
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_6', 10 );

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -31,7 +31,7 @@ if ( ! function_exists( 'wp_api_template_access_controller' ) ) {
 add_filter( 'register_post_type_args', 'wp_api_template_access_controller', 10, 2 );
 
 function gutenberg_block_editor_preload_paths_6_6( $paths, $context ) {
-	if ( $context->name === 'core/edit-site' ) {
+	if ( 'core/edit-site' === $context->name ) {
 		// When merging back to core, these should be added here:
 		// https://github.com/WordPress/wordpress-develop/blob/7159243c090e429a7d2a1fd2a9509e323f67a39d/src/wp-admin/site-editor.php#L90-L117
 		$paths[] = array( '/wp/v2/settings', 'OPTIONS' );

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -29,3 +29,23 @@ if ( ! function_exists( 'wp_api_template_access_controller' ) ) {
 	}
 }
 add_filter( 'register_post_type_args', 'wp_api_template_access_controller', 10, 2 );
+
+function gutenberg_block_editor_preload_paths_6_6( $paths ) {
+	$paths[] = array( '/wp/v2/settings', 'OPTIONS' );
+	$paths[] = '/wp/v2/settings';
+	$paths[] = array( '/wp/v2/templates', 'OPTIONS' );
+	$paths[] = '/wp/v2/types?context=edit';
+	$paths[] = '/?_fields=' . urlencode( implode( ',', [
+		'description',
+		'gmt_offset',
+		'home',
+		'name',
+		'site_icon',
+		'site_icon_url',
+		'site_logo',
+		'timezone_string',
+		'url',
+	] ) );
+	return $paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_6', 10 );

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -30,11 +30,15 @@ if ( ! function_exists( 'wp_api_template_access_controller' ) ) {
 }
 add_filter( 'register_post_type_args', 'wp_api_template_access_controller', 10, 2 );
 
-function gutenberg_block_editor_preload_paths_6_6( $paths ) {
-	$paths[] = array( '/wp/v2/settings', 'OPTIONS' );
-	$paths[] = '/wp/v2/settings';
-	$paths[] = array( '/wp/v2/templates', 'OPTIONS' );
-	$paths[] = '/wp/v2/types?context=edit';
+function gutenberg_block_editor_preload_paths_6_6( $paths, $context ) {
+	if ( $context->name === 'core/edit-site' ) {
+		// When merging back to core, these should be added here:
+		// https://github.com/WordPress/wordpress-develop/blob/7159243c090e429a7d2a1fd2a9509e323f67a39d/src/wp-admin/site-editor.php#L90-L117
+		$paths[] = array( '/wp/v2/settings', 'OPTIONS' );
+		$paths[] = '/wp/v2/settings';
+		$paths[] = array( '/wp/v2/templates', 'OPTIONS' );
+		$paths[] = '/wp/v2/types?context=edit';
+	}
 	return $paths;
 }
-add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_6', 10 );
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_6', 10, 2 );

--- a/packages/core-commands/src/hooks.js
+++ b/packages/core-commands/src/hooks.js
@@ -5,6 +5,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
 export function useIsTemplatesAccessible() {
+	// This resource is preloaded.
 	return useSelect(
 		( select ) => select( coreStore ).canUser( 'read', 'templates' ),
 		[]

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -27,6 +27,8 @@ export const rootEntitiesConfig = [
 		name: '__unstableBase',
 		baseURL: '/',
 		baseURLParams: {
+			// This resource is preloaded. Please ensure the preload is
+			// updated when this list changes.
 			_fields: [
 				'description',
 				'gmt_offset',
@@ -291,7 +293,7 @@ function makeBlocksSerializable( blocks ) {
  */
 async function loadPostTypeEntities() {
 	const postTypes = await apiFetch( {
-		path: '/wp/v2/types?context=view',
+		path: '/wp/v2/types?context=edit',
 	} );
 	return Object.entries( postTypes ?? {} ).map( ( [ name, postType ] ) => {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -293,7 +293,7 @@ function makeBlocksSerializable( blocks ) {
  */
 async function loadPostTypeEntities() {
 	const postTypes = await apiFetch( {
-		path: '/wp/v2/types?context=edit',
+		path: '/wp/v2/types?context=view',
 	} );
 	return Object.entries( postTypes ?? {} ).map( ( [ name, postType ] ) => {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -27,8 +27,6 @@ export const rootEntitiesConfig = [
 		name: '__unstableBase',
 		baseURL: '/',
 		baseURLParams: {
-			// This resource is preloaded. Please ensure the preload is
-			// updated when this list changes.
 			_fields: [
 				'description',
 				'gmt_offset',

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -146,6 +146,7 @@ export default function Editor( { isLoading, onClick } ) {
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			showIconLabels: get( 'core', 'showIconLabels' ),
+			// This resourse is preloaded.
 			postTypeLabel: getPostTypeLabel(),
 		};
 	}, [] );

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -146,7 +146,7 @@ export default function Editor( { isLoading, onClick } ) {
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			showIconLabels: get( 'core', 'showIconLabels' ),
-			// This resourse is preloaded.
+			// This resource is preloaded.
 			postTypeLabel: getPostTypeLabel(),
 		};
 	}, [] );

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -35,12 +35,9 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 		url,
 		frontPageTemplateId,
 	} = useSelect( ( select ) => {
-		const { getSite, getUnstableBase, getEntityRecords } =
-			select( coreDataStore );
+		const { getSite, getEntityRecords } = select( coreDataStore );
 		// This resource is preloaded.
 		const siteData = getSite();
-		// This resource is preloaded.
-		const base = getUnstableBase();
 		// This resource is preloaded.
 		const templates = getEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
 			per_page: -1,
@@ -66,10 +63,10 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 				: false;
 		}
 		return {
-			hasLoadedAllDependencies: !! base && !! siteData,
+			hasLoadedAllDependencies: !! siteData,
 			homepageId: _homepageId,
 			postsPageId: _postsPageId,
-			url: base?.home,
+			url: siteData?.home,
 			frontPageTemplateId: _frontPageTemplateId,
 		};
 	}, [] );

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -37,8 +37,11 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 	} = useSelect( ( select ) => {
 		const { getSite, getUnstableBase, getEntityRecords } =
 			select( coreDataStore );
+		// This resource is preloaded.
 		const siteData = getSite();
+		// This resource is preloaded.
 		const base = getUnstableBase();
+		// This resource is preloaded.
 		const templates = getEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
 			per_page: -1,
 		} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Some resources block the editor from fetching the post, which increases the site editor load time. For example, knowing whether a different page is loaded for the index, and which page ID is required, is needed before fetching the post.

Additionally I added an `/templates` OPTIONS request which seems to be needed for a command. Here I'm wondering whether these commands can't be initialised whenever the command UI is shown though, instead of initialising all commands on page load.

|Before|After|
|-|-|
|<img width="502" alt="Screenshot 2024-04-25 at 11 29 12" src="https://github.com/WordPress/gutenberg/assets/4710635/1f3421ca-31cf-4bd5-a4bc-c7fbd6be7803">|<img width="487" alt="Screenshot 2024-04-25 at 11 28 20" src="https://github.com/WordPress/gutenberg/assets/4710635/f8ba89e1-13d7-435e-8b55-6da046917860">|

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We have lots of requests for different interdependent resources, which slows down load.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We can preload the always required data.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check the network tab, ideally the network panel in a performance recording.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
