### PR TITLE
Fix typo in clear customizations text

### DIFF
--- a/packages/edit-site/src/components/template-actions/index.js
+++ b/packages/edit-site/src/components/template-actions/index.js
@@ -135,7 +135,7 @@ function ResetMenuItem( { template, onClose } ) {
 				onCancel={ () => setIsModalOpen( false ) }
 				confirmButtonText={ __( 'Reset' ) }
 			>
-				{ __( 'Rese to default and clear all customizations?' ) }
+				{ __( 'Reset to default and clear all customizations?' ) }
 			</ConfirmDialog>
 		</>
 	);


### PR DESCRIPTION
Fixes a bug raised here https://github.com/WordPress/gutenberg/issues/61052

## What?
There is a typo in below line- 
Rese to default and clear all customizations?

Should be
Reset to default and clear all customizations?

