### PR TITLE
Site editor: prevent blocking global styles request

### DIFF
--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -37,9 +37,9 @@ function gutenberg_block_editor_preload_paths_6_6( $paths, $context ) {
 		$paths_to_remove = array(
 			'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(),
 		);
-		$paths = array_filter(
+		$paths           = array_filter(
 			$paths,
-			function( $path ) use ( $paths_to_remove ) {
+			function ( $path ) use ( $paths_to_remove ) {
 				return ! in_array( $path, $paths_to_remove, true );
 			}
 		);

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -29,3 +29,21 @@ if ( ! function_exists( 'wp_api_template_access_controller' ) ) {
 	}
 }
 add_filter( 'register_post_type_args', 'wp_api_template_access_controller', 10, 2 );
+
+function gutenberg_block_editor_preload_paths_6_6( $paths, $context ) {
+	if ( 'core/edit-site' === $context->name ) {
+		// When merging back to core, these should be removed here:
+		// https://github.com/WordPress/wordpress-develop/blob/7159243c090e429a7d2a1fd2a9509e323f67a39d/src/wp-admin/site-editor.php#L99
+		$paths_to_remove = array(
+			'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(),
+		);
+		$paths = array_filter(
+			$paths,
+			function( $path ) use ( $paths_to_remove ) {
+				return ! in_array( $path, $paths_to_remove, true );
+			}
+		);
+	}
+	return $paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_6', 10, 2 );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -543,13 +543,12 @@ export const __experimentalGetCurrentGlobalStylesId =
 		const globalStylesURL =
 			activeThemes?.[ 0 ]?._links?.[ 'wp:user-global-styles' ]?.[ 0 ]
 				?.href;
-		if ( globalStylesURL ) {
-			const globalStylesObject = await apiFetch( {
-				url: globalStylesURL,
-			} );
-			dispatch.__experimentalReceiveCurrentGlobalStylesId(
-				globalStylesObject.id
-			);
+		if ( ! globalStylesURL ) {
+			return;
+		}
+		const id = +globalStylesURL.split( '/' ).pop();
+		if ( id ) {
+			dispatch.__experimentalReceiveCurrentGlobalStylesId( id );
 		}
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

There's a single global styles request that blocks all other loading and requests for the site editor:

<img width="1065" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/023644cd-9030-45ba-aeda-d21997d4b6f7">



The interesting thing is that this data is [preloaded](https://github.com/WordPress/wordpress-develop/blob/7159243c090e429a7d2a1fd2a9509e323f67a39d/src/wp-admin/site-editor.php#L99), so why is this request made?

Well, it looks like this is requested with `apiFetch`, but with the `url` option, because this is a url coming from the active theme links.

https://github.com/WordPress/gutenberg/blob/a1b07cd115b9773b310bb99ed99fa1eaa944c503/packages/core-data/src/resolvers.js#L543-L553

Unfortunately preload data is designed to only work with the path option, and the root url middleware is loaded after preload data, so it would be a pain to fix preload data for url options.

Upon closer inspection, I noticed that this resource is only fetched to get the global styles ID for the active theme. But we already know this ID from the url, so we shouldn't need to make an additional request.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Slows down site editor load.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See above

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check the network tab for the site editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
