### PR TITLE
ESLint Plugin: Handle multi-line translator comments

### DIFF
--- a/packages/eslint-plugin/rules/__tests__/i18n-translator-comments.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-translator-comments.js
@@ -34,6 +34,23 @@ sprintf(
 // translators: %s: Color
 i18n.sprintf( i18n.__( 'Color: %s' ), color );`,
 		},
+		{
+			code: `
+sprintf(
+	/*
+	 * translators: %s is the name of the city we couldn't locate.
+	 * Replace the examples with cities related to your locale. Test that
+	 * they match the expected location and have upcoming events before
+	 * including them. If no cities related to your locale have events,
+	 * then use cities related to your locale that would be recognizable
+	 * to most users. Use only the city name itself, without any region
+	 * or country. Use the endonym (native locale name) instead of the
+	 * English name if possible.
+	 */
+	__( 'We couldn’t locate %s. Please try another nearby city. For example: Kansas City; Springfield; Portland.' ),
+templateParams.unknownCity
+);`,
+		},
 	],
 	invalid: [
 		{

--- a/packages/eslint-plugin/rules/i18n-translator-comments.js
+++ b/packages/eslint-plugin/rules/i18n-translator-comments.js
@@ -78,7 +78,7 @@ module.exports = {
 					const {
 						value: commentText,
 						loc: {
-							start: { line: commentLine },
+							end: { line: commentLine },
 						},
 					} = comment;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Noticed a bug in the `i18n-translator-comments` ESLint rule while working on the WordPress core codebase. This PR addresses the bug.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Look at the end line of the translator comment, in case it's a multi-line comment.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Tests should be passing.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
