### PR TITLE
docgen: fix qualified types with type parameters

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -150,7 +150,7 @@ _Parameters_
 
 _Returns_
 
--   `undefined< 'edit' >`: Current user object.
+-   `ET.User< 'edit' >`: Current user object.
 
 ### getDefaultTemplateId
 
@@ -178,7 +178,7 @@ _Parameters_
 
 _Returns_
 
--   `undefined< EntityRecord > | false`: The entity record, merged with its edits.
+-   `ET.Updatable< EntityRecord > | false`: The entity record, merged with its edits.
 
 ### getEmbedPreview
 
@@ -504,7 +504,7 @@ _Parameters_
 
 _Returns_
 
--   `undefined< 'edit' >[]`: Users list.
+-   `ET.User< 'edit' >[]`: Users list.
 
 ### hasEditsForEntityRecord
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -471,7 +471,7 @@ _Parameters_
 
 _Returns_
 
--   `undefined< 'edit' >`: Current user object.
+-   `ET.User< 'edit' >`: Current user object.
 
 ### getDefaultTemplateId
 
@@ -499,7 +499,7 @@ _Parameters_
 
 _Returns_
 
--   `undefined< EntityRecord > | false`: The entity record, merged with its edits.
+-   `ET.Updatable< EntityRecord > | false`: The entity record, merged with its edits.
 
 ### getEmbedPreview
 
@@ -825,7 +825,7 @@ _Parameters_
 
 _Returns_
 
--   `undefined< 'edit' >[]`: Users list.
+-   `ET.User< 'edit' >[]`: Users list.
 
 ### hasEditsForEntityRecord
 

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -237,16 +237,20 @@ function getMappedTypeAnnotation( typeAnnotation ) {
  * @param {babelTypes.TSTypeReference} typeAnnotation
  */
 function getTypeReferenceTypeAnnotation( typeAnnotation ) {
-	if ( ! typeAnnotation.typeParameters ) {
-		if ( babelTypes.isTSQualifiedName( typeAnnotation.typeName ) ) {
-			return unifyQualifiedName( typeAnnotation.typeName );
-		}
-		return typeAnnotation.typeName.name;
+	let typeName;
+	if ( babelTypes.isTSQualifiedName( typeAnnotation.typeName ) ) {
+		typeName = unifyQualifiedName( typeAnnotation.typeName );
+	} else {
+		typeName = typeAnnotation.typeName.name;
 	}
-	const typeParams = typeAnnotation.typeParameters.params
-		.map( getTypeAnnotation )
-		.join( ', ' );
-	return `${ typeAnnotation.typeName.name }< ${ typeParams } >`;
+
+	if ( typeAnnotation.typeParameters ) {
+		const typeParams = typeAnnotation.typeParameters.params
+			.map( getTypeAnnotation )
+			.join( ', ' );
+		typeName = `${ typeName }< ${ typeParams } >`;
+	}
+	return typeName;
 }
 
 /**

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -100,6 +100,26 @@ describe( 'Type annotations', () => {
 		} );
 	} );
 
+	describe( 'qualified types', () => {
+		const node = parse( `
+			function fn( foo: My.Foo< string >, bar: My.Bar ) {
+				return 0;
+			}
+		` );
+
+		it( 'should get the qualified param type with type parameters', () => {
+			expect(
+				getTypeAnnotation( { tag: 'param', name: 'foo' }, node, 0 )
+			).toBe( 'My.Foo< string >' );
+		} );
+
+		it( 'should get the qualified param type without type parameters', () => {
+			expect(
+				getTypeAnnotation( { tag: 'param', name: 'bar' }, node, 1 )
+			).toBe( 'My.Bar' );
+		} );
+	} );
+
 	describe( 'literal values', () => {
 		it.each( [ "'a-string-literal'", '1000n', 'true', '1000' ] )(
 			'should handle %s',


### PR DESCRIPTION
Fixed a docgen bug that I noticed when reviewing https://github.com/WordPress/gutenberg/pull/60988#discussion_r1579051526. If a parameter has "qualified type name" and type parameters, i.e. `X.Y<Z>`, the docgen tool failed to format that type to a string and produced `undefined<Z>`.

It was a simple omission in the `getTypeReferenceTypeAnnotation` that correctly formatted `X.Y` without type parameters but forgot to check for the special `X.Y` syntax when there are type parameters.

**How to test:**
- there is a new unit test for `getTypeAnnotation` that checks this case and would fail without the fix.
- I regenerated the docs for the `core-data` package -- note how nicely fixed they are now!