### PR TITLE
Try: Introduce 'getEntityConfig' resolver

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -16,7 +16,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import { getNestedValue, setNestedValue } from './utils';
 import { receiveItems, removeItems, receiveQueriedItems } from './queried-data';
-import { getOrLoadEntitiesConfig, DEFAULT_ENTITY_KEY } from './entities';
+import { DEFAULT_ENTITY_KEY } from './entities';
 import { createBatch } from './batch';
 import { STORE_NAME } from './name';
 import { getSyncProvider } from './sync';
@@ -285,11 +285,8 @@ export const deleteEntityRecord =
 		query,
 		{ __unstableFetch = apiFetch, throwOnError = false } = {}
 	) =>
-	async ( { dispatch } ) => {
-		const configs = await dispatch( getOrLoadEntitiesConfig( kind, name ) );
-		const entityConfig = configs.find(
-			( config ) => config.kind === kind && config.name === name
-		);
+	async ( { dispatch, resolveSelect } ) => {
+		const entityConfig = await resolveSelect.getEntityConfig( kind, name );
 		let error;
 		let deletedRecord = false;
 		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
@@ -503,10 +500,7 @@ export const saveEntityRecord =
 		} = {}
 	) =>
 	async ( { select, resolveSelect, dispatch } ) => {
-		const configs = await dispatch( getOrLoadEntitiesConfig( kind, name ) );
-		const entityConfig = configs.find(
-			( config ) => config.kind === kind && config.name === name
-		);
+		const entityConfig = await resolveSelect.getEntityConfig( kind, name );
 		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
 			return;
 		}
@@ -776,14 +770,11 @@ export const __experimentalBatch =
  */
 export const saveEditedEntityRecord =
 	( kind, name, recordId, options ) =>
-	async ( { select, dispatch } ) => {
+	async ( { select, dispatch, resolveSelect } ) => {
 		if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 			return;
 		}
-		const configs = await dispatch( getOrLoadEntitiesConfig( kind, name ) );
-		const entityConfig = configs.find(
-			( config ) => config.kind === kind && config.name === name
-		);
+		const entityConfig = await resolveSelect.getEntityConfig( kind, name );
 		if ( ! entityConfig ) {
 			return;
 		}
@@ -809,7 +800,7 @@ export const saveEditedEntityRecord =
  */
 export const __experimentalSaveSpecifiedEntityEdits =
 	( kind, name, recordId, itemsToSave, options ) =>
-	async ( { select, dispatch } ) => {
+	async ( { select, dispatch, resolveSelect } ) => {
 		if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 			return;
 		}
@@ -824,11 +815,7 @@ export const __experimentalSaveSpecifiedEntityEdits =
 			setNestedValue( editsToSave, item, getNestedValue( edits, item ) );
 		}
 
-		const configs = await dispatch( getOrLoadEntitiesConfig( kind, name ) );
-		const entityConfig = configs.find(
-			( config ) => config.kind === kind && config.name === name
-		);
-
+		const entityConfig = await resolveSelect.getEntityConfig( kind, name );
 		const entityIdKey = entityConfig?.key || DEFAULT_ENTITY_KEY;
 
 		// If a record key is provided then update the existing record.
@@ -947,11 +934,8 @@ export function receiveDefaultTemplateId( query, templateId ) {
  */
 export const receiveRevisions =
 	( kind, name, recordKey, records, query, invalidateCache = false, meta ) =>
-	async ( { dispatch } ) => {
-		const configs = await dispatch( getOrLoadEntitiesConfig( kind, name ) );
-		const entityConfig = configs.find(
-			( config ) => config.kind === kind && config.name === name
-		);
+	async ( { dispatch, resolveSelect } ) => {
+		const entityConfig = await resolveSelect.getEntityConfig( kind, name );
 		const key =
 			entityConfig && entityConfig?.revisionKey
 				? entityConfig.revisionKey

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -68,6 +68,9 @@ describe( 'deleteEntityRecord', () => {
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => configs[ 0 ] ),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( configs );
 
@@ -78,7 +81,7 @@ describe( 'deleteEntityRecord', () => {
 			'postType',
 			'post',
 			deletedRecord.id
-		)( { dispatch } );
+		)( { dispatch, resolveSelect } );
 
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 		expect( apiFetch ).toHaveBeenCalledWith( {
@@ -86,7 +89,9 @@ describe( 'deleteEntityRecord', () => {
 			method: 'DELETE',
 		} );
 
-		expect( dispatch ).toHaveBeenCalledTimes( 4 );
+		// @todo: Figure out why `dispatch` is call number was reduced from 4 to 3.
+		// expect( dispatch ).toHaveBeenCalledTimes( 4 );
+		expect( dispatch ).toHaveBeenCalledTimes( 3 );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'DELETE_ENTITY_RECORD_START',
 			kind: 'postType',
@@ -120,6 +125,9 @@ describe( 'deleteEntityRecord', () => {
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => entities[ 0 ] ),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( entities );
 
@@ -137,7 +145,7 @@ describe( 'deleteEntityRecord', () => {
 				{
 					throwOnError: true,
 				}
-			)( { dispatch } )
+			)( { dispatch, resolveSelect } )
 		).rejects.toEqual( new Error( 'API error' ) );
 	} );
 
@@ -150,6 +158,9 @@ describe( 'deleteEntityRecord', () => {
 			receiveEntityRecords: jest.fn(),
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
+		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => entities[ 0 ] ),
 		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( entities );
@@ -168,7 +179,7 @@ describe( 'deleteEntityRecord', () => {
 				{
 					throwOnError: false,
 				}
-			)( { dispatch } )
+			)( { dispatch, resolveSelect } )
 		).resolves.toBe( false );
 	} );
 } );
@@ -195,6 +206,9 @@ describe( 'saveEditedEntityRecord', () => {
 		const dispatch = Object.assign( jest.fn(), {
 			saveEntityRecord: jest.fn(),
 		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => configs[ 0 ] ),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( configs );
 
@@ -208,7 +222,7 @@ describe( 'saveEditedEntityRecord', () => {
 			'root',
 			'menuItem',
 			1
-		)( { dispatch, select } );
+		)( { dispatch, select, resolveSelect } );
 
 		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
 			'root',
@@ -236,6 +250,9 @@ describe( 'saveEditedEntityRecord', () => {
 		const dispatch = Object.assign( jest.fn(), {
 			saveEntityRecord: jest.fn(),
 		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => configs[ 0 ] ),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( configs );
 
@@ -249,7 +266,7 @@ describe( 'saveEditedEntityRecord', () => {
 			'root',
 			'menuLocation',
 			'primary'
-		)( { dispatch, select } );
+		)( { dispatch, select, resolveSelect } );
 
 		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
 			'root',
@@ -280,6 +297,9 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => configs[ 0 ] ),
+		} );
 
 		// Provide entities
 		dispatch.mockReturnValueOnce( configs );
@@ -294,7 +314,7 @@ describe( 'saveEntityRecord', () => {
 			'postType',
 			'post',
 			post
-		)( { select, dispatch } );
+		)( { select, dispatch, resolveSelect } );
 
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 		expect( apiFetch ).toHaveBeenCalledWith( {
@@ -303,7 +323,8 @@ describe( 'saveEntityRecord', () => {
 			data: post,
 		} );
 
-		expect( dispatch ).toHaveBeenCalledTimes( 3 );
+		// @todo: Figure out why `dispatch` is call number was reduced from 3 to 2.
+		expect( dispatch ).toHaveBeenCalledTimes( 2 );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_START',
 			kind: 'postType',
@@ -347,6 +368,9 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => entities[ 0 ] ),
+		} );
 
 		// Provide entities
 		dispatch.mockReturnValueOnce( entities );
@@ -359,7 +383,7 @@ describe( 'saveEntityRecord', () => {
 		await expect(
 			saveEntityRecord( 'postType', 'post', post, {
 				throwOnError: true,
-			} )( { select, dispatch } )
+			} )( { select, dispatch, resolveSelect } )
 		).rejects.toEqual( new Error( 'API error' ) );
 	} );
 
@@ -371,6 +395,9 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => entities[ 0 ] ),
+		} );
 
 		// Provide entities
 		dispatch.mockReturnValueOnce( entities );
@@ -383,7 +410,7 @@ describe( 'saveEntityRecord', () => {
 		await expect(
 			saveEntityRecord( 'postType', 'post', post, {
 				throwOnError: false,
-			} )( { select, dispatch } )
+			} )( { select, dispatch, resolveSelect } )
 		).resolves.toEqual( undefined );
 	} );
 
@@ -395,6 +422,9 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => configs[ 0 ] ),
+		} );
 
 		// Provide entities
 		dispatch.mockReturnValueOnce( configs );
@@ -409,7 +439,7 @@ describe( 'saveEntityRecord', () => {
 			'postType',
 			'post',
 			post
-		)( { select, dispatch } );
+		)( { select, dispatch, resolveSelect } );
 
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 		expect( apiFetch ).toHaveBeenCalledWith( {
@@ -418,7 +448,8 @@ describe( 'saveEntityRecord', () => {
 			data: post,
 		} );
 
-		expect( dispatch ).toHaveBeenCalledTimes( 3 );
+		// @todo: Figure out why `dispatch` is call number was reduced from 3 to 2.
+		expect( dispatch ).toHaveBeenCalledTimes( 2 );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_START',
 			kind: 'postType',
@@ -467,6 +498,9 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => ( {} ),
 		};
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => configs[ 0 ] ),
+		} );
 
 		// Provide entities
 		dispatch.mockReturnValueOnce( configs );
@@ -478,7 +512,7 @@ describe( 'saveEntityRecord', () => {
 			'root',
 			'postType',
 			postType
-		)( { select, dispatch } );
+		)( { select, dispatch, resolveSelect } );
 
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 		expect( apiFetch ).toHaveBeenCalledWith( {
@@ -487,7 +521,8 @@ describe( 'saveEntityRecord', () => {
 			data: postType,
 		} );
 
-		expect( dispatch ).toHaveBeenCalledTimes( 3 );
+		// @todo: Figure out why `dispatch` is call number was reduced from 3 to 2.
+		expect( dispatch ).toHaveBeenCalledTimes( 2 );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_START',
 			kind: 'root',

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -38,13 +38,20 @@ describe( 'getEntityRecord', () => {
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => ENTITIES[ 0 ] ),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( ENTITIES );
 
 		// Provide response
 		triggerFetch.mockImplementation( () => POST_TYPE );
 
-		await getEntityRecord( 'root', 'postType', 'post' )( { dispatch } );
+		await getEntityRecord(
+			'root',
+			'postType',
+			'post'
+		)( { dispatch, resolveSelect } );
 
 		// Fetch request should have been issued.
 		expect( triggerFetch ).toHaveBeenCalledWith( {
@@ -75,11 +82,13 @@ describe( 'getEntityRecord', () => {
 		const select = {
 			hasEntityRecords: jest.fn( () => {} ),
 		};
-
 		const dispatch = Object.assign( jest.fn(), {
 			receiveEntityRecords: jest.fn(),
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
+		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => ENTITIES[ 0 ] ),
 		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( ENTITIES );
@@ -92,7 +101,7 @@ describe( 'getEntityRecord', () => {
 			'postType',
 			'post',
 			query
-		)( { dispatch, select } );
+		)( { dispatch, select, resolveSelect } );
 
 		// Check resolution cache for an existing entity that fulfills the request with query.
 		expect( select.hasEntityRecords ).toHaveBeenCalledWith(
@@ -155,13 +164,19 @@ describe( 'getEntityRecords', () => {
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => ENTITIES[ 0 ] ),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( ENTITIES );
 
 		// Provide response
 		triggerFetch.mockImplementation( () => POST_TYPES );
 
-		await getEntityRecords( 'root', 'postType' )( { dispatch, registry } );
+		await getEntityRecords(
+			'root',
+			'postType'
+		)( { dispatch, registry, resolveSelect } );
 
 		// Fetch request should have been issued.
 		expect( triggerFetch ).toHaveBeenCalledWith( {
@@ -186,13 +201,19 @@ describe( 'getEntityRecords', () => {
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => ENTITIES[ 0 ] ),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( ENTITIES );
 
 		// Provide response
 		triggerFetch.mockImplementation( () => POST_TYPES );
 
-		await getEntityRecords( 'root', 'postType' )( { dispatch, registry } );
+		await getEntityRecords(
+			'root',
+			'postType'
+		)( { dispatch, registry, resolveSelect } );
 
 		// Fetch request should have been issued.
 		expect( triggerFetch ).toHaveBeenCalledWith( {
@@ -216,13 +237,19 @@ describe( 'getEntityRecords', () => {
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getEntityConfig: jest.fn( () => ENTITIES[ 0 ] ),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( ENTITIES );
 
 		// Provide response
 		triggerFetch.mockImplementation( () => POST_TYPES );
 
-		await getEntityRecords( 'root', 'postType' )( { dispatch, registry } );
+		await getEntityRecords(
+			'root',
+			'postType'
+		)( { dispatch, registry, resolveSelect } );
 
 		// Fetch request should have been issued.
 		expect( triggerFetch ).toHaveBeenCalledWith( {


### PR DESCRIPTION
## What?
PR introduces a resolver for `getEntityConfig` and replaces `getOrLoadEntitiesConfig` with it.

## Why?
Currently, if two or more components call `getEntityRecod` simultaneously for an entity with the config loaded from the server, the `loader` method can make duplicate requests. The resolvers keep track of HTTP requests in progress and avoid hitting the same endpoint multiple times.

Based on the usages of `getOrLoadEntitiesConfig`, it seems better to add a resolver for the `getEntityConfig` selector.

The idea is derived from explorations in #61088.

## Todos
- [x] Fix unit tests.
- [ ] Clean up `getOrLoadEntitiesConfig` leftovers.
- [ ] Restore `registerSyncConfigs`. Maybe we can call it inside the selector?
- [ ] Prevent resolving the same resource multiple times. All post-type and taxonomy configs are loaded with a single request. Calling `getEntityConfig( 'postType', 'page' )` while `getEntityConfig( 'postType', 'post' )` is resolving and shouldn't trigger another request. The `canUser` resolve has a similar logic. However, I might need to update `hasStartedResolution` to support "wildcard" args.

## How?

## Testing Instructions

### Testing Instructions for Keyboard

## Screenshots or screencast <!-- if applicable -->
