### PR TITLE
Add Image Prefetching for Click to expand Images

### DIFF
--- a/packages/block-library/src/image/constants.js
+++ b/packages/block-library/src/image/constants.js
@@ -8,3 +8,9 @@ export const ALLOWED_MEDIA_TYPES = [ 'image' ];
 export const MEDIA_ID_NO_FEATURED_IMAGE_SET = 0;
 export const SIZED_LAYOUTS = [ 'flex', 'grid' ];
 export const DEFAULT_MEDIA_SIZE_SLUG = 'full';
+
+/**
+ * Delay in milliseconds before preloading an image after hovering.
+ * This prevents unnecessary preloading during quick scrolling or mouse movements.
+ */
+export const IMAGE_PRELOAD_DELAY = 200;

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -196,7 +196,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$img_styles        = $processor->get_attribute( 'style' );
 	$img_width         = 'none';
 	$img_height        = 'none';
-	$img_sizes         = '100vw';
 	$aria_label        = __( 'Enlarge' );
 	$dialog_aria_label = __( 'Enlarged image' );
 
@@ -223,7 +222,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 				$unique_image_id => array(
 					'uploadedSrc'      => $img_uploaded_src,
 					'lightboxSrcset'   => $img_srcset,
-					'lightboxSizes'    => $img_sizes,
 					'figureClassNames' => $figure_class_names,
 					'figureStyles'     => $figure_styles,
 					'imgClassNames'    => $img_class_names,
@@ -262,7 +260,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// before the predefined delay.
 	$processor->set_attribute( 'data-wp-on--pointerenter', 'actions.preloadImageWithDelay' );
 	$processor->set_attribute( 'data-wp-on--pointerdown', 'actions.preloadImage' );
-	$processor->set_attribute( 'data-wp-on--pointerleave', 'actions.cancelPrefetch' );
+	$processor->set_attribute( 'data-wp-on--pointerleave', 'actions.cancelPreload' );
 
 	// Sets an event callback on the `img` because the `figure` element can also
 	// contain a caption, and we don't want to trigger the lightbox when the
@@ -361,7 +359,7 @@ function block_core_image_print_lightbox_overlay() {
 							data-wp-bind--style="state.imgStyles"
 							data-wp-bind--src="state.enlargedSrc"
 							data-wp-bind--srcset="state.enlargedSrcset"
-							data-wp-bind--sizes="state.enlargedSizes"
+							sizes="100vw"
 						>
 					</figure>
 				</div>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -254,8 +254,10 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$processor->set_attribute( 'data-wp-on-window--resize', 'callbacks.setButtonStyles' );
 
 	// Set an event to prefetch the image on pointerenter and pointerdown(mobile).
-	$processor->set_attribute( 'data-wp-on--pointerenter', 'actions.prefetchImage' );
+	$processor->set_attribute( 'data-wp-on--pointerenter', 'actions.prefetchImageWithDelay' );
 	$processor->set_attribute( 'data-wp-on--pointerdown', 'actions.prefetchImage' );
+	$processor->set_attribute( 'data-wp-on--pointerleave', 'actions.cancelPrefetch' );
+
 	// Sets an event callback on the `img` because the `figure` element can also
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -254,6 +254,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$processor->set_attribute( 'data-wp-on-window--resize', 'callbacks.setButtonStyles' );
 
 	// Set an event to prefetch the image on pointerenter and pointerdown(mobile).
+	// Pointerleave is used to cancel the prefetch if the user hovers away from the image
+	// before the predefined delay.
 	$processor->set_attribute( 'data-wp-on--pointerenter', 'actions.prefetchImageWithDelay' );
 	$processor->set_attribute( 'data-wp-on--pointerdown', 'actions.prefetchImage' );
 	$processor->set_attribute( 'data-wp-on--pointerleave', 'actions.cancelPrefetch' );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -257,11 +257,11 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$processor->set_attribute( 'data-wp-on--load', 'callbacks.setButtonStyles' );
 	$processor->set_attribute( 'data-wp-on-window--resize', 'callbacks.setButtonStyles' );
 
-	// Set an event to prefetch the image on pointerenter and pointerdown(mobile).
-	// Pointerleave is used to cancel the prefetch if the user hovers away from the image
+	// Set an event to preload the image on pointerenter and pointerdown(mobile).
+	// Pointerleave is used to cancel the preload if the user hovers away from the image
 	// before the predefined delay.
-	$processor->set_attribute( 'data-wp-on--pointerenter', 'actions.prefetchImageWithDelay' );
-	$processor->set_attribute( 'data-wp-on--pointerdown', 'actions.prefetchImage' );
+	$processor->set_attribute( 'data-wp-on--pointerenter', 'actions.preloadImageWithDelay' );
+	$processor->set_attribute( 'data-wp-on--pointerdown', 'actions.preloadImage' );
 	$processor->set_attribute( 'data-wp-on--pointerleave', 'actions.cancelPrefetch' );
 
 	// Sets an event callback on the `img` because the `figure` element can also

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -196,12 +196,14 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$img_styles        = $processor->get_attribute( 'style' );
 	$img_width         = 'none';
 	$img_height        = 'none';
+	$img_sizes         = '100vw';
 	$aria_label        = __( 'Enlarge' );
 	$dialog_aria_label = __( 'Enlarged image' );
 
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_uploaded_src = wp_get_attachment_url( $block['attrs']['id'] );
 		$img_metadata     = wp_get_attachment_metadata( $block['attrs']['id'] );
+		$img_srcset       = wp_get_attachment_image_srcset( $block['attrs']['id'] );
 		$img_width        = $img_metadata['width'] ?? 'none';
 		$img_height       = $img_metadata['height'] ?? 'none';
 	}
@@ -220,6 +222,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			'metadata' => array(
 				$unique_image_id => array(
 					'uploadedSrc'      => $img_uploaded_src,
+					'lightboxSrcset'   => $img_srcset,
+					'lightboxSizes'    => $img_sizes,
 					'figureClassNames' => $figure_class_names,
 					'figureStyles'     => $figure_styles,
 					'imgClassNames'    => $img_class_names,
@@ -351,7 +355,14 @@ function block_core_image_print_lightbox_overlay() {
 				</div>
 				<div class="lightbox-image-container">
 					<figure data-wp-bind--class="state.currentImage.figureClassNames" data-wp-bind--style="state.figureStyles">
-						<img data-wp-bind--alt="state.currentImage.alt" data-wp-bind--class="state.currentImage.imgClassNames" data-wp-bind--style="state.imgStyles" data-wp-bind--src="state.enlargedSrc">
+						<img
+							data-wp-bind--alt="state.currentImage.alt"
+							data-wp-bind--class="state.currentImage.imgClassNames"
+							data-wp-bind--style="state.imgStyles"
+							data-wp-bind--src="state.enlargedSrc"
+							data-wp-bind--srcset="state.enlargedSrcset"
+							data-wp-bind--sizes="state.enlargedSizes"
+						>
 					</figure>
 				</div>
 				<div class="scrim" style="background-color: $background_color" aria-hidden="true"></div>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -252,6 +252,10 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$processor->set_attribute( 'data-wp-init', 'callbacks.setButtonStyles' );
 	$processor->set_attribute( 'data-wp-on--load', 'callbacks.setButtonStyles' );
 	$processor->set_attribute( 'data-wp-on-window--resize', 'callbacks.setButtonStyles' );
+
+	// Set an event to prefetch the image on pointerenter and pointerdown(mobile).
+	$processor->set_attribute( 'data-wp-on--pointerenter', 'actions.prefetchImage' );
+	$processor->set_attribute( 'data-wp-on--pointerdown', 'actions.prefetchImage' );
 	// Sets an event callback on the `img` because the `figure` element can also
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -203,8 +203,6 @@ const { state, actions, callbacks } = store(
 			},
 			preloadImage() {
 				const { imageId } = getContext();
-				const imageMetadata = state.metadata[ imageId ];
-				const uploadedSrc = imageMetadata.uploadedSrc;
 
 				// Bails if it has already been preloaded. This could help
 				// prevent unnecessary preloading of the same image multiple times,
@@ -213,10 +211,12 @@ const { state, actions, callbacks } = store(
 					return;
 				}
 
+				// Link element to preload the image.
+				const imageMetadata = state.metadata[ imageId ];
 				const imageLink = document.createElement( 'link' );
 				imageLink.rel = 'preload';
 				imageLink.as = 'image';
-				imageLink.href = uploadedSrc;
+				imageLink.href = imageMetadata.uploadedSrc;
 
 				// Apply srcset if available for responsive preloading
 				const srcset = imageMetadata.lightboxSrcset;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -51,8 +51,8 @@ const { state, actions, callbacks } = store(
 	{
 		state: {
 			currentImageId: null,
-			prefetchTimers: {},
-			prefetchedImageIds: new Set(),
+			preloadTimers: {},
+			preloadedImageIds: new Set(),
 			get currentImage() {
 				return state.metadata[ state.currentImageId ];
 			},
@@ -217,15 +217,15 @@ const { state, actions, callbacks } = store(
 					}
 				}
 			},
-			prefetchImage() {
+			preloadImage() {
 				const { imageId } = getContext();
 				const imageMetadata = state.metadata[ imageId ];
 				const uploadedSrc = imageMetadata.uploadedSrc;
 
-				// Bails if the image is not valid or if it has already been prefetched.
+				// Bails if the image is not valid or if it has already been preloaded.
 				if (
 					! isValidLink( uploadedSrc ) ||
-					state.prefetchedImageIds.has( imageId )
+					state.preloadedImageIds.has( imageId )
 				) {
 					return;
 				}
@@ -238,37 +238,37 @@ const { state, actions, callbacks } = store(
 				imageLink.as = 'image';
 				imageLink.href = uploadedSrc;
 
-				// Apply srcset if available for better responsive prefetching
+				// Apply srcset if available for better responsive preloading
 				if ( srcset ) {
 					imageLink.setAttribute( 'imagesrcset', srcset );
 					imageLink.setAttribute( 'imagesizes', '100vw' );
 				}
 
 				document.head.appendChild( imageLink );
-				state.prefetchedImageIds.add( imageId );
+				state.preloadedImageIds.add( imageId );
 			},
-			prefetchImageWithDelay() {
+			preloadImageWithDelay() {
 				const { imageId } = getContext();
 
-				// Cancels any previous prefetch timer for the same image.
-				if ( state.prefetchTimers && state.prefetchTimers[ imageId ] ) {
-					clearTimeout( state.prefetchTimers[ imageId ] );
+				// Cancels any previous preload timer for the same image.
+				if ( state.preloadTimers && state.preloadTimers[ imageId ] ) {
+					clearTimeout( state.preloadTimers[ imageId ] );
 				}
 
-				// Set a new timer to prefetch the image after a short delay.
-				state.prefetchTimers[ imageId ] = setTimeout(
+				// Set a new timer to preload the image after a short delay.
+				state.preloadTimers[ imageId ] = setTimeout(
 					withScope( () => {
-						actions.prefetchImage();
-						delete state.prefetchTimers[ imageId ];
+						actions.preloadImage();
+						delete state.preloadTimers[ imageId ];
 					} ),
 					200
 				);
 			},
 			cancelPrefetch() {
 				const { imageId } = getContext();
-				if ( state.prefetchTimers && state.prefetchTimers[ imageId ] ) {
-					clearTimeout( state.prefetchTimers[ imageId ] );
-					delete state.prefetchTimers[ imageId ];
+				if ( state.preloadTimers && state.preloadTimers[ imageId ] ) {
+					clearTimeout( state.preloadTimers[ imageId ] );
+					delete state.preloadTimers[ imageId ];
 				}
 			},
 		},

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -31,36 +31,36 @@ let isTouching = false;
 let lastTouchTime = 0;
 
 /**
- * Returns the appropriate src URL for an image
+ * Returns the appropriate src URL for an image.
  *
- * @param {Object} imageMetadata Image metadata object
- * @return {string} The source URL
+ * @param {string} uploadedSrc - Full size image src.
+ * @return {string} The source URL.
  */
-function getImageSrc( imageMetadata ) {
+function getImageSrc( { uploadedSrc } ) {
 	return (
-		imageMetadata.uploadedSrc ||
+		uploadedSrc ||
 		'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 	);
 }
 
 /**
- * Returns the appropriate srcset for an image
+ * Returns the appropriate srcset for an image.
  *
- * @param {Object} imageMetadata Image metadata object
- * @return {string} The srcset value
+ * @param {string} lightboxSrcset - Image srcset.
+ * @return {string} The srcset value.
  */
-function getImageSrcset( imageMetadata ) {
-	return imageMetadata.lightboxSrcset || '';
+function getImageSrcset( { lightboxSrcset } ) {
+	return lightboxSrcset || '';
 }
 
 /**
- * Returns the appropriate sizes attribute for an image
+ * Returns the appropriate sizes attribute for an image.
  *
- * @param {Object} imageMetadata Image metadata object
- * @return {string} The sizes value, defaulting to 100vw
+ * @param {string} lightboxSizes - Image responsive sizes attribute.
+ * @return {string} The sizes value, defaulting to 100vw.
  */
-function getImageSizes( imageMetadata ) {
-	return imageMetadata.lightboxSizes || '100vw';
+function getImageSizes( { lightboxSizes } ) {
+	return lightboxSizes || '100vw';
 }
 
 const { state, actions, callbacks } = store(

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -211,22 +211,28 @@ const { state, actions, callbacks } = store(
 					return;
 				}
 
-				// Link element to preload the image.
-				const imageMetadata = state.metadata[ imageId ];
+				// Sets the current image ID to preload.
+				state.currentImageId = imageId;
+
+				// Create link element to preload the image.
 				const imageLink = document.createElement( 'link' );
 				imageLink.rel = 'preload';
 				imageLink.as = 'image';
-				imageLink.href = imageMetadata.uploadedSrc;
+				imageLink.href = state.enlargedSrc;
 
-				// Apply srcset if available for responsive preloading
-				const srcset = imageMetadata.lightboxSrcset;
+				// Apply srcset if available for responsive preloading.
+				const srcset = state.enlargedSrcset;
 				if ( srcset ) {
 					imageLink.setAttribute( 'imagesrcset', srcset );
-					imageLink.setAttribute( 'imagesizes', '100vw' );
+					imageLink.setAttribute( 'imagesizes', state.enlargedSizes );
 				}
 
+				// Append the link element to the document head to trigger preloading.
 				document.head.appendChild( imageLink );
 				state.preloadedImageIds.add( imageId );
+
+				// Reset state after preloading the image.
+				state.currentImageId = null;
 			},
 			preloadImageWithDelay() {
 				const { imageId } = getContext();

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -211,28 +211,22 @@ const { state, actions, callbacks } = store(
 					return;
 				}
 
-				// Sets the current image ID to preload.
-				state.currentImageId = imageId;
-
-				// Create link element to preload the image.
+				// Link element to preload the image.
+				const imageMetadata = state.metadata[ imageId ];
 				const imageLink = document.createElement( 'link' );
 				imageLink.rel = 'preload';
 				imageLink.as = 'image';
-				imageLink.href = state.enlargedSrc;
+				imageLink.href = imageMetadata.uploadedSrc;
 
-				// Apply srcset if available for responsive preloading.
-				const srcset = state.enlargedSrcset;
+				// Apply srcset if available for responsive preloading
+				const srcset = imageMetadata.lightboxSrcset;
 				if ( srcset ) {
 					imageLink.setAttribute( 'imagesrcset', srcset );
-					imageLink.setAttribute( 'imagesizes', state.enlargedSizes );
+					imageLink.setAttribute( 'imagesizes', '100vw' );
 				}
 
-				// Append the link element to the document head to trigger preloading.
 				document.head.appendChild( imageLink );
 				state.preloadedImageIds.add( imageId );
-
-				// Reset state after preloading the image.
-				state.currentImageId = null;
 			},
 			preloadImageWithDelay() {
 				const { imageId } = getContext();

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -223,7 +223,6 @@ const { state, actions, callbacks } = store(
 				imageLink.as = 'image';
 				imageLink.href = uploadedSrc;
 
-				// Appends the link element to start the prefetch.
 				document.head.appendChild( imageLink );
 			},
 			prefetchImageWithDelay() {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -215,6 +215,7 @@ const { state, actions, callbacks } = store(
 				const { imageId } = getContext();
 				const uploadedSrc = state.metadata[ imageId ].uploadedSrc;
 
+				// Bails if the image is not valid or if it has already been prefetched.
 				if (
 					! isValidLink( uploadedSrc ) ||
 					state.prefetchedImageIds.has( imageId )
@@ -233,10 +234,12 @@ const { state, actions, callbacks } = store(
 			prefetchImageWithDelay() {
 				const { imageId } = getContext();
 
+				// Cancels any previous prefetch timer for the same image.
 				if ( state.prefetchTimers && state.prefetchTimers[ imageId ] ) {
 					clearTimeout( state.prefetchTimers[ imageId ] );
 				}
 
+				// Set a new timer to prefetch the image after a short delay.
 				state.prefetchTimers[ imageId ] = setTimeout(
 					withScope( () => {
 						actions.prefetchImage();

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -222,7 +222,10 @@ const { state, actions, callbacks } = store(
 				const srcset = imageMetadata.lightboxSrcset;
 				if ( srcset ) {
 					imageLink.setAttribute( 'imagesrcset', srcset );
-					imageLink.setAttribute( 'imagesizes', '100vw' );
+					imageLink.setAttribute(
+						'imagesizes',
+						imageMetadata.lightboxSizes || '100vw'
+					);
 				}
 
 				document.head.appendChild( imageLink );

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -30,6 +30,39 @@ let isTouching = false;
  */
 let lastTouchTime = 0;
 
+/**
+ * Returns the appropriate src URL for an image
+ *
+ * @param {Object} imageMetadata Image metadata object
+ * @return {string} The source URL
+ */
+function getImageSrc( imageMetadata ) {
+	return (
+		imageMetadata.uploadedSrc ||
+		'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
+	);
+}
+
+/**
+ * Returns the appropriate srcset for an image
+ *
+ * @param {Object} imageMetadata Image metadata object
+ * @return {string} The srcset value
+ */
+function getImageSrcset( imageMetadata ) {
+	return imageMetadata.lightboxSrcset || '';
+}
+
+/**
+ * Returns the appropriate sizes attribute for an image
+ *
+ * @param {Object} imageMetadata Image metadata object
+ * @return {string} The sizes value, defaulting to 100vw
+ */
+function getImageSizes( imageMetadata ) {
+	return imageMetadata.lightboxSizes || '100vw';
+}
+
 const { state, actions, callbacks } = store(
 	'core/image',
 	{
@@ -50,16 +83,13 @@ const { state, actions, callbacks } = store(
 				return state.overlayOpened ? 'true' : null;
 			},
 			get enlargedSrc() {
-				return (
-					state.currentImage.uploadedSrc ||
-					'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
-				);
+				return getImageSrc( state.currentImage );
 			},
 			get enlargedSrcset() {
-				return state.currentImage.lightboxSrcset || '';
+				return getImageSrcset( state.currentImage );
 			},
 			get enlargedSizes() {
-				return state.currentImage.lightboxSizes || '100vw';
+				return getImageSizes( state.currentImage );
 			},
 			get figureStyles() {
 				return (
@@ -216,15 +246,15 @@ const { state, actions, callbacks } = store(
 				const imageLink = document.createElement( 'link' );
 				imageLink.rel = 'preload';
 				imageLink.as = 'image';
-				imageLink.href = imageMetadata.uploadedSrc;
+				imageLink.href = getImageSrc( imageMetadata );
 
 				// Apply srcset if available for responsive preloading
-				const srcset = imageMetadata.lightboxSrcset;
+				const srcset = getImageSrcset( imageMetadata );
 				if ( srcset ) {
 					imageLink.setAttribute( 'imagesrcset', srcset );
 					imageLink.setAttribute(
 						'imagesizes',
-						imageMetadata.lightboxSizes || '100vw'
+						getImageSizes( imageMetadata )
 					);
 				}
 

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -24,6 +24,27 @@ let isTouching = false;
  */
 let lastTouchTime = 0;
 
+/**
+ * Checks if the given url is a valid.
+ *
+ * @param {string} url The url to check.
+ */
+const isValidLink = ( url ) => {
+	try {
+		const imageUrl = new URL( url );
+		if (
+			imageUrl.origin !== window.location.origin &&
+			! imageUrl.pathname.startsWith( '/wp-admin' ) &&
+			! imageUrl.pathname.startsWith( '/wp-login.php' )
+		) {
+			return false;
+		}
+		return true;
+	} catch {
+		return false;
+	}
+};
+
 const { state, actions, callbacks } = store(
 	'core/image',
 	{
@@ -186,6 +207,21 @@ const { state, actions, callbacks } = store(
 						);
 					}
 				}
+			},
+			prefetchImage() {
+				const ctx = getContext();
+				if ( ! isValidLink( ctx.uploadedSrc ) ) {
+					return;
+				}
+
+				// Creates a link element to prefetch the image.
+				const imageLink = document.createElement( 'link' );
+				imageLink.rel = 'prefetch';
+				imageLink.as = 'image';
+				imageLink.href = ctx.uploadedSrc;
+
+				// Appends the link element to the head of the document to start the prefetch.
+				document.head.appendChild( imageLink );
 			},
 		},
 		callbacks: {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -25,27 +25,6 @@ let isTouching = false;
  */
 let lastTouchTime = 0;
 
-/**
- * Checks if the given url is a valid.
- *
- * @param {string} url The url to check.
- */
-const isValidLink = ( url ) => {
-	try {
-		const imageUrl = new URL( url );
-		if (
-			imageUrl.origin !== window.location.origin &&
-			! imageUrl.pathname.startsWith( '/wp-admin' ) &&
-			! imageUrl.pathname.startsWith( '/wp-login.php' )
-		) {
-			return false;
-		}
-		return true;
-	} catch {
-		return false;
-	}
-};
-
 const { state, actions, callbacks } = store(
 	'core/image',
 	{
@@ -222,11 +201,8 @@ const { state, actions, callbacks } = store(
 				const imageMetadata = state.metadata[ imageId ];
 				const uploadedSrc = imageMetadata.uploadedSrc;
 
-				// Bails if the image is not valid or if it has already been preloaded.
-				if (
-					! isValidLink( uploadedSrc ) ||
-					state.preloadedImageIds.has( imageId )
-				) {
+				// Bails if it has already been preloaded.
+				if ( state.preloadedImageIds.has( imageId ) ) {
 					return;
 				}
 

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -52,6 +52,7 @@ const { state, actions, callbacks } = store(
 		state: {
 			currentImageId: null,
 			prefetchTimers: {},
+			prefetchedImageIds: new Set(),
 			get currentImage() {
 				return state.metadata[ state.currentImageId ];
 			},
@@ -214,7 +215,10 @@ const { state, actions, callbacks } = store(
 				const { imageId } = getContext();
 				const uploadedSrc = state.metadata[ imageId ].uploadedSrc;
 
-				if ( ! isValidLink( uploadedSrc ) ) {
+				if (
+					! isValidLink( uploadedSrc ) ||
+					state.prefetchedImageIds.has( imageId )
+				) {
 					return;
 				}
 
@@ -224,6 +228,7 @@ const { state, actions, callbacks } = store(
 				imageLink.href = uploadedSrc;
 
 				document.head.appendChild( imageLink );
+				state.prefetchedImageIds.add( imageId );
 			},
 			prefetchImageWithDelay() {
 				const { imageId } = getContext();

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -10,6 +10,11 @@ import {
 } from '@wordpress/interactivity';
 
 /**
+ * Internal dependencies
+ */
+import { IMAGE_PRELOAD_DELAY } from './constants';
+
+/**
  * Tracks whether user is touching screen; used to differentiate behavior for
  * touch and mouse input.
  *
@@ -30,7 +35,7 @@ const { state, actions, callbacks } = store(
 	{
 		state: {
 			currentImageId: null,
-			preloadTimers: {},
+			preloadTimers: new Map(),
 			preloadedImageIds: new Set(),
 			get currentImage() {
 				return state.metadata[ state.currentImageId ];
@@ -227,24 +232,25 @@ const { state, actions, callbacks } = store(
 				const { imageId } = getContext();
 
 				// Cancels any previous preload timer for the same image.
-				if ( state.preloadTimers && state.preloadTimers[ imageId ] ) {
-					clearTimeout( state.preloadTimers[ imageId ] );
+				if ( state.preloadTimers.has( imageId ) ) {
+					clearTimeout( state.preloadTimers.get( imageId ) );
 				}
 
 				// Set a new timer to preload the image after a short delay.
-				state.preloadTimers[ imageId ] = setTimeout(
+				const timerId = setTimeout(
 					withScope( () => {
 						actions.preloadImage();
-						delete state.preloadTimers[ imageId ];
+						state.preloadTimers.delete( imageId );
 					} ),
-					200
+					IMAGE_PRELOAD_DELAY
 				);
+				state.preloadTimers.set( imageId, timerId );
 			},
 			cancelPrefetch() {
 				const { imageId } = getContext();
-				if ( state.preloadTimers && state.preloadTimers[ imageId ] ) {
-					clearTimeout( state.preloadTimers[ imageId ] );
-					delete state.preloadTimers[ imageId ];
+				if ( state.preloadTimers.has( imageId ) ) {
+					clearTimeout( state.preloadTimers.get( imageId ) );
+					state.preloadTimers.delete( imageId );
 				}
 			},
 		},

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -201,7 +201,9 @@ const { state, actions, callbacks } = store(
 				const imageMetadata = state.metadata[ imageId ];
 				const uploadedSrc = imageMetadata.uploadedSrc;
 
-				// Bails if it has already been preloaded.
+				// Bails if it has already been preloaded. This could help
+				// prevent unnecessary preloading of the same image multiple times,
+				// leading to duplicate link elements in the document head.
 				if ( state.preloadedImageIds.has( imageId ) ) {
 					return;
 				}

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -6,6 +6,7 @@ import {
 	getContext,
 	getElement,
 	withSyncEvent,
+	withScope,
 } from '@wordpress/interactivity';
 
 /**
@@ -50,6 +51,7 @@ const { state, actions, callbacks } = store(
 	{
 		state: {
 			currentImageId: null,
+			prefetchTimers: {},
 			get currentImage() {
 				return state.metadata[ state.currentImageId ];
 			},
@@ -209,19 +211,42 @@ const { state, actions, callbacks } = store(
 				}
 			},
 			prefetchImage() {
-				const ctx = getContext();
-				if ( ! isValidLink( ctx.uploadedSrc ) ) {
+				const { imageId } = getContext();
+				const uploadedSrc = state.metadata[ imageId ].uploadedSrc;
+
+				if ( ! isValidLink( uploadedSrc ) ) {
 					return;
 				}
 
-				// Creates a link element to prefetch the image.
 				const imageLink = document.createElement( 'link' );
 				imageLink.rel = 'prefetch';
 				imageLink.as = 'image';
-				imageLink.href = ctx.uploadedSrc;
+				imageLink.href = uploadedSrc;
 
-				// Appends the link element to the head of the document to start the prefetch.
+				// Appends the link element to start the prefetch.
 				document.head.appendChild( imageLink );
+			},
+			prefetchImageWithDelay() {
+				const { imageId } = getContext();
+
+				if ( state.prefetchTimers && state.prefetchTimers[ imageId ] ) {
+					clearTimeout( state.prefetchTimers[ imageId ] );
+				}
+
+				state.prefetchTimers[ imageId ] = setTimeout(
+					withScope( () => {
+						actions.prefetchImage();
+						delete state.prefetchTimers[ imageId ];
+					} ),
+					200
+				);
+			},
+			cancelPrefetch() {
+				const { imageId } = getContext();
+				if ( state.prefetchTimers && state.prefetchTimers[ imageId ] ) {
+					clearTimeout( state.prefetchTimers[ imageId ] );
+					delete state.prefetchTimers[ imageId ];
+				}
 			},
 		},
 		callbacks: {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -206,15 +206,13 @@ const { state, actions, callbacks } = store(
 					return;
 				}
 
-				// Get the original img element's srcset
-				const srcset = imageMetadata.lightboxSrcset;
-
 				const imageLink = document.createElement( 'link' );
 				imageLink.rel = 'preload';
 				imageLink.as = 'image';
 				imageLink.href = uploadedSrc;
 
-				// Apply srcset if available for better responsive preloading
+				// Apply srcset if available for responsive preloading
+				const srcset = imageMetadata.lightboxSrcset;
 				if ( srcset ) {
 					imageLink.setAttribute( 'imagesrcset', srcset );
 					imageLink.setAttribute( 'imagesizes', '100vw' );

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -71,6 +71,12 @@ const { state, actions, callbacks } = store(
 					'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 				);
 			},
+			get enlargedSrcset() {
+				return state.currentImage.lightboxSrcset || '';
+			},
+			get enlargedSizes() {
+				return state.currentImage.lightboxSizes || '100vw';
+			},
 			get figureStyles() {
 				return (
 					state.overlayOpened &&
@@ -213,7 +219,8 @@ const { state, actions, callbacks } = store(
 			},
 			prefetchImage() {
 				const { imageId } = getContext();
-				const uploadedSrc = state.metadata[ imageId ].uploadedSrc;
+				const imageMetadata = state.metadata[ imageId ];
+				const uploadedSrc = imageMetadata.uploadedSrc;
 
 				// Bails if the image is not valid or if it has already been prefetched.
 				if (
@@ -223,10 +230,19 @@ const { state, actions, callbacks } = store(
 					return;
 				}
 
+				// Get the original img element's srcset
+				const srcset = imageMetadata.lightboxSrcset;
+
 				const imageLink = document.createElement( 'link' );
-				imageLink.rel = 'prefetch';
+				imageLink.rel = 'preload';
 				imageLink.as = 'image';
 				imageLink.href = uploadedSrc;
+
+				// Apply srcset if available for better responsive prefetching
+				if ( srcset ) {
+					imageLink.setAttribute( 'imagesrcset', srcset );
+					imageLink.setAttribute( 'imagesizes', '100vw' );
+				}
 
 				document.head.appendChild( imageLink );
 				state.prefetchedImageIds.add( imageId );

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -53,16 +53,6 @@ function getImageSrcset( { lightboxSrcset } ) {
 	return lightboxSrcset || '';
 }
 
-/**
- * Returns the appropriate sizes attribute for an image.
- *
- * @param {string} lightboxSizes - Image responsive sizes attribute.
- * @return {string} The sizes value, defaulting to 100vw.
- */
-function getImageSizes( { lightboxSizes } ) {
-	return lightboxSizes || '100vw';
-}
-
 const { state, actions, callbacks } = store(
 	'core/image',
 	{
@@ -87,9 +77,6 @@ const { state, actions, callbacks } = store(
 			},
 			get enlargedSrcset() {
 				return getImageSrcset( state.currentImage );
-			},
-			get enlargedSizes() {
-				return getImageSizes( state.currentImage );
 			},
 			get figureStyles() {
 				return (
@@ -252,10 +239,7 @@ const { state, actions, callbacks } = store(
 				const srcset = getImageSrcset( imageMetadata );
 				if ( srcset ) {
 					imageLink.setAttribute( 'imagesrcset', srcset );
-					imageLink.setAttribute(
-						'imagesizes',
-						getImageSizes( imageMetadata )
-					);
+					imageLink.setAttribute( 'imagesizes', '100vw' );
 				}
 
 				document.head.appendChild( imageLink );
@@ -264,10 +248,7 @@ const { state, actions, callbacks } = store(
 			preloadImageWithDelay() {
 				const { imageId } = getContext();
 
-				// Cancels any previous preload timer for the same image.
-				if ( state.preloadTimers.has( imageId ) ) {
-					clearTimeout( state.preloadTimers.get( imageId ) );
-				}
+				actions.cancelPreload();
 
 				// Set a new timer to preload the image after a short delay.
 				const timerId = setTimeout(
@@ -279,7 +260,7 @@ const { state, actions, callbacks } = store(
 				);
 				state.preloadTimers.set( imageId, timerId );
 			},
-			cancelPrefetch() {
+			cancelPreload() {
 				const { imageId } = getContext();
 				if ( state.preloadTimers.has( imageId ) ) {
 					clearTimeout( state.preloadTimers.get( imageId ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #60883 

## What?
Prefetch full-resolution image to speed up display of Click to expand images.
see https://github.com/WordPress/gutenberg/issues/60883 for more details

## Why?
Hovering over a click-to-expand image block does not proactively attempt to prefetch the full-scale image in Lighbox. This can result in a prolonged period in which the low-resolution scaled-up image is displayed in the lightbox.

## How?
- Implement prefetchImage action that prefetches an image and keeps it in the browser cache.
- Then utilising the above add pointer event directives that trigger it on `pointerup` & `pointerdown`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Create a post with a click to expand image on it.
2. Open Dev tools and throttle network to slow 3G and notice the network tab.
3. Hover over the image, this will trigger the image to load.
4. When the loading is complete, click the image for it to load in full resolution without any delay or loading.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="842" alt="Screenshot 2024-04-25 at 10 18 51 PM" src="https://github.com/WordPress/gutenberg/assets/71006004/4f918217-9598-41ca-8e1b-9ac31ccbce8b">
