### PR TITLE
Move search into inserter tabs

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -14,6 +14,7 @@ import MobileTabNavigation from '../mobile-tab-navigation';
 import { PatternCategoryPreviews } from './pattern-category-previews';
 import { usePatternCategories } from './use-pattern-categories';
 import CategoryTabs from '../category-tabs';
+import InserterNoResults from '../no-results';
 
 function BlockPatternsTab( {
 	onSelectCategory,
@@ -27,6 +28,10 @@ function BlockPatternsTab( {
 	const categories = usePatternCategories( rootClientId );
 
 	const isMobile = useViewportMatch( 'medium', '<' );
+
+	if ( ! categories.length ) {
+		return <InserterNoResults />;
+	}
 
 	return (
 		<>

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -14,7 +14,6 @@ import MobileTabNavigation from '../mobile-tab-navigation';
 import { PatternCategoryPreviews } from './pattern-category-previews';
 import { usePatternCategories } from './use-pattern-categories';
 import CategoryTabs from '../category-tabs';
-import InserterNoResults from '../no-results';
 
 function BlockPatternsTab( {
 	onSelectCategory,
@@ -28,10 +27,6 @@ function BlockPatternsTab( {
 	const categories = usePatternCategories( rootClientId );
 
 	const isMobile = useViewportMatch( 'medium', '<' );
-
-	if ( ! categories.length ) {
-		return <InserterNoResults />;
-	}
 
 	return (
 		<>

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -13,6 +13,7 @@ import InserterPanel from './panel';
 import useBlockTypesState from './hooks/use-block-types-state';
 import InserterListbox from '../inserter-listbox';
 import { orderBy } from '../../utils/sorting';
+import InserterNoResults from './no-results';
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
@@ -101,6 +102,10 @@ export function BlockTypesTab( {
 	const currentlyRenderedCollections = useAsyncList(
 		didRenderAllCategories ? collectionEntries : EMPTY_ARRAY
 	);
+
+	if ( ! items.length ) {
+		return <InserterNoResults />;
+	}
 
 	return (
 		<InserterListbox>

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -13,7 +13,6 @@ import InserterPanel from './panel';
 import useBlockTypesState from './hooks/use-block-types-state';
 import InserterListbox from '../inserter-listbox';
 import { orderBy } from '../../utils/sorting';
-import InserterNoResults from './no-results';
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
@@ -102,10 +101,6 @@ export function BlockTypesTab( {
 	const currentlyRenderedCollections = useAsyncList(
 		didRenderAllCategories ? collectionEntries : EMPTY_ARRAY
 	);
-
-	if ( ! items.length ) {
-		return <InserterNoResults />;
-	}
 
 	return (
 		<InserterListbox>

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -16,6 +16,7 @@ import { useMediaCategories } from './hooks';
 import { getBlockAndPreviewFromMedia } from './utils';
 import MobileTabNavigation from '../mobile-tab-navigation';
 import CategoryTabs from '../category-tabs';
+import InserterNoResults from '../no-results';
 
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video', 'audio' ];
 
@@ -47,6 +48,10 @@ function MediaTab( {
 			} ) ),
 		[ mediaCategories ]
 	);
+
+	if ( ! categories.length ) {
+		return <InserterNoResults />;
+	}
 
 	return (
 		<>

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -16,7 +16,6 @@ import { useMediaCategories } from './hooks';
 import { getBlockAndPreviewFromMedia } from './utils';
 import MobileTabNavigation from '../mobile-tab-navigation';
 import CategoryTabs from '../category-tabs';
-import InserterNoResults from '../no-results';
 
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video', 'audio' ];
 
@@ -48,10 +47,6 @@ function MediaTab( {
 			} ) ),
 		[ mediaCategories ]
 	);
-
-	if ( ! categories.length ) {
-		return <InserterNoResults />;
-	}
 
 	return (
 		<>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -6,7 +6,14 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { forwardRef, useState, useCallback, useMemo } from '@wordpress/element';
+import {
+	forwardRef,
+	useEffect,
+	useState,
+	useCallback,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -230,6 +237,15 @@ function InserterMenu(
 		}
 		setSelectedTab( value );
 	};
+
+	const searchRef = useRef();
+	useEffect( () => {
+		const focusTimeout = setTimeout( () => {
+			searchRef?.current?.focus();
+		} );
+		return () => clearTimeout( focusTimeout );
+	}, [ selectedTab ] );
+
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {
 			return null;
@@ -247,6 +263,7 @@ function InserterMenu(
 					value={ filterValue }
 					label={ __( 'Search for blocks and patterns' ) }
 					placeholder={ __( 'Search' ) }
+					ref={ searchRef }
 				/>
 				{ !! delayedFilterValue && (
 					<InserterSearchResults
@@ -282,6 +299,7 @@ function InserterMenu(
 		rootClientId,
 		__experimentalInsertionIndex,
 		isAppender,
+		searchRef,
 	] );
 
 	return (

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -10,8 +10,8 @@ import {
 	forwardRef,
 	useState,
 	useCallback,
-	useImperativeHandle,
 	useMemo,
+	useImperativeHandle,
 	useRef,
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -6,13 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	forwardRef,
-	useState,
-	useCallback,
-	useMemo,
-	useRef,
-} from '@wordpress/element';
+import { forwardRef, useState, useCallback, useMemo } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDebouncedInput } from '@wordpress/compose';
@@ -121,8 +115,6 @@ function InserterMenu(
 
 	const showMediaPanel = selectedTab === 'media' && selectedMediaCategory;
 
-	const searchRef = useRef();
-
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {
 			return null;
@@ -141,7 +133,6 @@ function InserterMenu(
 					value={ filterValue }
 					label={ __( 'Search for blocks and patterns' ) }
 					placeholder={ __( 'Search' ) }
-					ref={ searchRef }
 				/>
 				{ !! delayedFilterValue && (
 					<InserterSearchResults
@@ -177,7 +168,6 @@ function InserterMenu(
 		rootClientId,
 		__experimentalInsertionIndex,
 		isAppender,
-		searchRef,
 	] );
 
 	const blocksTab = useMemo(

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -36,7 +36,6 @@ import { store as blockEditorStore } from '../../store';
 import { useZoomOut } from '../../hooks/use-zoom-out';
 
 const NOOP = () => {};
-
 function InserterMenu(
 	{
 		rootClientId,

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -6,18 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	forwardRef,
-	useEffect,
-	useState,
-	useCallback,
-	useMemo,
-	useRef,
-} from '@wordpress/element';
+import { forwardRef, useState, useCallback, useMemo } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useDebouncedInput } from '@wordpress/compose';
+import { useDebouncedInput, useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -238,14 +231,11 @@ function InserterMenu(
 		setSelectedTab( value );
 	};
 
-	const searchRef = useRef();
-	useEffect( () => {
-		// We need to wait for the next frame to focus the search input
-		// becase the tabs component will try to focus the selected tab
-		window.requestAnimationFrame( () => {
-			searchRef?.current?.focus();
-		} );
-	}, [ selectedTab ] );
+	const searchRef = useRefEffect( ( element ) => {
+		if ( element ) {
+			element.focus();
+		}
+	} );
 
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -240,6 +240,8 @@ function InserterMenu(
 
 	const searchRef = useRef();
 	useEffect( () => {
+		// We need to wait for the next frame to focus the search input
+		// becase the tabs component will try to focus the selected tab
 		window.requestAnimationFrame( () => {
 			searchRef?.current?.focus();
 		} );

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -135,10 +135,16 @@ function InserterMenu(
 		! delayedFilterValue &&
 		selectedPatternCategory;
 
-	const showMediaPanel =
-		selectedTab === 'media' &&
-		! delayedFilterValue &&
-		selectedMediaCategory;
+	const showMediaPanel = selectedTab === 'media' && selectedMediaCategory;
+
+	const searchRef = useRef();
+	useImperativeHandle( ref, () => ( {
+		focusSearch: () => {
+			searchRef.current.focus();
+		},
+	} ) );
+
+	const showAsTabs = showPatterns || showMedia;
 
 	const blocksTab = useMemo(
 		() => (
@@ -227,24 +233,6 @@ function InserterMenu(
 		]
 	);
 
-	const inserterTabsContents = useMemo(
-		() => ( {
-			blocks: blocksTab,
-			patterns: patternsTab,
-			media: mediaTab,
-		} ),
-		[ blocksTab, mediaTab, patternsTab ]
-	);
-
-	const searchRef = useRef();
-	useImperativeHandle( ref, () => ( {
-		focusSearch: () => {
-			searchRef.current.focus();
-		},
-	} ) );
-
-	const showAsTabs = ! delayedFilterValue && ( showPatterns || showMedia );
-
 	// When the pattern panel is showing, we want to use zoom out mode
 	useZoomOut( showPatternPanel );
 
@@ -267,49 +255,103 @@ function InserterMenu(
 					'show-as-tabs': showAsTabs,
 				} ) }
 			>
-				<SearchControl
-					__nextHasNoMarginBottom
-					className="block-editor-inserter__search"
-					onChange={ ( value ) => {
-						if ( hoveredItem ) {
-							setHoveredItem( null );
-						}
-						setFilterValue( value );
-					} }
-					value={ filterValue }
-					label={ __( 'Search for blocks and patterns' ) }
-					placeholder={ __( 'Search' ) }
-					ref={ searchRef }
-				/>
-				{ !! delayedFilterValue && (
-					<div className="block-editor-inserter__no-tab-container">
-						<InserterSearchResults
-							filterValue={ delayedFilterValue }
-							onSelect={ onSelect }
-							onHover={ onHover }
-							onHoverPattern={ onHoverPattern }
-							rootClientId={ rootClientId }
-							clientId={ clientId }
-							isAppender={ isAppender }
-							__experimentalInsertionIndex={
-								__experimentalInsertionIndex
-							}
-							showBlockDirectory
-							shouldFocusBlock={ shouldFocusBlock }
-						/>
-					</div>
-				) }
 				{ showAsTabs && (
 					<InserterTabs
 						showPatterns={ showPatterns }
 						showMedia={ showMedia }
 						onSelect={ handleSetSelectedTab }
-						tabsContents={ inserterTabsContents }
-					/>
+					>
+						{ ( selectedTab === 'blocks' ||
+							selectedTab === 'patterns' ) && (
+							<>
+								{ /* TODO: Make this into a component */ }
+								<SearchControl
+									__nextHasNoMarginBottom
+									className="block-editor-inserter__search"
+									onChange={ ( value ) => {
+										if ( hoveredItem )
+											setHoveredItem( null );
+										setFilterValue( value );
+									} }
+									value={ filterValue }
+									label={ __(
+										'Search for blocks and patterns'
+									) }
+									placeholder={ __( 'Search' ) }
+									ref={ searchRef }
+								/>
+								{ !! delayedFilterValue && (
+									<div className="block-editor-inserter__no-tab-container">
+										<InserterSearchResults
+											filterValue={ delayedFilterValue }
+											onSelect={ onSelect }
+											onHover={ onHover }
+											onHoverPattern={ onHoverPattern }
+											rootClientId={ rootClientId }
+											clientId={ clientId }
+											isAppender={ isAppender }
+											__experimentalInsertionIndex={
+												__experimentalInsertionIndex
+											}
+											showBlockDirectory
+											shouldFocusBlock={
+												shouldFocusBlock
+											}
+											prioritizePatterns={
+												selectedTab === 'patterns'
+											}
+										/>
+									</div>
+								) }
+							</>
+						) }
+						{ selectedTab === 'blocks' &&
+							! delayedFilterValue &&
+							blocksTab }
+						{ selectedTab === 'patterns' &&
+							! delayedFilterValue &&
+							patternsTab }
+						{ selectedTab === 'media' && mediaTab }
+					</InserterTabs>
 				) }
-				{ ! delayedFilterValue && ! showAsTabs && (
+				{ ! showAsTabs && (
 					<div className="block-editor-inserter__no-tab-container">
-						{ blocksTab }
+						<>
+							<SearchControl
+								__nextHasNoMarginBottom
+								className="block-editor-inserter__search"
+								onChange={ ( value ) => {
+									if ( hoveredItem ) setHoveredItem( null );
+									setFilterValue( value );
+								} }
+								value={ filterValue }
+								label={ __( 'Search for blocks and patterns' ) }
+								placeholder={ __( 'Search' ) }
+								ref={ searchRef }
+							/>
+							{ !! delayedFilterValue && (
+								<div className="block-editor-inserter__no-tab-container">
+									<InserterSearchResults
+										filterValue={ delayedFilterValue }
+										onSelect={ onSelect }
+										onHover={ onHover }
+										onHoverPattern={ onHoverPattern }
+										rootClientId={ rootClientId }
+										clientId={ clientId }
+										isAppender={ isAppender }
+										__experimentalInsertionIndex={
+											__experimentalInsertionIndex
+										}
+										showBlockDirectory
+										shouldFocusBlock={ shouldFocusBlock }
+										prioritizePatterns={
+											selectedTab === 'patterns'
+										}
+									/>
+								</div>
+							) }
+						</>
+						{ ! delayedFilterValue && { blocksTab } }
 					</div>
 				) }
 			</div>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -140,104 +140,6 @@ function InserterMenu(
 
 	const showAsTabs = showPatterns || showMedia;
 
-	const blocksTab = useMemo(
-		() => (
-			<>
-				<div className="block-editor-inserter__block-list">
-					<BlockTypesTab
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsert }
-						onHover={ onHover }
-						showMostUsedBlocks={ showMostUsedBlocks }
-					/>
-				</div>
-				{ showInserterHelpPanel && (
-					<div className="block-editor-inserter__tips">
-						<VisuallyHidden as="h2">
-							{ __( 'A tip for using the block editor' ) }
-						</VisuallyHidden>
-						<Tips />
-					</div>
-				) }
-			</>
-		),
-		[
-			destinationRootClientId,
-			onInsert,
-			onHover,
-			showMostUsedBlocks,
-			showInserterHelpPanel,
-		]
-	);
-
-	const patternsTab = useMemo(
-		() => (
-			<BlockPatternsTab
-				rootClientId={ destinationRootClientId }
-				onInsert={ onInsertPattern }
-				onSelectCategory={ onClickPatternCategory }
-				selectedCategory={ selectedPatternCategory }
-			>
-				{ showPatternPanel && (
-					<PatternCategoryPreviewPanel
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsertPattern }
-						onHover={ onHoverPattern }
-						category={ selectedPatternCategory }
-						patternFilter={ patternFilter }
-						showTitlesAsTooltip
-					/>
-				) }
-			</BlockPatternsTab>
-		),
-		[
-			destinationRootClientId,
-			onHoverPattern,
-			onInsertPattern,
-			onClickPatternCategory,
-			patternFilter,
-			selectedPatternCategory,
-			showPatternPanel,
-		]
-	);
-
-	const mediaTab = useMemo(
-		() => (
-			<MediaTab
-				rootClientId={ destinationRootClientId }
-				selectedCategory={ selectedMediaCategory }
-				onSelectCategory={ setSelectedMediaCategory }
-				onInsert={ onInsert }
-			>
-				{ showMediaPanel && (
-					<MediaCategoryPanel
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsert }
-						category={ selectedMediaCategory }
-					/>
-				) }
-			</MediaTab>
-		),
-		[
-			destinationRootClientId,
-			onInsert,
-			selectedMediaCategory,
-			setSelectedMediaCategory,
-			showMediaPanel,
-		]
-	);
-
-	// When the pattern panel is showing, we want to use zoom out mode
-	useZoomOut( showPatternPanel );
-
-	const handleSetSelectedTab = ( value ) => {
-		// If no longer on patterns tab remove the category setting.
-		if ( value !== 'patterns' ) {
-			setSelectedPatternCategory( null );
-		}
-		setSelectedTab( value );
-	};
-
 	const searchRef = useRef();
 	useImperativeHandle( ref, () => ( {
 		focusSearch: () => {
@@ -255,7 +157,9 @@ function InserterMenu(
 					__nextHasNoMarginBottom
 					className="block-editor-inserter__search"
 					onChange={ ( value ) => {
-						if ( hoveredItem ) setHoveredItem( null );
+						if ( hoveredItem ) {
+							setHoveredItem( null );
+						}
 						setFilterValue( value );
 					} }
 					value={ filterValue }
@@ -300,6 +204,123 @@ function InserterMenu(
 		searchRef,
 	] );
 
+	const blocksTab = useMemo(
+		() => (
+			<>
+				{ inserterSearch }
+				<div className="block-editor-inserter__block-list">
+					<BlockTypesTab
+						rootClientId={ destinationRootClientId }
+						onInsert={ onInsert }
+						onHover={ onHover }
+						showMostUsedBlocks={ showMostUsedBlocks }
+					/>
+				</div>
+				{ showInserterHelpPanel && (
+					<div className="block-editor-inserter__tips">
+						<VisuallyHidden as="h2">
+							{ __( 'A tip for using the block editor' ) }
+						</VisuallyHidden>
+						<Tips />
+					</div>
+				) }
+			</>
+		),
+		[
+			destinationRootClientId,
+			onInsert,
+			onHover,
+			showMostUsedBlocks,
+			showInserterHelpPanel,
+			inserterSearch,
+		]
+	);
+
+	const patternsTab = useMemo(
+		() => (
+			<>
+				{ inserterSearch }
+				<BlockPatternsTab
+					rootClientId={ destinationRootClientId }
+					onInsert={ onInsertPattern }
+					onSelectCategory={ onClickPatternCategory }
+					selectedCategory={ selectedPatternCategory }
+				>
+					{ showPatternPanel && (
+						<PatternCategoryPreviewPanel
+							rootClientId={ destinationRootClientId }
+							onInsert={ onInsertPattern }
+							onHover={ onHoverPattern }
+							category={ selectedPatternCategory }
+							patternFilter={ patternFilter }
+							showTitlesAsTooltip
+						/>
+					) }
+				</BlockPatternsTab>
+			</>
+		),
+		[
+			destinationRootClientId,
+			onHoverPattern,
+			onInsertPattern,
+			onClickPatternCategory,
+			patternFilter,
+			selectedPatternCategory,
+			showPatternPanel,
+			inserterSearch,
+		]
+	);
+
+	const mediaTab = useMemo(
+		() => (
+			<>
+				{ inserterSearch }
+				<MediaTab
+					rootClientId={ destinationRootClientId }
+					selectedCategory={ selectedMediaCategory }
+					onSelectCategory={ setSelectedMediaCategory }
+					onInsert={ onInsert }
+				>
+					{ showMediaPanel && (
+						<MediaCategoryPanel
+							rootClientId={ destinationRootClientId }
+							onInsert={ onInsert }
+							category={ selectedMediaCategory }
+						/>
+					) }
+				</MediaTab>
+			</>
+		),
+		[
+			destinationRootClientId,
+			onInsert,
+			selectedMediaCategory,
+			setSelectedMediaCategory,
+			showMediaPanel,
+			inserterSearch,
+		]
+	);
+
+	const inserterTabsContents = useMemo(
+		() => ( {
+			blocks: blocksTab,
+			patterns: patternsTab,
+			media: mediaTab,
+		} ),
+		[ blocksTab, mediaTab, patternsTab ]
+	);
+
+	// When the pattern panel is showing, we want to use zoom out mode
+	useZoomOut( showPatternPanel );
+
+	const handleSetSelectedTab = ( value ) => {
+		// If no longer on patterns tab remove the category setting.
+		if ( value !== 'patterns' ) {
+			setSelectedPatternCategory( null );
+		}
+		setSelectedTab( value );
+	};
+
 	return (
 		<div
 			className={ classnames( 'block-editor-inserter__menu', {
@@ -317,18 +338,8 @@ function InserterMenu(
 						showPatterns={ showPatterns }
 						showMedia={ showMedia }
 						onSelect={ handleSetSelectedTab }
-					>
-						{ ( selectedTab === 'blocks' ||
-							selectedTab === 'patterns' ) &&
-							inserterSearch }
-						{ selectedTab === 'blocks' &&
-							! delayedFilterValue &&
-							blocksTab }
-						{ selectedTab === 'patterns' &&
-							! delayedFilterValue &&
-							patternsTab }
-						{ selectedTab === 'media' && mediaTab }
-					</InserterTabs>
+						tabsContents={ inserterTabsContents }
+					/>
 				) }
 				{ ! showAsTabs && (
 					<div className="block-editor-inserter__no-tab-container">

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -10,9 +10,9 @@ import {
 	forwardRef,
 	useState,
 	useCallback,
+	useImperativeHandle,
 	useMemo,
 	useRef,
-	useImperativeHandle,
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -240,10 +240,9 @@ function InserterMenu(
 
 	const searchRef = useRef();
 	useEffect( () => {
-		const focusTimeout = setTimeout( () => {
+		window.requestAnimationFrame( () => {
 			searchRef?.current?.focus();
 		} );
-		return () => clearTimeout( focusTimeout );
 	}, [ selectedTab ] );
 
 	const inserterSearch = useMemo( () => {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -6,7 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { forwardRef, useState, useCallback, useMemo } from '@wordpress/element';
+import {
+	forwardRef,
+	useState,
+	useCallback,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -53,7 +59,7 @@ function InserterMenu(
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
-	const [ selectedTab, setSelectedTab ] = useState( null );
+	const [ selectedTab, setSelectedTab ] = useState( 'blocks' );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {
@@ -231,17 +237,18 @@ function InserterMenu(
 		setSelectedTab( value );
 	};
 
+	const hasAutoFocused = useRef( false );
 	const searchRef = useRefEffect( ( element ) => {
-		if ( element ) {
-			element.focus();
+		if ( element && hasAutoFocused.current === false ) {
+			hasAutoFocused.current = true;
+			window.requestAnimationFrame( () => element.focus() );
 		}
-	} );
+	}, [] );
 
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {
 			return null;
 		}
-
 		return (
 			<>
 				<SearchControl

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -6,7 +6,14 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { forwardRef, useState, useCallback, useMemo } from '@wordpress/element';
+import {
+	forwardRef,
+	useState,
+	useCallback,
+	useMemo,
+	useRef,
+	useLayoutEffect,
+} from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDebouncedInput } from '@wordpress/compose';
@@ -291,6 +298,18 @@ function InserterMenu(
 		setSelectedTab( value );
 	};
 
+	// Focus first active tab, if any
+	const tabsRef = useRef();
+	useLayoutEffect( () => {
+		if ( tabsRef.current ) {
+			window.requestAnimationFrame( () => {
+				tabsRef.current
+					.querySelector( '[role="tab"][aria-selected="true"]' )
+					?.focus();
+			} );
+		}
+	}, [] );
+
 	return (
 		<div
 			className={ classnames( 'block-editor-inserter__menu', {
@@ -300,6 +319,7 @@ function InserterMenu(
 		>
 			<div className="block-editor-inserter__main-area">
 				<InserterTabs
+					ref={ tabsRef }
 					onSelect={ handleSetSelectedTab }
 					tabsContents={ inserterTabsContents }
 				/>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -12,11 +12,12 @@ import {
 	useCallback,
 	useMemo,
 	useRef,
+	useImperativeHandle,
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useDebouncedInput, useRefEffect } from '@wordpress/compose';
+import { useDebouncedInput } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -237,13 +238,12 @@ function InserterMenu(
 		setSelectedTab( value );
 	};
 
-	const hasAutoFocused = useRef( false );
-	const searchRef = useRefEffect( ( element ) => {
-		if ( element && hasAutoFocused.current === false ) {
-			hasAutoFocused.current = true;
-			window.requestAnimationFrame( () => element.focus() );
-		}
-	}, [] );
+	const searchRef = useRef();
+	useImperativeHandle( ref, () => ( {
+		focusSearch: () => {
+			window.requestAnimationFrame( () => searchRef.current.focus() );
+		},
+	} ) );
 
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -136,6 +136,11 @@ $block-inserter-tabs-height: 44px;
 		flex-direction: column;
 		overflow-y: auto;
 	}
+
+	// The first tab panel needs space-between to prevent a flash of the "hint" from appearing at the top then moving down.
+	.block-editor-inserter__tablist + .block-editor-inserter__tabpanel {
+		justify-content: space-between;
+	}
 }
 
 .block-editor-inserter__no-tab-container {

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -32,7 +32,7 @@ function InserterTabs( {
 	showPatterns = false,
 	showMedia = false,
 	onSelect,
-	children,
+	tabsContents,
 } ) {
 	const tabs = [
 		blocksTab,
@@ -61,7 +61,7 @@ function InserterTabs( {
 						focusable={ false }
 						className="block-editor-inserter__tabpanel"
 					>
-						{ children }
+						{ tabsContents[ tab.name ] }
 					</Tabs.TabPanel>
 				) ) }
 			</Tabs>

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -28,17 +28,8 @@ const mediaTab = {
 	title: __( 'Media' ),
 };
 
-function InserterTabs( {
-	showPatterns = false,
-	showMedia = false,
-	onSelect,
-	tabsContents,
-} ) {
-	const tabs = [
-		blocksTab,
-		showPatterns && patternsTab,
-		showMedia && mediaTab,
-	].filter( Boolean );
+function InserterTabs( { onSelect, tabsContents } ) {
+	const tabs = [ blocksTab, patternsTab, mediaTab ].filter( Boolean );
 
 	return (
 		<div className="block-editor-inserter__tabs">

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -3,6 +3,7 @@
  */
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -28,11 +29,11 @@ const mediaTab = {
 	title: __( 'Media' ),
 };
 
-function InserterTabs( { onSelect, tabsContents } ) {
+function InserterTabs( { onSelect, tabsContents }, ref ) {
 	const tabs = [ blocksTab, patternsTab, mediaTab ];
 
 	return (
-		<div className="block-editor-inserter__tabs">
+		<div className="block-editor-inserter__tabs" ref={ ref }>
 			<Tabs onSelect={ onSelect }>
 				<Tabs.TabList className="block-editor-inserter__tablist">
 					{ tabs.map( ( tab ) => (
@@ -60,4 +61,4 @@ function InserterTabs( { onSelect, tabsContents } ) {
 	);
 }
 
-export default InserterTabs;
+export default forwardRef( InserterTabs );

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -32,7 +32,7 @@ function InserterTabs( {
 	showPatterns = false,
 	showMedia = false,
 	onSelect,
-	tabsContents,
+	children,
 } ) {
 	const tabs = [
 		blocksTab,
@@ -61,7 +61,7 @@ function InserterTabs( {
 						focusable={ false }
 						className="block-editor-inserter__tabpanel"
 					>
-						{ tabsContents[ tab.name ] }
+						{ children }
 					</Tabs.TabPanel>
 				) ) }
 			</Tabs>

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -29,7 +29,7 @@ const mediaTab = {
 };
 
 function InserterTabs( { onSelect, tabsContents } ) {
-	const tabs = [ blocksTab, patternsTab, mediaTab ].filter( Boolean );
+	const tabs = [ blocksTab, patternsTab, mediaTab ];
 
 	return (
 		<div className="block-editor-inserter__tabs">

--- a/packages/edit-widgets/src/components/layout/style.scss
+++ b/packages/edit-widgets/src/components/layout/style.scss
@@ -18,6 +18,10 @@
 	// Leave space for the close button
 	height: calc(100% - #{$button-size} - #{$grid-unit-10});
 
+	.block-editor-inserter__tab {
+		display: none;
+	}
+
 	@include break-medium() {
 		height: 100%;
 	}

--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -31,7 +31,7 @@ export default function InserterSidebar() {
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: closeInserter,
-		focusOnMount: false,
+		focusOnMount: null, // Needs to be null not force for Firefox.
 	} );
 
 	const libraryRef = useRef();

--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -8,7 +8,7 @@ import {
 	useViewportMatch,
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
-import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -35,9 +35,6 @@ export default function InserterSidebar() {
 	} );
 
 	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
 
 	return (
 		<div

--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -8,7 +8,7 @@ import {
 	useViewportMatch,
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
-import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -31,13 +31,10 @@ export default function InserterSidebar() {
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: closeInserter,
-		focusOnMount: null,
+		focusOnMount: false,
 	} );
 
 	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
 
 	return (
 		<div

--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -8,7 +8,7 @@ import {
 	useViewportMatch,
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -35,6 +35,9 @@ export default function InserterSidebar() {
 	} );
 
 	const libraryRef = useRef();
+	useEffect( () => {
+		libraryRef.current.focusSearch();
+	}, [] );
 
 	return (
 		<div

--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -31,7 +31,7 @@ export default function InserterSidebar() {
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: closeInserter,
-		focusOnMount: null, // Needs to be null not force for Firefox.
+		focusOnMount: true,
 	} );
 
 	const libraryRef = useRef();

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -10,7 +10,7 @@ import {
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
@@ -41,10 +41,6 @@ export default function InserterSidebar( {
 	} );
 
 	const libraryRef = useRef();
-	useEffect( () => {
-		// TODO: Fix focus search
-		// libraryRef.current.focusSearch();
-	}, [] );
 
 	return (
 		<div

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -37,7 +37,7 @@ export default function InserterSidebar( {
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
-		focusOnMount: false,
+		focusOnMount: null, // Needs to be null not force for Firefox.
 	} );
 
 	const libraryRef = useRef();

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -42,7 +42,8 @@ export default function InserterSidebar( {
 
 	const libraryRef = useRef();
 	useEffect( () => {
-		libraryRef.current.focusSearch();
+		// TODO: Fix focus search
+		// libraryRef.current.focusSearch();
 	}, [] );
 
 	return (

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -37,7 +37,7 @@ export default function InserterSidebar( {
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
-		focusOnMount: null, // Needs to be null not force for Firefox.
+		focusOnMount: true,
 	} );
 
 	const libraryRef = useRef();

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -10,7 +10,7 @@ import {
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
@@ -37,13 +37,10 @@ export default function InserterSidebar( {
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
-		focusOnMount: null,
+		focusOnMount: false,
 	} );
 
 	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
 
 	return (
 		<div

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -10,7 +10,7 @@ import {
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
@@ -41,6 +41,9 @@ export default function InserterSidebar( {
 	} );
 
 	const libraryRef = useRef();
+	useEffect( () => {
+		libraryRef.current.focusSearch();
+	}, [] );
 
 	return (
 		<div

--- a/test/e2e/specs/editor/various/adding-patterns.spec.js
+++ b/test/e2e/specs/editor/various/adding-patterns.spec.js
@@ -9,10 +9,9 @@ test.describe( 'adding patterns', () => {
 	} );
 
 	test( 'should insert a block pattern', async ( { page, editor } ) => {
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
-		);
+		await page.getByLabel( 'Toggle block inserter' ).click();
 
+		await page.getByRole( 'tab', { name: 'Patterns' } ).click();
 		await page.fill(
 			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',
 			'Social links with a shared background color'

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -598,6 +598,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.getByRole( 'searchbox', {
 				name: 'Search for blocks and patterns',
 			} )
+			.first()
 			.fill( 'Verse' );
 		await page.getByRole( 'button', { name: 'Browse All' } ).click();
 
@@ -607,9 +608,10 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 				.getByRole( 'searchbox', {
 					name: 'Search for blocks and patterns',
 				} )
+				.first()
 		).toHaveValue( 'Verse' );
 		await expect(
-			page.getByRole( 'listbox', { name: 'Blocks' } )
+			page.getByRole( 'listbox', { name: 'Blocks' } ).first()
 		).toHaveCount( 1 );
 	} );
 

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -418,9 +418,11 @@ test.describe( 'Post Editor Performance', () => {
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Toggle block inserter',
 			} );
-
 			// Open Inserter.
 			await globalInserterToggle.click();
+
+			await page.getByPlaceholder( 'Search' ).click();
+
 			await perfUtils.expectExpandedState( globalInserterToggle, 'true' );
 
 			const samples = 10;

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -421,7 +421,7 @@ test.describe( 'Post Editor Performance', () => {
 			// Open Inserter.
 			await globalInserterToggle.click();
 
-			await page.getByPlaceholder( 'Search' ).click();
+			await page.getByRole( 'searchbox' ).click();
 
 			await perfUtils.expectExpandedState( globalInserterToggle, 'true' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This moves the search box in the inserter inside the blocks and patterns tab and prioritizes the search by the tab (blocks search prioritizes blocks, for example).

## Why?
To keep the inserter open after users insert patterns as this will provide a better experience for assembling pages with patterns (see https://github.com/WordPress/gutenberg/issues/61051).

To achieve this we need to add a close button to the inserter.

To achieve this we need to move the search box below the tabs so that the close button can sit alongside the tabs like we do in other side panels, hence this PR.

## How?

- Move the search field below the tabs (see why above)
- Remove the auto focus on the search control ([reasoning](https://github.com/WordPress/gutenberg/pull/61108#issuecomment-2088347999))
- Always show the tabs even if there are no available contents in them
- Show a message when there are no blocks or patterns available

## Testing Instructions
1. Open the inserter
2. Check that the active tab is focused 
3. Search for something in the blocks tab
4. Should prioritize block results
5. Switch to patterns tab
6. Patterns from search should be shown

Do the same thing in the widget editor, site editor and post editor.

## Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/107534/9a1d7585-d11a-4850-9085-426286c99c10

