### PR TITLE
Documentation: Add EditorSnackbars component docs

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -288,7 +288,11 @@ Undocumented declaration.
 
 ### EditorSnackbars
 
-Undocumented declaration.
+Renders the editor snackbars component.
+
+_Returns_
+
+-   `JSX.Element`: The rendered component.
 
 ### EntitiesSavedStates
 

--- a/packages/editor/src/components/editor-snackbars/index.js
+++ b/packages/editor/src/components/editor-snackbars/index.js
@@ -8,6 +8,11 @@ import { store as noticesStore } from '@wordpress/notices';
 // Last three notices. Slices from the tail end of the list.
 const MAX_VISIBLE_NOTICES = -3;
 
+/**
+ * Renders the editor snackbars component.
+ *
+ * @return {JSX.Element} The rendered component.
+ */
 export default function EditorSnackbars() {
 	const notices = useSelect(
 		( select ) => select( noticesStore ).getNotices(),


### PR DESCRIPTION
## What? & Why?
Addresses one item in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add JSDocs formatted doc blocks to existing EditorSnackBars component.

## Testing Instructions
Add a JSDoc comment to the `EditorSnackBars` component and run `npm run docs:build` to populate the README with the newly added documents.
