### PR TITLE
DocumentBar: Account for when top toolbar is open

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -102,7 +102,13 @@ export default function HeaderEditMode() {
 		>
 			{ hasDefaultEditorCanvasView && (
 				<motion.div
-					className="edit-site-header-edit-mode__start"
+					className={ classnames(
+						'edit-site-header-edit-mode__start',
+						{
+							'is-opened':
+								! isBlockToolsCollapsed && showTopToolbar,
+						}
+					) }
 					variants={ toolbarVariants }
 					transition={ toolbarTransition }
 				>

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -98,17 +98,12 @@ export default function HeaderEditMode() {
 		<div
 			className={ classnames( 'edit-site-header-edit-mode', {
 				'show-icon-labels': showIconLabels,
+				'show-block-toolbar': ! isBlockToolsCollapsed && showTopToolbar,
 			} ) }
 		>
 			{ hasDefaultEditorCanvasView && (
 				<motion.div
-					className={ classnames(
-						'edit-site-header-edit-mode__start',
-						{
-							'is-opened':
-								! isBlockToolsCollapsed && showTopToolbar,
-						}
-					) }
+					className="edit-site-header-edit-mode__start"
 					variants={ toolbarVariants }
 					transition={ toolbarTransition }
 				>
@@ -126,15 +121,7 @@ export default function HeaderEditMode() {
 			) }
 
 			{ ! isDistractionFree && (
-				<div
-					className={ classnames(
-						'edit-site-header-edit-mode__center',
-						{
-							'is-collapsed':
-								! isBlockToolsCollapsed && showTopToolbar,
-						}
-					) }
-				>
+				<div className="edit-site-header-edit-mode__center">
 					{ ! hasDefaultEditorCanvasView ? (
 						getEditorCanvasContainerTitle( editorCanvasView )
 					) : (

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -29,6 +29,11 @@
 			// the toolbar to grow outside of the allowed container space.
 			overflow: hidden;
 		}
+
+		&.is-opened {
+			// When top toolbar is engaged and should expand fully.
+			flex-basis: 100%;
+		}
 	}
 
 	.edit-site-header-edit-mode__end {

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -10,6 +10,19 @@
 	border-bottom: $border-width solid $gray-200;
 	padding-left: $header-height;
 
+	// When top toolbar is engaged and should expand fully.
+	&.show-block-toolbar {
+
+		.edit-site-header-edit-mode__start,
+		.edit-site-header-edit-mode__end {
+			flex-basis: auto;
+		}
+
+		.edit-site-header-edit-mode__center {
+			display: none;
+		}
+	}
+
 	.edit-site-header-edit-mode__start {
 		display: flex;
 		border: none;
@@ -28,11 +41,6 @@
 			// overflow scroll. If the overflow is visible, flexbox allows
 			// the toolbar to grow outside of the allowed container space.
 			overflow: hidden;
-		}
-
-		&.is-opened {
-			// When top toolbar is engaged and should expand fully.
-			flex-basis: 100%;
 		}
 	}
 
@@ -185,12 +193,6 @@
 				left: calc(50% + 1px);
 			}
 		}
-	}
-}
-
-.has-fixed-toolbar {
-	.edit-site-header-edit-mode__center.is-collapsed {
-		display: none;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up as reported in https://github.com/WordPress/gutenberg/pull/59134#issuecomment-2078015701 to account for when the top toolbar is opened.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Set the "Top toolbar" option. 
3. Select a block. 
4. Hide/Show block tools in the top toolbar. 
5. See the tools can expand the full available width without horizontal scroll.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-04-25 at 15 45 41](https://github.com/WordPress/gutenberg/assets/1813435/aced976c-f21d-4cca-8311-9ae75db42f25)
