### PR TITLE
Scripts: Import CSS files before optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,7 @@
 				"npm-run-all": "4.1.5",
 				"patch-package": "8.0.0",
 				"postcss": "8.4.38",
+				"postcss-import": "16.1.0",
 				"postcss-loader": "6.2.1",
 				"postcss-local-keyframes": "^0.0.2",
 				"prettier": "npm:wp-prettier@3.0.3",
@@ -41328,6 +41329,29 @@
 				"postcss": "^8.2.15"
 			}
 		},
+		"node_modules/postcss-import": {
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
+			"integrity": "sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/postcss-import/node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true
+		},
 		"node_modules/postcss-loader": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -43408,6 +43432,15 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+			"dev": true,
+			"dependencies": {
+				"pify": "^2.3.0"
 			}
 		},
 		"node_modules/read-cmd-shim": {
@@ -54555,6 +54588,7 @@
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
 				"postcss": "^8.4.5",
+				"postcss-import": "^16.1.0",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
 				"puppeteer-core": "^13.2.0",
@@ -68733,6 +68767,7 @@
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
 				"postcss": "^8.4.5",
+				"postcss-import": "^16.1.0",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
 				"puppeteer-core": "^13.2.0",
@@ -87490,6 +87525,25 @@
 			"integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
 			"dev": true
 		},
+		"postcss-import": {
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
+			"integrity": "sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+					"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+					"dev": true
+				}
+			}
+		},
 		"postcss-loader": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -89040,6 +89094,15 @@
 					"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
 					"dev": true
 				}
+			}
+		},
+		"read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+			"dev": true,
+			"requires": {
+				"pify": "^2.3.0"
 			}
 		},
 		"read-cmd-shim": {

--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
 		"npm-run-all": "4.1.5",
 		"patch-package": "8.0.0",
 		"postcss": "8.4.38",
+		"postcss-import": "16.1.0",
 		"postcss-loader": "6.2.1",
 		"postcss-local-keyframes": "^0.0.2",
 		"prettier": "npm:wp-prettier@3.0.3",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Inlines CSS files imported from other CSS files before optimization in the `build` command ([#61121](https://github.com/WordPress/gutenberg/pull/61121)).
+
 ### Bug Fixes
 
 -   Added chunk filename in webpack config to avoid reading stale files ([#58176](https://github.com/WordPress/gutenberg/pull/58176)).

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -119,6 +119,7 @@ const cssLoaders = [
 					plugins: isProduction
 						? [
 								...postcssPlugins,
+								require( 'postcss-import' ),
 								require( 'cssnano' )( {
 									// Provide a fallback configuration if there's not
 									// one explicitly available in the project.

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -73,6 +73,7 @@
 		"npm-package-json-lint": "^6.4.0",
 		"npm-packlist": "^3.0.0",
 		"postcss": "^8.4.5",
+		"postcss-import": "^16.1.0",
 		"postcss-loader": "^6.2.1",
 		"prettier": "npm:wp-prettier@3.0.3",
 		"puppeteer-core": "^13.2.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Import CSS files before the minification process.

Closes #61112.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Small performance improvement for people using CSS imports and the @wordpress/scripts package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
postcss-import is run before cssnano

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Scaffold a block
2. Rename your main stylesheet from .scss to .css
4. Create 2 CSS files
5. Import these files in the main stylesheet
6. Run `npm run build`
7. See that you have a resulting stylesheet that is minified (only one line instead of two)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
