### PR TITLE
Block editor: just testing moving static select out of render

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
 import { useMergeRefs, useDisabled } from '@wordpress/compose';
 import warning from '@wordpress/warning';
+import { useRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -105,17 +106,17 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		defaultClassName,
 		templateLock,
 	} = useContext( PrivateBlockContext );
-
+	const registry = useRegistry();
 	// translators: %s: Type of block (i.e. Text, Image etc)
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
 	const mergedRefs = useMergeRefs( [
 		props.ref,
-		useFocusFirstElement( { clientId, initialPosition } ),
+		useFocusFirstElement( { clientId, initialPosition, registry } ),
 		useBlockRefProvider( clientId ),
-		useFocusHandler( clientId ),
-		useEventHandlers( { clientId, isSelected } ),
-		useNavModeExit( clientId ),
+		useFocusHandler( { clientId, registry } ),
+		useEventHandlers( { clientId, isSelected, registry } ),
+		useNavModeExit( { clientId, registry } ),
 		useIsHovered( { isEnabled: isOutlineEnabled } ),
 		useIntersectionObserver(),
 		useMovingAnimation( { triggerAnimationOnChange: index, clientId } ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -8,7 +8,6 @@ import {
 	isTextField,
 	placeCaretAtHorizontalEdge,
 } from '@wordpress/dom';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -26,12 +25,17 @@ import { store as blockEditorStore } from '../../../store';
  *
  * @return {RefObject} React ref with the block element.
  */
-export function useFocusFirstElement( { clientId, initialPosition } ) {
+export function useFocusFirstElement( {
+	clientId,
+	initialPosition,
+	registry,
+} ) {
 	const ref = useRef();
-	const { isBlockSelected, isMultiSelecting, __unstableGetEditorMode } =
-		useSelect( blockEditorStore );
 
 	useEffect( () => {
+		const { isBlockSelected, isMultiSelecting, __unstableGetEditorMode } =
+			registry.select( blockEditorStore );
+
 		// Check if the block is still selected at the time this effect runs.
 		if (
 			! isBlockSelected( clientId ) ||
@@ -86,7 +90,7 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 			}
 		}
 		placeCaretAtHorizontalEdge( target, isReverse );
-	}, [ initialPosition, clientId ] );
+	}, [ initialPosition, clientId, registry ] );
 
 	return ref;
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -13,12 +12,11 @@ import { store as blockEditorStore } from '../../../store';
 /**
  * Selects the block if it receives focus.
  *
- * @param {string} clientId Block client ID.
+ * @param {Object} options
+ * @param {string} options.clientId Block client ID.
+ * @param {Object} options.registry
  */
-export function useFocusHandler( clientId ) {
-	const { isBlockSelected } = useSelect( blockEditorStore );
-	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
-
+export function useFocusHandler( { clientId, registry } ) {
 	return useRefEffect(
 		( node ) => {
 			/**
@@ -37,6 +35,10 @@ export function useFocusHandler( clientId ) {
 				) {
 					return;
 				}
+
+				const { isBlockSelected } = registry.select( blockEditorStore );
+				const { selectBlock, selectionChange } =
+					registry.dispatch( blockEditorStore );
 
 				// Check synchronously because a non-selected block might be
 				// getting data through `useSelect` asynchronously.
@@ -63,6 +65,6 @@ export function useFocusHandler( clientId ) {
 				node.removeEventListener( 'focusin', onFocus );
 			};
 		},
-		[ isBlockSelected, selectBlock ]
+		[ registry ]
 	);
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -14,17 +13,21 @@ import { store as blockEditorStore } from '../../../store';
  *
  * @param {string} clientId Block client ID.
  */
-export function useNavModeExit( clientId ) {
-	const { isNavigationMode, isBlockSelected } = useSelect( blockEditorStore );
-	const { setNavigationMode, selectBlock } = useDispatch( blockEditorStore );
+export function useNavModeExit( { clientId, registry } ) {
 	return useRefEffect(
 		( node ) => {
 			function onMouseDown( event ) {
+				const { isNavigationMode, isBlockSelected } =
+					registry.select( blockEditorStore );
+
 				// Don't select a block if it's already handled by a child
 				// block.
 				if ( isNavigationMode() && ! event.defaultPrevented ) {
 					// Prevent focus from moving to the block.
 					event.preventDefault();
+
+					const { setNavigationMode, selectBlock } =
+						registry.dispatch( blockEditorStore );
 
 					// When clicking on a selected block, exit navigation mode.
 					if ( isBlockSelected( clientId ) ) {
@@ -41,6 +44,6 @@ export function useNavModeExit( clientId ) {
 				node.removeEventListener( 'mousedown', onMouseDown );
 			};
 		},
-		[ clientId, isNavigationMode, isBlockSelected, setNavigationMode ]
+		[ clientId, registry ]
 	);
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -3,7 +3,6 @@
  */
 import { isTextField } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
-import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -19,11 +18,7 @@ import { store as blockEditorStore } from '../../../store';
  *
  * @param {string} clientId Block client ID.
  */
-export function useEventHandlers( { clientId, isSelected } ) {
-	const { getBlockRootClientId, getBlockIndex } =
-		useSelect( blockEditorStore );
-	const { insertAfterBlock, removeBlock } = useDispatch( blockEditorStore );
-
+export function useEventHandlers( { clientId, isSelected, registry } ) {
 	return useRefEffect(
 		( node ) => {
 			if ( ! isSelected ) {
@@ -56,6 +51,9 @@ export function useEventHandlers( { clientId, isSelected } ) {
 
 				event.preventDefault();
 
+				const { insertAfterBlock, removeBlock } =
+					registry.select( blockEditorStore );
+
 				if ( keyCode === ENTER ) {
 					insertAfterBlock( clientId );
 				} else {
@@ -81,13 +79,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				node.removeEventListener( 'dragstart', onDragStart );
 			};
 		},
-		[
-			clientId,
-			isSelected,
-			getBlockRootClientId,
-			getBlockIndex,
-			insertAfterBlock,
-			removeBlock,
-		]
+		[ clientId, isSelected, registry ]
 	);
 }

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
-import { useDispatch, useRegistry } from '@wordpress/data';
+import { useRegistry } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
@@ -69,7 +69,6 @@ export default function useNestedSettingsUpdate(
 	// Instead of adding a useSelect mapping here, please add to the useSelect
 	// mapping in InnerBlocks! Every subscription impacts performance.
 
-	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 	const registry = useRegistry();
 
 	// Implementors often pass a new array on every render,
@@ -163,6 +162,8 @@ export default function useNestedSettingsUpdate(
 		window.queueMicrotask( () => {
 			if ( pendingSettingsUpdates.get( registry )?.length ) {
 				registry.batch( () => {
+					const { updateBlockListSettings } =
+						registry.dispatch( blockEditorStore );
 					pendingSettingsUpdates
 						.get( registry )
 						.forEach( ( args ) => {
@@ -183,7 +184,6 @@ export default function useNestedSettingsUpdate(
 		__experimentalDirectInsert,
 		captureToolbars,
 		orientation,
-		updateBlockListSettings,
 		layout,
 		registry,
 	] );

--- a/packages/block-editor/src/components/use-flash-editable-blocks/index.js
+++ b/packages/block-editor/src/components/use-flash-editable-blocks/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useRefEffect } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
+import { useRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,8 +14,7 @@ export function useFlashEditableBlocks( {
 	clientId = '',
 	isEnabled = true,
 } = {} ) {
-	const { getEnabledClientIdsTree } = unlock( useSelect( blockEditorStore ) );
-
+	const registry = useRegistry();
 	return useRefEffect(
 		( element ) => {
 			if ( ! isEnabled ) {
@@ -23,6 +22,9 @@ export function useFlashEditableBlocks( {
 			}
 
 			const flashEditableBlocks = () => {
+				const { getEnabledClientIdsTree } = unlock(
+					registry.select( blockEditorStore )
+				);
 				getEnabledClientIdsTree( clientId ).forEach(
 					( { clientId: id } ) => {
 						const block = element.querySelector(

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -8,7 +8,7 @@ import { Controller } from '@react-spring/web';
  */
 import { useLayoutEffect, useMemo, useRef } from '@wordpress/element';
 import { getScrollContainer } from '@wordpress/dom';
-import { useSelect } from '@wordpress/data';
+import { useRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -45,15 +45,7 @@ function getAbsolutePosition( element ) {
  */
 function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 	const ref = useRef();
-	const {
-		isTyping,
-		getGlobalBlockCount,
-		isBlockSelected,
-		isFirstMultiSelectedBlock,
-		isBlockMultiSelected,
-		isAncestorMultiSelected,
-	} = useSelect( blockEditorStore );
-
+	const registry = useRegistry();
 	// Whenever the trigger changes, we need to take a snapshot of the current
 	// position of the block to use it as a destination point for the animation.
 	const { previous, prevRect } = useMemo(
@@ -70,6 +62,14 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 			return;
 		}
 
+		const {
+			isTyping,
+			getGlobalBlockCount,
+			isBlockSelected,
+			isFirstMultiSelectedBlock,
+			isBlockMultiSelected,
+			isAncestorMultiSelected,
+		} = registry.select( blockEditorStore );
 		const scrollContainer = getScrollContainer( ref.current );
 		const isSelected = isBlockSelected( clientId );
 		const adjustScrolling =
@@ -144,17 +144,7 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 			controller.stop();
 			controller.set( { x: 0, y: 0 } );
 		};
-	}, [
-		previous,
-		prevRect,
-		clientId,
-		isTyping,
-		getGlobalBlockCount,
-		isBlockSelected,
-		isFirstMultiSelectedBlock,
-		isBlockMultiSelected,
-		isAncestorMultiSelected,
-	] );
+	}, [ previous, prevRect, clientId, registry ] );
 
 	return ref;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
