### PR TITLE
Add content only descriptions in dropdown menus for patterns and templates

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -31,10 +31,12 @@ export default function BlockActions( {
 				getDirectInsertBlock,
 				canMoveBlocks,
 				canRemoveBlocks,
+				getBlockEditingMode,
 			} = select( blockEditorStore );
 
 			const blocks = getBlocksByClientId( clientIds );
 			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
+			const rootBlockEditingMode = getBlockEditingMode( rootClientId );
 			const canInsertDefaultBlock = canInsertBlockType(
 				getDefaultBlockName(),
 				rootClientId
@@ -46,7 +48,9 @@ export default function BlockActions( {
 			return {
 				canMove: canMoveBlocks( clientIds, rootClientId ),
 				canRemove: canRemoveBlocks( clientIds, rootClientId ),
-				canInsertBlock: canInsertDefaultBlock || !! directInsertBlock,
+				canInsertBlock:
+					( canInsertDefaultBlock || !! directInsertBlock ) &&
+					rootBlockEditingMode === 'default',
 				canCopyStyles: blocks.every( ( block ) => {
 					return (
 						!! block &&

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -27,15 +27,20 @@ import { BlockRenameControl, useBlockRename } from '../block-rename';
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
 const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
-	const { selectedBlocks, selectedClientIds } = useSelect(
+	const { selectedBlocks, selectedClientIds, isContentOnly } = useSelect(
 		( select ) => {
-			const { getBlockNamesByClientId, getSelectedBlockClientIds } =
-				select( blockEditorStore );
+			const {
+				getBlockNamesByClientId,
+				getSelectedBlockClientIds,
+				getBlockEditingMode,
+			} = select( blockEditorStore );
 			const ids =
 				clientIds !== null ? clientIds : getSelectedBlockClientIds();
 			return {
 				selectedBlocks: getBlockNamesByClientId( ids ),
 				selectedClientIds: ids,
+				isContentOnly:
+					getBlockEditingMode( ids[ 0 ] ) === 'contentOnly',
 			};
 		},
 		[ clientIds ]
@@ -43,8 +48,10 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 
 	const { canLock } = useBlockLock( selectedClientIds[ 0 ] );
 	const { canRename } = useBlockRename( selectedBlocks[ 0 ] );
-	const showLockButton = selectedClientIds.length === 1 && canLock;
-	const showRenameButton = selectedClientIds.length === 1 && canRename;
+	const showLockButton =
+		selectedClientIds.length === 1 && canLock && ! isContentOnly;
+	const showRenameButton =
+		selectedClientIds.length === 1 && canRename && ! isContentOnly;
 
 	// Check if current selection of blocks is Groupable or Ungroupable
 	// and pass this props down to ConvertToGroupButton.

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -106,7 +106,7 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 								{ __( 'Move to' ) }
 							</MenuItem>
 						) }
-						{ fillProps?.count === 1 && (
+						{ fillProps?.count === 1 && ! isContentOnly && (
 							<BlockModeToggle
 								clientId={ fillProps?.firstBlockClientId }
 								onToggle={ fillProps?.onClose }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -96,16 +96,18 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 							/>
 						) }
 						{ fills }
-						{ fillProps?.canMove && ! fillProps?.onlyBlock && (
-							<MenuItem
-								onClick={ pipe(
-									fillProps?.onClose,
-									fillProps?.onMoveTo
-								) }
-							>
-								{ __( 'Move to' ) }
-							</MenuItem>
-						) }
+						{ fillProps?.canMove &&
+							! fillProps?.onlyBlock &&
+							! isContentOnly && (
+								<MenuItem
+									onClick={ pipe(
+										fillProps?.onClose,
+										fillProps?.onMoveTo
+									) }
+								>
+									{ __( 'Move to' ) }
+								</MenuItem>
+							) }
 						{ fillProps?.count === 1 && ! isContentOnly && (
 							<BlockModeToggle
 								clientId={ fillProps?.firstBlockClientId }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -63,6 +63,7 @@ export function BlockSettingsDropdown( {
 		previousBlockClientId,
 		selectedBlockClientIds,
 		openedBlockSettingsMenu,
+		isContentOnly,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -73,6 +74,7 @@ export function BlockSettingsDropdown( {
 				getSelectedBlockClientIds,
 				getBlockAttributes,
 				getOpenedBlockSettingsMenu,
+				getBlockEditingMode,
 			} = unlock( select( blockEditorStore ) );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -96,6 +98,8 @@ export function BlockSettingsDropdown( {
 					getPreviousBlockClientId( firstBlockClientId ),
 				selectedBlockClientIds: getSelectedBlockClientIds(),
 				openedBlockSettingsMenu: getOpenedBlockSettingsMenu(),
+				isContentOnly:
+					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
 			};
 		},
 		[ firstBlockClientId ]
@@ -231,11 +235,15 @@ export function BlockSettingsDropdown( {
 										clientId={ firstBlockClientId }
 									/>
 								) }
-								<CopyMenuItem
-									clientIds={ clientIds }
-									onCopy={ onCopy }
-									shortcut={ displayShortcut.primary( 'c' ) }
-								/>
+								{ ! isContentOnly && (
+									<CopyMenuItem
+										clientIds={ clientIds }
+										onCopy={ onCopy }
+										shortcut={ displayShortcut.primary(
+											'c'
+										) }
+									/>
+								) }
 								{ canDuplicate && (
 									<MenuItem
 										onClick={ pipe(
@@ -271,7 +279,7 @@ export function BlockSettingsDropdown( {
 									</>
 								) }
 							</MenuGroup>
-							{ canCopyStyles && (
+							{ canCopyStyles && ! isContentOnly && (
 								<MenuGroup>
 									<CopyMenuItem
 										clientIds={ clientIds }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -16,6 +16,7 @@ import { forwardRef } from '@wordpress/element';
 import { Icon, lockSmall as lock, pinSmall } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
+import { store as blockEditorStore } from '../../store';
 
 function ListViewBlockSelectButton(
 	{
@@ -51,6 +53,15 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
+	const { isContentOnly } = useSelect(
+		( select ) => ( {
+			isContentOnly:
+				select( blockEditorStore ).getBlockEditingMode( clientId ) ===
+				'contentOnly',
+		} ),
+		[ clientId ]
+	);
+	const shouldShowLockIcon = isLocked && ! isContentOnly;
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
 
@@ -147,7 +158,7 @@ function ListViewBlockSelectButton(
 						) ) }
 					</span>
 				) : null }
-				{ isLocked && (
+				{ shouldShowLockIcon && (
 					<span className="block-editor-list-view-block-select-button__lock">
 						<Icon icon={ lock } />
 					</span>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -104,46 +104,26 @@ function ListViewBlock( {
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 
-	const { block, allowRightClickOverrides, showBlockActions } = useSelect(
+	const { block, blockName, allowRightClickOverrides } = useSelect(
 		( select ) => {
-			const {
-				getBlock,
-				getBlockName,
-				getSettings,
-				getContentLockingParent,
-				getBlockEditingMode,
-				getTemplateLock,
-			} = unlock( select( blockEditorStore ) );
-			const _blockName = getBlockName( clientId );
-			const isContentOnly =
-				getBlockEditingMode( clientId ) === 'contentOnly';
-			const contentLockingParent = getContentLockingParent( clientId );
-			// Don't show the block actions for template lock contentOnly.
-			// This block currently doesn't have any action to display in the menu dropdown.
-			const isContentLockingParentTemplateLock =
-				getTemplateLock( contentLockingParent ) === 'contentOnly';
-			// When a block hides its toolbar it also hides the block settings menu,
-			// since that menu is part of the toolbar in the editor canvas.
-			// List View respects this by also hiding the block settings menu.
-			const hasToolbar = hasBlockSupport(
-				_blockName,
-				'__experimentalToolbar',
-				true
-			);
+			const { getBlock, getBlockName, getSettings } =
+				select( blockEditorStore );
 
 			return {
 				block: getBlock( clientId ),
-				blockName: _blockName,
+				blockName: getBlockName( clientId ),
 				allowRightClickOverrides:
 					getSettings().allowRightClickOverrides,
-				showBlockActions:
-					hasToolbar &&
-					! ( isContentOnly && isContentLockingParentTemplateLock ),
 			};
 		},
 		[ clientId ]
 	);
 
+	const showBlockActions =
+		// When a block hides its toolbar it also hides the block settings menu,
+		// since that menu is part of the toolbar in the editor canvas.
+		// List View respects this by also hiding the block settings menu.
+		hasBlockSupport( blockName, '__experimentalToolbar', true );
 	const instanceId = useInstanceId( ListViewBlock );
 	const descriptionId = `list-view-block-select-button__description-${ instanceId }`;
 

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -130,8 +130,8 @@ function ListViewBlock( {
 		// since that menu is part of the toolbar in the editor canvas.
 		// List View respects this by also hiding the block settings menu.
 		hasBlockSupport( blockName, '__experimentalToolbar', true ) &&
-		// Don't show the settings menu if block is disabled or content only.
-		blockEditingMode === 'default';
+		// Don't show the settings menu if block is disabled.
+		blockEditingMode !== 'disabled';
 	const instanceId = useInstanceId( ListViewBlock );
 	const descriptionId = `list-view-block-select-button__description-${ instanceId }`;
 

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -20,7 +20,6 @@ import { unlock } from '../lock-unlock';
 // also includes artifacts on the store (actions, reducers, and selector).
 
 function ContentLockControlsPure( { clientId, isSelected } ) {
-	const { getBlockListSettings, getSettings } = useSelect( blockEditorStore );
 	const { templateLock, isLockedByParent, isEditingAsBlocks } = useSelect(
 		( select ) => {
 			const {
@@ -37,16 +36,11 @@ function ContentLockControlsPure( { clientId, isSelected } ) {
 		[ clientId ]
 	);
 
-	const {
-		updateSettings,
-		updateBlockListSettings,
-		__unstableSetTemporarilyEditingAsBlocks,
-	} = useDispatch( blockEditorStore );
-	const { stopEditingAsBlocks } = unlock( useDispatch( blockEditorStore ) );
+	const { stopEditingAsBlocks, modifyContentLockBlock } = unlock(
+		useDispatch( blockEditorStore )
+	);
 	const isContentLocked =
 		! isLockedByParent && templateLock === 'contentOnly';
-	const { __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
-		useDispatch( blockEditorStore );
 
 	const stopEditingAsBlockCallback = useCallback( () => {
 		stopEditingAsBlocks( clientId );
@@ -73,30 +67,19 @@ function ContentLockControlsPure( { clientId, isSelected } ) {
 			) }
 			{ showStartEditingAsBlocks && (
 				<BlockSettingsMenuControls>
-					{ ( { onClose } ) => (
-						<MenuItem
-							onClick={ () => {
-								__unstableMarkNextChangeAsNotPersistent();
-								updateBlockAttributes( clientId, {
-									templateLock: undefined,
-								} );
-								updateBlockListSettings( clientId, {
-									...getBlockListSettings( clientId ),
-									templateLock: false,
-								} );
-								const focusModeToRevert =
-									getSettings().focusMode;
-								updateSettings( { focusMode: true } );
-								__unstableSetTemporarilyEditingAsBlocks(
-									clientId,
-									focusModeToRevert
-								);
-								onClose();
-							} }
-						>
-							{ __( 'Modify' ) }
-						</MenuItem>
-					) }
+					{ ( { selectedClientIds, onClose } ) =>
+						selectedClientIds.length === 1 &&
+						selectedClientIds[ 0 ] === clientId && (
+							<MenuItem
+								onClick={ () => {
+									modifyContentLockBlock( clientId );
+									onClose();
+								} }
+							>
+								{ __( 'Modify' ) }
+							</MenuItem>
+						)
+					}
 				</BlockSettingsMenuControls>
 			) }
 		</>

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -391,3 +391,22 @@ export function expandBlock( clientId ) {
 		clientId,
 	};
 }
+
+export const modifyContentLockBlock =
+	( clientId ) =>
+	( { select, dispatch } ) => {
+		dispatch.__unstableMarkNextChangeAsNotPersistent();
+		dispatch.updateBlockAttributes( clientId, {
+			templateLock: undefined,
+		} );
+		dispatch.updateBlockListSettings( clientId, {
+			...select.getBlockListSettings( clientId ),
+			templateLock: false,
+		} );
+		const focusModeToRevert = select.getSettings().focusMode;
+		dispatch.updateSettings( { focusMode: true } );
+		dispatch.__unstableSetTemporarilyEditingAsBlocks(
+			clientId,
+			focusModeToRevert
+		);
+	};

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -392,6 +392,11 @@ export function expandBlock( clientId ) {
 	};
 }
 
+/**
+ * Temporarily modify/unlock the content-only block for editions.
+ *
+ * @param {string} clientId The client id of the block.
+ */
 export const modifyContentLockBlock =
 	( clientId ) =>
 	( { select, dispatch } ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1759,14 +1759,16 @@ export function canMoveBlock( state, clientId, rootClientId = null ) {
 	if ( attributes === null ) {
 		return true;
 	}
+	if ( getBlockEditingMode( state, rootClientId ) !== 'default' ) {
+		return false;
+	}
 	if ( attributes.lock?.move !== undefined ) {
 		return ! attributes.lock.move;
 	}
 	if ( getTemplateLock( state, rootClientId ) === 'all' ) {
 		return false;
 	}
-
-	return getBlockEditingMode( state, rootClientId ) !== 'disabled';
+	return true;
 }
 
 /**

--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -27,11 +27,22 @@ export default function TemplatePartConverter() {
 }
 
 function TemplatePartConverterMenuItem( { clientIds, onClose } ) {
-	const blocks = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlocksByClientId( clientIds ),
+	const { isContentOnly, blocks } = useSelect(
+		( select ) => {
+			const { getBlocksByClientId, getBlockEditingMode } =
+				select( blockEditorStore );
+			return {
+				blocks: getBlocksByClientId( clientIds ),
+				isContentOnly:
+					clientIds.length === 1 &&
+					getBlockEditingMode( clientIds[ 0 ] ) === 'contentOnly',
+			};
+		},
 		[ clientIds ]
 	);
+
+	// Do not show the convert button if the block is in content-only mode.
+	if ( isContentOnly ) return null;
 
 	// Allow converting a single template part to standard blocks.
 	if ( blocks.length === 1 && blocks[ 0 ]?.name === 'core/template-part' ) {

--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -42,7 +42,9 @@ function TemplatePartConverterMenuItem( { clientIds, onClose } ) {
 	);
 
 	// Do not show the convert button if the block is in content-only mode.
-	if ( isContentOnly ) return null;
+	if ( isContentOnly ) {
+		return null;
+	}
 
 	// Allow converting a single template part to standard blocks.
 	if ( blocks.length === 1 && blocks[ 0 ]?.name === 'core/template-part' ) {

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -148,7 +148,7 @@ function TemplateLockContentOnlyMenuItems( { clientId, onClose } ) {
 					{ sprintf(
 						// translators: %s: block's title.
 						__(
-							'Only the content of blocks inside "%s" can be edited.'
+							'The parent "%s" block is partially locked, preventing the movement or deletion of child blocks, as well as the addition of any inner blocks.'
 						),
 						blockDisplayInformation.title
 					) }
@@ -162,7 +162,11 @@ function TemplateLockContentOnlyMenuItems( { clientId, onClose } ) {
 					onClose();
 				} }
 			>
-				{ __( 'Remove template lock' ) }
+				{ sprintf(
+					// translators: %s: block's title.
+					__( 'Unlock "%s"' ),
+					blockDisplayInformation.title
+				) }
 			</MenuItem>
 		</>
 	);

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -1,0 +1,118 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	BlockSettingsMenuControls,
+	__unstableBlockSettingsMenuFirstItem as BlockSettingsMenuFirstItem,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { __experimentalText as Text, MenuItem } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+function ContentOnlySettingsMenuItems( { clientId } ) {
+	const { entity, onNavigateToEntityRecord } = useSelect(
+		( select ) => {
+			const {
+				getBlockEditingMode,
+				getBlockParentsByBlockName,
+				getSettings,
+				getBlockAttributes,
+			} = select( blockEditorStore );
+			const contentOnly =
+				getBlockEditingMode( clientId ) === 'contentOnly';
+			if ( ! contentOnly ) return {};
+			const patternParent = getBlockParentsByBlockName(
+				clientId,
+				'core/block',
+				true
+			)[ 0 ];
+
+			let record;
+			if ( patternParent ) {
+				record = select( coreStore ).getEntityRecord(
+					'postType',
+					'wp_block',
+					getBlockAttributes( patternParent ).ref
+				);
+			} else {
+				const templateId = select( editorStore ).getCurrentTemplateId();
+				if ( templateId ) {
+					record = select( coreStore ).getEntityRecord(
+						'postType',
+						'wp_template',
+						templateId
+					);
+				}
+			}
+			return {
+				entity: record,
+				onNavigateToEntityRecord:
+					getSettings().onNavigateToEntityRecord,
+			};
+		},
+		[ clientId ]
+	);
+
+	if ( ! entity ) return null;
+
+	const isPattern = entity.type === 'wp_block';
+
+	return (
+		<>
+			<BlockSettingsMenuFirstItem>
+				<Text
+					variant="muted"
+					as="p"
+					className="editor-content-only-settings-menu__description"
+				>
+					{ isPattern
+						? sprintf(
+								// translators: %s: pattern's title.
+								__(
+									'This block is part of the synced pattern: "%s". To move, delete, or edit other properties, you must edit the pattern.'
+								),
+								entity.title.raw
+						  )
+						: sprintf(
+								// translators: %s: template's title.
+								__(
+									'This block is part of the template: "%s". To move, delete, or edit other properties, you must edit the template.'
+								),
+								entity.title.rendered
+						  ) }
+				</Text>
+			</BlockSettingsMenuFirstItem>
+			<MenuItem
+				onClick={ () => {
+					onNavigateToEntityRecord( {
+						postId: entity.id,
+						postType: entity.type,
+					} );
+				} }
+			>
+				{ isPattern ? __( 'Edit pattern' ) : __( 'Edit template' ) }
+			</MenuItem>
+		</>
+	);
+}
+
+export default function TemplateContentOnlySettingsMenu() {
+	return (
+		<BlockSettingsMenuControls>
+			{ ( { selectedClientIds } ) =>
+				selectedClientIds.length === 1 && (
+					<ContentOnlySettingsMenuItems
+						clientId={ selectedClientIds[ 0 ] }
+					/>
+				)
+			}
+		</BlockSettingsMenuControls>
+	);
+}

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -42,8 +42,11 @@ function ContentOnlySettingsMenuItems( { clientId } ) {
 					getBlockAttributes( patternParent ).ref
 				);
 			} else {
-				const templateId = select( editorStore ).getCurrentTemplateId();
-				if ( templateId ) {
+				const { getCurrentPostType, getCurrentTemplateId } =
+					select( editorStore );
+				const currentPostType = getCurrentPostType();
+				const templateId = getCurrentTemplateId();
+				if ( currentPostType === 'page' && templateId ) {
 					record = select( coreStore ).getEntityRecord(
 						'postType',
 						'wp_template',

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -133,7 +133,9 @@ function TemplateLockContentOnlyMenuItems( { clientId, onClose } ) {
 		useBlockDisplayInformation( contentLockingParent );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-	if ( ! blockDisplayInformation?.title ) return null;
+	if ( ! blockDisplayInformation?.title ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -103,7 +103,7 @@ function ContentOnlySettingsMenuItems( { clientId } ) {
 	);
 }
 
-export default function TemplateContentOnlySettingsMenu() {
+export default function ContentOnlySettingsMenu() {
 	return (
 		<BlockSettingsMenuControls>
 			{ ( { selectedClientIds } ) =>

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -76,14 +76,14 @@ function ContentOnlySettingsMenuItems( { clientId } ) {
 						? sprintf(
 								// translators: %s: pattern's title.
 								__(
-									'This block is part of the synced pattern: "%s". To move, delete, or edit other properties, you must edit the pattern.'
+									'This block belongs to "%s". Edit the pattern to move or delete it.'
 								),
 								entity.title.raw
 						  )
 						: sprintf(
 								// translators: %s: template's title.
 								__(
-									'This block is part of the template: "%s". To move, delete, or edit other properties, you must edit the template.'
+									'This block belongs to "%s". Edit the template to move or delete it.'
 								),
 								entity.title.rendered
 						  ) }

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -27,7 +27,9 @@ function ContentOnlySettingsMenuItems( { clientId } ) {
 			} = select( blockEditorStore );
 			const contentOnly =
 				getBlockEditingMode( clientId ) === 'contentOnly';
-			if ( ! contentOnly ) return {};
+			if ( ! contentOnly ) {
+				return {};
+			}
 			const patternParent = getBlockParentsByBlockName(
 				clientId,
 				'core/block',
@@ -63,7 +65,9 @@ function ContentOnlySettingsMenuItems( { clientId } ) {
 		[ clientId ]
 	);
 
-	if ( ! entity ) return null;
+	if ( ! entity ) {
+		return null;
+	}
 
 	const isPattern = entity.type === 'wp_block';
 

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -131,7 +131,11 @@ function TemplateLockContentOnlyMenuItems( { clientId, onClose } ) {
 	);
 	const blockDisplayInformation =
 		useBlockDisplayInformation( contentLockingParent );
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	// Disable reason: We're using a hook here so it has to be on top-level.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { modifyContentLockBlock, selectBlock } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	if ( ! blockDisplayInformation?.title ) {
 		return null;
@@ -156,15 +160,14 @@ function TemplateLockContentOnlyMenuItems( { clientId, onClose } ) {
 			</BlockSettingsMenuFirstItem>
 			<MenuItem
 				onClick={ () => {
-					updateBlockAttributes( contentLockingParent, {
-						templateLock: undefined,
-					} );
+					selectBlock( contentLockingParent );
+					modifyContentLockBlock( contentLockingParent );
 					onClose();
 				} }
 			>
 				{ sprintf(
 					// translators: %s: block's title.
-					__( 'Unlock "%s"' ),
+					__( 'Modify "%s"' ),
 					blockDisplayInformation.title
 				) }
 			</MenuItem>

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -90,14 +90,14 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 						? sprintf(
 								// translators: %s: pattern's title.
 								__(
-									'This block belongs to "%s". Edit the pattern to move or delete it.'
+									'This block is part of the pattern: "%s". Edit the pattern to move or delete it.'
 								),
 								entity.title.raw
 						  )
 						: sprintf(
 								// translators: %s: template's title.
 								__(
-									'This block belongs to "%s". Edit the template to move or delete it.'
+									'This block is part of the template: "%s". Edit the template to move or delete it.'
 								),
 								entity.title.rendered
 						  ) }

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -10,7 +10,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { __experimentalText as Text, MenuItem } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -81,38 +81,30 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 	return (
 		<>
 			<BlockSettingsMenuFirstItem>
-				<Text
-					variant="muted"
-					as="p"
-					className="editor-content-only-settings-menu__description"
+				<MenuItem
+					onClick={ () => {
+						onNavigateToEntityRecord( {
+							postId: entity.id,
+							postType: entity.type,
+						} );
+					} }
 				>
-					{ isPattern
-						? sprintf(
-								// translators: %s: pattern's title.
-								__(
-									'This block is part of the pattern: "%s". Edit the pattern to move or delete it.'
-								),
-								entity.title.raw
-						  )
-						: sprintf(
-								// translators: %s: template's title.
-								__(
-									'This block is part of the template: "%s". Edit the template to move or delete it.'
-								),
-								entity.title.rendered
-						  ) }
-				</Text>
+					{ isPattern ? __( 'Edit pattern' ) : __( 'Edit template' ) }
+				</MenuItem>
 			</BlockSettingsMenuFirstItem>
-			<MenuItem
-				onClick={ () => {
-					onNavigateToEntityRecord( {
-						postId: entity.id,
-						postType: entity.type,
-					} );
-				} }
+			<Text
+				variant="muted"
+				as="p"
+				className="editor-content-only-settings-menu__description"
 			>
-				{ isPattern ? __( 'Edit pattern' ) : __( 'Edit template' ) }
-			</MenuItem>
+				{ isPattern
+					? __(
+							'Edit the pattern to move, delete, or make further changes to this block.'
+					  )
+					: __(
+							'Edit the template to move, delete, or make further changes to this block.'
+					  ) }
+			</Text>
 		</>
 	);
 }
@@ -144,33 +136,25 @@ function TemplateLockContentOnlyMenuItems( { clientId, onClose } ) {
 	return (
 		<>
 			<BlockSettingsMenuFirstItem>
-				<Text
-					variant="muted"
-					as="p"
-					className="editor-content-only-settings-menu__description"
+				<MenuItem
+					onClick={ () => {
+						selectBlock( contentLockingParent );
+						modifyContentLockBlock( contentLockingParent );
+						onClose();
+					} }
 				>
-					{ sprintf(
-						// translators: %s: block's title.
-						__(
-							'The parent "%s" block is partially locked, preventing the movement or deletion of child blocks, as well as the addition of any inner blocks.'
-						),
-						blockDisplayInformation.title
-					) }
-				</Text>
+					{ __( 'Unlock' ) }
+				</MenuItem>
 			</BlockSettingsMenuFirstItem>
-			<MenuItem
-				onClick={ () => {
-					selectBlock( contentLockingParent );
-					modifyContentLockBlock( contentLockingParent );
-					onClose();
-				} }
+			<Text
+				variant="muted"
+				as="p"
+				className="editor-content-only-settings-menu__description"
 			>
-				{ sprintf(
-					// translators: %s: block's title.
-					__( 'Modify "%s"' ),
-					blockDisplayInformation.title
+				{ __(
+					'Temporarily unlock the parent block to edit, delete or make further changes to this block.'
 				) }
-			</MenuItem>
+			</Text>
 		</>
 	);
 }

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.native.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.native.js
@@ -1,0 +1,4 @@
+// Render nothing in native for now.
+export default function ContentOnlySettingsMenu() {
+	return null;
+}

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.native.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.native.js
@@ -1,0 +1,3 @@
+export default function ContentOnlySettingsMenu() {
+	return null;
+}

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.native.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.native.js
@@ -1,3 +1,0 @@
-export default function ContentOnlySettingsMenu() {
-	return null;
-}

--- a/packages/editor/src/components/block-settings-menu/style.scss
+++ b/packages/editor/src/components/block-settings-menu/style.scss
@@ -1,0 +1,4 @@
+.editor-content-only-settings-menu__description {
+	padding: $grid-unit;
+	min-width: 235px;
+}

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -28,6 +28,7 @@ import useCommands from '../commands';
 import BlockRemovalWarnings from '../block-removal-warnings';
 import StartPageOptions from '../start-page-options';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
+import ContentOnlySettingsMenu from '../block-settings-menu/content-only-settings-menu';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -264,6 +265,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 							{ ! settings.__unstableIsPreviewMode && (
 								<>
 									<PatternsMenuItems />
+									<ContentOnlySettingsMenu />
 									{ mode === 'template-locked' && (
 										<DisableNonPageContentBlocks />
 									) }

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -3,6 +3,7 @@
 @import "./components/autocompleters/style.scss";
 @import "./components/block-manager/style.scss";
 @import "./components/collapsible-block-toolbar/style.scss";
+@import "./components/block-settings-menu/style.scss";
 @import "./components/document-bar/style.scss";
 @import "./components/document-outline/style.scss";
 @import "./components/document-tools/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Based on #61012. Implement the design in https://github.com/WordPress/gutenberg/issues/60834#issuecomment-2063662703.

Add descriptions for content-only blocks inside patterns or templates in the dropdown menu.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #60834.

This is a UI enhancement for content-only blocks. Most of the actions in the original dropdown aren't needed for content-only blocks. We remove them and provide descriptions and links to edit the entities instead.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Hide original actions and inject descriptions for content-only blocks. The wording and the design are still TBD and can be tweaked.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
**For patterns**:
- Create a synced pattern with overridable blocks.
- Insert the pattern into a post.
- Use list view to select the overridable blocks and open the options dropdown.
- Expect to see the description and the "Edit pattern" menu item.
- Clicking on "Edit pattern" should navigate to the pattern editor.
- The same flow should also work in the site editor.

**For templates**:
- Enable twentytwentyfour theme.
- Go to Site editor -> Pages -> Privacy Policy.
- Open list view and select the "Featured Image" block.
- Open the Options dropdown and expect to see the description and the "Edit template" menu item.
- Clicking on it should navigate to the template editor.

## Screenshots or screencast <!-- if applicable -->

**Patterns**:
![pattern](https://github.com/WordPress/gutenberg/assets/7753001/ccf02911-f4ef-4899-b1cc-837a22d0b961)

**Templates**:
![template](https://github.com/WordPress/gutenberg/assets/7753001/b58cf628-5cf0-41f8-a675-d2b720a2975d)

