### PR TITLE
Add documentation for DocumentOutline and DocumentOutlineCheck components

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -242,8 +242,8 @@ Renders a document outline component.
 
 _Parameters_
 
--   _props_ `Object`: The component props.
--   _props.onSelect_ `Function`: The function to be called when an outline item is selected.
+-   _props_ `Object`: Props.
+-   _props.onSelect_ `Function`: Function to be called when an outline item is selected.
 -   _props.isTitleSupported_ `boolean`: Indicates whether the title is supported.
 -   _props.hasOutlineItemsDisabled_ `boolean`: Indicates whether the outline items are disabled.
 
@@ -258,11 +258,11 @@ Component check if there are any headings (core/heading blocks) present in the d
 _Parameters_
 
 -   _props_ `Object`: Props.
--   _props.children_ `Element`: The child elements to render.
+-   _props.children_ `Element`: Children to be rendered.
 
 _Returns_
 
--   `Component|null`: The rendered child elements or null if there are headings.
+-   `Component|null`: The component to be rendered or null if there are headings.
 
 ### EditorHistoryRedo
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -238,11 +238,31 @@ Undocumented declaration.
 
 ### DocumentOutline
 
-Undocumented declaration.
+Renders a document outline component.
+
+_Parameters_
+
+-   _props_ `Object`: The component props.
+-   _props.onSelect_ `Function`: The function to be called when an outline item is selected.
+-   _props.isTitleSupported_ `boolean`: Indicates whether the title is supported.
+-   _props.hasOutlineItemsDisabled_ `boolean`: Indicates whether the outline items are disabled.
+
+_Returns_
+
+-   `Component`: The component to be rendered.
 
 ### DocumentOutlineCheck
 
-Undocumented declaration.
+Component check if there are any headings (core/heading blocks) present in the document.
+
+_Parameters_
+
+-   _props_ `Object`: Props.
+-   _props.children_ `Element`: The child elements to render.
+
+_Returns_
+
+-   `Component|null`: The rendered child elements or null if there are headings.
 
 ### EditorHistoryRedo
 

--- a/packages/editor/src/components/document-outline/check.js
+++ b/packages/editor/src/components/document-outline/check.js
@@ -4,6 +4,14 @@
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
+/**
+ * Component check if there are any headings (core/heading blocks) present in the document.
+ *
+ * @param {Object}  props          Props.
+ * @param {Element} props.children The child elements to render.
+ *
+ * @return {Component|null} The rendered child elements or null if there are headings.
+ */
 export default function DocumentOutlineCheck( { children } ) {
 	const hasHeadings = useSelect( ( select ) => {
 		const { getGlobalBlockCount } = select( blockEditorStore );

--- a/packages/editor/src/components/document-outline/check.js
+++ b/packages/editor/src/components/document-outline/check.js
@@ -8,9 +8,9 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  * Component check if there are any headings (core/heading blocks) present in the document.
  *
  * @param {Object}  props          Props.
- * @param {Element} props.children The child elements to render.
+ * @param {Element} props.children Children to be rendered.
  *
- * @return {Component|null} The rendered child elements or null if there are headings.
+ * @return {Component|null} The component to be rendered or null if there are headings.
  */
 export default function DocumentOutlineCheck( { children } ) {
 	const hasHeadings = useSelect( ( select ) => {

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -101,8 +101,8 @@ const isEmptyHeading = ( heading ) =>
 /**
  * Renders a document outline component.
  *
- * @param {Object}   props                         The component props.
- * @param {Function} props.onSelect                The function to be called when an outline item is selected.
+ * @param {Object}   props                         Props.
+ * @param {Function} props.onSelect                Function to be called when an outline item is selected.
  * @param {boolean}  props.isTitleSupported        Indicates whether the title is supported.
  * @param {boolean}  props.hasOutlineItemsDisabled Indicates whether the outline items are disabled.
  *

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -98,6 +98,16 @@ const isEmptyHeading = ( heading ) =>
 	! heading.attributes.content ||
 	heading.attributes.content.trim().length === 0;
 
+/**
+ * Renders a document outline component.
+ *
+ * @param {Object}   props                         The component props.
+ * @param {Function} props.onSelect                The function to be called when an outline item is selected.
+ * @param {boolean}  props.isTitleSupported        Indicates whether the title is supported.
+ * @param {boolean}  props.hasOutlineItemsDisabled Indicates whether the outline items are disabled.
+ *
+ * @return {Component} The component to be rendered.
+ */
 export default function DocumentOutline( {
 	onSelect,
 	isTitleSupported,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of: https://github.com/WordPress/gutenberg/issues/60358

Added documentation in the readme for `DocumentOutline`, `DocumentOutlineCheck` components and also on components itself. 