### PR TITLE
List View: Unify shortcut handlers

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -12,10 +12,7 @@ import { moreVertical } from '@wordpress/icons';
 import { Children, cloneElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { displayShortcut } from '@wordpress/keycodes';
-import {
-	store as keyboardShortcutsStore,
-	__unstableUseShortcutEventMatch,
-} from '@wordpress/keyboard-shortcuts';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { pipe, useCopyToClipboard } from '@wordpress/compose';
 
 /**
@@ -125,7 +122,6 @@ export function BlockSettingsDropdown( {
 			),
 		};
 	}, [] );
-	const isMatch = __unstableUseShortcutEventMatch();
 	const hasSelectedBlocks = selectedBlockClientIds.length > 0;
 
 	async function updateSelectionAfterDuplicate( clientIdsPromise ) {
@@ -213,52 +209,6 @@ export function BlockSettingsDropdown( {
 					open={ open }
 					onToggle={ onToggle }
 					noIcons
-					menuProps={ {
-						/**
-						 * @param {KeyboardEvent} event
-						 */
-						onKeyDown( event ) {
-							if ( event.defaultPrevented ) return;
-
-							if (
-								isMatch( 'core/block-editor/remove', event ) &&
-								canRemove
-							) {
-								event.preventDefault();
-								onRemove();
-								updateSelectionAfterRemove();
-							} else if (
-								isMatch(
-									'core/block-editor/duplicate',
-									event
-								) &&
-								canDuplicate
-							) {
-								event.preventDefault();
-								updateSelectionAfterDuplicate( onDuplicate() );
-							} else if (
-								isMatch(
-									'core/block-editor/insert-after',
-									event
-								) &&
-								canInsertBlock
-							) {
-								event.preventDefault();
-								setOpenedBlockSettingsMenu( undefined );
-								onInsertAfter();
-							} else if (
-								isMatch(
-									'core/block-editor/insert-before',
-									event
-								) &&
-								canInsertBlock
-							) {
-								event.preventDefault();
-								setOpenedBlockSettingsMenu( undefined );
-								onInsertBefore();
-							}
-						},
-					} }
 					{ ...props }
 				>
 					{ ( { onClose } ) => (

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 import { Icon, lockSmall as lock, pinSmall } from '@wordpress/icons';
+import { SPACE, ENTER } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -70,6 +71,15 @@ function ListViewBlockSelectButton(
 		onDragStart?.( event );
 	};
 
+	/**
+	 * @param {KeyboardEvent} event
+	 */
+	function onKeyDown( event ) {
+		if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
+			onClick( event );
+		}
+	}
+
 	return (
 		<>
 			<Button
@@ -79,6 +89,7 @@ function ListViewBlockSelectButton(
 				) }
 				onClick={ onClick }
 				onContextMenu={ onContextMenu }
+				onKeyDown={ onKeyDown }
 				onMouseDown={ onMouseDown }
 				ref={ ref }
 				tabIndex={ tabIndex }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { hasBlockSupport } from '@wordpress/blocks';
 import {
 	Button,
 	__experimentalHStack as HStack,
@@ -15,11 +14,7 @@ import {
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 import { Icon, lockSmall as lock, pinSmall } from '@wordpress/icons';
-import { SPACE, ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { __, sprintf } from '@wordpress/i18n';
-import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -29,9 +24,7 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
-import { store as blockEditorStore } from '../../store';
 import useListViewImages from './use-list-view-images';
-import { useListViewContext } from './context';
 
 function ListViewBlockSelectButton(
 	{
@@ -48,7 +41,6 @@ function ListViewBlockSelectButton(
 		draggable,
 		isExpanded,
 		ariaDescribedBy,
-		updateFocusAndSelection,
 	},
 	ref
 ) {
@@ -58,27 +50,8 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const {
-		canInsertBlockType,
-		getSelectedBlockClientIds,
-		getPreviousBlockClientId,
-		getBlockRootClientId,
-		getBlockOrder,
-		getBlockParents,
-		getBlocksByClientId,
-		canRemoveBlocks,
-	} = useSelect( blockEditorStore );
-	const {
-		duplicateBlocks,
-		multiSelect,
-		removeBlocks,
-		insertAfterBlock,
-		insertBeforeBlock,
-	} = useDispatch( blockEditorStore );
-	const isMatch = useShortcutEventMatch();
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
-	const { collapseAll, expand, rootClientId } = useListViewContext();
 
 	const positionLabel = blockInformation?.positionLabel
 		? sprintf(
@@ -97,180 +70,6 @@ function ListViewBlockSelectButton(
 		onDragStart?.( event );
 	};
 
-	// Determine which blocks to update:
-	// If the current (focused) block is part of the block selection, use the whole selection.
-	// If the focused block is not part of the block selection, only update the focused block.
-	function getBlocksToUpdate() {
-		const selectedBlockClientIds = getSelectedBlockClientIds();
-		const isUpdatingSelectedBlocks =
-			selectedBlockClientIds.includes( clientId );
-		const firstBlockClientId = isUpdatingSelectedBlocks
-			? selectedBlockClientIds[ 0 ]
-			: clientId;
-		const firstBlockRootClientId =
-			getBlockRootClientId( firstBlockClientId );
-
-		const blocksToUpdate = isUpdatingSelectedBlocks
-			? selectedBlockClientIds
-			: [ clientId ];
-
-		return {
-			blocksToUpdate,
-			firstBlockClientId,
-			firstBlockRootClientId,
-			selectedBlockClientIds,
-		};
-	}
-
-	/**
-	 * @param {KeyboardEvent} event
-	 */
-	async function onKeyDownHandler( event ) {
-		if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
-			onClick( event );
-		} else if (
-			event.keyCode === BACKSPACE ||
-			event.keyCode === DELETE ||
-			isMatch( 'core/block-editor/remove', event )
-		) {
-			const {
-				blocksToUpdate: blocksToDelete,
-				firstBlockClientId,
-				firstBlockRootClientId,
-				selectedBlockClientIds,
-			} = getBlocksToUpdate();
-
-			// Don't update the selection if the blocks cannot be deleted.
-			if ( ! canRemoveBlocks( blocksToDelete, firstBlockRootClientId ) ) {
-				return;
-			}
-
-			let blockToFocus =
-				getPreviousBlockClientId( firstBlockClientId ) ??
-				// If the previous block is not found (when the first block is deleted),
-				// fallback to focus the parent block.
-				firstBlockRootClientId;
-
-			removeBlocks( blocksToDelete, false );
-
-			// Update the selection if the original selection has been removed.
-			const shouldUpdateSelection =
-				selectedBlockClientIds.length > 0 &&
-				getSelectedBlockClientIds().length === 0;
-
-			// If there's no previous block nor parent block, focus the first block.
-			if ( ! blockToFocus ) {
-				blockToFocus = getBlockOrder()[ 0 ];
-			}
-
-			updateFocusAndSelection( blockToFocus, shouldUpdateSelection );
-		} else if ( isMatch( 'core/block-editor/duplicate', event ) ) {
-			if ( event.defaultPrevented ) {
-				return;
-			}
-			event.preventDefault();
-
-			const { blocksToUpdate, firstBlockRootClientId } =
-				getBlocksToUpdate();
-
-			const canDuplicate = getBlocksByClientId( blocksToUpdate ).every(
-				( block ) => {
-					return (
-						!! block &&
-						hasBlockSupport( block.name, 'multiple', true ) &&
-						canInsertBlockType( block.name, firstBlockRootClientId )
-					);
-				}
-			);
-
-			if ( canDuplicate ) {
-				const updatedBlocks = await duplicateBlocks(
-					blocksToUpdate,
-					false
-				);
-
-				if ( updatedBlocks?.length ) {
-					// If blocks have been duplicated, focus the first duplicated block.
-					updateFocusAndSelection( updatedBlocks[ 0 ], false );
-				}
-			}
-		} else if ( isMatch( 'core/block-editor/insert-before', event ) ) {
-			if ( event.defaultPrevented ) {
-				return;
-			}
-			event.preventDefault();
-
-			const { blocksToUpdate } = getBlocksToUpdate();
-			await insertBeforeBlock( blocksToUpdate[ 0 ] );
-			const newlySelectedBlocks = getSelectedBlockClientIds();
-
-			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
-			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
-		} else if ( isMatch( 'core/block-editor/insert-after', event ) ) {
-			if ( event.defaultPrevented ) {
-				return;
-			}
-			event.preventDefault();
-
-			const { blocksToUpdate } = getBlocksToUpdate();
-			await insertAfterBlock( blocksToUpdate.at( -1 ) );
-			const newlySelectedBlocks = getSelectedBlockClientIds();
-
-			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
-			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
-		} else if ( isMatch( 'core/block-editor/select-all', event ) ) {
-			if ( event.defaultPrevented ) {
-				return;
-			}
-			event.preventDefault();
-
-			const { firstBlockRootClientId, selectedBlockClientIds } =
-				getBlocksToUpdate();
-			const blockClientIds = getBlockOrder( firstBlockRootClientId );
-			if ( ! blockClientIds.length ) {
-				return;
-			}
-
-			// If we have selected all sibling nested blocks, try selecting up a level.
-			// This is a similar implementation to that used by `useSelectAll`.
-			// `isShallowEqual` is used for the list view instead of a length check,
-			// as the array of siblings of the currently focused block may be a different
-			// set of blocks from the current block selection if the user is focused
-			// on a different part of the list view from the block selection.
-			if ( isShallowEqual( selectedBlockClientIds, blockClientIds ) ) {
-				// Only select up a level if the first block is not the root block.
-				// This ensures that the block selection can't break out of the root block
-				// used by the list view, if the list view is only showing a partial hierarchy.
-				if (
-					firstBlockRootClientId &&
-					firstBlockRootClientId !== rootClientId
-				) {
-					updateFocusAndSelection( firstBlockRootClientId, true );
-					return;
-				}
-			}
-
-			// Select all while passing `null` to skip focusing to the editor canvas,
-			// and retain focus within the list view.
-			multiSelect(
-				blockClientIds[ 0 ],
-				blockClientIds[ blockClientIds.length - 1 ],
-				null
-			);
-		} else if ( isMatch( 'core/block-editor/collapse-list-view', event ) ) {
-			if ( event.defaultPrevented ) {
-				return;
-			}
-			event.preventDefault();
-			const { firstBlockClientId } = getBlocksToUpdate();
-			const blockParents = getBlockParents( firstBlockClientId, false );
-			// Collapse all blocks.
-			collapseAll();
-			// Expand all parents of the current block.
-			expand( blockParents );
-		}
-	}
-
 	return (
 		<>
 			<Button
@@ -280,7 +79,6 @@ function ListViewBlockSelectButton(
 				) }
 				onClick={ onClick }
 				onContextMenu={ onContextMenu }
-				onKeyDown={ onKeyDownHandler }
 				onMouseDown={ onMouseDown }
 				ref={ ref }
 				tabIndex={ tabIndex }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -81,81 +81,79 @@ function ListViewBlockSelectButton(
 	}
 
 	return (
-		<>
-			<Button
-				className={ classnames(
-					'block-editor-list-view-block-select-button',
-					className
-				) }
-				onClick={ onClick }
-				onContextMenu={ onContextMenu }
-				onKeyDown={ onKeyDown }
-				onMouseDown={ onMouseDown }
-				ref={ ref }
-				tabIndex={ tabIndex }
-				onFocus={ onFocus }
-				onDragStart={ onDragStartHandler }
-				onDragEnd={ onDragEnd }
-				draggable={ draggable }
-				href={ `#block-${ clientId }` }
-				aria-describedby={ ariaDescribedBy }
-				aria-expanded={ isExpanded }
+		<Button
+			className={ classnames(
+				'block-editor-list-view-block-select-button',
+				className
+			) }
+			onClick={ onClick }
+			onContextMenu={ onContextMenu }
+			onKeyDown={ onKeyDown }
+			onMouseDown={ onMouseDown }
+			ref={ ref }
+			tabIndex={ tabIndex }
+			onFocus={ onFocus }
+			onDragStart={ onDragStartHandler }
+			onDragEnd={ onDragEnd }
+			draggable={ draggable }
+			href={ `#block-${ clientId }` }
+			aria-describedby={ ariaDescribedBy }
+			aria-expanded={ isExpanded }
+		>
+			<ListViewExpander onClick={ onToggleExpanded } />
+			<BlockIcon
+				icon={ blockInformation?.icon }
+				showColors
+				context="list-view"
+			/>
+			<HStack
+				alignment="center"
+				className="block-editor-list-view-block-select-button__label-wrapper"
+				justify="flex-start"
+				spacing={ 1 }
 			>
-				<ListViewExpander onClick={ onToggleExpanded } />
-				<BlockIcon
-					icon={ blockInformation?.icon }
-					showColors
-					context="list-view"
-				/>
-				<HStack
-					alignment="center"
-					className="block-editor-list-view-block-select-button__label-wrapper"
-					justify="flex-start"
-					spacing={ 1 }
-				>
-					<span className="block-editor-list-view-block-select-button__title">
-						<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
-					</span>
-					{ blockInformation?.anchor && (
-						<span className="block-editor-list-view-block-select-button__anchor-wrapper">
-							<Truncate
-								className="block-editor-list-view-block-select-button__anchor"
-								ellipsizeMode="auto"
-							>
-								{ blockInformation.anchor }
-							</Truncate>
-						</span>
-					) }
-					{ positionLabel && isSticky && (
-						<Tooltip text={ positionLabel }>
-							<Icon icon={ pinSmall } />
-						</Tooltip>
-					) }
-					{ images.length ? (
-						<span
-							className="block-editor-list-view-block-select-button__images"
-							aria-hidden
+				<span className="block-editor-list-view-block-select-button__title">
+					<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
+				</span>
+				{ blockInformation?.anchor && (
+					<span className="block-editor-list-view-block-select-button__anchor-wrapper">
+						<Truncate
+							className="block-editor-list-view-block-select-button__anchor"
+							ellipsizeMode="auto"
 						>
-							{ images.map( ( image, index ) => (
-								<span
-									className="block-editor-list-view-block-select-button__image"
-									key={ image.clientId }
-									style={ {
-										backgroundImage: `url(${ image.url })`,
-										zIndex: images.length - index, // Ensure the first image is on top, and subsequent images are behind.
-									} }
-								/>
-							) ) }
-						</span>
-					) : null }
-					{ isLocked && (
-						<span className="block-editor-list-view-block-select-button__lock">
-							<Icon icon={ lock } />
-						</span>
-					) }
-				</HStack>
-			</Button>
-		</>
+							{ blockInformation.anchor }
+						</Truncate>
+					</span>
+				) }
+				{ positionLabel && isSticky && (
+					<Tooltip text={ positionLabel }>
+						<Icon icon={ pinSmall } />
+					</Tooltip>
+				) }
+				{ images.length ? (
+					<span
+						className="block-editor-list-view-block-select-button__images"
+						aria-hidden
+					>
+						{ images.map( ( image, index ) => (
+							<span
+								className="block-editor-list-view-block-select-button__image"
+								key={ image.clientId }
+								style={ {
+									backgroundImage: `url(${ image.url })`,
+									zIndex: images.length - index, // Ensure the first image is on top, and subsequent images are behind.
+								} }
+							/>
+						) ) }
+					</span>
+				) : null }
+				{ isLocked && (
+					<span className="block-editor-list-view-block-select-button__lock">
+						<Icon icon={ lock } />
+					</span>
+				) }
+			</HStack>
+		</Button>
 	);
 }
 

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -22,7 +22,9 @@ import {
 } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { ESCAPE } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, ESCAPE, ENTER, SPACE } from '@wordpress/keycodes';
+import isShallowEqual from '@wordpress/is-shallow-equal';
+import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -78,7 +80,25 @@ function ListViewBlock( {
 		isSelected &&
 		selectedClientIds[ selectedClientIds.length - 1 ] === clientId;
 
-	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
+	const {
+		toggleBlockHighlight,
+		duplicateBlocks,
+		multiSelect,
+		removeBlocks,
+		insertAfterBlock,
+		insertBeforeBlock,
+	} = useDispatch( blockEditorStore );
+
+	const {
+		canInsertBlockType,
+		getSelectedBlockClientIds,
+		getPreviousBlockClientId,
+		getBlockRootClientId,
+		getBlockOrder,
+		getBlockParents,
+		getBlocksByClientId,
+		canRemoveBlocks,
+	} = useSelect( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 
@@ -116,26 +136,191 @@ function ListViewBlock( {
 	const {
 		expand,
 		collapse,
+		collapseAll,
 		BlockSettingsMenu,
 		listViewInstanceId,
 		expandedState,
 		setInsertedBlock,
 		treeGridElementRef,
+		rootClientId,
 	} = useListViewContext();
+	const isMatch = useShortcutEventMatch();
 
-	// If multiple blocks are selected, deselect all blocks when the user
-	// presses the escape key.
-	const onKeyDown = ( event ) => {
-		if (
-			event.keyCode === ESCAPE &&
-			! event.defaultPrevented &&
-			selectedClientIds.length > 0
-		) {
+	// Determine which blocks to update:
+	// If the current (focused) block is part of the block selection, use the whole selection.
+	// If the focused block is not part of the block selection, only update the focused block.
+	function getBlocksToUpdate() {
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+		const isUpdatingSelectedBlocks =
+			selectedBlockClientIds.includes( clientId );
+		const firstBlockClientId = isUpdatingSelectedBlocks
+			? selectedBlockClientIds[ 0 ]
+			: clientId;
+		const firstBlockRootClientId =
+			getBlockRootClientId( firstBlockClientId );
+
+		const blocksToUpdate = isUpdatingSelectedBlocks
+			? selectedBlockClientIds
+			: [ clientId ];
+
+		return {
+			blocksToUpdate,
+			firstBlockClientId,
+			firstBlockRootClientId,
+			selectedBlockClientIds,
+		};
+	}
+
+	/**
+	 * @param {KeyboardEvent} event
+	 */
+	async function onKeyDownHandler( event ) {
+		if ( event.defaultPrevented ) {
+			return;
+		}
+
+		// If multiple blocks are selected, deselect all blocks when the user
+		// presses the escape key.
+		if ( event.keyCode === ESCAPE && selectedClientIds.length > 0 ) {
 			event.stopPropagation();
 			event.preventDefault();
 			selectBlock( event, undefined );
+		} else if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
+			selectEditorBlock( event );
+		} else if (
+			event.keyCode === BACKSPACE ||
+			event.keyCode === DELETE ||
+			isMatch( 'core/block-editor/remove', event )
+		) {
+			const {
+				blocksToUpdate: blocksToDelete,
+				firstBlockClientId,
+				firstBlockRootClientId,
+				selectedBlockClientIds,
+			} = getBlocksToUpdate();
+
+			// Don't update the selection if the blocks cannot be deleted.
+			if ( ! canRemoveBlocks( blocksToDelete, firstBlockRootClientId ) ) {
+				return;
+			}
+
+			let blockToFocus =
+				getPreviousBlockClientId( firstBlockClientId ) ??
+				// If the previous block is not found (when the first block is deleted),
+				// fallback to focus the parent block.
+				firstBlockRootClientId;
+
+			removeBlocks( blocksToDelete, false );
+
+			// Update the selection if the original selection has been removed.
+			const shouldUpdateSelection =
+				selectedBlockClientIds.length > 0 &&
+				getSelectedBlockClientIds().length === 0;
+
+			// If there's no previous block nor parent block, focus the first block.
+			if ( ! blockToFocus ) {
+				blockToFocus = getBlockOrder()[ 0 ];
+			}
+
+			updateFocusAndSelection( blockToFocus, shouldUpdateSelection );
+		} else if ( isMatch( 'core/block-editor/duplicate', event ) ) {
+			event.preventDefault();
+
+			const { blocksToUpdate, firstBlockRootClientId } =
+				getBlocksToUpdate();
+
+			const canDuplicate = getBlocksByClientId( blocksToUpdate ).every(
+				( blockToUpdate ) => {
+					return (
+						!! blockToUpdate &&
+						hasBlockSupport(
+							blockToUpdate.name,
+							'multiple',
+							true
+						) &&
+						canInsertBlockType(
+							blockToUpdate.name,
+							firstBlockRootClientId
+						)
+					);
+				}
+			);
+
+			if ( canDuplicate ) {
+				const updatedBlocks = await duplicateBlocks(
+					blocksToUpdate,
+					false
+				);
+
+				if ( updatedBlocks?.length ) {
+					// If blocks have been duplicated, focus the first duplicated block.
+					updateFocusAndSelection( updatedBlocks[ 0 ], false );
+				}
+			}
+		} else if ( isMatch( 'core/block-editor/insert-before', event ) ) {
+			event.preventDefault();
+
+			const { blocksToUpdate } = getBlocksToUpdate();
+			await insertBeforeBlock( blocksToUpdate[ 0 ] );
+			const newlySelectedBlocks = getSelectedBlockClientIds();
+
+			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
+			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
+		} else if ( isMatch( 'core/block-editor/insert-after', event ) ) {
+			event.preventDefault();
+
+			const { blocksToUpdate } = getBlocksToUpdate();
+			await insertAfterBlock( blocksToUpdate.at( -1 ) );
+			const newlySelectedBlocks = getSelectedBlockClientIds();
+
+			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
+			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
+		} else if ( isMatch( 'core/block-editor/select-all', event ) ) {
+			event.preventDefault();
+
+			const { firstBlockRootClientId, selectedBlockClientIds } =
+				getBlocksToUpdate();
+			const blockClientIds = getBlockOrder( firstBlockRootClientId );
+			if ( ! blockClientIds.length ) {
+				return;
+			}
+
+			// If we have selected all sibling nested blocks, try selecting up a level.
+			// This is a similar implementation to that used by `useSelectAll`.
+			// `isShallowEqual` is used for the list view instead of a length check,
+			// as the array of siblings of the currently focused block may be a different
+			// set of blocks from the current block selection if the user is focused
+			// on a different part of the list view from the block selection.
+			if ( isShallowEqual( selectedBlockClientIds, blockClientIds ) ) {
+				// Only select up a level if the first block is not the root block.
+				// This ensures that the block selection can't break out of the root block
+				// used by the list view, if the list view is only showing a partial hierarchy.
+				if (
+					firstBlockRootClientId &&
+					firstBlockRootClientId !== rootClientId
+				) {
+					updateFocusAndSelection( firstBlockRootClientId, true );
+					return;
+				}
+			}
+
+			// Select all while passing `null` to skip focusing to the editor canvas,
+			// and retain focus within the list view.
+			multiSelect(
+				blockClientIds[ 0 ],
+				blockClientIds[ blockClientIds.length - 1 ],
+				null
+			);
+		} else if ( isMatch( 'core/block-editor/collapse-list-view', event ) ) {
+			event.preventDefault();
+			const { firstBlockClientId } = getBlocksToUpdate();
+			const blockParents = getBlockParents( firstBlockClientId, false );
+			// Collapse all blocks.
+			collapseAll();
+			// Expand all parents of the current block.
+			expand( blockParents );
 		}
-	};
+	}
 
 	const onMouseEnter = useCallback( () => {
 		setIsHovered( true );
@@ -306,7 +491,7 @@ function ListViewBlock( {
 		<ListViewLeaf
 			className={ classes }
 			isDragged={ isDragged }
-			onKeyDown={ onKeyDown }
+			onKeyDown={ onKeyDownHandler }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
 			onFocus={ onMouseEnter }
@@ -346,7 +531,6 @@ function ListViewBlock( {
 							isExpanded={ canEdit ? isExpanded : undefined }
 							selectedClientIds={ selectedClientIds }
 							ariaDescribedBy={ descriptionId }
-							updateFocusAndSelection={ updateFocusAndSelection }
 						/>
 						<AriaReferencedText id={ descriptionId }>
 							{ `${ blockPositionDescription } ${ blockPropertiesDescription }` }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -22,7 +22,7 @@ import {
 } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { BACKSPACE, DELETE, ESCAPE, ENTER, SPACE } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 
@@ -174,7 +174,7 @@ function ListViewBlock( {
 	/**
 	 * @param {KeyboardEvent} event
 	 */
-	async function onKeyDownHandler( event ) {
+	async function onKeyDown( event ) {
 		if ( event.defaultPrevented ) {
 			return;
 		}
@@ -185,8 +185,6 @@ function ListViewBlock( {
 			event.stopPropagation();
 			event.preventDefault();
 			selectBlock( event, undefined );
-		} else if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
-			selectEditorBlock( event );
 		} else if (
 			event.keyCode === BACKSPACE ||
 			event.keyCode === DELETE ||
@@ -491,7 +489,7 @@ function ListViewBlock( {
 		<ListViewLeaf
 			className={ classes }
 			isDragged={ isDragged }
-			onKeyDown={ onKeyDownHandler }
+			onKeyDown={ onKeyDown }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
 			onFocus={ onMouseEnter }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -46,6 +46,7 @@ import { store as blockEditorStore } from '../../store';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
 import AriaReferencedText from './aria-referenced-text';
+import { unlock } from '../../lock-unlock';
 
 function ListViewBlock( {
 	block: { clientId },
@@ -87,7 +88,8 @@ function ListViewBlock( {
 		removeBlocks,
 		insertAfterBlock,
 		insertBeforeBlock,
-	} = useDispatch( blockEditorStore );
+		setOpenedBlockSettingsMenu,
+	} = unlock( useDispatch( blockEditorStore ) );
 
 	const {
 		canInsertBlockType,
@@ -263,6 +265,7 @@ function ListViewBlock( {
 			const newlySelectedBlocks = getSelectedBlockClientIds();
 
 			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
+			setOpenedBlockSettingsMenu( undefined );
 			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
 		} else if ( isMatch( 'core/block-editor/insert-after', event ) ) {
 			event.preventDefault();
@@ -272,6 +275,7 @@ function ListViewBlock( {
 			const newlySelectedBlocks = getSelectedBlockClientIds();
 
 			// Focus the first block of the newly inserted blocks, to keep focus within the list view.
+			setOpenedBlockSettingsMenu( undefined );
 			updateFocusAndSelection( newlySelectedBlocks[ 0 ], false );
 		} else if ( isMatch( 'core/block-editor/select-all', event ) ) {
 			event.preventDefault();


### PR DESCRIPTION
## What?
PR removes special List View shortcut handling (introduced in #50422) from the `BlockSettingsDropdown` component. Now, all the list view shortcuts are handled in a single place.

## Why?
It matches how the block shortcuts are handled in the canvas.

## How?
PR moves the shortcut handlers from the `ListViewBlockSelectButton` to the `ListViewBlock` component. This way, events propagated from the popover are also captured.

It's better to review with whitespace hidden - https://github.com/WordPress/gutenberg/pull/61130/files?diff=unified&w=1

## Testing Instructions
1. Open a post or page.
2. Add a few blocks.
3. Open the List View.
4. Open the "Options" dropdown for a block in the List View.
5. Confirm that shortcuts like Duplicate and Insert After|Before work as expected.
6. Confirm that the same shortcuts work when the block is selected in the list view, and the dropdown is closed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/b0b3fc4c-9cc5-4ed7-9d0c-d459edeead18

