### PR TITLE
Fix Truncate component for long unbreakable text.

### DIFF
--- a/packages/components/src/truncate/hook.ts
+++ b/packages/components/src/truncate/hook.ts
@@ -57,7 +57,7 @@ export default function useTruncate(
 		// breaks even when it contains 'unbreakable' content such as long URLs.
 		// See https://github.com/WordPress/gutenberg/issues/60860.
 		const truncateLines = css`
-			word-break: break-all;
+			${ numberOfLines === 1 ? 'word-break: break-all;' : '' }
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: ${ numberOfLines };
 			display: -webkit-box;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/61125
Amends https://github.com/WordPress/gutenberg/pull/60890
See https://github.com/WordPress/gutenberg/issues/60860

## What?
<!-- In a few words, what is the PR actually doing? -->
https://github.com/WordPress/gutenberg/pull/60890 broke the display of text that uses the `Truncate` component making words always 'breakable'. When the Truncate component forces text in one line, we still need to make sure 'unbreakable' text can break otherwise the `-webkit-line-clamp` CSS property will not work. However, when the Truncate component is set to force 2 or more lines, the text should not be forced to be 'breakable'.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When the Truncate component forces text in one line, we still need to make sure 'unbreakable' text can break otherwise the `-webkit-line-clamp` CSS property will not work. However, when the Truncate component is set to force 2 or more lines, the text should not be forced to be 'breakable'.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Makes `Truncate` use `word-break: break-all` only when `-webkit-line-clamp` is `1`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the reproduction instructions from the issue https://github.com/WordPress/gutenberg/issues/60860
- Observe long URls in the link preview are truncated.
- Observe the buttons 'Edit link', 'Remove link', and 'Copy link' are visible
- Open the block inserter.
- Search for blocks with long titles that go in two or 3 lines e.g. 'Table of Contents' or 'Comments Form' or 'Latest Comments'
- Observe the block titles don't have words that break in a new line.

Note: other places to optionally check are, for example, the filename of the Site Logo image, see screenshot:

![Screenshot 2024-04-26 at 09 55 19](https://github.com/WordPress/gutenberg/assets/1682452/44ba9610-7914-4e80-bd27-338fc2aeafa7)

or the filename of the background image of a Group block.

Notice in these cases the element rendered by the Truncate component already receives some more custom CSS rules including `word-break: break-all` because filenames, like URLs, can be very long and 'unbreakable'. We could consider to remove the custom `word-break: break-all` set on these elements to be more clean, but keeping it doesn't harm much.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
