### PR TITLE
Update item height in Navigation menu list views

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -142,7 +142,10 @@ const MenuInspectorControls = ( props ) => {
 
 	return (
 		<InspectorControls group="list">
-			<PanelBody title={ null }>
+			<PanelBody
+				title={ null }
+				className="wp-block-navigation-off-canvas-editor__list-view"
+			>
 				<HStack className="wp-block-navigation-off-canvas-editor__header">
 					<Heading
 						className="wp-block-navigation-off-canvas-editor__title"

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -515,6 +515,14 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 	margin: 0;
 }
 
+.wp-block-navigation-off-canvas-editor__list-view {
+	.block-editor-list-view-leaf {
+		.block-editor-list-view-block-contents {
+			height: $grid-unit-50;
+		}
+	}
+}
+
 .wp-block-navigation-off-canvas-editor__header {
 	margin-bottom: $grid-unit-10;
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -64,12 +64,15 @@
 		}
 	}
 
-	.block-editor-list-view-leaf .block-editor-list-view-block__contents-cell {
-		width: 100%;
-	}
+	.block-editor-list-view-leaf {
+		.block-editor-list-view-block__contents-cell {
+			width: 100%;
+		}
 
-	.block-editor-list-view-leaf .block-editor-list-view-block-contents {
-		white-space: normal;
+		.block-editor-list-view-block-contents {
+			white-space: normal;
+			height: $grid-unit-50;
+		}
 	}
 
 	.block-editor-list-view-block__title {


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/60713 reduced spacing in List View. This also affected Navigation menu list views, both in the block inspector and in the site editor dark sidebar. 

Navigation menus rarely contain as many blocks as documents like pages and templates, so the reduced sizing is unnecessary in this context. This PR increases the height of list view items to 40px, which also restores alignment between site editor menu items and list view items.

<img width="358" alt="Screenshot 2024-04-26 at 10 03 33" src="https://github.com/WordPress/gutenberg/assets/846565/984c4fc6-3622-4f76-8402-533bd05459bc">

<img width="281" alt="Screenshot 2024-04-26 at 10 03 13" src="https://github.com/WordPress/gutenberg/assets/846565/b726c305-cadb-473c-91db-bc0bdcf1c7a7">

A trade-off here is that the displacement effect in list view is based on a 32px height, so that doesn't work quite as nicely in this context. @andrewserong is it possible to override that value in this scenario?