### PR TITLE
Block editor: remove CSS appender hiding

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/content.scss
+++ b/packages/block-editor/src/components/block-list-appender/content.scss
@@ -9,12 +9,3 @@
 .block-list-appender > .block-editor-inserter {
 	display: block;
 }
-
-// Hide the nested appender unless parent or child is selected.
-// This selector targets unselected blocks that have only a single nesting level.
-.block-editor-block-list__block:not(.is-selected):not(.has-child-selected):not(.block-editor-block-list__layout) {
-	.block-editor-block-list__layout > .block-list-appender .block-list-appender__toggle {
-		opacity: 0;
-		transform: scale(0);
-	}
-}

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -259,11 +259,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		}
 	}
 
-	// Reusable blocks parent border.
-	&.is-reusable.has-child-selected::after {
-		box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
-	}
-
 	// Clear floats.
 	&[data-clear="true"] {
 		float: none;
@@ -442,15 +437,6 @@ body.is-zoomed-out {
 	animation: block-editor-inserter__toggle__fade-in-animation 0.1s ease;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
-}
-
-.block-editor-block-list__block:not(.is-selected):not(.has-child-selected) .block-editor-default-block-appender {
-	display: none;
-
-	.block-editor-inserter__toggle {
-		opacity: 0;
-		transform: scale(0);
-	}
 }
 
 .block-editor-block-list__block .block-editor-block-list__block-html-textarea {

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -198,20 +198,22 @@ function Items( {
 				}
 
 				const selectedBlockClientId = getSelectedBlockClientId();
+				const isParentSelected = rootClientId === selectedBlockClientId;
+				const isEmpty = ! _order.length;
+				const shouldShowAppender = isParentSelected || isEmpty;
+
 				return {
 					order: _order,
 					selectedBlocks: getSelectedBlockClientIds(),
 					visibleBlocks: __unstableGetVisibleBlocks(),
 					shouldRenderAppender:
 						hasAppender &&
+						shouldShowAppender &&
 						__unstableGetEditorMode() !== 'zoom-out' &&
 						( hasCustomAppender
 							? ! getTemplateLock( rootClientId ) &&
 							  getBlockEditingMode( rootClientId ) !== 'disabled'
-							: rootClientId === selectedBlockClientId ||
-							  ( ! rootClientId &&
-									! selectedBlockClientId &&
-									! _order.length ) ),
+							: true ),
 				};
 			},
 			[ rootClientId, hasAppender, hasCustomAppender ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

All appenders should be hidden unless the (containing) block is selected, or the block is empty. Currently our logic for normal appenders and custom appenders has diverged, probably not by intention. This also allows us to remove some hiding done by CSS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
