### PR TITLE
Update template and template parts labels

### DIFF
--- a/lib/compat/wordpress-6.6/post.php
+++ b/lib/compat/wordpress-6.6/post.php
@@ -13,3 +13,27 @@ function gutenberg_add_excerpt_support_to_wp_block() {
 }
 
 add_action( 'init', 'gutenberg_add_excerpt_support_to_wp_block' );
+
+/**
+ * Updates the labels for the template post type.
+ *
+ * @param  object $labels Object with labels for the post type as member variables.
+ * @return object Object with all the labels as member variables.
+ */
+function gutenberg_update_wp_template_labels( $labels ) {
+	$labels->item_updated = __( 'Template updated.', 'gutenberg' );
+	return $labels;
+}
+add_filter( 'post_type_labels_wp_template', 'gutenberg_update_wp_template_labels', 10, 1 );
+
+/**
+ * Updates the labels for the template parts post type.
+ *
+ * @param  object $labels Object with labels for the post type as member variables.
+ * @return object Object with all the labels as member variables.
+ */
+function gutenberg_update_wp_template__part_labels( $labels ) {
+	$labels->item_updated = __( 'Template part updated.', 'gutenberg' );
+	return $labels;
+}
+add_filter( 'post_type_labels_wp_template_part', 'gutenberg_update_wp_template__part_labels', 10, 1 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR updates the template and template parts labels to use a specific `item_updated` label. Without it, if you save/update a template or template part the notification message renders `post updated`.

I noticed this in this [PR](https://github.com/WordPress/gutenberg/pull/61136) that brings the publish flow to site editor, but the issue is in post editor too right now, when you edit a template or template part and save.


## Testing Instructions
1. In post editor edit a template and save.
2. Observe that the notification renders `Template updated.`
3. Do the same for a template part and observe that it renders `Template part updated.`


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/d3890f92-bccd-4717-b3cf-57c9e1ba2d25


