### PR TITLE
Data views: Unbox items in grid layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -292,24 +292,25 @@
 	}
 
 	.dataviews-view-grid__card {
-		border-radius: $radius-block-ui * 2;
-		border: 1px solid $gray-200;
 		height: 100%;
 		justify-content: flex-start;
 
 		.dataviews-view-grid__title-actions {
-			padding: $grid-unit-05 $grid-unit $grid-unit-05 $grid-unit-05;
+			padding: $grid-unit-10 0 $grid-unit-05;
 		}
 
 		.dataviews-view-grid__primary-field {
-			min-height: $grid-unit-50;
+			min-height: $grid-unit-40; // Preserve layout when there is no ellipsis button
 		}
-		&.is-selected {
-			border-color: var(--wp-admin-theme-color);
-			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 
+		&.is-selected {
 			.dataviews-view-grid__fields .dataviews-view-grid__field .dataviews-view-grid__field-value {
 				color: $gray-900;
+			}
+
+			.page-pages-preview-field__button::after {
+				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			}
 		}
 	}
@@ -318,14 +319,26 @@
 		width: 100%;
 		min-height: 200px;
 		aspect-ratio: 1/1;
-		border-bottom: 1px solid $gray-200;
 		background-color: $gray-100;
-		border-radius: 3px 3px 0 0;
+		border-radius: $grid-unit-05;
+		overflow: hidden;
+		position: relative;
 
 		img {
 			object-fit: cover;
 			width: 100%;
 			height: 100%;
+		}
+
+		.page-pages-preview-field__button::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);
+			border-radius: $grid-unit-05;
 		}
 	}
 
@@ -337,7 +350,6 @@
 		&:not(:empty) {
 			padding: $grid-unit-15 0;
 			padding-top: 0;
-			margin: 0 $grid-unit-15;
 		}
 
 		.dataviews-view-grid__field {
@@ -366,8 +378,7 @@
 
 	.dataviews-view-grid__badge-fields {
 		&:not(:empty) {
-			padding: $grid-unit-15;
-			padding-top: 0;
+			padding-bottom: $grid-unit-15;
 		}
 
 		.dataviews-view-grid__field-value {
@@ -553,10 +564,6 @@
 
 .dataviews-bulk-edit-button.components-button {
 	flex-shrink: 0;
-}
-
-.dataviews-view-grid__title-actions .dataviews-view-table-selection-checkbox {
-	margin-left: $grid-unit-10;
 }
 
 .dataviews-filter-summary__popover {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -330,7 +330,7 @@
 			height: 100%;
 		}
 
-		.page-pages-preview-field__button::after {
+		&::after {
 			content: "";
 			position: absolute;
 			top: 0;

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -50,4 +50,15 @@
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 	}
+
+	// Make the button targetable for clicks
+	&::after {
+		content: "";
+		height: 100%;
+		left: 0;
+		position: absolute;
+		top: 0;
+		width: 100%;
+		z-index: 1;
+	}
 }


### PR DESCRIPTION
Recently-added field display options ([badge](https://github.com/WordPress/gutenberg/pull/60284), [row / column](https://github.com/WordPress/gutenberg/pull/60083)) and other tweaks like [decreasing checkbox size](https://github.com/WordPress/gutenberg/pull/60475) improve information density in grid layout, thereby alleviating the need to visually stress the grid structure. 

In this PR the 'box' around each grid item is removed giving the overall layout more room to breath.

### Before
<img width="1006" alt="Screenshot 2024-04-26 at 15 56 09" src="https://github.com/WordPress/gutenberg/assets/846565/05a13e44-4039-429b-a966-9cdd11ea578f">


### After
<img width="1007" alt="Screenshot 2024-04-26 at 15 55 40" src="https://github.com/WordPress/gutenberg/assets/846565/b49a4d05-9fa7-47fa-9eeb-7881577ed305">

### Testing instructions
1. Open a data view such as Patterns or Pages in the site editor.
2. Switch to grid layout
3. Observe the updated grid item display
4. Toggle fields on and off and ensure everything appears as expected