### PR TITLE
Focusing a ref inside tabs needs to wait, why?

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -140,9 +140,52 @@ function InserterMenu(
 		! delayedFilterValue &&
 		selectedMediaCategory;
 
+	const searchRef = useRef();
+	useImperativeHandle( ref, () => ( {
+		focusSearch: () => {
+			searchRef.current.focus();
+		},
+	} ) );
+
+	const inserterSearch = (
+		<>
+			<SearchControl
+				__nextHasNoMarginBottom
+				className="block-editor-inserter__search"
+				onChange={ ( value ) => {
+					if ( hoveredItem ) setHoveredItem( null );
+					setFilterValue( value );
+				} }
+				value={ filterValue }
+				label={ __( 'Search for blocks and patterns' ) }
+				placeholder={ __( 'Search' ) }
+				ref={ searchRef }
+			/>
+			{ !! delayedFilterValue && (
+				<div className="block-editor-inserter__no-tab-container">
+					<InserterSearchResults
+						filterValue={ delayedFilterValue }
+						onSelect={ onSelect }
+						onHover={ onHover }
+						onHoverPattern={ onHoverPattern }
+						rootClientId={ rootClientId }
+						clientId={ clientId }
+						isAppender={ isAppender }
+						__experimentalInsertionIndex={
+							__experimentalInsertionIndex
+						}
+						showBlockDirectory
+						shouldFocusBlock={ shouldFocusBlock }
+					/>
+				</div>
+			) }
+		</>
+	);
+
 	const blocksTab = useMemo(
 		() => (
 			<>
+				{ inserterSearch }
 				<div className="block-editor-inserter__block-list">
 					<BlockTypesTab
 						rootClientId={ destinationRootClientId }
@@ -167,28 +210,32 @@ function InserterMenu(
 			onHover,
 			showMostUsedBlocks,
 			showInserterHelpPanel,
+			inserterSearch,
 		]
 	);
 
 	const patternsTab = useMemo(
 		() => (
-			<BlockPatternsTab
-				rootClientId={ destinationRootClientId }
-				onInsert={ onInsertPattern }
-				onSelectCategory={ onClickPatternCategory }
-				selectedCategory={ selectedPatternCategory }
-			>
-				{ showPatternPanel && (
-					<PatternCategoryPreviewPanel
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsertPattern }
-						onHover={ onHoverPattern }
-						category={ selectedPatternCategory }
-						patternFilter={ patternFilter }
-						showTitlesAsTooltip
-					/>
-				) }
-			</BlockPatternsTab>
+			<>
+				{ inserterSearch }
+				<BlockPatternsTab
+					rootClientId={ destinationRootClientId }
+					onInsert={ onInsertPattern }
+					onSelectCategory={ onClickPatternCategory }
+					selectedCategory={ selectedPatternCategory }
+				>
+					{ showPatternPanel && (
+						<PatternCategoryPreviewPanel
+							rootClientId={ destinationRootClientId }
+							onInsert={ onInsertPattern }
+							onHover={ onHoverPattern }
+							category={ selectedPatternCategory }
+							patternFilter={ patternFilter }
+							showTitlesAsTooltip
+						/>
+					) }
+				</BlockPatternsTab>
+			</>
 		),
 		[
 			destinationRootClientId,
@@ -198,6 +245,7 @@ function InserterMenu(
 			patternFilter,
 			selectedPatternCategory,
 			showPatternPanel,
+			inserterSearch,
 		]
 	);
 
@@ -236,13 +284,6 @@ function InserterMenu(
 		[ blocksTab, mediaTab, patternsTab ]
 	);
 
-	const searchRef = useRef();
-	useImperativeHandle( ref, () => ( {
-		focusSearch: () => {
-			searchRef.current.focus();
-		},
-	} ) );
-
 	const showAsTabs = ! delayedFilterValue && ( showPatterns || showMedia );
 
 	// When the pattern panel is showing, we want to use zoom out mode
@@ -267,36 +308,6 @@ function InserterMenu(
 					'show-as-tabs': showAsTabs,
 				} ) }
 			>
-				<SearchControl
-					__nextHasNoMarginBottom
-					className="block-editor-inserter__search"
-					onChange={ ( value ) => {
-						if ( hoveredItem ) setHoveredItem( null );
-						setFilterValue( value );
-					} }
-					value={ filterValue }
-					label={ __( 'Search for blocks and patterns' ) }
-					placeholder={ __( 'Search' ) }
-					ref={ searchRef }
-				/>
-				{ !! delayedFilterValue && (
-					<div className="block-editor-inserter__no-tab-container">
-						<InserterSearchResults
-							filterValue={ delayedFilterValue }
-							onSelect={ onSelect }
-							onHover={ onHover }
-							onHoverPattern={ onHoverPattern }
-							rootClientId={ rootClientId }
-							clientId={ clientId }
-							isAppender={ isAppender }
-							__experimentalInsertionIndex={
-								__experimentalInsertionIndex
-							}
-							showBlockDirectory
-							shouldFocusBlock={ shouldFocusBlock }
-						/>
-					</div>
-				) }
 				{ showAsTabs && (
 					<InserterTabs
 						showPatterns={ showPatterns }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Moving the search control inside the tab makes the ref be set after the parent component of the tab is mounted. It shouldn't be the case, but it appears that tabs render last.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We tried in #61108 to move the search control into the inserter tabs and _keep the search control auto focus behavior_. In the mean time this route is not what makes most sense, but the problem still remains:

- how to manage focus to something in the tabs if the ref.current is available after the parent that manages the focus is mounted? Should we rely on `requestAnimationFrame`? 

If a component steps out of normal rendering timing via timeouts, effects or other async stuff maybe emiting a ready event when it’s all done is needed?

In the screenshot below the search control should be focused, like it is on trunk.

<img width="1343" alt="Screenshot 2024-05-01 at 18 20 01" src="https://github.com/WordPress/gutenberg/assets/107534/1fcf746d-3fd9-4463-a4b0-5b5141715163">

