### PR TITLE
Fix crash when switching to code editor

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -130,9 +130,6 @@ function Iframe( {
 	] = useResizeObserver();
 
 	const setRef = useRefEffect( ( node ) => {
-		node._load = () => {
-			setIframeDocument( node.contentDocument );
-		};
 		let iFrameDocument;
 		// Prevent the default browser action for files dropped outside of dropzones.
 		function preventFileDropDefault( event ) {
@@ -145,6 +142,7 @@ function Iframe( {
 
 			documentElement.classList.add( 'block-editor-iframe__html' );
 
+			setIframeDocument( node.contentDocument );
 			clearerRef( documentElement );
 
 			// Ideally ALL classes that are added through get_body_class should
@@ -194,7 +192,6 @@ function Iframe( {
 		node.addEventListener( 'load', onLoad );
 
 		return () => {
-			delete node._load;
 			node.removeEventListener( 'load', onLoad );
 			iFrameDocument?.removeEventListener(
 				'dragover',
@@ -241,7 +238,6 @@ function Iframe( {
 <html>
 	<head>
 		<meta charset="utf-8">
-		<script>window.frameElement._load()</script>
 		<style>
 			html{
 				height: auto !important;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -354,7 +354,7 @@ function Iframe( {
 			>
 				{ iframeDocument &&
 					createPortal(
-						// We want to prevent React events from bubbling throught the iframe
+						// We want to prevent React events from bubbling through the iframe
 						// we bubble these manually.
 						/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
 						<body

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -356,7 +356,6 @@ function Iframe( {
 					createPortal(
 						// We want to prevent React events from bubbling through the iframe
 						// we bubble these manually.
-						/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
 						<body
 							ref={ bodyRef }
 							className={ classnames(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -277,12 +277,14 @@ function Iframe( {
 			? scale( contentWidth, contentHeight )
 			: scale;
 
+	const isZoomedOut = scale !== 1;
+
 	useEffect( () => {
 		if ( ! iframeDocument ) {
 			return;
 		}
 
-		if ( scale !== 1 ) {
+		if ( isZoomedOut ) {
 			// Hack to get proper margins when scaling the iframe document.
 			const bottomFrameSize = frameSize - contentHeight * ( 1 - scale );
 
@@ -297,14 +299,14 @@ function Iframe( {
 				iframeDocument.documentElement.style.marginBottom = '';
 			};
 		}
-	}, [ scale, frameSize, iframeDocument, contentHeight ] );
+	}, [ scale, frameSize, iframeDocument, contentHeight, isZoomedOut ] );
 
 	// Make sure to not render the before and after focusable div elements in view
 	// mode. They're only needed to capture focus in edit mode.
 	const shouldRenderFocusCaptureElements = tabIndex >= 0 && ! isPreviewMode;
 
 	const scaleMinHeight =
-		scale !== 1 && iframeWindowInnerHeight > contentHeight * scale
+		isZoomedOut && iframeWindowInnerHeight > contentHeight * scale
 			? `${ Math.floor(
 					( iframeWindowInnerHeight - 2 * frameSize ) / scale
 			  ) }px`
@@ -359,7 +361,7 @@ function Iframe( {
 						<body
 							ref={ bodyRef }
 							className={ classnames(
-								scale !== 1 && 'is-zoomed-out',
+								isZoomedOut && 'is-zoomed-out',
 								'block-editor-iframe__body',
 								'editor-styles-wrapper',
 								...bodyClasses

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -286,38 +286,29 @@ function Iframe( {
 			// Hack to get proper margins when scaling the iframe document.
 			const bottomFrameSize = frameSize - contentHeight * ( 1 - scale );
 
-			iframeDocument.body.classList.add( 'is-zoomed-out' );
-
 			iframeDocument.documentElement.style.transform = `scale( ${ scale } )`;
 			iframeDocument.documentElement.style.marginTop = `${ frameSize }px`;
 			// TODO: `marginBottom` doesn't work in Firefox. We need another way to do this.
 			iframeDocument.documentElement.style.marginBottom = `${ bottomFrameSize }px`;
-			if ( iframeWindowInnerHeight > contentHeight * scale ) {
-				iframeDocument.body.style.minHeight = `${ Math.floor(
-					( iframeWindowInnerHeight - 2 * frameSize ) / scale
-				) }px`;
-			}
 
 			return () => {
-				iframeDocument.body.classList.remove( 'is-zoomed-out' );
 				iframeDocument.documentElement.style.transform = '';
 				iframeDocument.documentElement.style.marginTop = '';
 				iframeDocument.documentElement.style.marginBottom = '';
-				iframeDocument.body.style.minHeight = '';
 			};
 		}
-	}, [
-		scale,
-		frameSize,
-		iframeDocument,
-		contentHeight,
-		iframeWindowInnerHeight,
-		contentWidth,
-	] );
+	}, [ scale, frameSize, iframeDocument, contentHeight ] );
 
 	// Make sure to not render the before and after focusable div elements in view
 	// mode. They're only needed to capture focus in edit mode.
 	const shouldRenderFocusCaptureElements = tabIndex >= 0 && ! isPreviewMode;
+
+	const scaleMinHeight =
+		scale !== 1 && iframeWindowInnerHeight > contentHeight * scale
+			? `${ Math.floor(
+					( iframeWindowInnerHeight - 2 * frameSize ) / scale
+			  ) }px`
+			: undefined;
 
 	return (
 		<>
@@ -369,10 +360,14 @@ function Iframe( {
 						<body
 							ref={ bodyRef }
 							className={ classnames(
+								scale !== 1 && 'is-zoomed-out',
 								'block-editor-iframe__body',
 								'editor-styles-wrapper',
 								...bodyClasses
 							) }
+							style={ {
+								minHeight: scaleMinHeight,
+							} }
 						>
 							{ contentResizeListener }
 							<StyleProvider document={ iframeDocument }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue where triggering zoom-out while the code editor was open caused an editor crash.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

On page load, there is a script to remove the `body` of the document so it can be replaced with the React one in the portal. However, in the effect, we're referencing the `body` that gets removed, so on unmount (when switching to the code editor) you get the error: `Uncaught TypeError: iframeDocument.body is null`.

This is fixed by moving `body`-related code inside the portal.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the site editor.
2. Go to the code view mode.
3. Enter zoom-out mode by navigating to global styles > browse styles.
4. Exit code view.
5. See that there are no errors and the editor doesn't crash.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
