### PR TITLE
Fix: Pattern details page backpath

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/index.js
@@ -23,7 +23,7 @@ export default function SidebarNavigationScreenPattern() {
 	const history = useHistory();
 	const location = useLocation();
 	const {
-		params: { postType, postId },
+		params: { postType, postId, categoryId, categoryType },
 	} = location;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 
@@ -48,10 +48,14 @@ export default function SidebarNavigationScreenPattern() {
 	 * Depending on whether the theme supports block-template-parts, we go back to Patterns or Template screens.
 	 * This is temporary. We aim to consolidate to /patterns.
 	 */
-	const backPath =
-		isTemplatePartsMode && postType === 'wp_template_part'
-			? { path: '/wp_template_part/all' }
-			: { path: '/patterns' };
+	const backPath = {
+		categoryId,
+		categoryType,
+		path:
+			isTemplatePartsMode && postType === 'wp_template_part'
+				? '/wp_template_part/all'
+				: '/patterns',
+	};
 
 	return (
 		<SidebarNavigationScreen

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -66,4 +66,30 @@ test.describe( 'Site editor url navigation', () => {
 			'/wp-admin/site-editor.php?postId=emptytheme%2F%2Fdemo&postType=wp_template_part&canvas=edit'
 		);
 	} );
+
+	test( 'The Patterns page should keep the previously selected template part category', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		const navigation = page.getByRole( 'region', {
+			name: 'Navigation',
+		} );
+		await navigation.getByRole( 'button', { name: 'Patterns' } ).click();
+		await navigation.getByRole( 'button', { name: 'General' } ).click();
+		await page
+			.getByRole( 'region', {
+				name: 'Patterns content',
+			} )
+			.getByLabel( 'header', { exact: true } )
+			.click();
+		await expect(
+			page.getByRole( 'region', { name: 'Editor content' } )
+		).toBeVisible();
+		await page.getByRole( 'button', { name: 'Open navigation' } ).click();
+		await navigation.getByRole( 'button', { name: 'Back' } ).click();
+		await expect(
+			navigation.getByRole( 'button', { name: 'General' } )
+		).toHaveAttribute( 'aria-current', 'true' );
+	} );
 } );


### PR DESCRIPTION
Fix part of #61172
Related to #60466

## What?
This PR ensures that the previously selected category is selected when you return from the Pattern details/Template part details page.

## Why?

On the pattern page, the `categoryType` parameter indicates which template part or pattern is selected, and the `categoryId` parameter indicates which category is selected.

Previously, these parameters were carried over when returning from the details page, but after #60466 was merged, it appears that the only explicitly specified parameter (`path`) is carried over.

## How?

I explicitly included `categoryId` and `categoryType` in the `backpath`. I would appreciate any advice on whether this is the correct approach.

## Testing Instructions

### Patterns

- Create a pattern.
- Click the "My patterns" category.
- Click on the pattern you just created.
- Click the back button. The pattern details page is displayed.
- Click the back button.
- The "My patterns" category should be selected.

### Template Part

- Click the "Header" category.
- Click on the "Header" template part.
- Click the back button. The template part details page is displayed.
- Click the back button.
- The "Header" category should be selected.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/599c320e-ae35-461c-a4dc-f65c0ec125ed



