### PR TITLE
DataViews: Enable types

### DIFF
--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -1,10 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import type { Field } from './types';
+
+/**
  * Apply default values and normalize the fields config.
  *
- * @param {Object[]} fields Raw Fields.
- * @return {Object[]} Normalized fields.
+ * @param fields Fields config.
+ * @return Normalized fields config.
  */
-export function normalizeFields( fields ) {
+export function normalizeFields( fields: Field[] ): Field[] {
 	return fields.map( ( field ) => {
 		const getValue = field.getValue || ( ( { item } ) => item[ field.id ] );
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+type Item = Record< string, any >;
+
+interface Option {
+	value: any;
+	label: string;
+}
+
+interface filterByConfig {
+	operators?: string[];
+	isPrimary?: boolean;
+}
+
+export interface Field {
+	/**
+	 * The unique identifier of the field.
+	 */
+	id: string;
+
+	/**
+	 * The label of the field. Defaults to the id.
+	 */
+	header?: string;
+
+	/**
+	 * Callback used to retrieve the value of the field from the item.
+	 * Defaults to `item[ field.id ]`.
+	 */
+	getValue?: ( { item }: { item: Item } ) => any;
+
+	/**
+	 * Callback used to render the field. Defaults to `field.getValue`.
+	 */
+	render?: ( { item }: { item: Item } ) => ReactNode;
+
+	/**
+	 * The width of the field column.
+	 */
+	width?: string | number;
+
+	/**
+	 * The minimum width of the field column.
+	 */
+	maxWidth?: string | number;
+
+	/**
+	 * The maximum width of the field column.
+	 */
+	minWidth?: string | number;
+
+	/**
+	 * Whether the field is sortable.
+	 */
+	enableSorting?: boolean;
+
+	/**
+	 * Whether the field is searchable.
+	 */
+	enableGlobalSearch?: boolean;
+
+	/**
+	 * Whether the field is filterable.
+	 */
+	enableHiding?: boolean;
+
+	/**
+	 * The type of the field.
+	 */
+	type?: string;
+
+	/**
+	 * The list of options to pick from when using the field as a filter.
+	 */
+	elements?: Option[];
+
+	/**
+	 * Filter config for the field.
+	 */
+	filterBy?: filterByConfig;
+}

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -68,11 +68,6 @@ export interface Field {
 	enableHiding?: boolean;
 
 	/**
-	 * The type of the field.
-	 */
-	type?: string;
-
-	/**
 	 * The list of options to pick from when using the field as a filter.
 	 */
 	elements?: Option[];

--- a/packages/dataviews/tsconfig.json
+++ b/packages/dataviews/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"references": [
+		{ "path": "../a11y" },
+		{ "path": "../components" },
+		{ "path": "../compose" },
+		{ "path": "../element" },
+		{ "path": "../i18n" },
+		{ "path": "../icons" },
+		{ "path": "../keycodes" },
+		{ "path": "../primitives" },
+		{ "path": "../private-apis" }
+	],
+	"include": [ "src/**/*.ts", "src/**/*.tsx" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		{ "path": "packages/compose" },
 		{ "path": "packages/core-data" },
 		{ "path": "packages/data" },
+		{ "path": "packages/dataviews" },
 		{ "path": "packages/data-controls" },
 		{ "path": "packages/date" },
 		{ "path": "packages/deprecated" },


### PR DESCRIPTION
Related #55083 

## What?

The DataViews package is a types heavy package. There's a lot of structures that need to be documented properly. So this PR introduces types and typescript to the package. It's not exhaustive by any means, The idea is to add the config and start typing bit by bit. This one adds a "Field" type which is one of the most important ones and only types a single file in the package. We can expand the coverage in follow-ups.

## Testing instructions

There's no functional change, it's essentially a code quality + documentation change.