### PR TITLE
Update alignment of preview contents in Patterns and Templates data views

### DIFF
--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -51,7 +51,6 @@
 
 		&.is-viewtype-grid {
 			.block-editor-block-preview__container {
-				height: 100%;
 				border-radius: 3px 3px 0 0;
 			}
 		}

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -30,7 +30,7 @@
 
 	&.is-viewtype-grid {
 		.block-editor-block-preview__container {
-			height: auto;
+			height: 100%;
 		}
 
 		.page-templates-preview-field__button {


### PR DESCRIPTION
It's tricky to find a solution that works perfectly given the diverse arrangements that can exist in block patterns / templates. But the current implementation feels backwards. Templates which tend to be longer are centrally aligned which can result in previews where the header isn't flush with the top of the container. The top alignment applied to patterns suggest an inaccurate height.

This PR flips the treatments:

## Patterns
### Before (top aligned)
<img width="1174" alt="Screenshot 2024-04-29 at 11 39 14" src="https://github.com/WordPress/gutenberg/assets/846565/6f088481-a97a-4445-9c11-1c041ca40d07">

### After (centrally aligned)
<img width="1180" alt="Screenshot 2024-04-29 at 11 37 54" src="https://github.com/WordPress/gutenberg/assets/846565/54423db0-b5bb-41d2-9e81-4e934d70c061">

## Templates
### Before (centrally aligned)
<img width="1185" alt="Screenshot 2024-04-29 at 11 39 05" src="https://github.com/WordPress/gutenberg/assets/846565/98ee1147-b43c-4d6a-b375-ae21ece9e09f">

### After (top aligned)
<img width="1178" alt="Screenshot 2024-04-29 at 11 38 07" src="https://github.com/WordPress/gutenberg/assets/846565/a2128227-9500-4b60-8c9f-12a48ed031f0">

While this is a small improvement, ideally consumers are offered more expressive display options (https://github.com/WordPress/gutenberg/issues/60891) in the future.