### PR TITLE
Update: Make duplicate post action available only on the plugin for now.

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -189,16 +189,28 @@ function FeaturedImage( { item, viewType } ) {
 	);
 }
 
-const PAGE_ACTIONS = [
+let PAGE_ACTIONS = [
 	'edit-post',
 	'view-post',
 	'restore',
 	'permanently-delete',
 	'view-post-revisions',
-	'duplicate-post',
 	'rename-post',
 	'move-to-trash',
 ];
+
+if ( process.env.IS_GUTENBERG_PLUGIN ) {
+	PAGE_ACTIONS = [
+		'edit-post',
+		'view-post',
+		'restore',
+		'permanently-delete',
+		'view-post-revisions',
+		'duplicate-post',
+		'rename-post',
+		'move-to-trash',
+	];
+}
 
 export default function PagePages() {
 	const postType = 'page';

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -31,13 +31,22 @@ const {
 	kebabCase,
 } = unlock( componentsPrivateApis );
 
-const POST_ACTIONS_WHILE_EDITING = [
+let POST_ACTIONS_WHILE_EDITING = [
 	'view-post',
 	'view-post-revisions',
-	'duplicate-post',
 	'rename-post',
 	'move-to-trash',
 ];
+
+if ( process.env.IS_GUTENBERG_PLUGIN ) {
+	POST_ACTIONS_WHILE_EDITING = [
+		'view-post',
+		'view-post-revisions',
+		'duplicate-post',
+		'rename-post',
+		'move-to-trash',
+	];
+}
 
 export default function PostActions( { onActionPerformed, buttonProps } ) {
 	const [ isActionsMenuOpen, setIsActionsMenuOpen ] = useState( false );


### PR DESCRIPTION
This PR applies a possibility raised by @youknowriad on the core editor channel of making the duplicate action available only on the Gutenberg plugin while we iterated on it.

The reason for making this action only available in the plugin contrary to the other actions that are available on plugin and core is to allow some time for an actions API that allows register and unregistering actions to exist. People expressed some interest in extending/customizing this action specifically.



## Testing Instructions
I verified the duplicate post action is still available and works as expected.