### PR TITLE
Fix: Missing format, categories, and tags on the duplicate post action.

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -547,9 +547,12 @@ export const duplicatePostAction = {
 						parent: item.parent,
 						password: item.password,
 						template: item.template,
+						format: item.format,
 						featured_media: item.featured_media,
 						menu_order: item.menu_order,
 						ping_status: item.ping_status,
+						categories: item.categories,
+						tags: item.tags,
 					},
 					{ throwOnError: true }
 				);


### PR DESCRIPTION
This PR adds some missing post properties on the duplicate post action that I think should be kept during the duplication: post format, categories, and tags.



## Testing Instructions
I selected the theme 2013 (which has post formats).
I created a new post, selected the link post format, and added some tags and categories to it.
I executed the duplicate action and verified the format, categories, and tags of the duplicate post are the same as on the original post.
