### PR TITLE
Fix unlabeled PostURL Copy button.

### DIFF
--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -89,6 +89,7 @@ export default function PostURL( { onClose } ) {
 								<Button
 									icon={ copySmall }
 									ref={ copyButtonRef }
+									label={ __( 'Copy' ) }
 								/>
 							}
 							label={ __( 'Link' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes part of https://github.com/WordPress/gutenberg/issues/56381#issuecomment-2061235862

This is one more instance where an interactive control is completely unlabeled. There's only an icon. No visitble text, no aria-label, no other labeling. This proves, once again, that some base components can be misused and, in fact, they'r econtinously misused. I would like, once again, to highlight that the sheer amount of cases of unlabeled controls in the hisotry of this project proves the only solid solution to this problem is to make the `label` prop required as requested in https://github.com/WordPress/gutenberg/issues/51740

Cc @ciampo @ntsekouras @joedolson @alexstine @andrewhayward 

## What?
<!-- In a few words, what is the PR actually doing? -->
The PostURL Copy button is unlabaled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All interactive controls must be labeled. Icon buttons, at the very least, must have an aria-label attribute and a tooltip to visually expose their name.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a missing `label` prop to the Button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

On trunk:
- Edit a published post (to make sure the post does have a saved slug).
- In the Post settings panel, click 'Link' to open the permalink popover.
- Inspect the source and observe the Copy button is unlabeled.
- Use a screen reader and navigate to the Copy button.
- Observe the button is announced just as 'button'.

On this PR:
- Repeat the steps above.
- Observe the button does have an `aria-label="Copy"` attribute.
- Observe the button is announced by screen readers as 'Copy, button'.
- Hover or focus the button and observe there is a tooltip with text 'Copy'.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
