### PR TITLE
Try: Prep fix for placeholder background-blur filter.

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -134,7 +134,7 @@
 
 
 /**
- * Dashed style placeholders
+ * Blurred BG style placeholders
  */
 
 // @todo
@@ -143,7 +143,6 @@
 .components-placeholder.has-illustration {
 	color: inherit;
 	display: flex;
-	box-shadow: none;
 
 	// Blur the background so layered dashed placeholders are still visually separate.
 	// Make the background transparent to not interfere with the background overlay in placeholder-style() pseudo element
@@ -164,6 +163,20 @@
 		margin-right: 0;
 	}
 
+	// Fix issue with flickering on subpixel scaling in Blink.
+	// We add left/right-margin to the blurred placeholder, and unset it on-select.
+	// https://github.com/WordPress/gutenberg/issues/52313
+	width: auto;
+	$edge-buffer: 1px;
+	margin-left: $edge-buffer;
+	margin-right: $edge-buffer;
+
+	// Draw a matching border left and right to make the placeholder optically
+	// line up in a column. Uses color-mix to combine currentColor with opacity.
+	box-shadow:
+		-$edge-buffer 0 0 0 color-mix(in srgb, currentColor 10%, transparent),
+		$edge-buffer 0 0 0 color-mix(in srgb, currentColor 10%, transparent);
+
 	// Show placeholder buttons on block selection.
 	// Note that these can't be display: none; or visibility: hidden;, as that breaks the writing flow.
 	.components-placeholder__label,
@@ -176,6 +189,11 @@
 	}
 
 	.is-selected > & {
+		// Unset blur-flickering margin.
+		margin-left: 0;
+		margin-right: 0;
+
+		// Show contents.
 		.components-placeholder__label,
 		.components-placeholder__instructions,
 		.components-button {


### PR DESCRIPTION
## What?

Tentative fix for #52313. In a draft state because the scaling issue that caused the original bug has recently regressed: https://github.com/WordPress/gutenberg/issues/52313#issuecomment-2082062446

The Placeholder component uses a backdrop-filter to make text legible inside, despite underlying backgrounds being present. When this is combined with a sub-pixel math, the Blink rendering engine has a way to render the blur that can cause a flickering effect. Here's a codepen demoing the issue: https://codepen.io/joen/pen/poBBKbZ?editors=1100 — hover the blurred element to see the flicker effect.

This PR fixes that by doing a few things:

* It applies a left and right-margin to the placeholder, which ensures that the blurred element never is close enough to the edge to touch the outside color which would cause the flickering.
* It applies a box-shadow left and right, to cover the offset by the margin.

The result looks like this:

![placeholder on photo background](https://github.com/WordPress/gutenberg/assets/1204802/69a71dea-3d26-4888-bc78-2372e6151708)

![placeholder on white background](https://github.com/WordPress/gutenberg/assets/1204802/e4b326cd-661c-45f3-b528-a24b73411edc)

## Testing Instructions

This cannot yet be tested since trunk is missing the animation that caused it. But the way to repro is otherwise outlined in the referenced issue.
