### PR TITLE
Eslint: Restore curly rule with prettier

### DIFF
--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -241,10 +241,13 @@ const formatType = ( prop ) => {
 		const types = [];
 
 		propTypes.forEach( ( item ) => {
-			if ( item.type ) types.push( item.type );
+			if ( item.type ) {
+				types.push( item.type );
+			}
 			// refComplete is always an object
-			if ( item.$ref && item.$ref === '#/definitions/refComplete' )
+			if ( item.$ref && item.$ref === '#/definitions/refComplete' ) {
 				types.push( 'object' );
+			}
 		} );
 
 		type = [ ...new Set( types ) ].join( ', ' );

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -63,7 +63,9 @@ function sanitizeBranchName( branch ) {
  * @return {number|undefined} Median value or undefined if array empty.
  */
 function median( array ) {
-	if ( ! array || ! array.length ) return undefined;
+	if ( ! array || ! array.length ) {
+		return undefined;
+	}
 
 	const numbers = [ ...array ].sort( ( a, b ) => a - b );
 	const middleIndex = Math.floor( numbers.length / 2 );

--- a/packages/block-editor/src/components/alignment-control/ui.js
+++ b/packages/block-editor/src/components/alignment-control/ui.js
@@ -45,7 +45,9 @@ function AlignmentUI( {
 	);
 
 	function setIcon() {
-		if ( activeAlignment ) return activeAlignment.icon;
+		if ( activeAlignment ) {
+			return activeAlignment.icon;
+		}
 		return isRTL() ? alignRight : alignLeft;
 	}
 

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -90,7 +90,9 @@ export const BlockMover = ( {
 		const option = blockPageMoverOptions.find(
 			( el ) => el.value === value
 		);
-		if ( option && option.onSelect ) option.onSelect();
+		if ( option && option.onSelect ) {
+			option.onSelect();
+		}
 	};
 
 	const onLongPressMoveUp = useCallback(

--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -34,7 +34,9 @@ function PatternTransformationsMenu( {
 } ) {
 	const [ showTransforms, setShowTransforms ] = useState( false );
 	const patterns = useTransformedPatterns( statePatterns, blocks );
-	if ( ! patterns.length ) return null;
+	if ( ! patterns.length ) {
+		return null;
+	}
 
 	return (
 		<MenuGroup className="block-editor-block-switcher__pattern__transforms__menugroup">

--- a/packages/block-editor/src/components/block-switcher/use-transformed-patterns.js
+++ b/packages/block-editor/src/components/block-switcher/use-transformed-patterns.js
@@ -62,7 +62,9 @@ export const getPatternTransformedBlocks = (
 				selectedBlock.name,
 				consumedBlocks
 			);
-			if ( ! match ) continue;
+			if ( ! match ) {
+				continue;
+			}
 			isMatch = true;
 			consumedBlocks.add( match.clientId );
 			// We update (mutate) the matching pattern block.
@@ -71,7 +73,9 @@ export const getPatternTransformedBlocks = (
 			break;
 		}
 		// Bail eary if a selected block has not been matched.
-		if ( ! isMatch ) return;
+		if ( ! isMatch ) {
+			return;
+		}
 	}
 	return _patternBlocks;
 };

--- a/packages/block-editor/src/components/block-switcher/utils.js
+++ b/packages/block-editor/src/components/block-switcher/utils.js
@@ -22,8 +22,12 @@ export const getMatchingBlockByName = (
 ) => {
 	const { clientId, name, innerBlocks = [] } = block;
 	// Check if block has been consumed already.
-	if ( consumedBlocks.has( clientId ) ) return;
-	if ( name === selectedBlockName ) return block;
+	if ( consumedBlocks.has( clientId ) ) {
+		return;
+	}
+	if ( name === selectedBlockName ) {
+		return block;
+	}
 	// Try to find a matching block from InnerBlocks recursively.
 	for ( const innerBlock of innerBlocks ) {
 		const match = getMatchingBlockByName(
@@ -31,7 +35,9 @@ export const getMatchingBlockByName = (
 			selectedBlockName,
 			consumedBlocks
 		);
-		if ( match ) return match;
+		if ( match ) {
+			return match;
+		}
 	}
 };
 
@@ -47,11 +53,14 @@ export const getMatchingBlockByName = (
  */
 export const getRetainedBlockAttributes = ( name, attributes ) => {
 	const contentAttributes = getBlockAttributesNamesByRole( name, 'content' );
-	if ( ! contentAttributes?.length ) return attributes;
+	if ( ! contentAttributes?.length ) {
+		return attributes;
+	}
 
 	return contentAttributes.reduce( ( _accumulator, attribute ) => {
-		if ( attributes[ attribute ] )
+		if ( attributes[ attribute ] ) {
 			_accumulator[ attribute ] = attributes[ attribute ];
+		}
 		return _accumulator;
 	}, {} );
 };

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -85,7 +85,9 @@ export default function BlockTools( {
 	} = unlock( useDispatch( blockEditorStore ) );
 
 	function onKeyDown( event ) {
-		if ( event.defaultPrevented ) return;
+		if ( event.defaultPrevented ) {
+			return;
+		}
 
 		if ( isMatch( 'core/block-editor/move-up', event ) ) {
 			const clientIds = getSelectedBlockClientIds();

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -180,7 +180,9 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	};
 
 	// Skip rendering if there are no variations
-	if ( ! variations?.length ) return null;
+	if ( ! variations?.length ) {
+		return null;
+	}
 
 	const baseClass = 'block-editor-block-variation-transforms';
 

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -47,8 +47,9 @@ const FloatingToolbar = ( {
 	}, [ showFloatingToolbar ] );
 
 	useEffect( () => {
-		if ( showFloatingToolbar )
+		if ( showFloatingToolbar ) {
 			setPreviousSelection( { clientId: selectedClientId, parentId } );
+		}
 	}, [ selectedClientId ] );
 
 	const translationRange =
@@ -115,7 +116,9 @@ export default compose( [
 
 		const selectedClientId = getSelectedBlockClientId();
 
-		if ( ! selectedClientId ) return;
+		if ( ! selectedClientId ) {
+			return;
+		}
 
 		const rootBlockId = getBlockHierarchyRootClientId( selectedClientId );
 

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -587,7 +587,9 @@ export default function ColorPanel( {
 	].filter( Boolean );
 
 	elements.forEach( ( { name, label, showPanel } ) => {
-		if ( ! showPanel ) return;
+		if ( ! showPanel ) {
+			return;
+		}
 
 		const elementBackgroundColor = decodeValue(
 			inheritedValue?.elements?.[ name ]?.color?.background

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -271,7 +271,9 @@ function InserterMenu(
 					__nextHasNoMarginBottom
 					className="block-editor-inserter__search"
 					onChange={ ( value ) => {
-						if ( hoveredItem ) setHoveredItem( null );
+						if ( hoveredItem ) {
+							setHoveredItem( null );
+						}
 						setFilterValue( value );
 					} }
 					value={ filterValue }

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -28,7 +28,9 @@ const LineHeightControl = ( {
 
 	const adjustNextValue = ( nextValue, wasTypedOrPasted ) => {
 		// Set the next value without modification if lineHeight has been defined.
-		if ( isDefined ) return nextValue;
+		if ( isDefined ) {
+			return nextValue;
+		}
 
 		/**
 		 * The following logic handles the initial spin up/down action
@@ -47,7 +49,9 @@ const LineHeightControl = ( {
 			case '0': {
 				// This means the user explicitly input '0', rather than using the
 				// spin down action from an undefined value state.
-				if ( wasTypedOrPasted ) return nextValue;
+				if ( wasTypedOrPasted ) {
+					return nextValue;
+				}
 				// Decrement by spin value.
 				return BASE_DEFAULT_VALUE - spin;
 			}

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -63,7 +63,9 @@ function SearchItemIcon( { isURL, suggestion } ) {
 function addLeadingSlash( url ) {
 	const trimmedURL = url?.trim();
 
-	if ( ! trimmedURL?.length ) return url;
+	if ( ! trimmedURL?.length ) {
+		return url;
+	}
 
 	return url?.replace( /^\/?/, '/' );
 }
@@ -71,7 +73,9 @@ function addLeadingSlash( url ) {
 function removeTrailingSlash( url ) {
 	const trimmedURL = url?.trim();
 
-	if ( ! trimmedURL?.length ) return url;
+	if ( ! trimmedURL?.length ) {
+		return url;
+	}
 
 	return url?.replace( /\/$/, '' );
 }
@@ -95,7 +99,9 @@ const defaultTo = ( d ) => ( v ) => {
  * @return {string} the processed url to display.
  */
 function getURLForDisplay( url ) {
-	if ( ! url ) return url;
+	if ( ! url ) {
+		return url;
+	}
 
 	return pipe(
 		safeDecodeURI,

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -74,7 +74,9 @@ export function focusListItem( focusClientId, treeGridElement ) {
 		const row = treeGridElement?.querySelector(
 			`[role=row][data-block="${ focusClientId }"]`
 		);
-		if ( ! row ) return null;
+		if ( ! row ) {
+			return null;
+		}
 		// Focus the first focusable in the row, which is the ListViewBlockSelectButton.
 		return focus.focusable.find( row )[ 0 ];
 	};

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -165,7 +165,9 @@ function useToolbarFocus( {
 		}
 		return () => {
 			window.cancelAnimationFrame( raf );
-			if ( ! onIndexChange || ! navigableToolbarRef ) return;
+			if ( ! onIndexChange || ! navigableToolbarRef ) {
+				return;
+			}
 			// When the toolbar element is unmounted and onIndexChange is passed, we
 			// pass the focused toolbar item index so it can be hydrated later.
 			const items = getAllFocusableToolbarItemsIn( navigableToolbarRef );

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -198,8 +198,9 @@ export default function useBlockSync( {
 			// the subscription is triggering for a block (`clientId !== null`)
 			// and its block name can't be found because it's not on the list.
 			// (`getBlockName( clientId ) === null`).
-			if ( clientId !== null && getBlockName( clientId ) === null )
+			if ( clientId !== null && getBlockName( clientId ) === null ) {
 				return;
+			}
 
 			// When RESET_BLOCKS on parent blocks get called, the controlled blocks
 			// can reset to uncontrolled, in these situations, it means we need to populate

--- a/packages/block-editor/src/components/rich-text/multiline.js
+++ b/packages/block-editor/src/components/rich-text/multiline.js
@@ -84,7 +84,9 @@ function RichTextMultiline(
 							const newValues = values.slice();
 							let offset = 0;
 							if ( forward ) {
-								if ( ! newValues[ index + 1 ] ) return;
+								if ( ! newValues[ index + 1 ] ) {
+									return;
+								}
 								newValues.splice(
 									index,
 									2,
@@ -92,7 +94,9 @@ function RichTextMultiline(
 								);
 								offset = newValues[ index ].length - 1;
 							} else {
-								if ( ! newValues[ index - 1 ] ) return;
+								if ( ! newValues[ index - 1 ] ) {
+									return;
+								}
 								newValues.splice(
 									index - 1,
 									2,

--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -29,7 +29,9 @@ const interactiveContentTags = new Set( [
 ] );
 
 function prefixSelectKeys( selected, prefix ) {
-	if ( typeof selected !== 'object' ) return { [ prefix ]: selected };
+	if ( typeof selected !== 'object' ) {
+		return { [ prefix ]: selected };
+	}
 	return Object.fromEntries(
 		Object.entries( selected ).map( ( [ key, value ] ) => [
 			`${ prefix }.${ key }`,
@@ -39,7 +41,9 @@ function prefixSelectKeys( selected, prefix ) {
 }
 
 function getPrefixedSelectKeys( selected, prefix ) {
-	if ( selected[ prefix ] ) return selected[ prefix ];
+	if ( selected[ prefix ] ) {
+		return selected[ prefix ];
+	}
 	return Object.keys( selected )
 		.filter( ( key ) => key.startsWith( prefix + '.' ) )
 		.reduce( ( accumulator, key ) => {

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -68,14 +68,18 @@ function getPositionTypeLabel( attributes ) {
 export default function useBlockDisplayInformation( clientId ) {
 	return useSelect(
 		( select ) => {
-			if ( ! clientId ) return null;
+			if ( ! clientId ) {
+				return null;
+			}
 			const { getBlockName, getBlockAttributes } =
 				select( blockEditorStore );
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
-			if ( ! blockType ) return null;
+			if ( ! blockType ) {
+				return null;
+			}
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const isSynced =
@@ -95,7 +99,9 @@ export default function useBlockDisplayInformation( clientId ) {
 				positionType: attributes?.style?.position?.type,
 				name: attributes?.metadata?.name,
 			};
-			if ( ! match ) return blockTypeInfo;
+			if ( ! match ) {
+				return blockTypeInfo;
+			}
 
 			return {
 				isSynced,

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -252,7 +252,9 @@ export default function useOnBlockDrop(
 			initialPosition = 0,
 			clientIdsToReplace = []
 		) => {
-			if ( ! Array.isArray( blocks ) ) blocks = [ blocks ];
+			if ( ! Array.isArray( blocks ) ) {
+				blocks = [ blocks ];
+			}
 
 			const clientIds = getBlockOrder( targetRootClientId );
 			const clientId = clientIds[ targetBlockIndex ];

--- a/packages/block-editor/src/components/writing-flow/use-drag-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-drag-selection.js
@@ -18,7 +18,9 @@ import { store as blockEditorStore } from '../../store';
 function setContentEditableWrapper( node, value ) {
 	node.contentEditable = value;
 	// Firefox doesn't automatically move focus.
-	if ( value ) node.focus();
+	if ( value ) {
+		node.focus();
+	}
 }
 
 /**

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -118,7 +118,9 @@ export default function useTabNav() {
 				// do it again here because after clearing block selection,
 				// focus land on the writing flow container and pressing Tab
 				// will no longer send focus through the focus capture element.
-				if ( event.target === node ) setNavigationMode( true );
+				if ( event.target === node ) {
+					setNavigationMode( true );
+				}
 				return;
 			}
 

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -291,7 +291,9 @@ function useDuotoneStyles( {
 	const blockElement = useBlockElement( clientId );
 
 	useEffect( () => {
-		if ( ! isValidFilter ) return;
+		if ( ! isValidFilter ) {
+			return;
+		}
 
 		// Safari does not always update the duotone filter when the duotone colors
 		// are changed. When using Safari, force the block element to be repainted by

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -149,7 +149,9 @@ export function useStyleOverride( {
 	const fallbackId = useId();
 	useEffect( () => {
 		// Unmount if there is CSS and assets are empty.
-		if ( ! css && ! assets ) return;
+		if ( ! css && ! assets ) {
+			return;
+		}
 
 		const _id = id || fallbackId;
 		const override = {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -675,7 +675,9 @@ export const __unstableDeleteSelection =
 		const selectionAnchor = select.getSelectionStart();
 		const selectionFocus = select.getSelectionEnd();
 
-		if ( selectionAnchor.clientId === selectionFocus.clientId ) return;
+		if ( selectionAnchor.clientId === selectionFocus.clientId ) {
+			return;
+		}
 
 		// It's not mergeable if there's no rich text selection.
 		if (
@@ -683,8 +685,9 @@ export const __unstableDeleteSelection =
 			! selectionFocus.attributeKey ||
 			typeof selectionAnchor.offset === 'undefined' ||
 			typeof selectionFocus.offset === 'undefined'
-		)
+		) {
 			return false;
+		}
 
 		const anchorRootClientId = select.getBlockRootClientId(
 			selectionAnchor.clientId
@@ -825,7 +828,9 @@ export const __unstableSplitSelection =
 		const selectionAnchor = select.getSelectionStart();
 		const selectionFocus = select.getSelectionEnd();
 
-		if ( selectionAnchor.clientId === selectionFocus.clientId ) return;
+		if ( selectionAnchor.clientId === selectionFocus.clientId ) {
+			return;
+		}
 
 		// Can't split if the selection is not set.
 		if (
@@ -833,8 +838,9 @@ export const __unstableSplitSelection =
 			! selectionFocus.attributeKey ||
 			typeof selectionAnchor.offset === 'undefined' ||
 			typeof selectionFocus.offset === 'undefined'
-		)
+		) {
 			return;
+		}
 
 		const anchorRootClientId = select.getBlockRootClientId(
 			selectionAnchor.clientId
@@ -931,7 +937,9 @@ export const mergeBlocks =
 		const blockA = select.getBlock( clientIdA );
 		const blockAType = getBlockType( blockA.name );
 
-		if ( ! blockAType ) return;
+		if ( ! blockAType ) {
+			return;
+		}
 
 		const blockB = select.getBlock( clientIdB );
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1030,7 +1030,9 @@ export function __unstableIsSelectionMergeable( state, isForward ) {
 	const selectionFocus = getSelectionEnd( state );
 
 	// It's not mergeable if the start and end are within the same block.
-	if ( selectionAnchor.clientId === selectionFocus.clientId ) return false;
+	if ( selectionAnchor.clientId === selectionFocus.clientId ) {
+		return false;
+	}
 
 	// It's not mergeable if there's no rich text selection.
 	if (
@@ -1038,8 +1040,9 @@ export function __unstableIsSelectionMergeable( state, isForward ) {
 		! selectionFocus.attributeKey ||
 		typeof selectionAnchor.offset === 'undefined' ||
 		typeof selectionFocus.offset === 'undefined'
-	)
+	) {
 		return false;
+	}
 
 	const anchorRootClientId = getBlockRootClientId(
 		state,
@@ -1081,12 +1084,16 @@ export function __unstableIsSelectionMergeable( state, isForward ) {
 	const targetBlockName = getBlockName( state, targetBlockClientId );
 	const targetBlockType = getBlockType( targetBlockName );
 
-	if ( ! targetBlockType.merge ) return false;
+	if ( ! targetBlockType.merge ) {
+		return false;
+	}
 
 	const blockToMerge = getBlock( state, blockToMergeClientId );
 
 	// It's mergeable if the blocks are of the same type.
-	if ( blockToMerge.name === targetBlockName ) return true;
+	if ( blockToMerge.name === targetBlockName ) {
+		return true;
+	}
 
 	// If the blocks are of a different type, try to transform the block being
 	// merged into the same type of block.
@@ -1938,7 +1945,9 @@ const buildBlockTypeItem =
 			isDisabled,
 			frecency: calculateFrecency( time, count ),
 		};
-		if ( buildScope === 'transform' ) return blockItemBase;
+		if ( buildScope === 'transform' ) {
+			return blockItemBase;
+		}
 
 		const inserterVariations = getBlockVariations(
 			blockType.name,
@@ -2379,7 +2388,9 @@ export const __experimentalGetAllowedPatterns = createRegistrySelector(
 export const getPatternsByBlockTypes = createRegistrySelector( ( select ) =>
 	createSelector(
 		( state, blockNames, rootClientId = null ) => {
-			if ( ! blockNames ) return EMPTY_ARRAY;
+			if ( ! blockNames ) {
+				return EMPTY_ARRAY;
+			}
 			const patterns =
 				select( STORE_NAME ).__experimentalGetAllowedPatterns(
 					rootClientId
@@ -2438,7 +2449,9 @@ export const __experimentalGetPatternTransformItems = createRegistrySelector(
 	( select ) =>
 		createSelector(
 			( state, blocks, rootClientId = null ) => {
-				if ( ! blocks ) return EMPTY_ARRAY;
+				if ( ! blocks ) {
+					return EMPTY_ARRAY;
+				}
 				/**
 				 * For now we only handle blocks without InnerBlocks and take into account
 				 * the `__experimentalRole` property of blocks' attributes for the transformation.

--- a/packages/block-editor/src/utils/order-inserter-block-items.js
+++ b/packages/block-editor/src/utils/order-inserter-block-items.js
@@ -17,8 +17,12 @@ export const orderInserterBlockItems = ( items, priority ) => {
 		let aIndex = priority.indexOf( aName );
 		let bIndex = priority.indexOf( bName );
 		// All other block items should come after that.
-		if ( aIndex < 0 ) aIndex = priority.length;
-		if ( bIndex < 0 ) bIndex = priority.length;
+		if ( aIndex < 0 ) {
+			aIndex = priority.length;
+		}
+		if ( bIndex < 0 ) {
+			bIndex = priority.length;
+		}
 		return aIndex - bIndex;
 	} );
 

--- a/packages/block-editor/src/utils/pasting.js
+++ b/packages/block-editor/src/utils/pasting.js
@@ -112,7 +112,9 @@ export function shouldDismissPastedFiles( files, html /*, plainText */ ) {
 		// other elements found, like <figure>, but we assume that the user's
 		// intention is to paste the actual image file.
 		const IMAGE_TAG = /<\s*img\b/gi;
-		if ( html.match( IMAGE_TAG )?.length !== 1 ) return true;
+		if ( html.match( IMAGE_TAG )?.length !== 1 ) {
+			return true;
+		}
 
 		// Even when there is exactly one <img> tag in the HTML payload, we
 		// choose to weed out local images, i.e. those whose source starts with
@@ -121,7 +123,9 @@ export function shouldDismissPastedFiles( files, html /*, plainText */ ) {
 		// text and exactly one image, and pasting that content using Google
 		// Chrome.
 		const IMG_WITH_LOCAL_SRC = /<\s*img\b[^>]*\bsrc="file:\/\//i;
-		if ( html.match( IMG_WITH_LOCAL_SRC ) ) return true;
+		if ( html.match( IMG_WITH_LOCAL_SRC ) ) {
+			return true;
+		}
 	}
 
 	return false;

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -92,7 +92,9 @@ const useInferredLayout = ( blocks, parentLayout ) => {
 
 function hasOverridableBlocks( blocks ) {
 	return blocks.some( ( block ) => {
-		if ( isOverridableBlock( block ) ) return true;
+		if ( isOverridableBlock( block ) ) {
+			return true;
+		}
 		return hasOverridableBlocks( block.innerBlocks );
 	} );
 }
@@ -159,7 +161,9 @@ function getContentValuesFromInnerBlocks( blocks, defaultValues, legacyIdMap ) {
 	/** @type {Record<string, { values: Record<string, unknown>}>} */
 	const content = {};
 	for ( const block of blocks ) {
-		if ( block.name === patternBlockName ) continue;
+		if ( block.name === patternBlockName ) {
+			continue;
+		}
 		if ( block.innerBlocks.length ) {
 			Object.assign(
 				content,

--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -220,7 +220,9 @@ function ColumnEditWrapper( props ) {
 	const { verticalAlignment } = props.attributes;
 
 	const getVerticalAlignmentRemap = ( alignment ) => {
-		if ( ! alignment ) return styles.flexBase;
+		if ( ! alignment ) {
+			return styles.flexBase;
+		}
 		return {
 			...styles.flexBase,
 			...styles[ `is-vertically-aligned-${ alignment }` ],

--- a/packages/block-library/src/comment-template/util.js
+++ b/packages/block-library/src/comment-template/util.js
@@ -30,7 +30,9 @@
 export const convertToTree = ( data ) => {
 	const table = {};
 
-	if ( ! data ) return [];
+	if ( ! data ) {
+		return [];
+	}
 
 	// First create a hash table of { [id]: { ...comment, children: [] }}
 	data.forEach( ( item ) => {

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -103,7 +103,9 @@ export function getPositionClassName( contentPosition ) {
 	/*
 	 * Only render a className if the contentPosition is not center (the default).
 	 */
-	if ( isContentPositionCenter( contentPosition ) ) return '';
+	if ( isContentPositionCenter( contentPosition ) ) {
+		return '';
+	}
 
 	return POSITION_CLASSNAMES[ contentPosition ];
 }

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -97,7 +97,9 @@ export const createUpgradedEmbedBlock = (
 	const { preview, attributes = {} } = props;
 	const { url, providerNameSlug, type, ...restAttributes } = attributes;
 
-	if ( ! url || ! getBlockType( DEFAULT_EMBED_BLOCK ) ) return;
+	if ( ! url || ! getBlockType( DEFAULT_EMBED_BLOCK ) ) {
+		return;
+	}
 
 	const matchedBlock = findMoreSuitableBlock( url );
 

--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -368,7 +368,9 @@ const variations = [
  *  Block by providing its attributes.
  */
 variations.forEach( ( variation ) => {
-	if ( variation.isActive ) return;
+	if ( variation.isActive ) {
+		return;
+	}
 	variation.isActive = ( blockAttributes, variationAttributes ) =>
 		blockAttributes.providerNameSlug ===
 		variationAttributes.providerNameSlug;

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -20,10 +20,14 @@ export default function WpEmbedPreview( { html } ) {
 		const iframe = doc.querySelector( 'iframe' );
 		const iframeProps = {};
 
-		if ( ! iframe ) return iframeProps;
+		if ( ! iframe ) {
+			return iframeProps;
+		}
 
 		Array.from( iframe.attributes ).forEach( ( { name, value } ) => {
-			if ( name === 'style' ) return;
+			if ( name === 'style' ) {
+				return;
+			}
 			iframeProps[ attributeMap[ name ] || name ] = value;
 		} );
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -200,7 +200,9 @@ export default function Image( {
 			return;
 		}
 
-		if ( externalBlob ) return;
+		if ( externalBlob ) {
+			return;
+		}
 
 		window
 			// Avoid cache, which seems to help avoid CORS problems.

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -174,7 +174,9 @@ const { state, actions, callbacks } = store(
 		},
 		callbacks: {
 			setOverlayStyles() {
-				if ( ! imageRef ) return;
+				if ( ! imageRef ) {
+					return;
+				}
 
 				let {
 					naturalWidth,

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -35,8 +35,12 @@ export default function useMerge( clientId, onMerge ) {
 	function getParentListItemId( id ) {
 		const listId = getBlockRootClientId( id );
 		const parentListItemId = getBlockRootClientId( listId );
-		if ( ! parentListItemId ) return;
-		if ( getBlockName( parentListItemId ) !== 'core/list-item' ) return;
+		if ( ! parentListItemId ) {
+			return;
+		}
+		if ( getBlockName( parentListItemId ) !== 'core/list-item' ) {
+			return;
+		}
 		return parentListItemId;
 	}
 
@@ -49,9 +53,13 @@ export default function useMerge( clientId, onMerge ) {
 	 */
 	function _getNextId( id ) {
 		const next = getNextBlockClientId( id );
-		if ( next ) return next;
+		if ( next ) {
+			return next;
+		}
 		const parentListItemId = getParentListItemId( id );
-		if ( ! parentListItemId ) return;
+		if ( ! parentListItemId ) {
+			return;
+		}
 		return _getNextId( parentListItemId );
 	}
 

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -27,8 +27,12 @@ export default function useOutdentListItem() {
 	function getParentListItemId( id ) {
 		const listId = getBlockRootClientId( id );
 		const parentListItemId = getBlockRootClientId( listId );
-		if ( ! parentListItemId ) return;
-		if ( getBlockName( parentListItemId ) !== 'core/list-item' ) return;
+		if ( ! parentListItemId ) {
+			return;
+		}
+		if ( getBlockName( parentListItemId ) !== 'core/list-item' ) {
+			return;
+		}
 		return parentListItemId;
 	}
 
@@ -37,17 +41,23 @@ export default function useOutdentListItem() {
 			clientIds = [ clientIds ];
 		}
 
-		if ( ! clientIds.length ) return;
+		if ( ! clientIds.length ) {
+			return;
+		}
 
 		const firstClientId = clientIds[ 0 ];
 
 		// Can't outdent if it's not a list item.
-		if ( getBlockName( firstClientId ) !== 'core/list-item' ) return;
+		if ( getBlockName( firstClientId ) !== 'core/list-item' ) {
+			return;
+		}
 
 		const parentListItemId = getParentListItemId( firstClientId );
 
 		// Can't outdent if it's at the top level.
-		if ( ! parentListItemId ) return;
+		if ( ! parentListItemId ) {
+			return;
+		}
 
 		const parentListId = getBlockRootClientId( firstClientId );
 		const lastClientId = clientIds[ clientIds.length - 1 ];

--- a/packages/block-library/src/navigation/edit/are-blocks-dirty.js
+++ b/packages/block-library/src/navigation/edit/are-blocks-dirty.js
@@ -30,7 +30,9 @@ const isDeepEqual = ( x, y, shouldSkip ) => {
 		y !== null &&
 		y !== undefined
 	) {
-		if ( Object.keys( x ).length !== Object.keys( y ).length ) return false;
+		if ( Object.keys( x ).length !== Object.keys( y ).length ) {
+			return false;
+		}
 
 		for ( const prop in x ) {
 			if ( y.hasOwnProperty( prop ) ) {
@@ -39,9 +41,12 @@ const isDeepEqual = ( x, y, shouldSkip ) => {
 					return true;
 				}
 
-				if ( ! isDeepEqual( x[ prop ], y[ prop ], shouldSkip ) )
+				if ( ! isDeepEqual( x[ prop ], y[ prop ], shouldSkip ) ) {
 					return false;
-			} else return false;
+				}
+			} else {
+				return false;
+			}
 		}
 
 		return true;

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -49,7 +49,9 @@ function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
 
 	const setInsertedBlockAttributes =
 		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
-			if ( ! _insertedBlockClientId ) return;
+			if ( ! _insertedBlockClientId ) {
+				return;
+			}
 			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
 		};
 

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -94,7 +94,9 @@ const { state, actions } = store(
 				const ctx = getContext();
 				const { ref } = getElement();
 				// Safari won't send focus to the clicked element, so we need to manually place it: https://bugs.webkit.org/show_bug.cgi?id=22261
-				if ( window.document.activeElement !== ref ) ref.focus();
+				if ( window.document.activeElement !== ref ) {
+					ref.focus();
+				}
 				const { menuOpenedBy } = state;
 				if ( menuOpenedBy.click || menuOpenedBy.focus ) {
 					actions.closeMenu( 'click' );

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -89,7 +89,9 @@ export default function PostExcerptEditor( {
 	 * excerpt has been produced from the content.
 	 */
 	const strippedRenderedExcerpt = useMemo( () => {
-		if ( ! renderedExcerpt ) return '';
+		if ( ! renderedExcerpt ) {
+			return '';
+		}
 		const document = new window.DOMParser().parseFromString(
 			renderedExcerpt,
 			'text/html'

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -81,7 +81,9 @@ const DimensionControls = ( {
 		 * we don't want to set the attribute, as it would
 		 * end up having the unit as value without any number.
 		 */
-		if ( isNaN( parsedValue ) && nextValue ) return;
+		if ( isNaN( parsedValue ) && nextValue ) {
+			return;
+		}
 		setAttributes( {
 			[ dimension ]: parsedValue < 0 ? '0' : nextValue,
 		} );

--- a/packages/block-library/src/post-navigation-link/variations.js
+++ b/packages/block-library/src/post-navigation-link/variations.js
@@ -34,7 +34,9 @@ const variations = [
  *  Block by providing its attributes.
  */
 variations.forEach( ( variation ) => {
-	if ( variation.isActive ) return;
+	if ( variation.isActive ) {
+		return;
+	}
 	variation.isActive = ( blockAttributes, variationAttributes ) =>
 		blockAttributes.type === variationAttributes.type;
 } );

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -49,7 +49,9 @@ export default function PostTermsEdit( {
 
 	const selectedTerm = useSelect(
 		( select ) => {
-			if ( ! term ) return {};
+			if ( ! term ) {
+				return {};
+			}
 			const { getTaxonomy } = select( coreStore );
 			const taxonomy = getTaxonomy( term );
 			return taxonomy?.visibility?.publicly_queryable ? taxonomy : {};

--- a/packages/block-library/src/query-title/variations.js
+++ b/packages/block-library/src/query-title/variations.js
@@ -38,7 +38,9 @@ const variations = [
  *  Block by providing its attributes.
  */
 variations.forEach( ( variation ) => {
-	if ( variation.isActive ) return;
+	if ( variation.isActive ) {
+		return;
+	}
 	variation.isActive = ( blockAttributes, variationAttributes ) =>
 		blockAttributes.type === variationAttributes.type;
 } );

--- a/packages/block-library/src/query/edit/inspector-controls/author-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/author-control.js
@@ -52,14 +52,18 @@ function AuthorControl( { value, onChange } ) {
 
 	const getIdByValue = ( entitiesMappedByName, authorValue ) => {
 		const id = authorValue?.id || entitiesMappedByName[ authorValue ]?.id;
-		if ( id ) return id;
+		if ( id ) {
+			return id;
+		}
 	};
 	const onAuthorChange = ( newValue ) => {
 		const ids = Array.from(
 			newValue.reduce( ( accumulator, author ) => {
 				// Verify that new values point to existing entities.
 				const id = getIdByValue( authorsInfo.mapByName, author );
-				if ( id ) accumulator.add( id );
+				if ( id ) {
+					accumulator.add( id );
+				}
 				return accumulator;
 			}, new Set() )
 		);

--- a/packages/block-library/src/query/edit/inspector-controls/create-new-post-link.js
+++ b/packages/block-library/src/query/edit/inspector-controls/create-new-post-link.js
@@ -8,7 +8,9 @@ import { addQueryArgs } from '@wordpress/url';
 const CreateNewPostLink = ( {
 	attributes: { query: { postType } = {} } = {},
 } ) => {
-	if ( ! postType ) return null;
+	if ( ! postType ) {
+		return null;
+	}
 	const newPostUrl = addQueryArgs( 'post-new.php', {
 		post_type: postType,
 	} );

--- a/packages/block-library/src/query/edit/inspector-controls/parent-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/parent-control.js
@@ -55,7 +55,9 @@ function ParentControl( { parents, postType, onChange } ) {
 	);
 	const currentParents = useSelect(
 		( select ) => {
-			if ( ! parents?.length ) return EMPTY_ARRAY;
+			if ( ! parents?.length ) {
+				return EMPTY_ARRAY;
+			}
 			const { getEntityRecords } = select( coreStore );
 			return getEntityRecords( 'postType', postType, {
 				...BASE_QUERY,
@@ -71,7 +73,9 @@ function ParentControl( { parents, postType, onChange } ) {
 		if ( ! parents?.length ) {
 			setValue( EMPTY_ARRAY );
 		}
-		if ( ! currentParents?.length ) return;
+		if ( ! currentParents?.length ) {
+			return;
+		}
 		const currentParentsInfo = getEntitiesInfo(
 			mapToIHasNameAndId( currentParents, 'title.rendered' )
 		);
@@ -91,27 +95,35 @@ function ParentControl( { parents, postType, onChange } ) {
 	}, [ parents, currentParents ] );
 
 	const entitiesInfo = useMemo( () => {
-		if ( ! searchResults?.length ) return EMPTY_ARRAY;
+		if ( ! searchResults?.length ) {
+			return EMPTY_ARRAY;
+		}
 		return getEntitiesInfo(
 			mapToIHasNameAndId( searchResults, 'title.rendered' )
 		);
 	}, [ searchResults ] );
 	// Update suggestions only when the query has resolved.
 	useEffect( () => {
-		if ( ! searchHasResolved ) return;
+		if ( ! searchHasResolved ) {
+			return;
+		}
 		setSuggestions( entitiesInfo.names );
 	}, [ entitiesInfo.names, searchHasResolved ] );
 
 	const getIdByValue = ( entitiesMappedByName, entity ) => {
 		const id = entity?.id || entitiesMappedByName?.[ entity ]?.id;
-		if ( id ) return id;
+		if ( id ) {
+			return id;
+		}
 	};
 	const onParentChange = ( newValue ) => {
 		const ids = Array.from(
 			newValue.reduce( ( accumulator, entity ) => {
 				// Verify that new values point to existing entities.
 				const id = getIdByValue( entitiesInfo.mapByName, entity );
-				if ( id ) accumulator.add( id );
+				if ( id ) {
+					accumulator.add( id );
+				}
 				return accumulator;
 			}, new Set() )
 		);

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -124,7 +124,9 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 	// and to sanitize the provided `termIds`, by setting only the ones that exist.
 	const existingTerms = useSelect(
 		( select ) => {
-			if ( ! termIds?.length ) return EMPTY_ARRAY;
+			if ( ! termIds?.length ) {
+				return EMPTY_ARRAY;
+			}
 			const { getEntityRecords } = select( coreStore );
 			return getEntityRecords( 'taxonomy', taxonomy.slug, {
 				...BASE_QUERY,
@@ -140,7 +142,9 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 		if ( ! termIds?.length ) {
 			setValue( EMPTY_ARRAY );
 		}
-		if ( ! existingTerms?.length ) return;
+		if ( ! existingTerms?.length ) {
+			return;
+		}
 		// Returns only the existing entity ids. This prevents the component
 		// from crashing in the editor, when non existing ids are provided.
 		const sanitizedValue = termIds.reduce( ( accumulator, id ) => {
@@ -157,7 +161,9 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 	}, [ termIds, existingTerms ] );
 	// Update suggestions only when the query has resolved.
 	useEffect( () => {
-		if ( ! searchHasResolved ) return;
+		if ( ! searchHasResolved ) {
+			return;
+		}
 		setSuggestions( searchResults.map( ( result ) => result.name ) );
 	}, [ searchResults, searchHasResolved ] );
 	const onTermsChange = ( newTermValues ) => {

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -108,7 +108,9 @@ export const usePostTypes = () => {
 		return filteredPostTypes;
 	}, [] );
 	const postTypesTaxonomiesMap = useMemo( () => {
-		if ( ! postTypes?.length ) return;
+		if ( ! postTypes?.length ) {
+			return;
+		}
 		return postTypes.reduce( ( accumulator, type ) => {
 			accumulator[ type.slug ] = type.taxonomies;
 			return accumulator;

--- a/packages/block-library/src/social-link/variations.js
+++ b/packages/block-library/src/social-link/variations.js
@@ -339,7 +339,9 @@ const variations = [
  *  Block by providing its attributes.
  */
 variations.forEach( ( variation ) => {
-	if ( variation.isActive ) return;
+	if ( variation.isActive ) {
+		return;
+	}
 	variation.isActive = ( blockAttributes, variationAttributes ) =>
 		blockAttributes.service === variationAttributes.service;
 } );

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -31,10 +31,14 @@ export function enhanceTemplatePartVariations( settings, name ) {
 			const { area, theme, slug } = blockAttributes;
 			// We first check the `area` block attribute which is set during insertion.
 			// This property is removed on the creation of a template part.
-			if ( area ) return area === variationAttributes.area;
+			if ( area ) {
+				return area === variationAttributes.area;
+			}
 			// Find a matching variation from the created template part
 			// by checking the entity's `area` property.
-			if ( ! slug ) return false;
+			if ( ! slug ) {
+				return false;
+			}
 			const { getCurrentTheme, getEntityRecord } =
 				select( coreDataStore );
 			const entity = getEntityRecord(

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -128,7 +128,9 @@ export function getSaveElement(
 ) {
 	const blockType = normalizeBlockType( blockTypeOrName );
 
-	if ( ! blockType?.save ) return null;
+	if ( ! blockType?.save ) {
+		return null;
+	}
 
 	let { save } = blockType;
 

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -334,9 +334,13 @@ export function __experimentalSanitizeBlockAttributes( name, attributes ) {
  */
 export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 	const attributes = getBlockType( name )?.attributes;
-	if ( ! attributes ) return [];
+	if ( ! attributes ) {
+		return [];
+	}
 	const attributesNames = Object.keys( attributes );
-	if ( ! role ) return attributesNames;
+	if ( ! role ) {
+		return attributesNames;
+	}
 	return attributesNames.filter(
 		( attributeName ) =>
 			attributes[ attributeName ]?.__experimentalRole === role

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -221,7 +221,9 @@ export function CommandMenu() {
 		/** @type {import('react').KeyboardEventHandler} */
 		( event ) => {
 			// Bails to avoid obscuring the effect of the preceding handler(s).
-			if ( event.defaultPrevented ) return;
+			if ( event.defaultPrevented ) {
+				return;
+			}
 
 			event.preventDefault();
 			if ( isOpen ) {

--- a/packages/components/src/alignment-matrix-control/index.tsx
+++ b/packages/components/src/alignment-matrix-control/index.tsx
@@ -61,7 +61,9 @@ export function AlignmentMatrixControl( {
 		activeId: getItemId( baseId, value ),
 		setActiveId: ( nextActiveId ) => {
 			const nextValue = getItemValue( baseId, nextActiveId );
-			if ( nextValue ) onChange?.( nextValue );
+			if ( nextValue ) {
+				onChange?.( nextValue );
+			}
 		},
 		rtl: isRTL(),
 	} );

--- a/packages/components/src/alignment-matrix-control/utils.tsx
+++ b/packages/components/src/alignment-matrix-control/utils.tsx
@@ -65,7 +65,9 @@ export function getItemId(
 	value?: AlignmentMatrixControlValue
 ) {
 	const normalized = normalize( value );
-	if ( ! normalized ) return;
+	if ( ! normalized ) {
+		return;
+	}
 
 	const id = normalized.replace( ' ', '-' );
 	return `${ prefixId }-${ id }`;
@@ -94,7 +96,9 @@ export function getAlignmentIndex(
 	alignment: AlignmentMatrixControlValue = 'center'
 ) {
 	const normalized = normalize( alignment );
-	if ( ! normalized ) return undefined;
+	if ( ! normalized ) {
+		return undefined;
+	}
 
 	const index = ALIGNMENTS.indexOf( normalized );
 	return index > -1 ? index : undefined;

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -55,7 +55,9 @@ export function getAutoCompleterUI( autocompleter: WPCompleter ) {
 			popoverRef,
 			useRefEffect(
 				( node ) => {
-					if ( ! contentRef.current ) return;
+					if ( ! contentRef.current ) {
+						return;
+					}
 
 					// If the popover is rendered in a different document than
 					// the content, we need to duplicate the options list in the

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -253,7 +253,9 @@ export function useAutocomplete( {
 
 	useEffect( () => {
 		if ( ! textContent ) {
-			if ( autocompleter ) reset();
+			if ( autocompleter ) {
+				reset();
+			}
 			return;
 		}
 
@@ -277,7 +279,9 @@ export function useAutocomplete( {
 		);
 
 		if ( ! completer ) {
-			if ( autocompleter ) reset();
+			if ( autocompleter ) {
+				reset();
+			}
 			return;
 		}
 
@@ -293,7 +297,9 @@ export function useAutocomplete( {
 		// significantly. This could happen, for example, if `matchingWhileBackspacing`
 		// is true and one of the "words" end up being too long. If that's the case,
 		// it will be caught by this guard.
-		if ( tooDistantFromTrigger ) return;
+		if ( tooDistantFromTrigger ) {
+			return;
+		}
 
 		const mismatch = filteredOptions.length === 0;
 		const wordsFromTrigger = textWithoutTrigger.split( /\s/ );
@@ -318,7 +324,9 @@ export function useAutocomplete( {
 			backspacing.current && wordsFromTrigger.length <= 3;
 
 		if ( mismatch && ! ( matchingWhileBackspacing || hasOneTriggerWord ) ) {
-			if ( autocompleter ) reset();
+			if ( autocompleter ) {
+				reset();
+			}
 			return;
 		}
 
@@ -333,7 +341,9 @@ export function useAutocomplete( {
 				textAfterSelection
 			)
 		) {
-			if ( autocompleter ) reset();
+			if ( autocompleter ) {
+				reset();
+			}
 			return;
 		}
 
@@ -341,12 +351,16 @@ export function useAutocomplete( {
 			/^\s/.test( textWithoutTrigger ) ||
 			/\s\s+$/.test( textWithoutTrigger )
 		) {
-			if ( autocompleter ) reset();
+			if ( autocompleter ) {
+				reset();
+			}
 			return;
 		}
 
 		if ( ! /[\u0000-\uFFFF]*$/.test( textWithoutTrigger ) ) {
-			if ( autocompleter ) reset();
+			if ( autocompleter ) {
+				reset();
+			}
 			return;
 		}
 

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -21,7 +21,9 @@ import type { HexInputProps } from './types';
 
 export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	const handleChange = ( nextValue: string | undefined ) => {
-		if ( ! nextValue ) return;
+		if ( ! nextValue ) {
+			return;
+		}
 		const hexValue = nextValue.startsWith( '#' )
 			? nextValue
 			: '#' + nextValue;

--- a/packages/components/src/color-picker/hue-picker.native.js
+++ b/packages/components/src/color-picker/hue-picker.native.js
@@ -72,8 +72,12 @@ export default class HuePicker extends Component {
 	}
 
 	normalizeValue( value ) {
-		if ( value < 0 ) return 0;
-		if ( value > 1 ) return 1;
+		if ( value < 0 ) {
+			return 0;
+		}
+		if ( value > 1 ) {
+			return 1;
+		}
 		return value;
 	}
 

--- a/packages/components/src/color-picker/index.native.js
+++ b/packages/components/src/color-picker/index.native.js
@@ -82,9 +82,15 @@ function ColorPicker( {
 	const currentColor = combineToHex();
 
 	const updateColor = ( { hue: h, saturation: s, value: v } ) => {
-		if ( h !== undefined ) setHue( h );
-		if ( s !== undefined ) setSaturation( s );
-		if ( v !== undefined ) setValue( v );
+		if ( h !== undefined ) {
+			setHue( h );
+		}
+		if ( s !== undefined ) {
+			setSaturation( s );
+		}
+		if ( v !== undefined ) {
+			setValue( v );
+		}
 		setColor( combineToHex( h, s, v ) );
 	};
 

--- a/packages/components/src/color-picker/saturation-picker.native.js
+++ b/packages/components/src/color-picker/saturation-picker.native.js
@@ -56,8 +56,12 @@ export default class SaturationValuePicker extends Component {
 	}
 
 	normalizeValue( value ) {
-		if ( value < 0 ) return 0;
-		if ( value > 1 ) return 1;
+		if ( value < 0 ) {
+			return 0;
+		}
+		if ( value > 1 ) {
+			return 1;
+		}
 		return value;
 	}
 

--- a/packages/components/src/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/color-picker/use-deprecated-props.ts
@@ -25,11 +25,17 @@ function isLegacyProps( props: any ): props is LegacyProps {
 function getColorFromLegacyProps(
 	color: LegacyProps[ 'color' ]
 ): string | undefined {
-	if ( color === undefined ) return;
+	if ( color === undefined ) {
+		return;
+	}
 
-	if ( typeof color === 'string' ) return color;
+	if ( typeof color === 'string' ) {
+		return color;
+	}
 
-	if ( color.hex ) return color.hex;
+	if ( color.hex ) {
+		return color.hex;
+	}
 
 	return undefined;
 }

--- a/packages/components/src/context/context-connect.ts
+++ b/packages/components/src/context/context-connect.ts
@@ -116,7 +116,9 @@ function _contextConnect<
 export function getConnectNamespace(
 	Component: ReactChild | undefined | {}
 ): string[] {
-	if ( ! Component ) return [];
+	if ( ! Component ) {
+		return [];
+	}
 
 	let namespaces = [];
 
@@ -145,7 +147,9 @@ export function hasConnectNamespace(
 	Component: ReactNode,
 	match: string[] | string
 ): boolean {
-	if ( ! Component ) return false;
+	if ( ! Component ) {
+		return false;
+	}
 
 	if ( typeof match === 'string' ) {
 		return getConnectNamespace( Component ).includes( match );

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -30,7 +30,9 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	// Forward props + store from v2 implementation
 	const store = Ariakit.useSelectStore( {
 		async setValue( nextValue ) {
-			if ( ! onChange ) return;
+			if ( ! onChange ) {
+				return;
+			}
 
 			// Executes the logic in a microtask after the popup is closed.
 			// This is simply to ensure the isOpen state matches that in Downshift.

--- a/packages/components/src/dropdown/styles.ts
+++ b/packages/components/src/dropdown/styles.ts
@@ -11,7 +11,9 @@ import { space } from '../utils/space';
 import type { DropdownContentWrapperProps } from './types';
 
 const padding = ( { paddingSize = 'small' }: DropdownContentWrapperProps ) => {
-	if ( paddingSize === 'none' ) return;
+	if ( paddingSize === 'none' ) {
+		return;
+	}
 
 	const paddingValues = {
 		small: space( 2 ),

--- a/packages/components/src/duotone-picker/utils.ts
+++ b/packages/components/src/duotone-picker/utils.ts
@@ -31,7 +31,9 @@ export function getDefaultColors(
 	palette: DuotonePickerProps[ 'colorPalette' ]
 ) {
 	// A default dark and light color are required.
-	if ( ! palette || palette.length < 2 ) return [ '#000', '#fff' ];
+	if ( ! palette || palette.length < 2 ) {
+		return [ '#000', '#fff' ];
+	}
 
 	return palette
 		.map( ( { color } ) => ( {

--- a/packages/components/src/focal-point-picker/controls.tsx
+++ b/packages/components/src/focal-point-picker/controls.tsx
@@ -38,7 +38,9 @@ export default function FocalPointPickerControls( {
 		value: Parameters< UnitControlOnChangeCallback >[ 0 ],
 		axis: FocalPointAxis
 	) => {
-		if ( value === undefined ) return;
+		if ( value === undefined ) {
+			return;
+		}
 
 		const num = parseInt( value, 10 );
 

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -111,7 +111,9 @@ export function FocalPointPicker( {
 
 			// `value` can technically be undefined if getValueWithinDragArea() is
 			// called before dragAreaRef is set, but this shouldn't happen in reality.
-			if ( ! value ) return;
+			if ( ! value ) {
+				return;
+			}
 
 			onDragStart?.( value, event );
 			setPoint( value );
@@ -120,7 +122,9 @@ export function FocalPointPicker( {
 			// Prevents text-selection when dragging.
 			event.preventDefault();
 			const value = getValueWithinDragArea( event );
-			if ( ! value ) return;
+			if ( ! value ) {
+				return;
+			}
 			onDrag?.( value, event );
 			setPoint( value );
 		},
@@ -136,7 +140,9 @@ export function FocalPointPicker( {
 	const dragAreaRef = useRef< HTMLDivElement >( null );
 	const [ bounds, setBounds ] = useState( INITIAL_BOUNDS );
 	const refUpdateBounds = useRef( () => {
-		if ( ! dragAreaRef.current ) return;
+		if ( ! dragAreaRef.current ) {
+			return;
+		}
 
 		const { clientWidth: width, clientHeight: height } =
 			dragAreaRef.current;
@@ -150,7 +156,9 @@ export function FocalPointPicker( {
 
 	useEffect( () => {
 		const updateBounds = refUpdateBounds.current;
-		if ( ! dragAreaRef.current ) return;
+		if ( ! dragAreaRef.current ) {
+			return;
+		}
 
 		const { defaultView } = dragAreaRef.current.ownerDocument;
 		defaultView?.addEventListener( 'resize', updateBounds );
@@ -171,7 +179,9 @@ export function FocalPointPicker( {
 		clientY: number;
 		shiftKey: boolean;
 	} ) => {
-		if ( ! dragAreaRef.current ) return;
+		if ( ! dragAreaRef.current ) {
+			return;
+		}
 
 		const { top, left } = dragAreaRef.current.getBoundingClientRect();
 		let nextX = ( clientX - left ) / bounds.width;
@@ -203,8 +213,9 @@ export function FocalPointPicker( {
 			! [ 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight' ].includes(
 				code
 			)
-		)
+		) {
 			return;
+		}
 
 		event.preventDefault();
 		const value = { x, y };
@@ -253,7 +264,9 @@ export function FocalPointPicker( {
 					onKeyDown={ arrowKeyStep }
 					onMouseDown={ startDrag }
 					onBlur={ () => {
-						if ( isDragging ) endDrag();
+						if ( isDragging ) {
+							endDrag();
+						}
 					} }
 					ref={ dragAreaRef }
 					role="button"

--- a/packages/components/src/focal-point-picker/utils.ts
+++ b/packages/components/src/focal-point-picker/utils.ts
@@ -34,7 +34,9 @@ export function getExtension( filename = '' ): string {
  * @return Whether the file is a video.
  */
 export function isVideoType( filename: string = '' ): boolean {
-	if ( ! filename ) return false;
+	if ( ! filename ) {
+		return false;
+	}
 	return (
 		filename.startsWith( 'data:video/' ) ||
 		VIDEO_EXTENSIONS.includes( getExtension( filename ) )

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -155,7 +155,9 @@ function InputField(
 				target,
 			};
 
-			if ( ! distance ) return;
+			if ( ! distance ) {
+				return;
+			}
 			event.stopPropagation();
 
 			/**

--- a/packages/components/src/input-control/label.tsx
+++ b/packages/components/src/input-control/label.tsx
@@ -15,7 +15,9 @@ export default function Label( {
 	htmlFor,
 	...props
 }: WordPressComponentProps< InputControlLabelProps, 'label', false > ) {
-	if ( ! children ) return null;
+	if ( ! children ) {
+		return null;
+	}
 
 	if ( hideLabelFromVision ) {
 		return (

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -107,9 +107,13 @@ const containerWidthStyles = ( {
 	__unstableInputWidth,
 	labelPosition,
 }: ContainerProps ) => {
-	if ( ! __unstableInputWidth ) return css( { width: '100%' } );
+	if ( ! __unstableInputWidth ) {
+		return css( { width: '100%' } );
+	}
 
-	if ( labelPosition === 'side' ) return '';
+	if ( labelPosition === 'side' ) {
+		return '';
+	}
 
 	if ( labelPosition === 'edge' ) {
 		return css( {
@@ -143,7 +147,9 @@ type InputProps = {
 };
 
 const disabledStyles = ( { disabled }: InputProps ) => {
-	if ( ! disabled ) return '';
+	if ( ! disabled ) {
+		return '';
+	}
 
 	return css( {
 		color: COLORS.ui.textDisabled,
@@ -161,7 +167,9 @@ export const fontSizeStyles = ( { inputSize: size }: InputProps ) => {
 	const fontSize = sizes[ size as Size ] || sizes.default;
 	const fontSizeMobile = '16px';
 
-	if ( ! fontSize ) return '';
+	if ( ! fontSize ) {
+		return '';
+	}
 
 	return css`
 		font-size: ${ fontSizeMobile };

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -112,10 +112,13 @@ describe( 'InputControl', () => {
 				const onKeyDown = ( { key } ) => {
 					heldKeySet.add( key );
 					if ( key === 'Escape' ) {
-						if ( heldKeySet.has( 'Meta' ) ) setState( 'qux' );
-						else if ( heldKeySet.has( 'Alt' ) )
+						if ( heldKeySet.has( 'Meta' ) ) {
+							setState( 'qux' );
+						} else if ( heldKeySet.has( 'Alt' ) ) {
 							setState( undefined );
-						else setState( '' );
+						} else {
+							setState( '' );
+						}
 					}
 				};
 				const onKeyUp = ( { key } ) => heldKeySet.delete( key );
@@ -204,8 +207,9 @@ describe( 'InputControl', () => {
 						if (
 							action.type === 'COMMIT' &&
 							action.payload.event.type === 'blur'
-						)
+						) {
 							value = value.replace( /\bnow\b/, 'meow' );
+						}
 
 						return { ...state, value };
 					} }

--- a/packages/components/src/input-control/utils.ts
+++ b/packages/components/src/input-control/utils.ts
@@ -86,10 +86,11 @@ export function useDraft( props: {
 	useLayoutEffect( () => {
 		const { current: previousValue } = refPreviousValue;
 		refPreviousValue.current = props.value;
-		if ( draft.value !== undefined && ! draft.isStale )
+		if ( draft.value !== undefined && ! draft.isStale ) {
 			setDraft( { ...draft, isStale: true } );
-		else if ( draft.isStale && props.value !== previousValue )
+		} else if ( draft.isStale && props.value !== previousValue ) {
 			setDraft( {} );
+		}
 	}, [ props.value, draft ] );
 
 	const onChange: InputChangeCallback = ( nextValue, extra ) => {

--- a/packages/components/src/mobile/gradient/index.native.js
+++ b/packages/components/src/mobile/gradient/index.native.js
@@ -51,7 +51,9 @@ export function getGradientAngle( gradientValue ) {
 		}
 	} else if ( angleType === 'angle' ) {
 		return parseFloat( angle );
-	} else return 4 * angleBase;
+	} else {
+		return 4 * angleBase;
+	}
 }
 
 export function getGradientColorGroup( gradientValue ) {

--- a/packages/components/src/modal/aria-helper.ts
+++ b/packages/components/src/modal/aria-helper.ts
@@ -25,7 +25,9 @@ export function modalize( modalElement?: HTMLDivElement ) {
 	const hiddenElements: Element[] = [];
 	hiddenElementsByDepth.push( hiddenElements );
 	for ( const element of elements ) {
-		if ( element === modalElement ) continue;
+		if ( element === modalElement ) {
+			continue;
+		}
 
 		if ( elementShouldBeHidden( element ) ) {
 			element.setAttribute( 'aria-hidden', 'true' );
@@ -56,8 +58,11 @@ export function elementShouldBeHidden( element: Element ) {
  */
 export function unmodalize() {
 	const hiddenElements = hiddenElementsByDepth.pop();
-	if ( ! hiddenElements ) return;
+	if ( ! hiddenElements ) {
+		return;
+	}
 
-	for ( const element of hiddenElements )
+	for ( const element of hiddenElements ) {
 		element.removeAttribute( 'aria-hidden' );
+	}
 }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -154,7 +154,9 @@ function UnforwardedModal(
 	useEffect( () => {
 		dismissers.push( refOnRequestClose );
 		const [ first, second ] = dismissers;
-		if ( second ) first?.current?.();
+		if ( second ) {
+			first?.current?.();
+		}
 
 		const nested = nestedDismissers.current;
 		return () => {
@@ -243,7 +245,9 @@ function UnforwardedModal(
 		onPointerUp: ( { target, button } ) => {
 			const isSameTarget = target === pressTarget;
 			pressTarget = null;
-			if ( button === 0 && isSameTarget ) onRequestClose();
+			if ( button === 0 && isSameTarget ) {
+				onRequestClose();
+			}
 		},
 	};
 

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -178,7 +178,9 @@ describe( 'Modal', () => {
 					{ isShown && (
 						<Modal
 							onKeyDown={ ( { key } ) => {
-								if ( key === 'o' ) setIsShown( false );
+								if ( key === 'o' ) {
+									setIsShown( false );
+								}
 							} }
 							onRequestClose={ noop }
 						>
@@ -402,12 +404,17 @@ describe( 'Modal', () => {
 					metaKey,
 				} ) => {
 					if ( key === 'a' ) {
-						if ( metaKey ) return setIsA1Shown( ( v ) => ! v );
+						if ( metaKey ) {
+							return setIsA1Shown( ( v ) => ! v );
+						}
 						return setIsAShown( ( v ) => ! v );
 					}
-					if ( key === 'b' ) return setIsBShown( ( v ) => ! v );
-					if ( key === 'c' )
+					if ( key === 'b' ) {
+						return setIsBShown( ( v ) => ! v );
+					}
+					if ( key === 'c' ) {
 						return setIsClassOverriden( ( v ) => ! v );
+					}
 				};
 				document.addEventListener( 'keydown', toggles );
 				return () =>

--- a/packages/components/src/panel/body.tsx
+++ b/packages/components/src/panel/body.tsx
@@ -109,7 +109,9 @@ const PanelBodyTitle = forwardRef(
 		}: WordPressComponentProps< PanelBodyTitleProps, 'button' >,
 		ref: React.ForwardedRef< any >
 	) => {
-		if ( ! title ) return null;
+		if ( ! title ) {
+			return null;
+		}
 
 		return (
 			<h2 className="components-panel__body-title">

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -226,8 +226,9 @@ const UnforwardedPopover = (
 					const { firstElementChild } = refs.floating.current ?? {};
 
 					// Only HTMLElement instances have the `style` property.
-					if ( ! ( firstElementChild instanceof HTMLElement ) )
+					if ( ! ( firstElementChild instanceof HTMLElement ) ) {
 						return;
+					}
 
 					// Reduce the height of the popover to the available space.
 					Object.assign( firstElementChild.style, {

--- a/packages/components/src/popover/overlay-middlewares.tsx
+++ b/packages/components/src/popover/overlay-middlewares.tsx
@@ -17,7 +17,9 @@ export function overlayMiddlewares() {
 				const { firstElementChild } = elements.floating ?? {};
 
 				// Only HTMLElement instances have the `style` property.
-				if ( ! ( firstElementChild instanceof HTMLElement ) ) return;
+				if ( ! ( firstElementChild instanceof HTMLElement ) ) {
+					return;
+				}
 
 				// Reduce the height of the popover to the available space.
 				Object.assign( firstElementChild.style, {

--- a/packages/components/src/query-controls/author-select.tsx
+++ b/packages/components/src/query-controls/author-select.tsx
@@ -13,7 +13,9 @@ export default function AuthorSelect( {
 	selectedAuthorId,
 	onChange: onChangeProp,
 }: AuthorSelectProps ) {
-	if ( ! authorList ) return null;
+	if ( ! authorList ) {
+		return null;
+	}
 	const termsTree = buildTermsTree( authorList );
 	return (
 		<TreeSelect

--- a/packages/components/src/range-control/rail.tsx
+++ b/packages/components/src/range-control/rail.tsx
@@ -92,7 +92,7 @@ function useMarks( {
 	if ( ! Array.isArray( marks ) ) {
 		marks = [];
 		const count = 1 + Math.round( range / step );
-		while ( count > marks.push( { value: step * marks.length + min } ) );
+		while ( count > marks.push( { value: step * marks.length + min } ) ) {}
 	}
 
 	const placedMarks: RangeMarkProps[] = [];

--- a/packages/components/src/resizable-box/resize-tooltip/index.tsx
+++ b/packages/components/src/resizable-box/resize-tooltip/index.tsx
@@ -55,7 +55,9 @@ function ResizeTooltip(
 		position,
 	} );
 
-	if ( ! isVisible ) return null;
+	if ( ! isVisible ) {
+		return null;
+	}
 
 	const classes = classnames( 'components-resize-tooltip', className );
 

--- a/packages/components/src/resizable-box/resize-tooltip/label.tsx
+++ b/packages/components/src/resizable-box/resize-tooltip/label.tsx
@@ -41,7 +41,9 @@ function Label(
 	const isBottom = position === POSITIONS.bottom;
 	const isCorner = position === POSITIONS.corner;
 
-	if ( ! showLabel ) return null;
+	if ( ! showLabel ) {
+		return null;
+	}
 
 	let style: React.CSSProperties = {
 		opacity: showLabel ? 1 : undefined,

--- a/packages/components/src/resizable-box/resize-tooltip/utils.ts
+++ b/packages/components/src/resizable-box/resize-tooltip/utils.ts
@@ -90,7 +90,9 @@ export function useResizeLabel( {
 			 * If axis is controlled, we will avoid resetting the moveX and moveY values.
 			 * This will allow for the preferred axis values to persist in the label.
 			 */
-			if ( isAxisControlled ) return;
+			if ( isAxisControlled ) {
+				return;
+			}
 			setMoveX( false );
 			setMoveY( false );
 		};
@@ -109,12 +111,16 @@ export function useResizeLabel( {
 		 */
 		const isRendered = width !== null || height !== null;
 
-		if ( ! isRendered ) return;
+		if ( ! isRendered ) {
+			return;
+		}
 
 		const didWidthChange = width !== widthRef.current;
 		const didHeightChange = height !== heightRef.current;
 
-		if ( ! didWidthChange && ! didHeightChange ) return;
+		if ( ! didWidthChange && ! didHeightChange ) {
+			return;
+		}
 
 		/*
 		 * After the initial render, the useResizeAware will set the first
@@ -194,7 +200,9 @@ function getSizeLabel( {
 	showPx = false,
 	width,
 }: GetSizeLabelArgs ): string | undefined {
-	if ( ! moveX && ! moveY ) return undefined;
+	if ( ! moveX && ! moveY ) {
+		return undefined;
+	}
 
 	/*
 	 * Corner position...

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -55,7 +55,9 @@ function UnforwardedSelectControl(
 	const helpId = help ? `${ id }__help` : undefined;
 
 	// Disable reason: A select with an onchange throws a warning.
-	if ( ! options?.length && ! children ) return null;
+	if ( ! options?.length && ! children ) {
+		return null;
+	}
 
 	const handleOnChange = (
 		event: React.ChangeEvent< HTMLSelectElement >

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -24,7 +24,9 @@ interface SelectProps
 }
 
 const disabledStyles = ( { disabled }: SelectProps ) => {
-	if ( ! disabled ) return '';
+	if ( ! disabled ) {
+		return '';
+	}
 
 	return css( {
 		color: COLORS.ui.textDisabled,

--- a/packages/components/src/text/get-line-height.ts
+++ b/packages/components/src/text/get-line-height.ts
@@ -14,9 +14,13 @@ export function getLineHeight(
 	adjustLineHeightForInnerControls: Props[ 'adjustLineHeightForInnerControls' ],
 	lineHeight: CSSProperties[ 'lineHeight' ]
 ) {
-	if ( lineHeight ) return lineHeight;
+	if ( lineHeight ) {
+		return lineHeight;
+	}
 
-	if ( ! adjustLineHeightForInnerControls ) return;
+	if ( ! adjustLineHeightForInnerControls ) {
+		return;
+	}
 
 	let value = `calc(${ CONFIG.controlHeight } + ${ space( 2 ) })`;
 

--- a/packages/components/src/text/utils.ts
+++ b/packages/components/src/text/utils.ts
@@ -99,8 +99,12 @@ export function createHighlighterText( {
 	unhighlightClassName = '',
 	unhighlightStyle,
 }: Options ) {
-	if ( ! children ) return null;
-	if ( typeof children !== 'string' ) return children;
+	if ( ! children ) {
+		return null;
+	}
+	if ( typeof children !== 'string' ) {
+		return children;
+	}
 
 	const textToHighlight = children;
 

--- a/packages/components/src/theme/color-algorithms.ts
+++ b/packages/components/src/theme/color-algorithms.ts
@@ -76,7 +76,9 @@ function warnContrastIssues( issues: ReturnType< typeof checkContrasts > ) {
 }
 
 function generateAccentDependentColors( accent?: string ) {
-	if ( ! accent ) return {};
+	if ( ! accent ) {
+		return {};
+	}
 
 	return {
 		accent,
@@ -87,7 +89,9 @@ function generateAccentDependentColors( accent?: string ) {
 }
 
 function generateBackgroundDependentColors( background?: string ) {
-	if ( ! background ) return {};
+	if ( ! background ) {
+		return {};
+	}
 
 	const foreground = getForegroundForColor( background );
 

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -147,7 +147,9 @@ function ToggleGroupControlOptionBase(
 								{ ...commonProps }
 								onFocus={ ( event ) => {
 									onFocusProp?.( event );
-									if ( event.defaultPrevented ) return;
+									if ( event.defaultPrevented ) {
+										return;
+									}
 									toggleGroupControlContext.setValue( value );
 								} }
 							/>

--- a/packages/components/src/tree-grid/roving-tab-index-item.tsx
+++ b/packages/components/src/tree-grid/roving-tab-index-item.tsx
@@ -41,7 +41,9 @@ export const RovingTabIndexItem = forwardRef(
 			return children( allProps );
 		}
 
-		if ( ! Component ) return null;
+		if ( ! Component ) {
+			return null;
+		}
 
 		return <Component { ...allProps }>{ children }</Component>;
 	}

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -170,8 +170,12 @@ function UnforwardedUnitControl(
 			// Unless the meta key was pressed (to avoid interfering with
 			// shortcuts, e.g. pastes), moves focus to the unit select if a key
 			// matches the first character of a unit.
-			if ( ! event.metaKey && reFirstCharacterOfUnits.test( event.key ) )
+			if (
+				! event.metaKey &&
+				reFirstCharacterOfUnits.test( event.key )
+			) {
 				refInputSuffix.current?.focus();
+			}
 		};
 	}
 

--- a/packages/components/src/utils/colors.js
+++ b/packages/components/src/utils/colors.js
@@ -29,7 +29,9 @@ export function rgba( hexValue = '', alpha = 1 ) {
  * @return {HTMLDivElement | undefined} The HTML element for color computation.
  */
 function getColorComputationNode() {
-	if ( typeof document === 'undefined' ) return;
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
 
 	if ( ! colorComputationNode ) {
 		// Create a temporary element for style computation.
@@ -49,7 +51,9 @@ function getColorComputationNode() {
  * @return {boolean} Whether the value is a valid color.
  */
 function isColor( value ) {
-	if ( typeof value !== 'string' ) return false;
+	if ( typeof value !== 'string' ) {
+		return false;
+	}
 	const test = colord( value );
 
 	return test.isValid();
@@ -64,16 +68,26 @@ function isColor( value ) {
  * @return {string} The computed background color.
  */
 function _getComputedBackgroundColor( backgroundColor ) {
-	if ( typeof backgroundColor !== 'string' ) return '';
+	if ( typeof backgroundColor !== 'string' ) {
+		return '';
+	}
 
-	if ( isColor( backgroundColor ) ) return backgroundColor;
+	if ( isColor( backgroundColor ) ) {
+		return backgroundColor;
+	}
 
-	if ( ! backgroundColor.includes( 'var(' ) ) return '';
-	if ( typeof document === 'undefined' ) return '';
+	if ( ! backgroundColor.includes( 'var(' ) ) {
+		return '';
+	}
+	if ( typeof document === 'undefined' ) {
+		return '';
+	}
 
 	// Attempts to gracefully handle CSS variables color values.
 	const el = getColorComputationNode();
-	if ( ! el ) return '';
+	if ( ! el ) {
+		return '';
+	}
 
 	el.style.background = backgroundColor;
 	// Grab the style.

--- a/packages/components/src/utils/font-size.ts
+++ b/packages/components/src/utils/font-size.ts
@@ -51,7 +51,9 @@ export function getFontSize(
 
 	if ( typeof size !== 'number' ) {
 		const parsed = parseFloat( size );
-		if ( Number.isNaN( parsed ) ) return size;
+		if ( Number.isNaN( parsed ) ) {
+			return size;
+		}
 		size = parsed;
 	}
 

--- a/packages/components/src/utils/get-valid-children.ts
+++ b/packages/components/src/utils/get-valid-children.ts
@@ -18,7 +18,9 @@ import { Children, isValidElement } from '@wordpress/element';
 export function getValidChildren(
 	children: ReactNode
 ): Array< ReactChild | ReactFragment | ReactPortal > {
-	if ( typeof children === 'string' ) return [ children ];
+	if ( typeof children === 'string' ) {
+		return [ children ];
+	}
 
 	return Children.toArray( children ).filter( ( child ) =>
 		isValidElement( child )

--- a/packages/components/src/utils/use-responsive-value.ts
+++ b/packages/components/src/utils/use-responsive-value.ts
@@ -60,8 +60,9 @@ export function useResponsiveValue< T >(
 	const index = useBreakpointIndex( options );
 
 	// Allow calling the function with a "normal" value without having to check on the outside.
-	if ( ! Array.isArray( values ) && typeof values !== 'function' )
+	if ( ! Array.isArray( values ) && typeof values !== 'function' ) {
 		return values;
+	}
 
 	const array = values || [];
 

--- a/packages/compose/src/hooks/use-focusable-iframe/index.ts
+++ b/packages/compose/src/hooks/use-focusable-iframe/index.ts
@@ -17,9 +17,13 @@ import useRefEffect from '../use-ref-effect';
 export default function useFocusableIframe(): RefCallback< HTMLIFrameElement > {
 	return useRefEffect( ( element ) => {
 		const { ownerDocument } = element;
-		if ( ! ownerDocument ) return;
+		if ( ! ownerDocument ) {
+			return;
+		}
 		const { defaultView } = ownerDocument;
-		if ( ! defaultView ) return;
+		if ( ! defaultView ) {
+			return;
+		}
 
 		/**
 		 * Checks whether the iframe is the activeElement, inferring that it has

--- a/packages/compose/src/hooks/use-instance-id/index.ts
+++ b/packages/compose/src/hooks/use-instance-id/index.ts
@@ -51,7 +51,9 @@ function useInstanceId(
 	preferredId?: string | number
 ): string | number {
 	return useMemo( () => {
-		if ( preferredId ) return preferredId;
+		if ( preferredId ) {
+			return preferredId;
+		}
 		const id = createId( object );
 
 		return prefix ? `${ prefix }-${ id }` : id;

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -12,17 +12,23 @@ let oldFootnotes = {};
 
 export function updateFootnotesFromMeta( blocks, meta ) {
 	const output = { blocks };
-	if ( ! meta ) return output;
+	if ( ! meta ) {
+		return output;
+	}
 
 	// If meta.footnotes is empty, it means the meta is not registered.
-	if ( meta.footnotes === undefined ) return output;
+	if ( meta.footnotes === undefined ) {
+		return output;
+	}
 
 	const newOrder = getFootnotesOrder( blocks );
 
 	const footnotes = meta.footnotes ? JSON.parse( meta.footnotes ) : [];
 	const currentOrder = footnotes.map( ( fn ) => fn.id );
 
-	if ( currentOrder.join( '' ) === newOrder.join( '' ) ) return output;
+	if ( currentOrder.join( '' ) === newOrder.join( '' ) ) {
+		return output;
+	}
 
 	const newFootnotes = newOrder.map(
 		( fnId ) =>

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -619,9 +619,13 @@ export const getEntityRecordsTotalPages = (
 	if ( ! queriedState ) {
 		return null;
 	}
-	if ( query.per_page === -1 ) return 1;
+	if ( query.per_page === -1 ) {
+		return 1;
+	}
 	const totalItems = getQueriedTotalItems( queriedState, query );
-	if ( ! totalItems ) return totalItems;
+	if ( ! totalItems ) {
+		return totalItems;
+	}
 	// If `per_page` is not set and the query relies on the defaults of the
 	// REST endpoint, get the info from query's meta.
 	if ( ! query.per_page ) {

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -108,8 +108,12 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 				const compareByModuleIdentifier = ( m1, m2 ) => {
 					const i1 = m1.identifier();
 					const i2 = m2.identifier();
-					if ( i1 < i2 ) return -1;
-					if ( i1 > i2 ) return 1;
+					if ( i1 < i2 ) {
+						return -1;
+					}
+					if ( i1 > i2 ) {
+						return 1;
+					}
 					return 0;
 				};
 

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -43,10 +43,18 @@ export default function getRectangleFromRange( range ) {
 		} = filteredRects[ 0 ];
 
 		for ( const { top, bottom, left, right } of filteredRects ) {
-			if ( top < furthestTop ) furthestTop = top;
-			if ( bottom > furthestBottom ) furthestBottom = bottom;
-			if ( left < furthestLeft ) furthestLeft = left;
-			if ( right > furthestRight ) furthestRight = right;
+			if ( top < furthestTop ) {
+				furthestTop = top;
+			}
+			if ( bottom > furthestBottom ) {
+				furthestBottom = bottom;
+			}
+			if ( left < furthestLeft ) {
+				furthestLeft = left;
+			}
+			if ( right > furthestRight ) {
+				furthestRight = right;
+			}
 		}
 
 		return new window.DOMRect(

--- a/packages/dom/src/dom/place-caret-at-edge.js
+++ b/packages/dom/src/dom/place-caret-at-edge.js
@@ -75,7 +75,9 @@ export default function placeCaretAtEdge( container, isReverse, x ) {
 		getRange( container, isReverse, x )
 	);
 
-	if ( ! range ) return;
+	if ( ! range ) {
+		return;
+	}
 
 	const { ownerDocument } = container;
 	const { defaultView } = ownerDocument;

--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.ts
@@ -24,10 +24,18 @@ export async function createNewPost(
 	const query = new URLSearchParams();
 	const { postType, title, content, excerpt } = options;
 
-	if ( postType ) query.set( 'post_type', postType );
-	if ( title ) query.set( 'post_title', title );
-	if ( content ) query.set( 'content', content );
-	if ( excerpt ) query.set( 'excerpt', excerpt );
+	if ( postType ) {
+		query.set( 'post_type', postType );
+	}
+	if ( title ) {
+		query.set( 'post_title', title );
+	}
+	if ( content ) {
+		query.set( 'content', content );
+	}
+	if ( excerpt ) {
+		query.set( 'excerpt', excerpt );
+	}
 
 	await this.visitAdminPage( 'post-new.php', query.toString() );
 

--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -24,10 +24,18 @@ export async function visitSiteEditor(
 	const { postId, postType, path, canvas } = options;
 	const query = new URLSearchParams();
 
-	if ( postId ) query.set( 'postId', String( postId ) );
-	if ( postType ) query.set( 'postType', postType );
-	if ( path ) query.set( 'path', path );
-	if ( canvas ) query.set( 'canvas', canvas );
+	if ( postId ) {
+		query.set( 'postId', String( postId ) );
+	}
+	if ( postType ) {
+		query.set( 'postType', postType );
+	}
+	if ( path ) {
+		query.set( 'path', path );
+	}
+	if ( canvas ) {
+		query.set( 'canvas', canvas );
+	}
 
 	await this.visitAdminPage( 'site-editor.php', query.toString() );
 

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
@@ -147,9 +147,9 @@ store( 'directive-each', {
 			state
 				.animalBreeds
 				.forEach( ( { name, breeds } ) => {
-					if ( name === 'Dog') breeds.unshift( 'german shepherd' );
-					if ( name === 'Cat') breeds.unshift( 'maine coon' );
-					if ( name === 'Rat') breeds.unshift( 'satin' );
+					if ( name === 'Dog') {breeds.unshift( 'german shepherd' );}
+					if ( name === 'Cat') {breeds.unshift( 'maine coon' );}
+					if ( name === 'Rat') {breeds.unshift( 'satin' );}
 				} );
 		}
 	}

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/view.js
@@ -24,8 +24,8 @@ const namespace = 'directive-priorities';
  */
 const executionProof = ( n ) => {
 	const el = document.querySelector( '[data-testid="execution order"]' );
-	if ( ! el.textContent ) el.textContent = n;
-	else el.textContent += `, ${ n }`;
+	if ( ! el.textContent ) {el.textContent = n;}
+	else {el.textContent += `, ${ n }`;}
 };
 
 /**

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-watch/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-watch/view.js
@@ -13,7 +13,7 @@ directive(
 	'show-mock',
 	( { directives: { 'show-mock': showMock }, element, evaluate } ) => {
 		const entry = showMock.find( ( { suffix } ) => suffix === 'default' );
-		if ( ! evaluate( entry ) ) return null;
+		if ( ! evaluate( entry ) ) {return null;}
 		return element;
 	}
 );

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -131,7 +131,9 @@ export default function AddNewPattern( { canCreateParts, canCreatePatterns } ) {
 				ref={ patternUploadInputRef }
 				onChange={ async ( event ) => {
 					const file = event.target.files?.[ 0 ];
-					if ( ! file ) return;
+					if ( ! file ) {
+						return;
+					}
 					try {
 						let currentCategoryId;
 						// When we're not handling template parts, we should

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -99,7 +99,9 @@ function useSearchSuggestions( entityForSuggestions, search ) {
 		);
 	const [ suggestions, setSuggestions ] = useState( EMPTY_ARRAY );
 	useEffect( () => {
-		if ( ! searchHasResolved ) return;
+		if ( ! searchHasResolved ) {
+			return;
+		}
 		let newSuggestions = EMPTY_ARRAY;
 		if ( searchResults?.length ) {
 			newSuggestions = searchResults;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -496,11 +496,15 @@ function FontLibraryProvider( { children } ) {
 
 	const loadFontFaceAsset = async ( fontFace ) => {
 		// If the font doesn't have a src, don't load it.
-		if ( ! fontFace.src ) return;
+		if ( ! fontFace.src ) {
+			return;
+		}
 		// Get the src of the font.
 		const src = getDisplaySrcFromFontFace( fontFace.src );
 		// If the font is already loaded, don't load it again.
-		if ( ! src || loadedFontUrls.has( src ) ) return;
+		if ( ! src || loadedFontUrls.has( src ) ) {
+			return;
+		}
 		// Load the font in the browser.
 		loadFontFaceInBrowser( fontFace, src, 'document' );
 		// Add the font to the loaded fonts list.
@@ -518,7 +522,9 @@ function FontLibraryProvider( { children } ) {
 			const hasData = !! collections.find(
 				( collection ) => collection.slug === slug
 			)?.font_families;
-			if ( hasData ) return;
+			if ( hasData ) {
+				return;
+			}
 			const response = await fetchFontCollection( slug );
 			const updatedCollections = collections.map( ( collection ) =>
 				collection.slug === slug

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/sort-font-faces.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/sort-font-faces.js
@@ -16,8 +16,12 @@ function getNumericFontWeight( value ) {
 export function sortFontFaces( faces ) {
 	return faces.sort( ( a, b ) => {
 		// Ensure 'normal' fontStyle is always first
-		if ( a.fontStyle === 'normal' && b.fontStyle !== 'normal' ) return -1;
-		if ( b.fontStyle === 'normal' && a.fontStyle !== 'normal' ) return 1;
+		if ( a.fontStyle === 'normal' && b.fontStyle !== 'normal' ) {
+			return -1;
+		}
+		if ( b.fontStyle === 'normal' && a.fontStyle !== 'normal' ) {
+			return 1;
+		}
 
 		// If both fontStyles are the same, sort by fontWeight
 		if ( a.fontStyle === b.fontStyle ) {

--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -52,7 +52,9 @@ export default function PatternsHeader( {
 		description = patternCategory?.description;
 	}
 
-	if ( ! title ) return null;
+	if ( ! title ) {
+		return null;
+	}
 
 	return (
 		<VStack className="edit-site-patterns__section-header">

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -226,8 +226,9 @@ function ResizableFrame( {
 			variants={ frameAnimationVariants }
 			animate={ isFullWidth ? 'fullWidth' : 'default' }
 			onAnimationComplete={ ( definition ) => {
-				if ( definition === 'fullWidth' )
+				if ( definition === 'fullWidth' ) {
 					setFrameSize( { width: '100%', height: '100%' } );
+				}
 			} }
 			transition={ FRAME_TRANSITION }
 			size={ frameSize }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menus.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menus.js
@@ -10,7 +10,9 @@ import TemplatePartNavigationMenu from './template-part-navigation-menu';
 import TemplatePartNavigationMenuList from './template-part-navigation-menu-list';
 
 export default function TemplatePartNavigationMenus( { menus } ) {
-	if ( ! menus.length ) return null;
+	if ( ! menus.length ) {
+		return null;
+	}
 
 	// if there is a single menu then render TemplatePartNavigationMenu
 	if ( menus.length === 1 ) {

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -38,7 +38,9 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		}, [] );
 	const { setDeviceType } = useDispatch( editorStore );
 	const isMobile = useViewportMatch( 'medium', '<' );
-	if ( isMobile ) return null;
+	if ( isMobile ) {
+		return null;
+	}
 
 	const popoverProps = {
 		placement: 'bottom-end',

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -838,7 +838,9 @@ export const getSuggestedPostFormat = createRegistrySelector(
 	( select ) => () => {
 		const blocks = select( blockEditorStore ).getBlocks();
 
-		if ( blocks.length > 2 ) return null;
+		if ( blocks.length > 2 ) {
+			return null;
+		}
 
 		let name;
 		// If there is only one block in the content of the post grab its name

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Enable `curly` eslint rule when using prettier ([#61204](https://github.com/WordPress/gutenberg/pull/61204)).
+
 ## 17.13.0 (2024-04-19)
 
 ## 17.12.0 (2024-04-03)

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -25,6 +25,12 @@ if ( isPackageInstalled( 'prettier' ) ) {
 	const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
 	config.rules = {
 		'prettier/prettier': [ 'error', prettierConfig ],
+		// Prettier _disables_ this rule, but we want it!
+		// See https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#curly
+		// > This rule requires certain options.
+		// > …
+		// > If you like this rule, it can be used just fine with Prettier as long as you don’t use the "multi-line" or "multi-or-nest" option.
+		curly: [ 'error', 'all' ],
 	};
 }
 

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -102,8 +102,12 @@ export function createLinkFormat( {
 		},
 	};
 
-	if ( type ) format.attributes.type = type;
-	if ( id ) format.attributes.id = id;
+	if ( type ) {
+		format.attributes.type = type;
+	}
+	if ( id ) {
+		format.attributes.id = id;
+	}
 
 	if ( opensInNewWindow ) {
 		format.attributes.target = '_blank';

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -39,9 +39,15 @@ function parseCSS( css = '' ) {
 	return css.split( ';' ).reduce( ( accumulator, rule ) => {
 		if ( rule ) {
 			const [ property, value ] = rule.split( ':' );
-			if ( property === 'color' ) accumulator.color = value;
-			if ( property === 'background-color' && value !== transparentValue )
+			if ( property === 'color' ) {
+				accumulator.color = value;
+			}
+			if (
+				property === 'background-color' &&
+				value !== transparentValue
+			) {
 				accumulator.backgroundColor = value;
+			}
 		}
 		return accumulator;
 	}, {} );
@@ -108,8 +114,12 @@ function setColors( value, name, colorSettings, colors ) {
 		}
 	}
 
-	if ( styles.length ) attributes.style = styles.join( ';' );
-	if ( classNames.length ) attributes.class = classNames.join( ' ' );
+	if ( styles.length ) {
+		attributes.style = styles.join( ';' );
+	}
+	if ( classNames.length ) {
+		attributes.class = classNames.join( ' ' );
+	}
 
 	return applyFormat( value, { type: name, attributes } );
 }

--- a/packages/format-library/src/text-color/inline.native.js
+++ b/packages/format-library/src/text-color/inline.native.js
@@ -28,9 +28,15 @@ function parseCSS( css = '' ) {
 	return css.split( ';' ).reduce( ( accumulator, rule ) => {
 		if ( rule ) {
 			const [ property, value ] = rule.replace( / /g, '' ).split( ':' );
-			if ( property === 'color' ) accumulator.color = value;
-			if ( property === 'background-color' && value !== transparentValue )
+			if ( property === 'color' ) {
+				accumulator.color = value;
+			}
+			if (
+				property === 'background-color' &&
+				value !== transparentValue
+			) {
 				accumulator.backgroundColor = value;
+			}
 		}
 		return accumulator;
 	}, {} );
@@ -82,8 +88,12 @@ function setColors( value, name, colorSettings, colors, contentRef ) {
 		}
 	}
 
-	if ( styles.length ) attributes.style = styles.join( ';' );
-	if ( classNames.length ) attributes.class = classNames.join( ' ' );
+	if ( styles.length ) {
+		attributes.style = styles.join( ';' );
+	}
+	if ( classNames.length ) {
+		attributes.class = classNames.join( ' ' );
+	}
 
 	const format = { type: name, attributes };
 	const hasNoSelection = value.start === value.end;

--- a/packages/interactivity-router/src/head.js
+++ b/packages/interactivity-router/src/head.js
@@ -21,11 +21,13 @@ export const updateHead = async ( newHead ) => {
 	for ( const child of document.head.children ) {
 		const id = getTagId( child );
 		// Always remove styles and links as they might change.
-		if ( child.nodeName === 'LINK' || child.nodeName === 'STYLE' )
+		if ( child.nodeName === 'LINK' || child.nodeName === 'STYLE' ) {
 			toRemove.push( child );
-		else if ( newHeadMap.has( id ) ) newHeadMap.delete( id );
-		else if ( child.nodeName !== 'SCRIPT' && child.nodeName !== 'META' )
+		} else if ( newHeadMap.has( id ) ) {
+			newHeadMap.delete( id );
+		} else if ( child.nodeName !== 'SCRIPT' && child.nodeName !== 'META' ) {
 			toRemove.push( child );
+		}
 	}
 
 	// Prepare new assets.

--- a/packages/interactivity-router/src/index.js
+++ b/packages/interactivity-router/src/index.js
@@ -41,7 +41,9 @@ const fetchPage = async ( url, { html } ) => {
 	try {
 		if ( ! html ) {
 			const res = await window.fetch( url );
-			if ( res.status !== 200 ) return false;
+			if ( res.status !== 200 ) {
+				return false;
+			}
 			html = await res.text();
 		}
 		const dom = new window.DOMParser().parseFromString( html, 'text/html' );
@@ -232,7 +234,9 @@ export const { state, actions } = store( 'core/router', {
 
 			// Don't update the navigation status immediately, wait 400 ms.
 			const loadingTimeout = setTimeout( () => {
-				if ( navigatingTo !== href ) return;
+				if ( navigatingTo !== href ) {
+					return;
+				}
 
 				if ( loadingAnimation ) {
 					navigation.hasStarted = true;
@@ -254,7 +258,9 @@ export const { state, actions } = store( 'core/router', {
 			// Once the page is fetched, the destination URL could have changed
 			// (e.g., by clicking another link in the meantime). If so, bail
 			// out, and let the newer execution to update the HTML.
-			if ( navigatingTo !== href ) return;
+			if ( navigatingTo !== href ) {
+				return;
+			}
 
 			if (
 				page &&
@@ -289,7 +295,9 @@ export const { state, actions } = store( 'core/router', {
 
 				// Scroll to the anchor if exits in the link.
 				const { hash } = new URL( href, window.location );
-				if ( hash ) document.querySelector( hash )?.scrollIntoView();
+				if ( hash ) {
+					document.querySelector( hash )?.scrollIntoView();
+				}
 			} else {
 				yield forcePageReload( href );
 			}
@@ -308,7 +316,9 @@ export const { state, actions } = store( 'core/router', {
 		 */
 		prefetch( url, options = {} ) {
 			const { clientNavigationDisabled } = getConfig();
-			if ( clientNavigationDisabled ) return;
+			if ( clientNavigationDisabled ) {
+				return;
+			}
 
 			const pagePath = getPagePath( url );
 			if ( options.force || ! pages.has( pagePath ) ) {

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -285,7 +285,9 @@ export default () => {
 		on.filter( ( { suffix } ) => suffix !== 'default' ).forEach(
 			( entry ) => {
 				const event = entry.suffix.split( '--' )[ 0 ];
-				if ( ! events.has( event ) ) events.set( event, new Set() );
+				if ( ! events.has( event ) ) {
+					events.set( event, new Set() );
+				}
 				events.get( event ).add( entry );
 			}
 		);
@@ -318,14 +320,15 @@ export default () => {
 						`(^|\\s)${ className }(\\s|$)`,
 						'g'
 					);
-					if ( ! result )
+					if ( ! result ) {
 						element.props.class = currentClass
 							.replace( classFinder, ' ' )
 							.trim();
-					else if ( ! classFinder.test( currentClass ) )
+					} else if ( ! classFinder.test( currentClass ) ) {
 						element.props.class = currentClass
 							? `${ currentClass } ${ className }`
 							: className;
+					}
 
 					useInit( () => {
 						/*
@@ -351,12 +354,16 @@ export default () => {
 				const styleProp = entry.suffix;
 				const result = evaluate( entry );
 				element.props.style = element.props.style || {};
-				if ( typeof element.props.style === 'string' )
+				if ( typeof element.props.style === 'string' ) {
 					element.props.style = cssStringToObject(
 						element.props.style
 					);
-				if ( ! result ) delete element.props.style[ styleProp ];
-				else element.props.style[ styleProp ] = result;
+				}
+				if ( ! result ) {
+					delete element.props.style[ styleProp ];
+				} else {
+					element.props.style[ styleProp ] = result;
+				}
 
 				useInit( () => {
 					/*
@@ -395,8 +402,9 @@ export default () => {
 					 * logic: https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L110-L129
 					 */
 					if ( attribute === 'style' ) {
-						if ( typeof result === 'string' )
+						if ( typeof result === 'string' ) {
 							el.style.cssText = result;
+						}
 						return;
 					} else if (
 						attribute !== 'width' &&
@@ -496,7 +504,9 @@ export default () => {
 			element,
 			evaluate,
 		} ) => {
-			if ( element.type !== 'template' ) return;
+			if ( element.type !== 'template' ) {
+				return;
+			}
 
 			const { Provider } = inheritedContext;
 			const inheritedValue = useContext( inheritedContext );

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -112,8 +112,9 @@ const immutableHandlers = {
 	deleteProperty: immutableError,
 };
 const deepImmutable = < T extends Object = {} >( target: T ): T => {
-	if ( ! immutableMap.has( target ) )
+	if ( ! immutableMap.has( target ) ) {
 		immutableMap.set( target, new Proxy( target, immutableHandlers ) );
+	}
 	return immutableMap.get( target );
 };
 
@@ -359,7 +360,9 @@ const Directives = ( {
 
 	for ( const directiveName of currentPriorityLevel ) {
 		const wrapper = directiveCallbacks[ directiveName ]?.( directiveArgs );
-		if ( wrapper !== undefined ) props.children = wrapper;
+		if ( wrapper !== undefined ) {
+			props.children = wrapper;
+		}
 	}
 
 	resetScope();
@@ -373,10 +376,11 @@ options.vnode = ( vnode: VNode< any > ) => {
 	if ( vnode.props.__directives ) {
 		const props = vnode.props;
 		const directives = props.__directives;
-		if ( directives.key )
+		if ( directives.key ) {
 			vnode.key = directives.key.find(
 				( { suffix } ) => suffix === 'default'
 			).value;
+		}
 		delete props.__directives;
 		const priorityLevels = getPriorityLevels( directives );
 		if ( priorityLevels.length > 0 ) {
@@ -392,5 +396,7 @@ options.vnode = ( vnode: VNode< any > ) => {
 		}
 	}
 
-	if ( old ) old( vnode );
+	if ( old ) {
+		old( vnode );
+	}
 };

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -26,7 +26,9 @@ const deepMerge = ( target: any, source: any ) => {
 			if ( typeof getter === 'function' ) {
 				Object.defineProperty( target, key, { get: getter } );
 			} else if ( isObject( source[ key ] ) ) {
-				if ( ! target[ key ] ) target[ key ] = {};
+				if ( ! target[ key ] ) {
+					target[ key ] = {};
+				}
 				deepMerge( target[ key ], source[ key ] );
 			} else {
 				try {
@@ -133,7 +135,9 @@ const handlers = {
 						resetNamespace();
 					}
 
-					if ( it.done ) break;
+					if ( it.done ) {
+						break;
+					}
 				}
 
 				return value;
@@ -155,7 +159,9 @@ const handlers = {
 		}
 
 		// Check if the property is an object. If it is, proxyify it.
-		if ( isObject( result ) ) return proxify( result, ns );
+		if ( isObject( result ) ) {
+			return proxify( result, ns );
+		}
 
 		return result;
 	},

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -141,7 +141,9 @@ export function withScope( func: ( ...args: unknown[] ) => unknown ) {
 				} catch ( e ) {
 					gen.throw( e );
 				}
-				if ( it.done ) break;
+				if ( it.done ) {
+					break;
+				}
 			}
 			return value;
 		};

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -50,7 +50,9 @@ export function toVdom( root ) {
 	function walk( node ) {
 		const { attributes, nodeType, localName } = node;
 
-		if ( nodeType === 3 ) return [ node.data ];
+		if ( nodeType === 3 ) {
+			return [ node.data ];
+		}
 		if ( nodeType === 4 ) {
 			const next = treeWalker.nextSibling();
 			node.replaceWith( new window.Text( node.nodeValue ) );
@@ -100,7 +102,7 @@ export function toVdom( root ) {
 			props[ n ] = attributes[ i ].value;
 		}
 
-		if ( ignore && ! island )
+		if ( ignore && ! island ) {
 			return [
 				h( localName, {
 					...props,
@@ -108,14 +110,19 @@ export function toVdom( root ) {
 					__directives: { ignore: true },
 				} ),
 			];
-		if ( island ) hydratedIslands.add( node );
+		}
+		if ( island ) {
+			hydratedIslands.add( node );
+		}
 
 		if ( directives.length ) {
 			props.__directives = directives.reduce(
 				( obj, [ name, ns, value ] ) => {
 					const [ , prefix, suffix = 'default' ] =
 						directiveParser.exec( name );
-					if ( ! obj[ prefix ] ) obj[ prefix ] = [];
+					if ( ! obj[ prefix ] ) {
+						obj[ prefix ] = [];
+					}
 					obj[ prefix ].push( {
 						namespace: ns ?? currentNamespace(),
 						value,
@@ -136,7 +143,9 @@ export function toVdom( root ) {
 			if ( child ) {
 				while ( child ) {
 					const [ vnode, nextChild ] = walk( child );
-					if ( vnode ) children.push( vnode );
+					if ( vnode ) {
+						children.push( vnode );
+					}
 					child = nextChild || treeWalker.nextSibling();
 				}
 				treeWalker.parentNode();
@@ -144,7 +153,9 @@ export function toVdom( root ) {
 		}
 
 		// Restore previous namespace.
-		if ( island ) namespaces.pop();
+		if ( island ) {
+			namespaces.pop();
+		}
 
 		return [ h( localName, props, children ) ];
 	}

--- a/packages/keyboard-shortcuts/src/components/shortcut-provider.js
+++ b/packages/keyboard-shortcuts/src/components/shortcut-provider.js
@@ -23,7 +23,9 @@ export function ShortcutProvider( props ) {
 	const [ keyboardShortcuts ] = useState( () => new Set() );
 
 	function onKeyDown( event ) {
-		if ( props.onKeyDown ) props.onKeyDown( event );
+		if ( props.onKeyDown ) {
+			props.onKeyDown( event );
+		}
 
 		for ( const keyboardShortcut of keyboardShortcuts ) {
 			keyboardShortcut( event );

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -85,7 +85,9 @@ function PatternOverridesControls( { attributes, name, setAttributes } ) {
 	}
 
 	// Avoid overwriting other (e.g. meta) bindings.
-	if ( isConnectedToOtherSources ) return null;
+	if ( isConnectedToOtherSources ) {
+		return null;
+	}
 
 	const hasName = !! attributes.metadata?.name;
 	const allowOverrides =

--- a/packages/rich-text/src/component/use-anchor-ref.js
+++ b/packages/rich-text/src/component/use-anchor-ref.js
@@ -40,7 +40,9 @@ export function useAnchorRef( { ref, value, settings = {} } ) {
 	const activeFormat = name ? getActiveFormat( value, name ) : undefined;
 
 	return useMemo( () => {
-		if ( ! ref.current ) return;
+		if ( ! ref.current ) {
+			return;
+		}
 		const {
 			ownerDocument: { defaultView },
 		} = ref.current;

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -41,9 +41,15 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 		element = element.parentElement;
 	}
 
-	if ( ! element ) return;
-	if ( element === editableContentElement ) return;
-	if ( ! editableContentElement.contains( element ) ) return;
+	if ( ! element ) {
+		return;
+	}
+	if ( element === editableContentElement ) {
+		return;
+	}
+	if ( ! editableContentElement.contains( element ) ) {
+		return;
+	}
 
 	const selector = tagName + ( className ? '.' + className : '' );
 
@@ -100,18 +106,26 @@ function createVirtualAnchorElement( range, editableContentElement ) {
  * @return {HTMLElement|VirtualAnchorElement|undefined} The anchor.
  */
 function getAnchor( editableContentElement, tagName, className ) {
-	if ( ! editableContentElement ) return;
+	if ( ! editableContentElement ) {
+		return;
+	}
 
 	const { ownerDocument } = editableContentElement;
 	const { defaultView } = ownerDocument;
 	const selection = defaultView.getSelection();
 
-	if ( ! selection ) return;
-	if ( ! selection.rangeCount ) return;
+	if ( ! selection ) {
+		return;
+	}
+	if ( ! selection.rangeCount ) {
+		return;
+	}
 
 	const range = selection.getRangeAt( 0 );
 
-	if ( ! range || ! range.startContainer ) return;
+	if ( ! range || ! range.startContainer ) {
+		return;
+	}
 
 	const formatElement = getFormatElement(
 		range,
@@ -120,7 +134,9 @@ function getAnchor( editableContentElement, tagName, className ) {
 		className
 	);
 
-	if ( formatElement ) return formatElement;
+	if ( formatElement ) {
+		return formatElement;
+	}
 
 	return createVirtualAnchorElement( range, editableContentElement );
 }
@@ -145,7 +161,9 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 	const wasActive = usePrevious( isActive );
 
 	useLayoutEffect( () => {
-		if ( ! editableContentElement ) return;
+		if ( ! editableContentElement ) {
+			return;
+		}
 
 		function callback() {
 			setAnchor(

--- a/packages/rich-text/src/component/use-default-style.js
+++ b/packages/rich-text/src/component/use-default-style.js
@@ -33,7 +33,9 @@ const minWidth = '1px';
 
 export function useDefaultStyle() {
 	return useCallback( ( element ) => {
-		if ( ! element ) return;
+		if ( ! element ) {
+			return;
+		}
 		element.style.whiteSpace = whiteSpace;
 		element.style.minWidth = minWidth;
 	}, [] );

--- a/packages/rich-text/src/component/use-select-object.js
+++ b/packages/rich-text/src/component/use-select-object.js
@@ -22,7 +22,9 @@ export function useSelectObject() {
 
 			// If it's already selected, do nothing and let default behavior
 			// happen. This means it's "click-through".
-			if ( selection.containsNode( target ) ) return;
+			if ( selection.containsNode( target ) ) {
+				return;
+			}
 
 			const range = ownerDocument.createRange();
 			// If the target is within a non editable element, select the non

--- a/packages/rich-text/src/component/use-selection-change-compat.js
+++ b/packages/rich-text/src/component/use-selection-change-compat.js
@@ -43,7 +43,9 @@ export function useSelectionChangeCompat() {
 
 			function onUp() {
 				onCancel();
-				if ( isRangeEqual( range, getRange() ) ) return;
+				if ( isRangeEqual( range, getRange() ) ) {
+					return;
+				}
 				ownerDocument.dispatchEvent( new Event( 'selectionchange' ) );
 			}
 

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -532,7 +532,9 @@ function createFromElement( { element, range, isEditableTree } ) {
 			continue;
 		}
 
-		if ( format ) delete format.formatType;
+		if ( format ) {
+			delete format.formatType;
+		}
 
 		const value = createFromElement( {
 			element: node,

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -223,7 +223,9 @@ export function toTree( {
 
 		if ( character === OBJECT_REPLACEMENT_CHARACTER ) {
 			const replacement = replacements[ i ];
-			if ( ! replacement ) continue;
+			if ( ! replacement ) {
+				continue;
+			}
 			const { type, attributes, innerHTML } = replacement;
 			const formatType = getFormatType( type );
 

--- a/packages/scripts/config/jest-environment-puppeteer/global.js
+++ b/packages/scripts/config/jest-environment-puppeteer/global.js
@@ -45,7 +45,9 @@ async function setup( jestConfig = {} ) {
 
 	// If we are in watch mode, - only setupServer() once.
 	if ( jestConfig.watch || jestConfig.watchAll ) {
-		if ( didAlreadyRunInWatchMode ) return;
+		if ( didAlreadyRunInWatchMode ) {
+			return;
+		}
 		didAlreadyRunInWatchMode = true;
 	}
 

--- a/packages/scripts/config/jest-github-actions-reporter/index.js
+++ b/packages/scripts/config/jest-github-actions-reporter/index.js
@@ -35,7 +35,9 @@ class GithubActionsReporter {
 }
 
 function getMessages( results ) {
-	if ( ! results ) return [];
+	if ( ! results ) {
+		return [];
+	}
 
 	return results.reduce(
 		flatMap( ( { testFilePath, testResults } ) =>

--- a/packages/url/src/get-path-and-query-string.js
+++ b/packages/url/src/get-path-and-query-string.js
@@ -20,7 +20,11 @@ export function getPathAndQueryString( url ) {
 	const path = getPath( url );
 	const queryString = getQueryString( url );
 	let value = '/';
-	if ( path ) value += path;
-	if ( queryString ) value += `?${ queryString }`;
+	if ( path ) {
+		value += path;
+	}
+	if ( queryString ) {
+		value += `?${ queryString }`;
+	}
 	return value;
 }

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -344,7 +344,9 @@ test.describe( 'Quote', () => {
 		await pageUtils.pressKeys( 'Shift+ArrowUp' );
 		let error;
 		page.on( 'console', ( msg ) => {
-			if ( msg.type() === 'error' ) error = msg.text();
+			if ( msg.type() === 'error' ) {
+				error = msg.text();
+			}
 		} );
 		await page.keyboard.press( 'Backspace' );
 		expect( error ).toBeUndefined();

--- a/test/e2e/specs/editor/plugins/plugins-api-error-boundary.spec.js
+++ b/test/e2e/specs/editor/plugins/plugins-api-error-boundary.spec.js
@@ -22,8 +22,9 @@ test.describe( 'Plugins API Error Boundary', () => {
 	} ) => {
 		let hasError = false;
 		page.on( 'console', ( msg ) => {
-			if ( msg.type() === 'error' && msg.text().includes( 'Whoops!' ) )
+			if ( msg.type() === 'error' && msg.text().includes( 'Whoops!' ) ) {
 				hasError = true;
+			}
 		} );
 
 		await admin.createNewPost();

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -499,7 +499,9 @@ test.describe( 'Synced pattern', () => {
 
 		let hasError = false;
 		page.on( 'console', ( msg ) => {
-			if ( msg.type() === 'error' ) hasError = true;
+			if ( msg.type() === 'error' ) {
+				hasError = true;
+			}
 		} );
 
 		// Need to reload the page to make pattern available in the store.

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -46,7 +46,9 @@ export default class InteractivityUtils {
 			? `${ name } ${ JSON.stringify( attributes ) }`
 			: name;
 
-		if ( ! alias ) alias = block;
+		if ( ! alias ) {
+			alias = block;
+		}
 
 		const payload = {
 			content: `<!-- wp:${ block } /-->`,

--- a/test/performance/utils.js
+++ b/test/performance/utils.js
@@ -4,19 +4,25 @@
 import { existsSync, readFileSync, unlinkSync } from 'fs';
 
 export function sum( array ) {
-	if ( ! array || ! array.length ) return undefined;
+	if ( ! array || ! array.length ) {
+		return undefined;
+	}
 
 	return array.reduce( ( a, b ) => a + b, 0 );
 }
 
 export function average( array ) {
-	if ( ! array || ! array.length ) return undefined;
+	if ( ! array || ! array.length ) {
+		return undefined;
+	}
 
 	return sum( array ) / array.length;
 }
 
 export function median( array ) {
-	if ( ! array || ! array.length ) return undefined;
+	if ( ! array || ! array.length ) {
+		return undefined;
+	}
 
 	const numbers = [ ...array ].sort( ( a, b ) => a - b );
 	const middleIndex = Math.floor( numbers.length / 2 );
@@ -28,13 +34,17 @@ export function median( array ) {
 }
 
 export function minimum( array ) {
-	if ( ! array || ! array.length ) return undefined;
+	if ( ! array || ! array.length ) {
+		return undefined;
+	}
 
 	return Math.min( ...array );
 }
 
 export function maximum( array ) {
-	if ( ! array || ! array.length ) return undefined;
+	if ( ! array || ! array.length ) {
+		return undefined;
+	}
 
 	return Math.max( ...array );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Restore the [`curly` eslint rule](https://eslint.org/docs/latest/rules/curly) to the recommended eslint config when using prettier.

**Note to reviewers:**

This contains an autofix applied by eslint. It's good to review a sample of the changes although they're likely very safe since this is a core eslint rule.

I recommend reviewing this by commit. The manual changes are separated from the automated changes and can be reviewed in their own commit.

## Why?

> [This rule is aimed at preventing bugs and increasing code clarity by ensuring that block statements are wrapped in curly braces. It will warn when it encounters blocks that omit curly braces.](https://eslint.org/docs/latest/rules/curly#rule-details)

This is aligned with the Core JavaScript Coding Standards on "blocks and curly braces":

> [`if`, `else`, `for`, `while`, and `try` blocks should always use braces, and always go on multiple lines.](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/#blocks-and-curly-braces)

As far as I can tell, this was unintentionally removed when the prettier config was added or in a subsequent upgrade of the eslint-plugin-prettier package. This rule is explicitly declared and I believe it was always intended to be included:


https://github.com/WordPress/gutenberg/blob/5b154e584c553432f1dd7a84db8d678220f320c2/packages/eslint-plugin/configs/es5.js#L16

This was proposed and abandoned previously in https://github.com/WordPress/gutenberg/pull/26886.

## How?

See the code.

The prettier config disables this rule, so when we merge in prettier config the rule was turned off.

[But the motivation is only for certain configurations we do not use](https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#curly): `"multi-line"` or `"multi-or-nest"`. With `"all"` there should be no conflict with prettier.

This restores the rule explicitly when the prettier configuration is added.

This also applies the provided autofix to the entire repo.

## Testing Instructions

Code review, manual testing isn't necessary.