### PR TITLE
Update 3rd party actions within composite action.

### DIFF
--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -10,7 +10,7 @@ runs:
     using: 'composite'
     steps:
         - name: Use desired version of Node.js
-          uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+          uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
           with:
               node-version-file: '.nvmrc'
               node-version: ${{ inputs.node-version }}
@@ -25,7 +25,7 @@ runs:
 
         - name: Cache node_modules
           id: cache-node_modules
-          uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+          uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
           with:
               path: '**/node_modules'
               key: node_modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.node-version.outputs.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This updates the 3rd party actions used within the `setup-node` composite action. Unfortunately, it seems that Dependabot does not currently update workflows found outside of the `.github/workflows` directory, so these have fallen out of date.