### PR TITLE
Use output buffer and HTML tag processor to inject directives on BODY tag for full-page client-side navigation

### DIFF
--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -42,16 +42,57 @@ add_filter( 'render_block_data', '_gutenberg_add_enhanced_pagination_to_query_bl
  * @return array The same block content with the directives needed.
  */
 function _gutenberg_add_client_side_navigation_directives( $content ) {
-	$p = new WP_HTML_Tag_Processor( $content );
-	// Hack to add the necessary directives to the body tag.
-	// TODO: Find a proper way to add directives to the body tag.
 	static $body_interactive_added;
 	if ( ! $body_interactive_added ) {
 		$body_interactive_added = true;
-		return (string) $p . '<body data-wp-interactive="core/experimental" data-wp-context="{}">';
+		add_filter( 'gutenberg_template_output_buffer', static function ( $html ) {
+			$p = new WP_HTML_Tag_Processor( $html );
+			if ( $p->next_tag( array( 'tag_name' => 'BODY' ) ) ) {
+				$p->set_attribute( 'data-wp-interactive', 'core/experimental' );
+				$p->set_attribute( 'data-wp-context', '{}' );
+				$html = $p->get_updated_html();
+			}
+			return $html;
+		} );
 	}
-	return (string) $p;
+	return $content;
 }
 
 // TODO: Explore moving this to the server directive processing.
 add_filter( 'render_block', '_gutenberg_add_client_side_navigation_directives' );
+
+/**
+ * Starts output buffering at the end of the 'template_include' filter.
+ *
+ * This is to implement #43258 in core.
+ *
+ * This is a hack which would eventually be replaced with something like this in wp-includes/template-loader.php:
+ *
+ *          $template = apply_filters( 'template_include', $template );
+ *     +    ob_start( 'wp_template_output_buffer_callback' );
+ *          if ( $template ) {
+ *              include $template;
+ *          } elseif ( current_user_can( 'switch_themes' ) ) {
+ *
+ * @since 0.1.0
+ * @link https://core.trac.wordpress.org/ticket/43258
+ *
+ * @param string $passthrough Value for the template_include filter which is passed through.
+ *
+ * @return string Unmodified value of $passthrough.
+ */
+function _gutenberg_buffer_template_output( string $passthrough ): string {
+	ob_start(
+		static function ( string $output ): string {
+			/**
+			 * Filters the template output buffer prior to sending to the client.
+			 *
+			 * @param string $output Output buffer.
+			 * @return string Filtered output buffer.
+			 */
+			return (string) apply_filters( 'gutenberg_template_output_buffer', $output );
+		}
+	);
+	return $passthrough;
+}
+add_filter( 'template_include', '_gutenberg_buffer_template_output', PHP_INT_MAX );

--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -37,18 +37,29 @@ add_filter( 'render_block_data', '_gutenberg_add_enhanced_pagination_to_query_bl
  *
  * Note: This should probably be done per site, not by default when this option is enabled.
  *
- * @param string $html The rendered template.
+ * @param string $response_body The response body.
  *
  * @return string The rendered template with modified BODY attributes.
  */
-function _gutenberg_add_client_side_navigation_directives( $html ) {
-	$p = new WP_HTML_Tag_Processor( $html );
+function _gutenberg_add_client_side_navigation_directives( $response_body ) {
+	$is_html_content_type = false;
+	foreach ( headers_list() as $header ) {
+		$header_parts = preg_split( '/\s*[:;]\s*/', strtolower( $header ) );
+		if ( count( $header_parts ) >= 2 && 'content-type' === $header_parts[0] ) {
+			$is_html_content_type = in_array( $header_parts[1], array( 'text/html', 'application/xhtml+xml' ), true );
+		}
+	}
+	if ( ! $is_html_content_type ) {
+		return $response_body;
+	}
+
+	$p = new WP_HTML_Tag_Processor( $response_body );
 	if ( $p->next_tag( array( 'tag_name' => 'BODY' ) ) ) {
 		$p->set_attribute( 'data-wp-interactive', 'core/experimental' );
 		$p->set_attribute( 'data-wp-context', '{}' );
-		$html = $p->get_updated_html();
+		$response_body = $p->get_updated_html();
 	}
-	return $html;
+	return $response_body;
 }
 
 // TODO: Explore moving this to the server directive processing.

--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -37,15 +37,15 @@ add_filter( 'render_block_data', '_gutenberg_add_enhanced_pagination_to_query_bl
  *
  * Note: This should probably be done per site, not by default when this option is enabled.
  *
- * @param array $content The block content.
+ * @param string $content The block content.
  *
- * @return array The same block content with the directives needed.
+ * @return string The same block content with the directives needed.
  */
 function _gutenberg_add_client_side_navigation_directives( $content ) {
 	static $body_interactive_added;
 	if ( ! $body_interactive_added ) {
 		$body_interactive_added = true;
-		add_filter( 'gutenberg_template_output_buffer', static function ( $html ) {
+		add_filter( 'gutenberg_template_output_buffer', static function ( string $html ): string {
 			$p = new WP_HTML_Tag_Processor( $html );
 			if ( $p->next_tag( array( 'tag_name' => 'BODY' ) ) ) {
 				$p->set_attribute( 'data-wp-interactive', 'core/experimental' );

--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -33,33 +33,26 @@ function _gutenberg_add_enhanced_pagination_to_query_block( $parsed_block ) {
 add_filter( 'render_block_data', '_gutenberg_add_enhanced_pagination_to_query_block' );
 
 /**
- * Add directives to all links.
+ * Adds client-side navigation directives to BODY tag.
  *
  * Note: This should probably be done per site, not by default when this option is enabled.
  *
- * @param string $content The block content.
+ * @param string $html The rendered template.
  *
- * @return string The same block content with the directives needed.
+ * @return string The rendered template with modified BODY attributes.
  */
-function _gutenberg_add_client_side_navigation_directives( $content ) {
-	static $body_interactive_added;
-	if ( ! $body_interactive_added ) {
-		$body_interactive_added = true;
-		add_filter( 'gutenberg_template_output_buffer', static function ( string $html ): string {
-			$p = new WP_HTML_Tag_Processor( $html );
-			if ( $p->next_tag( array( 'tag_name' => 'BODY' ) ) ) {
-				$p->set_attribute( 'data-wp-interactive', 'core/experimental' );
-				$p->set_attribute( 'data-wp-context', '{}' );
-				$html = $p->get_updated_html();
-			}
-			return $html;
-		} );
+function _gutenberg_add_client_side_navigation_directives( $html ) {
+	$p = new WP_HTML_Tag_Processor( $html );
+	if ( $p->next_tag( array( 'tag_name' => 'BODY' ) ) ) {
+		$p->set_attribute( 'data-wp-interactive', 'core/experimental' );
+		$p->set_attribute( 'data-wp-context', '{}' );
+		$html = $p->get_updated_html();
 	}
-	return $content;
+	return $html;
 }
 
 // TODO: Explore moving this to the server directive processing.
-add_filter( 'render_block', '_gutenberg_add_client_side_navigation_directives' );
+add_filter( 'gutenberg_template_output_buffer', '_gutenberg_add_client_side_navigation_directives' );
 
 /**
  * Starts output buffering at the end of the 'template_include' filter.

--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -67,7 +67,6 @@ add_filter( 'gutenberg_template_output_buffer', '_gutenberg_add_client_side_navi
  *              include $template;
  *          } elseif ( current_user_can( 'switch_themes' ) ) {
  *
- * @since 0.1.0
  * @link https://core.trac.wordpress.org/ticket/43258
  *
  * @param string $passthrough Value for the template_include filter which is passed through.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This implements a resolution for this task from #60951: 

> * Explore how to modify the body tag without the hack: [link](https://github.com/WordPress/gutenberg/pull/59707#discussion_r1559952673).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As [discussed](https://github.com/WordPress/gutenberg/pull/59707#discussion_r1559952673), the code is currently injecting an additional `<body>` tag after the BODY has already been opened, like so:

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8">
  </head>
  <body>
    <h1>
      Hello World!
    </h1>
    <body data-wp-context="{}" data-wp-interactive="core/experimental">
  </body>
</html>
```

Surprisingly (to me at least), this actually [works](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0A%3Chtml%20lang%3D%22en%22%3E%0A%20%20%3Chead%3E%0A%20%20%20%20%3Cmeta%20charset%3D%22utf-8%22%3E%0A%20%20%3C%2Fhead%3E%0A%20%20%3Cbody%3E%0A%20%20%20%20%3Ch1%3E%0A%20%20%20%20%20%20Hello%20World!%0A%20%20%20%20%3C%2Fh1%3E%0A%20%20%20%20%3Cbody%20data-wp-context%3D%22%7B%7D%22%20data-wp-interactive%3D%22core%2Fexperimental%22%3E%0A%20%20%3C%2Fbody%3E%0A%3C%2Fhtml%3E):

![image](https://github.com/WordPress/gutenberg/assets/134745/3055c79b-7f10-40a8-9caf-8116060d056d)

Maybe I shouldn't be surprised given HTML's loose parsing rules. But I can imagine other plugins that try to parse the HTML to, for example, apply various optimizations would get might confused when encountering multiple BODY tags.

The attributes could rather get injected on the existing BODY tag instead with the HTML Tag Processor. I see this is not currently possible since the BODY tag is hard-coded in [`template-canvas.php`](https://github.com/WordPress/wordpress-develop/blob/f525e665b6ea6e88289d82cad5fc1dfac57db109/src/wp-includes/template-canvas.php#L20). This brings up the question again of output buffering for the entire template (Core-43258). It's something I've been working on in the context of the Performance team's [Optimization Detective](https://wordpress.org/plugins/optimization-detective/) plugin which output buffers the entire template and then uses HTML Tag Processor to do optimizations.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR copies the [same output-buffering approach](https://github.com/WordPress/performance/blob/db834903c82b499ed9164ed8b081b6163ac8908c/plugins/optimization-detective/optimization.php#L13-L48) taken from the Optimization Detective plugin. Since there is no existing filter for the rendered template output, it starts an output buffer immediately before the template begins rendering. This is at the `template_include` _filter_.

## Testing Instructions

1. Enable the "Enable full page client-side navigation using the Interactivity API" experiment.
2. Go to the frontend.
3. Make sure that the `data-wp-interactive` and `data-wp-context` attributes appear on the BODY. (There should be only one `<body>` start tag when looking at the HTML source.)
4. Ensure that client-side navigation is working as expected.

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->