### PR TITLE
Fix import in block editor’s readme example

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -17,9 +17,9 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ```js
 import { useState } from 'react';
 import {
+	BlockCanvas,
 	BlockEditorProvider,
 	BlockList,
-	WritingFlow,
 } from '@wordpress/block-editor';
 
 function MyEditorComponent() {


### PR DESCRIPTION
## What?
Fixes imports in example.

## Why?
Docs should not contain mistakes.

## How?
- Removes `WritingFlow` import that was unused.
- Adds `BlockCanvas` import that was missing.