### PR TITLE
Query Block: Improve force page reload modal message

### DIFF
--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -6,7 +6,7 @@ import {
 	Modal,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 
 /**
@@ -17,14 +17,37 @@ import { useUnsupportedBlocks } from '../utils';
 const modalDescriptionId =
 	'wp-block-query-enhanced-pagination-modal__description';
 
+/**
+ * Function that takes an array of block titles and returns a formatted
+ * string with commas and 'and'.
+ *
+ * @param {Array} unsupportedBlocksList Array of unsupported blocks.
+ * @return {string} The formated list.
+ */
+
+const formatUnsupportedBlocksList = ( unsupportedBlocksList ) => {
+	if ( unsupportedBlocksList.length === 0 ) return '';
+	if ( unsupportedBlocksList.length === 1 ) return unsupportedBlocksList[ 0 ];
+	const andWord = __( 'and' );
+	if ( unsupportedBlocksList.length === 2 )
+		return unsupportedBlocksList.join( ' ' + andWord + ' ' );
+
+	const lastItem = unsupportedBlocksList.pop();
+	return unsupportedBlocksList.join( ', ' ) + ', ' + andWord + ' ' + lastItem;
+};
+
 export default function EnhancedPaginationModal( {
 	clientId,
 	attributes: { enhancedPagination },
 	setAttributes,
 } ) {
 	const [ isOpen, setOpen ] = useState( false );
-	const { hasBlocksFromPlugins, hasPostContentBlock, hasUnsupportedBlocks } =
-		useUnsupportedBlocks( clientId );
+	const {
+		hasBlocksFromPlugins,
+		hasPostContentBlock,
+		hasUnsupportedBlocks,
+		unsupportedBlocksList,
+	} = useUnsupportedBlocks( clientId );
 
 	useEffect( () => {
 		if (
@@ -41,13 +64,19 @@ export default function EnhancedPaginationModal( {
 		setOpen( false );
 	};
 
-	let notice = __(
-		'If you still want to prevent full page reloads, remove that block, then disable "Force page reload" again in the Query Block settings.'
+	let notice = _n(
+		'If you still want to prevent full page reloads, remove that block, then disable "Force page reload" again in the Query Block settings.',
+		'If you still want to prevent full page reloads, remove those blocks, then disable "Force page reload" again in the Query Block settings.',
+		unsupportedBlocksList.length
 	);
 	if ( hasBlocksFromPlugins ) {
 		notice =
-			__(
-				'Currently, avoiding full page reloads is not possible when non-interactive or non-client Navigation compatible blocks from plugins are present inside the Query block.'
+			_n( 'The ', 'The ', unsupportedBlocksList.length ) +
+			formatUnsupportedBlocksList( unsupportedBlocksList ) +
+			_n(
+				' block present inside the query block does not explicity support avoiding full page reloads.',
+				' blocks present inside the query block do not explicity support avoiding full page reloads.',
+				unsupportedBlocksList.length
 			) +
 			' ' +
 			notice;

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -9,6 +9,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import {
 	cloneBlock,
 	getBlockSupport,
+	getBlockType,
 	store as blocksStore,
 } from '@wordpress/blocks';
 
@@ -356,9 +357,10 @@ export const usePatterns = ( clientId, name ) => {
  * unsupported blocks present inside the Query block.
  *
  * @typedef  {Object}  UnsupportedBlocksInfo
- * @property {boolean} hasBlocksFromPlugins True if blocks from plugins are present.
- * @property {boolean} hasPostContentBlock  True if a 'core/post-content' block is present.
- * @property {boolean} hasUnsupportedBlocks True if there are any unsupported blocks.
+ * @property {boolean} hasBlocksFromPlugins  True if blocks from plugins are present.
+ * @property {boolean} hasPostContentBlock   True if a 'core/post-content' block is present.
+ * @property {boolean} hasUnsupportedBlocks  True if there are any unsupported blocks.
+ * @property {Array}   unsupportedBlocksList Array of unique, unsupported block titles.
  */
 
 /**
@@ -376,6 +378,7 @@ export const useUnsupportedBlocks = ( clientId ) => {
 			const { getClientIdsOfDescendants, getBlockName } =
 				select( blockEditorStore );
 			const blocks = {};
+			const unsupportedBlocksList = [];
 			getClientIdsOfDescendants( clientId ).forEach(
 				( descendantClientId ) => {
 					const blockName = getBlockName( descendantClientId );
@@ -398,6 +401,8 @@ export const useUnsupportedBlocks = ( clientId ) => {
 						blockSupportsInteractivityClientNavigation;
 					if ( ! blockInteractivity ) {
 						blocks.hasBlocksFromPlugins = true;
+						const blockType = getBlockType( blockName );
+						unsupportedBlocksList.push( blockType.title );
 					} else if ( blockName === 'core/post-content' ) {
 						blocks.hasPostContentBlock = true;
 					}
@@ -405,6 +410,9 @@ export const useUnsupportedBlocks = ( clientId ) => {
 			);
 			blocks.hasUnsupportedBlocks =
 				blocks.hasBlocksFromPlugins || blocks.hasPostContentBlock;
+			blocks.unsupportedBlocksList = [
+				...new Set( unsupportedBlocksList ),
+			];
 			return blocks;
 		},
 		[ clientId ]


### PR DESCRIPTION
## What?
Updates the modal message displayed to users when they insert a non-interactive or non-client-side-navigation compatible block.

## Why?
Addresses https://github.com/WordPress/gutenberg/issues/60485 in hopes that typical users understand what has happened, how to correct it, and who to reach out to for support.

## How?
This now returns a unique list of unsupported block titles when it checks if there are unsupported blocks inside the query block. That is used in the modal message to explain exactly which blocks are preventing the query block from avoiding page refresh navigation.

## Testing Instructions
1. Open a post or page.
2. Insert a query block
3. Insert one non-interactive blocks within the query
    core/shortcode is one you might try
    lots of 3rd party blocks do not declare interactivity support
4. Review the message on the modal.
5. Insert several non-interactive blocks by inserting a pattern, etc
6. Review the message on the modal.

### Testing Instructions for Keyboard
Testing as above. It should not differ using a pointer device vs keyboard.

## Screenshots or screencast


https://github.com/WordPress/gutenberg/assets/2152870/cf1334aa-5fbb-42af-af9f-e6a3dbdf4f84

