### PR TITLE
List View: Use 'isMatch' for unselect the shortcut

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -22,7 +22,7 @@ import {
 } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { BACKSPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 
@@ -183,7 +183,10 @@ function ListViewBlock( {
 
 		// If multiple blocks are selected, deselect all blocks when the user
 		// presses the escape key.
-		if ( event.keyCode === ESCAPE && selectedClientIds.length > 0 ) {
+		if (
+			isMatch( 'core/block-editor/unselect', event ) &&
+			selectedClientIds.length > 0
+		) {
 			event.stopPropagation();
 			event.preventDefault();
 			selectBlock( event, undefined );


### PR DESCRIPTION
## What?
PR updates the List View shortcuts handler to use the `isMatch` helper for the selection shortcut.

## Why?
It matches how canvas handlers have the same action.

## Testing Instructions
1. Open a post or page.
2. Insert multiple blocks.
3. Open the List View.
4. Select all blocks in the list view.
5. Press <kbd>Escape</kbd> key.
6. Shorctu should deselect the blocks.

### Testing Instructions for Keyboard
Same.
