### PR TITLE
Code Quality: Use contentOnly locking for pattern block

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -95,8 +95,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			blockType: _blockType,
 			topLevelLockedBlock:
 				getContentLockingParent( _selectedBlockClientId ) ||
-				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly' ||
-				_selectedBlockName === 'core/block'
+				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly'
 					? _selectedBlockClientId
 					: undefined ),
 		};

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -402,7 +402,7 @@ function ReusableBlockEdit( {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		templateLock: 'all',
+		templateLock: 'contentOnly',
 		layout,
 		renderAppender: innerBlocks?.length
 			? undefined


### PR DESCRIPTION
## What?
Minor tidy-up. In trunk, the pattern block uses `templateLock: 'all` to prevent insertion between its inner blocks. It could use `templateLock: contentOnly` instead to achieve the same thing.

Furthermore, there's a hard-coded check in the block inspector that ensures the pattern block shows the contentOnly quick navigation in the block inspector. This is actually not needed if the pattern block is set to `templateLock: contentOnly` so can be removed

## Why?
It allows deletion of one line of code while achieving the same thing.

## Testing Instructions
Everything should be the same as in `trunk`

1. Insert a pattern with overrides
2. Check that the quick navigation shows in the sidebar when the pattern block is selected, as it does in trunk
3. Ensure that you can't insert between blocks or do anything else that you couldn't before
