### PR TITLE
Editor: move around wordcount, post status and last edited info in page summary

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -84,9 +84,9 @@ export default function PostStatus() {
 					<>
 						{ showExcerptAndLastEditedPanels && (
 							<VStack
-								spacing={ 2 }
+								spacing={ 3 }
 								//  TODO: this needs to be consolidated with the panel in site editor, when we unify them.
-								style={ { marginBlockEnd: '12px' } }
+								style={ { marginBlockEnd: '24px' } }
 							>
 								<PostFeaturedImagePanel
 									withPanelBody={ false }
@@ -94,18 +94,23 @@ export default function PostStatus() {
 
 								<>
 									<PrivatePostExcerptPanel />
-									<div>
+									<VStack spacing={ 1 }>
 										<PostContentInformation />
 										<PostLastEditedPanel />
-									</div>
+									</VStack>
 								</>
 							</VStack>
 						) }
-						<PostStatusPanel />
-						<PostSchedulePanel />
-						<PostTemplatePanel />
-						<PostURLPanel />
-						<PostSyncStatus />
+						<VStack
+							spacing={ 1 }
+							style={ { marginBlockEnd: '12px' } }
+						>
+							<PostStatusPanel />
+							<PostSchedulePanel />
+							<PostTemplatePanel />
+							<PostURLPanel />
+							<PostSyncStatus />
+						</VStack>
 						<PostSticky />
 						<PostFormat />
 						<PostSlug />

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -42,7 +42,7 @@ const {
 const PANEL_NAME = 'post-status';
 
 export default function PostStatus() {
-	const { isOpened, isRemoved, showExcerptAndLastEditedPanels } = useSelect(
+	const { isOpened, isRemoved, showPostContentPanels } = useSelect(
 		( select ) => {
 			// We use isEditorPanelRemoved to hide the panel if it was programatically removed. We do
 			// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
@@ -57,7 +57,7 @@ export default function PostStatus() {
 				isOpened: isEditorPanelOpened( PANEL_NAME ),
 				// Post excerpt panel is rendered in different place depending on the post type.
 				// So we cannot make this check inside the PostExcerpt component based on the current edited entity.
-				showExcerptAndLastEditedPanels: ! [
+				showPostContentPanels: ! [
 					'wp_template',
 					'wp_template_part',
 					'wp_block',
@@ -82,7 +82,7 @@ export default function PostStatus() {
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
 					<>
-						{ showExcerptAndLastEditedPanels && (
+						{ showPostContentPanels && (
 							<VStack
 								spacing={ 3 }
 								//  TODO: this needs to be consolidated with the panel in site editor, when we unify them.
@@ -91,14 +91,11 @@ export default function PostStatus() {
 								<PostFeaturedImagePanel
 									withPanelBody={ false }
 								/>
-
-								<>
-									<PrivatePostExcerptPanel />
-									<VStack spacing={ 1 }>
-										<PostContentInformation />
-										<PostLastEditedPanel />
-									</VStack>
-								</>
+								<PrivatePostExcerptPanel />
+								<VStack spacing={ 1 }>
+									<PostContentInformation />
+									<PostLastEditedPanel />
+								</VStack>
 							</VStack>
 						) }
 						<VStack

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -42,7 +42,7 @@ const {
 const PANEL_NAME = 'post-status';
 
 export default function PostStatus() {
-	const { isOpened, isRemoved, showPostExcerptPanel } = useSelect(
+	const { isOpened, isRemoved, showExcerptAndLastEditedPanels } = useSelect(
 		( select ) => {
 			// We use isEditorPanelRemoved to hide the panel if it was programatically removed. We do
 			// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
@@ -57,7 +57,7 @@ export default function PostStatus() {
 				isOpened: isEditorPanelOpened( PANEL_NAME ),
 				// Post excerpt panel is rendered in different place depending on the post type.
 				// So we cannot make this check inside the PostExcerpt component based on the current edited entity.
-				showPostExcerptPanel: ! [
+				showExcerptAndLastEditedPanels: ! [
 					'wp_template',
 					'wp_template_part',
 					'wp_block',
@@ -82,15 +82,26 @@ export default function PostStatus() {
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
 					<>
-						<VStack spacing={ 2 }>
-							<PostStatusPanel />
-							<PostFeaturedImagePanel withPanelBody={ false } />
-							{ showPostExcerptPanel && (
-								<PrivatePostExcerptPanel />
-							) }
-							<PostContentInformation />
-							<PostLastEditedPanel />
-						</VStack>
+						{ showExcerptAndLastEditedPanels && (
+							<VStack
+								spacing={ 2 }
+								//  TODO: this needs to be consolidated with the panel in site editor, when we unify them.
+								style={ { marginBlockEnd: '12px' } }
+							>
+								<PostFeaturedImagePanel
+									withPanelBody={ false }
+								/>
+
+								<>
+									<PrivatePostExcerptPanel />
+									<div>
+										<PostContentInformation />
+										<PostLastEditedPanel />
+									</div>
+								</>
+							</VStack>
+						) }
+						<PostStatusPanel />
 						<PostSchedulePanel />
 						<PostTemplatePanel />
 						<PostURLPanel />

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 	PanelBody,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -28,8 +29,12 @@ import PostSlug from '../post-slug';
 import PostFormat from '../post-format';
 import { unlock } from '../../../lock-unlock';
 
-const { PostStatus: PostStatusPanel, PrivatePostExcerptPanel } =
-	unlock( editorPrivateApis );
+const {
+	PostStatus: PostStatusPanel,
+	PrivatePostExcerptPanel,
+	PostContentInformation,
+	PostLastEditedPanel,
+} = unlock( editorPrivateApis );
 
 /**
  * Module Constants
@@ -77,9 +82,15 @@ export default function PostStatus() {
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
 					<>
-						<PostStatusPanel />
-						<PostFeaturedImagePanel withPanelBody={ false } />
-						{ showPostExcerptPanel && <PrivatePostExcerptPanel /> }
+						<VStack spacing={ 2 }>
+							<PostStatusPanel />
+							<PostFeaturedImagePanel withPanelBody={ false } />
+							{ showPostExcerptPanel && (
+								<PrivatePostExcerptPanel />
+							) }
+							<PostContentInformation />
+							<PostLastEditedPanel />
+						</VStack>
 						<PostSchedulePanel />
 						<PostTemplatePanel />
 						<PostURLPanel />

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
@@ -17,7 +17,12 @@ import {
  */
 import { unlock } from '../../../lock-unlock';
 
-const { PrivatePostExcerptPanel, PostStatus } = unlock( editorPrivateApis );
+const {
+	PrivatePostExcerptPanel,
+	PostStatus,
+	PostContentInformation,
+	PostLastEditedPanel,
+} = unlock( editorPrivateApis );
 
 export default function PageSummary() {
 	return (
@@ -25,9 +30,13 @@ export default function PageSummary() {
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
 					<>
-						<PostStatus />
-						<PostFeaturedImagePanel withPanelBody={ false } />
-						<PrivatePostExcerptPanel />
+						<VStack spacing={ 2 }>
+							<PostStatus />
+							<PostFeaturedImagePanel withPanelBody={ false } />
+							<PrivatePostExcerptPanel />
+							<PostContentInformation />
+							<PostLastEditedPanel />
+						</VStack>
 						<PostSchedulePanel />
 						<PostTemplatePanel />
 						<PostURLPanel />

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
@@ -31,21 +31,26 @@ export default function PageSummary() {
 				{ ( fills ) => (
 					<>
 						<VStack
-							spacing={ 2 }
+							spacing={ 3 }
 							//  TODO: this needs to be consolidated with the panel in post editor, when we unify them.
-							style={ { marginBlockEnd: '12px' } }
+							style={ { marginBlockEnd: '24px' } }
 						>
 							<PostFeaturedImagePanel withPanelBody={ false } />
 							<PrivatePostExcerptPanel />
-							<div>
+							<VStack spacing={ 1 }>
 								<PostContentInformation />
 								<PostLastEditedPanel />
-							</div>
+							</VStack>
 						</VStack>
-						<PostStatus />
-						<PostSchedulePanel />
-						<PostTemplatePanel />
-						<PostURLPanel />
+						<VStack
+							spacing={ 1 }
+							style={ { marginBlockEnd: '12px' } }
+						>
+							<PostStatus />
+							<PostSchedulePanel />
+							<PostTemplatePanel />
+							<PostURLPanel />
+						</VStack>
 						<PostAuthorPanel />
 						{ fills }
 					</>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
@@ -30,13 +30,19 @@ export default function PageSummary() {
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
 					<>
-						<VStack spacing={ 2 }>
-							<PostStatus />
+						<VStack
+							spacing={ 2 }
+							//  TODO: this needs to be consolidated with the panel in post editor, when we unify them.
+							style={ { marginBlockEnd: '12px' } }
+						>
 							<PostFeaturedImagePanel withPanelBody={ false } />
 							<PrivatePostExcerptPanel />
-							<PostContentInformation />
-							<PostLastEditedPanel />
+							<div>
+								<PostContentInformation />
+								<PostLastEditedPanel />
+							</div>
 						</VStack>
+						<PostStatus />
 						<PostSchedulePanel />
 						<PostTemplatePanel />
 						<PostURLPanel />

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -33,7 +33,7 @@ import { unlock } from '../../lock-unlock';
 import TemplateAreas from '../template-areas';
 
 export default function PostCardPanel( { className, actions } ) {
-	const { title, showExcerptAndLastEditedPanels, icon, postType } = useSelect(
+	const { title, showPostContentPanels, icon, postType } = useSelect(
 		( select ) => {
 			const {
 				getEditedPostAttribute,
@@ -59,7 +59,7 @@ export default function PostCardPanel( { className, actions } ) {
 				} ),
 				// Post excerpt panel and Last Edited info are rendered in different place depending on the post type.
 				// So we cannot make this check inside the PostExcerpt or PostLastEditedPanel component based on the current edited entity.
-				showExcerptAndLastEditedPanels: [
+				showPostContentPanels: [
 					TEMPLATE_POST_TYPE,
 					TEMPLATE_PART_POST_TYPE,
 					PATTERN_POST_TYPE,
@@ -72,7 +72,7 @@ export default function PostCardPanel( { className, actions } ) {
 		<PanelBody>
 			<div
 				className={ classnames( 'editor-post-card-panel', className, {
-					'has-description': showExcerptAndLastEditedPanels,
+					'has-description': showPostContentPanels,
 				} ) }
 			>
 				<HStack
@@ -96,7 +96,7 @@ export default function PostCardPanel( { className, actions } ) {
 					{ actions }
 				</HStack>
 				<VStack className="editor-post-card-panel__content">
-					{ showExcerptAndLastEditedPanels && (
+					{ showPostContentPanels && (
 						<VStack
 							className="editor-post-card-panel__description"
 							spacing={ 2 }

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -15,11 +15,8 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { __, _x, _n, sprintf } from '@wordpress/i18n';
-import { humanTimeDiff } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { count as wordCount } from '@wordpress/wordcount';
-import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,60 +28,46 @@ import {
 	PATTERN_POST_TYPE,
 } from '../../store/constants';
 import { PrivatePostExcerptPanel } from '../post-excerpt/panel';
+import PostLastEditedPanel from '../post-last-edited-panel';
 import { unlock } from '../../lock-unlock';
 import TemplateAreas from '../template-areas';
 
 export default function PostCardPanel( { className, actions } ) {
-	const {
-		modified,
-		title,
-		showPostExcerptPanel,
-		icon,
-		postType,
-		isPostsPage,
-	} = useSelect( ( select ) => {
-		const {
-			getEditedPostAttribute,
-			getCurrentPostType,
-			getCurrentPostId,
-			__experimentalGetTemplateInfo,
-		} = select( editorStore );
-		const { getEditedEntityRecord, getEntityRecord } = select( coreStore );
-		const siteSettings = getEntityRecord( 'root', 'site' );
-		const _type = getCurrentPostType();
-		const _id = getCurrentPostId();
-		const _record = getEditedEntityRecord( 'postType', _type, _id );
-		const _templateInfo =
-			[ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes( _type ) &&
-			__experimentalGetTemplateInfo( _record );
-		return {
-			title: _templateInfo?.title || getEditedPostAttribute( 'title' ),
-			modified: getEditedPostAttribute( 'modified' ),
-			id: _id,
-			postType: _type,
-			icon: unlock( select( editorStore ) ).getPostIcon( _type, {
-				area: _record?.area,
-			} ),
-			isPostsPage: +_id === siteSettings?.page_for_posts,
-			// Post excerpt panel is rendered in different place depending on the post type.
-			// So we cannot make this check inside the PostExcerpt component based on the current edited entity.
-			showPostExcerptPanel: [
-				TEMPLATE_POST_TYPE,
-				TEMPLATE_PART_POST_TYPE,
-				PATTERN_POST_TYPE,
-			].includes( _type ),
-		};
-	}, [] );
-	const lastEditedText =
-		modified &&
-		sprintf(
-			// translators: %s: Human-readable time difference, e.g. "2 days ago".
-			__( 'Last edited %s.' ),
-			humanTimeDiff( modified )
-		);
-	const showPostContentInfo =
-		! isPostsPage &&
-		! [ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes( postType );
+	const { title, showExcerptAndLastEditedPanels, icon, postType } = useSelect(
+		( select ) => {
+			const {
+				getEditedPostAttribute,
+				getCurrentPostType,
+				getCurrentPostId,
+				__experimentalGetTemplateInfo,
+			} = select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const _type = getCurrentPostType();
+			const _id = getCurrentPostId();
+			const _record = getEditedEntityRecord( 'postType', _type, _id );
+			const _templateInfo =
+				[ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes(
+					_type
+				) && __experimentalGetTemplateInfo( _record );
+			return {
+				title:
+					_templateInfo?.title || getEditedPostAttribute( 'title' ),
+				id: _id,
+				postType: _type,
+				icon: unlock( select( editorStore ) ).getPostIcon( _type, {
+					area: _record?.area,
+				} ),
+				// Post excerpt panel and Last Edited info are rendered in different place depending on the post type.
+				// So we cannot make this check inside the PostExcerpt or PostLastEditedPanel component based on the current edited entity.
+				showExcerptAndLastEditedPanels: [
+					TEMPLATE_POST_TYPE,
+					TEMPLATE_PART_POST_TYPE,
+					PATTERN_POST_TYPE,
+				].includes( _type ),
+			};
+		},
+		[]
+	);
 	return (
 		<PanelBody>
 			<div
@@ -111,65 +94,18 @@ export default function PostCardPanel( { className, actions } ) {
 					{ actions }
 				</HStack>
 				<VStack className="editor-post-card-panel__content">
-					<VStack
-						className="editor-post-card-panel__description"
-						spacing={ 2 }
-					>
-						{ showPostExcerptPanel && <PrivatePostExcerptPanel /> }
-						{ showPostContentInfo && <PostContentInfo /> }
-						{ lastEditedText && <Text>{ lastEditedText }</Text> }
-					</VStack>
+					{ showExcerptAndLastEditedPanels && (
+						<VStack
+							className="editor-post-card-panel__description"
+							spacing={ 2 }
+						>
+							<PrivatePostExcerptPanel />
+							<PostLastEditedPanel />
+						</VStack>
+					) }
 					{ postType === TEMPLATE_POST_TYPE && <TemplateAreas /> }
 				</VStack>
 			</div>
 		</PanelBody>
-	);
-}
-
-// Taken from packages/editor/src/components/time-to-read/index.js.
-const AVERAGE_READING_RATE = 189;
-
-// This component renders the wordcount and reading time for the post.
-function PostContentInfo() {
-	const postContent = useSelect(
-		( select ) => select( editorStore ).getEditedPostAttribute( 'content' ),
-		[]
-	);
-	/*
-	 * translators: If your word count is based on single characters (e.g. East Asian characters),
-	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-	 * Do not translate into your own language.
-	 */
-	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
-	const wordsCounted = useMemo(
-		() => ( postContent ? wordCount( postContent, wordCountType ) : 0 ),
-		[ postContent, wordCountType ]
-	);
-	if ( ! wordsCounted ) {
-		return null;
-	}
-	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
-	const wordsCountText = sprintf(
-		// translators: %s: the number of words in the post.
-		_n( '%s word', '%s words', wordsCounted ),
-		wordsCounted.toLocaleString()
-	);
-	const minutesText =
-		readingTime <= 1
-			? __( '1 minute' )
-			: sprintf(
-					// translators: %s: the number of minutes to read the post.
-					_n( '%s minute', '%s minutes', readingTime ),
-					readingTime.toLocaleString()
-			  );
-	return (
-		<Text>
-			{ sprintf(
-				/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
-				__( '%1$s, %2$s read time.' ),
-				wordsCountText,
-				minutesText
-			) }
-		</Text>
 	);
 }

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -71,7 +71,9 @@ export default function PostCardPanel( { className, actions } ) {
 	return (
 		<PanelBody>
 			<div
-				className={ classnames( 'editor-post-card-panel', className ) }
+				className={ classnames( 'editor-post-card-panel', className, {
+					'has-description': showExcerptAndLastEditedPanels,
+				} ) }
 			>
 				<HStack
 					spacing={ 2 }

--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -20,6 +20,9 @@
 	&__header {
 		display: flex;
 		justify-content: space-between;
-		margin: 0 0 $grid-unit-10;
+	}
+
+	&.has-description &__header {
+		margin-bottom: $grid-unit-10;
 	}
 }

--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -22,11 +22,4 @@
 		justify-content: space-between;
 		margin: 0 0 $grid-unit-10;
 	}
-
-	&__description {
-		color: $gray-700;
-		& .components-text {
-			color: inherit;
-		}
-	}
 }

--- a/packages/editor/src/components/post-content-information/index.js
+++ b/packages/editor/src/components/post-content-information/index.js
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalText as Text } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
+import { count as wordCount } from '@wordpress/wordcount';
+import { useMemo } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+} from '../../store/constants';
+
+// Taken from packages/editor/src/components/time-to-read/index.js.
+const AVERAGE_READING_RATE = 189;
+
+// This component renders the wordcount and reading time for the post.
+export default function PostContentInformation() {
+	const { postContent } = useSelect( ( select ) => {
+		const { getEditedPostAttribute, getCurrentPostType, getCurrentPostId } =
+			select( editorStore );
+		const { getEntityRecord } = select( coreStore );
+		const siteSettings = getEntityRecord( 'root', 'site' );
+		const postType = getCurrentPostType();
+		const _id = getCurrentPostId();
+		const isPostsPage = +_id === siteSettings?.page_for_posts;
+		const showPostContentInfo =
+			! isPostsPage &&
+			! [ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes(
+				postType
+			);
+		return {
+			postContent:
+				showPostContentInfo && getEditedPostAttribute( 'content' ),
+		};
+	}, [] );
+
+	/*
+	 * translators: If your word count is based on single characters (e.g. East Asian characters),
+	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+	 * Do not translate into your own language.
+	 */
+	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
+	const wordsCounted = useMemo(
+		() => ( postContent ? wordCount( postContent, wordCountType ) : 0 ),
+		[ postContent, wordCountType ]
+	);
+	if ( ! wordsCounted ) {
+		return null;
+	}
+	const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
+	const wordsCountText = sprintf(
+		// translators: %s: the number of words in the post.
+		_n( '%s word', '%s words', wordsCounted ),
+		wordsCounted.toLocaleString()
+	);
+	const minutesText =
+		readingTime <= 1
+			? __( '1 minute' )
+			: sprintf(
+					// translators: %s: the number of minutes to read the post.
+					_n( '%s minute', '%s minutes', readingTime ),
+					readingTime.toLocaleString()
+			  );
+	return (
+		<div className="editor-post-content-information">
+			<Text>
+				{ sprintf(
+					/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
+					__( '%1$s, %2$s read time.' ),
+					wordsCountText,
+					minutesText
+				) }
+			</Text>
+		</div>
+	);
+}

--- a/packages/editor/src/components/post-content-information/style.scss
+++ b/packages/editor/src/components/post-content-information/style.scss
@@ -1,0 +1,6 @@
+.editor-post-content-information {
+	color: $gray-700;
+	& .components-text {
+		color: inherit;
+	}
+}

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -32,7 +32,7 @@ const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 // Used when labels from post type were not yet loaded or when they are not present.
 const DEFAULT_FEATURE_IMAGE_LABEL = __( 'Featured image' );
-const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
+const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Add a featured image' );
 
 const instructions = (
 	<p>

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -31,7 +31,7 @@
 	box-shadow: 0 0 0 0 var(--wp-admin-theme-color);
 	overflow: hidden; // Ensure the focus style properly encapsulates the image.
 	outline-offset: -#{$border-width};
-	min-height: $grid-unit-50 * 2;
+	min-height: $grid-unit-50;
 	margin-bottom: $grid-unit-20;
 
 	display: flex;

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -51,16 +51,11 @@
 
 .editor-post-featured-image__toggle {
 	border-radius: $radius-block-ui;
-	background-color: $gray-100;
 	height: 100%;
 	line-height: 20px;
 	padding: $grid-unit-10 0;
 	text-align: center;
-
-	&:hover {
-		background: $gray-300;
-		color: $gray-900;
-	}
+	box-shadow: inset 0 0 0 $border-width $gray-400;
 }
 
 .editor-post-featured-image__actions {

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -32,7 +32,6 @@
 	overflow: hidden; // Ensure the focus style properly encapsulates the image.
 	outline-offset: -#{$border-width};
 	min-height: $grid-unit-50;
-	margin-bottom: $grid-unit-20;
 
 	display: flex;
 	justify-content: center;

--- a/packages/editor/src/components/post-last-edited-panel/index.js
+++ b/packages/editor/src/components/post-last-edited-panel/index.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalText as Text } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { humanTimeDiff } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+export default function PostLastEditedPanel() {
+	const modified = useSelect(
+		( select ) =>
+			select( editorStore ).getEditedPostAttribute( 'modified' ),
+		[]
+	);
+	const lastEditedText =
+		modified &&
+		sprintf(
+			// translators: %s: Human-readable time difference, e.g. "2 days ago".
+			__( 'Last edited %s.' ),
+			humanTimeDiff( modified )
+		);
+	if ( ! lastEditedText ) {
+		return null;
+	}
+	return (
+		<div className="editor-post-last-edited-panel">
+			<Text>{ lastEditedText }</Text>
+		</div>
+	);
+}

--- a/packages/editor/src/components/post-last-edited-panel/style.scss
+++ b/packages/editor/src/components/post-last-edited-panel/style.scss
@@ -1,0 +1,6 @@
+.editor-post-last-edited-panel {
+	color: $gray-700;
+	& .components-text {
+		color: inherit;
+	}
+}

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -1,6 +1,6 @@
 .editor-post-panel__row {
 	width: 100%;
-	min-height: $button-size-next-default-40px;
+	min-height: $grid-unit-40;
 	justify-content: flex-start !important;
 	align-items: flex-start !important;
 }
@@ -8,14 +8,14 @@
 .editor-post-panel__row-label {
 	width: 30%;
 	flex-shrink: 0;
-	min-height: $button-size-next-default-40px;
+	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
 }
 
 .editor-post-panel__row-control {
 	flex-grow: 1;
-	min-height: $button-size-next-default-40px;
+	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
 }

--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -62,7 +62,7 @@ export default function PostSchedulePanel() {
 					contentClassName="editor-post-schedule__dialog"
 					renderToggle={ ( { onToggle, isOpen } ) => (
 						<Button
-							__next40pxDefaultSize
+							size="compact"
 							className="editor-post-schedule__dialog-toggle"
 							variant="tertiary"
 							onClick={ onToggle }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -8,16 +8,3 @@
 		padding: $grid-unit-20;
 	}
 }
-
-.editor-post-schedule__dialog-toggle.components-button {
-	display: block;
-	max-width: 100%;
-	overflow: hidden;
-	text-align: left;
-	white-space: unset;
-	height: auto;
-
-	// The line height + the padding should be the same as the button size.
-	padding: math.div($button-size - $grid-unit-20, 2) 12px;
-	line-height: $grid-unit-20;
-}

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -8,3 +8,14 @@
 		padding: $grid-unit-20;
 	}
 }
+
+.editor-post-schedule__dialog-toggle.components-button {
+	overflow: hidden;
+	text-align: left;
+	white-space: unset;
+	height: auto;
+	min-height: $button-size-compact;
+
+	// The line height + the padding should be the same as the button size.
+	line-height: inherit;
+}

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -226,12 +226,7 @@ export default function PostStatus() {
 
 	return (
 		<PostPanelRow label={ __( 'Status' ) } ref={ setPopoverAnchor }>
-			{ ! canEdit && (
-				<div className="editor-post-status">
-					<PostStatusLabel />
-				</div>
-			) }
-			{ canEdit && (
+			{ canEdit ? (
 				<Dropdown
 					className="editor-post-status"
 					contentClassName="editor-change-status__content"
@@ -313,6 +308,10 @@ export default function PostStatus() {
 						</>
 					) }
 				/>
+			) : (
+				<div className="editor-post-status">
+					<PostStatusLabel />
+				</div>
 			) }
 		</PostPanelRow>
 	);

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -21,6 +21,7 @@ import { useState, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 import { useInstanceId } from '@wordpress/compose';
+import { Icon, chevronDownSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -31,8 +32,8 @@ import {
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
 } from '../../store/constants';
+import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
-import { Icon, chevronDownSmall } from '@wordpress/icons';
 
 function PostStatusLabel( { canEdit } ) {
 	const status = useSelect(
@@ -183,14 +184,6 @@ export default function PostStatus() {
 		return null;
 	}
 
-	if ( ! canEdit ) {
-		return (
-			<div className="editor-post-status">
-				<PostStatusLabel />
-			</div>
-		);
-	}
-
 	const updatePost = ( {
 		status: newStatus = status,
 		password: newPassword = password,
@@ -232,79 +225,95 @@ export default function PostStatus() {
 	};
 
 	return (
-		<Dropdown
-			className="editor-post-status"
-			contentClassName="editor-change-status__content"
-			popoverProps={ popoverProps }
-			focusOnMount
-			ref={ setPopoverAnchor }
-			renderToggle={ ( { onToggle } ) => (
-				<Button
-					className="editor-post-status-trigger"
-					onClick={ onToggle }
-				>
-					<PostStatusLabel canEdit={ canEdit } />
-				</Button>
+		<PostPanelRow label={ __( 'Status' ) } ref={ setPopoverAnchor }>
+			{ ! canEdit && (
+				<div className="editor-post-status">
+					<PostStatusLabel />
+				</div>
 			) }
-			renderContent={ ( { onClose } ) => (
-				<>
-					<InspectorPopoverHeader
-						title={ __( 'Status & visibility' ) }
-						onClose={ onClose }
-					/>
-					<form>
-						<VStack spacing={ 4 }>
-							<RadioControl
-								className="editor-change-status__options"
-								hideLabelFromVision
-								label={ __( 'Status' ) }
-								options={ STATUS_OPTIONS }
-								onChange={ handleStatus }
-								selected={
-									status === 'auto-draft' ? 'draft' : status
-								}
+			{ canEdit && (
+				<Dropdown
+					className="editor-post-status"
+					contentClassName="editor-change-status__content"
+					popoverProps={ popoverProps }
+					focusOnMount
+					renderToggle={ ( { onToggle } ) => (
+						<Button
+							className="editor-post-status-trigger"
+							onClick={ onToggle }
+						>
+							<PostStatusLabel canEdit={ canEdit } />
+						</Button>
+					) }
+					renderContent={ ( { onClose } ) => (
+						<>
+							<InspectorPopoverHeader
+								title={ __( 'Status & visibility' ) }
+								onClose={ onClose }
 							/>
-							{ status !== 'private' && (
-								<VStack
-									as="fieldset"
-									spacing={ 4 }
-									className="editor-change-status__password-fieldset"
-								>
-									<CheckboxControl
-										__nextHasNoMarginBottom
-										label={ __( 'Password protected' ) }
-										help={ __(
-											'Only visible to those who know the password'
-										) }
-										checked={ showPassword }
-										onChange={ handleTogglePassword }
+							<form>
+								<VStack spacing={ 4 }>
+									<RadioControl
+										className="editor-change-status__options"
+										hideLabelFromVision
+										label={ __( 'Status' ) }
+										options={ STATUS_OPTIONS }
+										onChange={ handleStatus }
+										selected={
+											status === 'auto-draft'
+												? 'draft'
+												: status
+										}
 									/>
-									{ showPassword && (
-										<div className="editor-change-status__password-input">
-											<TextControl
-												label={ __( 'Password' ) }
-												onChange={ ( value ) =>
-													updatePost( {
-														password: value,
-													} )
-												}
-												value={ password }
-												placeholder={ __(
-													'Use a secure password'
-												) }
-												type="text"
-												id={ passwordInputId }
-												__next40pxDefaultSize
+									{ status !== 'private' && (
+										<VStack
+											as="fieldset"
+											spacing={ 4 }
+											className="editor-change-status__password-fieldset"
+										>
+											<CheckboxControl
 												__nextHasNoMarginBottom
+												label={ __(
+													'Password protected'
+												) }
+												help={ __(
+													'Only visible to those who know the password'
+												) }
+												checked={ showPassword }
+												onChange={
+													handleTogglePassword
+												}
 											/>
-										</div>
+											{ showPassword && (
+												<div className="editor-change-status__password-input">
+													<TextControl
+														label={ __(
+															'Password'
+														) }
+														onChange={ ( value ) =>
+															updatePost( {
+																password: value,
+															} )
+														}
+														value={ password }
+														placeholder={ __(
+															'Use a secure password'
+														) }
+														type="text"
+														id={ passwordInputId }
+														__next40pxDefaultSize
+														__nextHasNoMarginBottom
+													/>
+												</div>
+											) }
+										</VStack>
 									) }
 								</VStack>
-							) }
-						</VStack>
-					</form>
-				</>
+							</form>
+						</>
+					) }
+				/>
 			) }
-		/>
+		</PostPanelRow>
 	);
 }

--- a/packages/editor/src/components/post-status/style.scss
+++ b/packages/editor/src/components/post-status/style.scss
@@ -1,6 +1,5 @@
 .editor-post-status {
 	max-width: 100%;
-	margin-bottom: $grid-unit-20;
 
 	.editor-post-status-trigger {
 		padding: 1px;

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -76,7 +76,7 @@ export default function BlockThemeControl( { id } ) {
 			popoverProps={ POPOVER_PROPS }
 			focusOnMount
 			toggleProps={ {
-				__next40pxDefaultSize: true,
+				size: 'compact',
 				variant: 'tertiary',
 			} }
 			label={ __( 'Template options' ) }

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -60,7 +60,7 @@ function PostURLToggle( { isOpen, onClick } ) {
 	const decodedSlug = safeDecodeURIComponent( slug );
 	return (
 		<Button
-			__next40pxDefaultSize
+			size="compact"
 			className="editor-post-url__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -32,6 +32,8 @@ import ViewMoreMenuGroup from './components/more-menu/view-more-menu-group';
 import { PrivatePostExcerptPanel } from './components/post-excerpt/panel';
 import PostPublishButtonOrToggle from './components/post-publish-button/post-publish-button-or-toggle';
 import SavePublishPanels from './components/save-publish-panels';
+import PostContentInformation from './components/post-content-information';
+import PostLastEditedPanel from './components/post-last-edited-panel';
 
 const { store: interfaceStore, ...remainingInterfaceApis } = interfaceApis;
 
@@ -60,6 +62,8 @@ lock( privateApis, {
 	PrivatePostExcerptPanel,
 	PostPublishButtonOrToggle,
 	SavePublishPanels,
+	PostContentInformation,
+	PostLastEditedPanel,
 
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.
 	useAutoSwitchEditorSidebars,

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -15,9 +15,11 @@
 @import "./components/post-author/style.scss";
 @import "./components/post-actions/style.scss";
 @import "./components/post-card-panel/style.scss";
+@import "./components/post-content-information/style.scss";
 @import "./components/post-excerpt/style.scss";
 @import "./components/post-featured-image/style.scss";
 @import "./components/post-format/style.scss";
+@import "./components/post-last-edited-panel/style.scss";
 @import "./components/post-last-revision/style.scss";
 @import "./components/post-locked-modal/style.scss";
 @import "./components/post-panel-row/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/59689

This PR moves around some components based on the updated designs shared [here](https://github.com/WordPress/gutenberg/issues/59689#issuecomment-2079407346).


<img width="1139" alt="Screenshot 2024-04-26 at 14 30 10" src="https://github.com/WordPress/gutenberg/assets/846565/73523fa9-82a6-4794-b00f-d8447d0b47bd">
<!-- In a few words, what is the PR actually doing? -->


### Notes
There will be a follow up for the PostExcerpt panel with the a11y concerns.

## Testing Instructions
1. In both editors test the wordcount, post status and last edited info's placement - according to the new designs.
2. The featured image placeholder is smaller
3. Templates, template parts and patterns should remain the same since we render some of these info in PostCard panel. 


#### Page with no image and no excerpt
Before               |  After
-----------------------------------------|-------------------------
<img width="505" alt="page before" src="https://github.com/WordPress/gutenberg/assets/16275880/cb78949b-97b9-49e2-af10-3df27c9b8877"> | <img width="505" alt="post editor page after no image" src="https://github.com/WordPress/gutenberg/assets/16275880/40f47731-2dbb-4520-a154-93404f487040">


#### Post with image and excerpt
Before               |  After
-----------------------------------------|-------------------------
 <img width="505" alt="post before" src="https://github.com/WordPress/gutenberg/assets/16275880/a4bad7a3-aa8a-466a-8b87-a59523a78d0f"> | <img width="505" alt="post editor post after" src="https://github.com/WordPress/gutenberg/assets/16275880/f7883e1d-ad11-4a73-958c-dbd5d9746051">
