### PR TITLE
Block Bindings: Simplify the HTML replacement logic until the HTML API is ready

### DIFF
--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -65,68 +65,22 @@ function gutenberg_block_bindings_replace_html( $block_content, $block_name, str
 	switch ( $block_type->attributes[ $attribute_name ]['source'] ) {
 		case 'html':
 		case 'rich-text':
-			$block_reader = new WP_HTML_Tag_Processor( $block_content );
-
-			// TODO: Support for CSS selectors whenever they are ready in the HTML API.
-			// In the meantime, support comma-separated selectors by exploding them into an array.
-			$selectors = explode( ',', $block_type->attributes[ $attribute_name ]['selector'] );
-			// Add a bookmark to the first tag to be able to iterate over the selectors.
-			$block_reader->next_tag();
-			$block_reader->set_bookmark( 'iterate-selectors' );
-
-			// TODO: This shouldn't be needed when the `set_inner_html` function is ready.
-			// Store the parent tag and its attributes to be able to restore them later in the button.
-			// The button block has a wrapper while the paragraph and heading blocks don't.
-			if ( 'core/button' === $block_name ) {
-				$button_wrapper                 = $block_reader->get_tag();
-				$button_wrapper_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
-				$button_wrapper_attrs           = array();
-				foreach ( $button_wrapper_attribute_names as $name ) {
-					$button_wrapper_attrs[ $name ] = $block_reader->get_attribute( $name );
-				}
+			// Hardcode the selectors and processing until the HTML API is able to read CSS selectors and replace inner HTML.
+			// TODO: Use the HTML API instead.
+			if ( 'core/paragraph' === $block_name && 'content' === $attribute_name ) {
+				$selector = 'p';
 			}
-
-			foreach ( $selectors as $selector ) {
-				// If the parent tag, or any of its children, matches the selector, replace the HTML.
-				if ( strcasecmp( $block_reader->get_tag( $selector ), $selector ) === 0 || $block_reader->next_tag(
-					array(
-						'tag_name' => $selector,
-					)
-				) ) {
-					$block_reader->release_bookmark( 'iterate-selectors' );
-
-					// TODO: Use `set_inner_html` method whenever it's ready in the HTML API.
-					// Until then, it is hardcoded for the paragraph, heading, and button blocks.
-					// Store the tag and its attributes to be able to restore them later.
-					$selector_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
-					$selector_attrs           = array();
-					foreach ( $selector_attribute_names as $name ) {
-						$selector_attrs[ $name ] = $block_reader->get_attribute( $name );
-					}
-					$selector_markup = "<$selector>" . wp_kses_post( $source_value ) . "</$selector>";
-					$amended_content = new WP_HTML_Tag_Processor( $selector_markup );
-					$amended_content->next_tag();
-					foreach ( $selector_attrs as $attribute_key => $attribute_value ) {
-						$amended_content->set_attribute( $attribute_key, $attribute_value );
-					}
-					if ( 'core/paragraph' === $block_name || 'core/heading' === $block_name ) {
-						return $amended_content->get_updated_html();
-					}
-					if ( 'core/button' === $block_name ) {
-						$button_markup  = "<$button_wrapper>{$amended_content->get_updated_html()}</$button_wrapper>";
-						$amended_button = new WP_HTML_Tag_Processor( $button_markup );
-						$amended_button->next_tag();
-						foreach ( $button_wrapper_attrs as $attribute_key => $attribute_value ) {
-							$amended_button->set_attribute( $attribute_key, $attribute_value );
-						}
-						return $amended_button->get_updated_html();
-					}
-				} else {
-					$block_reader->seek( 'iterate-selectors' );
-				}
+			if ( 'core/heading' === $block_name && 'content' === $attribute_name ) {
+				$selector = 'h[1-6]';
 			}
-			$block_reader->release_bookmark( 'iterate-selectors' );
-			return $block_content;
+			if ( 'core/button' === $block_name && 'text' === $attribute_name ) {
+				$selector = 'a';
+			}
+			if ( empty( $selector ) ) {
+				return $block_content;
+			}
+			$pattern = '/(<' . $selector . '[^>]*>).*?(<\/' . $selector . '>)/i';
+			return preg_replace( $pattern, '$1' . wp_kses_post( $source_value ) . '$2', $block_content );
 
 		case 'attribute':
 			$amended_content = new WP_HTML_Tag_Processor( $block_content );

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -74,7 +74,12 @@ function gutenberg_block_bindings_replace_html( $block_content, $block_name, str
 				$selector = 'h[1-6]';
 			}
 			if ( 'core/button' === $block_name && 'text' === $attribute_name ) {
-				$selector = 'a';
+				// Check if it is a <button> or <a> tag.
+				if ( preg_match( '/<button[^>]*>.*?<\/button>/', $block_content ) ) {
+					$selector = 'button';
+				} else {
+					$selector = 'a';
+				}
 			}
 			if ( empty( $selector ) ) {
 				return $block_content;


### PR DESCRIPTION
## What?
Change the block bindings HTML replacement logic to use a hardcoded list of selectors based on the block and a regex to substitute the inner content.

## Why?
The existing logic is too complex because the HTML API doesn't support CSS selectors yet and it doesn't have an official way to modify the inner HTML. This makes it difficult to understand, iterate on it and add new functionalities.

As it will be solved in the future once the HTML API is ready, I believe it is better to keep a simple hardcoded version that is easier to understand and iterate on.

## How?
* Change the selector based on the supported blocks.
* Using a regex, replace the inner content.

## Testing Instructions

0. Register a custom field in your site to test it. You can use a code snippet like this:
```
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

1. Go to a page and insert a paragraph block.
2. Go to the Code editor and connect the paragraph to the custom field by adding the metadata bindings property. It should look something like this:
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<p>Original content</p>
<!-- /wp:paragraph -->
```
3. Save the page and check that in the frontend, the text defined in the custom field is used.
4. Repeat the process for heading, and button blocks.
