### PR TITLE
editPost: __experimentalPluginPostExcerpt return `<PluginPostExcerpt />`

### DIFF
--- a/packages/edit-post/src/deprecated.js
+++ b/packages/edit-post/src/deprecated.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	privateApis as editorPrivateApis,
 	PluginBlockSettingsMenuItem as EditorPluginBlockSettingsMenuItem,
 	PluginDocumentSettingPanel as EditorPluginDocumentSettingPanel,
 	PluginMoreMenuItem as EditorPluginMoreMenuItem,
@@ -12,6 +13,12 @@ import {
 	PluginSidebarMoreMenuItem as EditorPluginSidebarMoreMenuItem,
 } from '@wordpress/editor';
 import deprecated from '@wordpress/deprecated';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from './lock-unlock';
+const { PluginPostExcerpt } = unlock( editorPrivateApis );
 
 const deprecateSlot = ( name ) => {
 	deprecated( `wp.editPost.${ name }`, {
@@ -94,7 +101,7 @@ export function __experimentalPluginPostExcerpt() {
 		hint: 'Core and custom panels can be access programmatically using their panel name.',
 		link: 'https://developer.wordpress.org/block-editor/reference-guides/slotfills/plugin-document-setting-panel/#accessing-a-panel-programmatically',
 	} );
-	return null;
+	return PluginPostExcerpt;
 }
 
 /* eslint-enable jsdoc/require-param */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

` __experimentalPluginPostExcerpt` return `< PluginPostExcerpt />`, instead of `no-op`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because of https://github.com/WordPress/gutenberg/issues/61219 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`__experimentalPluginPostExcerpt` returns `<PluginPostExcerpt />` instead of `null`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Edit/Create a new post
2. Open the dev console
3. Create an __experimentalPluginPostExcerpt instance

```es6
const instance = wp.editPost.__experimentalPluginPostExcerpt()
```

4. print the instance

```
console.dir( instance )
```

5. Confirm it's a `PluginPostExcerpt` instance

<img width="485" alt="image" src="https://github.com/WordPress/gutenberg/assets/77539/a4b4d269-a19a-4510-af20-acda8feac020">



## Screenshots or screencast <!-- if applicable -->
