### PR TITLE
Editor: Cleanup edit-post classnames and docs

### DIFF
--- a/docs/reference-guides/slotfills/plugin-post-publish-panel.md
+++ b/docs/reference-guides/slotfills/plugin-post-publish-panel.md
@@ -6,7 +6,7 @@ This slot allows for injecting items into the bottom of the post-publish panel t
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { PluginPostPublishPanel } from '@wordpress/editor';
 
 const PluginPostPublishPanelTest = () => (
 	<PluginPostPublishPanel>

--- a/docs/reference-guides/slotfills/plugin-pre-publish-panel.md
+++ b/docs/reference-guides/slotfills/plugin-pre-publish-panel.md
@@ -6,7 +6,7 @@ This slot allows for injecting items into the bottom of the pre-publish panel th
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/editor';
 
 const PluginPrePublishPanelTest = () => (
 	<PluginPrePublishPanel>

--- a/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
+++ b/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
@@ -11,9 +11,9 @@ import { blockDefault } from '@wordpress/icons';
 import CompactList from '../../components/compact-list';
 import { store as blockDirectoryStore } from '../../store';
 
-// We shouldn't import the edit-post package directly
-// because it would include the wp-edit-post in all pages loading the block-directory script.
-const { PluginPrePublishPanel } = window?.wp?.editPost ?? {};
+// We shouldn't import the editor package directly
+// because it would include the wp-editor in all pages loading the block-directory script.
+const { PluginPrePublishPanel } = window?.wp?.editor ?? {};
 
 export default function InstalledBlocksPrePublishPanel() {
 	const newBlockTypes = useSelect(

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -676,7 +676,7 @@ _Usage_
 ```jsx
 // Using ESNext syntax
 import { __ } from '@wordpress/i18n';
-import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { PluginPostPublishPanel } from '@wordpress/editor';
 
 const MyPluginPostPublishPanel = () => (
 	<PluginPostPublishPanel
@@ -755,7 +755,7 @@ _Usage_
 ```jsx
 // Using ESNext syntax
 import { __ } from '@wordpress/i18n';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/editor';
 
 const MyPluginPrePublishPanel = () => (
 	<PluginPrePublishPanel
@@ -822,7 +822,7 @@ function MyPluginSidebar() {
 // Using ESNext syntax
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { PluginSidebar } from '@wordpress/edit-post';
+import { PluginSidebar } from '@wordpress/editor';
 import { more } from '@wordpress/icons';
 
 const MyPluginSidebar = () => (

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -129,7 +129,7 @@ export default function ListViewSidebar() {
 				// can be rendered internally.
 				defaultTabId="list-view"
 			>
-				<div className="edit-post-editor__document-overview-panel__header">
+				<div className="editor-list-view-sidebar__header">
 					<Button
 						className="editor-list-view-sidebar__close-button"
 						icon={ closeSmall }

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -8,7 +8,7 @@
 		// @see packages/block-editor/src/components/inserter/style.scss
 		width: 350px;
 	}
-	.edit-post-editor__document-overview-panel__header {
+	.editor-list-view-sidebar__header {
 		display: flex;
 		border-bottom: $border-width solid $gray-300;
 	}

--- a/packages/editor/src/components/plugin-post-publish-panel/index.js
+++ b/packages/editor/src/components/plugin-post-publish-panel/index.js
@@ -21,7 +21,7 @@ const { Fill, Slot } = createSlotFill( 'PluginPostPublishPanel' );
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';
- * import { PluginPostPublishPanel } from '@wordpress/edit-post';
+ * import { PluginPostPublishPanel } from '@wordpress/editor';
  *
  * const MyPluginPostPublishPanel = () => (
  * 	<PluginPostPublishPanel

--- a/packages/editor/src/components/plugin-pre-publish-panel/index.js
+++ b/packages/editor/src/components/plugin-pre-publish-panel/index.js
@@ -24,7 +24,7 @@ const { Fill, Slot } = createSlotFill( 'PluginPrePublishPanel' );
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';
- * import { PluginPrePublishPanel } from '@wordpress/edit-post';
+ * import { PluginPrePublishPanel } from '@wordpress/editor';
  *
  * const MyPluginPrePublishPanel = () => (
  * 	<PluginPrePublishPanel

--- a/packages/editor/src/components/plugin-sidebar/index.js
+++ b/packages/editor/src/components/plugin-sidebar/index.js
@@ -60,7 +60,7 @@ import { store as editorStore } from '../../store';
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';
  * import { PanelBody } from '@wordpress/components';
- * import { PluginSidebar } from '@wordpress/edit-post';
+ * import { PluginSidebar } from '@wordpress/editor';
  * import { more } from '@wordpress/icons';
  *
  * const MyPluginSidebar = () => (

--- a/packages/editor/src/components/post-excerpt/plugin.js
+++ b/packages/editor/src/components/post-excerpt/plugin.js
@@ -20,7 +20,7 @@ const { Fill, Slot } = createSlotFill( 'PluginPostExcerpt' );
  * ```js
  * // Using ES5 syntax
  * var __ = wp.i18n.__;
- * var PluginPostExcerpt = wp.editPost.PluginPostExcerpt;
+ * var PluginPostExcerpt = wp.editPost.__experimentalPluginPostExcerpt;
  *
  * function MyPluginPostExcerpt() {
  * 	return React.createElement(
@@ -37,7 +37,7 @@ const { Fill, Slot } = createSlotFill( 'PluginPostExcerpt' );
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';
- * import { PluginPostExcerpt } from '@wordpress/edit-post';
+ * import { __experimentalPluginPostExcerpt as PluginPostExcerpt } from '@wordpress/editor';
  *
  * const MyPluginPostExcerpt = () => (
  * 	<PluginPostExcerpt className="my-plugin-post-excerpt">

--- a/packages/editor/src/components/post-excerpt/plugin.js
+++ b/packages/editor/src/components/post-excerpt/plugin.js
@@ -37,7 +37,7 @@ const { Fill, Slot } = createSlotFill( 'PluginPostExcerpt' );
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';
- * import { __experimentalPluginPostExcerpt as PluginPostExcerpt } from '@wordpress/editor';
+ * import { __experimentalPluginPostExcerpt as PluginPostExcerpt } from '@wordpress/edit-post';
  *
  * const MyPluginPostExcerpt = () => (
  * 	<PluginPostExcerpt className="my-plugin-post-excerpt">

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -45,7 +45,6 @@ function PostTemplateToggle( { isOpen, onClick } ) {
 	return (
 		<Button
 			__next40pxDefaultSize
-			className="edit-post-post-template__toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			aria-label={ __( 'Template options' ) }

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -1,4 +1,4 @@
-.edit-post-text-editor__body textarea.editor-post-text-editor {
+textarea.editor-post-text-editor {
 	border: $border-width solid $gray-600;
 	border-radius: 0;
 	display: block;

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -1,5 +1,5 @@
 // Raw Text Variant
-.edit-post-text-editor__body .editor-post-title.is-raw-text {
+.editor-post-title.is-raw-text {
 	margin-bottom: $grid-unit-30;
 	margin-top: 2px; // space for focus outline to appear.
 	max-width: none;


### PR DESCRIPTION
## What?

As we're aligning post and site editors, we're moving a lot of code from edit-post to editor, which means the chance of small leftovers is high: classnames not renamed properly, still using old edit-post imports...

This PR updates the editor package to cleanup these things.

## Testing Instructions

There should be no style or functional change. (One thing to test could be the code editor styles)