### PR TITLE
Interactivity API: Prevent wrong written directives from killing the runtime

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on/render.php
@@ -6,13 +6,13 @@
  */
 ?>
 
-<div data-wp-interactive="directive-on">
+<?php // A wrong directive name like "data-wp-on--" should not kill the interactivity. ?>
+<div data-wp-interactive="directive-on" data-wp-on--="">
 	<div>
 		<p data-wp-text="state.counter" data-testid="counter">0</p>
 		<button
 			data-testid="button"
 			data-wp-on--click="actions.clickHandler"
-			data-wp-on--=""
 		>Click me!</button>
 	</div>
 	<div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on/render.php
@@ -12,6 +12,7 @@
 		<button
 			data-testid="button"
 			data-wp-on--click="actions.clickHandler"
+			data-wp-on--=""
 		>Click me!</button>
 	</div>
 	<div>

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 -   Hooks useMemo and useCallback should return a value. ([#60474](https://github.com/WordPress/gutenberg/pull/60474))
 
+-	Prevent wrong written directives from killing the runtime ([#61249](https://github.com/WordPress/gutenberg/pull/61249))
+
 ## 5.4.0 (2024-04-03)
 
 ## 5.3.0 (2024-03-21)

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -	Allow multiple event handlers for the same type with `data-wp-on-document` and `data-wp-on-window`. ([#61009](https://github.com/WordPress/gutenberg/pull/61009))
 
+-	Prevent wrong written directives from killing the runtime ([#61249](https://github.com/WordPress/gutenberg/pull/61249))
+
 ## 5.6.0 (2024-05-02)
 
 ## 5.5.0 (2024-04-19)
@@ -17,8 +19,6 @@
 ### Bug Fixes
 
 -   Hooks useMemo and useCallback should return a value. ([#60474](https://github.com/WordPress/gutenberg/pull/60474))
-
--	Prevent wrong written directives from killing the runtime ([#61249](https://github.com/WordPress/gutenberg/pull/61249))
 
 ## 5.4.0 (2024-04-03)
 

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -125,17 +125,18 @@ export function toVdom( root ) {
 							? directiveMatch[ 2 ]
 							: 'default';
 
-					if (
-						! directiveMatch &&
-						// @ts-expect-error This is a debug-only warning.
-						typeof SCRIPT_DEBUG !== 'undefined' &&
-						// @ts-expect-error
-						SCRIPT_DEBUG === true
-					) {
-						// eslint-disable-next-line no-console
-						console.warn( `Invalid directive: ${ name }.` );
+					if ( ! directiveMatch ) {
+						if (
+							// @ts-expect-error This is a debug-only warning.
+							typeof SCRIPT_DEBUG !== 'undefined' &&
+							// @ts-expect-error
+							SCRIPT_DEBUG === true
+						) {
+							// eslint-disable-next-line no-console
+							console.warn( `Invalid directive: ${ name }.` );
+						}
+						return obj;
 					}
-
 					obj[ prefix ] = obj[ prefix ] || [];
 					obj[ prefix ].push( {
 						namespace: ns ?? currentNamespace(),

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -119,17 +119,11 @@ export function toVdom( root ) {
 			props.__directives = directives.reduce(
 				( obj, [ name, ns, value ] ) => {
 					const directiveMatch = directiveParser.exec( name );
-					const prefix = directiveMatch ? directiveMatch[ 1 ] : '';
-					const suffix =
-						directiveMatch && directiveMatch[ 2 ]
-							? directiveMatch[ 2 ]
-							: 'default';
-
 					if ( ! directiveMatch ) {
 						if (
 							// @ts-expect-error This is a debug-only warning.
 							typeof SCRIPT_DEBUG !== 'undefined' &&
-							// @ts-expect-error
+							// @ts-expect-error This is a debug-only warning.
 							SCRIPT_DEBUG === true
 						) {
 							// eslint-disable-next-line no-console
@@ -137,6 +131,9 @@ export function toVdom( root ) {
 						}
 						return obj;
 					}
+					const prefix = directiveMatch[ 1 ] || '';
+					const suffix = directiveMatch[ 2 ] || 'default';
+
 					obj[ prefix ] = obj[ prefix ] || [];
 					obj[ prefix ].push( {
 						namespace: ns ?? currentNamespace(),

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -119,7 +119,7 @@ export function toVdom( root ) {
 			props.__directives = directives.reduce(
 				( obj, [ name, ns, value ] ) => {
 					const directiveMatch = directiveParser.exec( name );
-					if ( ! directiveMatch ) {
+					if ( directiveMatch === null ) {
 						if (
 							// @ts-expect-error This is a debug-only warning.
 							typeof SCRIPT_DEBUG !== 'undefined' &&

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -142,7 +142,6 @@ export function toVdom( root ) {
 						value,
 						suffix,
 					} );
-
 					return obj;
 				},
 				{}

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -118,8 +118,22 @@ export function toVdom( root ) {
 		if ( directives.length ) {
 			props.__directives = directives.reduce(
 				( obj, [ name, ns, value ] ) => {
-					const [ , prefix, suffix = 'default' ] =
-						directiveParser.exec( name );
+					let [ prefix, suffix ] = [ '', 'default' ];
+
+					const directiveMatch = directiveParser.exec( name );
+					if ( directiveMatch ) {
+						const [ , _prefix, _suffix ] = directiveMatch;
+						prefix = _prefix;
+						suffix = _suffix ?? 'default';
+					} else if (
+						// @ts-expect-error
+						typeof SCRIPT_DEBUG !== 'undefined' &&
+						// @ts-expect-error
+						SCRIPT_DEBUG === true
+					) {
+						// eslint-disable-next-line no-console
+						console.warn( `Invalid directive: ${ name }.` );
+					}
 					if ( ! obj[ prefix ] ) {
 						obj[ prefix ] = [];
 					}

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -118,15 +118,16 @@ export function toVdom( root ) {
 		if ( directives.length ) {
 			props.__directives = directives.reduce(
 				( obj, [ name, ns, value ] ) => {
-					let [ prefix, suffix ] = [ '', 'default' ];
-
 					const directiveMatch = directiveParser.exec( name );
-					if ( directiveMatch ) {
-						const [ , _prefix, _suffix ] = directiveMatch;
-						prefix = _prefix;
-						suffix = _suffix ?? 'default';
-					} else if (
-						// @ts-expect-error
+					const prefix = directiveMatch ? directiveMatch[ 1 ] : '';
+					const suffix =
+						directiveMatch && directiveMatch[ 2 ]
+							? directiveMatch[ 2 ]
+							: 'default';
+
+					if (
+						! directiveMatch &&
+						// @ts-expect-error This is a debug-only warning.
 						typeof SCRIPT_DEBUG !== 'undefined' &&
 						// @ts-expect-error
 						SCRIPT_DEBUG === true
@@ -134,14 +135,14 @@ export function toVdom( root ) {
 						// eslint-disable-next-line no-console
 						console.warn( `Invalid directive: ${ name }.` );
 					}
-					if ( ! obj[ prefix ] ) {
-						obj[ prefix ] = [];
-					}
+
+					obj[ prefix ] = obj[ prefix ] || [];
 					obj[ prefix ].push( {
 						namespace: ns ?? currentNamespace(),
 						value,
 						suffix,
 					} );
+
 					return obj;
 				},
 				{}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent wrong written directives killing the runtime of the Interactivity API.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A directive like `data-wp-on-window--` can kill the runtime process in the Interactivity API.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Refactored the code that gets the directives and parse them.

## Testing Instructions
1) Create an Interactive block with a wrong directive like `data-wp-on-document--`
2) Check that the rest of directives are processed.

## Screenshots or screencast <!-- if applicable -->

Before:
![Screenshot 2024-04-29 at 18 01 14](https://github.com/WordPress/gutenberg/assets/37012961/d7cf2ffd-fc73-4354-ba57-1a454369bad5)

After:

![Screenshot 2024-04-30 at 18 50 19](https://github.com/WordPress/gutenberg/assets/37012961/978e3e80-9048-43a7-bff9-189ed574cb6b)
