### PR TITLE
Make pattern preview click area larger

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -339,6 +339,7 @@
 			height: 100%;
 			box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);
 			border-radius: $grid-unit-05;
+			pointer-events: none;
 		}
 	}
 

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -50,15 +50,4 @@
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 	}
-
-	// Make the button targetable for clicks
-	&::after {
-		content: "";
-		height: 100%;
-		left: 0;
-		position: absolute;
-		top: 0;
-		width: 100%;
-		z-index: 1;
-	}
 }


### PR DESCRIPTION
## What
Make the full pattern preview thumbnail clickable so that it's easier to select smaller patterns

## Why?
Fix a regression in https://github.com/WordPress/gutenberg/pull/61159.


### Before

https://github.com/WordPress/gutenberg/assets/846565/e6258322-67fa-437f-908f-ac27d8fc2f04



### After

https://github.com/WordPress/gutenberg/assets/846565/de5cf668-07c4-4e54-8b28-7cd4d0ba6042


## To test
1. Navigate to 'My Patterns' in the Site Editor
2. Notice that you can click anywhere in the thumbnail to go and edit the pattern