### PR TITLE
Add clarification about importing css/scss files

### DIFF
--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -138,13 +138,16 @@ And a `style.css` file to load on the frontend:
 
 The files will automatically be enqueued when specified in the block.json.
 
-You will still need to import your stylesheet within your corresponding JavaSript file in order for `@wordpress/scripts` to process the stylesheet.
+<div class="callout callout-info">
+
+If you are using `@wordpress/scripts` you will need to import your stylesheet within your corresponding JavaSript file in order for `@wordpress/scripts` to process the stylesheet.
 
 Example:
 
 - In `edit.js` you would place `import './editor.scss';`
 - In `index.js` you would place `import './style.scss';`
 - In `view.js` you would place `import './view.scss';` (interactive block template)
+</div>
 
 **Note:** If you have multiple files to include, you can use standard `wp_enqueue_style` functions like any other plugin or theme. You will want to use the following hooks for the block editor:
 

--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -138,6 +138,14 @@ And a `style.css` file to load on the frontend:
 
 The files will automatically be enqueued when specified in the block.json.
 
+You will still need to import your stylesheet within your corresponding JavaSript file in order for `@wordpress/scripts` to process the stylesheet.
+
+Example:
+
+- In `edit.js` you would place `import './editor.scss';`
+- In `index.js` you would place `import './style.scss';`
+- In `view.js` you would place `import './view.scss';` (interactive block template)
+
 **Note:** If you have multiple files to include, you can use standard `wp_enqueue_style` functions like any other plugin or theme. You will want to use the following hooks for the block editor:
 
 -   `enqueue_block_editor_assets` - to load only in editor view

--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -140,7 +140,7 @@ The files will automatically be enqueued when specified in the block.json.
 
 <div class="callout callout-info">
 
-If you are using `@wordpress/scripts` you will need to import your stylesheet within your corresponding JavaSript file in order for `@wordpress/scripts` to process the stylesheet.
+If you are using `@wordpress/scripts` you will need to import your stylesheet within your corresponding JavaScript file in order for `@wordpress/scripts` to process the stylesheet.
 
 Example:
 


### PR DESCRIPTION
## What?
Additional clarification in [Block Editor Handbook](https://developer.wordpress.org/block-editor/) / [How-to Guides](https://developer.wordpress.org/block-editor/how-to-guides/) / [Blocks](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/) / [Use styles and stylesheets](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/applying-styles-with-stylesheets/) to remind folks that they will need to `import './editor.scss'` in their `edit.js`, etc. 

I've forgotten and missed this rather obvious detail a few times. Also, I requested clarification on this yesterday, which inspired the follow up PR: https://github.com/WordPress/gutenberg/issues/54491#issuecomment-2084753998

## Why?
Trying to empower folks to understand and use standard approaches.

## How?
Clarification in documentation

Preview changes here: https://github.com/WordPress/gutenberg/pull/61252/files#diff-5fa0fb78d92f47c4d5770f668b186c3c3ea593e5fdb2d2b2a8ce3d2f2c775c03

