### PR TITLE
Remove `Button` component from social link block, replace with `button` element

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -158,7 +158,7 @@ const SocialLinkEdit = ( {
 				/>
 			</InspectorControls>
 			<li { ...blockProps }>
-				<Button
+				<button
 					className="wp-block-social-link-anchor"
 					ref={ setPopoverAnchor }
 					onClick={ () => setPopover( true ) }
@@ -171,7 +171,7 @@ const SocialLinkEdit = ( {
 					>
 						{ socialLinkText }
 					</span>
-				</Button>
+				</button>
 				{ isSelected && showURLPopover && (
 					<SocialLinkURLPopover
 						url={ url }

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -20,6 +20,15 @@
 
 	// This rule is duplicated from the style.scss and needs to be the same as there.
 	padding: 0.25em;
+
+	// Focus styles replicate the `@wordpress/components` button component.
+	&:focus:not(:disabled) {
+		border-radius: 2px;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 3px solid transparent;
+	}
 }
 
 .wp-block-social-links.is-style-pill-shape .wp-social-link button {

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -1,20 +1,25 @@
-// The editor uses the button component, the frontend uses a link.
-// Therefore we unstyle the button component to make it more like the frontend.
 .wp-block-social-links .wp-social-link {
 	line-height: 0;
+}
 
-	button {
-		font-size: inherit;
-		color: currentColor;
-		height: auto;
-		line-height: 0;
+// The editor uses the button element, the frontend uses a link.
+// Therefore we unstyle the button element to make it more like the frontend.
+.wp-block-social-link-anchor {
+	align-items: center;
+	background: none;
+	border: 0;
+	box-sizing: border-box;
+	cursor: pointer;
+	display: inline-flex;
+	font-size: inherit;
+	color: currentColor;
+	height: auto;
 
-		// This rule ensures social link buttons display correctly in template parts.
-		opacity: 1;
+	// This rule ensures social link buttons display correctly in template parts.
+	opacity: 1;
 
-		// This rule is duplicated from the style.scss and needs to be the same as there.
-		padding: 0.25em;
-	}
+	// This rule is duplicated from the style.scss and needs to be the same as there.
+	padding: 0.25em;
 }
 
 .wp-block-social-links.is-style-pill-shape .wp-social-link button {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #61269

See https://github.com/WordPress/gutenberg/pull/61032#issuecomment-2087867699 for some background. This PR ties in to the work to improve the block variation styles feature as a means to achieving section styles. That work requires block specificity to be as low as possible, which this change helps with.

The social link block is currently using the `@wordpress/components` `Button` component for its in canvas UI.

This PR replaces it with the standard `button` element while keeping the same styles.

## Why?
There are a few reasons why using the `Button` component isn't a great idea for the editor canvas:
- Third parties can incorrectly target the `components-button` class name - this is the reason why a dev note will be needed for this PR.
- There's less control over the specificity of styles that `@wordpress/components` components have, whereas for blocks we need to keep the specificity as low as possible so that extenders have a comfortable time implementing styles.
- The CSS variables used by a `@wordpress/components` component are not available in the editor canvas iframe, so this could mean breakage in the future.
- The styles added to the social link block contravene the BEM and block styling guidelines.
- If `@wordpress/components` ever changes to a different visual style or has a refactor it could break the block
- I'm also not sure how well emotion styles will work in the canvas.

## How?
Use a normal `<button>` element. Some styles from the components package need to be replicated in the block, but this is fairly minimal.

## Testing Instructions
1. Insert the social links block
2. Add some social links
3. Try different styles
4. Everything should look the same as `trunk` in the editor