### PR TITLE
Remove default entry into Navigation Menu focus mode but retain ability to access via "Edit"

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -148,8 +148,20 @@ export default function useLayoutAreas() {
 
 	// Navigation
 	if ( path === '/navigation' ) {
+		if ( postId ) {
+			return {
+				key: 'navigation',
+				areas: {
+					sidebar: <SidebarNavigationScreenNavigationMenu />,
+					preview: <Editor isLoading={ isSiteEditorLoading } />,
+					mobile: canvas === 'edit' && (
+						<Editor isLoading={ isSiteEditorLoading } />
+					),
+				},
+			};
+		}
 		return {
-			key: 'styles',
+			key: 'navigation',
 			areas: {
 				sidebar: <SidebarNavigationScreenNavigationMenus />,
 				preview: <Editor isLoading={ isSiteEditorLoading } />,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -86,6 +86,7 @@ export default function SidebarNavigationScreenNavigationMenu() {
 			<SidebarNavigationScreenWrapper
 				actions={
 					<ScreenNavigationMoreMenu
+						menuId={ navigationMenu?.id }
 						menuTitle={ decodeEntities( menuTitle ) }
 						onDelete={ _handleDelete }
 						onSave={ _handleSave }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -5,23 +5,29 @@ import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
  */
 import RenameModal from './rename-modal';
 import DeleteConfirmDialog from './delete-confirm-dialog';
+import { unlock } from '../../lock-unlock';
+
+const { useHistory } = unlock( routerPrivateApis );
 
 const POPOVER_PROPS = {
 	position: 'bottom right',
 };
 
 export default function ScreenNavigationMoreMenu( props ) {
-	const { onDelete, onSave, onDuplicate, menuTitle } = props;
+	const { onDelete, onSave, onDuplicate, menuTitle, menuId } = props;
 
 	const [ renameModalOpen, setRenameModalOpen ] = useState( false );
 	const [ deleteConfirmDialogOpen, setDeleteConfirmDialogOpen ] =
 		useState( false );
+
+	const history = useHistory();
 
 	const closeModals = () => {
 		setRenameModalOpen( false );
@@ -49,6 +55,17 @@ export default function ScreenNavigationMoreMenu( props ) {
 								} }
 							>
 								{ __( 'Rename' ) }
+							</MenuItem>
+							<MenuItem
+								onClick={ () => {
+									history.push( {
+										postId: menuId,
+										postType: 'wp_navigation',
+										canvas: 'edit',
+									} );
+								} }
+							>
+								{ __( 'Edit' ) }
 							</MenuItem>
 							<MenuItem
 								onClick={ () => {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -24,6 +24,7 @@ export default function SingleNavigationMenu( {
 			actions={
 				<>
 					<ScreenNavigationMoreMenu
+						menuId={ navigationMenu?.id }
 						menuTitle={ decodeEntities( menuTitle ) }
 						onDelete={ handleDelete }
 						onSave={ handleSave }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -152,7 +152,7 @@ export function SidebarNavigationScreenWrapper( {
 const NavMenuItem = ( { postId, ...props } ) => {
 	const linkInfo = useLink( {
 		postId,
-		postType: NAVIGATION_POST_TYPE,
+		path: '/navigation',
 	} );
 	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
 };

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -33,6 +33,13 @@ import { SidebarNavigationContext } from '../sidebar';
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 function getBackPath( params ) {
+	// Navigation Menus are not currently part of a data view.
+	// Therefore when navigating back from a navigation menu
+	// the target path is the navigation listing view.
+	if ( params.path === '/navigation' && params.postId ) {
+		return { path: '/navigation' };
+	}
+
 	// From a data view path we navigate back to root
 	if ( params.path ) {
 		return {};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the _default_ behaviour of navigating to the navigation focus mode editor when clicking on a single Navigation Menu in the "Site Hub" (left hand black sidebar). Instead remains showing the full editor canvas.

Retains the ability to access the navigation menu focus mode via a new `Edit` option to the Navigation Menu's options.

This PR is an alternative to https://github.com/WordPress/gutenberg/pull/59340. I did try to work on that PR but it had diverged from `trunk` and so - having confirmed with @draganescu - it made sense to start afresh.

Co-authored-by: Andrei Draganescu <107534+draganescu@users.noreply.github.com>
Co-authored-by: Rich Tabor <1813435+richtabor@users.noreply.github.com>




## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

During the discussion in https://github.com/WordPress/gutenberg/pull/59340 contributors raised valid concerns regarding the utility of the focused navigation menu edit mode. Principally some contributors utilise this to edit menus which are not currently used within a Template (which incidentally is _exactly_ why it exists!).

Therefore this PR does not remove the ability to edit a Navigation Menu in the focused editor mode, but rather deprioritises it in the default UX of interacting with `Navigation` in the Site Hub sidebar.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Now when clicking on a single Navigation Menu you are shown the details of that menu in the siderbar but the editor canvas does not enter "focus mode". This avoids the confusion that has been associated with this view which is really aimed at more advanced use cases.

The ability to access the Navigation Menu in focus mode is retained via the addition of an `Edit` link in the Navigation Menu's options menu. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Create a single Navigation
- Click through to that Navigation
- Check it doesn't enter focus mode.
- Use the dropdown to find the `Edit` option.
- Check it _does_ enter focus mode.
- Use the back buttons to confirm behaviour is as expected when navigating between views.
- Now duplicate the existing Navigation Menu and repeat the above steps.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/e293a6fa-94cf-4832-afac-693ad811f3b5



