### PR TITLE
Persist busy state on hover

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `View`: Fix prop types ([#60919](https://github.com/WordPress/gutenberg/pull/60919)).
 -   `Placeholder`: Unify appearance across. ([#59275](https://github.com/WordPress/gutenberg/pull/59275)).
 -   `Toolbar`: Adjust top toolbar to use same metrics as block toolbar ([#61126](https://github.com/WordPress/gutenberg/pull/61126)).
+-   `Button`: Ensure busy styles are visible on hover ([#61276](https://github.com/WordPress/gutenberg/pull/61276)).
 
 ### Bug Fix
 

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -174,7 +174,7 @@ export function UnforwardedButton(
 	const anchorProps: ComponentPropsWithoutRef< 'a' > =
 		Tag === 'a' ? { href, target } : {};
 
-	if ( disabled && isFocusable ) {
+	if ( ( disabled && isFocusable ) || isBusy ) {
 		// In this case, the button will be disabled, but still focusable and
 		// perceivable by screen reader users.
 		buttonProps[ 'aria-disabled' ] = true;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -56,7 +56,7 @@
 		// Show the boundary of the button, in High Contrast Mode.
 		outline: 1px solid transparent;
 
-		&:hover:not(:disabled):not(.is-busy) {
+		&:hover:not(:disabled) {
 			background: $components-color-accent-darker-10;
 			color: $components-color-accent-inverted;
 		}
@@ -75,7 +75,7 @@
 		&:disabled:active:enabled,
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
-		&[aria-disabled="true"]:active:enabled {
+		&[aria-disabled="true"]:active:enabled:not(.is-busy) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			color: rgba($white, 0.4);
 			background: $components-color-accent;
@@ -121,12 +121,16 @@
 		}
 
 		&:disabled,
-		&[aria-disabled="true"],
-		&[aria-disabled="true"]:hover {
-			color: $gray-600;
+		&[aria-disabled="true"]:not(.is-busy),
+		&[aria-disabled="true"]:hover:not(.is-busy) {
 			background: transparent;
 			transform: none;
 			opacity: 1;
+		}
+
+		&[aria-disabled="true"],
+		&[aria-disabled="true"]:hover {
+			color: $gray-600;
 		}
 	}
 
@@ -161,7 +165,7 @@
 		color: $components-color-accent;
 		background: transparent;
 
-		&:hover:not(:disabled, [aria-disabled="true"]):not(.is-busy) {
+		&:hover:not(:disabled, [aria-disabled="true"]) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -56,7 +56,7 @@
 		// Show the boundary of the button, in High Contrast Mode.
 		outline: 1px solid transparent;
 
-		&:hover:not(:disabled) {
+		&:hover:not(:disabled):not(.is-busy) {
 			background: $components-color-accent-darker-10;
 			color: $components-color-accent-inverted;
 		}
@@ -161,7 +161,7 @@
 		color: $components-color-accent;
 		background: transparent;
 
-		&:hover:not(:disabled, [aria-disabled="true"]) {
+		&:hover:not(:disabled, [aria-disabled="true"]):not(.is-busy) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);


### PR DESCRIPTION
This came up in https://github.com/WordPress/gutenberg/pull/59714.

## What?
Ensure 'busy' styling remains visible when hovering busy buttons.

## Why?
When clicking a button involves immediately invoking the busy state, you cannot currently see that the button is busy because the hover styles override the busy styles:

https://github.com/WordPress/gutenberg/assets/846565/1a986723-2605-4c57-b245-be38c90d0041

## How?
Do not apply hover styles when the button `is-busy`:



https://github.com/WordPress/gutenberg/assets/846565/13386325-ff9d-416b-b9a3-f1f602707046




## Testing Instructions
1. `npm run storybook:dev`
2. Navigate to the Button component
3. Toggle on the `busy` prop
4. Mouse over (or focus) the button preview and observe the animation persists
5. Check all button variants

## Sidenote
Should busy buttons still show the `pointer` cursor on hover? That seems a bit unexpected to me. 
