### PR TITLE
Fix: Remove color styles from typography variation controls - #61217

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview-iframe.js
+++ b/packages/edit-site/src/components/global-styles/preview-iframe.js
@@ -38,6 +38,7 @@ export default function PreviewIframe( {
 	label,
 	isFocused,
 	withHoverView,
+	addGlobalStyles = true,
 } ) {
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
@@ -129,7 +130,10 @@ export default function PreviewIframe( {
 						style={ {
 							height: normalizedHeight * ratio,
 							width: '100%',
-							background: gradientValue ?? backgroundColor,
+							color: addGlobalStyles ? undefined : '#000',
+							background: addGlobalStyles
+								? gradientValue ?? backgroundColor
+								: '#fff',
 							cursor: withHoverView ? 'pointer' : undefined,
 						} }
 						initial="start"

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -31,7 +31,10 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen">
 				<VStack spacing={ 7 }>
-					<TypographyVariations title={ __( 'Presets' ) } />
+					<TypographyVariations
+						addGlobalStyles={ false }
+						title={ __( 'Presets' ) }
+					/>
 					{ ! window.__experimentalDisableFontLibrary &&
 						fontLibraryEnabled && <FontFamilies /> }
 					<TypographyElements />

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -16,7 +16,11 @@ import PreviewIframe from '../preview-iframe';
 import Variation from './variation';
 import Subtitle from '../subtitle';
 
-export default function TypographyVariations( { title, gap = 2 } ) {
+export default function TypographyVariations( {
+	title,
+	gap = 2,
+	addGlobalStyles = false,
+} ) {
 	const typographyVariations = useTypographyVariations();
 
 	if ( ! typographyVariations?.length ) {
@@ -37,6 +41,7 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 						<Variation key={ index } variation={ variation }>
 							{ ( isFocused ) => (
 								<PreviewIframe
+									addGlobalStyles={ addGlobalStyles }
 									label={ variation?.title }
 									isFocused={ isFocused }
 								>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -94,6 +94,7 @@ function SidebarNavigationScreenGlobalStylesContent() {
 				) }
 				{ typographyVariations?.length && (
 					<TypographyVariations
+						addGlobalStyles
 						title={ __( 'Typography' ) }
 						gap={ gap }
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - https://github.com/WordPress/gutenberg/issues/61217

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- This would remove the global style colors being added to the typography variation in the style's editor page.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR adds the extra props `addGlobalStyles`, if this is passed as false, it would not add the style to the iframe preview.
- This is necessary because, the same component reused at multiple instance, hence in order to not make effect to other place, such as the style variations we need to pass it as a prop and do action based on the prop provided.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Checkout to this branch.
2. Run the NPM run build process.
3. Open the site → editor → styles → typography.
4. You would see that, the typography options have now natural black and white color combination, and it would be the same for each of the style variations.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NIL

## Screenshots or screencast <!-- if applicable -->

[GB Issue- 61217.webm](https://github.com/WordPress/gutenberg/assets/58802366/ce8b8ea3-a8d7-456b-823c-f2c942c27e6c)
