### PR TITLE
Use `math.div` for scss division

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -117,12 +117,12 @@
 
 	&.is-left {
 		// Subtract half of the handle width to properly center.
-		left: -$grid-unit-20 - ($grid-unit-05 / 2);
+		left: -$grid-unit-20 - math.div($grid-unit-05, 2);
 	}
 
 	&.is-right {
 		// Subtract half of the handle width to properly center.
-		right: -$grid-unit-20 - ($grid-unit-05 / 2);
+		right: -$grid-unit-20 - math.div($grid-unit-05, 2);
 	}
 
 	&:hover,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As @t-hamano mentioned [here](https://github.com/WordPress/gutenberg/pull/60712#discussion_r1586198576), we should use `math.div` for scss divisions in order to avoid warnings while building.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To avoid future deprecation warnings while building.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replacing the css division with `math.div`