### PR TITLE
Fix block tab spacing when few available blocks

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -136,11 +136,6 @@ $block-inserter-tabs-height: 44px;
 		flex-direction: column;
 		overflow-y: auto;
 	}
-
-	// The first tab panel needs space-between to prevent a flash of the "hint" from appearing at the top then moving down.
-	.block-editor-inserter__tablist + .block-editor-inserter__tabpanel {
-		justify-content: space-between;
-	}
 }
 
 .block-editor-inserter__no-tab-container {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Follow-up to https://github.com/WordPress/gutenberg/pull/61108

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It caused a regression for the design when there are few blocks and also when searching for blocks.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes justify-content: center from tab panel. 
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Click list block
- Open inserter


## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2024-05-01 at 14 45 57](https://github.com/WordPress/gutenberg/assets/1813435/15da6fd4-4895-4c38-aa09-58dacc90a050)


**After**
<img width="355" alt="Screenshot 2024-05-01 at 2 16 44 PM" src="https://github.com/WordPress/gutenberg/assets/967608/771023c0-1f71-460f-ad71-be29a64f48f5">