### PR TITLE
Background image: tools panel shouldn't show reset button for inherited values

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -275,9 +275,7 @@ function BackgroundImageToolsPanelItem( {
 		};
 	}, [] );
 
-	const hasValue =
-		hasBackgroundImageValue( style ) ||
-		hasBackgroundImageValue( inheritedValue );
+	const hasValue = hasBackgroundImageValue( style );
 
 	return (
 		<ToolsPanelItem


### PR DESCRIPTION

## What?

Ensure that the tools panel doesn't show a reset button for site background images defined by theme.json.

| Before  | After |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-05-02 at 2 45 12 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/f43f1609-7207-4e39-af94-5291d0300898">  | <img width="300" alt="Screenshot 2024-05-02 at 2 43 53 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/f9adbfa5-ca3b-4249-9f35-b667b5721c26"> |

Props to @tellthemachines for spotting it!

See https://github.com/WordPress/gutenberg/pull/61271#pullrequestreview-2034697563

## Why?

Because site background images defined by theme.json can't "reset" in the site editor.

## How?

Only tell the tools panel that it has a value when there are styles that are not inherited from theme.json

## Testing Instructions

Here is some test theme.json I prepared earlier.

```json

{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "https://images.pexels.com/photos/22484288/pexels-photo-22484288/free-photo-of-the-circular-stone-terraces-of-the-inca-ruins.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
				"source": "file"
			}
		}
	}
}

```

1. Head over to the Site Editor, open Global Styles > Background Image
2. Check that your theme.json-defined background image appears in the preview.
3. Ensure that you don't have the option to reset the background image
4. Replace with one of your own. You can reset this one still I hope!


https://github.com/WordPress/gutenberg/assets/6458278/155d7fba-3c6b-4885-be8a-95ebef3704b6










