### PR TITLE
Theme.json: update schema with working create theme link

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -4,7 +4,7 @@
 	"definitions": {
 		"//": {
 			"explainer": "https://developer.wordpress.org/themes/advanced-topics/theme-json/",
-			"createTheme": "https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/",
+			"createTheme": "https://developer.wordpress.org/themes/",
 			"reference": "https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/"
 		},
 		"refComplete": {


### PR DESCRIPTION


Fixes https://github.com/WordPress/gutenberg/issues/61282

Updates theme.json schema doc with working create theme documentation link. The current one returns a 404.

Old one: https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/

New one: https://developer.wordpress.org/themes/


