### PR TITLE
DataView: only reset page if search has actually changed

### DIFF
--- a/packages/dataviews/src/search.js
+++ b/packages/dataviews/src/search.js
@@ -25,7 +25,7 @@ const Search = memo( function Search( { label, view, onChangeView } ) {
 				search: debouncedSearch,
 			} );
 		}
-	}, [ debouncedSearch ] );
+	}, [ debouncedSearch, view ] );
 	const searchLabel = label || __( 'Search' );
 	return (
 		<SearchControl

--- a/packages/dataviews/src/search.js
+++ b/packages/dataviews/src/search.js
@@ -18,11 +18,13 @@ const Search = memo( function Search( { label, view, onChangeView } ) {
 		onChangeViewRef.current = onChangeView;
 	}, [ onChangeView ] );
 	useEffect( () => {
-		onChangeViewRef.current( {
-			...view,
-			page: 1,
-			search: debouncedSearch,
-		} );
+		if ( debouncedSearch !== view.search ) {
+			onChangeViewRef.current( {
+				...view,
+				page: 1,
+				search: debouncedSearch,
+			} );
+		}
 	}, [ debouncedSearch ] );
 	const searchLabel = label || __( 'Search' );
 	return (

--- a/packages/dataviews/src/test/search.js
+++ b/packages/dataviews/src/test/search.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Search from '../search.js';
+
+describe( 'DataViews search component', () => {
+	const onChangeView = jest.fn();
+	it( 'should not reset page when first rendered', () => {
+		const view = {
+			search: '',
+		};
+		render(
+			<Search
+				label="search"
+				view={ view }
+				onChangeView={ onChangeView }
+			/>
+		);
+		expect( onChangeView ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'should reset page if search term was changed', () => {
+		const view = {
+			search: '',
+		};
+		const { rerender } = render(
+			<Search
+				label="search"
+				view={ view }
+				onChangeView={ onChangeView }
+			/>
+		);
+		const viewNext = {
+			search: 'search term',
+		};
+		rerender(
+			<Search
+				label="search"
+				view={ viewNext }
+				onChangeView={ onChangeView }
+			/>
+		);
+		expect( onChangeView ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
I came across this while trying to use the component in calypso, I haven't been able to isolate the issue and reproduce it in a storybook.

The component is used in calypso to show a list of sites, clicking on a site opens a panel and reconfigures the layout.

However this is also causing this `useEffect` block within `search.js` to be hit, this resets the pagination control back to page one.

I confirmed that this line was causing the problem in calypso and confirmed that this would fix the issue and not cause regressions with search.

 Before: (The page selector is reset when selecting a site)

https://github.com/WordPress/gutenberg/assets/22446385/93a7474d-9582-41df-8ec1-af24fe3279ac

After:


https://github.com/WordPress/gutenberg/assets/22446385/61af2ccf-57d1-412f-83af-3dabd667f610

### Testing instructions

Unfortunately, I've been unable to isolate it to the point where I can see exactly why this is happening, I think it would require a very deep understanding of that calypso code and the react rendering cycle. It is a lot easier to simply fix this issue in the DataView component and reason about the code without being able to make a test case for it.

I did a regression test by running `npm run storybook:dev` and going to `http://localhost:50240/?path=/story/dataviews-dataviews--default`

