### PR TITLE
Add aria-haspopup="dialog" to Enable/Disable overrides button

### DIFF
--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -110,6 +110,7 @@ function PatternOverridesControls( { attributes, name, setAttributes } ) {
 						__next40pxDefaultSize
 						className="pattern-overrides-control__allow-overrides-button"
 						variant="secondary"
+						aria-haspopup="dialog"
 						onClick={ () => {
 							if ( allowOverrides ) {
 								setShowDisallowOverridesModal( true );


### PR DESCRIPTION
## What?
The 'Enable overrides' and 'Disable overrides' buttons open a modal so they should have `aria-haspopup="dialog"` specified.

## Why?
Originally I missed it during code review.

## How?
Add it.

### Testing Instructions
Use a screenreader

1. Edit a synced pattern
2. Insert a paragraph in the synced pattern
3. Go to the block inspector, open the Advanced section and focus the 'Enable overrides' button
4. It should announce as having a dialog