### PR TITLE
Fix ESLint warning in Performance test files

### DIFF
--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -269,7 +269,7 @@ test.describe( 'Post Editor Performance', () => {
 			const iterations = samples + throwaway;
 			for ( let i = 1; i <= iterations; i++ ) {
 				// Wait for the browser to be idle before starting the monitoring.
-				// eslint-disable-next-line no-restricted-syntax
+				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
 
 				// Start tracing.
@@ -318,7 +318,7 @@ test.describe( 'Post Editor Performance', () => {
 			const iterations = samples + throwaway;
 			for ( let i = 1; i <= iterations; i++ ) {
 				// Wait for the browser to be idle before starting the monitoring.
-				// eslint-disable-next-line no-restricted-syntax
+				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
 
 				// Start tracing.
@@ -368,7 +368,7 @@ test.describe( 'Post Editor Performance', () => {
 			const iterations = samples + throwaway;
 			for ( let i = 1; i <= iterations; i++ ) {
 				// Wait for the browser to be idle before starting the monitoring.
-				// eslint-disable-next-line no-restricted-syntax
+				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
 
 				// Start tracing.
@@ -430,7 +430,7 @@ test.describe( 'Post Editor Performance', () => {
 			const iterations = samples + throwaway;
 			for ( let i = 1; i <= iterations; i++ ) {
 				// Wait for the browser to be idle before starting the monitoring.
-				// eslint-disable-next-line no-restricted-syntax
+				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
 
 				// Start tracing.
@@ -493,7 +493,7 @@ test.describe( 'Post Editor Performance', () => {
 			const iterations = samples + throwaway;
 			for ( let i = 1; i <= iterations; i++ ) {
 				// Wait for the browser to be idle before starting the monitoring.
-				// eslint-disable-next-line no-restricted-syntax
+				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
 
 				// Start tracing.
@@ -647,7 +647,7 @@ test.describe( 'Post Editor Performance', () => {
 			const iterations = samples + throwaway;
 			for ( let i = 1; i <= iterations; i++ ) {
 				// Wait for the browser to be idle before starting the monitoring.
-				// eslint-disable-next-line no-restricted-syntax
+				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
 
 				await globalInserterToggle.click();

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -311,7 +311,7 @@ test.describe( 'Site Editor Performance', () => {
 				}
 
 				// Wait for the browser to be idle before starting the monitoring.
-				// eslint-disable-next-line no-restricted-syntax
+				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
 
 				const startTime = performance.now();


### PR DESCRIPTION
## What?
PR fixes ESLint warnings in the Performance test files.

## Why?
Ignored warnings can distract from the actual issues, and they're annoying 😄

## Testing Instructions
None
