### PR TITLE
fix use local version of theme.json schema in bundled files

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
 		"appearanceTools": false,

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-layout/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-layout/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
 		"appearanceTools": true,

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
 		"appearanceTools": true,

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
 		"appearanceTools": true,

--- a/phpunit/data/themedir1/block-theme-child/theme.json
+++ b/phpunit/data/themedir1/block-theme-child/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
 		"color": {

--- a/phpunit/data/themedir1/block-theme/theme.json
+++ b/phpunit/data/themedir1/block-theme/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../../../schemas/json/theme.json",
 	"version": 3,
 	"title": "Block theme",
 	"settings": {

--- a/phpunit/data/themedir1/fonts-block-theme/theme.json
+++ b/phpunit/data/themedir1/fonts-block-theme/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
 		"appearanceTools": true,

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
 		"appearanceTools": true,

--- a/test/gutenberg-test-themes/style-variations/theme.json
+++ b/test/gutenberg-test-themes/style-variations/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "../../../schemas/json/theme.json",
 	"version": 3,
 	"styles": {
 		"color": {

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -35,10 +35,11 @@ describe( 'theme.json schema', () => {
 	} );
 
 	test.each( jsonFiles )( 'validates schema for `%s`', ( filepath ) => {
-		// We want to validate the block.json file using the local schema.
+		// We want to validate the theme.json file using the local schema.
 		const { $schema, ...metadata } = require( filepath );
 
-		expect( $schema ).toBe( 'https://schemas.wp.org/trunk/theme.json' );
+		// we expect the $schema property to be present in the theme.json file
+		expect( $schema ).toBeTruthy();
 
 		const result = ajv.validate( themeSchema, metadata ) || ajv.errors;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Use the bundled `theme.json` SCHEMA to validate all the bundled `theme.json` files in the Gutenberg Repository.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Before this update all the bundled files referenced the schema of the trunk branch. Because of that it was not possible to validate changes to the schema in the local files. With this update any changes you make to the schema directly get validated right on the bundled files.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changing the `$schema` from `https://schemas.wp.org/trunk/theme.json` to a relative file path pointing to `schemas/json/theme.json`
