### PR TITLE
Update URLPopover role and focus return

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -60,28 +60,37 @@ const InsertFromURLPopover = ( {
 	</URLPopover>
 );
 
-const URLSelectionUI = ( {
-	isURLInputVisible,
-	src,
-	onChangeSrc,
-	onSubmitSrc,
-	openURLInput,
-	closeURLInput,
-} ) => {
+const URLSelectionUI = ( { src, onChangeSrc, onSelectURL } ) => {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	const [ isURLInputVisible, setIsURLInputVisible ] = useState( false );
+
+	const openURLInput = () => {
+		setIsURLInputVisible( true );
+	};
+	const closeURLInput = () => {
+		setIsURLInputVisible( false );
+		popoverAnchor?.focus();
+	};
+
+	const onSubmitSrc = ( event ) => {
+		event.preventDefault();
+		if ( src && onSelectURL ) {
+			onSelectURL( src );
+			closeURLInput();
+		}
+	};
 
 	return (
-		<div
-			className="block-editor-media-placeholder__url-input-container"
-			ref={ setPopoverAnchor }
-		>
+		<div className="block-editor-media-placeholder__url-input-container">
 			<Button
 				className="block-editor-media-placeholder__button"
 				onClick={ openURLInput }
 				isPressed={ isURLInputVisible }
 				variant="secondary"
+				aria-haspopup="dialog"
+				ref={ setPopoverAnchor }
 			>
 				{ __( 'Insert from URL' ) }
 			</Button>
@@ -138,7 +147,6 @@ export function MediaPlaceholder( {
 		return getSettings().mediaUpload;
 	}, [] );
 	const [ src, setSrc ] = useState( '' );
-	const [ isURLInputVisible, setIsURLInputVisible ] = useState( false );
 
 	useEffect( () => {
 		setSrc( value?.src ?? '' );
@@ -157,21 +165,6 @@ export function MediaPlaceholder( {
 
 	const onChangeSrc = ( event ) => {
 		setSrc( event.target.value );
-	};
-
-	const openURLInput = () => {
-		setIsURLInputVisible( true );
-	};
-	const closeURLInput = () => {
-		setIsURLInputVisible( false );
-	};
-
-	const onSubmitSrc = ( event ) => {
-		event.preventDefault();
-		if ( src && onSelectURL ) {
-			onSelectURL( src );
-			closeURLInput();
-		}
 	};
 
 	const onFilesUpload = ( files ) => {
@@ -404,12 +397,9 @@ export function MediaPlaceholder( {
 		return (
 			onSelectURL && (
 				<URLSelectionUI
-					isURLInputVisible={ isURLInputVisible }
 					src={ src }
 					onChangeSrc={ onChangeSrc }
-					onSubmitSrc={ onSubmitSrc }
-					openURLInput={ openURLInput }
-					closeURLInput={ closeURLInput }
+					onSelectURL={ onSelectURL }
 				/>
 			)
 		);

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -72,6 +72,7 @@ const URLPopover = forwardRef(
 			<Popover
 				ref={ ref }
 				role="dialog"
+				aria-label={ __( 'Link settings' ) }
 				className="block-editor-url-popover"
 				focusOnMount={ focusOnMount }
 				placement={ computedPlacement }

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -71,6 +71,7 @@ const URLPopover = forwardRef(
 		return (
 			<Popover
 				ref={ ref }
+				role="dialog"
 				className="block-editor-url-popover"
 				focusOnMount={ focusOnMount }
 				placement={ computedPlacement }

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -72,7 +72,7 @@ const URLPopover = forwardRef(
 			<Popover
 				ref={ ref }
 				role="dialog"
-				aria-label={ __( 'Link settings' ) }
+				aria-label={ __( 'Edit URL' ) }
 				className="block-editor-url-popover"
 				focusOnMount={ focusOnMount }
 				placement={ computedPlacement }

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -72,6 +72,7 @@ const URLPopover = forwardRef(
 			<Popover
 				ref={ ref }
 				role="dialog"
+				aria-modal="true"
 				aria-label={ __( 'Edit URL' ) }
 				className="block-editor-url-popover"
 				focusOnMount={ focusOnMount }

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -6,11 +6,15 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
+import { DELETE, BACKSPACE } from '@wordpress/keycodes';
+import { useDispatch } from '@wordpress/data';
+
 import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import {
@@ -32,7 +36,9 @@ const SocialLinkURLPopover = ( {
 	setAttributes,
 	setPopover,
 	popoverAnchor,
+	clientId,
 } ) => {
+	const { removeBlock } = useDispatch( blockEditorStore );
 	return (
 		<URLPopover
 			anchor={ popoverAnchor }
@@ -61,6 +67,18 @@ const SocialLinkURLPopover = ( {
 						label={ __( 'Enter social link' ) }
 						hideLabelFromVision
 						disableSuggestions
+						onKeyDown={ ( event ) => {
+							if (
+								!! url ||
+								event.defaultPrevented ||
+								! [ BACKSPACE, DELETE ].includes(
+									event.keyCode
+								)
+							) {
+								return;
+							}
+							removeBlock( clientId );
+						} }
 					/>
 				</div>
 				<Button
@@ -78,6 +96,7 @@ const SocialLinkEdit = ( {
 	context,
 	isSelected,
 	setAttributes,
+	clientId,
 } ) => {
 	const { url, service, label = '', rel } = attributes;
 	const {
@@ -165,6 +184,7 @@ const SocialLinkEdit = ( {
 						setAttributes={ setAttributes }
 						setPopover={ setPopover }
 						popoverAnchor={ popoverAnchor }
+						clientId={ clientId }
 					/>
 				) }
 			</li>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -36,6 +36,7 @@ const SocialLinkURLPopover = ( {
 	return (
 		<URLPopover
 			anchor={ popoverAnchor }
+			aria-label={ __( 'Edit social link' ) }
 			onClose={ () => {
 				setPopover( false );
 				popoverAnchor?.focus();

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -36,13 +36,17 @@ const SocialLinkURLPopover = ( {
 	return (
 		<URLPopover
 			anchor={ popoverAnchor }
-			onClose={ () => setPopover( false ) }
+			onClose={ () => {
+				setPopover( false );
+				popoverAnchor?.focus();
+			} }
 		>
 			<form
 				className="block-editor-url-popover__link-editor"
 				onSubmit={ ( event ) => {
 					event.preventDefault();
 					setPopover( false );
+					popoverAnchor?.focus();
 				} }
 			>
 				<div className="block-editor-url-input">
@@ -143,6 +147,7 @@ const SocialLinkEdit = ( {
 					className="wp-block-social-link-anchor"
 					ref={ setPopoverAnchor }
 					onClick={ () => setPopover( true ) }
+					aria-haspopup="dialog"
 				>
 					<IconComponent />
 					<span


### PR DESCRIPTION
## What?
Fixes a few a11y things for the social links block (that I noticed when working on it recently) and media placeholders

Social Links:
- The social links block uses a `URLPopover`, which didn't have a role (I think it should be role="dialog") and the opener button also didn't have `aria-haspopup` specified, so I've added it with the value 'dialog'.
- The URLPopover is now labelled. I'm open to feedback on the labelling.
- The URLPopover in the social links block doesn't return focus to the opener button when it's closed. This PR makes it do that.
- If you press backspace too many times in the url popover, it deletes the block, which I found unusual, and it feels like a bug, so I've removed that behavior. Input should be constrained in the popover. I think this is probably a hangover from a past implementation where the URLPopover used to automatically open.

Media Placeholder (e.g. on the image block):
- The 'Insert from URL' button had similar issues, it opens a `URLPopover` with no role, and there's no `aria-haspopup` on the opener button. This is fixed.
- There was also a focus loss when closing the popover using escape, now fixed. Submitting causes an image to load, so that's a little trickier, I might have to draw the line on fixing that one as this PR has already spiralled. 😄 
- The URLPopover is now labelled.

## Testing Instructions
(use a screenreader)

### Social links
1. Add a social links block
2. Navigate to the 'Add block' button in the social links block and select it
3. Add a WordPress block
4. Arrow down until the 'WordPress' button (I noticed that this could have better labelling). It should be announced as a 'dialog pop-up button' or similar. Select it
5. Focus should be transferred to what's now announced as a dialog
6. Press escape or type in a url and hit enter to submit
7. Focus should be transferred back to the button.
8. Reopen the dialog and press delete - focus should remain in the popover and the block isn't deleted

### Media placeholder
1. Insert an image block
2. Tab to the 'Insert from URL' button. It should be announced as a 'dialog pop-up button' or similar. Select it.
3. Focus should be transferred to what's now announced as a dialog
4. Press escape, focus should return back to the button