### PR TITLE
Try: Fix double-border.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fix
 
 -   `SlotFill`: fixed missing `getServerSnapshot` parameter in slot map ([#60943](https://github.com/WordPress/gutenberg/pull/60943)).
+-   `Panel`: fix issue with double border ([#61318](https://github.com/WordPress/gutenberg/pull/61318)).
 
 ### Enhancements
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -48,7 +48,7 @@
 	}
 }
 
-.components-panel__body + .components-panel__body,
+.components-panel__body,
 .components-panel__body + .components-panel__header,
 .components-panel__header + .components-panel__body,
 .components-panel__header + .components-panel__header {


### PR DESCRIPTION
## What?

Fixes #61055. 

There's a double-border above the first panel in the inspector now:

![double border](https://github.com/WordPress/gutenberg/assets/1204802/0ef00dea-9b53-4db8-b2c4-5c31f30f0de5)

This PR fixes it so it's only a single border, as expected:

![single border](https://github.com/WordPress/gutenberg/assets/1204802/619a251f-a6ab-4412-84fd-b22b42c92797)

## Why?

The panel component has a border all around. A negative margin is applied to make them stack visually with 1 border separation regardless.

## How?

This PR makes it target all the panels, not just the first one.

Please note, there was probably a good reason why this wasn't the case previously, so it would be good to check every panel that uses the panel component, to see that things look right.

## Testing Instructions

Open post, page, site editors, and check the first panel in the first tab of the inspector. There should only be a 1px border between tabs and content.