### PR TITLE
Fix styles panel header

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fix
 
 -   `SlotFill`: fixed missing `getServerSnapshot` parameter in slot map ([#60943](https://github.com/WordPress/gutenberg/pull/60943)).
+-   `Panel`: Fix issue with collapsing panel header ([#61319](https://github.com/WordPress/gutenberg/pull/61319)).
 
 ### Enhancements
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -32,6 +32,7 @@
 
 .components-panel__header {
 	display: flex;
+	flex-shrink: 0;
 	justify-content: space-between;
 	align-items: center;
 	padding: 0 $grid-unit-20;


### PR DESCRIPTION
## What?

Fixes #61283.

The Styles panel recently regressed, making the header collapse when going to the blocks page:

![before](https://github.com/WordPress/gutenberg/assets/1204802/8e2cae63-3428-48eb-aa26-e6ab013b7d4e)

This PR fixes it:

![after](https://github.com/WordPress/gutenberg/assets/1204802/41dd0700-1372-45a6-907f-b9bf4100f4fa)

## How?

The context started flexing, and without flex-shrink: 0; it collapsed.

## Testing Instructions

Go to global styles, go to "Blocks", and the panel header should be the same height in all those cases.