### PR TITLE
Quality: fix php warning error

### DIFF
--- a/lib/compat/wordpress-6.6/compat.php
+++ b/lib/compat/wordpress-6.6/compat.php
@@ -16,13 +16,15 @@ function gutenberg_change_patterns_link_and_remove_template_parts_submenu_item()
 	if ( ! wp_is_block_theme() ) {
 		global $submenu;
 
-		if ( ! empty( $submenu['themes.php'] ) ) {
-			foreach ( $submenu['themes.php'] as $key => $item ) {
-				if ( 'edit.php?post_type=wp_block' === $item[2] ) {
-					$submenu['themes.php'][ $key ][2] = 'site-editor.php?path=/patterns';
-				} elseif ( 'site-editor.php?path=/wp_template_part/all' === $item[2] ) {
-					unset( $submenu['themes.php'][ $key ] );
-				}
+		if ( empty( $submenu['themes.php'] ) ) {
+			return;
+		}
+
+		foreach ( $submenu['themes.php'] as $key => $item ) {
+			if ( 'edit.php?post_type=wp_block' === $item[2] ) {
+				$submenu['themes.php'][ $key ][2] = 'site-editor.php?path=/patterns';
+			} elseif ( 'site-editor.php?path=/wp_template_part/all' === $item[2] ) {
+				unset( $submenu['themes.php'][ $key ] );
 			}
 		}
 	}

--- a/lib/compat/wordpress-6.6/compat.php
+++ b/lib/compat/wordpress-6.6/compat.php
@@ -15,11 +15,14 @@
 function gutenberg_change_patterns_link_and_remove_template_parts_submenu_item() {
 	if ( ! wp_is_block_theme() ) {
 		global $submenu;
-		foreach ( $submenu['themes.php'] as $key => $item ) {
-			if ( 'edit.php?post_type=wp_block' === $item[2] ) {
-				$submenu['themes.php'][ $key ][2] = 'site-editor.php?path=/patterns';
-			} elseif ( 'site-editor.php?path=/wp_template_part/all' === $item[2] ) {
-				unset( $submenu['themes.php'][ $key ] );
+
+		if ( ! empty( $submenu['themes.php'] ) ) {
+			foreach ( $submenu['themes.php'] as $key => $item ) {
+				if ( 'edit.php?post_type=wp_block' === $item[2] ) {
+					$submenu['themes.php'][ $key ][2] = 'site-editor.php?path=/patterns';
+				} elseif ( 'site-editor.php?path=/wp_template_part/all' === $item[2] ) {
+					unset( $submenu['themes.php'][ $key ] );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Follow up #61080

Props to @Mamaduka for discovering the problem with [this comment]

## What?

This PR fixes a warning about undefined $submenu global variable.

## Why?

I was initially unable to reproduce this issue in the dashboard. However, for example, I noticed that this warning log is recorded when entering a keyword on the plugin page, that is, when an Ajax request is made.

I'm a little unsure, but I suspect that $submenu will be undefined in certain situations.

## Testing Instructions

- On the plugin search page, enter any keywords to update the list.
- No warning logs should be logged.
