### PR TITLE
Perf: batch block list settings in single action

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1841,11 +1841,11 @@ _Returns_
 
 ### updateBlockListSettings
 
-Action that changes the nested settings of a given block.
+Action that changes the nested settings of the given block(s).
 
 _Parameters_
 
--   _clientId_ `string`: Client ID of the block whose nested setting are being received.
+-   _clientId_ `string | SettingsByClientId`: Client ID of the block whose nested setting are being received, or object of settings by client ID.
 -   _settings_ `Object`: Object with the new settings for the nested block.
 
 _Returns_

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1506,11 +1506,18 @@ export const insertDefaultBlock =
 	};
 
 /**
- * Action that changes the nested settings of a given block.
+ * @typedef {Object< string, Object >} SettingsByClientId
+ */
+
+/**
+ * Action that changes the nested settings of the given block(s).
  *
- * @param {string} clientId Client ID of the block whose nested setting are
- *                          being received.
- * @param {Object} settings Object with the new settings for the nested block.
+ * @param {string | SettingsByClientId} clientId Client ID of the block whose
+ *                                               nested setting are being
+ *                                               received, or object of settings
+ *                                               by client ID.
+ * @param {Object}                      settings Object with the new settings
+ *                                               for the nested block.
  *
  * @return {Object} Action object
  */

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -27,6 +27,20 @@ const privateSettings = [
 ];
 
 /**
+ * Action that changes the nested settings of a given block.
+ *
+ * @param {Map} settingsByClientId A map of block client IDs to their settings.
+ *
+ * @return {Object} Action object
+ */
+export function batchUpdateBlockListSettings( settingsByClientId ) {
+	return {
+		type: 'BATCH_UPDATE_BLOCK_LIST_SETTINGS',
+		settingsByClientId,
+	};
+}
+
+/**
  * Action that updates the block editor settings and
  * conditionally preserves the experimental ones.
  *

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -27,20 +27,6 @@ const privateSettings = [
 ];
 
 /**
- * Action that changes the nested settings of a given block.
- *
- * @param {Map} settingsByClientId A map of block client IDs to their settings.
- *
- * @return {Object} Action object
- */
-export function batchUpdateBlockListSettings( settingsByClientId ) {
-	return {
-		type: 'BATCH_UPDATE_BLOCK_LIST_SETTINGS',
-		settingsByClientId,
-	};
-}
-
-/**
  * Action that updates the block editor settings and
  * conditionally preserves the experimental ones.
  *

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1769,6 +1769,19 @@ export const blockListSettings = ( state = {}, action ) => {
 				[ clientId ]: action.settings,
 			};
 		}
+
+		case 'BATCH_UPDATE_BLOCK_LIST_SETTINGS': {
+			const { settingsByClientId } = action;
+			const updates = {};
+			for ( const [ clientId, _settings ] of settingsByClientId ) {
+				if ( ! fastDeepEqual( state[ clientId ], _settings ) ) {
+					updates[ clientId ] = _settings;
+				}
+			}
+			return Object.keys( updates ).length
+				? { ...state, ...updates }
+				: state;
+		}
 	}
 	return state;
 };

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1750,37 +1750,37 @@ export const blockListSettings = ( state = {}, action ) => {
 			);
 		}
 		case 'UPDATE_BLOCK_LIST_SETTINGS': {
-			const { clientId } = action;
-			if ( ! action.settings ) {
-				if ( state.hasOwnProperty( clientId ) ) {
-					const { [ clientId ]: removedBlock, ...restBlocks } = state;
-					return restBlocks;
-				}
+			const updates =
+				typeof action.clientId === 'string'
+					? { [ action.clientId ]: action.settings }
+					: action.clientId;
 
+			// Remove settings that are the same as the current state.
+			for ( const clientId in updates ) {
+				if ( ! updates[ clientId ] ) {
+					if ( ! state[ clientId ] ) {
+						delete updates[ clientId ];
+					}
+				} else if (
+					fastDeepEqual( state[ clientId ], updates[ clientId ] )
+				) {
+					delete updates[ clientId ];
+				}
+			}
+
+			if ( Object.keys( updates ).length === 0 ) {
 				return state;
 			}
 
-			if ( fastDeepEqual( state[ clientId ], action.settings ) ) {
-				return state;
-			}
+			const merged = { ...state, ...updates };
 
-			return {
-				...state,
-				[ clientId ]: action.settings,
-			};
-		}
-
-		case 'BATCH_UPDATE_BLOCK_LIST_SETTINGS': {
-			const { settingsByClientId } = action;
-			const updates = {};
-			for ( const [ clientId, _settings ] of settingsByClientId ) {
-				if ( ! fastDeepEqual( state[ clientId ], _settings ) ) {
-					updates[ clientId ] = _settings;
+			for ( const clientId in updates ) {
+				if ( ! updates[ clientId ] ) {
+					delete merged[ clientId ];
 				}
 			}
-			return Object.keys( updates ).length
-				? { ...state, ...updates }
-				: state;
+
+			return merged;
 		}
 	}
 	return state;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Instead of reducing the store hundreds of times when updating with the initial block list settings, we could be combining them all into a single action.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In my testing this reduces the update from ~60-70ms to ~4-5ms.

~~The load perf test contains many, many things, so I don't expect a huge difference from a 60ms change. Still worth doing imo.~~

Actually the first block metric seems to be down a bit:

Post editor: -5.37%, 0.29%, -5.37% (yes, twice exactly the same)
Site editor: -2.30%, -6.78%, -1.66%

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

All tests should pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
