### PR TITLE
Rich text: remove double record sync on mount

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -92,7 +92,6 @@ export function useRichText( {
 
 	if ( ! record.current ) {
 		hadSelectionUpdate.current = isSelected;
-		setRecordFromProps();
 	} else if (
 		selectionStart !== record.current.start ||
 		selectionEnd !== record.current.end

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -92,6 +92,7 @@ export function useRichText( {
 
 	if ( ! record.current ) {
 		hadSelectionUpdate.current = isSelected;
+		record.current = create();
 	} else if (
 		selectionStart !== record.current.start ||
 		selectionEnd !== record.current.end


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It looks like we're currently syncing props to the record ref twice on mount: once during render, and once in a ref callback.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
