### PR TITLE
Fix inconsistent complementary header styles

### DIFF
--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -12,7 +12,3 @@
 		}
 	}
 }
-
-.edit-post-sidebar__panel {
-	margin-top: -1px;
-}

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -76,7 +76,11 @@ function GlobalStylesActionMenu() {
 
 	return (
 		<GlobalStylesMenuFill>
-			<DropdownMenu icon={ moreVertical } label={ __( 'More' ) }>
+			<DropdownMenu
+				icon={ moreVertical }
+				label={ __( 'More' ) }
+				toggleProps={ { size: 'compact' } }
+			>
 				{ ( { onClose } ) => (
 					<>
 						<MenuGroup>

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -136,7 +136,10 @@ export default function GlobalStylesSidebar() {
 			closeLabel={ __( 'Close Styles' ) }
 			panelClassName="edit-site-global-styles-sidebar__panel"
 			header={
-				<Flex className="edit-site-global-styles-sidebar__header">
+				<Flex
+					className="edit-site-global-styles-sidebar__header"
+					gap={ 1 }
+				>
 					<FlexBlock style={ { minWidth: 'min-content' } }>
 						<h2 className="edit-site-global-styles-sidebar__header-title">
 							{ __( 'Styles' ) }
@@ -151,6 +154,7 @@ export default function GlobalStylesSidebar() {
 							}
 							disabled={ shouldClearCanvasContainerView }
 							onClick={ toggleStyleBook }
+							size="compact"
 						/>
 					</FlexItem>
 					<FlexItem>
@@ -162,6 +166,7 @@ export default function GlobalStylesSidebar() {
 							isPressed={
 								isRevisionsOpened || isRevisionsStyleBookOpened
 							}
+							size="compact"
 						/>
 					</FlexItem>
 					<GlobalStylesMenuSlot />

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -141,7 +141,7 @@ export default function GlobalStylesSidebar() {
 					gap={ 1 }
 				>
 					<FlexBlock style={ { minWidth: 'min-content' } }>
-						<h2 className="edit-site-global-styles-sidebar__header-title">
+						<h2 className="interface-complementary-area-header__title">
 							{ __( 'Styles' ) }
 						</h2>
 					</FlexBlock>

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -141,7 +141,7 @@ export default function GlobalStylesSidebar() {
 					gap={ 1 }
 				>
 					<FlexBlock style={ { minWidth: 'min-content' } }>
-						<h2 className="interface-complementary-area-header__title">
+						<h2 className="edit-site-global-styles-sidebar__header-title">
 							{ __( 'Styles' ) }
 						</h2>
 					</FlexBlock>

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/style.scss
@@ -1,6 +1,5 @@
 .components-panel__header.edit-site-sidebar-edit-mode__panel-tabs {
 	padding-left: 0;
-	padding-right: $grid-unit-20;
 
 	.components-button.has-icon {
 		padding: 0;

--- a/packages/edit-site/src/components/sidebar-edit-mode/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/style.scss
@@ -100,6 +100,3 @@
 	}
 }
 
-.edit-site-sidebar__panel {
-	margin-top: -1px;
-}

--- a/packages/edit-site/src/components/sidebar-edit-mode/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/style.scss
@@ -34,6 +34,10 @@
 	}
 }
 
+.edit-site-global-styles-sidebar .edit-site-global-styles-sidebar__header-title {
+	margin: 0;
+}
+
 .edit-site-global-styles-sidebar .components-navigation__menu-title-heading {
 	font-size: $default-font-size * 1.2;
 	font-weight: 500;

--- a/packages/edit-site/src/components/sidebar-edit-mode/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/style.scss
@@ -34,14 +34,6 @@
 	}
 }
 
-.edit-site-global-styles-sidebar .interface-complementary-area-header .components-button.has-icon {
-	margin-left: 0;
-}
-
-.edit-site-global-styles-sidebar__reset-button.components-button {
-	margin-left: auto;
-}
-
 .edit-site-global-styles-sidebar .components-navigation__menu-title-heading {
 	font-size: $default-font-size * 1.2;
 	font-weight: 500;

--- a/packages/edit-site/src/components/sidebar-edit-mode/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/style.scss
@@ -34,10 +34,6 @@
 	}
 }
 
-.edit-site-global-styles-sidebar .edit-site-global-styles-sidebar__header-title {
-	margin: 0;
-}
-
 .edit-site-global-styles-sidebar .interface-complementary-area-header .components-button.has-icon {
 	margin-left: 0;
 }

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -35,6 +35,13 @@
 			display: flex;
 		}
 	}
+
+	// Emulate 'compact' button size, as Dropdown does not support compact yet.
+	.components-dropdown > .components-button.has-icon {
+		height: $grid-unit-40;
+		min-width: $grid-unit-40;
+		padding: $grid-unit-05;
+	}
 }
 
 // This overrides the negative margins between two consecutives panels.

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -17,7 +17,7 @@
 
 .interface-complementary-area-header {
 	background: $white;
-	padding-right: $grid-unit-05;
+	padding-right: $grid-unit-15; // Reduced padding to account for close buttons.
 
 	.interface-complementary-area-header__title {
 		margin: 0;

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -44,11 +44,3 @@
 		padding: $grid-unit-05;
 	}
 }
-
-// This overrides the negative margins between two consecutives panels.
-// since the first panel is hidden.
-.components-panel__header + .interface-complementary-area-header {
-	@include break-medium() {
-		margin-top: 0;
-	}
-}

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -36,11 +36,4 @@
 			display: flex;
 		}
 	}
-
-	// Emulate 'compact' button size, as Dropdown does not support compact yet.
-	.components-dropdown > .components-button.has-icon {
-		height: $grid-unit-40;
-		min-width: $grid-unit-40;
-		padding: $grid-unit-05;
-	}
 }

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -18,6 +18,7 @@
 .interface-complementary-area-header {
 	background: $white;
 	padding-right: $grid-unit-15; // Reduced padding to account for close buttons.
+	gap: $grid-unit-10; // Always ensure space between contents and close.
 
 	.interface-complementary-area-header__title {
 		margin: 0;

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -18,7 +18,7 @@
 .interface-complementary-area-header {
 	background: $white;
 	padding-right: $grid-unit-15; // Reduced padding to account for close buttons.
-	gap: $grid-unit-10; // Always ensure space between contents and close.
+	gap: $grid-unit-10; // Always ensure space between contents and close buttons.
 
 	.interface-complementary-area-header__title {
 		margin: 0;

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -39,7 +39,6 @@ function ComplementaryAreaToggle( {
 					enableComplementaryArea( scope, identifier );
 				}
 			} }
-			size="small"
 			{ ...props }
 		/>
 	);

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -39,6 +39,7 @@ function ComplementaryAreaToggle( {
 					enableComplementaryArea( scope, identifier );
 				}
 			} }
+			size="small"
 			{ ...props }
 		/>
 	);

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -330,6 +330,7 @@ function ComplementaryArea( {
 									}
 									isPressed={ isPinned }
 									aria-expanded={ isPinned }
+									size="compact"
 								/>
 							) }
 						</>

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -302,6 +302,7 @@ function ComplementaryArea( {
 					smallScreenTitle={ smallScreenTitle }
 					toggleButtonProps={ {
 						label: closeLabel,
+						size: 'small',
 						shortcut: toggleShortcut,
 						scope,
 						identifier,

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -39,6 +39,7 @@
 
 	h2 {
 		font-size: $default-font-size;
+		font-weight: 500;
 		color: $gray-900;
 		margin-bottom: 1.5em;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reduces displacement of close icon, inconsistent border/tab combinations (fixes https://github.com/WordPress/gutenberg/issues/61055) and uses the same icon sizes as in other sidebars. 

One part of this is an alternative approach to https://github.com/WordPress/gutenberg/pull/61318. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Open "Settings" sidebar.
3. Select a block. 
4. Switch between the post type and the block. 
5. Add a plugin with a plugin sidebar, like Jetpack or Yoast. 
6. Repeat check. 
7. Do the same within the Site Editor. 
8. Check to ensure tabs and the close icon look just like they do in the Inserter. 

## Visual <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/1813435/24ece3bb-bf71-4dda-a0d5-ef226d59515a

### After

https://github.com/WordPress/gutenberg/assets/1813435/62f6adff-bfc5-44be-acc0-5e55579c5c55

