### PR TITLE
Added check for duplicated slugs during manifest.json generation

### DIFF
--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -1,3 +1,5 @@
+/* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
+
 /**
  * External dependencies
  */
@@ -124,6 +126,29 @@ function generateRootManifestFromTOCItems( items, parent = null ) {
 			pageItems = pageItems.concat( getPackageManifest( packagePaths ) );
 		}
 	} );
+
+	const slugs = pageItems.map( ( { slug } ) => slug );
+	const duplicatedSlugs = slugs.filter(
+		( item, idx ) => idx !== slugs.indexOf( item )
+	);
+
+	const FgRed = '\x1b[31m';
+	const Reset = '\x1b[0m';
+
+	if ( duplicatedSlugs.length > 0 ) {
+		console.error(
+			`${ FgRed } The handbook generation setup creates pages based on their slug, so each slug has to be unique. ${ Reset }`
+		);
+		console.error(
+			`${ FgRed } More info at https://github.com/WordPress/gutenberg/issues/61206#issuecomment-2085361154 ${ Reset }\n`
+		);
+		throw new Error(
+			`${ FgRed } Duplicate slugs found in the TOC: ${ duplicatedSlugs.join(
+				', '
+			) } ${ Reset }`
+		);
+	}
+
 	return pageItems;
 }
 


### PR DESCRIPTION
## What?
Added check for duplicated slugs during manifest.json generation

## Why?
To prevent issues like https://github.com/WordPress/gutenberg/issues/61206 for future contributors

## How?
By adding a warning in "docs build time" if duplicated slugs are detected

## Testing Instructions

### Without errors

1- run `npm run docs:gen`

A `manifest.json` based on the content of `toc.json`  should be generated and no errors should be displayed 

### With errors

1- change the filename `docs/reference-guides/interactivity-api/`**`iapi-quick-start-guide.md`** to `docs/reference-guides/interactivity-api/`**`quick-start-guide.md`**
2- change the line 208 of `toc.json` to reflect the new name of this file
```
	"docs/reference-guides/interactivity-api/quick-start-guide.md": []
```
3- run `npm run docs:gen`

The following errors should be displayed 

```
...
The handbook generation setup creates pages based on their slug, so each slug has to be unique. 
More info at https://github.com/WordPress/gutenberg/issues/61206#issuecomment-2085361154 
...
Error:  Duplicate slugs found in the TOC: quick-start-guide
```
## Screenshots or screencast 
The following error appears when duplicated slugs are detected

![Screenshot 2024-05-02 at 17 04 23](https://github.com/WordPress/gutenberg/assets/422576/27731336-7823-4fcd-ac06-cfcc0e9fd40f)

