### PR TITLE
Update color variations

### DIFF
--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -13,6 +13,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import ColorVariations from './variations/variations-color';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 const mobilePopoverProps = { placement: 'bottom-start', offset: 8 };
@@ -88,6 +89,7 @@ export default function ColorPalettePanel( { name } ) {
 				slugPrefix="custom-"
 				popoverProps={ popoverProps }
 			/>
+			<ColorVariations title={ __( 'Presets' ) } />
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/preset-colors.js
+++ b/packages/edit-site/src/components/global-styles/preset-colors.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __unstableMotion as motion } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useStylesPreviewColors } from './hooks';
+
+export default function HighlightedColors( {
+	normalizedColorSwatchSize,
+	ratio,
+} ) {
+	const { paletteColors } = useStylesPreviewColors();
+	const scaledSwatchSize = normalizedColorSwatchSize * ratio;
+	return paletteColors.slice( 0, 5 ).map( ( { slug, color }, index ) => (
+		<motion.div
+			key={ `${ slug }-${ index }` }
+			style={ {
+				flexGrow: 1,
+				height: scaledSwatchSize,
+				background: color,
+			} }
+			animate={ {
+				scale: 1,
+				opacity: 1,
+			} }
+			initial={ {
+				scale: 0.1,
+				opacity: 0,
+			} }
+			transition={ {
+				delay: index === 1 ? 0.2 : 0.1,
+			} }
+		/>
+	) );
+}

--- a/packages/edit-site/src/components/global-styles/preset-colors.js
+++ b/packages/edit-site/src/components/global-styles/preset-colors.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __unstableMotion as motion } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
 import { useStylesPreviewColors } from './hooks';
@@ -11,23 +6,12 @@ import { useStylesPreviewColors } from './hooks';
 export default function PresetColors() {
 	const { paletteColors } = useStylesPreviewColors();
 	return paletteColors.slice( 0, 5 ).map( ( { slug, color }, index ) => (
-		<motion.div
+		<div
 			key={ `${ slug }-${ index }` }
 			style={ {
 				flexGrow: 1,
 				height: '100%',
 				background: color,
-			} }
-			animate={ {
-				scale: 1,
-				opacity: 1,
-			} }
-			initial={ {
-				scale: 0.1,
-				opacity: 0,
-			} }
-			transition={ {
-				delay: index === 1 ? 0.2 : 0.1,
 			} }
 		/>
 	) );

--- a/packages/edit-site/src/components/global-styles/preset-colors.js
+++ b/packages/edit-site/src/components/global-styles/preset-colors.js
@@ -8,18 +8,14 @@ import { __unstableMotion as motion } from '@wordpress/components';
  */
 import { useStylesPreviewColors } from './hooks';
 
-export default function HighlightedColors( {
-	normalizedColorSwatchSize,
-	ratio,
-} ) {
+export default function PresetColors() {
 	const { paletteColors } = useStylesPreviewColors();
-	const scaledSwatchSize = normalizedColorSwatchSize * ratio;
 	return paletteColors.slice( 0, 5 ).map( ( { slug, color }, index ) => (
 		<motion.div
 			key={ `${ slug }-${ index }` }
 			style={ {
 				flexGrow: 1,
-				height: scaledSwatchSize,
+				height: '100%',
 				background: color,
 			} }
 			animate={ {

--- a/packages/edit-site/src/components/global-styles/preview-colors.js
+++ b/packages/edit-site/src/components/global-styles/preview-colors.js
@@ -23,7 +23,6 @@ const firstFrameVariants = {
 	},
 };
 
-// Should match the value for is-pill in the packages/edit-site/src/components/global-styles/variations/style.scss file.
 const presetColorSwatchSize = 48;
 
 const StylesPreviewColors = ( { label, isFocused, withHoverView } ) => {

--- a/packages/edit-site/src/components/global-styles/preview-colors.js
+++ b/packages/edit-site/src/components/global-styles/preview-colors.js
@@ -23,15 +23,12 @@ const firstFrameVariants = {
 	},
 };
 
-const presetColorSwatchSize = 48;
-
 const StylesPreviewColors = ( { label, isFocused, withHoverView } ) => {
 	return (
 		<PreviewIframe
 			label={ label }
 			isFocused={ isFocused }
 			withHoverView={ withHoverView }
-			height={ presetColorSwatchSize }
 		>
 			{ ( { key } ) => (
 				<motion.div

--- a/packages/edit-site/src/components/global-styles/preview-colors.js
+++ b/packages/edit-site/src/components/global-styles/preview-colors.js
@@ -9,7 +9,7 @@ import {
 /**
  * Internal dependencies
  */
-import HighlightedColors from './highlighted-colors';
+import PresetColors from './preset-colors';
 import PreviewIframe from './preview-iframe';
 
 const firstFrameVariants = {
@@ -23,16 +23,18 @@ const firstFrameVariants = {
 	},
 };
 
+const normalizedColorSwatchSize = 48;
+
 const StylesPreviewColors = ( { label, isFocused, withHoverView } ) => {
 	return (
 		<PreviewIframe
 			label={ label }
 			isFocused={ isFocused }
 			withHoverView={ withHoverView }
+			height={ normalizedColorSwatchSize }
 		>
 			{ ( { ratio, key } ) => (
 				<motion.div
-					key={ key }
 					variants={ firstFrameVariants }
 					style={ {
 						height: '100%',
@@ -40,16 +42,18 @@ const StylesPreviewColors = ( { label, isFocused, withHoverView } ) => {
 					} }
 				>
 					<HStack
-						spacing={ 5 * ratio }
+						spacing={ 0 }
 						justify="center"
 						style={ {
 							height: '100%',
 							overflow: 'hidden',
 						} }
 					>
-						<HighlightedColors
-							normalizedColorSwatchSize={ 56 }
-							ratio={ ratio }
+						<PresetColors
+							normalizedColorSwatchSize={
+								normalizedColorSwatchSize
+							}
+							ratio={ 1 }
 						/>
 					</HStack>
 				</motion.div>

--- a/packages/edit-site/src/components/global-styles/preview-colors.js
+++ b/packages/edit-site/src/components/global-styles/preview-colors.js
@@ -23,7 +23,8 @@ const firstFrameVariants = {
 	},
 };
 
-const normalizedColorSwatchSize = 48;
+// Should match the value for is-pill in the packages/edit-site/src/components/global-styles/variations/style.scss file.
+const presetColorSwatchSize = 48;
 
 const StylesPreviewColors = ( { label, isFocused, withHoverView } ) => {
 	return (
@@ -31,10 +32,11 @@ const StylesPreviewColors = ( { label, isFocused, withHoverView } ) => {
 			label={ label }
 			isFocused={ isFocused }
 			withHoverView={ withHoverView }
-			height={ normalizedColorSwatchSize }
+			height={ presetColorSwatchSize }
 		>
-			{ ( { ratio, key } ) => (
+			{ ( { key } ) => (
 				<motion.div
+					key={ key }
 					variants={ firstFrameVariants }
 					style={ {
 						height: '100%',
@@ -49,12 +51,7 @@ const StylesPreviewColors = ( { label, isFocused, withHoverView } ) => {
 							overflow: 'hidden',
 						} }
 					>
-						<PresetColors
-							normalizedColorSwatchSize={
-								normalizedColorSwatchSize
-							}
-							ratio={ 1 }
-						/>
+						<PresetColors />
 					</HStack>
 				</motion.div>
 			) }

--- a/packages/edit-site/src/components/global-styles/preview-iframe.js
+++ b/packages/edit-site/src/components/global-styles/preview-iframe.js
@@ -38,6 +38,7 @@ export default function PreviewIframe( {
 	label,
 	isFocused,
 	withHoverView,
+	height = normalizedHeight,
 } ) {
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
@@ -118,7 +119,7 @@ export default function PreviewIframe( {
 				<Iframe
 					className="edit-site-global-styles-preview__iframe"
 					style={ {
-						height: normalizedHeight * ratio,
+						height: height * ratio,
 					} }
 					onMouseEnter={ () => setIsHovered( true ) }
 					onMouseLeave={ () => setIsHovered( false ) }
@@ -127,7 +128,7 @@ export default function PreviewIframe( {
 					<EditorStyles styles={ editorStyles } />
 					<motion.div
 						style={ {
-							height: normalizedHeight * ratio,
+							height: height * ratio,
 							width: '100%',
 							background: gradientValue ?? backgroundColor,
 							cursor: withHoverView ? 'pointer' : undefined,

--- a/packages/edit-site/src/components/global-styles/preview-iframe.js
+++ b/packages/edit-site/src/components/global-styles/preview-iframe.js
@@ -38,7 +38,6 @@ export default function PreviewIframe( {
 	label,
 	isFocused,
 	withHoverView,
-	height = normalizedHeight,
 } ) {
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
@@ -119,7 +118,7 @@ export default function PreviewIframe( {
 				<Iframe
 					className="edit-site-global-styles-preview__iframe"
 					style={ {
-						height: height * ratio,
+						height: normalizedHeight * ratio,
 					} }
 					onMouseEnter={ () => setIsHovered( true ) }
 					onMouseLeave={ () => setIsHovered( false ) }
@@ -128,7 +127,7 @@ export default function PreviewIframe( {
 					<EditorStyles styles={ editorStyles } />
 					<motion.div
 						style={ {
-							height: height * ratio,
+							height: normalizedHeight * ratio,
 							width: '100%',
 							background: gradientValue ?? backgroundColor,
 							cursor: withHoverView ? 'pointer' : undefined,

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -11,7 +11,6 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import ScreenHeader from './header';
 import Palette from './palette';
 import { unlock } from '../../lock-unlock';
-import ColorVariations from './variations/variations-color';
 
 const {
 	useGlobalStyle,
@@ -40,7 +39,6 @@ function ScreenColors() {
 			/>
 			<div className="edit-site-global-styles-screen">
 				<VStack spacing={ 7 }>
-					<ColorVariations title={ __( 'Presets' ) } />
 					<Palette />
 					<StylesColorPanel
 						inheritedValue={ inheritedStyle }

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -31,6 +31,12 @@
 			@include reduce-motion("transition");
 		}
 
+		&.is-pill,
+		&.is-pill::after {
+			border-radius: 48px; // Should match the value of presetColorSwatchSize in the /packages/edit-site/src/components/global-styles/preset-colors.js file.
+			overflow: hidden;
+		}
+
 		.edit-site-global-styles-color-variations & {
 			padding: $grid-unit-10;
 		}

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -31,6 +31,10 @@
 			@include reduce-motion("transition");
 		}
 
+		&.is-pill {
+			height: 48px;
+		}
+
 		&.is-pill,
 		&.is-pill::after {
 			border-radius: 100px;

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -6,58 +6,28 @@
 
 	.edit-site-global-styles-variations_item-preview {
 		border-radius: $radius-block-ui;
-		// Shown in Windows 10 high contrast mode.
-		outline: 1px solid transparent;
+		outline: $border-width solid rgba($black, 0.1);
+		outline-offset: -$border-width;
 		position: relative;
 		// Add the same transition that block style variations and other buttons have.
-		transition: box-shadow 0.1s linear;
+		transition: outline 0.1s linear;
 		@include reduce-motion("transition");
 
-		&::after {
-			content: "";
-			position: absolute;
-			top: -$border-width;
-			left: -$border-width;
-			bottom: -$border-width;
-			right: -$border-width;
-			// Visually resembles the $radius-block-ui.
-			border-radius: $radius-block-ui + $border-width;
-			box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
-			// Show a thin outline in Windows high contrast mode, otherwise the button is invisible.
-			border: $border-width solid transparent;
-			box-sizing: inherit;
-			// Add the same transition that block style variations and other buttons have.
-			transition: box-shadow 0.1s linear;
-			@include reduce-motion("transition");
-		}
-
 		&.is-pill {
-			height: 48px;
-		}
-
-		&.is-pill,
-		&.is-pill::after {
+			height: $button-size-next-default-40px;
 			border-radius: 100px;
 			overflow: hidden;
 		}
-
-		.edit-site-global-styles-color-variations & {
-			padding: $grid-unit-10;
-		}
 	}
 
-	&:not(.is-active):hover .edit-site-global-styles-variations_item-preview::after {
-		box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.4);
+	&:not(.is-active):hover .edit-site-global-styles-variations_item-preview {
+		outline-color: rgba($black, 0.3);
 	}
 
 	&.is-active .edit-site-global-styles-variations_item-preview,
 	&:focus-visible .edit-site-global-styles-variations_item-preview {
-		box-shadow: inset 0 0 0 $border-width $white, 0 0 0 var(--wp-admin-border-width-focus) $gray-900;
-		// Shown in Windows 10 high contrast mode.
-		outline-width: 3px;
-
-		&::after {
-			box-shadow: inset 0 0 0 1px $white;
-		}
+		outline-color: $gray-900;
+		outline-offset: $border-width;
+		outline-width: var(--wp-admin-border-width-focus);
 	}
 }

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -30,4 +30,8 @@
 		outline-offset: $border-width;
 		outline-width: var(--wp-admin-border-width-focus);
 	}
+
+	&:focus-visible .edit-site-global-styles-variations_item-preview {
+		outline-color: var(--wp-admin-theme-color);
+	}
 }

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -6,7 +6,7 @@
 
 	.edit-site-global-styles-variations_item-preview {
 		border-radius: $radius-block-ui;
-		outline: $border-width solid rgba($black, 0.1);
+		outline: $border-width solid rgba($black, 0.15);
 		outline-offset: -$border-width;
 		position: relative;
 		// Add the same transition that block style variations and other buttons have.

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -33,7 +33,7 @@
 
 		&.is-pill,
 		&.is-pill::after {
-			border-radius: 48px; // Should match the value of presetColorSwatchSize in the /packages/edit-site/src/components/global-styles/preset-colors.js file.
+			border-radius: 100px;
 			overflow: hidden;
 		}
 

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -21,7 +21,7 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
 
-export default function Variation( { variation, children } ) {
+export default function Variation( { variation, children, isPill } ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
 	const context = useMemo(
@@ -84,7 +84,12 @@ export default function Variation( { variation, children } ) {
 				onFocus={ () => setIsFocused( true ) }
 				onBlur={ () => setIsFocused( false ) }
 			>
-				<div className="edit-site-global-styles-variations_item-preview">
+				<div
+					className={ classnames(
+						'edit-site-global-styles-variations_item-preview',
+						{ 'is-pill': isPill }
+					) }
+				>
 					{ children( isFocused ) }
 				</div>
 			</div>

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -1,18 +1,15 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalGrid as Grid,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import Variation from './variation';
 import StylesPreviewColors from '../preview-colors';
 import { useColorVariations } from '../hooks';
 import Subtitle from '../subtitle';
+import Variation from './variation';
 
 export default function ColorVariations( { title, gap = 2 } ) {
 	const colorVariations = useColorVariations();
@@ -26,7 +23,7 @@ export default function ColorVariations( { title, gap = 2 } ) {
 			{ title && <Subtitle level={ 3 }>{ title }</Subtitle> }
 			<VStack spacing={ gap }>
 				{ colorVariations.map( ( variation, index ) => (
-					<Variation key={ index } variation={ variation }>
+					<Variation key={ index } variation={ variation } isPill>
 						{ () => <StylesPreviewColors /> }
 					</Variation>
 				) ) }

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -24,13 +24,13 @@ export default function ColorVariations( { title, gap = 2 } ) {
 	return (
 		<VStack spacing={ 3 }>
 			{ title && <Subtitle level={ 3 }>{ title }</Subtitle> }
-			<Grid columns={ 3 } gap={ gap }>
+			<VStack spacing={ gap }>
 				{ colorVariations.map( ( variation, index ) => (
 					<Variation key={ index } variation={ variation }>
 						{ () => <StylesPreviewColors /> }
 					</Variation>
 				) ) }
-			</Grid>
+			</VStack>
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -109,9 +109,12 @@
 		outline-color: rgba($white, 0.15);
 	}
 
-	&.is-active .edit-site-global-styles-variations_item-preview,
-	&:focus-visible .edit-site-global-styles-variations_item-preview {
+	&.is-active .edit-site-global-styles-variations_item-preview {
 		outline-color: $white;
+	}
+
+	&:focus-visible .edit-site-global-styles-variations_item-preview {
+		outline-color: var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -99,20 +99,19 @@
 }
 
 .edit-site-sidebar-navigation-screen__content .edit-site-global-styles-variations_item {
+
+	// Use a white outline to provide contrast with the dark background.
 	.edit-site-global-styles-variations_item-preview {
-		box-shadow: 0 0 0 $border-width $gray-900;
+		outline-color: rgba($white, 0.05);
 	}
 
-	&:focus .edit-site-global-styles-variations_item-preview,
-	&.is-active .edit-site-global-styles-variations_item-preview {
-		box-shadow: inset 0 0 0 $border-width $gray-900, 0 0 0 var(--wp-admin-border-width-focus) $white;
+	&:not(.is-active):hover .edit-site-global-styles-variations_item-preview {
+		outline-color: rgba($white, 0.15);
+	}
 
-		// Shown in Windows 10 high contrast mode.
-		outline-width: 3px;
-
-		&::after {
-			box-shadow: inset 0 0 0 1px $gray-900;
-		}
+	&.is-active .edit-site-global-styles-variations_item-preview,
+	&:focus-visible .edit-site-global-styles-variations_item-preview {
+		outline-color: $white;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the style of the color presets to match the design in https://github.com/WordPress/gutenberg/issues/61213, and moves them to the palette tab.

Closes https://github.com/WordPress/gutenberg/issues/61213.

## Why?
The presets can get quite long and push down other settings so it's better to move them into a drilldown.

## How?
1. Move component
2. Update the style of the component

## Testing Instructions
1. Open Global Styles
2. Open the colors panel
3. Open palettes
4. Check that the presets are present and match the design.

## Screenshots or screencast <!-- if applicable -->
<img width="362" alt="Screenshot 2024-05-03 at 14 00 29" src="https://github.com/WordPress/gutenberg/assets/275961/52d55d00-2108-4a31-89dd-02d7d520e36e">
