### PR TITLE
Improve `LineHeightControl` unit tests

### DIFF
--- a/packages/block-editor/src/components/line-height-control/test/index.js
+++ b/packages/block-editor/src/components/line-height-control/test/index.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { UP, DOWN } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -29,35 +29,37 @@ const ControlledLineHeightControl = () => {
 };
 
 describe( 'LineHeightControl', () => {
-	it( 'should immediately step up from the default value if up-arrowed from an unset state', () => {
+	it( 'should immediately step up from the default value if up-arrowed from an unset state', async () => {
+		const user = userEvent.setup();
 		render( <ControlledLineHeightControl /> );
 		const input = screen.getByRole( 'spinbutton' );
-		act( () => input.focus() );
-		fireEvent.keyDown( input, { keyCode: UP } );
+		await user.click( input );
+		await user.keyboard( '{ArrowUp}' );
 		expect( input ).toHaveValue( BASE_DEFAULT_VALUE + SPIN );
 	} );
 
-	it( 'should immediately step down from the default value if down-arrowed from an unset state', () => {
+	it( 'should immediately step down from the default value if down-arrowed from an unset state', async () => {
+		const user = userEvent.setup();
 		render( <ControlledLineHeightControl /> );
 		const input = screen.getByRole( 'spinbutton' );
-		act( () => input.focus() );
-		fireEvent.keyDown( input, { keyCode: DOWN } );
+		await user.click( input );
+		await user.keyboard( '{ArrowDown}' );
 		expect( input ).toHaveValue( BASE_DEFAULT_VALUE - SPIN );
 	} );
 
-	it( 'should immediately step up from the default value if spin button up was clicked from an unset state', () => {
+	it( 'should immediately step up from the default value if spin button up was clicked from an unset state', async () => {
+		const user = userEvent.setup();
 		render( <ControlledLineHeightControl /> );
 		const input = screen.getByRole( 'spinbutton' );
-		act( () => input.focus() );
-		fireEvent.change( input, { target: { value: 0.1 } } ); // simulates click on spin button up
+		await user.click( screen.getByRole( 'button', { name: 'Increment' } ) );
 		expect( input ).toHaveValue( BASE_DEFAULT_VALUE + SPIN );
 	} );
 
-	it( 'should immediately step down from the default value if spin button down was clicked from an unset state', () => {
+	it( 'should immediately step down from the default value if spin button down was clicked from an unset state', async () => {
+		const user = userEvent.setup();
 		render( <ControlledLineHeightControl /> );
 		const input = screen.getByRole( 'spinbutton' );
-		act( () => input.focus() );
-		fireEvent.change( input, { target: { value: 0 } } ); // simulates click on spin button down
+		await user.click( screen.getByRole( 'button', { name: 'Decrement' } ) );
 		expect( input ).toHaveValue( BASE_DEFAULT_VALUE - SPIN );
 	} );
 } );


### PR DESCRIPTION
## What?
Updates unit test for `LineHeightControl` to use `@testing-library/user-event`

## Why?
To test with greater parity to actual use (i.e. best practice). More specifically, to test the actual spin buttons rendered by `LineHeightControl` instead of simulating their use.

## How?
imports `userEvent` and uses it instead of `fireEvent`/`act`.

## Testing Instructions
1. With this branch checked out, in your terminal run the following:
```
npm run test:unit line-height-control
```
