### PR TITLE
Update platform docs intro

### DIFF
--- a/platform-docs/docs/intro.md
+++ b/platform-docs/docs/intro.md
@@ -10,11 +10,11 @@ Let's discover how to use the **Gutenberg Block Editor** to build your own block
 ## What you'll need
 
 - [Node.js](https://nodejs.org/en/download/) version 20.10 or above.
-- We're going to be using "vite" to setup our single page application (SPA) that contains a block editor. You can use your own setup, and your own application for this.
+- We're going to be using "Vite" to setup our single page application (SPA) that contains a block editor. You can use your own setup, and your own application for this.
 
 ## Preparing the SPA powered by Vite.
 
-First bootstrap a vite project using `npm create vite@latest` and pick `Vanilla` variant and `JavaScript` as a language.
+First bootstrap a Vite project using `npm create vite@latest` and pick `React` variant and `JavaScript` as a language.
 
 Once done, you can navigate to your application folder and run it locally using `npm run dev`. Open the displayed local URL in a browser.
 
@@ -22,64 +22,93 @@ Once done, you can navigate to your application folder and run it locally using 
 
 To build a block editor, you need to install the following dependencies:
 
+ - `@wordpress/blocks`
  - `@wordpress/block-editor`
  - `@wordpress/block-library`
  - `@wordpress/components`
 
+## Appease package expectations
+
+The package `@wordpress/block-library` expects an env variable `IS_GUTENBERG_PLUGIN` to be defined. The quickest way to meet this requirement is to add it with `define` to the Vite config in `vite.config.js`. If using another bundler/build tool refer to its documentation for how to do this.
+
+```js
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  // highlight-next-line
+  define: { 'process.env.IS_GUTENBERG_PLUGIN': false },
+  plugins: [react()],
+})
+```
+
 ## JSX
 
-We're going to be using JSX to write our UI and components. So one of the first steps we need to do is to configure our build tooling, By default vite supports JSX and and outputs the result as a React pragma. The Block editor uses React so there's no need to configure anything here but if you're using a different bundler/build tool, make sure the JSX transpilation is setup properly.
+We're going to be using JSX to write our UI and components as the block editor is built with React. Using the Vite bootstrap described above there’s no need to configure anything as it outputs the result as a React pragma. If you're using a different bundler/build tool, you may need to configure the JSX transpilation to do the same.
 
 ## Bootstrap your block editor
 
-It's time to render our first block editor.
+It's time to render our first block editor. Update your `src/App.jsx` file with the following code:
 
- - Update your `index.jsx` file with the following code:
 ```jsx
-import { createElement, useState } from "react";
-import { createRoot } from 'react-dom/client';
+import { useState } from "react";
 import {
   BlockEditorProvider,
   BlockCanvas,
 } from "@wordpress/block-editor";
 import { registerCoreBlocks } from "@wordpress/block-library";
+import { getBlockTypes } from "@wordpress/blocks";
 
 // Default styles that are needed for the editor.
-import "@wordpress/components/build-style/style.css";
-import "@wordpress/block-editor/build-style/style.css";
+import componentsStyles from "@wordpress/components/build-style/style.css?raw";
+import blockEditorStyles from "@wordpress/block-editor/build-style/style.css?raw";
+import blockEditorContentStyles from "@wordpress/block-editor/build-style/content.css?raw";
 
 // Default styles that are needed for the core blocks.
-import "@wordpress/block-library/build-style/common.css";
-import "@wordpress/block-library/build-style/style.css";
-import "@wordpress/block-library/build-style/editor.css";
+import blocksCommonStyles from "@wordpress/block-library/build-style/common.css?raw";
+import blocksStyles from "@wordpress/block-library/build-style/style.css?raw";
+import blocksEditorStyles from "@wordpress/block-library/build-style/editor.css?raw";
 
-// Register the default core block types.
-registerCoreBlocks();
+const styles = `
+  ${ componentsStyles }
+  ${ blockEditorStyles }
+  ${ blockEditorContentStyles }
+  ${ blocksCommonStyles }
+  ${ blocksStyles }
+  ${ blocksEditorStyles }
+`;
 
-function Editor() {
+const registeredBlockTypes = getBlockTypes();
+// Registers the default core block types, avoiding doing so again during HMR.
+if (
+  ! registeredBlockTypes.length ||
+  ! registeredBlockTypes.some((blockType) => blockType.name.startsWith('core/'))
+) registerCoreBlocks();
+
+export default function Editor() {
   const [blocks, setBlocks] = useState([]);
   return (
-    /*
-      The BlockEditorProvider is the wrapper of the block editor's state.
-      All the UI elements of the block editor need to be rendered within this provider.
-    */
-    <BlockEditorProvider
-      value={blocks}
-      onChange={setBlocks}
-      onInput={setBlocks}
-    >
+    <>
+      <style>{ styles }</style>
       {/*
+        The BlockEditorProvider is the wrapper of the block editor's state.
+        All the UI elements of the block editor need to be rendered within this provider.
+      */}
+      <BlockEditorProvider
+        value={blocks}
+        onChange={setBlocks}
+        onInput={setBlocks}
+      >
+        {/*
           The BlockCanvas component renders the block list within an iframe
-          and wire up all the necessary events to make the block editor work.
+          and wires up all the necessary events to make the block editor work.
         */}
-      <BlockCanvas height="500px" />
-    </BlockEditorProvider>
+        <BlockCanvas height="500px" styles={ [ { css: styles } ] }/>
+      </BlockEditorProvider>
+    </>
   );
 }
-
-// Render your React component instead
-const root = createRoot(document.getElementById("app"));
-root.render(<Editor />);
 ```
 
 That's it! You now have a very basic block editor with several block types included by default: paragraphs, headings, lists, quotes, images...

--- a/platform-docs/docs/intro.md
+++ b/platform-docs/docs/intro.md
@@ -27,22 +27,6 @@ To build a block editor, you need to install the following dependencies:
  - `@wordpress/block-library`
  - `@wordpress/components`
 
-## Appease package expectations
-
-The package `@wordpress/block-library` expects an env variable `IS_GUTENBERG_PLUGIN` to be defined. The quickest way to meet this requirement is to add it with `define` to the Vite config in `vite.config.js`. If using another bundler/build tool refer to its documentation for how to do this.
-
-```js
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-
-// https://vitejs.dev/config/
-export default defineConfig({
-  // highlight-next-line
-  define: { 'process.env.IS_GUTENBERG_PLUGIN': false },
-  plugins: [react()],
-})
-```
-
 ## JSX
 
 We're going to be using JSX to write our UI and components as the block editor is built with React. Using the Vite bootstrap described above there’s no need to configure anything as it outputs the result as a React pragma. If you're using a different bundler/build tool, you may need to configure the JSX transpilation to do the same.

--- a/platform-docs/docs/intro.md
+++ b/platform-docs/docs/intro.md
@@ -65,6 +65,13 @@ import blockEditorContentStyles from "@wordpress/block-editor/build-style/conten
 import blocksStyles from "@wordpress/block-library/build-style/style.css?raw";
 import blocksEditorStyles from "@wordpress/block-library/build-style/editor.css?raw";
 
+const contentStyles = [
+  { css: componentsStyles },
+  { css: blockEditorContentStyles },
+  { css: blocksStyles },
+  { css: blocksEditorStyles },
+];
+
 export default function Editor() {
   const [ blocks, setBlocks ] = useState( [] );
   return (
@@ -81,15 +88,7 @@ export default function Editor() {
         The BlockCanvas component renders the block list within an iframe
         and wires up all the necessary events to make the block editor work.
       */ }
-      <BlockCanvas
-        height="500px"
-        styles={ [
-          { css: componentsStyles },
-          { css: blockEditorContentStyles },
-          { css: blocksStyles },
-          { css: blocksEditorStyles },
-        ] }
-      />
+      <BlockCanvas height="500px" styles={ contentStyles } />
     </BlockEditorProvider>
   );
 }

--- a/platform-docs/docs/intro.md
+++ b/platform-docs/docs/intro.md
@@ -4,8 +4,7 @@ sidebar_position: 1
 
 # Getting Started
 
-Let's discover how to use the **Gutenberg Block Editor** to build your own block editor in less than 10 minutes**.
-
+Let's discover how to use the **Gutenberg Block Editor** to build your own block editor in less than 10 minutes.
 
 ## What you'll need
 
@@ -22,7 +21,6 @@ Once done, you can navigate to your application folder and run it locally using 
 
 To build a block editor, you need to install the following dependencies:
 
- - `@wordpress/blocks`
  - `@wordpress/block-editor`
  - `@wordpress/block-library`
  - `@wordpress/components`
@@ -33,7 +31,26 @@ We're going to be using JSX to write our UI and components as the block editor i
 
 ## Bootstrap your block editor
 
-It's time to render our first block editor. Update your `src/App.jsx` file with the following code:
+It's time to render our first block editor. We’ll do this with changes to three files – `index.html`, `src/main.jsx`, and `src/App.jsx`.
+
+First, we’ll add the base styles are for the editor UI. In `index.html` add these styles in the `<head>`:
+```html
+<link href="node_modules/@wordpress/components/build-style/style.css" rel="stylesheet" vite-ignore/>
+<link href="node_modules/@wordpress/block-editor/build-style/style.css" rel="stylesheet" vite-ignore/>
+```
+:::note
+
+There are more styles needed but can’t be added here because they are for the editor’s content which is in a separate document within an `<iframe>`. We’ll add those styles via the `BlockCanvas` component in a later step.
+
+:::
+
+Next, we’ll add blocks for the editor to work with. In `src/main.jsx` import and call `registerCoreBlocks`:
+```js
+import { registerCoreBlocks } from '@wordpress/block-library'
+registerCoreBlocks();
+```
+
+Finally, we’ll put our editor together. In `src/App.jsx` replace the contents with the following code:
 
 ```jsx
 import { useState } from "react";
@@ -41,58 +58,42 @@ import {
   BlockEditorProvider,
   BlockCanvas,
 } from "@wordpress/block-editor";
-import { registerCoreBlocks } from "@wordpress/block-library";
-import { getBlockTypes } from "@wordpress/blocks";
 
-// Default styles that are needed for the editor.
+// Base styles for the content within the block canvas iframe.
 import componentsStyles from "@wordpress/components/build-style/style.css?raw";
-import blockEditorStyles from "@wordpress/block-editor/build-style/style.css?raw";
 import blockEditorContentStyles from "@wordpress/block-editor/build-style/content.css?raw";
-
-// Default styles that are needed for the core blocks.
-import blocksCommonStyles from "@wordpress/block-library/build-style/common.css?raw";
 import blocksStyles from "@wordpress/block-library/build-style/style.css?raw";
 import blocksEditorStyles from "@wordpress/block-library/build-style/editor.css?raw";
 
-const styles = `
-  ${ componentsStyles }
-  ${ blockEditorStyles }
-  ${ blockEditorContentStyles }
-  ${ blocksCommonStyles }
-  ${ blocksStyles }
-  ${ blocksEditorStyles }
-`;
-
-const registeredBlockTypes = getBlockTypes();
-// Registers the default core block types, avoiding doing so again during HMR.
-if (
-  ! registeredBlockTypes.length ||
-  ! registeredBlockTypes.some((blockType) => blockType.name.startsWith('core/'))
-) registerCoreBlocks();
-
 export default function Editor() {
-  const [blocks, setBlocks] = useState([]);
+  const [ blocks, setBlocks ] = useState( [] );
   return (
-    <>
-      <style>{ styles }</style>
-      {/*
-        The BlockEditorProvider is the wrapper of the block editor's state.
-        All the UI elements of the block editor need to be rendered within this provider.
-      */}
-      <BlockEditorProvider
-        value={blocks}
-        onChange={setBlocks}
-        onInput={setBlocks}
-      >
-        {/*
-          The BlockCanvas component renders the block list within an iframe
-          and wires up all the necessary events to make the block editor work.
-        */}
-        <BlockCanvas height="500px" styles={ [ { css: styles } ] }/>
-      </BlockEditorProvider>
-    </>
+    /*
+      The BlockEditorProvider is the wrapper of the block editor's state.
+      All the UI elements of the block editor need to be rendered within this provider.
+    */
+    <BlockEditorProvider
+      value={ blocks }
+      onChange={ setBlocks }
+      onInput={ setBlocks }
+    >
+      { /*
+        The BlockCanvas component renders the block list within an iframe
+        and wires up all the necessary events to make the block editor work.
+      */ }
+      <BlockCanvas
+        height="500px"
+        styles={ [
+          { css: componentsStyles },
+          { css: blockEditorContentStyles },
+          { css: blocksStyles },
+          { css: blocksEditorStyles },
+        ] }
+      />
+    </BlockEditorProvider>
   );
 }
+
 ```
 
 That's it! You now have a very basic block editor with several block types included by default: paragraphs, headings, lists, quotes, images...


### PR DESCRIPTION
closes #67048 

## What?
Updates the `intro.md` with some critical things that were missing for a workable build to be produced when following the guide. Among those:
- Recommends the `React` variant as part of `npm create vite@latest` as without this JSX won’t work by default and react dependencies won’t be installed. The React variant also installs some other nice defaults like eslint with react related plugins.
- ~~Details that `@wordpress/block-library` expects `IS_GUTENBERG_PLUGIN` and how to provide it as without this a runtime error makes for a broken app.~~
- Adds a missing style import `@wordpress/block-editor/build-style/content.css`
- Specifies the `styles` prop of `BlockCanvas` with imported content styles as without this various things won’t be styled in the canvas.

Less important changes:
- Adds `?raw` param to style imports to avoid Vite ever trying to process them.
- Instructs that `registerCoreBlocks()` be put in `src/main.jsx` so it won’t execute during HMR and cause errors (they are non-fatal but they sure clutter up the console).
- Specifies to update `src/App.jsx` instead of `index.jsx` because it’s what’ll exist when using the `React` variant and it also means the `createRoot`/`render` bits can be removed from the code sample.

Along with that there were a some minor edits to either fix typos or try to make it read a little better.

## Why?
To hopefully approach the expectation that following this guide will produce a working example in 10 minutes. From the docs homepage:
<img width="325" alt="image" src="https://github.com/WordPress/gutenberg/assets/9000376/f248367e-2bad-4d96-aec0-a90d2f0fe6b8">
You’ll probably go well over 10 minutes if you have to discover how to fix all the gotchas you'll hit by following the guide as is. 

## How?
I think this is mostly covered in What. I may add some review comments.

## Testing Instructions
```
cd platform-docs
npm install
npm run start
```
Ensure it all looks good.