### PR TITLE
Paragraph: conditionally render inspector controls in drop cap component

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -73,22 +73,24 @@ function DropCapControl( { clientId, attributes, setAttributes } ) {
 	}
 
 	return (
-		<ToolsPanelItem
-			hasValue={ () => !! dropCap }
-			label={ __( 'Drop cap' ) }
-			onDeselect={ () => setAttributes( { dropCap: undefined } ) }
-			resetAllFilter={ () => ( { dropCap: undefined } ) }
-			panelId={ clientId }
-		>
-			<ToggleControl
-				__nextHasNoMarginBottom
+		<InspectorControls group="typography">
+			<ToolsPanelItem
+				hasValue={ () => !! dropCap }
 				label={ __( 'Drop cap' ) }
-				checked={ !! dropCap }
-				onChange={ () => setAttributes( { dropCap: ! dropCap } ) }
-				help={ helpText }
-				disabled={ hasDropCapDisabled( align ) ? true : false }
-			/>
-		</ToolsPanelItem>
+				onDeselect={ () => setAttributes( { dropCap: undefined } ) }
+				resetAllFilter={ () => ( { dropCap: undefined } ) }
+				panelId={ clientId }
+			>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Drop cap' ) }
+					checked={ !! dropCap }
+					onChange={ () => setAttributes( { dropCap: ! dropCap } ) }
+					help={ helpText }
+					disabled={ hasDropCapDisabled( align ) ? true : false }
+				/>
+			</ToolsPanelItem>
+		</InspectorControls>
 	);
 }
 
@@ -134,13 +136,11 @@ function ParagraphBlock( {
 					/>
 				</BlockControls>
 			) }
-			<InspectorControls group="typography">
-				<DropCapControl
-					clientId={ clientId }
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-				/>
-			</InspectorControls>
+			<DropCapControl
+				clientId={ clientId }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
 			<RichText
 				identifier="content"
 				tagName="p"


### PR DESCRIPTION
## What?

(Maybe) fixes https://github.com/WordPress/gutenberg/issues/61231

Thanks to @kraftner's debugging, this PR takes a stab at rendering `<InspectorControls />` inside `<DropCapControl />` so that `isDropCapFeatureEnabled` takes into account theme settings.

## Why?
`<InspectorControls />` will render even if the theme has set all typography settings, including `dropCap` to `false` because it's outside the `const [ isDropCapFeatureEnabled ] = useSettings( 'typography.dropCap' );` check.

## How?
Shuffling stuff around.

## Testing Instructions

Here's some test theme.json. By explicitly setting every individual typography setting to `false` themes should be able to disable the typography tools panel in the block editor's block settings sidebar.

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"typography": {
			"fontSizes": [],
			"customFontSize": false,
			"defaultFontSizes": false,
			"writingMode": false,
			"dropCap": false,
			"textDecoration": false,
			"letterSpacing": false,
			"textTransform": false,
			"fontWeight": false,
			"fontStyle": false,
			"lineHeight": false
		}
	}
}
```

| Before  | After |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-05-03 at 11 53 46 am"  src="https://github.com/WordPress/gutenberg/assets/6458278/6b3b0aff-78c9-4ba9-b7e0-7801e08b7766">  | <img width="300" alt="Screenshot 2024-05-03 at 11 54 07 am" src="https://github.com/WordPress/gutenberg/assets/6458278/f83d07e1-14d2-40ee-b3bc-053e727e10c1">  |




