### PR TITLE
Revert change that removes the social link block when pressing backspace in the URL Popover

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -6,15 +6,11 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { DELETE, BACKSPACE } from '@wordpress/keycodes';
-import { useDispatch } from '@wordpress/data';
-
 import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
 	useBlockProps,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import {
@@ -36,9 +32,7 @@ const SocialLinkURLPopover = ( {
 	setAttributes,
 	setPopover,
 	popoverAnchor,
-	clientId,
 } ) => {
-	const { removeBlock } = useDispatch( blockEditorStore );
 	return (
 		<URLPopover
 			anchor={ popoverAnchor }
@@ -62,18 +56,6 @@ const SocialLinkURLPopover = ( {
 						label={ __( 'Enter social link' ) }
 						hideLabelFromVision
 						disableSuggestions
-						onKeyDown={ ( event ) => {
-							if (
-								!! url ||
-								event.defaultPrevented ||
-								! [ BACKSPACE, DELETE ].includes(
-									event.keyCode
-								)
-							) {
-								return;
-							}
-							removeBlock( clientId );
-						} }
 					/>
 				</div>
 				<Button
@@ -91,7 +73,6 @@ const SocialLinkEdit = ( {
 	context,
 	isSelected,
 	setAttributes,
-	clientId,
 } ) => {
 	const { url, service, label = '', rel } = attributes;
 	const {
@@ -178,7 +159,6 @@ const SocialLinkEdit = ( {
 						setAttributes={ setAttributes }
 						setPopover={ setPopover }
 						popoverAnchor={ popoverAnchor }
-						clientId={ clientId }
 					/>
 				) }
 			</li>


### PR DESCRIPTION
## What?
Proposes reverting the change introduced in https://github.com/WordPress/gutenberg/pull/50903.

In that PR, a social link block is removed when backspace is pressed within the url popover. My personal feeling is that this isn't good for a few reasons:
- In no other places when interacting with a link control or url popover is a block removed when pressing backspace
- It breaks the convention of dialogs where users expect input to be contained
- It makes it very easy to accidentally remove a block, especially since the behavior is inconsistent across dialogs

Also see some points mentioned in https://github.com/WordPress/gutenberg/pull/61313#issuecomment-2092020964 about how this is inconsistent compared to a button block.

## How?
Removes the code

## Testing Instructions
1. Insert a social links block
2. Insert an inner social link block, like WordPress
3. Click or select the WordPress button to open the URL Popover
4. Try hitting backspace
