### PR TITLE
fix: Focus styles for site hub icon in site editor.

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -197,6 +197,13 @@
 		box-shadow: none;
 	}
 
+	&.edit-site-site-hub__view-mode-toggle--navigation::before {
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	}
+
 	// Lightened spot color focus.
 	&:focus::before {
 		box-shadow:

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -197,7 +197,7 @@
 		box-shadow: none;
 	}
 
-	&.edit-site-site-hub__view-mode-toggle--navigation::before {
+	&[role="button"]::before {
 		top: 0;
 		right: 0;
 		bottom: 0;

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -118,13 +118,7 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 				>
 					<Button
 						{ ...siteIconButtonProps }
-						className={ classnames(
-							'edit-site-layout__view-mode-toggle',
-							{
-								'edit-site-site-hub__view-mode-toggle--navigation':
-									siteIconButtonProps.role === 'button',
-							}
-						) }
+						className="edit-site-layout__view-mode-toggle"
 					>
 						<motion.div
 							initial={ false }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -118,7 +118,13 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 				>
 					<Button
 						{ ...siteIconButtonProps }
-						className="edit-site-layout__view-mode-toggle"
+						className={ classnames(
+							'edit-site-layout__view-mode-toggle',
+							{
+								'edit-site-site-hub__view-mode-toggle--navigation':
+									siteIconButtonProps.role === 'button',
+							}
+						) }
 					>
 						<motion.div
 							initial={ false }


### PR DESCRIPTION
## What?
Fixes #61339
It fixes the size of the focus ring on the site icon.

## Why?
The focus ring was smaller in size than the actual button because the same styles were being applied to it as the icon in the navigation, which is actually smaller in size.

## How?
It adds a class name when the site editor is in edit mode and removes the additional styles that were reducing its size.

## Testing Instructions

1. Open the site editor and click on the page, then the navigation will close automatically.
2. Use the keyboard to move focus to the site hub button.
3. You can observe the size of the focus ring.

### Testing Instructions for Keyboard
Nil

## Screenshots or screencast 

### Before
<img width="132" alt="image" src="https://github.com/WordPress/gutenberg/assets/55375170/af50b5b1-5fab-4068-8686-9596ce9d8264">
 

### After
<img width="136" alt="image" src="https://github.com/WordPress/gutenberg/assets/55375170/9093d06d-fc7a-4177-bbcf-c042e1210027">



