### PR TITLE
Site Logo: Add setting labels via the 'register_setting' method

### DIFF
--- a/lib/compat/wordpress-6.6/option.php
+++ b/lib/compat/wordpress-6.6/option.php
@@ -14,8 +14,6 @@ function gutenberg_update_initial_settings( $args, $defaults, $option_group, $op
 	$settings_label_map = array(
 		'blogname'               => __( 'Title' ),
 		'blogdescription'        => __( 'Tagline' ),
-		'site_logo'              => __( 'Logo' ),
-		'site_icon'              => __( 'Icon' ),
 		'show_on_front'          => __( 'Show on front' ),
 		'page_on_front'          => __( 'Page on front' ),
 		'posts_per_page'         => __( 'Maximum posts per page' ),

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -74,6 +74,7 @@ function register_block_core_site_logo_setting() {
 				'name' => 'site_logo',
 			),
 			'type'         => 'integer',
+			'label'        => __( 'Logo' ),
 			'description'  => __( 'Site logo.' ),
 		)
 	);
@@ -93,6 +94,7 @@ function register_block_core_site_icon_setting() {
 		array(
 			'show_in_rest' => true,
 			'type'         => 'integer',
+			'label'        => __( 'Icon' ),
 			'description'  => __( 'Site icon.' ),
 		)
 	);


### PR DESCRIPTION
## What?
PR updates the Site Logo block to provide setting labels via the registration function instead of using the shim.

## Why?
Unlike other core settings, these are associated with the block and must be synced via package updates. I remembered this while working on https://github.com/WordPress/wordpress-develop/pull/6495.

## Testing Instructions
1. Open a post.
2. Add a Site Logo block.
3. Select an image.
4. Save the post.
5. Confirm setting labels are correctly displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-03 at 12 55 31](https://github.com/WordPress/gutenberg/assets/240569/b8db6eaf-25f6-4660-a5bf-c4c77fe5f574)
