### PR TITLE
Fix: The latest post block - post titles overlapping.

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -16,6 +16,7 @@
 
 		li {
 			clear: both;
+			overflow-wrap: break-word;
 		}
 	}
 


### PR DESCRIPTION
## What?
Fixes  #61347 

## Why?
When the latest post block uses the grid view, and there are posts with long titles without a breaking space, post titles can overlap. Because the post titles do not break to a new line, they continue over to the next column in the grid view, covering other content.

## How?
 This PR adds the style to handle the overflow in the list item.

## Testing Instructions
1. Create one or more posts with extra long titles without a space.
2. Next create a new post and add the latest posts block.
3. In the block toolbar, select "Grid view".
4. Confirm that the titles wrap to new lines in the editor.
5. Save and view the post on the front, it should not overlap now.

### Testing Instructions for Keyboard
nil.

## Screenshots or screencast 
<img width="1035" alt="image" src="https://github.com/WordPress/gutenberg/assets/55375170/c9cb8b36-03db-4636-985b-086a73c59d8c">

