### PR TITLE
Tests: Fix flaky interactivity deferred test

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -16,5 +16,5 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				},
 			},
 		} );
-	}, 50 );
+	}, 100 );
 } );


### PR DESCRIPTION
## What?
Fix a flaky test https://github.com/WordPress/gutenberg/issues/59899

> Locator: getByTestId('result')
>    Expected string: ""
>    Received string: "Hello, world!"

The test expects to find some empty HTML initially then find it updated. I suspect the timeout is too short, causing this to be flaky. This PR doubles the timeout which should make this test more reliable.

Closes https://github.com/WordPress/gutenberg/issues/59899

## Why?

Fix the flaky test.

## How?

Double the timeout so the the empty HTML can be found before its updated.

## Testing Instructions
CI passes.
