### PR TITLE
Paste: add e2e tests for selection

### DIFF
--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-and-paste-individual-blocks-with-collapsed-selection-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-and-paste-individual-blocks-with-collapsed-selection-2-chromium.txt
@@ -3,5 +3,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>2Copy - collapsed selection</p>
+<p>2Copy - collapsed selection‸</p>
 <!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-only-partial-selection-of-text-blocks-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-only-partial-selection-of-text-blocks-2-chromium.txt
@@ -3,7 +3,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>B </p>
+<p>B‸</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
@@ -7,7 +7,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:paragraph -->
-<p>B </p>
+<p>B‸</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-and-paste-individual-blocks-with-collapsed-selection-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-and-paste-individual-blocks-with-collapsed-selection-2-chromium.txt
@@ -1,3 +1,3 @@
 <!-- wp:paragraph -->
-<p>2Cut - collapsed selection</p>
+<p>2Cut - collapsed selection‸</p>
 <!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-partial-selection-and-merge-like-a-normal-delete---not-forward-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-partial-selection-and-merge-like-a-normal-delete---not-forward-2-chromium.txt
@@ -3,7 +3,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Paragra</p>
+<p>Paragra‸</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
@@ -7,7 +7,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:paragraph -->
-<p>B </p>
+<p>B‸</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-2-chromium.txt
@@ -9,5 +9,5 @@
 <!-- wp:code -->
 <pre class="wp-block-code"><code>ading
 
-Paragra</code></pre>
+Paragra‸</code></pre>
 <!-- /wp:code -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-preformatted-in-list-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-preformatted-in-list-1-chromium.txt
@@ -1,5 +1,5 @@
 <!-- wp:list -->
 <ul><!-- wp:list-item -->
-<li>xy</li>
+<li>x‸</li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-single-line-in-post-title-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-single-line-in-post-title-1-chromium.txt
@@ -1,1 +1,1 @@
-Hello World
+Hello World‸

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-respect-inline-copy-in-places-like-input-fields-and-textareas-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-respect-inline-copy-in-places-like-input-fields-and-textareas-2-chromium.txt
@@ -3,5 +3,5 @@
 <!-- /wp:shortcode -->
 
 <!-- wp:paragraph -->
-<p>Pasted: e]</p>
+<p>Pasted: e]‸</p>
 <!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-respect-inline-copy-when-text-is-selected-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-respect-inline-copy-when-text-is-selected-2-chromium.txt
@@ -3,7 +3,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>ck</p>
+<p>ck‸</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -25,6 +25,8 @@ test.describe( 'Copy/cut/paste', () => {
 
 		await page.keyboard.press( 'ArrowDown' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -47,6 +49,8 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeys( 'Tab' );
 		await page.keyboard.press( 'ArrowDown' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -84,6 +88,7 @@ test.describe( 'Copy/cut/paste', () => {
 			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
 		} );
 		await editor.insertBlock( { name: 'core/paragraph' } );
+		// Ensure the selection is correct.
 		await pageUtils.pressKeys( 'primary+v' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -110,6 +115,8 @@ test.describe( 'Copy/cut/paste', () => {
 
 		await page.keyboard.press( 'Enter' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -131,6 +138,8 @@ test.describe( 'Copy/cut/paste', () => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'Pasted: ' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -272,6 +281,8 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -306,6 +317,8 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -338,6 +351,7 @@ test.describe( 'Copy/cut/paste', () => {
 		// Create a new block at the top of the document to paste there.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
+		// Ensure the selection is correct.
 		await pageUtils.pressKeys( 'primary+v' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -373,6 +387,8 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -404,6 +420,8 @@ test.describe( 'Copy/cut/paste', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -434,12 +452,15 @@ test.describe( 'Copy/cut/paste', () => {
 		// Create a new code block to paste there.
 		await editor.insertBlock( { name: 'core/code' } );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	test( 'should paste single line in post title', async ( {
 		pageUtils,
 		editor,
+		page,
 	} ) => {
 		// This test checks whether we are correctly handling single line
 		// pasting in the post title. Previously we were accidentally falling
@@ -450,6 +471,8 @@ test.describe( 'Copy/cut/paste', () => {
 			html: '<span style="border: 1px solid black">Hello World</span>',
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 		// Expect the span to be filtered out.
 		expect(
 			await editor.canvas
@@ -470,12 +493,12 @@ test.describe( 'Copy/cut/paste', () => {
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
 		// Ensure the selection is correct.
-		await page.keyboard.type( 'y' );
+		await page.keyboard.type( '‸' );
 		expect(
 			await editor.canvas
 				.locator( ':root' )
 				.evaluate( () => document.activeElement.innerHTML )
-		).toBe( 'axyb' );
+		).toBe( 'ax‸b' );
 	} );
 
 	test( 'should paste preformatted in list', async ( {
@@ -490,7 +513,7 @@ test.describe( 'Copy/cut/paste', () => {
 		await editor.insertBlock( { name: 'core/list' } );
 		await pageUtils.pressKeys( 'primary+v' );
 		// Ensure the selection is correct.
-		await page.keyboard.type( 'y' );
+		await page.keyboard.type( '‸' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -539,7 +562,7 @@ test.describe( 'Copy/cut/paste', () => {
 		] );
 	} );
 
-	test( 'should auto-link', async ( { pageUtils, editor } ) => {
+	test( 'should auto-link', async ( { pageUtils, editor, page } ) => {
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'a' },
@@ -549,12 +572,13 @@ test.describe( 'Copy/cut/paste', () => {
 			html: 'https://wordpress.org/gutenberg',
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
+		await page.keyboard.type( '‸' );
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
 					content:
-						'<a href="https://wordpress.org/gutenberg">https://wordpress.org/gutenberg</a>a',
+						'<a href="https://wordpress.org/gutenberg">https://wordpress.org/gutenberg</a>‸a',
 				},
 			},
 		] );
@@ -575,6 +599,7 @@ test.describe( 'Copy/cut/paste', () => {
 	test( 'should not link selection for non http(s) protocol', async ( {
 		pageUtils,
 		editor,
+		page,
 	} ) => {
 		await editor.insertBlock( {
 			name: 'core/paragraph',
@@ -588,11 +613,12 @@ test.describe( 'Copy/cut/paste', () => {
 			html: 'movie: b',
 		} );
 		await pageUtils.pressKeys( 'primary+v' );
+		await page.keyboard.type( '‸' );
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: 'movie: b',
+					content: 'movie: b‸',
 				},
 			},
 		] );

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -457,7 +457,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			.toEqual( [ 1, 2 ] );
 	} );
 
-	test( 'should cut and paste', async ( { editor, pageUtils } ) => {
+	test( 'should cut and paste', async ( { editor, pageUtils, page } ) => {
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: '1' },
@@ -474,10 +474,12 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		await expect.poll( editor.getBlocks ).toEqual( [] );
 
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{ name: 'core/paragraph', attributes: { content: '1' } },
-			{ name: 'core/paragraph', attributes: { content: '2' } },
+			{ name: 'core/paragraph', attributes: { content: '2‸' } },
 		] );
 	} );
 

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -488,6 +488,8 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.type( 'ab' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
@@ -496,7 +498,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			},
 			{
 				name: 'core/paragraph',
-				attributes: { content: '2b' },
+				attributes: { content: '2‸b' },
 			},
 		] );
 	} );
@@ -515,11 +517,13 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.type( '13' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
-				attributes: { content: '123' },
+				attributes: { content: '12‸3' },
 			},
 		] );
 	} );
@@ -542,11 +546,13 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.type( 'ab' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
-				attributes: { content: 'a1<strong>2</strong>3b' },
+				attributes: { content: 'a1<strong>2</strong>3‸b' },
 			},
 		] );
 	} );
@@ -592,11 +598,13 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
-				attributes: { content: '<strong>132</strong>3' },
+				attributes: { content: '<strong>13‸2</strong>3' },
 			},
 		] );
 	} );
@@ -685,6 +693,8 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 
 		// Paste paragraph contents.
 		await pageUtils.pressKeys( 'primary+v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( '‸' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
@@ -696,7 +706,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 				innerBlocks: [
 					{
 						name: 'core/list-item',
-						attributes: { content: '1<br>2' },
+						attributes: { content: '1<br>2‸' },
 					},
 				],
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

While working on #54543, I noticed that our paste e2e are lacking because we almost never test where the selection ends. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should make sure the selection after paste is correct.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
