### PR TITLE
Make it clearer how to edit a site's palette

### DIFF
--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -10,7 +10,7 @@ import {
 	ColorIndicator,
 	Button,
 } from '@wordpress/components';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { shuffle } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -55,13 +55,7 @@ function Palette( { name } ) {
 		? '/colors/palette'
 		: '/blocks/' + encodeURIComponent( name ) + '/colors/palette';
 	const paletteButtonText =
-		colors.length > 0
-			? sprintf(
-					// Translators: %d: Number of palette colors.
-					_n( '%d color', '%d colors', colors.length ),
-					colors.length
-			  )
-			: __( 'Add custom colors' );
+		colors.length > 0 ? __( 'Edit' ) : __( 'Add palette' );
 
 	return (
 		<VStack spacing={ 3 }>
@@ -87,7 +81,7 @@ function Palette( { name } ) {
 									</ColorIndicatorWrapper>
 								) ) }
 						</ZStack>
-						<FlexItem className="edit-site-global-styles-screen-colors__palette-count">
+						<FlexItem className="edit-site-global-styles-screen-colors__palette-text">
 							{ paletteButtonText }
 						</FlexItem>
 					</HStack>

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -10,8 +10,8 @@ import {
 	ColorIndicator,
 	Button,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { shuffle } from '@wordpress/icons';
+import { isRTL, __ } from '@wordpress/i18n';
+import { Icon, shuffle, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -55,7 +55,7 @@ function Palette( { name } ) {
 		? '/colors/palette'
 		: '/blocks/' + encodeURIComponent( name ) + '/colors/palette';
 	const paletteButtonText =
-		colors.length > 0 ? __( 'Edit' ) : __( 'Add palette' );
+		colors.length > 0 ? __( 'Edit palette' ) : __( 'Add colors' );
 
 	return (
 		<VStack spacing={ 3 }>
@@ -63,13 +63,12 @@ function Palette( { name } ) {
 			<ItemGroup isBordered isSeparated>
 				<NavigationButtonAsItem
 					path={ screenPath }
-					aria-label={ __( 'Color palettes' ) }
+					aria-label={ paletteButtonText }
 				>
-					<HStack
-						direction={
-							colors.length === 0 ? 'row-reverse' : 'row'
-						}
-					>
+					<HStack direction={ 'row' }>
+						{ colors.length <= 0 && (
+							<FlexItem>{ __( 'Add colors' ) }</FlexItem>
+						) }
 						<ZStack isLayered={ false } offset={ -8 }>
 							{ colors
 								.slice( 0, 5 )
@@ -81,9 +80,7 @@ function Palette( { name } ) {
 									</ColorIndicatorWrapper>
 								) ) }
 						</ZStack>
-						<FlexItem className="edit-site-global-styles-screen-colors__palette-text">
-							{ paletteButtonText }
-						</FlexItem>
+						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 					</HStack>
 				</NavigationButtonAsItem>
 			</ItemGroup>

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -65,7 +65,7 @@ function Palette( { name } ) {
 					path={ screenPath }
 					aria-label={ paletteButtonText }
 				>
-					<HStack direction={ 'row' }>
+					<HStack direction="row">
 						{ colors.length <= 0 && (
 							<FlexItem>{ __( 'Add colors' ) }</FlexItem>
 						) }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -58,10 +58,6 @@
 	row-gap: calc(#{$grid-unit-05} * 3);
 }
 
-.edit-site-global-styles-screen-colors__palette-text {
-	color: $gray-700;
-}
-
 .edit-site-global-styles-header__description {
 	padding: 0 $grid-unit-20;
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -58,7 +58,7 @@
 	row-gap: calc(#{$grid-unit-05} * 3);
 }
 
-.edit-site-global-styles-screen-colors__palette-count {
+.edit-site-global-styles-screen-colors__palette-text {
 	color: $gray-700;
 }
 

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -157,7 +157,7 @@ test.describe( 'Global styles variations', () => {
 		await page.click( 'role=button[name="pink"i]' );
 		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Colors styles"i]' );
-		await page.click( 'role=button[name="Color palettes"i]' );
+		await page.click( 'role=button[name="Edit palette"i]' );
 
 		await expect(
 			page.locator( 'role=option[name="Color: Foreground"i]' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
It needs to be clearer how to add or edit the site's palette. Currently we show how many colors you have, but I think showing ">" is a clearer call to action to navigate to the palette. Part of https://github.com/WordPress/gutenberg/issues/61213 and https://github.com/WordPress/gutenberg/issues/61215.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open global styles.
2. Select "Colors".
3. See a chevron instead of "X colors"

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-29 at 10 57 41](https://github.com/WordPress/gutenberg/assets/1813435/cb0e95bb-2285-4fc3-934b-b977bd39d093)|![CleanShot 2024-05-29 at 10 54 25](https://github.com/WordPress/gutenberg/assets/1813435/b91bcefb-7787-489b-a0bb-14fbddd2a6a6)|



| Before (no colors)  | After (no colors) |
| ------------- | ------------- |
|![CleanShot 2024-05-29 at 10 59 06](https://github.com/WordPress/gutenberg/assets/1813435/988eb130-4795-499f-864f-6a4a35e628cf)|![CleanShot 2024-05-29 at 11 00 26](https://github.com/WordPress/gutenberg/assets/1813435/54e9855a-392f-4da5-8b01-fb83db71c849)|




