### PR TITLE
Improve panel title and description for palette

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-color-palette.js
+++ b/packages/edit-site/src/components/global-styles/screen-color-palette.js
@@ -18,7 +18,7 @@ function ScreenColorPalette( { name } ) {
 	return (
 		<>
 			<ScreenHeader
-				title={ __( 'Palette' ) }
+				title={ __( 'Edit Palette' ) }
 				description={ __(
 					'Palettes are used to provide default color options for blocks and various design tools. Here you can edit the colors with their labels.'
 				) }

--- a/packages/edit-site/src/components/global-styles/screen-color-palette.js
+++ b/packages/edit-site/src/components/global-styles/screen-color-palette.js
@@ -18,9 +18,9 @@ function ScreenColorPalette( { name } ) {
 	return (
 		<>
 			<ScreenHeader
-				title={ __( 'Edit Palette' ) }
+				title={ __( 'Edit palette' ) }
 				description={ __(
-					'The combination of colors used across this site and in color pickers.'
+					'The combination of colors used across the site and in color pickers.'
 				) }
 			/>
 			<Tabs>

--- a/packages/edit-site/src/components/global-styles/screen-color-palette.js
+++ b/packages/edit-site/src/components/global-styles/screen-color-palette.js
@@ -20,7 +20,7 @@ function ScreenColorPalette( { name } ) {
 			<ScreenHeader
 				title={ __( 'Edit Palette' ) }
 				description={ __(
-					'Palettes are used to provide default color options for blocks and various design tools. Here you can edit the colors with their labels.'
+					'The combination of colors used across this site and in color pickers.'
 				) }
 			/>
 			<Tabs>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In support of https://github.com/WordPress/gutenberg/issues/61213, changes "Palette" title for the ScreenHeader to be more relative to the activity in this panel, editing the palette. Also makes it clearer what the palette is via an updated description. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open global styles.
2. Select "Colors".
3. Select the palette.
4. See "Edit Palette" and an improved description. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-03 at 13 04 23](https://github.com/WordPress/gutenberg/assets/1813435/50daec58-1aa0-4c3f-b3a3-588215fe2e91)|![CleanShot 2024-05-03 at 13 03 21](https://github.com/WordPress/gutenberg/assets/1813435/2234bfa9-d563-4de2-9d9d-210d037f7a52)|

