### PR TITLE
Improve outline and radius for is-focused canvas

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -35,11 +35,16 @@
 
 	.edit-site-visual-editor__editor-canvas {
 		&.is-focused {
-			outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
-			outline-offset: calc(-2 * var(--wp-admin-border-width-focus));
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-style: solid;
+			outline-color: var(--wp-admin-theme-color);
+			outline-offset: calc(-1.75 * var(--wp-admin-border-width-focus));
+		}
+
+		.edit-site-layout:not(.is-full-canvas) & {
+			border-radius: $radius-block-ui * 4;
 		}
 	}
-
 
 	&.is-focus-mode {
 		.edit-site-layout.is-full-canvas & {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixing the is-focused style applied to the editor canvas when focused. 

## Why?
It looks broken in its current state. Now it's consistent as it can be with other focused elements. It's not displaced outside the frame as the current behavior is to apply overflow-hidden. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. Tab to the editor canvas.
3. See changes. 

## Screenshots or screencast <!-- if applicable -->

### Before 

![CleanShot 2024-05-03 at 13 18 55](https://github.com/WordPress/gutenberg/assets/1813435/f9a6e319-894b-4c9f-afcc-3ae28c1e2f25)

### After 

|![CleanShot 2024-05-03 at 13 17 46](https://github.com/WordPress/gutenberg/assets/1813435/a3567815-2a54-451a-b7f8-897f838d2c1c)


