### PR TITLE
Tweak color pickers to use outlines and reduce spacing

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -44,7 +44,7 @@ $swatch-gap: 12px;
 		$panelPadding: $grid-unit-20;
 
 		// Ensure the popover perfectly wraps the swatches.
-		width: ( $swatch-size * 6 ) + ( $swatch-gap * 5 ) + ( $panelPadding * 2 );
+		width: ( $swatch-size * 5 ) + ( $swatch-gap * 6 ) + ( $panelPadding * 2 );
 		padding: $panelPadding;
 	}
 }

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -1,7 +1,7 @@
-// Must equal $color-palette-circle-size and $color-palette-circle-spacing from:
+// Must equal $swatch-size and $swatch-gap from:
 // @wordpress/components/src/circular-option-picker/style.scss
 $swatch-size: 28px;
-$swatch-gap: 12px;
+$swatch-gap: 8px;
 
 $popover-width: 260px;
 $popover-padding: $grid-unit-20;

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -1,5 +1,5 @@
-$color-palette-circle-size: 28px;
-$color-palette-circle-spacing: 12px;
+$swatch-size: 28px;
+$swatch-gap: 8px;
 
 .components-circular-option-picker {
 	display: inline-block;
@@ -15,7 +15,7 @@ $color-palette-circle-spacing: 12px;
 	.components-circular-option-picker__swatches {
 		display: flex;
 		flex-wrap: wrap;
-		gap: $color-palette-circle-spacing;
+		gap: $swatch-gap;
 		position: relative;
 		z-index: z-index(".components-circular-option-picker__swatches");
 	}
@@ -31,17 +31,12 @@ $color-palette-circle-spacing: 12px;
 
 .components-circular-option-picker__option-wrapper {
 	display: inline-block;
-	height: $color-palette-circle-size;
-	width: $color-palette-circle-size;
+	height: $swatch-size;
+	width: $swatch-size;
 	vertical-align: top;
-	transform: scale(1);
 	transition: 100ms transform ease;
 	will-change: transform;
 	@include reduce-motion("transition");
-
-	&:hover {
-		transform: scale(1.2);
-	}
 
 	// Ensure that the <div> that <Dropdown> wraps our toggle button with is full height
 	& > div {
@@ -72,22 +67,24 @@ $color-palette-circle-spacing: 12px;
 	border: none;
 	border-radius: 50%;
 	background: transparent;
-	box-shadow: inset 0 0 0 ($color-palette-circle-size * 0.5);
-	transition: 100ms box-shadow ease;
+	transition: 100ms outline ease;
+	outline: $border-width solid rgba($black, 0.15);
+	outline-offset: -$border-width;
+
 	@include reduce-motion("transition");
 	cursor: pointer;
 
 	&:hover {
-		// Override default button hover style.
-		box-shadow: inset 0 0 0 ($color-palette-circle-size * 0.5) !important;
+		outline-color: rgba($black, 0.3);
 	}
 
 	&[aria-pressed="true"],
 	&[aria-selected="true"] {
-		box-shadow: inset 0 0 0 4px;
+		box-shadow: none;
+		outline-color: rgba($black, 0.3);
+		overflow: visible;
 		position: relative;
 		z-index: z-index(".components-circular-option-picker__option.is-pressed");
-		overflow: visible;
 
 		& + svg {
 			position: absolute;
@@ -99,43 +96,18 @@ $color-palette-circle-spacing: 12px;
 		}
 	}
 
-	&::after {
-		content: "";
-		position: absolute;
-		top: -1px;
-		left: -1px;
-		bottom: -1px;
-		right: -1px;
-		border-radius: $radius-round;
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
-		// Show a thin circular outline in Windows high contrast mode, otherwise the button is invisible.
-		border: 1px solid transparent;
-		box-sizing: inherit;
-	}
-
-	&:focus {
-		&::after {
-			content: "";
-			border-radius: $radius-round;
-			box-shadow: inset 0 0 0 2px $white;
-
-			// Make sure it's always centered
-			position: absolute;
-			top: 50%;
-			left: 50%;
-			transform: translate(-50%, -50%);
-
-			// Make sure dimensions account for border width
-			border: #{ $border-width * 2 } solid $gray-700;
-			width: calc(100% + #{ ( $border-width * 2 ) * 2 });
-			height: calc(100% + #{ ( $border-width * 2 ) * 2 });
-		}
-	}
-
 	&.components-button:focus {
+		box-shadow: none;
+		outline-width: $border-width;
+		outline-color: rgba($black, 0.3);
+	}
+
+	&.components-button:focus-visible {
 		background-color: transparent;
-		box-shadow: inset 0 0 0 ($color-palette-circle-size * 0.5);
-		outline: none;
+		box-shadow: none;
+		outline-color: $components-color-accent;
+		outline-offset: $border-width;
+		outline-width: var(--wp-admin-border-width-focus);
 	}
 }
 

--- a/packages/components/src/color-indicator/style.scss
+++ b/packages/components/src/color-indicator/style.scss
@@ -1,9 +1,12 @@
 .component-color-indicator {
-	width: $grid-unit-50 * 0.5;
-	height: $grid-unit-50 * 0.5;
-	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+	background: $white linear-gradient(-45deg, transparent 48%, rgba($black, 0.15) 48%, rgba($black, 0.15) 52%, transparent 52%);
 	border-radius: 50%;
 	display: inline-block;
+	height: $grid-unit-50 * 0.5;
+	outline-color: rgba($black, 0.15);
+	outline-offset: -1px;
+	outline-style: solid;
+	outline-width: $border-width;
 	padding: 0;
-	background: $white linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
+	width: $grid-unit-50 * 0.5;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Trying tiny optimizations for color palette items. 
- Uses outlines rather than inset shadows, simplifying the styles quite a bit. Outlines match https://github.com/WordPress/gutenberg/pull/61334 outlines.  
- Smaller gap between colors, allowing for more to display horizontally within Global Styles, which reduces the change changing a color variation will displace the variations. See https://github.com/WordPress/gutenberg/pull/61334. 
- Try removing scale hover as it blurs the indicator.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a heading block.
3. Pick a color.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-03 at 13 54 45](https://github.com/WordPress/gutenberg/assets/1813435/78720325-5db6-4447-b1f9-8507ebefba6f)|![CleanShot 2024-05-03 at 13 54 17](https://github.com/WordPress/gutenberg/assets/1813435/0c60ab00-ac12-443d-ae1c-d934ecd6dd8c)|



