### PR TITLE
Query Block test inserting interactive and non-interactive blocks

### DIFF
--- a/test/e2e/specs/editor/blocks/query.spec.js
+++ b/test/e2e/specs/editor/blocks/query.spec.js
@@ -66,24 +66,6 @@ test.describe( 'Query block', () => {
 	} );
 	test.describe( 'Query Loop - interactivity', () => {
 		test( 'Insert interactive block', async ( { page, editor } ) => {
-			/* Open List View */
-			const listViewToggleButton = page
-				.getByRole( 'region', { name: 'Editor top bar' } )
-				.getByRole( 'button', { name: 'Document Overview' } );
-
-			const listViewIsClosed =
-				( await listViewToggleButton.getAttribute(
-					'aria-expanded'
-				) ) === 'false';
-
-			if ( listViewIsClosed ) {
-				await listViewToggleButton.click();
-				await page
-					.getByRole( 'region', { name: 'Document Overview' } )
-					.getByRole( 'button', { name: 'Close' } )
-					.waitFor();
-			}
-
 			await editor.insertBlock( { name: 'core/query' } );
 
 			await editor.canvas
@@ -153,24 +135,6 @@ test.describe( 'Query block', () => {
 
 			await expect( queryBlock ).toBeVisible();
 
-			/* Open List View */
-			const listViewToggleButton = page
-				.getByRole( 'region', { name: 'Editor top bar' } )
-				.getByRole( 'button', { name: 'Document Overview' } );
-
-			const listViewIsClosed =
-				( await listViewToggleButton.getAttribute(
-					'aria-expanded'
-				) ) === 'false';
-
-			if ( listViewIsClosed ) {
-				await listViewToggleButton.click();
-				await page
-					.getByRole( 'region', { name: 'Document Overview' } )
-					.getByRole( 'button', { name: 'Close' } )
-					.waitFor();
-			}
-
 			await editor.openDocumentSettingsSidebar();
 
 			await page.getByLabel( 'Force page reload' ).setChecked( false );
@@ -179,7 +143,6 @@ test.describe( 'Query block', () => {
 				page.getByLabel( 'Force page reload' )
 			).not.toBeChecked();
 
-			//
 			await queryBlock.focus();
 
 			await editor.canvas

--- a/test/e2e/specs/editor/blocks/query.spec.js
+++ b/test/e2e/specs/editor/blocks/query.spec.js
@@ -64,4 +64,157 @@ test.describe( 'Query block', () => {
 			] );
 		} );
 	} );
+	test.describe( 'Query Loop - interactivity', () => {
+		test( 'Insert interactive block', async ( { page, editor } ) => {
+			/* Open List View */
+			const listViewToggleButton = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Document Overview' } );
+
+			const listViewIsClosed =
+				( await listViewToggleButton.getAttribute(
+					'aria-expanded'
+				) ) === 'false';
+
+			if ( listViewIsClosed ) {
+				await listViewToggleButton.click();
+				await page
+					.getByRole( 'region', { name: 'Document Overview' } )
+					.getByRole( 'button', { name: 'Close' } )
+					.waitFor();
+			}
+
+			await editor.insertBlock( { name: 'core/query' } );
+
+			await editor.canvas
+				.getByRole( 'document', { name: 'Block: Query Loop' } )
+				.getByRole( 'button', { name: 'Choose' } )
+				.click();
+
+			await page
+				.getByRole( 'dialog', { name: 'Choose a pattern' } )
+				.getByRole( 'option', { name: 'Standard' } )
+				.click();
+
+			const queryBlock = editor.canvas.locator(
+				'role=document[name="Block: Query Loop"i]'
+			);
+
+			await expect( queryBlock ).toBeVisible();
+
+			await editor.openDocumentSettingsSidebar();
+
+			await page.getByLabel( 'Force page reload' ).setChecked( false );
+
+			await expect(
+				page.getByLabel( 'Force page reload' )
+			).not.toBeChecked();
+
+			await queryBlock.focus();
+
+			await editor.canvas
+				.locator( 'role=button[name="Add block"i]' )
+				.click();
+
+			await page
+				.getByRole( 'listbox', { name: 'Blocks' } )
+				.getByRole( 'option', { name: 'Heading' } )
+				.click();
+
+			await editor.canvas
+				.getByRole( 'document', { name: 'Block: Heading' } )
+				.fill( 'Test Heading' );
+
+			await queryBlock.focus();
+
+			await editor.openDocumentSettingsSidebar();
+
+			await expect(
+				page.getByLabel( 'Force page reload' )
+			).not.toBeChecked();
+		} );
+
+		test( 'Insert non-interactive block', async ( { page, editor } ) => {
+			await editor.insertBlock( { name: 'core/query' } );
+
+			await editor.canvas
+				.getByRole( 'document', { name: 'Block: Query Loop' } )
+				.getByRole( 'button', { name: 'Choose' } )
+				.click();
+
+			await page
+				.getByRole( 'dialog', { name: 'Choose a pattern' } )
+				.getByRole( 'option', { name: 'Standard' } )
+				.click();
+
+			const queryBlock = editor.canvas.locator(
+				'role=document[name="Block: Query Loop"i]'
+			);
+
+			await expect( queryBlock ).toBeVisible();
+
+			/* Open List View */
+			const listViewToggleButton = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Document Overview' } );
+
+			const listViewIsClosed =
+				( await listViewToggleButton.getAttribute(
+					'aria-expanded'
+				) ) === 'false';
+
+			if ( listViewIsClosed ) {
+				await listViewToggleButton.click();
+				await page
+					.getByRole( 'region', { name: 'Document Overview' } )
+					.getByRole( 'button', { name: 'Close' } )
+					.waitFor();
+			}
+
+			await editor.openDocumentSettingsSidebar();
+
+			await page.getByLabel( 'Force page reload' ).setChecked( false );
+
+			await expect(
+				page.getByLabel( 'Force page reload' )
+			).not.toBeChecked();
+
+			//
+			await queryBlock.focus();
+
+			await editor.canvas
+				.locator( 'role=button[name="Add block"i]' )
+				.click();
+
+			await page
+				.getByLabel( 'Search for blocks and patterns' )
+				.fill( 'Shortcode' );
+
+			await page
+				.getByRole( 'listbox', { name: 'Blocks' } )
+				.getByRole( 'option', { name: 'Shortcode' } )
+				.click();
+
+			await expect(
+				page.getByRole( 'alertdialog', {
+					name: 'Query block: Force page reload enabled',
+				} )
+			).toBeVisible();
+
+			await page
+				.getByRole( 'alertdialog', {
+					name: 'Query block: Force page reload enabled',
+				} )
+				.getByRole( 'button', { name: 'OK' } )
+				.click();
+
+			await queryBlock.focus();
+
+			await editor.openDocumentSettingsSidebar();
+
+			await expect(
+				page.getByLabel( 'Force page reload' )
+			).toBeChecked();
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?
Adds two tests for the query block inserting interactive and non-interactive blocks inside a query block set to interactive mode.

## Why?
With the release of the interactivity api users can add non-core blocks to the query block in interactive mode. These test will ensure we always check that the inserted block is compatible with interactive mode. This is a follow up to https://github.com/WordPress/gutenberg/pull/60006

## How?
Adds two tests, inserting a interactive and a non-interactive block (core/shortcode)

## Testing Instructions
`npm run test:e2e -- test/e2e/specs/editor/blocks/query.spec`
All tests should pass.



