### PR TITLE
RichText: Do not focus the input unless user is in an editing context

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -158,7 +158,7 @@ function getMissingText( type ) {
  * packages/block-library/src/navigation-submenu/edit.js
  * Consider reuseing this components for both blocks.
  */
-function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
+function Controls( { attributes, setAttributes } ) {
 	const { label, url, description, title, rel } = attributes;
 	return (
 		<PanelBody title={ __( 'Settings' ) }>
@@ -171,8 +171,6 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 				} }
 				label={ __( 'Text' ) }
 				autoComplete="off"
-				onFocus={ () => setIsLabelFieldFocused( true ) }
-				onBlur={ () => setIsLabelFieldFocused( false ) }
 			/>
 			<TextControl
 				__nextHasNoMarginBottom
@@ -263,10 +261,6 @@ export default function NavigationLinkEdit( {
 	const ref = useRef();
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
-
-	// Change the label using inspector causes rich text to change focus on firefox.
-	// This is a workaround to keep the focus on the label field when label filed is focused we don't render the rich text.
-	const [ isLabelFieldFocused, setIsLabelFieldFocused ] = useState( false );
 
 	const {
 		isAtMaxNesting,
@@ -484,7 +478,6 @@ export default function NavigationLinkEdit( {
 				<Controls
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					setIsLabelFieldFocused={ setIsLabelFieldFocused }
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
@@ -499,51 +492,47 @@ export default function NavigationLinkEdit( {
 						</div>
 					) : (
 						<>
-							{ ! isInvalid &&
-								! isDraft &&
-								! isLabelFieldFocused && (
-									<>
-										<RichText
-											ref={ ref }
-											identifier="label"
-											className="wp-block-navigation-item__label"
-											value={ label }
-											onChange={ ( labelValue ) =>
-												setAttributes( {
-													label: labelValue,
-												} )
-											}
-											onMerge={ mergeBlocks }
-											onReplace={ onReplace }
-											__unstableOnSplitAtEnd={ () =>
-												insertBlocksAfter(
-													createBlock(
-														'core/navigation-link'
-													)
+							{ ! isInvalid && ! isDraft && (
+								<>
+									<RichText
+										ref={ ref }
+										identifier="label"
+										className="wp-block-navigation-item__label"
+										value={ label }
+										onChange={ ( labelValue ) =>
+											setAttributes( {
+												label: labelValue,
+											} )
+										}
+										onMerge={ mergeBlocks }
+										onReplace={ onReplace }
+										__unstableOnSplitAtEnd={ () =>
+											insertBlocksAfter(
+												createBlock(
+													'core/navigation-link'
 												)
-											}
-											aria-label={ __(
-												'Navigation link text'
-											) }
-											placeholder={ itemLabelPlaceholder }
-											withoutInteractiveFormatting
-											allowedFormats={ [
-												'core/bold',
-												'core/italic',
-												'core/image',
-												'core/strikethrough',
-											] }
-										/>
-										{ description && (
-											<span className="wp-block-navigation-item__description">
-												{ description }
-											</span>
+											)
+										}
+										aria-label={ __(
+											'Navigation link text'
 										) }
-									</>
-								) }
-							{ ( isInvalid ||
-								isDraft ||
-								isLabelFieldFocused ) && (
+										placeholder={ itemLabelPlaceholder }
+										withoutInteractiveFormatting
+										allowedFormats={ [
+											'core/bold',
+											'core/italic',
+											'core/image',
+											'core/strikethrough',
+										] }
+									/>
+									{ description && (
+										<span className="wp-block-navigation-item__description">
+											{ description }
+										</span>
+									) }
+								</>
+							) }
+							{ ( isInvalid || isDraft ) && (
 								<div className="wp-block-navigation-link__placeholder-text wp-block-navigation-link__label">
 									<Tooltip text={ tooltipText }>
 										<span

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -288,6 +288,8 @@ export function applySelection( { startPath, endPath }, current ) {
 	// selection manipulations may shift focus, ensure that focus is restored to
 	// its previous state.
 	// Do not take focus if user is not in iFrame editing canvas.
+	//
+	// See: https://github.com/WordPress/gutenberg/issues/61315
 	if (
 		activeElement.closest( 'iframe' ) &&
 		activeElement !== ownerDocument.activeElement

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -271,6 +271,10 @@ export function applySelection( { startPath, endPath }, current ) {
 	range.setEnd( endContainer, endOffset );
 
 	const { activeElement } = ownerDocument;
+	const { frameElement } = activeElement.ownerDocument.defaultView;
+	const isInsideFrame = frameElement
+		? frameElement === frameElement.ownerDocument.activeElement
+		: true;
 
 	if ( selection.rangeCount > 0 ) {
 		// If the to be added range and the live range are the same, there's no
@@ -290,10 +294,7 @@ export function applySelection( { startPath, endPath }, current ) {
 	// Do not take focus if user is not in iFrame editing canvas.
 	//
 	// See: https://github.com/WordPress/gutenberg/issues/61315
-	if (
-		activeElement.closest( 'iframe' ) &&
-		activeElement !== ownerDocument.activeElement
-	) {
+	if ( isInsideFrame && activeElement !== ownerDocument.activeElement ) {
 		// The `instanceof` checks protect against edge cases where the focused
 		// element is not of the interface HTMLElement (does not have a `focus`
 		// or `blur` property).

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -287,7 +287,11 @@ export function applySelection( { startPath, endPath }, current ) {
 	// This function is not intended to cause a shift in focus. Since the above
 	// selection manipulations may shift focus, ensure that focus is restored to
 	// its previous state.
-	if ( activeElement !== ownerDocument.activeElement ) {
+	// Do not take focus if user is not in iFrame editing canvas.
+	if (
+		activeElement.closest( 'iframe' ) &&
+		activeElement !== ownerDocument.activeElement
+	) {
 		// The `instanceof` checks protect against edge cases where the focused
 		// element is not of the interface HTMLElement (does not have a `focus`
 		// or `blur` property).


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/72168 and https://github.com/WordPress/gutenberg/issues/68035

This was a hard bug to unravel. Essentially, every time a user types into a `RichText` field, we're building some type of virtual tree in memory. Apparently this can at times cause focus to shift unpredictibly so the solution was to hardcode a focus back to the input receiving the `onChange` values. The issue with this is if the user is changing the value from say a `TextControl` in the inspector sidebar, `RichText` still sees this as an `onChange` and will take focus back to the block editor canvas. I added a check to skip this focus check if the user was not in the context of an iFrame.

Worth noting, I have no idea if I have possibly broken anything. I would greatly value input from @ellatrix on if this is a viable solution or not.

Finally, removed the hack in the navigation link block to keep focus in one place.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Broken accessibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Explained above.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert a navigation block and custom link.
2. In the inspector sidebar, edit the link text label.
3. Notice how focus is not taken to the block editor canvas when you edit the label.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
