### PR TITLE
WP Scripts: Add a `--root-folder` argument to the `plugin-zip` command

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Add BlueOak-1.0.0 the GPLv2-comatible licenses recognized by check-licenses ([#66139](https://github.com/WordPress/gutenberg/pull/66139)).
+-   Add an optional `--zip-root-folder` argument to the `plugin-zip` command ([#61375](https://github.com/WordPress/gutenberg/pull/61375)). The command will use the plugin's name as the root folder of the zip by default. If the change in the behavior impacted your workflow, you could pass `--root-folder=''` to remove the root folder. 
 
 ### Internal
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Enhancements
 
--   Add BlueOak-1.0.0 the GPLv2-comatible licenses recognized by check-licenses ([#66139](https://github.com/WordPress/gutenberg/pull/66139)).
--   Add an optional `--root-folder` argument to the `plugin-zip` command ([#61375](https://github.com/WordPress/gutenberg/pull/61375)). By default, the command will use the plugin's name as the root folder of the zip. If the change in the behavior impacted your workflow, you could pass `--root-folder=''` to remove the root folder. 
+-   Add BlueOak-1.0.0 the GPLv2-compatible licenses recognized by check-licenses ([#66139](https://github.com/WordPress/gutenberg/pull/66139)).
+-   Add an optional `--root-folder` argument to the `plugin-zip` command ([#61375](https://github.com/WordPress/gutenberg/pull/61375)). By default, the command will use the plugin's name as the root folder of the zip. If the change in the behavior impacted your workflow, you could pass `--no-root-folder` to remove the root folder.
 
 ### Internal
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   Add BlueOak-1.0.0 the GPLv2-comatible licenses recognized by check-licenses ([#66139](https://github.com/WordPress/gutenberg/pull/66139)).
--   Add an optional `--zip-root-folder` argument to the `plugin-zip` command ([#61375](https://github.com/WordPress/gutenberg/pull/61375)). The command will use the plugin's name as the root folder of the zip by default. If the change in the behavior impacted your workflow, you could pass `--root-folder=''` to remove the root folder. 
+-   Add an optional `--root-folder` argument to the `plugin-zip` command ([#61375](https://github.com/WordPress/gutenberg/pull/61375)). By default, the command will use the plugin's name as the root folder of the zip. If the change in the behavior impacted your workflow, you could pass `--root-folder=''` to remove the root folder. 
 
 ### Internal
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -378,6 +378,13 @@ In the case where the plugin author wants to customize the files included in the
 
 It reuses the same logic as `npm pack` command to create an npm package tarball.
 
+This is how you create a zip for use with a custom plugin update system
+
+-   `--zip-root-folder` - When updating a plugin, WordPress expects a folder in the root of the zip file which matches the plugin name. The `--zip-root-folder` parameter will create a folder in the root of the zip file that matches your plugin name instead of adding all files to the root.
+
+-   `npm run plugin-zip --zip-root-folder` - which will use your plugin name as the folder.
+-   `npm run plugin-zip --zip-root-folder=plugin-name` - which will allow you to specify a plugin name.
+
 ### `start`
 
 Transforms your code according the configuration provided so it’s ready for development. The script will automatically rebuild if you make changes to the code, and you will see the build errors in the console.

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -378,12 +378,12 @@ In the case where the plugin author wants to customize the files included in the
 
 It reuses the same logic as `npm pack` command to create an npm package tarball.
 
-This is how you create a zip for use with a custom plugin update system
-
--   `--zip-root-folder` - When updating a plugin, WordPress expects a folder in the root of the zip file which matches the plugin name. The `--zip-root-folder` parameter will create a folder in the root of the zip file that matches your plugin name instead of adding all files to the root.
-
--   `npm run plugin-zip --zip-root-folder` - which will use your plugin name as the folder.
--   `npm run plugin-zip --zip-root-folder=plugin-name` - which will allow you to specify a plugin name.
+This is how you create a custom root folder inside the zip file.
+- When updating a plugin, WordPress expects a folder in the root of the zip file which matches the plugin name. So be aware that this may affect the plugin update process.
+-   `--root-folder` - Add a custom root folder to the zip file.
+-   `npm run plugin-zip` - By default, unzipping your plugin will result in a folder with the same name as your plugin.
+-   `npm run plugin-zip --root-folder=''` - This will create a zip file that has no folder inside, your plugin files will be unzipped directly into the target directory.
+-   `npm run plugin-zip --root-folder='custom-directory'` - Your plugin will be unzipped into a folder named `custom-directory`.
 
 ### `start`
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -381,9 +381,9 @@ It reuses the same logic as `npm pack` command to create an npm package tarball.
 This is how you create a custom root folder inside the zip file.
 - When updating a plugin, WordPress expects a folder in the root of the zip file which matches the plugin name. So be aware that this may affect the plugin update process.
 -   `--root-folder` - Add a custom root folder to the zip file.
--   `npm run plugin-zip` - By default, unzipping your plugin will result in a folder with the same name as your plugin.
--   `npm run plugin-zip --root-folder=''` - This will create a zip file that has no folder inside, your plugin files will be unzipped directly into the target directory.
--   `npm run plugin-zip --root-folder='custom-directory'` - Your plugin will be unzipped into a folder named `custom-directory`.
+-   `npm run plugin-zip` - By default, unzipping your plugin's zip file will result in a folder with the same name as your plugin.
+-   `npm run plugin-zip --root-folder='custom-directory'` - Your plugin's zip file will be unzipped into a folder named `custom-directory`.
+-   `npm run plugin-zip --no-root-folder` - This will create a zip file that has no folder inside, your plugin files will be unzipped directly into the target directory.
 
 ### `start`
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -379,7 +379,8 @@ In the case where the plugin author wants to customize the files included in the
 It reuses the same logic as `npm pack` command to create an npm package tarball.
 
 This is how you create a custom root folder inside the zip file.
-- When updating a plugin, WordPress expects a folder in the root of the zip file which matches the plugin name. So be aware that this may affect the plugin update process.
+
+-   When updating a plugin, WordPress expects a folder in the root of the zip file which matches the plugin name. So be aware that this may affect the plugin update process.
 -   `--root-folder` - Add a custom root folder to the zip file.
 -   `npm run plugin-zip` - By default, unzipping your plugin's zip file will result in a folder with the same name as your plugin.
 -   `npm run plugin-zip --root-folder='custom-directory'` - Your plugin's zip file will be unzipped into a folder named `custom-directory`.

--- a/packages/scripts/scripts/plugin-zip.js
+++ b/packages/scripts/scripts/plugin-zip.js
@@ -10,13 +10,15 @@ const { stdout } = require( 'process' );
 /**
  * Internal dependencies
  */
-const { hasPackageProp, getPackageProp } = require( '../utils' );
+const { hasPackageProp, getPackageProp, getArgFromCLI } = require( '../utils' );
 
 const name = getPackageProp( 'name' );
 stdout.write( `Creating archive for \`${ name }\` plugin... 🎁\n\n` );
 const zip = new AdmZip();
-
+const zipRootFolderArg = getArgFromCLI( '--zip-root-folder' );
+let zipRootFolder = null;
 let files = [];
+
 if ( hasPackageProp( 'files' ) ) {
 	stdout.write(
 		'Using the `files` field from `package.json` to detect files:\n\n'
@@ -47,10 +49,29 @@ if ( hasPackageProp( 'files' ) ) {
 	);
 }
 
+if ( zipRootFolderArg !== undefined ) {
+	if ( zipRootFolderArg === null ) {
+		stdout.write(
+			'No value provided for `--zip-root-folder`. Using the plugin name as the root folder.\n\n'
+		);
+		zipRootFolder = `${ name }/`;
+	} else {
+		zipRootFolder = `${ zipRootFolderArg }/`;
+	}
+	stdout.write(
+		`Adding the provided folder \`${ zipRootFolder }\` to the root of the package.\n\n`
+	);
+} else {
+	zipRootFolder = '';
+}
+
 files.forEach( ( file ) => {
 	stdout.write( `  Adding \`${ file }\`.\n` );
 	const zipDirectory = dirname( file );
-	zip.addLocalFile( file, zipDirectory !== '.' ? zipDirectory : '' );
+	zip.addLocalFile(
+		file,
+		zipRootFolder + ( zipDirectory !== '.' ? zipDirectory : '' )
+	);
 } );
 
 zip.writeZip( `./${ name }.zip` );

--- a/packages/scripts/scripts/plugin-zip.js
+++ b/packages/scripts/scripts/plugin-zip.js
@@ -15,8 +15,8 @@ const { hasPackageProp, getPackageProp, getArgFromCLI } = require( '../utils' );
 const name = getPackageProp( 'name' );
 stdout.write( `Creating archive for \`${ name }\` plugin... 🎁\n\n` );
 const zip = new AdmZip();
-const zipRootFolderArg = getArgFromCLI( '--zip-root-folder' );
-let zipRootFolder = null;
+const zipRootFolderArg = getArgFromCLI( '--root-folder' );
+let zipRootFolder = `${ name }/`;
 let files = [];
 
 if ( hasPackageProp( 'files' ) ) {
@@ -50,21 +50,20 @@ if ( hasPackageProp( 'files' ) ) {
 }
 
 if ( zipRootFolderArg !== undefined ) {
-	if ( zipRootFolderArg === null ) {
+	const trimmedZipRootFolderArg =
+		typeof zipRootFolderArg === 'string' ? zipRootFolderArg.trim() : null;
+	if ( ! trimmedZipRootFolderArg ) {
 		stdout.write(
-			'No value provided for `--zip-root-folder`. Using the plugin name as the root folder.\n\n'
+			'Plugin files will be zipped without a root folder.\n\n'
 		);
-		zipRootFolder = `${ name }/`;
+		zipRootFolder = '';
 	} else {
-		zipRootFolder = `${ zipRootFolderArg }/`;
+		zipRootFolder = `${ trimmedZipRootFolderArg }/`;
+		stdout.write(
+			`Adding the provided folder \`${ zipRootFolder }\` to the root of the package.\n\n`
+		);
 	}
-	stdout.write(
-		`Adding the provided folder \`${ zipRootFolder }\` to the root of the package.\n\n`
-	);
-} else {
-	zipRootFolder = '';
 }
-
 files.forEach( ( file ) => {
 	stdout.write( `  Adding \`${ file }\`.\n` );
 	const zipDirectory = dirname( file );

--- a/packages/scripts/scripts/plugin-zip.js
+++ b/packages/scripts/scripts/plugin-zip.js
@@ -52,19 +52,19 @@ if ( hasPackageProp( 'files' ) ) {
 
 if ( noRootFolderArg !== undefined ) {
 	zipRootFolder = '';
-	stdout.write( 'Plugin files will be zipped without a root folder.\n\n' );
+	stdout.write( '  Plugin files will be zipped without a root folder.\n\n' );
 } else if ( zipRootFolderArg !== undefined ) {
 	const trimmedZipRootFolderArg =
 		typeof zipRootFolderArg === 'string' ? zipRootFolderArg.trim() : null;
 	if ( trimmedZipRootFolderArg === null ) {
 		stdout.write(
-			'Please provide a `--root-folder` name or use `--no-root-folder.`\n\n'
+			'Unable to create zip package: please provide a `--root-folder` name or use `--no-root-folder.`\n\n'
 		);
 		process.exit( 1 );
 	}
 	zipRootFolder = `${ trimmedZipRootFolderArg }/`;
 	stdout.write(
-		`Adding the provided folder \`${ zipRootFolder }\` to the root of the package.\n\n`
+		`  Adding the provided folder \`${ zipRootFolder }\` to the root of the package.\n\n`
 	);
 }
 files.forEach( ( file ) => {

--- a/packages/scripts/scripts/plugin-zip.js
+++ b/packages/scripts/scripts/plugin-zip.js
@@ -16,6 +16,7 @@ const name = getPackageProp( 'name' );
 stdout.write( `Creating archive for \`${ name }\` plugin... 🎁\n\n` );
 const zip = new AdmZip();
 const zipRootFolderArg = getArgFromCLI( '--root-folder' );
+const noRootFolderArg = getArgFromCLI( '--no-root-folder' );
 let zipRootFolder = `${ name }/`;
 let files = [];
 
@@ -49,20 +50,22 @@ if ( hasPackageProp( 'files' ) ) {
 	);
 }
 
-if ( zipRootFolderArg !== undefined ) {
+if ( noRootFolderArg !== undefined ) {
+	zipRootFolder = '';
+	stdout.write( 'Plugin files will be zipped without a root folder.\n\n' );
+} else if ( zipRootFolderArg !== undefined ) {
 	const trimmedZipRootFolderArg =
 		typeof zipRootFolderArg === 'string' ? zipRootFolderArg.trim() : null;
-	if ( ! trimmedZipRootFolderArg ) {
+	if ( trimmedZipRootFolderArg === null ) {
 		stdout.write(
-			'Plugin files will be zipped without a root folder.\n\n'
+			'Please provide a `--root-folder` name or use `--no-root-folder.`\n\n'
 		);
-		zipRootFolder = '';
-	} else {
-		zipRootFolder = `${ trimmedZipRootFolderArg }/`;
-		stdout.write(
-			`Adding the provided folder \`${ zipRootFolder }\` to the root of the package.\n\n`
-		);
+		process.exit( 1 );
 	}
+	zipRootFolder = `${ trimmedZipRootFolderArg }/`;
+	stdout.write(
+		`Adding the provided folder \`${ zipRootFolder }\` to the root of the package.\n\n`
+	);
 }
 files.forEach( ( file ) => {
 	stdout.write( `  Adding \`${ file }\`.\n` );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #60481.

Allows adding a root folder to the zip file generated by plugin-zip

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This allows creating a zip file that can be used to update a plugin via the WP Admin update page, since the plugin updater expects the zip file to contain a folder with the name of the plugin in the root of the zip file.
Please refer to the issue I opened here: https://github.com/WordPress/gutenberg/issues/60481

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add an argument to the plugin-zip command that will allow a developer to specify the root folder inside the zip file. Modifies zip creation to use this argument if specified. Defaults to the plugin name if no string was passed along with the argument.

## Testing Instructions
Here's what I did to test:
1. Link local Gutenberg project globally: from inside the gutenberg directory `npm link`
1. Go back to my project directory: `cd ..`
1. Create a block plugin with wp-scripts: `npx @wordpress/create-block test`
1. Go into the block directory `cd test`
1. Link the local Gutenberg project `npm link gutenberg`
1. Build the block: `npm run build`
1. Run the local build script`../gutenberg/node_modules/.bin/wp-scripts plugin-zip`
1. View the zip file and ensure the contents are consistent with the default behavior:
Archive:  test.zip
```
  Length      Date    Time    Name
---------  ---------- -----   ----
      488  05-03-2024 18:02   build/block.json
      134  05-03-2024 18:02   build/index.asset.php
       51  05-03-2024 18:02   build/index.css
     1363  05-03-2024 18:02   build/index.js
       77  05-03-2024 18:02   build/style-index.css
       84  05-03-2024 18:02   build/view.asset.php
       59  05-03-2024 18:02   build/view.js
     1807  05-03-2024 17:43   readme.txt
      915  05-03-2024 17:43   test.php
---------                     -------
     4978                     9 files
```
### Test --zip-root-folder argument
Expected: should use the name of the plugin as the root folder.
1. Try using the new argument `../gutenberg/node_modules/.bin/wp-scripts plugin-zip --zip-root-folder`
1. Now running `unzip -l test.zip` should show you a `test` folder at the root of the zip:
```
Archive:  test.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      488  05-03-2024 18:02   test/build/block.json
      134  05-03-2024 18:02   test/build/index.asset.php
       51  05-03-2024 18:02   test/build/index.css
     1363  05-03-2024 18:02   test/build/index.js
       77  05-03-2024 18:02   test/build/style-index.css
       84  05-03-2024 18:02   test/build/view.asset.php
       59  05-03-2024 18:02   test/build/view.js
     1807  05-03-2024 17:43   test/readme.txt
      915  05-03-2024 17:43   test/test.php
---------                     -------
     4978                     9 files
```
### Test with --zip-root-folder argument with a value
Expected: should use a custom name for the root folder. Zip file name will remain unchanged.
1. Try with a value `../gutenberg/node_modules/.bin/wp-scripts plugin-zip --zip-root-folder=foo`
1. Now running `unzip -l test.zip` should show you a `foo` folder at the root of the zip:
```
Archive:  test.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      488  05-03-2024 18:02   foo/build/block.json
      134  05-03-2024 18:02   foo/build/index.asset.php
...
```
### Test files array in package.json still works
1. Add the following to the test block's package.json
```
	"files": [
		"build",
		".editorconfig"
	],
```
2. Run `../gutenberg/node_modules/.bin/wp-scripts plugin-zip --zip-root-folder=foo`
3. Running `unzip -l test.zip` should show you a `foo` folder at the root of the zip:, and the additional file(s) you add should be in the archive.
```
Archive:  test.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      369  05-03-2024 17:43   foo/.editorconfig
      488  05-03-2024 18:02   foo/build/block.json
... etc
```

Thanks for reading! I can't wait to get some feedback. Please let me know if there is anything I can improve on.