### PR TITLE
Several Typo Correction in Inline doc

### DIFF
--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -290,7 +290,7 @@ function gutenberg_register_block_hooks_rest_field() {
 		'block_hooks',
 		array(
 			'schema' => array(
-				'description'       => __( 'This block is automatically inserted near any occurence of the block types used as keys of this map, into a relative position given by the corresponding value.', 'gutenberg' ),
+				'description'       => __( 'This block is automatically inserted near any occurrence of the block types used as keys of this map, into a relative position given by the corresponding value.', 'gutenberg' ),
 				'type'              => 'object',
 				'patternProperties' => array(
 					'^[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$' => array(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -162,7 +162,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * The schema structure should mirror the data tree. Each value provided in the
 		 * schema should be a callable that will be applied to sanitize the corresponding
 		 * value in the data tree. Keys that are in the data tree, but not present in the
-		 * schema, will be removed in the santized data. Nested arrays are traversed recursively.
+		 * schema, will be removed in the sanitized data. Nested arrays are traversed recursively.
 		 *
 		 * @since 6.5.0
 		 *


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/61378