### PR TITLE
Fix JS lint error

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -82,7 +82,7 @@ export default function Variation( { variation, children, isPill } ) {
 				onBlur={ () => setIsFocused( false ) }
 			>
 				<div
-					className={ classnames(
+					className={ clsx(
 						'edit-site-global-styles-variations_item-preview',
 						{ 'is-pill': isPill }
 					) }

--- a/packages/interactivity-router/src/head.js
+++ b/packages/interactivity-router/src/head.js
@@ -3,7 +3,6 @@
  *
  * @async
  * @param {Array} newHead The head elements of the new page.
- *
  */
 export const updateHead = async ( newHead ) => {
 	// Helper to get the tag id store in the cache.


### PR DESCRIPTION
It seems that the lint check is causing an error on the trunk. I ran `lint:js:fix` locally and [one error was fixed](https://github.com/WordPress/gutenberg/pull/61380/files#diff-a669d0511ace79842f9a940efbf6f126aff0dd3c9ec3611d076823cbdcc50c40L6).

Looking at [the blame](https://github.com/WordPress/gutenberg/blame/trunk/packages/interactivity-router/src/head.js) for this file, this line was last updated about two weeks ago. So it's unclear why it's only now causing lint errors 🤷

Update: This seems to be caused by undefined `classnames` being used.