### PR TITLE
Use `grid-auto-rows` to ensure min height of new grid rows.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -479,7 +479,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			} else {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'grid-auto-rows' => 'minmax(50px, min-content)' ),
+					'declarations' => array( 'grid-auto-rows' => 'minmax(1.5em, min-content)' ),
 				);
 			}
 		} else {
@@ -489,7 +489,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				'selector'     => $selector,
 				'declarations' => array(
 					'grid-template-columns' => 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))',
-					'grid-auto-rows'        => 'minmax(50px, min-content)',
+					'grid-auto-rows'        => 'minmax(1.5em, min-content)',
 					'container-type'        => 'inline-size',
 				),
 			);

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -479,7 +479,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			} else {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'grid-auto-rows' => 'minmax(0, 1fr)' ),
+					'declarations' => array( 'grid-auto-rows' => 'minmax(50px, min-content)' ),
 				);
 			}
 		} else {
@@ -489,7 +489,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				'selector'     => $selector,
 				'declarations' => array(
 					'grid-template-columns' => 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))',
-					'grid-auto-rows'        => 'minmax(0, 1fr)',
+					'grid-auto-rows'        => 'minmax(50px, min-content)',
 					'container-type'        => 'inline-size',
 				),
 			);

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -476,6 +476,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'selector'     => $selector,
 					'declarations' => array( 'grid-template-rows' => 'repeat(' . $layout['rowCount'] . ', minmax(0, 1fr))' ),
 				);
+			} else {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'grid-auto-rows' => 'minmax(0, 1fr)' ),
+				);
 			}
 		} else {
 			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';
@@ -484,6 +489,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				'selector'     => $selector,
 				'declarations' => array(
 					'grid-template-columns' => 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))',
+					'grid-auto-rows'        => 'minmax(0, 1fr)',
 					'container-type'        => 'inline-size',
 				),
 			);

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -133,12 +133,12 @@ export default {
 					`grid-template-rows: repeat(${ rowCount }, minmax(0, 1fr))`
 				);
 			} else {
-				rules.push( `grid-auto-rows: minmax(50px, min-content)` );
+				rules.push( `grid-auto-rows: minmax(1.5em, min-content)` );
 			}
 		} else if ( minimumColumnWidth ) {
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(min(${ minimumColumnWidth }, 100%), 1fr))`,
-				`grid-auto-rows: minmax(50px, min-content)`,
+				`grid-auto-rows: minmax(1.5em, min-content)`,
 				`container-type: inline-size`
 			);
 		}

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -133,12 +133,12 @@ export default {
 					`grid-template-rows: repeat(${ rowCount }, minmax(0, 1fr))`
 				);
 			} else {
-				rules.push( `grid-auto-rows: minmax(0, 1fr)` );
+				rules.push( `grid-auto-rows: minmax(50px, min-content)` );
 			}
 		} else if ( minimumColumnWidth ) {
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(min(${ minimumColumnWidth }, 100%), 1fr))`,
-				`grid-auto-rows: minmax(0, 1fr)`,
+				`grid-auto-rows: minmax(50px, min-content)`,
 				`container-type: inline-size`
 			);
 		}

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -132,10 +132,13 @@ export default {
 				rules.push(
 					`grid-template-rows: repeat(${ rowCount }, minmax(0, 1fr))`
 				);
+			} else {
+				rules.push( `grid-auto-rows: minmax(0, 1fr)` );
 			}
 		} else if ( minimumColumnWidth ) {
 			rules.push(
 				`grid-template-columns: repeat(auto-fill, minmax(min(${ minimumColumnWidth }, 100%), 1fr))`,
+				`grid-auto-rows: minmax(0, 1fr)`,
 				`container-type: inline-size`
 			);
 		}

--- a/packages/block-editor/src/layouts/test/grid.js
+++ b/packages/block-editor/src/layouts/test/grid.js
@@ -5,7 +5,7 @@ import grid from '../grid';
 
 describe( 'getLayoutStyle', () => {
 	it( 'should return only `grid-template-columns`, `grid-auto-rows` and `container-type` properties if no non-default params are provided', () => {
-		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr)); grid-auto-rows: minmax(50px, min-content); container-type: inline-size; }`;
+		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr)); grid-auto-rows: minmax(1.5em, min-content); container-type: inline-size; }`;
 
 		const result = grid.getLayoutStyle( {
 			selector: '.my-container',
@@ -19,7 +19,7 @@ describe( 'getLayoutStyle', () => {
 		expect( result ).toBe( expected );
 	} );
 	it( 'should return only `grid-template-columns` and `grid-auto-rows` if columnCount property is provided', () => {
-		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(3, minmax(0, 1fr)); grid-auto-rows: minmax(50px, min-content); }`;
+		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(3, minmax(0, 1fr)); grid-auto-rows: minmax(1.5em, min-content); }`;
 
 		const result = grid.getLayoutStyle( {
 			selector: '.my-container',

--- a/packages/block-editor/src/layouts/test/grid.js
+++ b/packages/block-editor/src/layouts/test/grid.js
@@ -4,8 +4,8 @@
 import grid from '../grid';
 
 describe( 'getLayoutStyle', () => {
-	it( 'should return only `grid-template-columns` and `container-type` properties if no non-default params are provided', () => {
-		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr)); container-type: inline-size; }`;
+	it( 'should return only `grid-template-columns`, `grid-auto-rows` and `container-type` properties if no non-default params are provided', () => {
+		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr)); grid-auto-rows: minmax(0, 1fr); container-type: inline-size; }`;
 
 		const result = grid.getLayoutStyle( {
 			selector: '.my-container',
@@ -18,8 +18,8 @@ describe( 'getLayoutStyle', () => {
 
 		expect( result ).toBe( expected );
 	} );
-	it( 'should return only `grid-template-columns` if columnCount property is provided', () => {
-		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(3, minmax(0, 1fr)); }`;
+	it( 'should return only `grid-template-columns` and `grid-auto-rows` if columnCount property is provided', () => {
+		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(3, minmax(0, 1fr)); grid-auto-rows: minmax(0, 1fr); }`;
 
 		const result = grid.getLayoutStyle( {
 			selector: '.my-container',

--- a/packages/block-editor/src/layouts/test/grid.js
+++ b/packages/block-editor/src/layouts/test/grid.js
@@ -5,7 +5,7 @@ import grid from '../grid';
 
 describe( 'getLayoutStyle', () => {
 	it( 'should return only `grid-template-columns`, `grid-auto-rows` and `container-type` properties if no non-default params are provided', () => {
-		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr)); grid-auto-rows: minmax(0, 1fr); container-type: inline-size; }`;
+		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr)); grid-auto-rows: minmax(50px, min-content); container-type: inline-size; }`;
 
 		const result = grid.getLayoutStyle( {
 			selector: '.my-container',
@@ -19,7 +19,7 @@ describe( 'getLayoutStyle', () => {
 		expect( result ).toBe( expected );
 	} );
 	it( 'should return only `grid-template-columns` and `grid-auto-rows` if columnCount property is provided', () => {
-		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(3, minmax(0, 1fr)); grid-auto-rows: minmax(0, 1fr); }`;
+		const expected = `.editor-styles-wrapper .my-container { grid-template-columns: repeat(3, minmax(0, 1fr)); grid-auto-rows: minmax(50px, min-content); }`;
 
 		const result = grid.getLayoutStyle( {
 			selector: '.my-container',

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -371,7 +371,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'type' => 'grid',
 					),
 				),
-				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));grid-auto-rows:minmax(50px, min-content);container-type:inline-size;}',
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));grid-auto-rows:minmax(1.5em, min-content);container-type:inline-size;}',
 			),
 			'grid layout with columnCount'                 => array(
 				'args'            => array(
@@ -381,7 +381,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'columnCount' => 3,
 					),
 				),
-				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));grid-auto-rows:minmax(50px, min-content);}',
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));grid-auto-rows:minmax(1.5em, min-content);}',
 			),
 			'default layout with blockGap to verify converting gap value into valid CSS' => array(
 				'args'            => array(

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -371,7 +371,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'type' => 'grid',
 					),
 				),
-				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;}',
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));grid-auto-rows:minmax(0, 1fr);container-type:inline-size;}',
 			),
 			'grid layout with columnCount'                 => array(
 				'args'            => array(
@@ -381,7 +381,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'columnCount' => 3,
 					),
 				),
-				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));}',
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));grid-auto-rows:minmax(0, 1fr);}',
 			),
 			'default layout with blockGap to verify converting gap value into valid CSS' => array(
 				'args'            => array(

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -371,7 +371,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'type' => 'grid',
 					),
 				),
-				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));grid-auto-rows:minmax(0, 1fr);container-type:inline-size;}',
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));grid-auto-rows:minmax(50px, min-content);container-type:inline-size;}',
 			),
 			'grid layout with columnCount'                 => array(
 				'args'            => array(
@@ -381,7 +381,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'columnCount' => 3,
 					),
 				),
-				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));grid-auto-rows:minmax(0, 1fr);}',
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));grid-auto-rows:minmax(50px, min-content);}',
 			),
 			'default layout with blockGap to verify converting gap value into valid CSS' => array(
 				'args'            => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue that is becoming more visible with the work on #60986: when a grid item spans several rows, but there aren't otherwise enough items in the grid to occupy that number of rows, the auto rows created to support the multiple-row item are collapsed to 0 height. This looks quite odd, and is unlikely to be what's expected when resizing an item to take up more vertical space:
<img width="660" alt="Screenshot 2024-05-06 at 12 22 26 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/7d3a1c31-a2cd-4413-8559-aba5035e1caa">

This PR adds a default value to `grid-auto-rows`, so that auto-created rows always have the same minimum height as the other grid items:

<img width="717" alt="Screenshot 2024-05-06 at 12 24 29 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/f3dac2cf-888e-4a9b-9e16-ac4d3335b17b">


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

To test, add the following markup to a post:

<details>
<summary>test markup</summary>

```
<!-- wp:group {"layout":{"type":"grid"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"color":{"background":"#91ded8"},"layout":{"columnSpan":"2"}}} -->
<p class="has-background" style="background-color:#91ded8">grid item</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"color":{"background":"#91ded8"},"layout":{"rowSpan":"3"}}} -->
<p class="has-background" style="background-color:#91ded8">grid item</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"color":{"background":"#91ded8"}}} -->
<p class="has-background" style="background-color:#91ded8">grid item</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"color":{"background":"#91ded8"}}} -->
<p class="has-background" style="background-color:#91ded8">grid item</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"color":{"background":"#91ded8"}}} -->
<p class="has-background" style="background-color:#91ded8">grid item</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"color":{"background":"#91ded8"}}} -->
<p class="has-background" style="background-color:#91ded8">grid item</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
</details>

Then set the alignment of the grid to full, and resize the window so that all grid items fit on the same column.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
