### PR TITLE
Background image: size controls should show when an image is set

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -379,7 +379,9 @@ function BackgroundSizeToolsPanelItem( {
 		( currentValueForToggle === 'cover' && repeatValue === undefined )
 	);
 
-	const hasValue = hasBackgroundSizeValue( style );
+	const hasValue =
+		hasBackgroundSizeValue( inheritedValue ) ||
+		hasBackgroundSizeValue( style );
 
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -379,9 +379,7 @@ function BackgroundSizeToolsPanelItem( {
 		( currentValueForToggle === 'cover' && repeatValue === undefined )
 	);
 
-	const hasValue =
-		hasBackgroundSizeValue( inheritedValue ) ||
-		hasBackgroundSizeValue( style );
+	const hasValue = hasBackgroundSizeValue( style );
 
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {

--- a/packages/edit-site/src/components/global-styles/background-panel.js
+++ b/packages/edit-site/src/components/global-styles/background-panel.js
@@ -31,9 +31,7 @@ export default function BackgroundPanel() {
 
 	const defaultControls = {
 		backgroundImage: true,
-		backgroundSize:
-			!! style?.background?.backgroundImage &&
-			!! inheritedStyle?.background?.backgroundImage,
+		backgroundSize: false,
 	};
 
 	return (

--- a/packages/edit-site/src/components/global-styles/background-panel.js
+++ b/packages/edit-site/src/components/global-styles/background-panel.js
@@ -20,6 +20,21 @@ const {
 	BackgroundPanel: StylesBackgroundPanel,
 } = unlock( blockEditorPrivateApis );
 
+/**
+ * Checks if there is a current value in the background image block support
+ * attributes.
+ *
+ * @param {Object} style Style attribute.
+ * @return {boolean}     Whether the block has a background image value set.
+ */
+export function hasBackgroundImageValue( style ) {
+	return (
+		!! style?.background?.backgroundImage?.id ||
+		!! style?.background?.backgroundImage?.url ||
+		typeof style?.background?.backgroundImage === 'string'
+	);
+}
+
 export default function BackgroundPanel() {
 	const [ style ] = useGlobalStyle( '', undefined, 'user', {
 		shouldDecodeEncode: false,
@@ -31,7 +46,9 @@ export default function BackgroundPanel() {
 
 	const defaultControls = {
 		backgroundImage: true,
-		backgroundSize: false,
+		backgroundSize:
+			hasBackgroundImageValue( style ) ||
+			hasBackgroundImageValue( inheritedStyle ),
 	};
 
 	return (


### PR DESCRIPTION
Part of 

- https://github.com/WordPress/gutenberg/issues/54336

## What?
In the site editor, show the background size panel by default if an image value is present. 🎉 

Props to @andrewserong for [noticing](https://github.com/WordPress/gutenberg/pull/61271#issuecomment-2095236976) 

## Why?

So that the global styles control is consistent with other global styles. 

It should be, hence why this PR is labelled as "bug".

## How?

Checking for inherited background image value (from theme.json) as well as user-defined style value. If either is present, show the control unless background size is deactivated via theme.json settings.

## Testing Instructions

**TL;DR** In the site editor, for top-level global styles, the background size controls should show where there is an image value.

#### Background size controls are shown by default 

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "https://images.pexels.com/photos/22484288/pexels-photo-22484288/free-photo-of-the-circular-stone-terraces-of-the-inca-ruins.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
			}
		}
	}
}

```



#### Background size controls are displayed with theme.json value

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "https://images.pexels.com/photos/22484288/pexels-photo-22484288/free-photo-of-the-circular-stone-terraces-of-the-inca-ruins.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
			},
			"backgroundSize": "contain"
		}
	}
}
```



#### Background size controls are completely disabled

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"background": {
			"backgroundSize": false
		}
	},
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "https://images.pexels.com/photos/22484288/pexels-photo-22484288/free-photo-of-the-circular-stone-terraces-of-the-inca-ruins.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
			},
			"backgroundSize": "contain"
		}
	}
}
```


Also check that things work with your own site-wide background image, uploaded in global styles


Thank you for testing this PR. 🎖️ 



https://github.com/WordPress/gutenberg/assets/6458278/0375a676-b3a7-44b4-9aac-2a5cb1337746



