### PR TITLE
Writing flow: fix paste for input fields

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -60,6 +60,24 @@ export default function useClipboardHandler() {
 				return;
 			}
 
+			// Let native copy/paste behaviour take over in input fields.
+			// But always handle multiple selected blocks.
+			if ( ! hasMultiSelection() ) {
+				const { target } = event;
+				const { ownerDocument } = target;
+				// If copying, only consider actual text selection as selection.
+				// Otherwise, any focus on an input field is considered.
+				const hasSelection =
+					event.type === 'copy' || event.type === 'cut'
+						? documentHasUncollapsedSelection( ownerDocument )
+						: documentHasSelection( ownerDocument );
+
+				// Let native copy behaviour take over in input fields.
+				if ( hasSelection ) {
+					return;
+				}
+			}
+
 			const { activeElement } = event.target.ownerDocument;
 
 			if ( ! node.contains( activeElement ) ) {
@@ -72,22 +90,6 @@ export default function useClipboardHandler() {
 			const expandSelectionIsNeeded =
 				! shouldHandleWholeBlocks && ! isSelectionMergeable;
 			if ( event.type === 'copy' || event.type === 'cut' ) {
-				if ( ! hasMultiSelection() ) {
-					const { target } = event;
-					const { ownerDocument } = target;
-					// If copying, only consider actual text selection as selection.
-					// Otherwise, any focus on an input field is considered.
-					const hasSelection =
-						event.type === 'copy' || event.type === 'cut'
-							? documentHasUncollapsedSelection( ownerDocument )
-							: documentHasSelection( ownerDocument );
-
-					// Let native copy behaviour take over in input fields.
-					if ( hasSelection ) {
-						return;
-					}
-				}
-
 				event.preventDefault();
 
 				if ( selectedBlockClientIds.length === 1 ) {

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -70,7 +70,8 @@ export default function useClipboardHandler() {
 				const hasSelection =
 					event.type === 'copy' || event.type === 'cut'
 						? documentHasUncollapsedSelection( ownerDocument )
-						: documentHasSelection( ownerDocument );
+						: documentHasSelection( ownerDocument ) &&
+						  ! ownerDocument.activeElement.isContentEditable;
 
 				// Let native copy behaviour take over in input fields.
 				if ( hasSelection ) {

--- a/test/e2e/specs/editor/blocks/rss.spec.js
+++ b/test/e2e/specs/editor/blocks/rss.spec.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'RSS', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	// See: https://github.com/WordPress/gutenberg/pull/61389.
+	test( 'should retain native copy/paste behavior for input fields', async ( {
+		editor,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/rss' } );
+		pageUtils.setClipboardData( {
+			plainText: 'https://developer.wordpress.org/news/feed/',
+		} );
+		await pageUtils.pressKeys( 'primary+v' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/rss',
+				attributes: {
+					feedURL: 'https://developer.wordpress.org/news/feed/',
+				},
+			},
+		] );
+	} );
+} );

--- a/test/e2e/specs/editor/various/embedding.spec.js
+++ b/test/e2e/specs/editor/various/embedding.spec.js
@@ -69,8 +69,8 @@ const MOCK_BAD_WORDPRESS_RESPONSE = {
 };
 
 test.use( {
-	embedUtils: async ( { page, editor }, use ) => {
-		await use( new EmbedUtils( { page, editor } ) );
+	embedUtils: async ( { page, editor, pageUtils }, use ) => {
+		await use( new EmbedUtils( { page, editor, pageUtils } ) );
 	},
 } );
 
@@ -263,10 +263,12 @@ class EmbedUtils {
 	#page;
 	/** @type {Editor} */
 	#editor;
+	#pageUtils;
 
-	constructor( { page, editor } ) {
+	constructor( { page, editor, pageUtils } ) {
 		this.#page = page;
 		this.#editor = editor;
+		this.#pageUtils = pageUtils;
 	}
 
 	/**
@@ -301,10 +303,10 @@ class EmbedUtils {
 	async insertEmbed( url ) {
 		await test.step( `Inserting embed ${ url }`, async () => {
 			await this.#editor.insertBlock( { name: 'core/embed' } );
-			await this.#editor.canvas
-				.getByRole( 'textbox', { name: 'Embed URL' } )
-				.last()
-				.fill( url );
+			// Do not use `fill` here, it's not how the user interacts with the
+			// block.
+			this.#pageUtils.setClipboardData( { plainText: url } );
+			await this.#pageUtils.pressKeys( 'primary+v' );
 			await this.#page.keyboard.press( 'Enter' );
 		} );
 	}

--- a/test/e2e/specs/editor/various/embedding.spec.js
+++ b/test/e2e/specs/editor/various/embedding.spec.js
@@ -69,8 +69,8 @@ const MOCK_BAD_WORDPRESS_RESPONSE = {
 };
 
 test.use( {
-	embedUtils: async ( { page, editor, pageUtils }, use ) => {
-		await use( new EmbedUtils( { page, editor, pageUtils } ) );
+	embedUtils: async ( { page, editor }, use ) => {
+		await use( new EmbedUtils( { page, editor } ) );
 	},
 } );
 
@@ -263,12 +263,10 @@ class EmbedUtils {
 	#page;
 	/** @type {Editor} */
 	#editor;
-	#pageUtils;
 
-	constructor( { page, editor, pageUtils } ) {
+	constructor( { page, editor } ) {
 		this.#page = page;
 		this.#editor = editor;
-		this.#pageUtils = pageUtils;
 	}
 
 	/**
@@ -303,10 +301,10 @@ class EmbedUtils {
 	async insertEmbed( url ) {
 		await test.step( `Inserting embed ${ url }`, async () => {
 			await this.#editor.insertBlock( { name: 'core/embed' } );
-			// Do not use `fill` here, it's not how the user interacts with the
-			// block.
-			this.#pageUtils.setClipboardData( { plainText: url } );
-			await this.#pageUtils.pressKeys( 'primary+v' );
+			await this.#editor.canvas
+				.getByRole( 'textbox', { name: 'Embed URL' } )
+				.last()
+				.fill( url );
 			await this.#page.keyboard.press( 'Enter' );
 		} );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #61377. I don't remember exactly why I removed this check for the paste event.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Turns out I shouldn't have removed this condition for the paste event. We still don't want to handle paste for input and textarea elements, but we do want to override it for `contenteditable`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
