### PR TITLE
Try using coloured overlay instead of border for grid visualiser

### DIFF
--- a/packages/block-editor/src/components/grid-visualizer/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-visualizer.js
@@ -64,7 +64,13 @@ const GridVisualizerGrid = forwardRef( ( { blockElement }, ref ) => {
 			style={ gridInfo.style }
 		>
 			{ Array.from( { length: gridInfo.numItems }, ( _, i ) => (
-				<div key={ i } className="block-editor-grid-visualizer__item" />
+				<div
+					key={ i }
+					className="block-editor-grid-visualizer__item"
+					style={ {
+						boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${ gridInfo.currentColor } 20%, #0000)`,
+					} }
+				/>
 			) ) }
 		</div>
 	);
@@ -84,6 +90,7 @@ function getGridInfo( blockElement ) {
 	const numItems = numColumns * numRows;
 	return {
 		numItems,
+		currentColor: getComputedCSS( blockElement, 'color' ),
 		style: {
 			gridTemplateColumns,
 			gridTemplateRows,

--- a/packages/block-editor/src/components/grid-visualizer/style.scss
+++ b/packages/block-editor/src/components/grid-visualizer/style.scss
@@ -13,7 +13,9 @@
 }
 
 .block-editor-grid-visualizer__item {
-	border: $border-width dashed $gray-300;
+	background-color: color-mix(in srgb, currentColor 10%, transparent);
+	outline: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+	border-radius: 2px;
 }
 
 .block-editor-grid-item-resizer {

--- a/packages/block-editor/src/components/grid-visualizer/style.scss
+++ b/packages/block-editor/src/components/grid-visualizer/style.scss
@@ -14,8 +14,8 @@
 
 .block-editor-grid-visualizer__item {
 	background-color: color-mix(in srgb, currentColor 10%, transparent);
-	outline: 1px solid color-mix(in srgb, currentColor 20%, transparent);
-	border-radius: 2px;
+	outline: $border-width solid color-mix(in srgb, currentColor 20%, transparent);
+	border-radius: $radius-block-ui;
 }
 
 .block-editor-grid-item-resizer {

--- a/packages/block-editor/src/components/grid-visualizer/style.scss
+++ b/packages/block-editor/src/components/grid-visualizer/style.scss
@@ -14,7 +14,8 @@
 
 .block-editor-grid-visualizer__item {
 	background-color: color-mix(in srgb, currentColor 10%, transparent);
-	outline: $border-width solid color-mix(in srgb, currentColor 20%, transparent);
+	box-shadow: inset 0 0 0 $border-width color-mix(in srgb, currentColor 20%, #0000);
+	outline: 1px solid transparent;
 	border-radius: $radius-block-ui;
 }
 

--- a/packages/block-editor/src/components/grid-visualizer/style.scss
+++ b/packages/block-editor/src/components/grid-visualizer/style.scss
@@ -13,8 +13,6 @@
 }
 
 .block-editor-grid-visualizer__item {
-	background-color: color-mix(in srgb, currentColor 10%, transparent);
-	box-shadow: inset 0 0 0 $border-width color-mix(in srgb, currentColor 20%, #0000);
 	outline: 1px solid transparent;
 	border-radius: $radius-block-ui;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Addresses some of the feedback from [this comment](https://github.com/WordPress/gutenberg/pull/60986#issuecomment-2085708289), specifically about improving the look of the grid visualiser.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the grid experiment under Gutenberg > Experiments in WP admin.
2. Add a Grid block to a post or template, and in the sidebar controls set it to manual mode, and then set a number of columns and rows.
3. It should look something like this:

<img width="799" alt="Screenshot 2024-05-06 at 4 27 22 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/5729131d-c559-4777-be52-193b8ef87904">

My main question at this point is whether it makes sense to show the overlay across all blocks, or if perhaps the selected block doesn't need to show it? It does help to see the shape of the grid when there are items spanning multiple columns/rows:

<img width="775" alt="Screenshot 2024-05-06 at 4 34 55 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/a1f196c7-43b7-4cad-9c55-33d91d07491b">

Whereas on trunk it can be almost invisible:

<img width="712" alt="Screenshot 2024-05-06 at 4 36 49 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/fa37896b-365b-43e9-b53c-bc159f29ad94">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
