### PR TITLE
Check child layout exists before generating classname.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -619,12 +619,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$column_count         = isset( $block['parentLayout']['columnCount'] ) ? $block['parentLayout']['columnCount'] : null;
 
 		/*
-		* If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
-		* the columnSpan should be removed once the grid is smaller than the span, and columnStart should be removed
-		* once the grid has less columns than the start.
-		* If there's a minimumColumnWidth, the grid is responsive. But if the minimumColumnWidth value wasn't changed, it won't be set.
-		* In that case, if columnCount doesn't exist, we can assume that the grid is responsive.
-		*/
+		 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
+		 * the columnSpan should be removed once the grid is smaller than the span, and columnStart should be removed
+		 * once the grid has less columns than the start.
+		 * If there's a minimumColumnWidth, the grid is responsive. But if the minimumColumnWidth value wasn't changed, it won't be set.
+		 * In that case, if columnCount doesn't exist, we can assume that the grid is responsive.
+		 */
 		if ( ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
 			$column_span_number  = floatval( $column_span );
 			$column_start_number = floatval( $column_start );
@@ -669,9 +669,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 
 		/*
-		* Add to the style engine store to enqueue and render layout styles.
-		* Return styles here just to check if any exist.
-		*/
+		 * Add to the style engine store to enqueue and render layout styles.
+		 * Return styles here just to check if any exist.
+		 */
 		$child_css = gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$child_layout_styles,
 			array(
@@ -685,20 +685,20 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 	}
 
-		// Prep the processor for modifying the block output.
-		$processor = new WP_HTML_Tag_Processor( $block_content );
+	// Prep the processor for modifying the block output.
+	$processor = new WP_HTML_Tag_Processor( $block_content );
 
-		// Having no tags implies there are no tags onto which to add class names.
+	// Having no tags implies there are no tags onto which to add class names.
 	if ( ! $processor->next_tag() ) {
 		return $block_content;
 	}
 
-		/*
-		* A block may not support layout but still be affected by a parent block's layout.
-		*
-		* In these cases add the appropriate class names and then return early; there's
-		* no need to investigate on this block whether additional layout constraints apply.
-		*/
+	/*
+	 * A block may not support layout but still be affected by a parent block's layout.
+	 *
+	 * In these cases add the appropriate class names and then return early; there's
+	 * no need to investigate on this block whether additional layout constraints apply.
+	 */
 	if ( ! $block_supports_layout && ! empty( $outer_class_names ) ) {
 		foreach ( $outer_class_names as $class_name ) {
 			$processor->add_class( $class_name );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -573,128 +573,132 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$outer_class_names         = array();
-	$container_content_class   = wp_unique_id( 'wp-container-content-' );
-	$child_layout_declarations = array();
-	$child_layout_styles       = array();
+	$outer_class_names = array();
 
-	$self_stretch = isset( $block['attrs']['style']['layout']['selfStretch'] ) ? $block['attrs']['style']['layout']['selfStretch'] : null;
+	// Child layout specific logic.
+	if ( $child_layout ) {
+		$container_content_class   = wp_unique_id( 'wp-container-content-' );
+		$child_layout_declarations = array();
+		$child_layout_styles       = array();
 
-	if ( 'fixed' === $self_stretch && isset( $block['attrs']['style']['layout']['flexSize'] ) ) {
-		$child_layout_declarations['flex-basis'] = $block['attrs']['style']['layout']['flexSize'];
-		$child_layout_declarations['box-sizing'] = 'border-box';
-	} elseif ( 'fill' === $self_stretch ) {
-		$child_layout_declarations['flex-grow'] = '1';
-	}
+		$self_stretch = isset( $block['attrs']['style']['layout']['selfStretch'] ) ? $block['attrs']['style']['layout']['selfStretch'] : null;
 
-	$column_start = isset( $block['attrs']['style']['layout']['columnStart'] ) ? $block['attrs']['style']['layout']['columnStart'] : null;
-	$column_span  = isset( $block['attrs']['style']['layout']['columnSpan'] ) ? $block['attrs']['style']['layout']['columnSpan'] : null;
-	if ( $column_start && $column_span ) {
-		$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
-	} elseif ( $column_start ) {
-		$child_layout_declarations['grid-column'] = "$column_start";
-	} elseif ( $column_span ) {
-		$child_layout_declarations['grid-column'] = "span $column_span";
-	}
+		if ( 'fixed' === $self_stretch && isset( $block['attrs']['style']['layout']['flexSize'] ) ) {
+			$child_layout_declarations['flex-basis'] = $block['attrs']['style']['layout']['flexSize'];
+			$child_layout_declarations['box-sizing'] = 'border-box';
+		} elseif ( 'fill' === $self_stretch ) {
+			$child_layout_declarations['flex-grow'] = '1';
+		}
 
-	$row_start = isset( $block['attrs']['style']['layout']['rowStart'] ) ? $block['attrs']['style']['layout']['rowStart'] : null;
-	$row_span  = isset( $block['attrs']['style']['layout']['rowSpan'] ) ? $block['attrs']['style']['layout']['rowSpan'] : null;
-	if ( $row_start && $row_span ) {
-		$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
-	} elseif ( $row_start ) {
-		$child_layout_declarations['grid-row'] = "$row_start";
-	} elseif ( $row_span ) {
-		$child_layout_declarations['grid-row'] = "span $row_span";
-	}
+		$column_start = isset( $block['attrs']['style']['layout']['columnStart'] ) ? $block['attrs']['style']['layout']['columnStart'] : null;
+		$column_span  = isset( $block['attrs']['style']['layout']['columnSpan'] ) ? $block['attrs']['style']['layout']['columnSpan'] : null;
+		if ( $column_start && $column_span ) {
+			$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
+		} elseif ( $column_start ) {
+			$child_layout_declarations['grid-column'] = "$column_start";
+		} elseif ( $column_span ) {
+			$child_layout_declarations['grid-column'] = "span $column_span";
+		}
 
-	$child_layout_styles[] = array(
-		'selector'     => ".$container_content_class",
-		'declarations' => $child_layout_declarations,
-	);
+		$row_start = isset( $block['attrs']['style']['layout']['rowStart'] ) ? $block['attrs']['style']['layout']['rowStart'] : null;
+		$row_span  = isset( $block['attrs']['style']['layout']['rowSpan'] ) ? $block['attrs']['style']['layout']['rowSpan'] : null;
+		if ( $row_start && $row_span ) {
+			$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
+		} elseif ( $row_start ) {
+			$child_layout_declarations['grid-row'] = "$row_start";
+		} elseif ( $row_span ) {
+			$child_layout_declarations['grid-row'] = "span $row_span";
+		}
 
-	$minimum_column_width = isset( $block['parentLayout']['minimumColumnWidth'] ) ? $block['parentLayout']['minimumColumnWidth'] : null;
-	$column_count         = isset( $block['parentLayout']['columnCount'] ) ? $block['parentLayout']['columnCount'] : null;
+		$child_layout_styles[] = array(
+			'selector'     => ".$container_content_class",
+			'declarations' => $child_layout_declarations,
+		);
 
-	/*
-	 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
-	 * the columnSpan should be removed once the grid is smaller than the span, and columnStart should be removed
-	 * once the grid has less columns than the start.
-	 * If there's a minimumColumnWidth, the grid is responsive. But if the minimumColumnWidth value wasn't changed, it won't be set.
-	 * In that case, if columnCount doesn't exist, we can assume that the grid is responsive.
-	 */
-	if ( ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
-		$column_span_number  = floatval( $column_span );
-		$column_start_number = floatval( $column_start );
-		$highest_number      = max( $column_span_number, $column_start_number );
-		$parent_column_width = $minimum_column_width ? $minimum_column_width : '12rem';
-		$parent_column_value = floatval( $parent_column_width );
-		$parent_column_unit  = explode( $parent_column_value, $parent_column_width );
+		$minimum_column_width = isset( $block['parentLayout']['minimumColumnWidth'] ) ? $block['parentLayout']['minimumColumnWidth'] : null;
+		$column_count         = isset( $block['parentLayout']['columnCount'] ) ? $block['parentLayout']['columnCount'] : null;
 
 		/*
-		 * If there is no unit, the width has somehow been mangled so we reset both unit and value
-		 * to defaults.
-		 * Additionally, the unit should be one of px, rem or em, so that also needs to be checked.
-		 */
-		if ( count( $parent_column_unit ) <= 1 ) {
-			$parent_column_unit  = 'rem';
-			$parent_column_value = 12;
-		} else {
-			$parent_column_unit = $parent_column_unit[1];
+		* If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
+		* the columnSpan should be removed once the grid is smaller than the span, and columnStart should be removed
+		* once the grid has less columns than the start.
+		* If there's a minimumColumnWidth, the grid is responsive. But if the minimumColumnWidth value wasn't changed, it won't be set.
+		* In that case, if columnCount doesn't exist, we can assume that the grid is responsive.
+		*/
+		if ( ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
+			$column_span_number  = floatval( $column_span );
+			$column_start_number = floatval( $column_start );
+			$highest_number      = max( $column_span_number, $column_start_number );
+			$parent_column_width = $minimum_column_width ? $minimum_column_width : '12rem';
+			$parent_column_value = floatval( $parent_column_width );
+			$parent_column_unit  = explode( $parent_column_value, $parent_column_width );
 
-			if ( ! in_array( $parent_column_unit, array( 'px', 'rem', 'em' ), true ) ) {
-				$parent_column_unit = 'rem';
+			/*
+			 * If there is no unit, the width has somehow been mangled so we reset both unit and value
+			 * to defaults.
+			 * Additionally, the unit should be one of px, rem or em, so that also needs to be checked.
+			 */
+			if ( count( $parent_column_unit ) <= 1 ) {
+				$parent_column_unit  = 'rem';
+				$parent_column_value = 12;
+			} else {
+				$parent_column_unit = $parent_column_unit[1];
+
+				if ( ! in_array( $parent_column_unit, array( 'px', 'rem', 'em' ), true ) ) {
+					$parent_column_unit = 'rem';
+				}
 			}
+
+			/*
+			 * A default gap value is used for this computation because custom gap values may not be
+			 * viable to use in the computation of the container query value.
+			 */
+			$default_gap_value     = 'px' === $parent_column_unit ? 24 : 1.5;
+			$container_query_value = $highest_number * $parent_column_value + ( $highest_number - 1 ) * $default_gap_value;
+			$container_query_value = $container_query_value . $parent_column_unit;
+			// If a span is set we want to preserve it as long as possible, otherwise we just reset the value.
+			$grid_column_value = $column_span ? '1/-1' : 'auto';
+
+			$child_layout_styles[] = array(
+				'rules_group'  => "@container (max-width: $container_query_value )",
+				'selector'     => ".$container_content_class",
+				'declarations' => array(
+					'grid-column' => $grid_column_value,
+				),
+			);
 		}
 
 		/*
-		 * A default gap value is used for this computation because custom gap values may not be
-		 * viable to use in the computation of the container query value.
-		 */
-		$default_gap_value     = 'px' === $parent_column_unit ? 24 : 1.5;
-		$container_query_value = $highest_number * $parent_column_value + ( $highest_number - 1 ) * $default_gap_value;
-		$container_query_value = $container_query_value . $parent_column_unit;
-		// If a span is set we want to preserve it as long as possible, otherwise we just reset the value.
-		$grid_column_value = $column_span ? '1/-1' : 'auto';
-
-		$child_layout_styles[] = array(
-			'rules_group'  => "@container (max-width: $container_query_value )",
-			'selector'     => ".$container_content_class",
-			'declarations' => array(
-				'grid-column' => $grid_column_value,
-			),
+		* Add to the style engine store to enqueue and render layout styles.
+		* Return styles here just to check if any exist.
+		*/
+		$child_css = gutenberg_style_engine_get_stylesheet_from_css_rules(
+			$child_layout_styles,
+			array(
+				'context'  => 'block-supports',
+				'prettify' => false,
+			)
 		);
+
+		if ( $child_css ) {
+			$outer_class_names[] = $container_content_class;
+		}
 	}
 
-	/*
-	 * Add to the style engine store to enqueue and render layout styles.
-	 * Return styles here just to check if any exist.
-	 */
-	$child_css = gutenberg_style_engine_get_stylesheet_from_css_rules(
-		$child_layout_styles,
-		array(
-			'context'  => 'block-supports',
-			'prettify' => false,
-		)
-	);
+		// Prep the processor for modifying the block output.
+		$processor = new WP_HTML_Tag_Processor( $block_content );
 
-	if ( $child_css ) {
-		$outer_class_names[] = $container_content_class;
-	}
-
-	// Prep the processor for modifying the block output.
-	$processor = new WP_HTML_Tag_Processor( $block_content );
-
-	// Having no tags implies there are no tags onto which to add class names.
+		// Having no tags implies there are no tags onto which to add class names.
 	if ( ! $processor->next_tag() ) {
 		return $block_content;
 	}
 
-	/*
-	 * A block may not support layout but still be affected by a parent block's layout.
-	 *
-	 * In these cases add the appropriate class names and then return early; there's
-	 * no need to investigate on this block whether additional layout constraints apply.
-	 */
+		/*
+		* A block may not support layout but still be affected by a parent block's layout.
+		*
+		* In these cases add the appropriate class names and then return early; there's
+		* no need to investigate on this block whether additional layout constraints apply.
+		*/
 	if ( ! $block_supports_layout && ! empty( $outer_class_names ) ) {
 		foreach ( $outer_class_names as $class_name ) {
 			$processor->add_class( $class_name );

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -411,6 +411,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	 * @param string $expected_output The expected output.
 	 */
 	public function test_layout_support_flag_renders_classnames_on_wrapper( $args, $expected_output ) {
+		switch_theme( 'default' );
 		$actual_output = gutenberg_render_layout_support_flag( $args['block_content'], $args['block'] );
 		$this->assertEquals( $expected_output, $actual_output );
 	}
@@ -480,6 +481,27 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 					),
 				),
 				'expected_output' => '<div class="wp-block-group"><div class="wp-block-group__inner-wrapper is-layout-flow wp-block-group-is-layout-flow"></div></div>',
+			),
+			'block with child layout'                      => array(
+				'args'            => array(
+					'block_content' => '<p>Some text.</p>',
+					'block'         => array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(
+							'style' => array(
+								'layout' => array(
+									'columnSpan' => '2',
+								),
+							),
+						),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Some text.</p>',
+						'innerContent' => array(
+							'<p>Some text.</p>',
+						),
+					),
+				),
+				'expected_output' => '<p class="wp-container-content-1">Some text.</p>', // The generated classname number assumes `wp_unique_id` will not have run previously in this test.
 			),
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In writing a test to accompany https://github.com/WordPress/wordpress-develop/pull/6493, I realised the child layout classname was being generated for every block with layout, even if it doesn't have child layout. This PR adds the classname generation and remaining child layout logic inside a condition, so it only runs if there is child layout defined.

It also adds a test to check the child layout classname is generated.

I guess a further improvement could be to create a dedicated function for outputting child layout styles, similar to `gutenberg_get_layout_style`, which would allow us to test the actual styles output, though that may have limited value in that it will produce more test strings that will have to be updated when child layout rules change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run the PHP tests and make sure they pass: `npm run test:php`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
