### PR TITLE
Preserve the wp_theme_preview query arg when navigating in Site Editor

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
@@ -18,10 +18,6 @@ const POPOVER_PROPS = {
 /**
  * Internal dependencies
  */
-import {
-	isPreviewingTheme,
-	currentlyPreviewingTheme,
-} from '../../utils/is-previewing-theme';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -68,9 +64,6 @@ export default function LeafMoreMenu( props ) {
 					{
 						postType: attributes.type,
 						postId: attributes.id,
-						...( isPreviewingTheme() && {
-							wp_theme_preview: currentlyPreviewingTheme(),
-						} ),
 					},
 					{
 						backPath: params,
@@ -82,9 +75,6 @@ export default function LeafMoreMenu( props ) {
 					{
 						postType: 'page',
 						postId: attributes.id,
-						...( isPreviewingTheme() && {
-							wp_theme_preview: currentlyPreviewingTheme(),
-						} ),
 					},
 					{
 						backPath: params,

--- a/packages/edit-site/src/utils/use-activate-theme.js
+++ b/packages/edit-site/src/utils/use-activate-theme.js
@@ -23,7 +23,7 @@ const { useHistory, useLocation } = unlock( routerPrivateApis );
  */
 export function useActivateTheme() {
 	const history = useHistory();
-	const location = useLocation();
+	const { params } = useLocation();
 	const { startResolution, finishResolution } = useDispatch( coreStore );
 
 	return async () => {
@@ -36,9 +36,9 @@ export function useActivateTheme() {
 			startResolution( 'activateTheme' );
 			await window.fetch( activationURL );
 			finishResolution( 'activateTheme' );
-			const { wp_theme_preview: themePreview, ...params } =
-				location.params;
-			history.replace( params );
+			// Remove the wp_theme_preview query param: we've finished activating
+			// the queue and are switching to normal Site Editor.
+			history.replace( { ...params, wp_theme_preview: undefined } );
 		}
 	};
 }

--- a/packages/router/src/history.js
+++ b/packages/router/src/history.js
@@ -13,13 +13,28 @@ const history = createBrowserHistory();
 const originalHistoryPush = history.push;
 const originalHistoryReplace = history.replace;
 
+// Preserve the `wp_theme_preview` query parameter when navigating
+// around the Site Editor.
+// TODO: move this hack out of the router into Site Editor code.
+function preserveThemePreview( params ) {
+	if ( params.hasOwnProperty( 'wp_theme_preview' ) ) {
+		return params;
+	}
+	const currentSearch = new URLSearchParams( history.location.search );
+	const currentThemePreview = currentSearch.get( 'wp_theme_preview' );
+	if ( currentThemePreview === undefined ) {
+		return params;
+	}
+	return { ...params, wp_theme_preview: currentThemePreview };
+}
+
 function push( params, state ) {
-	const search = buildQueryString( params );
+	const search = buildQueryString( preserveThemePreview( params ) );
 	return originalHistoryPush.call( history, { search }, state );
 }
 
 function replace( params, state ) {
-	const search = buildQueryString( params );
+	const search = buildQueryString( preserveThemePreview( params ) );
 	return originalHistoryReplace.call( history, { search }, state );
 }
 

--- a/packages/router/src/history.js
+++ b/packages/router/src/history.js
@@ -22,7 +22,7 @@ function preserveThemePreview( params ) {
 	}
 	const currentSearch = new URLSearchParams( history.location.search );
 	const currentThemePreview = currentSearch.get( 'wp_theme_preview' );
-	if ( currentThemePreview === undefined ) {
+	if ( currentThemePreview === null ) {
 		return params;
 	}
 	return { ...params, wp_theme_preview: currentThemePreview };


### PR DESCRIPTION
Fixes #61239, a bug where the `wp_theme_preview` query param is not preserved when navigating around Site Editor in "Activate theme" mode.

It's a regression I commited in #60466, stopping to preserve query params automatically.

This fix is a not very good "temporary" hotfix. It's not a good solution to patch the router package, but I haven't found any other so far and I want to make the feature work again quickly.

**How to test:**
- open Site Editor with a `wp_theme_preview=theme-slug` query param.
- verify that the UI is modified accordingly: shows the "Previewing: Theme" label in the sidebar, and all save UI actions are "Activate Theme" instead of "Save". 