### PR TITLE
Add list item wrapper to social links when used in navigation block

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -23,6 +23,7 @@ class WP_Navigation_Block_Renderer {
 	private static $needs_list_item_wrapper = array(
 		'core/site-title',
 		'core/site-logo',
+		'core/social-links'
 	);
 
 	/**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -23,7 +23,7 @@ class WP_Navigation_Block_Renderer {
 	private static $needs_list_item_wrapper = array(
 		'core/site-title',
 		'core/site-logo',
-		'core/social-links'
+		'core/social-links',
 	);
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #61385

## Why?
As mentioned in that issue, when the social block is used in the navigation block, the front-end markup has a `<ul>` nested in a `<ul>`, when it seems the proper thing to do is have a wrapping `<li>` tag.

## How?
There's an array `$needs_list_item_wrapper` in the server render callback for the navigation block, and adding social links to that seems to do the trick.

## Testing Instructions
1. Add a navigation block
2. Add a social link to the navigation block
3. Save and (pre)view the frontend content
4. Inspect the markup of the social links block, it should now be wrapped in an `<li>` tag

Also check that none of the styling is broken (this is my greatest concern with the change).

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-05-06 at 4 11 28 pm](https://github.com/WordPress/gutenberg/assets/677833/30b679ea-f913-4b7d-beaf-0bfbfe2c0f52)