### PR TITLE
Editor styles: fix cache (by wrapper selector)

### DIFF
--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -5,7 +5,7 @@ import postcss, { CssSyntaxError } from 'postcss';
 import wrap from 'postcss-prefixwrap';
 import rebaseUrl from 'postcss-urlrebase';
 
-const transformStylesCache = new WeakMap();
+const cacheByWrapperSelector = new Map();
 
 function transformStyle(
 	{ css, ignoredSelectors = [], baseURL },
@@ -65,14 +65,18 @@ function transformStyle(
  * @return {Array} converted rules.
  */
 const transformStyles = ( styles, wrapperSelector = '' ) => {
+	let cache = cacheByWrapperSelector.get( wrapperSelector );
+	if ( ! cache ) {
+		cache = new WeakMap();
+		cacheByWrapperSelector.set( wrapperSelector, cache );
+	}
 	return styles.map( ( style ) => {
-		if ( transformStylesCache.has( style ) ) {
-			return transformStylesCache.get( style );
+		let css = cache.get( style );
+		if ( ! css ) {
+			css = transformStyle( style, wrapperSelector );
+			cache.set( style, css );
 		}
-
-		const transformedStyle = transformStyle( style, wrapperSelector );
-		transformStylesCache.set( style, transformedStyle );
-		return transformedStyle;
+		return css;
 	} );
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/60990#issuecomment-2094806820. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

#57810 mistakenly did not cache styles by wrapper selector, it treated all styles the same.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We can create a cache by wrapper selector. Note that there may be situations where we still want a cache for all the iframes where the main content may not be iframed. So we need to keep a cache for both.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
