### PR TITLE
Post Actions: Don't export duplicatePostAction for now

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -500,7 +500,7 @@ const renamePostAction = {
 	},
 };
 
-export const duplicatePostAction = {
+const duplicatePostAction = {
 	id: 'duplicate-post',
 	label: _x( 'Duplicate', 'action label' ),
 	isEligible( { status } ) {


### PR DESCRIPTION
`duplicatePostAction` was introduced in #60637. Until now, access to these actions is mediated by `usePostActions`, so they shouldn't be individually exported. This is bound to change with #61040, but until then it's good to be consistent.

## Testing Instructions
No change in behaviour.