### PR TITLE
DataViews: Add loading indicator for preview field

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -11,6 +11,7 @@ import {
 	Button,
 	Tooltip,
 	Flex,
+	Spinner,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import {
@@ -151,7 +152,7 @@ function Preview( { item, categoryId, viewType } ) {
 				{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
 				{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
 				{ ! isEmpty && (
-					<Async>
+					<Async placeholder={ <Spinner /> }>
 						<BlockPreview
 							blocks={ item.blocks }
 							viewportWidth={ item.viewportWidth }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import {
 	Icon,
+	Spinner,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	VisuallyHidden,
@@ -159,7 +160,7 @@ function Preview( { item, viewType } ) {
 				style={ { backgroundColor } }
 			>
 				{ viewType === LAYOUT_LIST && ! isEmpty && (
-					<Async>
+					<Async placeholder={ <Spinner /> }>
 						<BlockPreview blocks={ blocks } />
 					</Async>
 				) }
@@ -172,7 +173,7 @@ function Preview( { item, viewType } ) {
 					>
 						{ isEmpty && __( 'Empty template' ) }
 						{ ! isEmpty && (
-							<Async>
+							<Async placeholder={ <Spinner /> }>
 								<BlockPreview blocks={ blocks } />
 							</Async>
 						) }


### PR DESCRIPTION
Fixes #59832

## What?
This PR adds a loading indicator to the data view preview field.

## Why?

See #59832

## How?

Thankfully, the `Async` component added by #60425 supports the `placeholder` prop, so we can just pass in the component we want to display while loading and it seems to work as expected.

Also, this PR simply renders the Spinner component, but in table layouts it may be a good idea to set a minimum height for the preview area.

**Note**: Looking at the discussion around #60425, it appears that the Spinner component was once added, but eventually removed. In the current DataViews, I think it makes sense to display a Spinner component, but I would like to know what you think about this.

## Testing Instructions

Try reloading your browser or switching layouts on pages that use DataViews.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/1ec370e5-1c45-4957-8299-eb8c512901c9
