### PR TITLE
Interactivity API: Prevent empty namespace or different namespaces from killing the runtime

### DIFF
--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -177,7 +177,7 @@ export const removeAspectRatioClasses = ( existingClassNames ) => {
 	if ( ! existingClassNames ) {
 		// Avoids extraneous work and also, by returning the same value as
 		// received, ensures the post is not dirtied by a change of the block
-		// attribute from `undefined` to an emtpy string.
+		// attribute from `undefined` to an empty string.
 		return existingClassNames;
 	}
 	const aspectRatioClassNames = ASPECT_RATIOS.reduce(

--- a/packages/e2e-tests/plugins/interactive-blocks/namespace/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/namespace/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test-namespace/directive-bind",
+	"title": "E2E Interactivity tests - directive bind",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/namespace/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/namespace/render.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * HTML for testing the directive `data-wp-bind`.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+?>
+
+<div data-wp-interactive="">
+	<a data-wp-bind--href="state.url" data-testid="empty namespace"></a>
+</div>
+
+<div data-wp-interactive="namespace">
+	<a data-wp-bind--href="state.url" data-testid="correct namespace"></a>
+</div>
+
+<div data-wp-interactive="{}">
+	<a data-wp-bind--href="state.url" data-testid="object namespace"></a>
+</div>
+
+<div data-wp-interactive>
+	<a data-wp-bind--href="other::state.url" data-testid="other namespace"></a>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/namespace/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/namespace/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/namespace/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/namespace/view.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { store } from '@wordpress/interactivity';
+
+store( 'namespace', {
+	state: {
+		url: '/some-url',
+	},
+} );
+
+store( 'other', {
+	state: {
+		url: '/other-store-url',
+	},
+} );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -7,6 +7,7 @@
 -	Allow multiple event handlers for the same type with `data-wp-on-document` and `data-wp-on-window`. ([#61009](https://github.com/WordPress/gutenberg/pull/61009))
 
 -	Prevent wrong written directives from killing the runtime ([#61249](https://github.com/WordPress/gutenberg/pull/61249))
+-	Prevent empty namespace or different namespaces from killing the runtime ([#61409](https://github.com/WordPress/gutenberg/pull/61409))
 
 ## 5.6.0 (2024-05-02)
 
@@ -19,8 +20,6 @@
 ### Bug Fixes
 
 -   Hooks useMemo and useCallback should return a value. ([#60474](https://github.com/WordPress/gutenberg/pull/60474))
-
--   Prevent empty namespace or different namespaces from killing the runtime ([#61409](https://github.com/WordPress/gutenberg/pull/61409))
 
 ## 5.4.0 (2024-04-03)
 

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 -   Hooks useMemo and useCallback should return a value. ([#60474](https://github.com/WordPress/gutenberg/pull/60474))
 
+-   Prevent empty namespace or different namespaces from killing the runtime ([#61409](https://github.com/WordPress/gutenberg/pull/61409))
+
 ## 5.4.0 (2024-04-03)
 
 ## 5.3.0 (2024-03-21)

--- a/packages/interactivity/src/constants.js
+++ b/packages/interactivity/src/constants.js
@@ -1,1 +1,4 @@
 export const directivePrefix = 'wp';
+
+export const isDebug =
+	typeof SCRIPT_DEBUG !== 'undefined' && SCRIPT_DEBUG === true;

--- a/packages/interactivity/src/constants.js
+++ b/packages/interactivity/src/constants.js
@@ -1,4 +1,1 @@
 export const directivePrefix = 'wp';
-
-export const isDebug =
-	typeof SCRIPT_DEBUG !== 'undefined' && SCRIPT_DEBUG === true;

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -13,6 +13,7 @@ import { deepSignal, peek } from 'deepsignal';
 import { useWatch, useInit } from './utils';
 import { directive, getScope, getEvaluate } from './hooks';
 import { kebabToCamelCase } from './utils/kebab-to-camelcase';
+import { isDebug } from './constants';
 
 // Assigned objects should be ignore during proxification.
 const contextAssignedObjects = new WeakMap();
@@ -242,11 +243,7 @@ export default () => {
 				if ( defaultEntry ) {
 					const { namespace, value } = defaultEntry;
 					// Check that the value is a JSON object. Send a console warning if not.
-					if (
-						typeof SCRIPT_DEBUG !== 'undefined' &&
-						SCRIPT_DEBUG === true &&
-						! isPlainObject( value )
-					) {
+					if ( isDebug && ! isPlainObject( value ) ) {
 						// eslint-disable-next-line no-console
 						console.warn(
 							`The value of data-wp-context in "${ namespace }" store must be a valid stringified JSON object.`

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -13,7 +13,7 @@ import { deepSignal, peek } from 'deepsignal';
 import { useWatch, useInit } from './utils';
 import { directive, getScope, getEvaluate } from './hooks';
 import { kebabToCamelCase } from './utils/kebab-to-camelcase';
-import { isDebug } from './constants';
+import { warn } from './utils/warn';
 
 // Assigned objects should be ignore during proxification.
 const contextAssignedObjects = new WeakMap();
@@ -243,9 +243,8 @@ export default () => {
 				if ( defaultEntry ) {
 					const { namespace, value } = defaultEntry;
 					// Check that the value is a JSON object. Send a console warning if not.
-					if ( isDebug && ! isPlainObject( value ) ) {
-						// eslint-disable-next-line no-console
-						console.warn(
+					if ( ! isPlainObject( value ) ) {
+						warn(
 							`The value of data-wp-context in "${ namespace }" store must be a valid stringified JSON object.`
 						);
 					}

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -263,7 +263,7 @@ export const directive = (
 const resolve = ( path, namespace ) => {
 	if ( ! namespace ) {
 		warn(
-			`The "namespace" cannot be "{}", "null" or an emtpy string. Path: ${ path }`
+			`The "namespace" cannot be "{}", "null" or an empty string. Path: ${ path }`
 		);
 		return;
 	}

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -286,7 +286,7 @@ const resolve = ( path, namespace ) => {
 		if ( isDebug ) {
 			// eslint-disable-next-line no-console
 			console.warn(
-				`The namespace "${ namespace }" defined in "data-wp-interactive" does not match with the store.`
+				`There was an error when trying to resolve the path "${ path }" in the namespace "${ namespace }".`
 			);
 		}
 	}

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -280,11 +280,7 @@ const resolve = ( path, namespace ) => {
 	try {
 		// TODO: Support lazy/dynamically initialized stores
 		return path.split( '.' ).reduce( ( acc, key ) => acc[ key ], current );
-	} catch ( e ) {
-		warn(
-			`The path "${ path }" could not be resolved in the "${ namespace }" store.`
-		);
-	}
+	} catch ( e ) {}
 };
 
 // Generate the evaluate function.

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -261,6 +261,12 @@ export const directive = (
 
 // Resolve the path to some property of the store object.
 const resolve = ( path, namespace ) => {
+	if ( ! namespace ) {
+		warn(
+			`The "namespace" cannot be "{}", "null" or an emtpy string. Path: ${ path }`
+		);
+		return;
+	}
 	let resolvedStore = stores.get( namespace );
 	if ( typeof resolvedStore === 'undefined' ) {
 		resolvedStore = store( namespace, undefined, {
@@ -272,8 +278,13 @@ const resolve = ( path, namespace ) => {
 		context: getScope().context[ namespace ],
 	};
 	try {
+		// TODO: Support lazy/dynamically initialized stores
 		return path.split( '.' ).reduce( ( acc, key ) => acc[ key ], current );
-	} catch ( e ) {}
+	} catch ( e ) {
+		warn(
+			`The path "${ path }" could not be resolved in the "${ namespace }" store.`
+		);
+	}
 };
 
 // Generate the evaluate function.
@@ -283,12 +294,6 @@ export const getEvaluate: GetEvaluate =
 		let { value: path, namespace } = entry;
 		if ( typeof path !== 'string' ) {
 			throw new Error( 'The `value` prop should be a string path' );
-		}
-		if ( ! namespace ) {
-			// TODO: Support lazy/dynamically initialized stores
-			warn(
-				`The "namespace" cannot be "{}", "null" or an emtpy string. Path: ${ path }`
-			);
 		}
 		// If path starts with !, remove it and save a flag.
 		const hasNegationOperator =

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -284,7 +284,7 @@ export const getEvaluate: GetEvaluate =
 		if ( typeof path !== 'string' ) {
 			throw new Error( 'The `value` prop should be a string path' );
 		}
-		if ( ! namespace || namespace === '' ) {
+		if ( ! namespace ) {
 			// TODO: Support lazy/dynamically initialized stores
 			warn(
 				`The "namespace" cannot be "{}", "null" or an emtpy string. Path: ${ path }`

--- a/packages/interactivity/src/utils/warn.ts
+++ b/packages/interactivity/src/utils/warn.ts
@@ -1,0 +1,21 @@
+const logged = new Set();
+
+export const warn = ( message ) => {
+	// @ts-expect-error
+	if ( typeof SCRIPT_DEBUG !== 'undefined' && SCRIPT_DEBUG === true ) {
+		if ( logged.has( message ) ) {
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.warn( message );
+
+		// Adding a stack trace to the warning message to help with debugging.
+		try {
+			throw Error( message );
+		} catch ( e ) {
+			// Do nothing.
+		}
+		logged.add( message );
+	}
+};

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -5,7 +5,8 @@ import { h } from 'preact';
 /**
  * Internal dependencies
  */
-import { isDebug, directivePrefix as p } from './constants';
+import { directivePrefix as p } from './constants';
+import { warn } from './utils/warn';
 
 const ignoreAttr = `data-${ p }-ignore`;
 const islandAttr = `data-${ p }-interactive`;
@@ -120,10 +121,7 @@ export function toVdom( root ) {
 				( obj, [ name, ns, value ] ) => {
 					const directiveMatch = directiveParser.exec( name );
 					if ( directiveMatch === null ) {
-						if ( isDebug ) {
-							// eslint-disable-next-line no-console
-							console.warn( `Invalid directive: ${ name }.` );
-						}
+						warn( `Invalid directive: ${ name }.` );
 						return obj;
 					}
 					const prefix = directiveMatch[ 1 ] || '';

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -5,7 +5,7 @@ import { h } from 'preact';
 /**
  * Internal dependencies
  */
-import { directivePrefix as p } from './constants';
+import { isDebug, directivePrefix as p } from './constants';
 
 const ignoreAttr = `data-${ p }-ignore`;
 const islandAttr = `data-${ p }-interactive`;
@@ -120,12 +120,7 @@ export function toVdom( root ) {
 				( obj, [ name, ns, value ] ) => {
 					const directiveMatch = directiveParser.exec( name );
 					if ( directiveMatch === null ) {
-						if (
-							// @ts-expect-error This is a debug-only warning.
-							typeof SCRIPT_DEBUG !== 'undefined' &&
-							// @ts-expect-error This is a debug-only warning.
-							SCRIPT_DEBUG === true
-						) {
+						if ( isDebug ) {
 							// eslint-disable-next-line no-console
 							console.warn( `Invalid directive: ${ name }.` );
 						}

--- a/test/e2e/specs/interactivity/namespace.spec.ts
+++ b/test/e2e/specs/interactivity/namespace.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Namespaces', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test-namespace/directive-bind' );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test-namespace/directive-bind' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'Empty string as namespace should not work', async ( { page } ) => {
+		const el = page.getByTestId( 'empty namespace' );
+		await expect( el ).not.toHaveAttribute( 'href', '/some-url' );
+	} );
+
+	test( 'A string as namespace should work', async ( { page } ) => {
+		const el = page.getByTestId( 'correct namespace' );
+		await expect( el ).toHaveAttribute( 'href', '/some-url' );
+	} );
+
+	test( 'An empty object as namespace should work', async ( { page } ) => {
+		const el = page.getByTestId( 'object namespace' );
+		await expect( el ).not.toHaveAttribute( 'href', '/some-url' );
+	} );
+
+	test( 'A wrong namespace should not break the runtime', async ( {
+		page,
+	} ) => {
+		const el = page.getByTestId( 'object namespace' );
+		await expect( el ).not.toHaveAttribute( 'href', '/some-url' );
+		const correct = page.getByTestId( 'correct namespace' );
+		await expect( correct ).toHaveAttribute( 'href', '/some-url' );
+	} );
+
+	test( 'A different store namespace should work', async ( { page } ) => {
+		const el = page.getByTestId( 'other namespace' );
+		await expect( el ).toHaveAttribute( 'href', '/other-store-url' );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Similar to #61249, the Interactivity API throws an error in these two cases:
 - If the namespace is an empty string.
 - If the namespace defined on `data-wp-interactive` is different than the namespace defined in `store.js` file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We don't want that interactive blocks with these errors make the other ones stop working.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add some checks and try-catchs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Without the PR. Add an interactive block, the `data-wp-interactive` directive can be `diff` or an empty string.

render.php
```
<div
	<?php echo get_block_wrapper_attributes(); ?>
	data-wp-interactive="diff" 
>
    <div <?php echo wp_interactivity_data_wp_context($context) ; ?> >
        <input type="text" data-wp-bind--id="context.id" data-wp-bind--value="context.id"  data-wp-on-document--scroll="actions.log" >
    </div>
    <button data-wp-on--click="actions.log">Not work</button>
</div>
<div data-wp-interactive="create-block">
<button data-wp-on--click="actions.log">Click me</button>
</div>
```

view.js
```
/**
 * WordPress dependencies
 */
import { store, getContext } from "@wordpress/interactivity";

store("create-block", {
  actions: {
    log: () => {
      console.log("log 1");
    },
    secondLog: () => {
      console.log("log 2");
    },
  },
});

```

The second button should not log. Some errors should appear.

With the PR.

The second button should log. Some warnings should appear.
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-05-06 at 20 01 42](https://github.com/WordPress/gutenberg/assets/37012961/c7d4065b-1a15-4b4d-b3f9-9d452cd15946)

![Screenshot 2024-05-06 at 20 02 11](https://github.com/WordPress/gutenberg/assets/37012961/806973db-52c3-4240-9980-bc9455e7c6c5)
