### PR TITLE
Block editor: scroll block into view on insert

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
-import { useMergeRefs, useDisabled, useRefEffect } from '@wordpress/compose';
+import { useMergeRefs, useDisabled } from '@wordpress/compose';
 import warning from '@wordpress/warning';
 
 /**
@@ -28,6 +28,7 @@ import { useEventHandlers } from './use-selected-block-event-handlers';
 import { useNavModeExit } from './use-nav-mode-exit';
 import { useBlockRefProvider } from './use-block-refs';
 import { useIntersectionObserver } from './use-intersection-observer';
+import { useScrollIntoView } from './use-scroll-into-view';
 import { useFlashEditableBlocks } from '../../use-flash-editable-blocks';
 import { canBindBlock } from '../../../hooks/use-bindings-attributes';
 
@@ -122,28 +123,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			clientId,
 			isEnabled: name === 'core/block' || templateLock === 'contentOnly',
 		} ),
-		useRefEffect(
-			( node ) => {
-				if ( isSelected ) {
-					const { defaultView } = node.ownerDocument;
-					const observer = new defaultView.IntersectionObserver(
-						( entries ) => {
-							// Once observing starts, we always get an initial
-							// entry with the intersecting state.
-							if ( ! entries[ 0 ].isIntersecting ) {
-								node.scrollIntoView();
-								observer.disconnect();
-							}
-						}
-					);
-					observer.observe( node );
-					return () => {
-						observer.disconnect();
-					};
-				}
-			},
-			[ isSelected ]
-		),
+		useScrollIntoView( { isSelected } ),
 	] );
 
 	const blockEditContext = useBlockEditContext();

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
-import { useMergeRefs, useDisabled } from '@wordpress/compose';
+import { useMergeRefs, useDisabled, useRefEffect } from '@wordpress/compose';
 import warning from '@wordpress/warning';
 
 /**
@@ -122,6 +122,28 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			clientId,
 			isEnabled: name === 'core/block' || templateLock === 'contentOnly',
 		} ),
+		useRefEffect(
+			( node ) => {
+				if ( isSelected ) {
+					const { defaultView } = node.ownerDocument;
+					const observer = new defaultView.IntersectionObserver(
+						( entries ) => {
+							// Once observing starts, we always get an initial
+							// entry with the intersecting state.
+							if ( ! entries[ 0 ].isIntersecting ) {
+								node.scrollIntoView();
+								observer.disconnect();
+							}
+						}
+					);
+					observer.observe( node );
+					return () => {
+						observer.disconnect();
+					};
+				}
+			},
+			[ isSelected ]
+		),
 	] );
 
 	const blockEditContext = useBlockEditContext();

--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useRefEffect } from '@wordpress/compose';
+import { useReducedMotion, useRefEffect } from '@wordpress/compose';
 
 export function useScrollIntoView( { isSelected } ) {
+	const prefersReducedMotion = useReducedMotion();
 	return useRefEffect(
 		( node ) => {
 			if ( isSelected ) {
@@ -17,7 +18,11 @@ export function useScrollIntoView( { isSelected } ) {
 						// Once observing starts, we always get an initial
 						// entry with the intersecting state.
 						if ( ! entries[ 0 ].isIntersecting ) {
-							node.scrollIntoView();
+							node.scrollIntoView( {
+								behavior: prefersReducedMotion
+									? 'instant'
+									: 'smooth',
+							} );
 							observer.disconnect();
 						}
 					}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -9,7 +9,7 @@ export function useScrollIntoView( { isSelected } ) {
 			if ( isSelected ) {
 				const { ownerDocument } = node;
 				const { defaultView } = ownerDocument;
-				if ( ! defaultView ) {
+				if ( ! defaultView.IntersectionObserver ) {
 					return;
 				}
 				const observer = new defaultView.IntersectionObserver(

--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -7,7 +7,11 @@ export function useScrollIntoView( { isSelected } ) {
 	return useRefEffect(
 		( node ) => {
 			if ( isSelected ) {
-				const { defaultView } = node.ownerDocument;
+				const { ownerDocument } = node;
+				const { defaultView } = ownerDocument;
+				if ( ! defaultView ) {
+					return;
+				}
 				const observer = new defaultView.IntersectionObserver(
 					( entries ) => {
 						// Once observing starts, we always get an initial

--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+export function useScrollIntoView( { isSelected } ) {
+	return useRefEffect(
+		( node ) => {
+			if ( isSelected ) {
+				const { defaultView } = node.ownerDocument;
+				const observer = new defaultView.IntersectionObserver(
+					( entries ) => {
+						// Once observing starts, we always get an initial
+						// entry with the intersecting state.
+						if ( ! entries[ 0 ].isIntersecting ) {
+							node.scrollIntoView();
+							observer.disconnect();
+						}
+					}
+				);
+				observer.observe( node );
+				return () => {
+					observer.disconnect();
+				};
+			}
+		},
+		[ isSelected ]
+	);
+}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -23,8 +23,8 @@ export function useScrollIntoView( { isSelected } ) {
 									? 'instant'
 									: 'smooth',
 							} );
-							observer.disconnect();
 						}
+						observer.disconnect();
 					}
 				);
 				observer.observe( node );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2751,7 +2751,7 @@ export function wasBlockJustInserted( state, clientId, source ) {
  * @return {boolean} True if the block is visible.
  */
 export function isBlockVisible( state, clientId ) {
-	return state.blockVisibility?.[ clientId ];
+	return state.blockVisibility?.[ clientId ] ?? true;
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2751,7 +2751,7 @@ export function wasBlockJustInserted( state, clientId, source ) {
  * @return {boolean} True if the block is visible.
  */
 export function isBlockVisible( state, clientId ) {
-	return state.blockVisibility?.[ clientId ] ?? true;
+	return state.blockVisibility?.[ clientId ];
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When inserting a block (at the bottom, or after the selected block), the inserted block should be scrolled into view.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

You currently don't know if anything has been inserted.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When a block becomes selected, we can check if the block is in view, and if not, scroll it into view.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open any editor
2. Add a block or a pattern to an empty post
3.  Check that the post is not scrolled
4. Open a long post, scrolled to the top
5. Add a block or a pattern
6. Check that the block is scrolled into view

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/275961/7e705786-8125-4dfb-b992-f620b7d34206





