### PR TITLE
Grid interactivity: Improve `max` attribute logic

### DIFF
--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -223,7 +223,13 @@ export default function ChildLayoutControl( {
 									} }
 									value={ columnStart }
 									min={ 1 }
-									max={ parentLayout?.columnCount }
+									max={
+										parentLayout?.columnCount
+											? parentLayout.columnCount -
+											  ( columnSpan ?? 1 ) +
+											  1
+											: undefined
+									}
 								/>
 							</FlexItem>
 							<FlexItem style={ { width: '50%' } }>
@@ -241,7 +247,13 @@ export default function ChildLayoutControl( {
 									} }
 									value={ rowStart }
 									min={ 1 }
-									max={ parentLayout?.columnCount }
+									max={
+										parentLayout?.rowCount
+											? parentLayout.rowCount -
+											  ( rowSpan ?? 1 ) +
+											  1
+											: undefined
+									}
 								/>
 							</FlexItem>
 						</Flex>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small fix that I've split out of https://github.com/WordPress/gutenberg/pull/59490.

Improves the logic that sets the `max` attribute in the _Grid placement_ input controls. These are currently behind an experimental flag and I doubt they'll ship in WP 6.6.

## Why?
In a grid that's in manual mode (i.e. it has a column and row count), the user shouldn't be able to set the row or column placement to be such that it would extend past the boundary of the grid.

## How?
This makes `max` take into account the Grid block's number of columns/rows and the item's span.

## Testing Instructions
1. Enable the _Grid interactivity_ experiment.
2. Add a Grid block, set it to manual mode, and set a number of rows and columns.
3. Add an item to the Grid block.
4. Adjust the placement of that item using the controls in the Dimensions panel.