### PR TITLE
Grid interactivity: Improve how grid resizer handles 0-width and 0-height cells

### DIFF
--- a/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
@@ -85,6 +85,19 @@ export function GridItemResizer( { clientId, onChange } ) {
 	);
 }
 
+/**
+ * Given a grid-template-columns or grid-template-rows CSS property value, gets the start and end
+ * position in pixels of each grid track.
+ *
+ * https://css-tricks.com/snippets/css/complete-guide-grid/#aa-grid-track
+ *
+ * @param {string} template The grid-template-columns or grid-template-rows CSS property value.
+ *                          Only supports fixed sizes in pixels.
+ * @param {number} gap      The gap between grid tracks in pixels.
+ *
+ * @return {Array<{start: number, end: number}>} An array of objects with the start and end
+ *                                               position in pixels of each grid track.
+ */
 function getGridTracks( template, gap ) {
 	const tracks = [];
 	for ( const size of template.split( ' ' ) ) {
@@ -96,6 +109,21 @@ function getGridTracks( template, gap ) {
 	return tracks;
 }
 
+/**
+ * Given an array of grid tracks and a position in pixels, gets the index of the closest track to
+ * that position.
+ *
+ * https://css-tricks.com/snippets/css/complete-guide-grid/#aa-grid-track
+ *
+ * @param {Array<{start: number, end: number}>} tracks   An array of objects with the start and end
+ *                                                       position in pixels of each grid track.
+ * @param {number}                              position The position in pixels.
+ * @param {string}                              edge     The edge of the track to compare the
+ *                                                       position to. Either 'start' or 'end'.
+ *
+ * @return {number} The index of the closest track to the position. 0-based, unlike CSS grid which
+ *                  is 1-based.
+ */
 function getClosestTrack( tracks, position, edge = 'start' ) {
 	return tracks.reduce(
 		( closest, track, index ) =>

--- a/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
@@ -45,33 +45,39 @@ export function GridItemResizer( { clientId, onChange } ) {
 					const rowGap = parseFloat(
 						getComputedCSS( gridElement, 'row-gap' )
 					);
-					const gridColumnLines = getGridLines(
+					const gridColumnTracks = getGridTracks(
 						getComputedCSS( gridElement, 'grid-template-columns' ),
 						columnGap
 					);
-					const gridRowLines = getGridLines(
+					const gridRowTracks = getGridTracks(
 						getComputedCSS( gridElement, 'grid-template-rows' ),
 						rowGap
 					);
-					const columnStart = getClosestLine(
-						gridColumnLines,
-						blockElement.offsetLeft
-					);
-					const rowStart = getClosestLine(
-						gridRowLines,
-						blockElement.offsetTop
-					);
-					const columnEnd = getClosestLine(
-						gridColumnLines,
-						blockElement.offsetLeft + boxElement.offsetWidth
-					);
-					const rowEnd = getClosestLine(
-						gridRowLines,
-						blockElement.offsetTop + boxElement.offsetHeight
-					);
+					const columnStart =
+						getClosestTrack(
+							gridColumnTracks,
+							blockElement.offsetLeft
+						) + 1;
+					const rowStart =
+						getClosestTrack(
+							gridRowTracks,
+							blockElement.offsetTop
+						) + 1;
+					const columnEnd =
+						getClosestTrack(
+							gridColumnTracks,
+							blockElement.offsetLeft + boxElement.offsetWidth,
+							'end'
+						) + 1;
+					const rowEnd =
+						getClosestTrack(
+							gridRowTracks,
+							blockElement.offsetTop + boxElement.offsetHeight,
+							'end'
+						) + 1;
 					onChange( {
-						columnSpan: Math.max( columnEnd - columnStart, 1 ),
-						rowSpan: Math.max( rowEnd - rowStart, 1 ),
+						columnSpan: columnEnd - columnStart + 1,
+						rowSpan: rowEnd - rowStart + 1,
 					} );
 				} }
 			/>
@@ -79,20 +85,22 @@ export function GridItemResizer( { clientId, onChange } ) {
 	);
 }
 
-function getGridLines( template, gap ) {
-	const lines = [ 0 ];
+function getGridTracks( template, gap ) {
+	const tracks = [];
 	for ( const size of template.split( ' ' ) ) {
-		const line = parseFloat( size );
-		lines.push( lines[ lines.length - 1 ] + line + gap );
+		const previousTrack = tracks[ tracks.length - 1 ];
+		const start = previousTrack ? previousTrack.end + gap : 0;
+		const end = start + parseFloat( size );
+		tracks.push( { start, end } );
 	}
-	return lines;
+	return tracks;
 }
 
-function getClosestLine( lines, position ) {
-	return lines.reduce(
-		( closest, line, index ) =>
-			Math.abs( line - position ) <
-			Math.abs( lines[ closest ] - position )
+function getClosestTrack( tracks, position, edge = 'start' ) {
+	return tracks.reduce(
+		( closest, track, index ) =>
+			Math.abs( track[ edge ] - position ) <
+			Math.abs( tracks[ closest ][ edge ] - position )
 				? index
 				: closest,
 		0


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small fix that I've split out of https://github.com/WordPress/gutenberg/pull/59490.

Improves the grid item resizer's handling of empty 0-width or 0-height cells.

## Why?
It's basically impossible in `trunk` to resize a grid item using the drag handles to span an empty row. This PR improves the logic of how resizing is calculated to fix this.

## How?
In `trunk` we're using _grid lines_ to calculate the span. A grid line is where the cell starts. The problem with this approach is that you need to drag the resize box to be close to the _start of the next cell_ in order to span a cell. This is fine when the cell is a normal size but is impossible when it has no width or height.

So instead of calculating the new span using _grid lines_ which is just where a cell starts, use _grid tracks_ which contains where a cell starts and where it ends. We can then calculate the span by looking for the nearest end track and subtracting the nearest start track. This correctly handles the case where a cell has no width or height.

It's also just more logically correct 😊

## Testing Instructions
1. Enable the _Grid interactivity_ experiment.
2. Add a Grid block and insert three child blocks.
3. Set a _row span_ of 2 to one of the child blocks using the block inspector. This will create an empty row.
4. Use the grid item resize controls to change the row span of another child block to be 2. This should now be possible.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/612155/1f4b4084-6b94-4b3c-ae41-65b4549537df

After:

https://github.com/WordPress/gutenberg/assets/612155/a1c99e3b-7fa1-4bf1-92f9-087436db3178