### PR TITLE
Add visible close button to inserter sidebar

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -16,6 +16,7 @@ $z-layers: (
 	// These next three share a stacking context
 	".block-library-template-part__selection-search": 2, // higher sticky element
 	".block-library-query-pattern__selection-search": 2, // higher sticky element
+	".editor-inserter-sidebar__header": 2,
 
 	// These next two share a stacking context
 	".interface-complementary-area .components-panel" : 0, // lower scrolling content

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -116,7 +116,8 @@ $block-inserter-tabs-height: 44px;
 	overflow: hidden;
 
 	.block-editor-inserter__tablist {
-		border-bottom: $border-width solid $gray-300;
+		// Make room for the close button
+		width: calc(100% - #{$grid-unit-60});
 
 		button[role="tab"] {
 			flex-grow: 1;
@@ -135,6 +136,7 @@ $block-inserter-tabs-height: 44px;
 		flex-grow: 1;
 		flex-direction: column;
 		overflow-y: auto;
+		border-top: $border-width solid $gray-300;
 	}
 }
 

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -2,9 +2,9 @@
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Button, VisuallyHidden } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
-import { close } from '@wordpress/icons';
+import { closeSmall } from '@wordpress/icons';
 import {
 	useViewportMatch,
 	__experimentalUseDialog as useDialog,
@@ -34,7 +34,6 @@ export default function InserterSidebar( {
 	const { setIsInserterOpened } = useDispatch( editorStore );
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 		focusOnMount: true,
@@ -48,13 +47,15 @@ export default function InserterSidebar( {
 			{ ...inserterDialogProps }
 			className="editor-inserter-sidebar"
 		>
-			<TagName className="editor-inserter-sidebar__header">
+			<div className="editor-inserter-sidebar__header">
 				<Button
-					icon={ close }
+					className="editor-inserter-sidebar__close-button"
+					icon={ closeSmall }
 					label={ __( 'Close block inserter' ) }
 					onClick={ () => setIsInserterOpened( false ) }
+					size="small"
 				/>
-			</TagName>
+			</div>
 			<div className="editor-inserter-sidebar__content">
 				<Library
 					showMostUsedBlocks={ showMostUsedBlocks }

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -10,7 +10,7 @@
 	position: relative;
 	display: flex;
 	justify-content: flex-end;
-	z-index: 2;
+	z-index: z-index(".editor-inserter-sidebar__header");
 }
 
 .editor-inserter-sidebar__close-button {

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -7,16 +7,18 @@
 }
 
 .editor-inserter-sidebar__header {
-	padding-top: $grid-unit-10;
-	padding-right: $grid-unit-10;
+	position: relative;
 	display: flex;
 	justify-content: flex-end;
+	z-index: 2;
+}
+
+.editor-inserter-sidebar__close-button {
+	position: absolute;
+	top: $grid-unit-15;
+	right: $grid-unit-15;
 }
 
 .editor-inserter-sidebar__content {
-	// Leave space for the close button
-	height: calc(100% - #{$button-size} - #{$grid-unit-10});
-	@include break-medium() {
-		height: 100%;
-	}
+	height: 100%;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Alternative to https://github.com/WordPress/gutenberg/pull/61421 so we don't need to prop drill an `onClose` for the sidebar into the `<InserterTabs />`

## What?
Add a close button to the inserter.

## Why?
We'd like to leave the inserter always open, which means it needs a close button - see https://github.com/WordPress/gutenberg/pull/60391.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Absolutely positions the close button and reduces the width of the tablist to make room.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Close
2. Open Inserter
3. Click close button with mouse

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Open inserter
2. Focus should be on Blocks tab
3. Shift + Tab to move to close button

## Screenshots or screencast <!-- if applicable -->
