### PR TITLE
Grid interactivity: Make visualizer's cell UI at minimum 8x8 in size

### DIFF
--- a/packages/block-editor/src/components/grid-visualizer/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-visualizer.js
@@ -51,7 +51,9 @@ function GridVisualizerGrid( { blockElement } ) {
 			style={ gridInfo.style }
 		>
 			{ Array.from( { length: gridInfo.numItems }, ( _, i ) => (
-				<div key={ i } className="block-editor-grid-visualizer__item" />
+				<div key={ i } className="block-editor-grid-visualizer__cell">
+					<div className="block-editor-grid-visualizer__drop-zone" />
+				</div>
 			) ) }
 		</div>
 	);

--- a/packages/block-editor/src/components/grid-visualizer/style.scss
+++ b/packages/block-editor/src/components/grid-visualizer/style.scss
@@ -1,33 +1,52 @@
-// TODO: Specificity hacks to get rid of all these darn !importants.
-
 .block-editor-grid-visualizer {
-	z-index: z-index(".block-editor-grid-visualizer") !important;
-}
+	// Specificity to override the z-index and pointer-events set by .components-popover.
+	&.block-editor-grid-visualizer.block-editor-grid-visualizer {
+		z-index: z-index(".block-editor-grid-visualizer");
 
-.block-editor-grid-visualizer .components-popover__content * {
-	pointer-events: none !important;
+		.components-popover__content * {
+			pointer-events: none;
+		}
+	}
 }
 
 .block-editor-grid-visualizer__grid {
 	display: grid;
 }
 
-.block-editor-grid-visualizer__item {
+.block-editor-grid-visualizer__cell {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+}
+
+.block-editor-grid-visualizer__drop-zone {
 	border: $border-width dashed $gray-300;
+	width: 100%;
+	height: 100%;
+
+	// Make drop zone 8x8 at minimum so that it's easier to drag into. This will overflow the parent.
+	min-width: $grid-unit-10;
+	min-height: $grid-unit-10;
 }
 
 .block-editor-grid-item-resizer {
-	z-index: z-index(".block-editor-grid-visualizer") !important;
-}
+	// Specificity to override the z-index and pointer-events set by .components-popover.
+	&.block-editor-grid-item-resizer.block-editor-grid-item-resizer {
+		z-index: z-index(".block-editor-grid-visualizer");
 
-.block-editor-grid-item-resizer .components-popover__content * {
-	pointer-events: none !important;
+		.components-popover__content * {
+			pointer-events: none;
+		}
+	}
 }
 
 .block-editor-grid-item-resizer__box {
 	border: $border-width solid var(--wp-admin-theme-color);
 
 	.components-resizable-box__handle {
-		pointer-events: all !important;
+		// Specificity to override the pointer-events set by .components-popover.
+		&.components-resizable-box__handle.components-resizable-box__handle {
+			pointer-events: all;
+		}
 	}
 }


### PR DESCRIPTION
## What?
Small fix that I've split out of https://github.com/WordPress/gutenberg/pull/59490.

Makes the grid visualiser show empty cells as being at minimum 8x8 in size.

## Why?
This makes empty rows and columns in the grid appear at least 8px wide or tall. This allows the user to drag and drop into that cell (will be necessary in the future) and more easily resize grid items to span that cell.

## How?
Splits each grid visualiser cell `<div />` into a `<div><div /></div>`. The outer div is positioned by the grid layout and the inner div has a min size of 8x8.

This also removes the `!important` keywords from the grid visualiser CSS in favour of specificity hacks which, despite their name, are less hacky.

## Testing Instructions
1. Enable the _Grid interactivity_ experiment.
2. Add a Grid block and insert three child blocks.
3. Set a _row span_ of 2 to one of the child blocks using the block inspector. This will create an empty row.

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="788" alt="Screenshot 2024-05-07 at 16 58 09" src="https://github.com/WordPress/gutenberg/assets/612155/d2662f89-9a9c-4a59-8d39-bfc99f9a219e">


After:

<img width="742" alt="Screenshot 2024-05-07 at 16 57 10" src="https://github.com/WordPress/gutenberg/assets/612155/e6233f1e-42e8-4b46-a919-e8459620e51e">