### PR TITLE
Zoom out: show patterns when clearing block selection

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -23,11 +23,13 @@ import { unlock } from '../../../lock-unlock';
  * @return {Array} Returns the patterns state. (patterns, categories, onSelect handler)
  */
 const usePatternsState = ( onInsert, rootClientId ) => {
-	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
 	const { patternCategories, patterns, userPatternCategories } = useSelect(
 		( select ) => {
-			const { __experimentalGetAllowedPatterns, getSettings } =
-				select( blockEditorStore );
+			const {
+				__experimentalGetAllowedPatterns,
+				getSettings,
+				__unstableGetEditorMode,
+			} = select( blockEditorStore );
 			const {
 				__experimentalUserPatternCategories,
 				__experimentalBlockPatternCategories,

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -23,6 +23,7 @@ import { unlock } from '../../../lock-unlock';
  * @return {Array} Returns the patterns state. (patterns, categories, onSelect handler)
  */
 const usePatternsState = ( onInsert, rootClientId ) => {
+	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
 	const { patternCategories, patterns, userPatternCategories } = useSelect(
 		( select ) => {
 			const { __experimentalGetAllowedPatterns, getSettings } =
@@ -30,7 +31,6 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 			const {
 				__experimentalUserPatternCategories,
 				__experimentalBlockPatternCategories,
-				__unstableGetEditorMode,
 			} = getSettings();
 			let sectionRootClientId;
 

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -12,6 +12,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { store as blockEditorStore } from '../../../store';
 import { INSERTER_PATTERN_TYPES } from '../block-patterns-tab/utils';
+import { unlock } from '../../../lock-unlock';
 
 /**
  * Retrieves the block patterns inserter state.
@@ -29,9 +30,20 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 			const {
 				__experimentalUserPatternCategories,
 				__experimentalBlockPatternCategories,
+				__unstableGetEditorMode,
 			} = getSettings();
+			let sectionRootClientId;
+
+			if ( __unstableGetEditorMode() === 'zoom-out' ) {
+				sectionRootClientId = unlock(
+					getSettings()
+				).sectionRootClientId;
+			}
+
 			return {
-				patterns: __experimentalGetAllowedPatterns( rootClientId ),
+				patterns: __experimentalGetAllowedPatterns(
+					sectionRootClientId ?? rootClientId
+				),
 				userPatternCategories: __experimentalUserPatternCategories,
 				patternCategories: __experimentalBlockPatternCategories,
 			};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When in zoom out mode, and no block is selected, the block editing mode for the root is disabled, so we need to use the section root instead. Patterns should be inserted at the "section root", not the root of the document.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
