### PR TITLE
Create Block: Match specified engines with Gutenberg and Core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53697,8 +53697,8 @@
 				"wp-create-block": "index.js"
 			},
 			"engines": {
-				"node": ">=18",
-				"npm": ">=10.5.0"
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			}
 		},
 		"packages/create-block-tutorial-template": {

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -19,7 +19,7 @@ $ npm start
 The `slug` provided (`todo-list` in the example) defines the folder name for the scaffolded plugin and the internal block name. The WordPress plugin generated must [be installed manually](https://wordpress.org/documentation/article/manage-plugins/#manual-plugin-installation-1).
 
 
-_(requires `node` version `18.0.0` or above, and `npm` version `10.5.0` or above)_
+_(requires `node` version `20.10.0` or above, and `npm` version `10.2.3` or above)_
 
 
 > [Watch a video introduction to create-block on Learn.wordpress.org](https://learn.wordpress.org/tutorial/using-the-create-block-tool/)

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -20,8 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=18",
-		"npm": ">=10.5.0"
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
 	},
 	"files": [
 		"lib"


### PR DESCRIPTION
## What?
This is a follow-up to #60962.

PR updates engines specified in the `package.json` file to match [Gutenberg](https://github.com/WordPress/gutenberg/blob/e92b45adb5b10dd7d7eb9162d908f7493b94ab4d/package.json#L17-L20) and [WP Core](https://github.com/WordPress/wordpress-develop/blob/b0308b8f5299362c8a12e45e83d6a26cb01d7325/package.json#L9-L12).
CI checks should be green.

## Why?
The `npm install` might fail when using node version managers due to a version mismatch.

### Testing Instructions for Keyboard
Same.
