### PR TITLE
Open inserter sidebar when clicking on inserter buttons on zoom-out mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -47,6 +47,10 @@
 
 	top: calc(50% - #{$button-size-small * 0.5});
 	left: calc(50% - #{$button-size-small * 0.5});
+	.is-pattern-inserter & {
+		top: 50%;
+		left: 50%;
+	}
 }
 
 .block-editor-block-list__block-side-inserter-popover .components-popover__content > div {
@@ -261,4 +265,8 @@
 
 .is-dragging-components-draggable .components-tooltip {
 	display: none;
+}
+
+.block-editor-block-list__insertion-point.is-pattern-inserter .block-editor-button-pattern-inserter__button {
+	pointer-events: all;
 }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -47,10 +47,6 @@
 
 	top: calc(50% - #{$button-size-small * 0.5});
 	left: calc(50% - #{$button-size-small * 0.5});
-	.is-pattern-inserter & {
-		top: 50%;
-		left: 50%;
-	}
 }
 
 .block-editor-block-list__block-side-inserter-popover .components-popover__content > div {
@@ -267,6 +263,10 @@
 	display: none;
 }
 
-.block-editor-block-list__insertion-point.is-pattern-inserter .block-editor-button-pattern-inserter__button {
+.components-popover.block-editor-block-popover__inbetween .block-editor-button-pattern-inserter__button {
 	pointer-events: all;
+	position: absolute;
+	transform: translateX(-50%) translateY(-50%);
+	top: 50%;
+	left: 50%;
 }

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -14,79 +14,27 @@ import BlockPopoverInbetween from '../block-popover/inbetween';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-function Inserter( {
-	previousClientId,
-	nextClientId,
-	sectionRootClientId,
-	index,
-	setActiveInserter,
-} ) {
-	const { setInserterIsOpened, insertionIndex } = useSelect(
-		( select ) => {
-			const { getSettings, getBlockCount } = select( blockEditorStore );
-			const settings = getSettings();
-			return {
-				setInserterIsOpened: settings.__experimentalSetIsInserterOpened,
-				insertionIndex: index === -1 ? getBlockCount() : index,
-			};
-		},
-		[ index ]
-	);
-
-	const label = _x(
-		'Add pattern',
-		'Generic label for pattern inserter button'
-	);
-	return (
-		<BlockPopoverInbetween
-			previousClientId={ previousClientId }
-			nextClientId={ nextClientId }
-			className="block-editor-button-pattern-inserter"
-		>
-			<Button
-				variant="primary"
-				icon={ plus }
-				size="compact"
-				className="block-editor-button-pattern-inserter__button"
-				onClick={ () => {
-					setInserterIsOpened( {
-						rootClientId: sectionRootClientId,
-						insertionIndex,
-						tab: 'patterns',
-						category: 'all',
-					} );
-					setActiveInserter( index );
-				} }
-				label={ label }
-			/>
-		</BlockPopoverInbetween>
-	);
-}
-
-function ZoomOutModeInserters( { __unstableContentRef } ) {
+function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
-	const [ activeInserter, setActiveInserter ] = useState( null );
-	const { blockOrder, sectionRootClientId, isInserterOpened } = useSelect(
-		( select ) => {
-			const { sectionRootClientId: root } = unlock(
-				select( blockEditorStore ).getSettings()
-			);
-			return {
-				blockOrder: select( blockEditorStore ).getBlockOrder( root ),
-				// To do: move ZoomOutModeInserters to core/editor.
-				// eslint-disable-next-line @wordpress/data-no-store-string-literals
-				isInserterOpened: select( 'core/editor' ).isInserterOpened(),
-				sectionRootClientId: root,
-			};
-		},
-		[]
-	);
-
-	useEffect( () => {
-		if ( ! isInserterOpened ) {
-			setActiveInserter( null );
-		}
-	}, [ isInserterOpened ] );
+	const {
+		blockOrder,
+		sectionRootClientId,
+		insertionPoint,
+		setInserterIsOpened,
+	} = useSelect( ( select ) => {
+		const { getSettings, getBlockOrder } = select( blockEditorStore );
+		const { sectionRootClientId: root } = unlock( getSettings() );
+		// To do: move ZoomOutModeInserters to core/editor.
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
+		const editor = select( 'core/editor' );
+		return {
+			blockOrder: getBlockOrder( root ),
+			insertionPoint: unlock( editor ).getInsertionPoint(),
+			sectionRootClientId: root,
+			setInserterIsOpened:
+				getSettings().__experimentalSetIsInserterOpened,
+		};
+	}, [] );
 
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {
@@ -103,20 +51,35 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 	}
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
-		if ( activeInserter === index ) {
+		if ( insertionPoint.insertionIndex === index ) {
 			return null;
 		}
 		return (
-			<Inserter
+			<BlockPopoverInbetween
 				key={ index }
 				previousClientId={ clientId }
 				nextClientId={ blockOrder[ index ] }
-				sectionRootClientId={ sectionRootClientId }
-				index={ index }
-				blockOrder={ blockOrder }
-				__unstableContentRef={ __unstableContentRef }
-				setActiveInserter={ setActiveInserter }
-			/>
+				className="block-editor-button-pattern-inserter"
+			>
+				<Button
+					variant="primary"
+					icon={ plus }
+					size="compact"
+					className="block-editor-button-pattern-inserter__button"
+					onClick={ () => {
+						setInserterIsOpened( {
+							rootClientId: sectionRootClientId,
+							insertionIndex: index,
+							tab: 'patterns',
+							category: 'all',
+						} );
+					} }
+					label={ _x(
+						'Add pattern',
+						'Generic label for pattern inserter button'
+					) }
+				/>
+			</BlockPopoverInbetween>
 		);
 	} );
 }

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -3,17 +3,35 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
+import { __unstableMotion as motion, Button } from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
+import { plus } from '@wordpress/icons';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import BlockPopoverInbetween from '../block-popover/inbetween';
 import { store as blockEditorStore } from '../../store';
-import Inserter from '../inserter';
 import { unlock } from '../../lock-unlock';
 
 function ZoomOutModeInserters( { __unstableContentRef } ) {
 	const [ isReady, setIsReady ] = useState( false );
+	const { setInserterIsOpened, insertionIndex } = useSelect(
+		( select ) => {
+			const { getSettings, getBlockIndex, getBlockCount } =
+				select( blockEditorStore );
+			const settings = getSettings();
+			const index = getBlockIndex( clientId );
+			const blockCount = getBlockCount();
+
+			return {
+				setInserterIsOpened: settings.__experimentalSetIsInserterOpened,
+				insertionIndex: index === -1 ? blockCount : index,
+			};
+		},
+		[ clientId ]
+	);
 	const blockOrder = useSelect( ( select ) => {
 		const { sectionRootClientId } = unlock(
 			select( blockEditorStore ).getSettings()
@@ -31,25 +49,101 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 		};
 	}, [] );
 
+	useEffect( () => {
+		if ( setInserterIsOpened ) {
+			setInserterIsOpened( false );
+		}
+	}, [ setInserterIsOpened ] );
+
+	const disableMotion = useReducedMotion();
+
 	if ( ! isReady ) {
 		return null;
 	}
 
+	const lineVariants = {
+		// Initial position starts from the center and invisible.
+		start: {
+			opacity: 0,
+			scale: 0,
+		},
+		// The line expands to fill the container. If the inserter is visible it
+		// is delayed so it appears orchestrated.
+		rest: {
+			opacity: 1,
+			scale: 1,
+			transition: { delay: 0.5, type: 'tween' },
+		},
+		hover: {
+			opacity: 1,
+			scale: 1,
+			transition: { delay: 0.5, type: 'tween' },
+		},
+	};
+	const patternInserterVariants = {
+		start: {
+			scale: disableMotion ? 1 : 0,
+			translateX: '-50%',
+			translateY: '-50%',
+		},
+		rest: {
+			scale: 1,
+			transition: { delay: 0.4, type: 'tween' },
+		},
+	};
+
+	const label = _x(
+		'Add pattern',
+		'Generic label for pattern inserter button'
+	);
+
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
+		if ( index === blockOrder.length - 1 ) {
+			return null;
+		}
 		return (
 			<BlockPopoverInbetween
 				key={ index }
 				previousClientId={ clientId }
 				nextClientId={ blockOrder[ index ] }
 				__unstableContentRef={ __unstableContentRef }
+				className="block-editor-button-pattern-inserter"
 			>
-				<div className="block-editor-block-list__insertion-point-inserter is-with-inserter">
-					<Inserter
-						position="bottom center"
-						clientId={ blockOrder[ index ] }
-						__experimentalIsQuick
+				<motion.div
+					key={ clientId }
+					layout={ ! disableMotion }
+					initial={ disableMotion ? 'rest' : 'start' }
+					animate="rest"
+					whileHover="hover"
+					whileTap="pressed"
+					exit="start"
+					className="block-editor-block-list__insertion-point is-vertical is-pattern-inserter"
+				>
+					<motion.div
+						variants={ lineVariants }
+						className="block-editor-block-list__insertion-point-indicator"
+						data-testid="block-list-insertion-point-indicator"
 					/>
-				</div>
+					<motion.div
+						variants={ patternInserterVariants }
+						className="block-editor-block-list__insertion-point-inserter"
+					>
+						<Button
+							variant="primary"
+							icon={ plus }
+							size="compact"
+							className="block-editor-button-pattern-inserter__button"
+							onClick={ () => {
+								setInserterIsOpened( {
+									clientId,
+									insertionIndex,
+									filterValue,
+								} );
+							} }
+							label={ label }
+						/>
+					</motion.div>
+				</motion.div>
 			</BlockPopoverInbetween>
 		);
 	} );

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -65,10 +65,11 @@ function ZoomOutModeInserters() {
 				{ insertionPoint.insertionIndex === index && (
 					<div
 						style={ {
+							borderRadius: '0',
+							height: '12px',
 							opacity: 1,
-							height: '4px',
-							width: '100%',
 							transform: 'translateY(-50%)',
+							width: '100%',
 						} }
 						className="block-editor-block-list__insertion-point-indicator"
 					/>

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -40,6 +40,12 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
+	useEffect( () => {
+		// reset insertion point when the block order changes
+		setInserterIsOpened( true );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ blockOrder ] );
+
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {
 		const timeout = setTimeout( () => {

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -25,6 +25,10 @@ function ZoomOutModeInserters() {
 		const { getSettings, getBlockOrder } = select( blockEditorStore );
 		const { sectionRootClientId: root } = unlock( getSettings() );
 		// To do: move ZoomOutModeInserters to core/editor.
+		// Or we perhaps we should move the insertion point state to the
+		// block-editor store. I'm not sure what it was ever moved to the editor
+		// store, because all the inserter components all live in the
+		// block-editor package.
 		// eslint-disable-next-line @wordpress/data-no-store-string-literals
 		const editor = select( 'core/editor' );
 		return {

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -68,15 +68,27 @@ function Inserter( {
 function ZoomOutModeInserters( { __unstableContentRef } ) {
 	const [ isReady, setIsReady ] = useState( false );
 	const [ activeInserter, setActiveInserter ] = useState( null );
-	const { blockOrder, sectionRootClientId } = useSelect( ( select ) => {
-		const { sectionRootClientId: root } = unlock(
-			select( blockEditorStore ).getSettings()
-		);
-		return {
-			blockOrder: select( blockEditorStore ).getBlockOrder( root ),
-			sectionRootClientId: root,
-		};
-	}, [] );
+	const { blockOrder, sectionRootClientId, blockInsertionPoint } = useSelect(
+		( select ) => {
+			const { sectionRootClientId: root } = unlock(
+				select( blockEditorStore ).getSettings()
+			);
+			return {
+				blockOrder: select( blockEditorStore ).getBlockOrder( root ),
+				// To do: move ZoomOutModeInserters to core/editor.
+				// eslint-disable-next-line @wordpress/data-no-store-string-literals
+				blockInsertionPoint: select( 'core/editor' ).isInserterOpened(),
+				sectionRootClientId: root,
+			};
+		},
+		[]
+	);
+
+	useEffect( () => {
+		if ( ! blockInsertionPoint ) {
+			setActiveInserter( null );
+		}
+	}, [ blockInsertionPoint ] );
 
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -117,18 +117,6 @@ function Inserter( {
 
 function ZoomOutModeInserters( { __unstableContentRef } ) {
 	const [ isReady, setIsReady ] = useState( false );
-	// const { setInserterIsOpened } = useSelect( ( select ) => {
-	// 	const { getSettings, getBlockIndex, getBlockCount } =
-	// 		select( blockEditorStore );
-	// 	const settings = getSettings();
-	// 	const index = getBlockIndex( clientId );
-	// 	const blockCount = getBlockCount();
-
-	// 	return {
-	// 		setInserterIsOpened: settings.__experimentalSetIsInserterOpened,
-	// 		insertionIndex: index === -1 ? blockCount : index,
-	// 	};
-	// }, [] );
 	const { blockOrder, sectionRootClientId } = useSelect( ( select ) => {
 		const { sectionRootClientId: root } = unlock(
 			select( blockEditorStore ).getSettings()
@@ -148,12 +136,6 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 			clearTimeout( timeout );
 		};
 	}, [] );
-
-	// useEffect( () => {
-	// 	if ( setInserterIsOpened ) {
-	// 		setInserterIsOpened( false );
-	// 	}
-	// }, [ setInserterIsOpened ] );
 
 	const disableMotion = useReducedMotion();
 

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -55,9 +55,6 @@ function ZoomOutModeInserters() {
 	}
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
-		if ( insertionPoint.insertionIndex === index ) {
-			return null;
-		}
 		return (
 			<BlockPopoverInbetween
 				key={ index }
@@ -65,24 +62,37 @@ function ZoomOutModeInserters() {
 				nextClientId={ blockOrder[ index ] }
 				className="block-editor-button-pattern-inserter"
 			>
-				<Button
-					variant="primary"
-					icon={ plus }
-					size="compact"
-					className="block-editor-button-pattern-inserter__button"
-					onClick={ () => {
-						setInserterIsOpened( {
-							rootClientId: sectionRootClientId,
-							insertionIndex: index,
-							tab: 'patterns',
-							category: 'all',
-						} );
-					} }
-					label={ _x(
-						'Add pattern',
-						'Generic label for pattern inserter button'
-					) }
-				/>
+				{ insertionPoint.insertionIndex === index && (
+					<div
+						style={ {
+							opacity: 1,
+							height: '4px',
+							width: '100%',
+							transform: 'translateY(-50%)',
+						} }
+						className="block-editor-block-list__insertion-point-indicator"
+					/>
+				) }
+				{ insertionPoint.insertionIndex !== index && (
+					<Button
+						variant="primary"
+						icon={ plus }
+						size="compact"
+						className="block-editor-button-pattern-inserter__button"
+						onClick={ () => {
+							setInserterIsOpened( {
+								rootClientId: sectionRootClientId,
+								insertionIndex: index,
+								tab: 'patterns',
+								category: 'all',
+							} );
+						} }
+						label={ _x(
+							'Add pattern',
+							'Generic label for pattern inserter button'
+						) }
+					/>
+				) }
 			</BlockPopoverInbetween>
 		);
 	} );

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -15,52 +15,25 @@ import BlockPopoverInbetween from '../block-popover/inbetween';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-function ZoomOutModeInserters( { __unstableContentRef } ) {
-	const [ isReady, setIsReady ] = useState( false );
+function Inserter( {
+	previousClientId,
+	nextClientId,
+	sectionRootClientId,
+	disableMotion,
+	__unstableContentRef,
+	index,
+} ) {
 	const { setInserterIsOpened, insertionIndex } = useSelect(
 		( select ) => {
-			const { getSettings, getBlockIndex, getBlockCount } =
-				select( blockEditorStore );
+			const { getSettings, getBlockCount } = select( blockEditorStore );
 			const settings = getSettings();
-			const index = getBlockIndex( clientId );
-			const blockCount = getBlockCount();
-
 			return {
 				setInserterIsOpened: settings.__experimentalSetIsInserterOpened,
-				insertionIndex: index === -1 ? blockCount : index,
+				insertionIndex: index === -1 ? getBlockCount() : index,
 			};
 		},
-		[ clientId ]
+		[ index ]
 	);
-	const blockOrder = useSelect( ( select ) => {
-		const { sectionRootClientId } = unlock(
-			select( blockEditorStore ).getSettings()
-		);
-		return select( blockEditorStore ).getBlockOrder( sectionRootClientId );
-	}, [] );
-
-	// Defer the initial rendering to avoid the jumps due to the animation.
-	useEffect( () => {
-		const timeout = setTimeout( () => {
-			setIsReady( true );
-		}, 500 );
-		return () => {
-			clearTimeout( timeout );
-		};
-	}, [] );
-
-	useEffect( () => {
-		if ( setInserterIsOpened ) {
-			setInserterIsOpened( false );
-		}
-	}, [ setInserterIsOpened ] );
-
-	const disableMotion = useReducedMotion();
-
-	if ( ! isReady ) {
-		return null;
-	}
-
 	const lineVariants = {
 		// Initial position starts from the center and invisible.
 		start: {
@@ -96,55 +69,113 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 		'Add pattern',
 		'Generic label for pattern inserter button'
 	);
+	return (
+		<BlockPopoverInbetween
+			previousClientId={ previousClientId }
+			nextClientId={ nextClientId }
+			__unstableContentRef={ __unstableContentRef }
+			className="block-editor-button-pattern-inserter"
+		>
+			<motion.div
+				layout={ ! disableMotion }
+				initial={ disableMotion ? 'rest' : 'start' }
+				animate="rest"
+				whileHover="hover"
+				whileTap="pressed"
+				exit="start"
+				className="block-editor-block-list__insertion-point is-vertical is-pattern-inserter"
+			>
+				<motion.div
+					variants={ lineVariants }
+					className="block-editor-block-list__insertion-point-indicator"
+					data-testid="block-list-insertion-point-indicator"
+				/>
+				<motion.div
+					variants={ patternInserterVariants }
+					className="block-editor-block-list__insertion-point-inserter"
+				>
+					<Button
+						variant="primary"
+						icon={ plus }
+						size="compact"
+						className="block-editor-button-pattern-inserter__button"
+						onClick={ () => {
+							setInserterIsOpened( {
+								rootClientId: sectionRootClientId,
+								insertionIndex,
+								tab: 'patterns',
+								category: 'all',
+							} );
+						} }
+						label={ label }
+					/>
+				</motion.div>
+			</motion.div>
+		</BlockPopoverInbetween>
+	);
+}
+
+function ZoomOutModeInserters( { __unstableContentRef } ) {
+	const [ isReady, setIsReady ] = useState( false );
+	// const { setInserterIsOpened } = useSelect( ( select ) => {
+	// 	const { getSettings, getBlockIndex, getBlockCount } =
+	// 		select( blockEditorStore );
+	// 	const settings = getSettings();
+	// 	const index = getBlockIndex( clientId );
+	// 	const blockCount = getBlockCount();
+
+	// 	return {
+	// 		setInserterIsOpened: settings.__experimentalSetIsInserterOpened,
+	// 		insertionIndex: index === -1 ? blockCount : index,
+	// 	};
+	// }, [] );
+	const { blockOrder, sectionRootClientId } = useSelect( ( select ) => {
+		const { sectionRootClientId: root } = unlock(
+			select( blockEditorStore ).getSettings()
+		);
+		return {
+			blockOrder: select( blockEditorStore ).getBlockOrder( root ),
+			sectionRootClientId: root,
+		};
+	}, [] );
+
+	// Defer the initial rendering to avoid the jumps due to the animation.
+	useEffect( () => {
+		const timeout = setTimeout( () => {
+			setIsReady( true );
+		}, 500 );
+		return () => {
+			clearTimeout( timeout );
+		};
+	}, [] );
+
+	// useEffect( () => {
+	// 	if ( setInserterIsOpened ) {
+	// 		setInserterIsOpened( false );
+	// 	}
+	// }, [ setInserterIsOpened ] );
+
+	const disableMotion = useReducedMotion();
+
+	if ( ! isReady ) {
+		return null;
+	}
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
 		if ( index === blockOrder.length - 1 ) {
 			return null;
 		}
 		return (
-			<BlockPopoverInbetween
+			<Inserter
 				key={ index }
 				previousClientId={ clientId }
 				nextClientId={ blockOrder[ index ] }
+				sectionRootClientId={ sectionRootClientId }
+				disableMotion={ disableMotion }
+				index={ index }
+				blockOrder={ blockOrder }
 				__unstableContentRef={ __unstableContentRef }
-				className="block-editor-button-pattern-inserter"
-			>
-				<motion.div
-					key={ clientId }
-					layout={ ! disableMotion }
-					initial={ disableMotion ? 'rest' : 'start' }
-					animate="rest"
-					whileHover="hover"
-					whileTap="pressed"
-					exit="start"
-					className="block-editor-block-list__insertion-point is-vertical is-pattern-inserter"
-				>
-					<motion.div
-						variants={ lineVariants }
-						className="block-editor-block-list__insertion-point-indicator"
-						data-testid="block-list-insertion-point-indicator"
-					/>
-					<motion.div
-						variants={ patternInserterVariants }
-						className="block-editor-block-list__insertion-point-inserter"
-					>
-						<Button
-							variant="primary"
-							icon={ plus }
-							size="compact"
-							className="block-editor-button-pattern-inserter__button"
-							onClick={ () => {
-								setInserterIsOpened( {
-									clientId,
-									insertionIndex,
-									filterValue,
-								} );
-							} }
-							label={ label }
-						/>
-					</motion.div>
-				</motion.div>
-			</BlockPopoverInbetween>
+			/>
 		);
 	} );
 }

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -18,7 +18,6 @@ function Inserter( {
 	previousClientId,
 	nextClientId,
 	sectionRootClientId,
-	__unstableContentRef,
 	index,
 	setActiveInserter,
 } ) {
@@ -42,7 +41,6 @@ function Inserter( {
 		<BlockPopoverInbetween
 			previousClientId={ previousClientId }
 			nextClientId={ nextClientId }
-			__unstableContentRef={ __unstableContentRef }
 			className="block-editor-button-pattern-inserter"
 		>
 			<Button
@@ -68,7 +66,7 @@ function Inserter( {
 function ZoomOutModeInserters( { __unstableContentRef } ) {
 	const [ isReady, setIsReady ] = useState( false );
 	const [ activeInserter, setActiveInserter ] = useState( null );
-	const { blockOrder, sectionRootClientId, blockInsertionPoint } = useSelect(
+	const { blockOrder, sectionRootClientId, isInserterOpened } = useSelect(
 		( select ) => {
 			const { sectionRootClientId: root } = unlock(
 				select( blockEditorStore ).getSettings()
@@ -77,7 +75,7 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 				blockOrder: select( blockEditorStore ).getBlockOrder( root ),
 				// To do: move ZoomOutModeInserters to core/editor.
 				// eslint-disable-next-line @wordpress/data-no-store-string-literals
-				blockInsertionPoint: select( 'core/editor' ).isInserterOpened(),
+				isInserterOpened: select( 'core/editor' ).isInserterOpened(),
 				sectionRootClientId: root,
 			};
 		},
@@ -85,10 +83,10 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 	);
 
 	useEffect( () => {
-		if ( ! blockInsertionPoint ) {
+		if ( ! isInserterOpened ) {
 			setActiveInserter( null );
 		}
-	}, [ blockInsertionPoint ] );
+	}, [ isInserterOpened ] );
 
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
@@ -40,7 +40,13 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
+	const isMounted = useRef( false );
+
 	useEffect( () => {
+		if ( ! isMounted.current ) {
+			isMounted.current = true;
+			return;
+		}
 		// reset insertion point when the block order changes
 		setInserterIsOpened( true );
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -60,7 +60,6 @@ function ZoomOutModeInserters() {
 				key={ index }
 				previousClientId={ clientId }
 				nextClientId={ blockOrder[ index ] }
-				className="block-editor-button-pattern-inserter"
 			>
 				{ insertionPoint.insertionIndex === index && (
 					<div

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -3,8 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
-import { __unstableMotion as motion, Button } from '@wordpress/components';
-import { useReducedMotion } from '@wordpress/compose';
+import { Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 
@@ -19,7 +18,6 @@ function Inserter( {
 	previousClientId,
 	nextClientId,
 	sectionRootClientId,
-	disableMotion,
 	__unstableContentRef,
 	index,
 } ) {
@@ -34,36 +32,6 @@ function Inserter( {
 		},
 		[ index ]
 	);
-	const lineVariants = {
-		// Initial position starts from the center and invisible.
-		start: {
-			opacity: 0,
-			scale: 0,
-		},
-		// The line expands to fill the container. If the inserter is visible it
-		// is delayed so it appears orchestrated.
-		rest: {
-			opacity: 1,
-			scale: 1,
-			transition: { delay: 0.5, type: 'tween' },
-		},
-		hover: {
-			opacity: 1,
-			scale: 1,
-			transition: { delay: 0.5, type: 'tween' },
-		},
-	};
-	const patternInserterVariants = {
-		start: {
-			scale: disableMotion ? 1 : 0,
-			translateX: '-50%',
-			translateY: '-50%',
-		},
-		rest: {
-			scale: 1,
-			transition: { delay: 0.4, type: 'tween' },
-		},
-	};
 
 	const label = _x(
 		'Add pattern',
@@ -76,41 +44,21 @@ function Inserter( {
 			__unstableContentRef={ __unstableContentRef }
 			className="block-editor-button-pattern-inserter"
 		>
-			<motion.div
-				layout={ ! disableMotion }
-				initial={ disableMotion ? 'rest' : 'start' }
-				animate="rest"
-				whileHover="hover"
-				whileTap="pressed"
-				exit="start"
-				className="block-editor-block-list__insertion-point is-vertical is-pattern-inserter"
-			>
-				<motion.div
-					variants={ lineVariants }
-					className="block-editor-block-list__insertion-point-indicator"
-					data-testid="block-list-insertion-point-indicator"
-				/>
-				<motion.div
-					variants={ patternInserterVariants }
-					className="block-editor-block-list__insertion-point-inserter"
-				>
-					<Button
-						variant="primary"
-						icon={ plus }
-						size="compact"
-						className="block-editor-button-pattern-inserter__button"
-						onClick={ () => {
-							setInserterIsOpened( {
-								rootClientId: sectionRootClientId,
-								insertionIndex,
-								tab: 'patterns',
-								category: 'all',
-							} );
-						} }
-						label={ label }
-					/>
-				</motion.div>
-			</motion.div>
+			<Button
+				variant="primary"
+				icon={ plus }
+				size="compact"
+				className="block-editor-button-pattern-inserter__button"
+				onClick={ () => {
+					setInserterIsOpened( {
+						rootClientId: sectionRootClientId,
+						insertionIndex,
+						tab: 'patterns',
+						category: 'all',
+					} );
+				} }
+				label={ label }
+			/>
 		</BlockPopoverInbetween>
 	);
 }
@@ -137,8 +85,6 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 		};
 	}, [] );
 
-	const disableMotion = useReducedMotion();
-
 	if ( ! isReady ) {
 		return null;
 	}
@@ -153,7 +99,6 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 				previousClientId={ clientId }
 				nextClientId={ blockOrder[ index ] }
 				sectionRootClientId={ sectionRootClientId }
-				disableMotion={ disableMotion }
 				index={ index }
 				blockOrder={ blockOrder }
 				__unstableContentRef={ __unstableContentRef }

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -20,6 +20,7 @@ function Inserter( {
 	sectionRootClientId,
 	__unstableContentRef,
 	index,
+	setActiveInserter,
 } ) {
 	const { setInserterIsOpened, insertionIndex } = useSelect(
 		( select ) => {
@@ -56,6 +57,7 @@ function Inserter( {
 						tab: 'patterns',
 						category: 'all',
 					} );
+					setActiveInserter( index );
 				} }
 				label={ label }
 			/>
@@ -65,6 +67,7 @@ function Inserter( {
 
 function ZoomOutModeInserters( { __unstableContentRef } ) {
 	const [ isReady, setIsReady ] = useState( false );
+	const [ activeInserter, setActiveInserter ] = useState( null );
 	const { blockOrder, sectionRootClientId } = useSelect( ( select ) => {
 		const { sectionRootClientId: root } = unlock(
 			select( blockEditorStore ).getSettings()
@@ -90,7 +93,7 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 	}
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
-		if ( index === blockOrder.length - 1 ) {
+		if ( activeInserter === index ) {
 			return null;
 		}
 		return (
@@ -102,6 +105,7 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 				index={ index }
 				blockOrder={ blockOrder }
 				__unstableContentRef={ __unstableContentRef }
+				setActiveInserter={ setActiveInserter }
 			/>
 		);
 	} );

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -20,6 +20,8 @@ function InserterLibrary(
 		showInserterHelpPanel,
 		showMostUsedBlocks = false,
 		__experimentalInsertionIndex,
+		__experimentalInitialTab,
+		__experimentalInitialCategory,
 		__experimentalFilterValue,
 		__experimentalOnPatternCategorySelection,
 		onSelect = noop,
@@ -53,6 +55,8 @@ function InserterLibrary(
 			__experimentalOnPatternCategorySelection={
 				__experimentalOnPatternCategorySelection
 			}
+			__experimentalInitialTab={ __experimentalInitialTab }
+			__experimentalInitialCategory={ __experimentalInitialCategory }
 			shouldFocusBlock={ shouldFocusBlock }
 			ref={ ref }
 			onClose={ onClose }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -236,7 +236,6 @@ function InserterMenu(
 						category={ selectedPatternCategory }
 						patternFilter={ patternFilter }
 						showTitlesAsTooltip
-						initialCategory={ __experimentalInitialCategory }
 					/>
 				) }
 			</BlockPatternsTab>
@@ -249,7 +248,6 @@ function InserterMenu(
 		patternFilter,
 		selectedPatternCategory,
 		showPatternPanel,
-		__experimentalInitialCategory,
 	] );
 
 	const mediaTab = useMemo( () => {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -48,6 +48,8 @@ function InserterMenu(
 		shouldFocusBlock = true,
 		__experimentalOnPatternCategorySelection = NOOP,
 		onClose,
+		__experimentalInitialTab,
+		__experimentalInitialCategory,
 	},
 	ref
 ) {
@@ -59,12 +61,15 @@ function InserterMenu(
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
 		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
-	const [ selectedPatternCategory, setSelectedPatternCategory ] =
-		useState( null );
+	const [ selectedPatternCategory, setSelectedPatternCategory ] = useState(
+		__experimentalInitialCategory
+	);
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
-	const [ selectedTab, setSelectedTab ] = useState( 'blocks' );
+	const [ selectedTab, setSelectedTab ] = useState(
+		__experimentalInitialTab
+	);
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {
@@ -231,6 +236,7 @@ function InserterMenu(
 						category={ selectedPatternCategory }
 						patternFilter={ patternFilter }
 						showTitlesAsTooltip
+						initialCategory={ __experimentalInitialCategory }
 					/>
 				) }
 			</BlockPatternsTab>
@@ -243,6 +249,7 @@ function InserterMenu(
 		patternFilter,
 		selectedPatternCategory,
 		showPatternPanel,
+		__experimentalInitialCategory,
 	] );
 
 	const mediaTab = useMemo( () => {
@@ -306,6 +313,7 @@ function InserterMenu(
 					ref={ tabsRef }
 					onSelect={ handleSetSelectedTab }
 					onClose={ onClose }
+					selectedTab={ selectedTab }
 				>
 					{ inserterSearch }
 					{ selectedTab === 'blocks' &&

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -33,7 +33,7 @@ const mediaTab = {
 	title: __( 'Media' ),
 };
 
-function InserterTabs( { onClose, onSelect, children, selectedTab }, ref ) {
+function InserterTabs( { onSelect, children, onClose, selectedTab }, ref ) {
 	const tabs = [ blocksTab, patternsTab, mediaTab ];
 
 	return (

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -33,12 +33,12 @@ const mediaTab = {
 	title: __( 'Media' ),
 };
 
-function InserterTabs( { onSelect, children, onClose }, ref ) {
+function InserterTabs( { onClose, onSelect, children, selectedTab }, ref ) {
 	const tabs = [ blocksTab, patternsTab, mediaTab ];
 
 	return (
 		<div className="block-editor-inserter__tabs" ref={ ref }>
-			<Tabs onSelect={ onSelect }>
+			<Tabs onSelect={ onSelect } selectedTabId={ selectedTab }>
 				<div className="block-editor-inserter-sidebar__header">
 					<Button
 						className="block-editor-inserter-sidebar__close-button"

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -62,6 +62,8 @@ export default function InserterSidebar( {
 					__experimentalInsertionIndex={
 						insertionPoint.insertionIndex
 					}
+					__experimentalInitialTab={ insertionPoint.tab }
+					__experimentalInitialCategory={ insertionPoint.category }
 					__experimentalFilterValue={ insertionPoint.filterValue }
 					__experimentalOnPatternCategorySelection={
 						isRightSidebarOpen ? closeGeneralSidebar : undefined

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -61,4 +61,25 @@ test.describe( 'Zoom Out', () => {
 
 		await expect( zoomOutButton ).toBeFocused();
 	} );
+
+	test( 'Clicking on inserter while on zoom-out should open the patterns tab on the inserter', async ( {
+		page,
+	} ) => {
+		const zoomOutButton = page.getByRole( 'button', {
+			name: 'Zoom-out View',
+			exact: true,
+		} );
+
+		await zoomOutButton.click();
+		await expect( page.getByLabel( 'Add pattern' ) ).toHaveCount( 3 );
+		await page.getByLabel( 'Add pattern' ).first().click();
+		await expect( page.getByLabel( 'Add pattern' ) ).toHaveCount( 2 );
+
+		await expect(
+			page
+				.locator( '#tabs-2-allPatterns-view div' )
+				.filter( { hasText: 'All' } )
+				.nth( 1 )
+		).toBeVisible();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to https://github.com/WordPress/gutenberg/pull/61316

Partially addresses https://github.com/WordPress/gutenberg/issues/59739

We are exploring not changing the text of the button yet, we want the plus button to instead of opening the quick inserter, it opens the inserter with the patterns tab selected and the All category opened instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In zoom out mode it makes more sense to leverage the full inserter instead of the quick one, since it's a better experience for building with patterns.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We use a Button component instead of the Inserter component to open the inserter sidebar

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Click the zoom out mode icon
- Click one of the plus icons, the icon should disappear
- The inserter sidebar opens up with the category "All" selected
- Choose a pattern
- The pattern should be inserted in the correct position where the plus icon was clicked

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
