### PR TITLE
Upgrade Playwright to v1.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.45.0",
+				"@playwright/test": "1.45.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -6927,12 +6927,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.0.tgz",
-			"integrity": "sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==",
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
+			"integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.45.0"
+				"playwright": "1.45.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41994,12 +41994,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.0.tgz",
-			"integrity": "sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==",
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
+			"integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.45.0"
+				"playwright-core": "1.45.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -42012,9 +42012,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.0.tgz",
-			"integrity": "sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==",
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
+			"integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -55671,7 +55671,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.45.0",
+				"@playwright/test": "^1.45.1",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -60996,12 +60996,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.0.tgz",
-			"integrity": "sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==",
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
+			"integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.45.0"
+				"playwright": "1.45.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -88856,19 +88856,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.0.tgz",
-			"integrity": "sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==",
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
+			"integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.45.0"
+				"playwright-core": "1.45.1"
 			}
 		},
 		"playwright-core": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.0.tgz",
-			"integrity": "sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==",
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
+			"integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.44.1",
+				"@playwright/test": "1.45.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -6927,18 +6927,18 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.44.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-			"integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.0.tgz",
+			"integrity": "sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.44.1"
+				"playwright": "1.45.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -41994,33 +41994,33 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.44.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-			"integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.0.tgz",
+			"integrity": "sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.44.1"
+				"playwright-core": "1.45.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
 				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.44.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-			"integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.0.tgz",
+			"integrity": "sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/please-upgrade-node": {
@@ -55671,7 +55671,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.44.1",
+				"@playwright/test": "^1.45.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -60996,12 +60996,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.44.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-			"integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.0.tgz",
+			"integrity": "sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.44.1"
+				"playwright": "1.45.0"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -88856,19 +88856,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.44.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-			"integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.0.tgz",
+			"integrity": "sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.44.1"
+				"playwright-core": "1.45.0"
 			}
 		},
 		"playwright-core": {
-			"version": "1.44.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-			"integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.0.tgz",
+			"integrity": "sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.43.0",
+				"@playwright/test": "1.44.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -6927,12 +6927,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
-			"integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
+			"integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.43.0"
+				"playwright": "1.44.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41994,12 +41994,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
-			"integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+			"integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.43.0"
+				"playwright-core": "1.44.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -42012,9 +42012,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
-			"integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+			"integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -55671,7 +55671,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.43.0",
+				"@playwright/test": "^1.44.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -60996,12 +60996,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
-			"integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
+			"integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.43.0"
+				"playwright": "1.44.0"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -88856,19 +88856,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
-			"integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+			"integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.43.0"
+				"playwright-core": "1.44.0"
 			}
 		},
 		"playwright-core": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
-			"integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+			"integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.44.0",
+				"@playwright/test": "1.44.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -6927,12 +6927,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
-			"integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+			"version": "1.44.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+			"integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.44.0"
+				"playwright": "1.44.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41994,12 +41994,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-			"integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+			"version": "1.44.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+			"integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.44.0"
+				"playwright-core": "1.44.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -42012,9 +42012,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-			"integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+			"version": "1.44.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+			"integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -55671,7 +55671,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.44.0",
+				"@playwright/test": "^1.44.1",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -60996,12 +60996,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
-			"integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+			"version": "1.44.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+			"integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.44.0"
+				"playwright": "1.44.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -88856,19 +88856,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-			"integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+			"version": "1.44.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+			"integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.44.0"
+				"playwright-core": "1.44.1"
 			}
 		},
 		"playwright-core": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-			"integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+			"version": "1.44.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+			"integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.43.0",
+		"@playwright/test": "1.44.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.44.1",
+		"@playwright/test": "1.45.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.44.0",
+		"@playwright/test": "1.44.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.45.0",
+		"@playwright/test": "1.45.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -92,7 +92,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.44.0",
+		"@playwright/test": "^1.44.1",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -92,7 +92,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.43.0",
+		"@playwright/test": "^1.44.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -92,7 +92,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.44.1",
+		"@playwright/test": "^1.45.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -92,7 +92,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.45.0",
+		"@playwright/test": "^1.45.1",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -119,7 +119,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		expect( count ).toBe( 1 );
 	} );
 
-	test( 'should return focus when pressing formatting button', async ( {
+	test( 'should return focus when pressing formatting button (-firefox)', async ( {
 		page,
 		editor,
 	} ) => {
@@ -415,7 +415,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		] );
 	} );
 
-	test( 'should update internal selection after fresh focus', async ( {
+	test( 'should update internal selection after fresh focus (-firefox)', async ( {
 		page,
 		editor,
 		pageUtils,

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -62,11 +62,9 @@ test.describe( 'Editing Navigation Menus', () => {
 			await expect( navBlockNode ).toBeVisible();
 
 			// The Navigation block description should contain the locked state information.
-			const navBlockNodeDescriptionId =
-				await navBlockNode.getAttribute( 'aria-describedby' );
-			await expect(
-				listView.locator( `id=${ navBlockNodeDescriptionId }` )
-			).toHaveText( /This block is locked./ );
+			await expect( navBlockNode ).toHaveAccessibleDescription(
+				/This block is locked./
+			);
 
 			// The block should have no options menu.
 			await expect(


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.45

## What's new?
https://github.com/microsoft/playwright/releases/tag/v1.44.0
https://github.com/microsoft/playwright/releases/tag/v1.45.0

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.
