### PR TITLE
Fix user capabilities check for the Site Editor

### DIFF
--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -4,20 +4,23 @@
 import { useCommand } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
 import { plus, symbol } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { addQueryArgs, getPath } from '@wordpress/url';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
  */
-import { useIsTemplatesAccessible } from './hooks';
 import { unlock } from './lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
 
 export function useAdminNavigationCommands() {
 	const history = useHistory();
-	const isTemplatesAccessible = useIsTemplatesAccessible();
+	const canCreateTemplate = useSelect( ( select ) => {
+		return select( coreStore ).canUser( 'create', 'templates' );
+	}, [] );
 
 	const isSiteEditor = getPath( window.location.href )?.includes(
 		'site-editor.php'
@@ -45,10 +48,10 @@ export function useAdminNavigationCommands() {
 		icon: symbol,
 		callback: ( { close } ) => {
 			// The site editor and templates both check whether the user
-			// can read templates. We can leverage that here and this
+			// can create templates. We can leverage that here and this
 			// command links to the classic dashboard manage patterns page
 			// if the user can't access it.
-			if ( isTemplatesAccessible ) {
+			if ( canCreateTemplate ) {
 				const args = {
 					path: '/patterns',
 				};

--- a/packages/core-commands/src/hooks.js
+++ b/packages/core-commands/src/hooks.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 
 export function useIsTemplatesAccessible() {
 	return useSelect(
-		( select ) => select( coreStore ).canUser( 'read', 'templates' ),
+		( select ) => select( coreStore ).canUser( 'create', 'templates' ),
 		[]
 	);
 }

--- a/packages/core-commands/src/hooks.js
+++ b/packages/core-commands/src/hooks.js
@@ -4,13 +4,6 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
-export function useIsTemplatesAccessible() {
-	return useSelect(
-		( select ) => select( coreStore ).canUser( 'create', 'templates' ),
-		[]
-	);
-}
-
 export function useIsBlockBasedTheme() {
 	return useSelect(
 		( select ) => select( coreStore ).getCurrentTheme()?.is_block_theme,

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -21,7 +21,7 @@ import { useDebounce } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { useIsTemplatesAccessible, useIsBlockBasedTheme } from './hooks';
+import { useIsBlockBasedTheme } from './hooks';
 import { unlock } from './lock-unlock';
 import { orderEntityRecordsBySearch } from './utils/order-entity-records-by-search';
 
@@ -257,12 +257,14 @@ function useSiteEditorBasicNavigationCommands() {
 	const isSiteEditor = getPath( window.location.href )?.includes(
 		'site-editor.php'
 	);
-	const isTemplatesAccessible = useIsTemplatesAccessible();
+	const canCreateTemplate = useSelect( ( select ) => {
+		return select( coreStore ).canUser( 'create', 'templates' );
+	}, [] );
 	const isBlockBasedTheme = useIsBlockBasedTheme();
 	const commands = useMemo( () => {
 		const result = [];
 
-		if ( ! isTemplatesAccessible || ! isBlockBasedTheme ) {
+		if ( ! canCreateTemplate || ! isBlockBasedTheme ) {
 			return result;
 		}
 
@@ -339,7 +341,7 @@ function useSiteEditorBasicNavigationCommands() {
 		} );
 
 		return result;
-	}, [ history, isSiteEditor, isTemplatesAccessible, isBlockBasedTheme ] );
+	}, [ history, isSiteEditor, canCreateTemplate, isBlockBasedTheme ] );
 
 	return {
 		commands,

--- a/packages/edit-post/src/components/header/more-menu/manage-patterns-menu-item.js
+++ b/packages/edit-post/src/components/header/more-menu/manage-patterns-menu-item.js
@@ -20,7 +20,7 @@ function ManagePatternsMenuItem() {
 		// The site editor and templates both check whether the user has
 		// edit_theme_options capabilities. We can leverage that here and not
 		// display the manage patterns link if the user can't access it.
-		return canUser( 'read', 'templates' ) ? patternsUrl : defaultUrl;
+		return canUser( 'create', 'templates' ) ? patternsUrl : defaultUrl;
 	}, [] );
 
 	return (

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -37,7 +37,7 @@ function PatternsManageButton( { clientId } ) {
 				// The site editor and templates both check whether the user
 				// has edit_theme_options capabilities. We can leverage that here
 				// and omit the manage patterns link if the user can't access it.
-				managePatternsUrl: canUser( 'read', 'templates' )
+				managePatternsUrl: canUser( 'create', 'templates' )
 					? addQueryArgs( 'site-editor.php', {
 							path: '/patterns',
 					  } )

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -36,7 +36,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 				// The site editor and templates both check whether the user
 				// has edit_theme_options capabilities. We can leverage that here
 				// and omit the manage patterns link if the user can't access it.
-				managePatternsUrl: canUser( 'read', 'templates' )
+				managePatternsUrl: canUser( 'create', 'templates' )
 					? addQueryArgs( 'site-editor.php', {
 							path: '/patterns',
 					  } )


### PR DESCRIPTION
Fixes #61419

## What?

This PR correctly checks for non-admin user capabilities for commands and link buttons related to the site editor. This fixes an issue where unintended commands and links are displayed for non-admin users.

## Why?

Previously, determining whether the site editor was accessible depended on having permission to "read" templates. However, my understanding is that in #60326, permission to read templates was added for users with `edit_post` permissions.

This exposes commands and links that users cannot access even though they do not have `edit_theme_options` permission.

## How?

Related commands and links now check for "create" permission instead of "read" permission. This should now correctly determine whether users have the `edit_theme_options` permission as before.

## Testing Instructions

Open the post editor as an admin user and as an editor user and test the following.

### Admin

#### Command

- Patterns: Links to the Site Editor's Patterns page.
- Navigation, Styles, Pages, Templates: Displayed as before.

#### Link button

All links below link to the Site Editor's Patterns page.

- Options > Manage patterns
- Create a synced pattern > Block Toolbar > Manage patterns

### Editor

#### Command

- Patterns: Link to `edit.php?post_type=wp_block`.
- Navigation, Styles, Pagesm Templates: Not displayed.

#### Link button

All links below link to `edit.php?post_type=wp_block`.

- Options > Manage patterns
- Create a synced pattern > Block Toolbar > Manage patterns

> [!NOTE]
> While creating this PR, I also noticed that individual pages, individual templates, and individual template parts were exposed to non-admin users via the command palette. These are caused by the fact that there is no permission check in the first place, so I would like to fix it in a follow-up PR.

![permission-check](https://github.com/WordPress/gutenberg/assets/54422211/92e7035a-ebb0-4699-a62f-d1dbfdcff73a)


