### PR TITLE
Small fixes as per feedback received

### DIFF
--- a/docs/reference-guides/interactivity-api/README.md
+++ b/docs/reference-guides/interactivity-api/README.md
@@ -67,6 +67,19 @@ The Interactivity API provides the `@wordpress/interactivity` Script Module. Jav
 }
 ```
 
+The use of `viewScriptModule` also requires the `--experimental-modules` flag for both the [`build`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#build) and [`start`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#start) scripts of `wp-scripts` to ensure a proper build of the Script Modules.
+
+
+```json
+// package.json
+{
+    "scripts": {
+        ...
+		"build": "wp-scripts build --experimental-modules",
+		"start": "wp-scripts start --experimental-modules"
+	}
+```
+
 #### Add `wp-interactive` directive to a DOM element
 
 To "activate" the Interactivity API in a DOM element (and its children), add the [`wp-interactive`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-interactivity/packages-interactivity-api-reference/#wp-interactive) directive to the DOM element in the block's `render.php` or `save.js` files. 

--- a/docs/reference-guides/interactivity-api/iapi-about.md
+++ b/docs/reference-guides/interactivity-api/iapi-about.md
@@ -50,13 +50,13 @@ _Dynamic block example_
     Toggle
   </button>
  
-  <p id="p-1" data-wp-show="context.isOpen">
+  <p id="p-1" data-wp-bind--hidden="!context.isOpen">
     This element is now visible!
   </p>
 </div>
 ```
 
-As you can see, directives like `data-wp-on--click` or `data-wp-show` are added as custom HTML attributes. WordPress can process this HTML on the server, handling the directives’ logic and creating the appropriate markup.
+As you can see, directives like [`data-wp-on--click`](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#wp-on) or [`data-wp-bind--hidden`](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#wp-bind) are added as custom HTML attributes. WordPress can process this HTML on the server, handling the directives’ logic and creating the appropriate markup.
 
 ### Backward compatible
 
@@ -136,7 +136,7 @@ store( 'wpmovies', {
     Toggle
   </button>
  
-  <p id="p-1" data-wp-show="context.isOpen">
+  <p id="p-1" data-wp-bind--hidden="!context.isOpen">
     This element is now visible!
   </p>
 </div>
@@ -155,15 +155,13 @@ The API has been designed to be as performant as possible:
 
 Directives can be added, removed, or modified directly from the HTML. For example, users could use the [`render_block` filter](https://developer.wordpress.org/reference/hooks/render_block/) to modify the HTML and its behavior.
 
-In addition to using built-in directives, users can create custom directives to add any custom behaviors to their HTML.
-
 ### Atomic and composable
 
 Each directive controls a small part of the DOM, and you can combine multiple directives to create rich, interactive user experiences.
 
 ### Compatible with the existing block development tooling
 
-Using built-in directives does not require a build step and only requires a small runtime. A build step is necessary only when creating custom directives that return JSX. For such use cases, the API works out of the box with common block-building tools like [`wp-scripts`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/).
+The API works out of the box with standard block-building tools like [`wp-scripts`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/).
 
 ### Client-side navigation
 

--- a/docs/reference-guides/interactivity-api/iapi-about.md
+++ b/docs/reference-guides/interactivity-api/iapi-about.md
@@ -161,7 +161,7 @@ Each directive controls a small part of the DOM, and you can combine multiple di
 
 ### Compatible with the existing block development tooling
 
-The API works out of the box with standard block-building tools like [`wp-scripts`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/).
+The API works out of the box with standard block-building tools like [`wp-scripts`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/). The only requirement for `wp-scripts` to properly build the [Script Modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) using the Interactivity API is the use of the --experimental-modules flag for both [`build`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#build) and [`start`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#start) scripts.
 
 ### Client-side navigation
 

--- a/docs/reference-guides/interactivity-api/iapi-faq.md
+++ b/docs/reference-guides/interactivity-api/iapi-faq.md
@@ -99,7 +99,7 @@ The API has been designed with performance in mind, so it shouldn’t be a probl
 
 ## Does it work with the Core Translation API?
 
-As the Interactivity API works perfectly with server-side rendering, you can use all the WordPress APIs including [`__()`](https://developer.wordpress.org/reference/functions/__/) and [`_e()`](https://developer.wordpress.org/reference/functions/_e/). You can use it to translate the text in the HTML (as you normally would) and even use it inside the store when using `wp_initial_state()` on the server side. It might look something like this:
+As the Interactivity API works perfectly with server-side rendering, you can use all the WordPress APIs including [`__()`](https://developer.wordpress.org/reference/functions/__/) and [`_e()`](https://developer.wordpress.org/reference/functions/_e/). You can use it to translate the text in the HTML (as you normally would) and even use it inside the store when [using `wp_interactivity_state()` on the server side](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#setting-the-store). It might look something like this:
 
 ```php
 // render.php
@@ -111,8 +111,7 @@ wp_interactivity_state( 'favoriteMovies', array(
 ) );
 ```
 
-A translation API compatible with script modules (needed for the Interactivity API) is 
-currently being worked on. Check [#60234](https://core.trac.wordpress.org/ticket/60234) to follow the progress on this work.
+A translation API compatible with script modules (needed for the Interactivity API) is currently being worked on. Check [#60234](https://core.trac.wordpress.org/ticket/60234) to follow the progress on this work.
 
 ## I’m concerned about XSS; can JavaScript be injected into directives?
 


### PR DESCRIPTION
## What?

As per [feedback received](https://wordpress.slack.com/archives/C071CRKGKUP/p1715077916989169?thread_ts=1715000928.887279&cid=C071CRKGKUP) on the #core-interactivity-api channel at Make WordPress Slack by @luisherranz, this PR solves the issues mentioned.

> I've noticed a couple of details that could be improved:
> - In the FAQ, the wp_initial_state function is mentioned, which no longer exists.
> - On the about page, data-wp-show is mentioned, which doesn't exist yet.
> - It's also mentioned that custom directives can be created, which are also not yet available.
> 

## Why?
To keep docs updated to the latest version of the Interactivity API