### PR TITLE
PluginSidebar: show pin/unpin button on the site eitor

### DIFF
--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -85,13 +85,6 @@ body.js.site-editor-php {
 	.interface-interface-skeleton {
 		top: 0;
 	}
-
-	// Todo: Remove this rule when edit site gets support
-	// for opening unpinned sidebar items.
-	.interface-complementary-area__pin-unpin-item.components-button {
-		display: none;
-	}
-
 }
 
 /**


### PR DESCRIPTION
Alternative to #46067
Related to #60815

## What?

This PR displays the pin/unpin button of the `PluginSidebar` that was hidden in the site editor. This will allow pinning/unpinning of the plugin sidebar button as well as in the post editor.

## Why?

#60815 unified the `PluginSidebar` slot between post and site editors, but this button seems to have been hidden by CSS.

## Testing Instructions

Paste the code below into your browser console.

```javascript
var __ = wp.i18n.__;
var el = React.createElement;
var PanelBody = wp.components.PanelBody;
var PluginSidebar = wp.editor.PluginSidebar;

function MyPluginSidebar() {
	return el(
		PluginSidebar,
		{
			name: 'my-sidebar',
			title: 'My sidebar title',
			icon: 'admin-post',
		},
		el( PanelBody, {}, __( 'My sidebar content' ) )
	);
}
wp.plugins.registerPlugin( 'toto', { render: () => wp.element.createElement( MyPluginSidebar ) } );
```

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/9217cdcc-8fce-43c4-af10-a0483121afc3) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/927f7923-7973-4c93-9f98-e36fbe78e387)| 