### PR TITLE
Playwright Utils: Silence some of the warnings coming from Firefox

### DIFF
--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -60,7 +60,12 @@ function observeConsoleLogging( message: ConsoleMessage ) {
 	// See: https://core.trac.wordpress.org/ticket/37000
 	// See: https://www.chromestatus.com/feature/5088147346030592
 	// See: https://www.chromestatus.com/feature/5633521622188032
-	if ( text.includes( 'A cookie associated with a cross-site resource' ) ) {
+	if (
+		text.includes( 'A cookie associated with a cross-site resource' ) ||
+		text.includes(
+			'https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+		)
+	) {
 		return;
 	}
 
@@ -93,6 +98,18 @@ function observeConsoleLogging( message: ConsoleMessage ) {
 		return;
 	}
 
+	// https://bugzilla.mozilla.org/show_bug.cgi?id=1404468
+	if (
+		text.includes( 'Layout was forced before the page was fully loaded' )
+	) {
+		return;
+	}
+
+	// Deprecated warnings coming from the third-party libraries.
+	if ( text.includes( 'MouseEvent.moz' ) ) {
+		return;
+	}
+
 	const logFunction =
 		type as ( typeof OBSERVED_CONSOLE_MESSAGE_TYPES )[ number ];
 
@@ -100,7 +117,6 @@ function observeConsoleLogging( message: ConsoleMessage ) {
 	// which, unless the test explicitly anticipates the logging via
 	// @wordpress/jest-console matchers, will cause the intended test
 	// failure.
-
 	// eslint-disable-next-line no-console
 	console[ logFunction ]( text );
 }


### PR DESCRIPTION
## What?
PR updates the `observeConsoleLogging` method to silence some common warnings and avoid displaying them in the terminal.

Note: Warnings are still displayed when running tests in UI mode.

## Why?
The change reduces the noise in CI and local reports.

## Testing Instructions
Running the following command shouldn't display warnings in the terminal.

```
npm run test:e2e -- -g "can undo asterisk transform" --project=firefox
```

## Screenshot
![CleanShot 2024-05-07 at 21 11 15](https://github.com/WordPress/gutenberg/assets/240569/f5d2c2ad-b196-4c54-8e00-22dea0bc6f34)
