### PR TITLE
Enhancement: Added individual column and row gap controls.

### DIFF
--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -43,7 +43,8 @@
 		},
 		"spacing": {
 			"blockGap": {
-				"__experimentalDefault": "1.25em"
+				"__experimentalDefault": "1.25em",
+				"sides": [ "horizontal", "vertical" ]
 			},
 			"__experimentalDefaultControls": {
 				"blockGap": true


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/61298

## Why?
Limitations in the current Post Template block, inability to independently adjust column gaps without affecting row gaps, thus proposing an enhancement for more precise customization.

## How?
Implemented 'sides' property in block.json to enable independent adjustment of column gaps within 'blockGap' spacing support for Post Template block.

## Testing Instructions
1. Next create a new post and add the `Query Loop` block.
3. Select `Start Blank` pattern, then choose `Title & Date` template.
4. Select the `Post Template` block from Document Overview to toggle the block controls.
5. Choose the Grid View from the block controls.
6. Goto styles tab in the block controls sidebar.
7. You'll see separate controls for Row and Column gap.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast
![image](https://github.com/WordPress/gutenberg/assets/65603015/9c146acb-5f91-4cbf-a46f-e4aa83887f03)


