### PR TITLE
retain custom attributes for list block

### DIFF
--- a/packages/block-library/src/list/utils.js
+++ b/packages/block-library/src/list/utils.js
@@ -64,7 +64,7 @@ export function createListBlockFromDOMElement( listElement ) {
 }
 
 export function migrateToListV2( attributes ) {
-	const { values, start, reversed, ordered, type, ...otherAttributes } =
+	const { values, start, reversed, ordered, type } =
 		attributes;
 
 	const list = document.createElement( ordered ? 'ol' : 'ul' );

--- a/packages/block-library/src/list/utils.js
+++ b/packages/block-library/src/list/utils.js
@@ -64,8 +64,7 @@ export function createListBlockFromDOMElement( listElement ) {
 }
 
 export function migrateToListV2( attributes ) {
-	const { values, start, reversed, ordered, type } =
-		attributes;
+	const { values, start, reversed, ordered, type } = attributes;
 
 	const list = document.createElement( ordered ? 'ol' : 'ul' );
 	list.innerHTML = values;
@@ -81,15 +80,16 @@ export function migrateToListV2( attributes ) {
 
 	const [ listBlock ] = rawHandler( { HTML: list.outerHTML } );
 
-	Object.keys(attributes).forEach((key) => {
-		if(attributes[key] !== undefined && !['start','reversed','type','values'].includes(key))
-		 listBlock.attributes[key] = attributes[key]
-	  })
+	Object.keys( attributes ).forEach( ( key ) => {
+		if (
+			attributes[ key ] !== undefined &&
+			! [ 'start', 'reversed', 'type', 'values' ].includes( key )
+		) {
+			listBlock.attributes[ key ] = attributes[ key ];
+		}
+	} );
 
-	return [
-		listBlock.attributes,
-		listBlock.innerBlocks,
-	];
+	return [ listBlock.attributes, listBlock.innerBlocks ];
 }
 
 export function migrateTypeToInlineStyle( attributes ) {

--- a/packages/block-library/src/list/utils.js
+++ b/packages/block-library/src/list/utils.js
@@ -81,8 +81,13 @@ export function migrateToListV2( attributes ) {
 
 	const [ listBlock ] = rawHandler( { HTML: list.outerHTML } );
 
+	Object.keys(attributes).forEach((key) => {
+		if(attributes[key] !== undefined && !['start','reversed','type','values'].includes(key))
+		 listBlock.attributes[key] = attributes[key]
+	  })
+
 	return [
-		{ ...otherAttributes, ...listBlock.attributes },
+		listBlock.attributes,
 		listBlock.innerBlocks,
 	];
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
PR for fixing #61457 

## Why?
I have a custom attribute defined for a list block with default as an empty array
```
            someCustomAttribute: {
                type: "array",
                default: [],
            },  
```
With the current logic for [migrateToListV2](https://github.com/WordPress/gutenberg/blob/e92b45adb5b10dd7d7eb9162d908f7493b94ab4d/packages/block-library/src/list/utils.js#L66), even if I have `someCustomAttribute` array populated, doing [this](https://github.com/WordPress/gutenberg/blob/e92b45adb5b10dd7d7eb9162d908f7493b94ab4d/packages/block-library/src/list/utils.js#L85) will just reset it to default values (which is an empty array) which is incorrect. The current approach works well for all the custom attributes which don't have a default or are same as the current value

Related links:
-  https://github.com/WordPress/gutenberg/pull/46000
- https://github.com/WordPress/gutenberg/issues/45987

## How?
While migrating, if we can set the custom attributes manually in the listBlock if they exist in the block attributes.

## Testing Instructions
1. Run wordpress 5.5.1
2. Define custom attributes for the list block via a wordpress plugin using `blocks.registerBlockType` filter
3. Add a list block on the editor and save
4. Upgrade to wordpress 6.1.1
5. Open the list block and check its attributes
