### PR TITLE
Tiny tweak to position close button properly in the inserter

### DIFF
--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -8,6 +8,7 @@
 
 .editor-inserter-sidebar__header {
 	position: relative;
+	height: 100%;
 	display: flex;
 	justify-content: flex-end;
 	z-index: z-index(".editor-inserter-sidebar__header");
@@ -15,7 +16,7 @@
 
 .editor-inserter-sidebar__close-button {
 	position: absolute;
-	top: $grid-unit-15;
+	top: $grid-unit-15 - $border-width * 0.5; // Account for the existing border to make this the same close as in list view.
 	right: $grid-unit-15;
 }
 

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -8,7 +8,6 @@
 
 .editor-inserter-sidebar__header {
 	position: relative;
-	height: 100%;
 	display: flex;
 	justify-content: flex-end;
 	z-index: z-index(".editor-inserter-sidebar__header");


### PR DESCRIPTION
Account for the border while positioning the close button so that it's precisely in the same spot as the close icon within List view. Follow-up to https://github.com/WordPress/gutenberg/pull/61426.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open list view. 
2. See position of close icon. 
3. Open inserter. 
4. See position of close icon. 

*May be easier to see the difference with two different tabs open, per the animated sidebars. 

## Screenshots or screencast <!-- if applicable -->
