### PR TITLE
Fix close button position on inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -24,6 +24,7 @@ function InserterLibrary(
 		__experimentalOnPatternCategorySelection,
 		onSelect = noop,
 		shouldFocusBlock = false,
+		onClose,
 	},
 	ref
 ) {
@@ -41,6 +42,7 @@ function InserterLibrary(
 
 	return (
 		<InserterMenu
+			onClose={ onClose }
 			onSelect={ onSelect }
 			rootClientId={ destinationRootClientId }
 			clientId={ clientId }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -39,6 +39,7 @@ function InserterMenu(
 		clientId,
 		isAppender,
 		__experimentalInsertionIndex,
+		onClose,
 		onSelect,
 		showInserterHelpPanel,
 		showMostUsedBlocks,
@@ -293,7 +294,11 @@ function InserterMenu(
 			ref={ ref }
 		>
 			<div className="block-editor-inserter__main-area">
-				<InserterTabs ref={ tabsRef } onSelect={ handleSetSelectedTab }>
+				<InserterTabs
+					ref={ tabsRef }
+					onClose={ onClose }
+					onSelect={ handleSetSelectedTab }
+				>
 					{ inserterSearch }
 					{ selectedTab === 'blocks' &&
 						! delayedFilterValue &&

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -1,9 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -29,23 +33,32 @@ const mediaTab = {
 	title: __( 'Media' ),
 };
 
-function InserterTabs( { onSelect, children }, ref ) {
+function InserterTabs( { onClose, onSelect, children }, ref ) {
 	const tabs = [ blocksTab, patternsTab, mediaTab ];
 
 	return (
 		<div className="block-editor-inserter__tabs" ref={ ref }>
 			<Tabs onSelect={ onSelect }>
-				<Tabs.TabList className="block-editor-inserter__tablist">
-					{ tabs.map( ( tab ) => (
-						<Tabs.Tab
-							key={ tab.name }
-							tabId={ tab.name }
-							className="block-editor-inserter__tab"
-						>
-							{ tab.title }
-						</Tabs.Tab>
-					) ) }
-				</Tabs.TabList>
+				<div className="block-editor-inserter-sidebar__header">
+					<Button
+						className="editor-inserter-sidebar__close-button"
+						icon={ closeSmall }
+						label={ __( 'Close block inserter' ) }
+						onClick={ () => onClose() }
+						size="small"
+					/>
+					<Tabs.TabList className="block-editor-inserter__tablist">
+						{ tabs.map( ( tab ) => (
+							<Tabs.Tab
+								key={ tab.name }
+								tabId={ tab.name }
+								className="block-editor-inserter__tab"
+							>
+								{ tab.title }
+							</Tabs.Tab>
+						) ) }
+					</Tabs.TabList>
+				</div>
 				{ tabs.map( ( tab ) => (
 					<Tabs.TabPanel
 						key={ tab.name }

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -1,15 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
-import { closeSmall } from '@wordpress/icons';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	useViewportMatch,
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 
@@ -47,15 +44,6 @@ export default function InserterSidebar( {
 			{ ...inserterDialogProps }
 			className="editor-inserter-sidebar"
 		>
-			<div className="editor-inserter-sidebar__header">
-				<Button
-					className="editor-inserter-sidebar__close-button"
-					icon={ closeSmall }
-					label={ __( 'Close block inserter' ) }
-					onClick={ () => setIsInserterOpened( false ) }
-					size="small"
-				/>
-			</div>
 			<div className="editor-inserter-sidebar__content">
 				<Library
 					showMostUsedBlocks={ showMostUsedBlocks }
@@ -69,6 +57,7 @@ export default function InserterSidebar( {
 					__experimentalOnPatternCategorySelection={
 						isRightSidebarOpen ? closeGeneralSidebar : undefined
 					}
+					onClose={ () => setIsInserterOpened( false ) }
 					ref={ libraryRef }
 				/>
 			</div>

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -1,4 +1,4 @@
-// This width comes from the Inserter component.
+// This width comes from the Inserter component in the block editor package.
 $block-inserter-width: 350px;
 
 .editor-inserter-sidebar {

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -10,11 +10,15 @@ $block-inserter-width: 350px;
 }
 
 .editor-inserter-sidebar__header {
+	border-bottom: $border-width solid $gray-300;
 	position: relative;
 	display: flex;
-	justify-content: flex-end;
+	justify-content: space-between;
 	z-index: z-index(".editor-inserter-sidebar__header");
-	width: $block-inserter-width;
+	.editor-inserter-sidebar__close-button {
+		order: 1;
+		align-self: center;
+	}
 }
 
 .editor-inserter-sidebar__close-button {

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -1,3 +1,6 @@
+// This width comes from the Inserter component.
+$block-inserter-width: 350px;
+
 .editor-inserter-sidebar {
 	@include reset;
 
@@ -11,6 +14,7 @@
 	display: flex;
 	justify-content: flex-end;
 	z-index: z-index(".editor-inserter-sidebar__header");
+	width: $block-inserter-width;
 }
 
 .editor-inserter-sidebar__close-button {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The close button that we made visible in https://github.com/WordPress/gutenberg/pull/61426 is moving unexpectedly into the second sidebar when we navigate to a category inside patterns for example

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a bug, the button should stay in its place

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We make use of the width of the inserter sidebar component so it's always in the same spot

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the inserter
- Navigate to patterns
- Navigate to a category. 
- The close button should stay still
- Should do the same if you choose a media category too

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="1025" alt="Screenshot 2024-05-08 at 10 46 34" src="https://github.com/WordPress/gutenberg/assets/3593343/18296b9f-eaba-4d43-bb25-0d95caaf746f">

After:

<img width="1138" alt="Screenshot 2024-05-08 at 10 46 11" src="https://github.com/WordPress/gutenberg/assets/3593343/e49b4579-3f25-4cfc-867a-0784bf245cb9">


