### PR TITLE
Zoom out: maintain scroll position

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -20,6 +20,7 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
+	usePrevious,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -370,6 +371,29 @@ function Iframe( {
 	// Make sure to not render the before and after focusable div elements in view
 	// mode. They're only needed to capture focus in edit mode.
 	const shouldRenderFocusCaptureElements = tabIndex >= 0 && ! isPreviewMode;
+
+	const previousScale = usePrevious( scale );
+
+	// Scroll based on the new scale
+	useEffect( () => {
+		if ( ! iframeDocument || isZoomedOut ) {
+			return;
+		}
+
+		const maxWidth = 750;
+		const previousScaleNumber =
+			previousScale === 'default'
+				? Math.min( containerWidth, maxWidth ) /
+				  prevContainerWidthRef.current
+				: previousScale;
+
+		const { documentElement } = iframeDocument;
+		const { scrollTop, scrollLeft } = documentElement;
+		const delta = 1 + scale - previousScaleNumber;
+
+		documentElement.scrollTop = delta * scrollTop;
+		documentElement.scrollLeft = delta * scrollLeft;
+	}, [ scale, previousScale, iframeDocument, isZoomedOut, containerWidth ] );
 
 	const iframe = (
 		<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When toggling zoom out, we should maintain the scroll position to the currently visible content.

It's not perfect, but better than trunk.

Closes https://github.com/WordPress/gutenberg/issues/65884

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's disorienting be scrolled to the top when zoomed in, given the intent of the double click is to edit the section which was just in view before double click,

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Try to compute scroll position after the zoom out is exited getting the previous scale and scroll and applying them to the new scale.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- enable zoom out
- double click a section
- you should be seeing the section you double clicked, at normal scale

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/0453bb3a-82ea-4896-8d25-9129d3de9dc0

