### PR TITLE
Background images: remove lingering "file" prop

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -320,7 +320,6 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'background-image' => array(
 			array( 'background', 'backgroundImage', 'url' ),
-			array( 'background', 'backgroundImage', 'source' ),
 		),
 	);
 

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -23,7 +23,7 @@ export interface BorderIndividualStyles< T extends BoxEdge > {
 export interface Style {
 	background?: {
 		backgroundImage?:
-			| { url?: CSSProperties[ 'backgroundImage' ]; source?: string }
+			| { url?: CSSProperties[ 'backgroundImage' ] }
 			| CSSProperties[ 'backgroundImage' ];
 		backgroundPosition?: CSSProperties[ 'backgroundPosition' ];
 		backgroundRepeat?: CSSProperties[ 'backgroundRepeat' ];

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -23,7 +23,7 @@ export interface BorderIndividualStyles< T extends BoxEdge > {
 export interface Style {
 	background?: {
 		backgroundImage?:
-			| { url?: CSSProperties[ 'backgroundImage' ] }
+			| { url?: CSSProperties[ 'backgroundImage' ]; source?: string }
 			| CSSProperties[ 'backgroundImage' ];
 		backgroundPosition?: CSSProperties[ 'backgroundPosition' ];
 		backgroundRepeat?: CSSProperties[ 'backgroundRepeat' ];


### PR DESCRIPTION

## What?

This PR is a follow up to https://github.com/WordPress/gutenberg/pull/61387 - I missed a reference to source in the theme json class in `INDIRECT_PROPERTIES_METADATA`. Whoops!

The changes were first added in https://github.com/WordPress/gutenberg/pull/59454. 

The deleted line is not yet in Core, and the changes are already reflected in the latest 6.6 backport PR:

- https://github.com/WordPress/wordpress-develop/pull/6482

## Why?
Janitorial

## How?
DELETE

## Testing Instructions

The CI tests should pass.

If you're feeling up to it, you could test that there are no regressions to site wide background images in the side editor/frontend.

Here is some test json!

```jspon
{
	"$schema": "../../schemas/json/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "https://images.pexels.com/photos/22484288/pexels-photo-22484288/free-photo-of-the-circular-stone-terraces-of-the-inca-ruins.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
			},
			"backgroundSize": "contain"
		}
	}
}
```
