### PR TITLE
Image Block: Enable crop action when image has a link

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -141,13 +141,19 @@ figure.wp-block-image:not(.wp-block) {
 	width: 100%;
 	overflow: hidden;
 
-	// This removes the border from the img within the image cropper so it
-	// can be applied to the cropper itself. This then allows the image to be
-	// cropped within the visual border providing more accurate editing and
-	// smoother UX.
-	.reactEasyCrop_Container .reactEasyCrop_Image {
-		border: none;
-		border-radius: 0; // Prevent's theme.json radius bleeding into cropper.
+	.reactEasyCrop_Container {
+		// The linked Image block has `pointer-events: none` applied. Override it
+		// here to enable the crop action.
+		pointer-events: auto;
+
+		// This removes the border from the img within the image cropper so it
+		// can be applied to the cropper itself. This then allows the image to be
+		// cropped within the visual border providing more accurate editing and
+		// smoother UX.
+		.reactEasyCrop_Image {
+			border: none;
+			border-radius: 0; // Prevent's theme.json radius bleeding into cropper.
+		}
 	}
 }
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -82,7 +82,8 @@ const ImageWrapper = ( { href, children } ) => {
 				// When the Image block is linked,
 				// it's wrapped with a disabled <a /> tag.
 				// Restore cursor style so it doesn't appear 'clickable'
-				// Safari needs the display property.
+				// and remove pointer events. Safari needs the display property.
+				pointerEvents: 'none',
 				cursor: 'default',
 				display: 'inline',
 			} }


### PR DESCRIPTION
Fixes #60928

## What?

This PR fixes so that the crop tool can operate correctly when a image has a link.

## Why?

This issue is a regression caused by the following process:

1. [#56043](https://github.com/WordPress/gutenberg/pull/56043): When an Image block was linked, the image block itself could not be selected with a mouse click because the linked element was clickable. To fix this, `pointer-events: none` was added to the link element.
2. [#60081](https://github.com/WordPress/gutenberg/pull/60081): Another issue has been reported where the crop tool becomes inoperable due to pointer-events being disabled.
3. [#60305](https://github.com/WordPress/gutenberg/pull/60305): Re-enabled pointer events on the link element to allow the crop tool action.

## How?

I disabled the pointer-event for the link element again. Since `pointer-events` can be overwritten by child elements, I applied `auto` to the crop area.

This will allow the Image block itself to be selected correctly, and the crop tool should also work correctly.

## Testing Instructions

- Insert an Image block.
- Apply a link to the Image block.
- Remove focus from the Image block.
- Click on the Image block with your mouse.
- A blue outline will appear to indicate that the block is selected.
- When you press Enter, an empty Paragraph block will be generated next to the Image block.
- You can delete the image block by pressing the Delete key.
- Insert an Image block again and apply the link.
- Select the Crop tool button from the block toolbar.
- Zooming in/out using the mouse wheel and moving by dragging the mouse should work.

## Screenshots or screencast <!-- if applicable -->

The video below reproduces the testing procedure.

https://github.com/WordPress/gutenberg/assets/54422211/a9421c22-fb15-4316-8c2d-5c7575376e5c