### PR TITLE
PoC - Try easier column selection

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -98,15 +98,21 @@
 	* Individual Column Alignment
 	*/
 	&.is-vertically-aligned-top {
-		align-self: flex-start;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-start;
 	}
 
 	&.is-vertically-aligned-center {
-		align-self: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 	}
 
 	&.is-vertically-aligned-bottom {
-		align-self: flex-end;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
 	}
 
 	&.is-vertically-aligned-stretch {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Try to improve the selection of columns where contents are vertically aligned and where lots of space exist around them.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's confusing to not be able to select the column by clicking on the empty space (created by other columns with more content). The empty space _inside_ a column should respond to click.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replace the behaviour of vertically align a column to creating a column direction flex container, instead of using align self in the parent row flex container.

## Testing Instructions

1. In a post or template
2. Add a column block w/ 2 columns
3. In the 1st column add an image block with some image
4. In the 2nd column add 5-6 text paragraphs
5. In the 1st column select the column and align top/middle
6. Notice clicking _around_ the image selects the column

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

### Trunk

https://github.com/WordPress/gutenberg/assets/107534/dd8e6dcb-33ae-4cea-823f-5b4e3f2e7e49

### This branch

https://github.com/WordPress/gutenberg/assets/107534/fd4676f1-70b4-4adb-bf3e-da81d9a15627


