### PR TITLE
[WIP] List View: Try allowing page up and page down keys

### DIFF
--- a/packages/block-editor/src/components/list-view/use-block-selection.js
+++ b/packages/block-editor/src/components/list-view/use-block-selection.js
@@ -5,7 +5,15 @@ import { speak } from '@wordpress/a11y';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { UP, DOWN, HOME, END, ESCAPE } from '@wordpress/keycodes';
+import {
+	UP,
+	DOWN,
+	HOME,
+	END,
+	ESCAPE,
+	PAGEUP,
+	PAGEDOWN,
+} from '@wordpress/keycodes';
 import { store as blocksStore } from '@wordpress/blocks';
 
 /**
@@ -46,7 +54,9 @@ export default function useBlockSelection() {
 				( event.keyCode === UP ||
 					event.keyCode === DOWN ||
 					event.keyCode === HOME ||
-					event.keyCode === END );
+					event.keyCode === END ||
+					event.keyCode === PAGEUP ||
+					event.keyCode === PAGEDOWN );
 
 			// Handle clicking on a block when no blocks are selected, and return early.
 			if (

--- a/packages/components/src/tree-grid/types.ts
+++ b/packages/components/src/tree-grid/types.ts
@@ -120,4 +120,9 @@ export type TreeGridProps = {
 		startRow: HTMLElement,
 		destinationRow: HTMLElement
 	) => void;
+	/**
+	 * Number of rows for each page of the tree grid.
+	 * Used to calculate how far PAGEUP and PAGEDOWN keys should move the focus.
+	 */
+	pageSize?: number;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 WIP: not yet ready for review 🚧 🚧 🚧 🚧 

Explore allowing page up and page down keys to move up and down the list view (and therefore the tree grid component).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently page up and page down keys simply scroll the containing, which means you lose your position when navigating through the list view via keyboard. It could improve the usability when working with long list views via keyboard if we can allow the keys for page up and page down to move the focused item within the tree grid.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a page size to the tree grid, and move the focused row based on this when a user presses the page up or page down keys.

## To-do

* [ ] Determine the page size based on the visual height of the list view or tree grid instead of a hard-coded value
* [ ] Is this actually an improvement in terms of accessibility, or does it make it harder? I.e. what are the trade-offs here of bypassing browser defaults. The hope is that this makes the list view easier to use, but we should verify this assumption.
* [ ] Fix the list view's multi-select behaviour to support this. Currently it's unreliable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
