### PR TITLE
Do not wrap page-list, if navigation child

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -335,7 +335,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$show_submenu_icons = array_key_exists( 'showSubmenuIcon', $block->context ) ? $block->context['showSubmenuIcon'] : false;
 
-	$wrapper_markup = $is_nested ? '%2$s' : '<ul %1$s>%2$s</ul>';
+	$wrapper_markup = $is_nested || $is_navigation_child ? '%2$s' : '<ul %1$s>%2$s</ul>';
 
 	$items_markup = block_core_page_list_render_nested_page_list( $open_submenus_on_click, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids, $colors );
 


### PR DESCRIPTION
## What?
Do not add add `<ul>` -wrapper to page-list block, when the block is used inside of navigation-block.

## Why?
Fix for https://github.com/WordPress/gutenberg/issues/60500. When you use page-list -block as inner block of navigation block, there will be invalid html code (`<ul><ul><li></li></ul></ul>` -structure) in the frontend.

## Testing Instructions
1. Check [Playground PR Preview](https://playground.wordpress.net/#%7B%22landingPage%22:%22/%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/wordpress/pr%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/wordpress/pr/pr.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%2520Gutenberg%2520Plugin%2520Zip&artifact=gutenberg-plugin&pr=61475%22,%22caption%22:%22Downloading%20Gutenberg%20PR%2061475%22%7D,%22progress%22:%7B%22weight%22:2,%22caption%22:%22Applying%20Gutenberg%20PR%2061475%22%7D%7D,%7B%22step%22:%22unzip%22,%22zipPath%22:%22/wordpress/pr/pr.zip%22,%22extractToPath%22:%22/wordpress/pr%22%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/wordpress/pr/gutenberg.zip%22%7D%7D%5D%7D)
2. Inspect the navigation in header. It has `<ul><li></li></ul>` -structure, which is valid html

![Screenshot 2024-05-08 at 11 00 50](https://github.com/WordPress/gutenberg/assets/5536354/e7cf9dfa-8757-4fe1-805b-9989f55e5016)


