### PR TITLE
RadioControl: Fix shrinking radio controls

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -317,10 +317,14 @@
 	border-radius: $radius-round;
 	width: $radio-input-size-sm;
 	height: $radio-input-size-sm;
+	min-width: $radio-input-size-sm;
+	max-width: $radio-input-size-sm;
 
 	@include break-small() {
 		height: $radio-input-size;
 		width: $radio-input-size;
+		min-width: $radio-input-size;
+		max-width: $radio-input-size;
 	}
 
 	&:checked::before {


### PR DESCRIPTION
## What?
This PR alters the radio control radio buttons to be fixed width and height so they don't shrink and skew disproportionally when used in flex context. 

## Why?
This PR resolves an issue with radio buttons shrinking at certain smaller widths, as reported in https://github.com/WordPress/gutenberg/pull/61357#issuecomment-2097936855

## How?
We're essentially adding `min-width` and `max-width` as we want the actual radio button to remain constant width.

@jameskoster suggested using `flex-shrink`, but with radio buttons, we really want to keep a constant width instead. 

## Testing Instructions
* Test with https://github.com/WordPress/gutenberg/pull/61357 and verify that the Discussion box displays the radio buttons well at all widths
* Test `RadioControl` in storybook, try adding a width to the parent container (100px) and verify the radio buttons don't shrink anymore and remain constant width at all viewport sizes. 

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
Before (including the `width` I'm setting):
![Screenshot 2024-05-08 at 11 16 34](https://github.com/WordPress/gutenberg/assets/8436925/e71bdc54-05ee-47e5-8145-429c3148e4f6)

After:
![Screenshot 2024-05-08 at 11 18 21](https://github.com/WordPress/gutenberg/assets/8436925/93724bf1-7675-420d-b42e-f373a9a09cb9)

