### PR TITLE
Fix regression on keyboard navigation

### DIFF
--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -40,7 +40,7 @@ interface ListViewProps {
 }
 
 interface ListViewItemProps {
-	id: string;
+	id: any;
 	item: Item;
 	isSelected: boolean;
 	onSelect: ( item: Item ) => void;
@@ -183,7 +183,8 @@ export default function ViewList( props: ListViewProps ) {
 	);
 
 	const getItemDomId = useCallback(
-		( item?: Item ) => ( item ? `${ baseId }-${ getItemId( item ) }` : '' ),
+		( item?: Item ) =>
+			item ? `${ baseId }-${ getItemId( item ) }` : undefined,
 		[ baseId, getItemId ]
 	);
 

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -40,7 +40,7 @@ interface ListViewProps {
 }
 
 interface ListViewItemProps {
-	id: any;
+	id?: string;
 	item: Item;
 	isSelected: boolean;
 	onSelect: ( item: Item ) => void;


### PR DESCRIPTION
## What?

This PR fixes a [regression](https://github.com/WordPress/gutenberg/pull/61246/files#r1593684523) on keyboard navigation for the list layout (dataviews) by which the list items weren't reachable via TAB.

https://github.com/WordPress/gutenberg/assets/583546/e9d0654d-c271-423f-a16a-36e470c52c07

## How?

The result of `getItemDomId` needs to be undefined if there's no item.

## Testing Instructions

- Visit Site Editor > Pages.
- Try to reach the list items via keyboard navigation (TAB).
