### PR TITLE
Revert "useBlockSync: remove isControlled effect"

### DIFF
--- a/test/e2e/specs/site-editor/undo.spec.js
+++ b/test/e2e/specs/site-editor/undo.spec.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'undo', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'does not empty header', async ( { admin, page, editor } ) => {
+		await admin.visitSiteEditor( { canvas: 'edit' } );
+
+		// Check if there's a valid child block with a type (not appender).
+		await expect(
+			editor.canvas.locator(
+				'[data-type="core/template-part"] [data-type]'
+			)
+		).not.toHaveCount( 0 );
+
+		// insert a block
+		await editor.insertBlock( { name: 'core/paragraph' } );
+
+		// undo
+		await page
+			.getByRole( 'button', {
+				name: 'Undo',
+			} )
+			.click();
+
+		// Check if there's a valid child block with a type (not appender).
+		await expect(
+			editor.canvas.locator(
+				'[data-type="core/template-part"] [data-type]'
+			)
+		).not.toHaveCount( 0 );
+	} );
+} );


### PR DESCRIPTION
Reverts WordPress/gutenberg#61114

We need to revert this because undo is broken with template parts.

Step to reproduce:

Go to site editor. Add some content, then undo. Observe header and footer are gone.

~~To do: add regression e2e test either here of follow-up~~