### PR TITLE
Block API: Convert block alias into canonical block (PoC)

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	getBlockDefaultClassName,
 	getBlockType,
 	getBlockTypes,
 	getBlockVariations,
@@ -1866,6 +1867,9 @@ const getItemFromVariation = ( state, item ) => ( variation ) => {
 	const initialAttributes = {
 		...item.initialAttributes,
 		...variation.attributes,
+		...( supportsAlias && {
+			className: getBlockDefaultClassName( variation.name ),
+		} ),
 	};
 	return {
 		...item,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1862,6 +1862,11 @@ const canIncludeBlockTypeInInserter = ( state, blockType, rootClientId ) => {
 const getItemFromVariation = ( state, item ) => ( variation ) => {
 	const variationId = `${ item.id }/${ variation.name }`;
 	const { time, count = 0 } = getInsertUsage( state, variationId ) || {};
+	const supportsAlias = variation?.supports?.alias ?? false;
+	const initialAttributes = {
+		...item.initialAttributes,
+		...variation.attributes,
+	};
 	return {
 		...item,
 		id: variationId,
@@ -1874,8 +1879,12 @@ const getItemFromVariation = ( state, item ) => ( variation ) => {
 			? variation.example
 			: item.example,
 		initialAttributes: {
-			...item.initialAttributes,
-			...variation.attributes,
+			...initialAttributes,
+			metadata: {
+				...initialAttributes.metadata,
+				// If the variation supports alias, set the alias attribute to the variation name.
+				...( supportsAlias && { alias: variation.name } ),
+			},
 		},
 		innerBlocks: variation.innerBlocks,
 		keywords: variation.keywords || item.keywords,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1883,6 +1883,7 @@ const getItemFromVariation = ( state, item ) => ( variation ) => {
 			metadata: {
 				...initialAttributes.metadata,
 				// If the variation supports alias, set the alias attribute to the variation name.
+				// This is needed for convertAliasBlockNameAndAttributes to convert it to/from the alias/canonical block name.
 				...( supportsAlias && { alias: variation.name } ),
 			},
 		},

--- a/packages/blocks/src/api/parser/convert-alias-block.js
+++ b/packages/blocks/src/api/parser/convert-alias-block.js
@@ -1,0 +1,21 @@
+/**
+ * Convert alias blocks to their canonical form. This function is used
+ * both in the parser level for previous content and to convert such blocks
+ * used in Custom Post Types templates.
+ *
+ * @param {string} name       The block's name
+ * @param {Object} attributes The block's attributes
+ *
+ * @return {[string, Object]} The block's name and attributes, changed accordingly if a match was found
+ */
+export function convertAliasBlockNameAndAttributes( name, attributes ) {
+	const canonicalBlockName = attributes.metadata?.alias;
+	let blockName = name;
+	const newAttributes = { ...attributes };
+	if ( canonicalBlockName ) {
+		blockName = canonicalBlockName;
+		newAttributes.metadata.alias = name;
+	}
+
+	return [ blockName, newAttributes ];
+}

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -16,6 +16,7 @@ import { getSaveContent } from '../serializer';
 import { validateBlock } from '../validation';
 import { createBlock } from '../factory';
 import { convertLegacyBlockNameAndAttributes } from './convert-legacy-block';
+import { convertAliasBlockNameAndAttributes } from './convert-alias-block';
 import { serializeRawBlock } from './serialize-raw-block';
 import { getBlockAttributes } from './get-block-attributes';
 import { applyBlockDeprecatedVersions } from './apply-block-deprecated-versions';
@@ -68,6 +69,31 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
 function convertLegacyBlocks( rawBlock ) {
 	const [ correctName, correctedAttributes ] =
 		convertLegacyBlockNameAndAttributes(
+			rawBlock.blockName,
+			rawBlock.attrs
+		);
+	return {
+		...rawBlock,
+		blockName: correctName,
+		attrs: correctedAttributes,
+	};
+}
+
+/**
+ * Convert alias blocks to their canonical form. This function is used
+ * both in the parser level for previous content and to convert such blocks
+ * used in Custom Post Types templates.
+ *
+ * We are swapping the alias value with the block name depending on whether we are serializing or parsing.
+ * This is because the alias is used to serialize the block name, but when parsing, we need to convert the alias to the block name.
+ *
+ * @param {WPRawBlock} rawBlock
+ *
+ * @return {WPRawBlock} The block's name and attributes, changed accordingly if a match was found
+ */
+function convertAliasBlocks( rawBlock ) {
+	const [ correctName, correctedAttributes ] =
+		convertAliasBlockNameAndAttributes(
 			rawBlock.blockName,
 			rawBlock.attrs
 		);
@@ -200,6 +226,9 @@ export function parseRawBlock( rawBlock, options ) {
 	// and transformed others to new blocks. To avoid breaking existing content,
 	// we added this function to properly parse the old content.
 	normalizedBlock = convertLegacyBlocks( normalizedBlock );
+
+	// Convert alias blocks to their canonical form.
+	normalizedBlock = convertAliasBlocks( normalizedBlock );
 
 	// Try finding the type for known block name.
 	let blockType = getBlockType( normalizedBlock.blockName );

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -21,6 +21,7 @@ import {
 } from './registration';
 import { serializeRawBlock } from './parser/serialize-raw-block';
 import { isUnmodifiedDefaultBlock, normalizeBlockType } from './utils';
+import { convertAliasBlockNameAndAttributes } from './parser/convert-alias-block';
 
 /** @typedef {import('./parser').WPBlock} WPBlock */
 
@@ -322,15 +323,18 @@ export function getCommentDelimitedContent(
 	attributes,
 	content
 ) {
+	const [ correctBlockName, correctedAttributes ] =
+		convertAliasBlockNameAndAttributes( rawBlockName, attributes );
+
 	const serializedAttributes =
-		attributes && Object.entries( attributes ).length
-			? serializeAttributes( attributes ) + ' '
+		correctedAttributes && Object.entries( correctedAttributes ).length
+			? serializeAttributes( correctedAttributes ) + ' '
 			: '';
 
 	// Strip core blocks of their namespace prefix.
-	const blockName = rawBlockName?.startsWith( 'core/' )
-		? rawBlockName.slice( 5 )
-		: rawBlockName;
+	const blockName = correctBlockName?.startsWith( 'core/' )
+		? correctBlockName.slice( 5 )
+		: correctBlockName;
 
 	// @todo make the `wp:` prefix potentially configurable.
 


### PR DESCRIPTION
wordpress-develop counterpart: https://github.com/WordPress/wordpress-develop/pull/6523

**To do (that are known):**
- [x] Alias blocks to have an additional class name.
- [ ] Revisit code, especially around registration (linked PR).
- [ ] Test coverage.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related to: https://github.com/WordPress/gutenberg/issues/43743

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Add the "Register variant" code to register a variant of the `core/separator` block with a new alias of `block-variant/separartor-variant`.
2. Add the "Add variant to template" code to one of your block templates or add the "Variant Separator" via the inserter & Save template
3. Add the "Hook block" code to your site
4. Refresh template & reload on frontend to see hooked block

**Register variant**
```php
function register_block_alias_block_variation( $variations, $block_type) {
	if ( 'core/separator' !== $block_type->name ) {
		return $variations;
	}

	$variations[] = array(
		'title' => 'Separator Variant',
		'name' => 'block-alias/separator-variant',
		'supports' => array(
			'alias' => true,
		),
	);

	return $variations;
}

add_filter('get_block_type_variations', 'register_block_alias_block_variation', 10, 2);
```

**Hook block**
```php
function register_hooked_block( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
	if ( 'block-alias/separator-variant' === $anchor_block_type && 'after' === $relative_position ) {
		$hooked_block_types[] = 'core/loginout';
	}

	return $hooked_block_types;
}

add_filter( 'hooked_block_types', 'register_hooked_block', 10, 4 );
```

**Add variant to template**
```html
<!-- wp:block-alias/separator-variant {"metadata":{"alias":"core/separator"},"className":"wp-block-block-alias-separator-variant"} -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:block-alias/separator-variant -->
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
