### PR TITLE
Fix: Refactor Featured Image Block to use aspectRatio block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -642,8 +642,8 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 
 -	**Name:** core/post-featured-image
 -	**Category:** theme
--	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
--	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
+-	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
+-	**Attributes:** customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link
 

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -11,9 +11,6 @@
 			"type": "boolean",
 			"default": false
 		},
-		"aspectRatio": {
-			"type": "string"
-		},
 		"width": {
 			"type": "string"
 		},
@@ -63,6 +60,9 @@
 		"color": {
 			"text": false,
 			"background": false
+		},
+		"dimensions": {
+			"aspectRatio": true
 		},
 		"__experimentalBorder": {
 			"color": true,

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -76,7 +76,7 @@ const DimensionControls = ( {
 		} ) );
 
 	// Get the block Supports aspect ratio.
-	const blockSupportsAspectRatio = attributes?.style?.dimensions?.aspectRatio;
+	const aspectRatio = attributes?.style?.dimensions?.aspectRatio;
 
 	const onDimensionChange = ( dimension, nextValue ) => {
 		const parsedValue = parseFloat( nextValue );
@@ -95,8 +95,7 @@ const DimensionControls = ( {
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );
 
 	const showScaleControl =
-		height ||
-		( blockSupportsAspectRatio && blockSupportsAspectRatio !== 'auto' );
+		height || ( aspectRatio && aspectRatio !== 'auto' );
 
 	return (
 		<>

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -53,17 +53,12 @@ const scaleHelp = {
 
 const DimensionControls = ( {
 	clientId,
-	attributes: { aspectRatio, width, height, scale, sizeSlug },
+	attributes,
+	attributes: { width, height, scale, sizeSlug },
 	setAttributes,
 	media,
 } ) => {
-	const [ availableUnits, defaultRatios, themeRatios, showDefaultRatios ] =
-		useSettings(
-			'spacing.units',
-			'dimensions.aspectRatios.default',
-			'dimensions.aspectRatios.theme',
-			'dimensions.defaultAspectRatios'
-		);
+	const [ availableUnits ] = useSettings( 'spacing.units' );
 	const units = useCustomUnits( {
 		availableUnits: availableUnits || [ 'px', '%', 'vw', 'em', 'rem' ],
 	} );
@@ -79,6 +74,9 @@ const DimensionControls = ( {
 			value: slug,
 			label: name,
 		} ) );
+
+	// Get the block Supports aspect ratio.
+	const blockSupportsAspectRatio = attributes?.style?.dimensions?.aspectRatio;
 
 	const onDimensionChange = ( dimension, nextValue ) => {
 		const parsedValue = parseFloat( nextValue );
@@ -97,52 +95,11 @@ const DimensionControls = ( {
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );
 
 	const showScaleControl =
-		height || ( aspectRatio && aspectRatio !== 'auto' );
-
-	const themeOptions = themeRatios?.map( ( { name, ratio } ) => ( {
-		label: name,
-		value: ratio,
-	} ) );
-
-	const defaultOptions = defaultRatios?.map( ( { name, ratio } ) => ( {
-		label: name,
-		value: ratio,
-	} ) );
-
-	const aspectRatioOptions = [
-		{
-			label: _x(
-				'Original',
-				'Aspect ratio option for dimensions control'
-			),
-			value: 'auto',
-		},
-		...( showDefaultRatios ? defaultOptions : [] ),
-		...( themeOptions ? themeOptions : [] ),
-	];
+		height ||
+		( blockSupportsAspectRatio && blockSupportsAspectRatio !== 'auto' );
 
 	return (
 		<>
-			<ToolsPanelItem
-				hasValue={ () => !! aspectRatio }
-				label={ __( 'Aspect ratio' ) }
-				onDeselect={ () => setAttributes( { aspectRatio: undefined } ) }
-				resetAllFilter={ () => ( {
-					aspectRatio: undefined,
-				} ) }
-				isShownByDefault
-				panelId={ clientId }
-			>
-				<SelectControl
-					__nextHasNoMarginBottom
-					label={ __( 'Aspect ratio' ) }
-					value={ aspectRatio }
-					options={ aspectRatioOptions }
-					onChange={ ( nextAspectRatio ) =>
-						setAttributes( { aspectRatio: nextAspectRatio } )
-					}
-				/>
-			</ToolsPanelItem>
 			<ToolsPanelItem
 				className="single-column"
 				hasValue={ () => !! height }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -70,7 +70,7 @@ export default function PostFeaturedImageEdit( {
 		linkTarget,
 		useFirstImageFromPost,
 	} = attributes;
-	const blockSupportAspectRatio = attributes?.style?.dimensions?.aspectRatio;
+	const aspectRatio = attributes?.style?.dimensions?.aspectRatio;
 	const [ temporaryURL, setTemporaryURL ] = useState();
 
 	const [ storedFeaturedImage, setFeaturedImage ] = useEntityProp(
@@ -132,7 +132,7 @@ export default function PostFeaturedImageEdit( {
 	const mediaUrl = getMediaSourceUrlBySizeSlug( media, sizeSlug );
 
 	const blockProps = useBlockProps( {
-		style: { width, height, blockSupportAspectRatio },
+		style: { width, height, aspectRatio },
 		className: clsx( {
 			'is-transient': temporaryURL,
 		} ),
@@ -150,8 +150,8 @@ export default function PostFeaturedImageEdit( {
 				) }
 				withIllustration
 				style={ {
-					height: !! blockSupportAspectRatio && '100%',
-					width: !! blockSupportAspectRatio && '100%',
+					height: !! aspectRatio && '100%',
+					width: !! aspectRatio && '100%',
 					...borderProps.style,
 					...shadowProps.style,
 				} }
@@ -285,9 +285,9 @@ export default function PostFeaturedImageEdit( {
 	const imageStyles = {
 		...borderProps.style,
 		...shadowProps.style,
-		height: blockSupportAspectRatio ? '100%' : height,
-		width: !! blockSupportAspectRatio && '100%',
-		objectFit: !! ( height || blockSupportAspectRatio ) && scale,
+		height: aspectRatio ? '100%' : height,
+		width: !! aspectRatio && '100%',
+		objectFit: !! ( height || aspectRatio ) && scale,
 	};
 
 	/**

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -62,7 +62,6 @@ export default function PostFeaturedImageEdit( {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const {
 		isLink,
-		aspectRatio,
 		height,
 		width,
 		scale,
@@ -71,6 +70,7 @@ export default function PostFeaturedImageEdit( {
 		linkTarget,
 		useFirstImageFromPost,
 	} = attributes;
+	const blockSupportAspectRatio = attributes?.style?.dimensions?.aspectRatio;
 	const [ temporaryURL, setTemporaryURL ] = useState();
 
 	const [ storedFeaturedImage, setFeaturedImage ] = useEntityProp(
@@ -132,7 +132,7 @@ export default function PostFeaturedImageEdit( {
 	const mediaUrl = getMediaSourceUrlBySizeSlug( media, sizeSlug );
 
 	const blockProps = useBlockProps( {
-		style: { width, height, aspectRatio },
+		style: { width, height, blockSupportAspectRatio },
 		className: clsx( {
 			'is-transient': temporaryURL,
 		} ),
@@ -150,8 +150,8 @@ export default function PostFeaturedImageEdit( {
 				) }
 				withIllustration
 				style={ {
-					height: !! aspectRatio && '100%',
-					width: !! aspectRatio && '100%',
+					height: !! blockSupportAspectRatio && '100%',
+					width: !! blockSupportAspectRatio && '100%',
 					...borderProps.style,
 					...shadowProps.style,
 				} }
@@ -285,9 +285,9 @@ export default function PostFeaturedImageEdit( {
 	const imageStyles = {
 		...borderProps.style,
 		...shadowProps.style,
-		height: aspectRatio ? '100%' : height,
-		width: !! aspectRatio && '100%',
-		objectFit: !! ( height || aspectRatio ) && scale,
+		height: blockSupportAspectRatio ? '100%' : height,
+		width: !! blockSupportAspectRatio && '100%',
+		objectFit: !! ( height || blockSupportAspectRatio ) && scale,
 	};
 
 	/**

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -38,10 +38,13 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		}
 	}
 
+	// Get the aspect Ratio from the block supports.
+	$aspect_ratio = $attributes['style']['dimensions']['aspectRatio'] ?? '';
+
 	$extra_styles = '';
 
 	// Aspect ratio with a height set needs to override the default width/height.
-	if ( ! empty( $attributes['aspectRatio'] ) ) {
+	if ( ! empty( $aspect_ratio ) ) {
 		$extra_styles .= 'width:100%;height:100%;';
 	} elseif ( ! empty( $attributes['height'] ) ) {
 		$extra_styles .= "height:{$attributes['height']};";
@@ -114,8 +117,8 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$featured_image = $featured_image . $overlay_markup;
 	}
 
-	$aspect_ratio = ! empty( $attributes['aspectRatio'] )
-		? esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ) . ';'
+	$aspect_ratio = ! empty( $aspect_ratio )
+		? esc_attr( safecss_filter_attr( 'aspect-ratio:' . $aspect_ratio ) ) . ';'
 		: '';
 	$width        = ! empty( $attributes['width'] )
 		? esc_attr( safecss_filter_attr( 'width:' . $attributes['width'] ) ) . ';'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves  https://github.com/WordPress/gutenberg/issues/61432

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- To improve the code quality, we have removed the `aspectRatio` from attributes and used the `Block Supports` for the `core/post-featured-image`, because the attributes were redundant.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Have removed the `aspectRatio` from the attributes.
- Have added the `block supports`, `dimensions[aspectRatio]` in block.json.
- Used that value to update the block in editor and frontend as well.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post/page.
2. Added the `core/post-featured-image` block.
3. Check the aspect ratio dropdown. It is now using the block supports, instead of native attributes. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NIL

## Screenshots or screencast <!-- if applicable -->
- NIL, code quality improvement.
