### PR TITLE
Zoom out: try pattern inserter instead of starter pattern modal for new pages

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -13,7 +13,6 @@ import { useSelect } from '@wordpress/data';
 import PatternsExplorerModal from '../block-patterns-explorer';
 import MobileTabNavigation from '../mobile-tab-navigation';
 import { PatternCategoryPreviews } from './pattern-category-previews';
-import { usePatternCategories } from './use-pattern-categories';
 import CategoryTabs from '../category-tabs';
 import InserterNoResults from '../no-results';
 import { store as blockEditorStore } from '../../../store';
@@ -22,14 +21,12 @@ import { unlock } from '../../../lock-unlock';
 function BlockPatternsTab( {
 	onSelectCategory,
 	selectedCategory,
+	categories,
 	onInsert,
 	rootClientId,
 	children,
 } ) {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
-
-	const categories = usePatternCategories( rootClientId );
-
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const isResolvingPatterns = useSelect(
 		( select ) =>

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
@@ -14,6 +14,7 @@ import {
 	isPatternFiltered,
 	allPatternsCategory,
 	myPatternsCategory,
+	starterContentCategory,
 	INSERTER_PATTERN_TYPES,
 } from './utils';
 
@@ -67,6 +68,15 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 				label: _x( 'Uncategorized' ),
 			} );
 		}
+
+		if (
+			patterns.find( ( pattern ) =>
+				pattern.categories.includes( 'core/content' )
+			)
+		) {
+			categories.unshift( starterContentCategory );
+		}
+
 		if (
 			filteredPatterns.some(
 				( pattern ) => pattern.type === INSERTER_PATTERN_TYPES.user

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -22,7 +22,12 @@ export const allPatternsCategory = {
 
 export const myPatternsCategory = {
 	name: 'myPatterns',
-	label: __( 'My patterns' ),
+	label: __( 'My Patterns' ),
+};
+
+export const starterContentCategory = {
+	name: 'core/content',
+	label: __( 'Starter Content' ),
 };
 
 export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -32,6 +32,9 @@ import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import { store as blockEditorStore } from '../../store';
 import TabbedSidebar from '../tabbed-sidebar';
+import { useZoomOut } from '../../hooks/use-zoom-out';
+import { usePatternCategories } from './block-patterns-tab/use-pattern-categories';
+import { unlock } from '../../lock-unlock';
 
 const NOOP = () => {};
 function InserterMenu(
@@ -60,8 +63,11 @@ function InserterMenu(
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
 		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
+	const categories = usePatternCategories( rootClientId );
 	const [ selectedPatternCategory, setSelectedPatternCategory ] = useState(
-		__experimentalInitialCategory
+		categories.find(
+			( category ) => category.name === __experimentalInitialCategory
+		)
 	);
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
@@ -237,6 +243,7 @@ function InserterMenu(
 				onInsert={ onInsertPattern }
 				onSelectCategory={ onClickPatternCategory }
 				selectedCategory={ selectedPatternCategory }
+				categories={ categories }
 			>
 				{ showPatternPanel && (
 					<PatternCategoryPreviews

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2426,10 +2426,23 @@ export const getPatternsByBlockTypes = createRegistrySelector( ( select ) =>
 			if ( ! blockNames ) {
 				return EMPTY_ARRAY;
 			}
-			const patterns =
-				select( STORE_NAME ).__experimentalGetAllowedPatterns(
-					rootClientId
-				);
+			let patterns;
+
+			if ( rootClientId ) {
+				patterns =
+					select( STORE_NAME ).__experimentalGetAllowedPatterns(
+						rootClientId
+					);
+			} else {
+				const {
+					getAllPatterns,
+					__experimentalGetParsedPattern: getParsedPattern,
+				} = unlock( select( STORE_NAME ) );
+				patterns = getAllPatterns()
+					.filter( ( { inserter = true } ) => !! inserter )
+					.map( ( { name } ) => getParsedPattern( name ) );
+			}
+
 			const normalizedBlockNames = Array.isArray( blockNames )
 				? blockNames
 				: [ blockNames ];
@@ -2444,7 +2457,11 @@ export const getPatternsByBlockTypes = createRegistrySelector( ( select ) =>
 			return filteredPatterns;
 		},
 		( state, blockNames, rootClientId ) =>
-			getAllowedPatternsDependants( select )( state, rootClientId )
+			! rootClientId
+				? unlock( select( STORE_NAME ) ).getAllPatterns()
+				: select( STORE_NAME ).__experimentalGetAllowedPatterns(
+						rootClientId
+				  )
 	)
 );
 

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -33,6 +33,7 @@ export default function InserterSidebar() {
 			getInsertionPoint,
 			isPublishSidebarOpened,
 		} = unlock( select( editorStore ) );
+
 		const {
 			getBlockRootClientId,
 			__unstableGetEditorMode,
@@ -40,6 +41,7 @@ export default function InserterSidebar() {
 		} = unlock( select( blockEditorStore ) );
 		const { get } = select( preferencesStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
+
 		const getBlockSectionRootClientId = () => {
 			if ( __unstableGetEditorMode() === 'zoom-out' ) {
 				const sectionRootClientId = getSectionRootClientId();
@@ -54,10 +56,10 @@ export default function InserterSidebar() {
 			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
 			insertionPoint: getInsertionPoint(),
 			showMostUsedBlocks: get( 'core', 'mostUsedBlocks' ),
-			blockSectionRootClientId: getBlockSectionRootClientId(),
 			sidebarIsOpened: !! (
 				getActiveComplementaryArea( 'core' ) || isPublishSidebarOpened()
 			),
+			blockSectionRootClientId: getBlockSectionRootClientId(),
 		};
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( editorStore );
@@ -89,7 +91,7 @@ export default function InserterSidebar() {
 				showInserterHelpPanel
 				shouldFocusBlock={ isMobileViewport }
 				rootClientId={
-					blockSectionRootClientId ?? insertionPoint.rootClientId
+					insertionPoint.rootClientId ?? blockSectionRootClientId
 				}
 				__experimentalInsertionIndex={ insertionPoint.insertionIndex }
 				onSelect={ insertionPoint.onSelect }

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -34,21 +34,17 @@ export default function InserterSidebar() {
 			isPublishSidebarOpened,
 		} = unlock( select( editorStore ) );
 
-		const { getBlockRootClientId, getSectionRootClientId } = unlock(
-			select( blockEditorStore )
-		);
+		const { getSectionRootClientId } = unlock( select( blockEditorStore ) );
 		const { get } = select( preferencesStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 
 		const getBlockSectionRootClientId = () => {
 			const sectionRootClientId = getSectionRootClientId();
 
-			if ( sectionRootClientId ) {
-				return sectionRootClientId;
-			}
-
-			return getBlockRootClientId();
+			// '' is equiavlent to calling getBlockRootClientId() with no arguments.
+			return sectionRootClientId ?? '';
 		};
+
 		return {
 			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
 			insertionPoint: getInsertionPoint(),

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -34,22 +34,19 @@ export default function InserterSidebar() {
 			isPublishSidebarOpened,
 		} = unlock( select( editorStore ) );
 
-		const {
-			getBlockRootClientId,
-			__unstableGetEditorMode,
-			getSectionRootClientId,
-		} = unlock( select( blockEditorStore ) );
+		const { getBlockRootClientId, getSectionRootClientId } = unlock(
+			select( blockEditorStore )
+		);
 		const { get } = select( preferencesStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 
 		const getBlockSectionRootClientId = () => {
-			if ( __unstableGetEditorMode() === 'zoom-out' ) {
-				const sectionRootClientId = getSectionRootClientId();
+			const sectionRootClientId = getSectionRootClientId();
 
-				if ( sectionRootClientId ) {
-					return sectionRootClientId;
-				}
+			if ( sectionRootClientId ) {
+				return sectionRootClientId;
 			}
+
 			return getBlockRootClientId();
 		};
 		return {

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -11,7 +11,6 @@ import {
 	privateApis as preferencesPrivateApis,
 } from '@wordpress/preferences';
 import { store as interfaceStore } from '@wordpress/interface';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -27,6 +26,7 @@ import PageAttributesCheck from '../page-attributes/check';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { useStartPatterns } from '../start-page-options';
 
 const {
 	PreferencesModal,
@@ -34,17 +34,6 @@ const {
 	PreferencesModalSection,
 	PreferenceToggleControl,
 } = unlock( preferencesPrivateApis );
-
-function useStartPatterns() {
-	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
-	// and it has no postTypes declared and the current post type is page or if
-	// the current post type is part of the postTypes declared.
-	return useSelect( ( select ) =>
-		select( blockEditorStore ).getPatternsByBlockTypes(
-			'core/post-content'
-		)
-	);
-}
 
 export default function EditorPreferencesModal( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -11,6 +11,7 @@ import {
 	privateApis as preferencesPrivateApis,
 } from '@wordpress/preferences';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -26,7 +27,6 @@ import PageAttributesCheck from '../page-attributes/check';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { useStartPatterns } from '../start-page-options';
 
 const {
 	PreferencesModal,
@@ -34,6 +34,17 @@ const {
 	PreferencesModalSection,
 	PreferenceToggleControl,
 } = unlock( preferencesPrivateApis );
+
+function useStartPatterns() {
+	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
+	// and it has no postTypes declared and the current post type is page or if
+	// the current post type is part of the postTypes declared.
+	return useSelect( ( select ) =>
+		select( blockEditorStore ).getPatternsByBlockTypes(
+			'core/post-content'
+		)
+	);
+}
 
 export default function EditorPreferencesModal( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -1,9 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import {
+	store as blockEditorStore,
+	__experimentalBlockPatternsList as BlockPatternsList,
+} from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useAsyncList } from '@wordpress/compose';
+import { store as coreStore } from '@wordpress/core-data';
+import { __unstableSerializeAndClean } from '@wordpress/blocks';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -11,8 +21,124 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '../../store';
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
 
+export function useStartPatterns() {
+	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
+	// and it has no postTypes declared and the current post type is page or if
+	// the current post type is part of the postTypes declared.
+	const { blockPatternsWithPostContentBlockType, postType } = useSelect(
+		( select ) => {
+			const { getPatternsByBlockTypes, getBlocksByName } =
+				select( blockEditorStore );
+			const { getCurrentPostType, getRenderingMode } =
+				select( editorStore );
+			const rootClientId =
+				getRenderingMode() === 'post-only'
+					? ''
+					: getBlocksByName( 'core/post-content' )?.[ 0 ];
+			return {
+				blockPatternsWithPostContentBlockType: getPatternsByBlockTypes(
+					'core/post-content',
+					rootClientId
+				),
+				postType: getCurrentPostType(),
+			};
+		},
+		[]
+	);
+
+	return useMemo( () => {
+		if ( ! blockPatternsWithPostContentBlockType?.length ) {
+			return [];
+		}
+
+		/*
+		 * Filter patterns without postTypes declared if the current postType is page
+		 * or patterns that declare the current postType in its post type array.
+		 */
+		return blockPatternsWithPostContentBlockType.filter( ( pattern ) => {
+			return (
+				( postType === 'page' && ! pattern.postTypes ) ||
+				( Array.isArray( pattern.postTypes ) &&
+					pattern.postTypes.includes( postType ) )
+			);
+		} );
+	}, [ postType, blockPatternsWithPostContentBlockType ] );
+}
+
+function PatternSelection( { blockPatterns, onChoosePattern } ) {
+	const shownBlockPatterns = useAsyncList( blockPatterns );
+	const { editEntityRecord } = useDispatch( coreStore );
+	const { postType, postId } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+
+		return {
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
+		};
+	}, [] );
+	return (
+		<BlockPatternsList
+			blockPatterns={ blockPatterns }
+			shownPatterns={ shownBlockPatterns }
+			onClickPattern={ ( _pattern, blocks ) => {
+				editEntityRecord( 'postType', postType, postId, {
+					blocks,
+					content: ( { blocks: blocksForSerialization = [] } ) =>
+						__unstableSerializeAndClean( blocksForSerialization ),
+				} );
+				onChoosePattern();
+			} }
+		/>
+	);
+}
+
+function StartPageOptionsModal( { onClose } ) {
+	const startPatterns = useStartPatterns();
+	const hasStartPattern = startPatterns.length > 0;
+
+	if ( ! hasStartPattern ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ __( 'Choose a pattern' ) }
+			isFullScreen
+			onRequestClose={ onClose }
+		>
+			<div className="editor-start-page-options__modal-content">
+				<PatternSelection
+					blockPatterns={ startPatterns }
+					onChoosePattern={ onClose }
+				/>
+			</div>
+		</Modal>
+	);
+}
+
 export default function StartPageOptions() {
 	const [ isClosed, setIsClosed ] = useState( false );
+
+	// Select for starter page modal.
+	const shouldEnableModal = useSelect( ( select ) => {
+		const { isEditedPostDirty, isEditedPostEmpty, getCurrentPostType } =
+			select( editorStore );
+		const preferencesModalActive =
+			select( interfaceStore ).isModalActive( 'editor/preferences' );
+		const choosePatternModalEnabled = select( preferencesStore ).get(
+			'core',
+			'enableChoosePatternModal'
+		);
+		return (
+			choosePatternModalEnabled &&
+			! preferencesModalActive &&
+			! isEditedPostDirty() &&
+			isEditedPostEmpty() &&
+			TEMPLATE_POST_TYPE !== getCurrentPostType()
+		);
+	}, [] );
+
+	// Select for starter pattern inserter.
 	const { shouldEnableStartPage, postType, postId } = useSelect(
 		( select ) => {
 			const {
@@ -35,9 +161,6 @@ export default function StartPageOptions() {
 		[]
 	);
 
-	const { setIsInserterOpened } = useDispatch( editorStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
-
 	useEffect( () => {
 		// Should reset the start page state when navigating to a new page/post.
 		setIsClosed( false );
@@ -53,11 +176,15 @@ export default function StartPageOptions() {
 			).length
 	);
 
+	const { setIsInserterOpened } = useDispatch( editorStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+
 	const showInserterOnNewPage =
 		shouldEnableStartPage &&
 		! isClosed &&
 		hasStarterPatterns &&
 		window.__experimentalEnableZoomOutExperiment;
+
 	useEffect( () => {
 		if ( showInserterOnNewPage ) {
 			setIsInserterOpened( {
@@ -71,5 +198,14 @@ export default function StartPageOptions() {
 		setIsInserterOpened,
 		__unstableSetEditorMode,
 	] );
+
+	if (
+		shouldEnableModal &&
+		! isClosed &&
+		! window.__experimentalEnableZoomOutExperiment
+	) {
+		return <StartPageOptionsModal onClose={ () => setIsClosed( true ) } />;
+	}
+
 	return null;
 }

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -54,7 +54,10 @@ export default function StartPageOptions() {
 	);
 
 	const showInserterOnNewPage =
-		shouldEnableStartPage && ! isClosed && hasStarterPatterns;
+		shouldEnableStartPage &&
+		! isClosed &&
+		hasStarterPatterns &&
+		window.__experimentalEnableZoomOutExperiment;
 	useEffect( () => {
 		if ( showInserterOnNewPage ) {
 			setIsInserterOpened( {

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -1,19 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Modal } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { useState, useMemo } from '@wordpress/element';
-import {
-	store as blockEditorStore,
-	__experimentalBlockPatternsList as BlockPatternsList,
-} from '@wordpress/block-editor';
+import { useState, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useAsyncList } from '@wordpress/compose';
-import { store as coreStore } from '@wordpress/core-data';
-import { __unstableSerializeAndClean } from '@wordpress/blocks';
-import { store as preferencesStore } from '@wordpress/preferences';
-import { store as interfaceStore } from '@wordpress/interface';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -21,124 +11,62 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as editorStore } from '../../store';
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
 
-export function useStartPatterns() {
-	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
-	// and it has no postTypes declared and the current post type is page or if
-	// the current post type is part of the postTypes declared.
-	const { blockPatternsWithPostContentBlockType, postType } = useSelect(
+export default function StartPageOptions() {
+	const [ isClosed, setIsClosed ] = useState( false );
+	const { shouldEnableStartPage, postType, postId } = useSelect(
 		( select ) => {
-			const { getPatternsByBlockTypes, getBlocksByName } =
-				select( blockEditorStore );
-			const { getCurrentPostType, getRenderingMode } =
-				select( editorStore );
-			const rootClientId =
-				getRenderingMode() === 'post-only'
-					? ''
-					: getBlocksByName( 'core/post-content' )?.[ 0 ];
+			const {
+				isEditedPostDirty,
+				isEditedPostEmpty,
+				getCurrentPostType,
+				getCurrentPostId,
+			} = select( editorStore );
+			const _postType = getCurrentPostType();
+
 			return {
-				blockPatternsWithPostContentBlockType: getPatternsByBlockTypes(
-					'core/post-content',
-					rootClientId
-				),
-				postType: getCurrentPostType(),
+				shouldEnableStartPage:
+					! isEditedPostDirty() &&
+					isEditedPostEmpty() &&
+					TEMPLATE_POST_TYPE !== _postType,
+				postType: _postType,
+				postId: getCurrentPostId(),
 			};
 		},
 		[]
 	);
 
-	return useMemo( () => {
-		if ( ! blockPatternsWithPostContentBlockType?.length ) {
-			return [];
+	const { setIsInserterOpened } = useDispatch( editorStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		// Should reset the start page state when navigating to a new page/post.
+		setIsClosed( false );
+	}, [ postType, postId ] );
+
+	// A pattern is a start pattern if it includes 'core/post-content' in its
+	// blockTypes, and it has no postTypes declared and the current post type is
+	// page or if the current post type is part of the postTypes declared.
+	const hasStarterPatterns = useSelect(
+		( select ) =>
+			!! select( blockEditorStore ).getPatternsByBlockTypes(
+				'core/post-content'
+			).length
+	);
+
+	const showInserterOnNewPage =
+		shouldEnableStartPage && ! isClosed && hasStarterPatterns;
+	useEffect( () => {
+		if ( showInserterOnNewPage ) {
+			setIsInserterOpened( {
+				tab: 'patterns',
+				category: 'core/content',
+			} );
+			__unstableSetEditorMode( 'zoom-out' );
 		}
-
-		/*
-		 * Filter patterns without postTypes declared if the current postType is page
-		 * or patterns that declare the current postType in its post type array.
-		 */
-		return blockPatternsWithPostContentBlockType.filter( ( pattern ) => {
-			return (
-				( postType === 'page' && ! pattern.postTypes ) ||
-				( Array.isArray( pattern.postTypes ) &&
-					pattern.postTypes.includes( postType ) )
-			);
-		} );
-	}, [ postType, blockPatternsWithPostContentBlockType ] );
-}
-
-function PatternSelection( { blockPatterns, onChoosePattern } ) {
-	const shownBlockPatterns = useAsyncList( blockPatterns );
-	const { editEntityRecord } = useDispatch( coreStore );
-	const { postType, postId } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-
-		return {
-			postType: getCurrentPostType(),
-			postId: getCurrentPostId(),
-		};
-	}, [] );
-	return (
-		<BlockPatternsList
-			blockPatterns={ blockPatterns }
-			shownPatterns={ shownBlockPatterns }
-			onClickPattern={ ( _pattern, blocks ) => {
-				editEntityRecord( 'postType', postType, postId, {
-					blocks,
-					content: ( { blocks: blocksForSerialization = [] } ) =>
-						__unstableSerializeAndClean( blocksForSerialization ),
-				} );
-				onChoosePattern();
-			} }
-		/>
-	);
-}
-
-function StartPageOptionsModal( { onClose } ) {
-	const startPatterns = useStartPatterns();
-	const hasStartPattern = startPatterns.length > 0;
-
-	if ( ! hasStartPattern ) {
-		return null;
-	}
-
-	return (
-		<Modal
-			title={ __( 'Choose a pattern' ) }
-			isFullScreen
-			onRequestClose={ onClose }
-		>
-			<div className="editor-start-page-options__modal-content">
-				<PatternSelection
-					blockPatterns={ startPatterns }
-					onChoosePattern={ onClose }
-				/>
-			</div>
-		</Modal>
-	);
-}
-
-export default function StartPageOptions() {
-	const [ isClosed, setIsClosed ] = useState( false );
-	const shouldEnableModal = useSelect( ( select ) => {
-		const { isEditedPostDirty, isEditedPostEmpty, getCurrentPostType } =
-			select( editorStore );
-		const preferencesModalActive =
-			select( interfaceStore ).isModalActive( 'editor/preferences' );
-		const choosePatternModalEnabled = select( preferencesStore ).get(
-			'core',
-			'enableChoosePatternModal'
-		);
-		return (
-			choosePatternModalEnabled &&
-			! preferencesModalActive &&
-			! isEditedPostDirty() &&
-			isEditedPostEmpty() &&
-			TEMPLATE_POST_TYPE !== getCurrentPostType()
-		);
-	}, [] );
-
-	if ( ! shouldEnableModal || isClosed ) {
-		return null;
-	}
-
-	return <StartPageOptionsModal onClose={ () => setIsClosed( true ) } />;
+	}, [
+		showInserterOnNewPage,
+		setIsInserterOpened,
+		__unstableSetEditorMode,
+	] );
+	return null;
 }

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -199,11 +199,7 @@ export default function StartPageOptions() {
 		__unstableSetEditorMode,
 	] );
 
-	if (
-		shouldEnableModal &&
-		! isClosed &&
-		! window.__experimentalEnableZoomOutExperiment
-	) {
+	if ( shouldEnableModal && ! isClosed ) {
 		return <StartPageOptionsModal onClose={ () => setIsClosed( true ) } />;
 	}
 

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -3,13 +3,13 @@
  */
 import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	__experimentalBlockPatternsList as BlockPatternsList,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useAsyncList } from '@wordpress/compose';
+import { useAsyncList, usePrevious } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -161,10 +161,16 @@ export default function StartPageOptions() {
 		[]
 	);
 
-	useEffect( () => {
-		// Should reset the start page state when navigating to a new page/post.
+	const previousPostType = usePrevious( postType );
+	const previousPostId = usePrevious( postId );
+
+	// Reset the isClosed state when navigating to a new page/post.
+	if (
+		( previousPostType && previousPostType !== postType ) ||
+		( previousPostId && previousPostId !== postId )
+	) {
 		setIsClosed( false );
-	}, [ postType, postId ] );
+	}
 
 	// A pattern is a start pattern if it includes 'core/post-content' in its
 	// blockTypes, and it has no postTypes declared and the current post type is

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -180,24 +180,15 @@ export default function StartPageOptions() {
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const showInserterOnNewPage =
-		shouldEnableStartPage &&
-		! isClosed &&
-		hasStarterPatterns &&
-		window.__experimentalEnableZoomOutExperiment;
+		shouldEnableStartPage && ! isClosed && hasStarterPatterns;
 
-	useEffect( () => {
-		if ( showInserterOnNewPage ) {
-			setIsInserterOpened( {
-				tab: 'patterns',
-				category: 'core/content',
-			} );
-			__unstableSetEditorMode( 'zoom-out' );
-		}
-	}, [
-		showInserterOnNewPage,
-		setIsInserterOpened,
-		__unstableSetEditorMode,
-	] );
+	if ( showInserterOnNewPage ) {
+		setIsInserterOpened( {
+			tab: 'patterns',
+			category: 'core/content',
+		} );
+		__unstableSetEditorMode( 'zoom-out' );
+	}
 
 	if ( shouldEnableModal && ! isClosed ) {
 		return <StartPageOptionsModal onClose={ () => setIsClosed( true ) } />;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

# Moved to #66836.

## What?
<!-- In a few words, what is the PR actually doing? -->

Instead of showing the starter patterns modal when creating a draft page, this PR tries opening the patterns inserter instead (+ zoom out mode).

![zoom-out-starter](https://github.com/WordPress/gutenberg/assets/4710635/3c8f621a-b222-4165-a38f-fe3ea1c3655d)


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
