### PR TITLE
Try: Improve date-wrapping in prepublish flow

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -119,6 +119,11 @@
 	.editor-post-visibility__dialog-legend {
 		display: none;
 	}
+
+	.components-panel__body-title .components-button {
+		align-items: flex-start;
+		text-wrap: pretty;
+	}
 }
 
 .post-publish-panel__postpublish .components-panel__body {


### PR DESCRIPTION
## What?

If you schedule a post, the pre-publishing flow poorly wraps the date timestamp. As shown in this picture, the status is vertically centered with the timestamp itself wrapping on two lines, in an unbalanced fashion.

![before](https://github.com/WordPress/gutenberg/assets/1204802/08b67b88-dfb0-4903-b811-7864b092336a)

This PR adds better text wrapping and top alignment, so it balances better:

![after](https://github.com/WordPress/gutenberg/assets/1204802/a0a16668-9a92-41f2-b685-7da752b0aa61)

## Testing Instructions

Write a post, schedule it, start the pre-publish flow. The date dropdown should be top-aligned and wrap the long date-stamp well.