### PR TITLE
Try: Wrap date-time stamp well for publish status

### DIFF
--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -18,4 +18,10 @@
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
+
+	// This needs specificity.
+	.components-button.components-button {
+		text-wrap: pretty;
+	}
+
 }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -16,6 +16,11 @@
 	height: auto;
 	min-height: $button-size-compact;
 
+	// This needs specificity.
+	&.components-button {
+		text-wrap: pretty;
+	}
+
 	// The line height + the padding should be the same as the button size.
 	line-height: inherit;
 }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -16,11 +16,6 @@
 	height: auto;
 	min-height: $button-size-compact;
 
-	// This needs specificity.
-	&.components-button {
-		text-wrap: pretty;
-	}
-
 	// The line height + the padding should be the same as the button size.
 	line-height: inherit;
 }


### PR DESCRIPTION
## What?

The date-stamp in the summary panel can wrap poorly when it's long, usually putting the timezone on its own line out of context with the time itself:
![scheduled-wrapping-before](https://github.com/WordPress/gutenberg/assets/1204802/f1e30fd8-bdd9-466a-89f7-f221cadbad48)

This PR adds text-wrap: pretty; to address this so the timezone is more likely to be in context of the timestamp:

![scheduled wrapping after](https://github.com/WordPress/gutenberg/assets/1204802/ee6d1636-bf5b-46bb-ae70-bbf16d5a2593)

## Testing Instructions

Write a post, change its status to scheduled, and observe the date-stamp in the summary panel. It should wrap well.