### PR TITLE
Pass content property to onInput in useEntityBlockEditor

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -253,7 +253,12 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 		( newBlocks, options ) => {
 			const { selection, ...rest } = options;
 			const footnotesChanges = updateFootnotes( newBlocks );
-			const edits = { selection, ...footnotesChanges };
+			const edits = {
+				selection,
+				content: ( { blocks: blocksForSerialization = [] } ) =>
+					__unstableSerializeAndClean( blocksForSerialization ),
+				...footnotesChanges,
+			};
 
 			editEntityRecord( kind, name, id, edits, {
 				isCached: true,


### PR DESCRIPTION
## What?
As discussed [here](https://github.com/WordPress/gutenberg/pull/60721#issuecomment-2100517669), onInput should probably pass the content property, which marks the post dirty.
 
## Why?
To avoid unexpected issues like not having an undo option or updating the save button in some cases like [this one](https://github.com/WordPress/gutenberg/pull/60721#issuecomment-2097706514).

## How?
Copying and pasting the solution for `onChange`.

## Testing Instructions
Check if tests pass.
