### PR TITLE
Edit Post: Fix the 'usePaddingAppender' error

### DIFF
--- a/packages/edit-post/src/components/visual-editor/use-padding-appender.js
+++ b/packages/edit-post/src/components/visual-editor/use-padding-appender.js
@@ -27,7 +27,7 @@ export function usePaddingAppender() {
 					return;
 				}
 
-				// only handle clicks under the last child
+				// Only handle clicks under the last child.
 				const lastChild = node.lastElementChild;
 				if ( ! lastChild ) {
 					return;
@@ -44,6 +44,12 @@ export function usePaddingAppender() {
 					.select( blockEditorStore )
 					.getBlockOrder( '' );
 				const lastBlockClientId = blockOrder[ blockOrder.length - 1 ];
+
+				// Do nothing when only default block appender is present.
+				if ( ! lastBlockClientId ) {
+					return;
+				}
+
 				const lastBlock = registry
 					.select( blockEditorStore )
 					.getBlock( lastBlockClientId );


### PR DESCRIPTION
## What?
This is a follow-up to #60697.

PR fixes an error triggered by the `usePaddingAppender` hook when canvas has no blocks.

## Why?
A freshly created post does not have blocks; there's just a placeholder block appender that looks like a block.

## Testing Instructions
1. Create a new post.
2. Click below "Type / to choose a block".
3. Confirm no error is logged in the console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/240569/f221d70f-40ce-4d9a-97d7-e60f8066788a