### PR TITLE
build: Suggest workaround if `tsc --build` fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
 	"scripts": {
 		"build": "npm run build:packages && wp-scripts build",
 		"build:analyze-bundles": "npm run build -- --webpack-bundle-analyzer",
-		"build:package-types": "node ./bin/packages/validate-typescript-version.js && tsc --build && node ./bin/packages/check-build-type-declaration-files.js",
+		"build:package-types": "node ./bin/packages/validate-typescript-version.js && ( tsc --build || ( echo 'tsc failed. Try cleaning up first: `npm run clean:package-types`'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js",
 		"prebuild:packages": "npm run clean:packages && lerna run build",
 		"build:packages": "npm run build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",


### PR DESCRIPTION
Following the merge of #60796, developers may face build issues that require package types to be rebuilt. The problem is that `tsc --build` fails somewhat silently — or rather, there is some output, but it's not clear in the console which stage of the `build:package-types` command failed, and hence what the workaround should be.

This pull request alleviates the issue by logging a helpful message in the console if `tsc --build` fails:

> tsc failed. Try cleaning up first: `npm run clean:package-types`