### PR TITLE
Upgrade @use-gesture/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53559,12 +53559,12 @@
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
 		},
-		"packages/components/node_modules/@use-gesture/core": {
+		"node_modules/@use-gesture/core": {
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
 			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
 		},
-		"packages/components/node_modules/@use-gesture/react": {
+		"node_modules/@use-gesture/react": {
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
 			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16819,22 +16819,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@use-gesture/core": {
-			"version": "10.2.24",
-			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.24.tgz",
-			"integrity": "sha512-ZL7F9mgOn3Qlnp6QLI9jaOfcvqrx6JPE/BkdVSd8imveaFTm/a3udoO6f5Us/1XtqnL4347PsIiK6AtCvMHk2Q=="
-		},
-		"node_modules/@use-gesture/react": {
-			"version": "10.2.24",
-			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.24.tgz",
-			"integrity": "sha512-rAZ8Nnpu1g4eFzqCPlaq+TppJpMy0dTpYOQx5KpfoBF4P3aWnCqwj7eKxcmdIb1NJKpIJj50DPugUH4mq5cpBg==",
-			"dependencies": {
-				"@use-gesture/core": "10.2.24"
-			},
-			"peerDependencies": {
-				"react": ">= 16.8.0"
-			}
-		},
 		"node_modules/@wdio/config": {
 			"version": "8.16.20",
 			"resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.16.20.tgz",
@@ -53513,7 +53497,7 @@
 				"@floating-ui/react-dom": "^2.0.8",
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
-				"@use-gesture/react": "^10.2.24",
+				"@use-gesture/react": "^10.3.1",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/date": "file:../date",
@@ -53574,6 +53558,22 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
+		},
+		"packages/components/node_modules/@use-gesture/core": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
+		},
+		"packages/components/node_modules/@use-gesture/react": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+			"dependencies": {
+				"@use-gesture/core": "10.3.1"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0"
+			}
 		},
 		"packages/components/node_modules/framer-motion": {
 			"version": "10.13.0",
@@ -67588,19 +67588,6 @@
 				}
 			}
 		},
-		"@use-gesture/core": {
-			"version": "10.2.24",
-			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.24.tgz",
-			"integrity": "sha512-ZL7F9mgOn3Qlnp6QLI9jaOfcvqrx6JPE/BkdVSd8imveaFTm/a3udoO6f5Us/1XtqnL4347PsIiK6AtCvMHk2Q=="
-		},
-		"@use-gesture/react": {
-			"version": "10.2.24",
-			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.24.tgz",
-			"integrity": "sha512-rAZ8Nnpu1g4eFzqCPlaq+TppJpMy0dTpYOQx5KpfoBF4P3aWnCqwj7eKxcmdIb1NJKpIJj50DPugUH4mq5cpBg==",
-			"requires": {
-				"@use-gesture/core": "10.2.24"
-			}
-		},
 		"@wdio/config": {
 			"version": "8.16.20",
 			"resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.16.20.tgz",
@@ -68780,7 +68767,7 @@
 				"@floating-ui/react-dom": "^2.0.8",
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
-				"@use-gesture/react": "^10.2.24",
+				"@use-gesture/react": "^10.3.1",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/date": "file:../date",
@@ -68829,6 +68816,19 @@
 					"version": "0.1.3",
 					"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 					"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
+				},
+				"@use-gesture/core": {
+					"version": "10.3.1",
+					"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+					"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
+				},
+				"@use-gesture/react": {
+					"version": "10.3.1",
+					"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+					"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+					"requires": {
+						"@use-gesture/core": "10.3.1"
+					}
 				},
 				"framer-motion": {
 					"version": "10.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16819,6 +16819,22 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@use-gesture/core": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
+		},
+		"node_modules/@use-gesture/react": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+			"dependencies": {
+				"@use-gesture/core": "10.3.1"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0"
+			}
+		},
 		"node_modules/@wdio/config": {
 			"version": "8.16.20",
 			"resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.16.20.tgz",
@@ -53559,22 +53575,6 @@
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
 		},
-		"node_modules/@use-gesture/core": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
-			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
-		},
-		"node_modules/@use-gesture/react": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
-			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
-			"dependencies": {
-				"@use-gesture/core": "10.3.1"
-			},
-			"peerDependencies": {
-				"react": ">= 16.8.0"
-			}
-		},
 		"packages/components/node_modules/framer-motion": {
 			"version": "10.13.0",
 			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.13.0.tgz",
@@ -67588,6 +67588,19 @@
 				}
 			}
 		},
+		"@use-gesture/core": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
+		},
+		"@use-gesture/react": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+			"requires": {
+				"@use-gesture/core": "10.3.1"
+			}
+		},
 		"@wdio/config": {
 			"version": "8.16.20",
 			"resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.16.20.tgz",
@@ -68816,19 +68829,6 @@
 					"version": "0.1.3",
 					"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 					"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
-				},
-				"@use-gesture/core": {
-					"version": "10.3.1",
-					"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
-					"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
-				},
-				"@use-gesture/react": {
-					"version": "10.3.1",
-					"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
-					"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
-					"requires": {
-						"@use-gesture/core": "10.3.1"
-					}
 				},
 				"framer-motion": {
 					"version": "10.13.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   Replaced `classnames` package with the faster and smaller `clsx` package ([#61138](https://github.com/WordPress/gutenberg/pull/61138)).
+-   Upgrade `@use-gesture/react` package to `^10.3.1` ([#61503](https://github.com/WordPress/gutenberg/pull/61503)).
 
 ### Enhancements
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
 		"@floating-ui/react-dom": "^2.0.8",
 		"@types/gradient-parser": "0.1.3",
 		"@types/highlight-words-core": "1.2.1",
-		"@use-gesture/react": "^10.2.24",
+		"@use-gesture/react": "^10.3.1",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/date": "file:../date",


### PR DESCRIPTION

## What?

Upgrade @use-gesture/react package.

Includes #61532 
Extracted from #61486 

- https://diff.intrinsic.com/@use-gesture/react/10.2.24/10.3.1
- https://diff.intrinsic.com/@use-gesture/core/10.2.24/10.3.1

## Why?

This package has type conflicts with recent React types, these can manifest causing build issues.

## How?

Upgrade to a recent version of the package with the type incompatibilities fixed. https://github.com/pmndrs/use-gesture/pull/655

## Testing Instructions

CI is likely sufficient. I'm not familiar with this package usage in Gutenberg.
