### PR TITLE
Add link to VS Code Playwright Extension

### DIFF
--- a/docs/contributors/code/e2e/README.md
+++ b/docs/contributors/code/e2e/README.md
@@ -36,6 +36,7 @@ xvfb-run npm run test:e2e
 # Only run webkit tests.
 xvfb-run -- npm run test:e2e -- --project=webkit
 ```
+If you're already editing in VS Code, you may find the [Playwright extension](https://playwright.dev/docs/getting-started-vscode) helpful for running, writing and debugging tests.
 
 ## Best practices
 


### PR DESCRIPTION
## What?
Add link to VS Code Playwright Extension

## Why?
I just wrote my first tests and would have had an easier time if this document had pointed me to the VS Code extension. 

## Additional Help
This would be further improved by any VS Code + Playwright ninjas that can add details on how best to set up the playwright.config, etc.
