### PR TITLE
Feat: Adds the editing capability to the search title.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -775,7 +775,7 @@ Display the query title. ([Source](https://github.com/WordPress/gutenberg/tree/t
 -	**Name:** core/query-title
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, showPrefix, showSearchTerm, textAlign, type
+-	**Attributes:** level, searchResultsTerm, searchResultsTermSuffix, showPrefix, showSearchTerm, textAlign, type
 
 ## Quote
 

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -24,6 +24,12 @@
 		"showSearchTerm": {
 			"type": "boolean",
 			"default": true
+		},
+		"searchResultsTerm": {
+			"type": "string"
+		},
+		"searchResultsTermSuffix": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -14,6 +14,7 @@ import {
 	Warning,
 	HeadingLevelDropdown,
 	store as blockEditorStore,
+	RichText,
 } from '@wordpress/block-editor';
 import { ToggleControl, PanelBody } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -22,7 +23,15 @@ import { useSelect } from '@wordpress/data';
 const SUPPORTED_TYPES = [ 'archive', 'search' ];
 
 export default function QueryTitleEdit( {
-	attributes: { type, level, textAlign, showPrefix, showSearchTerm },
+	attributes: {
+		type,
+		level,
+		textAlign,
+		showPrefix,
+		showSearchTerm,
+		searchResultsTerm,
+		searchResultsTermSuffix,
+	},
 	setAttributes,
 } ) {
 	const { archiveTypeTitle, archiveNameLabel } = useSelect( ( select ) => {
@@ -123,11 +132,40 @@ export default function QueryTitleEdit( {
 					</PanelBody>
 				</InspectorControls>
 
-				<TagName { ...blockProps }>
-					{ showSearchTerm
-						? __( 'Search results for: “search term”' )
-						: __( 'Search results' ) }
-				</TagName>
+				{ showSearchTerm ? (
+					<div { ...blockProps }>
+						<RichText
+							tagName={ `h${ level }` }
+							value={ searchResultsTerm }
+							onChange={ ( content ) =>
+								setAttributes( { searchResultsTerm: content } )
+							}
+							placeholder={ __( 'Search Results for:' ) }
+						/>
+						<TagName>{ __( 'Search Term' ) }</TagName>
+						<RichText
+							tagName={ `h${ level }` }
+							value={ searchResultsTermSuffix }
+							onChange={ ( content ) =>
+								setAttributes( {
+									searchResultsTermSuffix: content,
+								} )
+							}
+							placeholder={ __( 'Suffix' ) }
+						/>
+					</div>
+				) : (
+					<RichText
+						{ ...blockProps }
+						tagName={ `h${ level }` }
+						value={ searchResultsTerm }
+						allowedFormats={ [] }
+						onChange={ ( content ) =>
+							setAttributes( { searchResultsTerm: content } )
+						}
+						placeholder={ __( 'Search Results' ) }
+					/>
+				) }
 			</>
 		);
 	}

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -38,20 +38,20 @@ function render_block_core_query_title( $attributes ) {
 		}
 	}
 	if ( $is_search ) {
-		$title = isset($attributes['searchResultsTerm']) && !empty($attributes['searchResultsTerm']) ? $attributes['searchResultsTerm'] : __( 'Search results' );
+		$title = isset( $attributes['searchResultsTerm'] ) && ! empty( $attributes['searchResultsTerm'] ) ? $attributes['searchResultsTerm'] : __( 'Search results' );
 
 		if ( isset( $attributes['showSearchTerm'] ) && $attributes['showSearchTerm'] ) {
 
 			// Get the prefix and suffix.
-			$prefix = isset($attributes['searchResultsTerm']) ? $attributes['searchResultsTerm'] : __('Search results for: ');
-			$suffix = isset($attributes['searchResultsTermSuffix']) ? $attributes['searchResultsTermSuffix'] : '';
+			$prefix = isset( $attributes['searchResultsTerm'] ) ? $attributes['searchResultsTerm'] : __( 'Search results for: ' );
+			$suffix = isset( $attributes['searchResultsTermSuffix'] ) ? $attributes['searchResultsTermSuffix'] : '';
 
 			// Get the search query.
 			$search_query = get_search_query();
 
 			$title = sprintf(
 				/* translators: 1: Search term prefix, 2: Search term, 3: Search term suffix. */
-				__('%1$s "%2$s" %3$s'),
+				__( '%1$s "%2$s" %3$s' ),
 				$prefix,
 				$search_query,
 				$suffix

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -38,13 +38,23 @@ function render_block_core_query_title( $attributes ) {
 		}
 	}
 	if ( $is_search ) {
-		$title = __( 'Search results' );
+		$title = isset($attributes['searchResultsTerm']) && !empty($attributes['searchResultsTerm']) ? $attributes['searchResultsTerm'] : __( 'Search results' );
 
 		if ( isset( $attributes['showSearchTerm'] ) && $attributes['showSearchTerm'] ) {
+
+			// Get the prefix and suffix.
+			$prefix = isset($attributes['searchResultsTerm']) ? $attributes['searchResultsTerm'] : __('Search results for: ');
+			$suffix = isset($attributes['searchResultsTermSuffix']) ? $attributes['searchResultsTermSuffix'] : '';
+
+			// Get the search query.
+			$search_query = get_search_query();
+
 			$title = sprintf(
-				/* translators: %s is the search term. */
-				__( 'Search results for: "%s"' ),
-				get_search_query()
+				/* translators: 1: Search term prefix, 2: Search term, 3: Search term suffix. */
+				__('%1$s "%2$s" %3$s'),
+				$prefix,
+				$search_query,
+				$suffix
 			);
 		}
 	}

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -38,7 +38,7 @@ function render_block_core_query_title( $attributes ) {
 		}
 	}
 	if ( $is_search ) {
-		$title = isset( $attributes['searchResultsTerm'] ) && ! empty( $attributes['searchResultsTerm'] ) ? $attributes['searchResultsTerm'] : __( 'Search results' );
+		$title = ! empty( $attributes['searchResultsTerm'] ) ? $attributes['searchResultsTerm'] : '';
 
 		if ( isset( $attributes['showSearchTerm'] ) && $attributes['showSearchTerm'] ) {
 

--- a/packages/block-library/src/query-title/style.scss
+++ b/packages/block-library/src/query-title/style.scss
@@ -2,3 +2,7 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
+div.wp-block-query-title__placeholder {
+	display: flex;
+	gap: 10px;
+}


### PR DESCRIPTION
## What?
Fixes issue #60701 
This PR adds the editing capability to the search results title block.

## Why?
- As mentioned in issue #60701 the search result title is not editable, so the user can't edit the text for the search results. 

## How?
- Adds the `richtext `component to make the title editable.

## Testing Instructions
1. Open the Site editor and edit the search template.
2. There you will find the "Search Results Title" Block.
3. You should be able to add and edit the text there.

### Testing Instructions for Keyboard
Nil

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/55375170/5ddc366a-8724-409d-b0d0-2d08b221026d

