### PR TITLE
Remove experimental zoom out control

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -13,9 +13,6 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-sync-collaboration', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableSync = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-zoomed-out-view', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomedOutView = true', 'before' );
-	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-custom-dataviews', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalCustomViews = true', 'before' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -56,18 +56,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-zoomed-out-view',
-		__( 'Zoomed out view ', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Test a new zoomed out view on the site editor (Warning: The new feature is not ready. You may experience UX issues that are being addressed)', 'gutenberg' ),
-			'id'    => 'gutenberg-zoomed-out-view',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-custom-dataviews',
 		__( 'Custom dataviews', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -111,21 +111,13 @@ function InserterMenu(
 		[ onToggleInsertionPoint ]
 	);
 
-	const isZoomedOutViewExperimentEnabled =
-		window?.__experimentalEnableZoomedOutView;
 	const onClickPatternCategory = useCallback(
 		( patternCategory, filter ) => {
 			setSelectedPatternCategory( patternCategory );
 			setPatternFilter( filter );
-			if ( isZoomedOutViewExperimentEnabled ) {
-				__experimentalOnPatternCategorySelection();
-			}
+			__experimentalOnPatternCategorySelection();
 		},
-		[
-			setSelectedPatternCategory,
-			__experimentalOnPatternCategorySelection,
-			isZoomedOutViewExperimentEnabled,
-		]
+		[ setSelectedPatternCategory, __experimentalOnPatternCategorySelection ]
 	);
 
 	const showPatternPanel =

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -15,7 +15,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { Button, ToolbarItem } from '@wordpress/components';
-import { listView, plus, chevronUpDown } from '@wordpress/icons';
+import { listView, plus } from '@wordpress/icons';
 import { useRef, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -39,9 +39,8 @@ function DocumentTools( {
 	listViewLabel = __( 'Document Overview' ),
 } ) {
 	const inserterButton = useRef();
-	const { setIsInserterOpened, setIsListViewOpened, setDeviceType } =
+	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editorStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 	const {
 		isDistractionFree,
 		isInserterOpened,
@@ -50,8 +49,6 @@ function DocumentTools( {
 		listViewToggleRef,
 		hasFixedToolbar,
 		showIconLabels,
-		isVisualMode,
-		isZoomedOutView,
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { get } = select( preferencesStore );
@@ -77,8 +74,6 @@ function DocumentTools( {
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideViewport = useViewportMatch( 'wide' );
-	const isZoomedOutViewExperimentEnabled =
-		window?.__experimentalEnableZoomedOutView && isVisualMode;
 
 	/* translators: accessibility text for the editor toolbar */
 	const toolbarAriaLabel = __( 'Document tools' );
@@ -185,28 +180,6 @@ function DocumentTools( {
 						) }
 					</>
 				) }
-
-				{ isZoomedOutViewExperimentEnabled &&
-					isLargeViewport &&
-					! isDistractionFree &&
-					! hasFixedToolbar && (
-						<ToolbarItem
-							as={ Button }
-							className="edit-site-header-edit-mode__zoom-out-view-toggle"
-							icon={ chevronUpDown }
-							isPressed={ isZoomedOutView }
-							/* translators: button label text should, if possible, be under 16 characters. */
-							label={ __( 'Zoom-out View' ) }
-							onClick={ () => {
-								setDeviceType( 'Desktop' );
-								__unstableSetEditorMode(
-									isZoomedOutView ? 'edit' : 'zoom-out'
-								);
-							} }
-							size="compact"
-							disabled={ disableBlockTools }
-						/>
-					) }
 			</div>
 		</NavigableToolbar>
 	);

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -4,64 +4,6 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Zoom Out', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'emptytheme' );
-	} );
-
-	test.beforeEach( async ( { admin, page, editor } ) => {
-		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
-
-		const zoomedOutCheckbox = page.getByLabel(
-			'Test a new zoomed out view on'
-		);
-
-		await zoomedOutCheckbox.setChecked( true );
-		await expect( zoomedOutCheckbox ).toBeChecked();
-		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
-
-		// Select a template part with a few blocks.
-		await admin.visitSiteEditor( {
-			postId: 'emptytheme//header',
-			postType: 'wp_template_part',
-		} );
-		await editor.canvas.locator( 'body' ).click();
-	} );
-
-	test.afterEach( async ( { admin, page } ) => {
-		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
-		const zoomedOutCheckbox = page.getByLabel(
-			'Test a new zoomed out view on'
-		);
-		await zoomedOutCheckbox.setChecked( false );
-		await expect( zoomedOutCheckbox ).not.toBeChecked();
-		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
-	} );
-
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
-	test( 'Zoom-out button should not steal focus when a block is focused', async ( {
-		page,
-		editor,
-	} ) => {
-		const zoomOutButton = page.getByRole( 'button', {
-			name: 'Zoom-out View',
-			exact: true,
-		} );
-
-		// Select a block for this test to surface the potential focus-stealing behavior
-		await editor.canvas.getByLabel( 'Site title text' ).click();
-
-		await zoomOutButton.click();
-
-		await expect( zoomOutButton ).toBeFocused();
-
-		await page.keyboard.press( 'Enter' );
-
-		await expect( zoomOutButton ).toBeFocused();
-	} );
-
 	test( 'Clicking on inserter while on zoom-out should open the patterns tab on the inserter', async ( {
 		page,
 	} ) => {

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -4,15 +4,26 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Zoom Out', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.visitSiteEditor();
+		await editor.canvas.locator( 'body' ).click();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
 	test( 'Clicking on inserter while on zoom-out should open the patterns tab on the inserter', async ( {
 		page,
 	} ) => {
-		const zoomOutButton = page.getByRole( 'button', {
-			name: 'Zoom-out View',
-			exact: true,
-		} );
+		// Trigger zoom out on Global Styles because there the inserter is not open.
+		await page.getByRole( 'button', { name: 'Styles' } ).click();
+		await page.getByRole( 'button', { name: 'Browse styles' } ).click();
 
-		await zoomOutButton.click();
 		await expect( page.getByLabel( 'Add pattern' ) ).toHaveCount( 3 );
 		await page.getByLabel( 'Add pattern' ).first().click();
 		await expect( page.getByLabel( 'Add pattern' ) ).toHaveCount( 2 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

- remove the zoom out view experiment from the experiments page
- remove the zoom out control from the site editor header
- _graduate the experimental auto closing of the block inspector when the second sidebar of the inserter opens for pattern preview_

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- the zoom out view has been out of experimental for a couple WP releases as it's used for the global styles theme style preview
- the control in the header started to get in the way of testing the pattern assembly view. If we ever want a control to enter zoom out it should maybe be moved to some other place as it's not as important as to warrant a header top level control.
- the pattern category preview auto closing the block inspector is a desirable behaviour for assembling patterns when building pages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Visit Gutenberg > Experiments:  no zoom out experiment
2. Visit the site editor: no zoom out control in header
3. Visit the site editor, and:
 - open a page
 - open block inspector
 - open inserter
 - open patterns
 - select a category
 - the inserter auto closes

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A