### PR TITLE
Hide the close button on the inserter for widgets editor

### DIFF
--- a/packages/edit-widgets/src/components/layout/style.scss
+++ b/packages/edit-widgets/src/components/layout/style.scss
@@ -18,7 +18,7 @@
 	// Leave space for the close button
 	height: calc(100% - #{$button-size} - #{$grid-unit-10});
 
-	.block-editor-inserter__tab {
+	.block-editor-inserter-sidebar__header {
 		display: none;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The widget editor is showing the close button from https://github.com/WordPress/gutenberg/pull/61421 when it doesn´t need it

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's a bug

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updating the CSS that hides the tabs, we hide the whole header to also include the new button

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Install a classic theme
- Go to Appearance > widgets
- Open the inserter and check that the close button is not showing

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="1083" alt="Screenshot 2024-05-09 at 12 16 22" src="https://github.com/WordPress/gutenberg/assets/3593343/3b612010-e9c8-4e4f-9665-59a5b339219f">

After:

<img width="669" alt="Screenshot 2024-05-09 at 12 16 07" src="https://github.com/WordPress/gutenberg/assets/3593343/a0f57381-76d3-4a82-8d65-660af4075b62">
