### PR TITLE
Zoom Out: Show a preview when dragging and dropping patterns from the inserter.

### DIFF
--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -63,11 +63,15 @@ const InserterDraggableBlocks = ( {
 				stopDragging();
 			} }
 			__experimentalDragComponent={
-				<BlockDraggableChip
-					count={ blocks.length }
-					icon={ icon || ( ! pattern && blockTypeIcon ) }
-					isPattern={ !! pattern }
-				/>
+				pattern ? (
+					false
+				) : (
+					<BlockDraggableChip
+						count={ blocks.length }
+						icon={ icon || ( ! pattern && blockTypeIcon ) }
+						isPattern={ !! pattern }
+					/>
+				)
 			}
 		>
 			{ ( { onDraggableStart, onDraggableEnd } ) => {

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -64,7 +64,7 @@ const InserterDraggableBlocks = ( {
 			} }
 			__experimentalDragComponent={
 				pattern ? (
-					false
+					false // Setting dragComponent explicitly to false, so that the browser handles the drag image.
 				) : (
 					<BlockDraggableChip
 						count={ blocks.length }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   Replaced `classnames` package with the faster and smaller `clsx` package ([#61138](https://github.com/WordPress/gutenberg/pull/61138)).
+-   Zoom Out: Show a preview when dragging and dropping patterns from the inserter. ([#61511](https://github.com/WordPress/gutenberg/pull/61511))
 
 ### Enhancements
 -   `PaletteEdit`: Use consistent spacing and metrics. ([#61368](https://github.com/WordPress/gutenberg/pull/61368)).

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -105,6 +105,7 @@ export function Draggable( {
 			JSON.stringify( transferData )
 		);
 
+		// If dragComponent is explicitly set to false then let the browser handle the drag image.
 		if ( dragComponent === false ) {
 			return;
 		}

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -105,6 +105,10 @@ export function Draggable( {
 			JSON.stringify( transferData )
 		);
 
+		if ( dragComponent === false ) {
+			return;
+		}
+
 		const cloneWrapper = ownerDocument.createElement( 'div' );
 		// Reset position to 0,0. Natural stacking order will position this lower, even with a transform otherwise.
 		cloneWrapper.style.top = '0';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When dragging and dropping patterns from the inserter we now show a preview of the pattern instead of the draggable chip.

## Why?
This will be more user friendly and easier for users to understand what they are doing.

## How?
Just let the browser handle the preview.

## Testing Instructions
1. Open the patterns inserter
2. Drag a pattern into the canvas
3. Check that you see a preview of the pattern you are moving

## Screenshots or screencast <!-- if applicable -->
<img width="1512" alt="Screenshot 2024-05-09 at 12 54 13" src="https://github.com/WordPress/gutenberg/assets/275961/5c78b9eb-76c7-46ec-8ebe-6763af781f51">
