### PR TITLE
Zoom out: add patterns loading state

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -3,8 +3,9 @@
  */
 import { useState } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,6 +16,8 @@ import { PatternCategoryPreviews } from './pattern-category-previews';
 import { usePatternCategories } from './use-pattern-categories';
 import CategoryTabs from '../category-tabs';
 import InserterNoResults from '../no-results';
+import { store as blockEditorStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
 
 function BlockPatternsTab( {
 	onSelectCategory,
@@ -28,6 +31,15 @@ function BlockPatternsTab( {
 	const categories = usePatternCategories( rootClientId );
 
 	const isMobile = useViewportMatch( 'medium', '<' );
+	const isResolvingPatterns = useSelect(
+		( select ) =>
+			unlock( select( blockEditorStore ) ).isResolvingPatterns(),
+		[]
+	);
+
+	if ( isResolvingPatterns ) {
+		return <Spinner />;
+	}
 
 	if ( ! categories.length ) {
 		return <InserterNoResults />;

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -38,7 +38,11 @@ function BlockPatternsTab( {
 	);
 
 	if ( isResolvingPatterns ) {
-		return <Spinner />;
+		return (
+			<div className="block-editor-inserter__patterns-loading">
+				<Spinner />
+			</div>
+		);
 	}
 
 	if ( ! categories.length ) {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -187,7 +187,8 @@ $block-inserter-tabs-height: 44px;
 	width: 100%;
 }
 
-.block-editor-inserter__no-results {
+.block-editor-inserter__no-results,
+.block-editor-inserter__patterns-loading {
 	padding: $grid-unit-40;
 	text-align: center;
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -401,6 +401,21 @@ export const getAllPatterns = createRegistrySelector( ( select ) =>
 	}, getAllPatternsDependants( select ) )
 );
 
+export const isResolvingPatterns = createRegistrySelector( ( select ) =>
+	createSelector( ( state ) => {
+		const blockPatternsSelect = state.settings[ selectBlockPatternsKey ];
+		const reusableBlocksSelect = state.settings[ reusableBlocksSelectKey ];
+		return (
+			( blockPatternsSelect
+				? blockPatternsSelect( select ) === undefined
+				: false ) ||
+			( reusableBlocksSelect
+				? reusableBlocksSelect( select ) === undefined
+				: false )
+		);
+	}, getAllPatternsDependants( select ) )
+);
+
 const EMPTY_ARRAY = [];
 
 export const getReusableBlocks = createRegistrySelector(

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -268,11 +268,12 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalBlockPatterns: blockPatterns,
 			[ unlock( privateApis ).selectBlockPatternsKey ]: ( select ) => {
-				const { isResolving, getBlockPatternsForPostType } = unlock(
-					select( coreStore )
-				);
+				const { hasFinishedResolution, getBlockPatternsForPostType } =
+					unlock( select( coreStore ) );
 				const patterns = getBlockPatternsForPostType( postType );
-				return isResolving( 'getBlockPatterns' ) ? undefined : patterns;
+				return hasFinishedResolution( 'getBlockPatterns' )
+					? patterns
+					: undefined;
 			},
 			[ unlock( privateApis ).reusableBlocksSelectKey ]:
 				__experimentalReusableBlocksSelect,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -267,10 +267,13 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			keepCaretInsideBlock,
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalBlockPatterns: blockPatterns,
-			[ unlock( privateApis ).selectBlockPatternsKey ]: ( select ) =>
-				unlock( select( coreStore ) ).getBlockPatternsForPostType(
-					postType
-				),
+			[ unlock( privateApis ).selectBlockPatternsKey ]: ( select ) => {
+				const { isResolving, getBlockPatternsForPostType } = unlock(
+					select( coreStore )
+				);
+				const patterns = getBlockPatternsForPostType( postType );
+				return isResolving( 'getBlockPatterns' ) ? undefined : patterns;
+			},
 			[ unlock( privateApis ).reusableBlocksSelectKey ]:
 				__experimentalReusableBlocksSelect,
 			__experimentalBlockPatternCategories: blockPatternCategories,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently we don't have a loading state in the patterns inserter, it just shows "no results" while loading, because the selector returns an empty array.

## Why?
It's misleading to say there are no results when in fact they just haven't loaded yet.

## How?
Uses the `selectBlockPatternsKey` to determine the fetch status of patterns.

## Testing Instructions
1. Open the site editor
2. Open the patterns inserter
3. Check that at first you see a loading spinner before the patterns load

## Screenshots or screencast <!-- if applicable -->
<img width="773" alt="Screenshot 2024-05-10 at 10 12 50" src="https://github.com/WordPress/gutenberg/assets/275961/53eb999e-d4e5-4487-bf7b-c00cbac0aa4c">
