### PR TITLE
Move sidebar close buttons to left side

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/style.scss
@@ -1,5 +1,5 @@
 .components-panel__header.edit-site-sidebar-edit-mode__panel-tabs {
-	padding-left: 0;
+	padding-left: $grid-unit-10;
 
 	.components-button.has-icon {
 		padding: 0;

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -8,13 +8,13 @@
 
 .block-editor-inserter-sidebar__header {
 	border-bottom: $border-width solid $gray-300;
-	padding-right: $grid-unit-10;
+	padding-left: $grid-unit-10;
 	display: flex;
 	justify-content: space-between;
 
 	.block-editor-inserter-sidebar__close-button {
-		order: 1;
 		align-self: center;
+		margin-right: $grid-unit-20;
 	}
 }
 

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -10,13 +10,13 @@
 	}
 	.editor-list-view-sidebar__header {
 		display: flex;
+		padding-left: $grid-unit-10;
 		border-bottom: $border-width solid $gray-300;
 	}
 	.editor-list-view-sidebar__close-button {
 		background: $white;
-		order: 1;
 		align-self: center;
-		margin-right: $grid-unit-15;
+		margin-right: $grid-unit-20;
 	}
 }
 

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -1,5 +1,4 @@
 .components-panel__header.editor-sidebar__panel-tabs {
-	padding-left: 0;
 	padding-left: $grid-unit-10;
 
 	.components-button.has-icon {

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -1,6 +1,6 @@
 .components-panel__header.editor-sidebar__panel-tabs {
 	padding-left: 0;
-	padding-right: $grid-unit-20;
+	padding-left: $grid-unit-10;
 
 	.components-button.has-icon {
 		padding: 0;

--- a/packages/interface/src/components/complementary-area-header/index.js
+++ b/packages/interface/src/components/complementary-area-header/index.js
@@ -40,8 +40,8 @@ const ComplementaryAreaHeader = ( {
 				) }
 				tabIndex={ -1 }
 			>
-				{ children }
 				{ toggleButton }
+				{ children }
 			</div>
 		</>
 	);

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -17,8 +17,9 @@
 
 .interface-complementary-area-header {
 	background: $white;
-	padding-right: $grid-unit-15; // Reduced padding to account for close buttons.
+	padding-left: $grid-unit-10; // Reduced padding to account for close buttons.
 	gap: $grid-unit-10; // Always ensure space between contents and close buttons.
+	justify-content: flex-start;
 
 	.interface-complementary-area-header__title {
 		margin: 0;
@@ -26,7 +27,6 @@
 
 	.components-button.has-icon {
 		display: none;
-		margin-left: auto;
 
 		~ .components-button {
 			margin-left: 0;
@@ -34,6 +34,7 @@
 
 		@include break-medium() {
 			display: flex;
+			margin-right: $grid-unit-20;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes accessibility issues where focus order must match visual order, and also not be between the tabs and tab panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Accessibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Moves Close button to before the tabs/removes flex order.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open inserter, test close button
- Open List view, test close button
- Open Settings panel, test close button

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|-|-|
| ![image](https://github.com/WordPress/gutenberg/assets/27339341/f0c51b8b-62a3-499d-98cc-be4b62dcc0a9) | ![image](https://github.com/WordPress/gutenberg/assets/27339341/1305020d-4c31-4a17-b172-20983b7f5150) |