### PR TITLE
Revert "Use contentOnly locking for pattern block, remove hard-coded block check in block inspector"

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -95,7 +95,8 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			blockType: _blockType,
 			topLevelLockedBlock:
 				getContentLockingParent( _selectedBlockClientId ) ||
-				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly'
+				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly' ||
+				_selectedBlockName === 'core/block'
 					? _selectedBlockClientId
 					: undefined ),
 		};

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -402,7 +402,7 @@ function ReusableBlockEdit( {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		templateLock: 'contentOnly',
+		templateLock: 'all',
 		layout,
 		renderAppender: innerBlocks?.length
 			? undefined


### PR DESCRIPTION
This reverts #61227 (commit 1351c672d76dc9fcba4ce28916be9632dc542c04.)

## What?
It was mentioned to me that synced patterns now have a 'Modify' option in the block options menu.

This is a result of the changes in #61227, and is in error, so I think it's best to revert that PR

## Testing Instructions
1. Insert a synced pattern
2. Check that there's no 'Modify' option in the block options menu