### PR TITLE
Try drill down for pattern inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -14,18 +14,11 @@ import PatternsExplorerModal from '../block-patterns-explorer';
 import MobileTabNavigation from '../mobile-tab-navigation';
 import { PatternCategoryPreviews } from './pattern-category-previews';
 import { usePatternCategories } from './use-pattern-categories';
-import CategoryTabs from '../category-tabs';
 import InserterNoResults from '../no-results';
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
-function BlockPatternsTab( {
-	onSelectCategory,
-	selectedCategory,
-	onInsert,
-	rootClientId,
-	children,
-} ) {
+function BlockPatternsTab( { selectedCategory, onInsert, rootClientId } ) {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
 
 	const categories = usePatternCategories( rootClientId );
@@ -51,38 +44,27 @@ function BlockPatternsTab( {
 
 	return (
 		<>
+			<MobileTabNavigation categories={ categories }>
+				{ ( category ) => (
+					<div className="block-editor-inserter__category-panel">
+						<PatternCategoryPreviews
+							key={ category.name }
+							onInsert={ onInsert }
+							rootClientId={ rootClientId }
+							category={ category }
+							showTitlesAsTooltip={ false }
+						/>
+					</div>
+				) }
+			</MobileTabNavigation>
 			{ ! isMobile && (
-				<div className="block-editor-inserter__block-patterns-tabs-container">
-					<CategoryTabs
-						categories={ categories }
-						selectedCategory={ selectedCategory }
-						onSelectCategory={ onSelectCategory }
-					>
-						{ children }
-					</CategoryTabs>
-					<Button
-						className="block-editor-inserter__patterns-explore-button"
-						onClick={ () => setShowPatternsExplorer( true ) }
-						variant="secondary"
-					>
-						{ __( 'Explore all patterns' ) }
-					</Button>
-				</div>
-			) }
-			{ isMobile && (
-				<MobileTabNavigation categories={ categories }>
-					{ ( category ) => (
-						<div className="block-editor-inserter__category-panel">
-							<PatternCategoryPreviews
-								key={ category.name }
-								onInsert={ onInsert }
-								rootClientId={ rootClientId }
-								category={ category }
-								showTitlesAsTooltip={ false }
-							/>
-						</div>
-					) }
-				</MobileTabNavigation>
+				<Button
+					className="block-editor-inserter__patterns-explore-button"
+					onClick={ () => setShowPatternsExplorer( true ) }
+					variant="secondary"
+				>
+					{ __( 'Explore all patterns' ) }
+				</Button>
 			) }
 			{ showPatternsExplorer && (
 				<PatternsExplorerModal

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -11,7 +11,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import PatternsExplorerModal from '../block-patterns-explorer';
-import MobileTabNavigation from '../mobile-tab-navigation';
+import InserterContentNavigator from '../inserter-content-navigator';
 import { PatternCategoryPreviews } from './pattern-category-previews';
 import { usePatternCategories } from './use-pattern-categories';
 import InserterNoResults from '../no-results';
@@ -44,7 +44,7 @@ function BlockPatternsTab( { selectedCategory, onInsert, rootClientId } ) {
 
 	return (
 		<>
-			<MobileTabNavigation categories={ categories }>
+			<InserterContentNavigator categories={ categories }>
 				{ ( category ) => (
 					<div className="block-editor-inserter__category-panel">
 						<PatternCategoryPreviews
@@ -56,7 +56,7 @@ function BlockPatternsTab( { selectedCategory, onInsert, rootClientId } ) {
 						/>
 					</div>
 				) }
-			</MobileTabNavigation>
+			</InserterContentNavigator>
 			{ ! isMobile && (
 				<Button
 					className="block-editor-inserter__patterns-explore-button"

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -166,23 +166,23 @@ export function PatternCategoryPreviews( {
 						{ __( 'No results found' ) }
 					</Text>
 				) }
-				{ currentCategoryPatterns.length > 0 && (
-					<BlockPatternsList
-						ref={ scrollContainerRef }
-						shownPatterns={ pagingProps.categoryPatternsAsyncList }
-						blockPatterns={ pagingProps.categoryPatterns }
-						onClickPattern={ onClickPattern }
-						onHover={ onHover }
-						label={ category.label }
-						orientation="vertical"
-						category={ category.name }
-						isDraggable
-						showTitlesAsTooltip={ showTitlesAsTooltip }
-						patternFilter={ patternSourceFilter }
-						pagingProps={ pagingProps }
-					/>
-				) }
 			</VStack>
+			{ currentCategoryPatterns.length > 0 && (
+				<BlockPatternsList
+					ref={ scrollContainerRef }
+					shownPatterns={ pagingProps.categoryPatternsAsyncList }
+					blockPatterns={ pagingProps.categoryPatterns }
+					onClickPattern={ onClickPattern }
+					onHover={ onHover }
+					label={ category.label }
+					orientation="vertical"
+					category={ category.name }
+					isDraggable
+					showTitlesAsTooltip={ showTitlesAsTooltip }
+					patternFilter={ patternSourceFilter }
+					pagingProps={ pagingProps }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -135,11 +135,6 @@ export function PatternCategoryPreviews( {
 			<VStack className="block-editor-inserter__patterns-category-panel-header">
 				<HStack>
 					<NavigatorBackButton
-						style={
-							// TODO: This style override is also used in ToolsPanelHeader.
-							// It should be supported out-of-the-box by Button.
-							{ minWidth: 24, padding: 0 }
-						}
 						icon={ isRTL() ? chevronRight : chevronLeft }
 						size="small"
 						label={ __( 'Back' ) }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -34,10 +34,11 @@ import {
 	myPatternsCategory,
 	INSERTER_PATTERN_TYPES,
 } from './utils';
+import { useZoomOut } from '../../../hooks/use-zoom-out';
 
 const noop = () => {};
 
-export function PatternCategoryPreviews( {
+function PatternCategoryPreviewsContent( {
 	rootClientId,
 	onInsert,
 	onHover = noop,
@@ -185,4 +186,18 @@ export function PatternCategoryPreviews( {
 			) }
 		</>
 	);
+}
+
+function PatternCategoryPreviewsContentWithZoomOut( props ) {
+	useZoomOut();
+	return <PatternCategoryPreviewsContent { ...props } />;
+}
+
+export function PatternCategoryPreviews( props ) {
+	// When the pattern panel is showing, we want to use zoom out mode
+	if ( window.__experimentalEnableZoomedOutPatternsTab ) {
+		return <PatternCategoryPreviewsContentWithZoomOut { ...props } />;
+	}
+
+	return <PatternCategoryPreviewsContent { ...props } />;
 }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -132,10 +132,7 @@ export function PatternCategoryPreviews( {
 
 	return (
 		<>
-			<VStack
-				spacing={ 2 }
-				className="block-editor-inserter__patterns-category-panel-header"
-			>
+			<VStack className="block-editor-inserter__patterns-category-panel-header">
 				<HStack>
 					<NavigatorBackButton
 						style={
@@ -174,24 +171,23 @@ export function PatternCategoryPreviews( {
 						{ __( 'No results found' ) }
 					</Text>
 				) }
+				{ currentCategoryPatterns.length > 0 && (
+					<BlockPatternsList
+						ref={ scrollContainerRef }
+						shownPatterns={ pagingProps.categoryPatternsAsyncList }
+						blockPatterns={ pagingProps.categoryPatterns }
+						onClickPattern={ onClickPattern }
+						onHover={ onHover }
+						label={ category.label }
+						orientation="vertical"
+						category={ category.name }
+						isDraggable
+						showTitlesAsTooltip={ showTitlesAsTooltip }
+						patternFilter={ patternSourceFilter }
+						pagingProps={ pagingProps }
+					/>
+				) }
 			</VStack>
-
-			{ currentCategoryPatterns.length > 0 && (
-				<BlockPatternsList
-					ref={ scrollContainerRef }
-					shownPatterns={ pagingProps.categoryPatternsAsyncList }
-					blockPatterns={ pagingProps.categoryPatterns }
-					onClickPattern={ onClickPattern }
-					onHover={ onHover }
-					label={ category.label }
-					orientation="vertical"
-					category={ category.name }
-					isDraggable
-					showTitlesAsTooltip={ showTitlesAsTooltip }
-					patternFilter={ patternSourceFilter }
-					pagingProps={ pagingProps }
-				/>
-			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -8,15 +8,17 @@ import {
 	useRef,
 	useEffect,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
+	__experimentalNavigatorBackButton as NavigatorBackButton,
 	FlexBlock,
 } from '@wordpress/components';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -135,6 +137,16 @@ export function PatternCategoryPreviews( {
 				className="block-editor-inserter__patterns-category-panel-header"
 			>
 				<HStack>
+					<NavigatorBackButton
+						style={
+							// TODO: This style override is also used in ToolsPanelHeader.
+							// It should be supported out-of-the-box by Button.
+							{ minWidth: 24, padding: 0 }
+						}
+						icon={ isRTL() ? chevronRight : chevronLeft }
+						size="small"
+						label={ __( 'Back' ) }
+					/>
 					<FlexBlock>
 						<Heading
 							className="block-editor-inserter__patterns-category-panel-title"

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -114,7 +114,7 @@ export function PatternsFilter( {
 					placement: 'right-end',
 				} }
 				label={ __( 'Filter patterns' ) }
-				toggleProps={ { size: 'compact' } }
+				toggleProps={ { size: 'small' } }
 				icon={
 					<Icon
 						icon={

--- a/packages/block-editor/src/components/inserter/inserter-content-navigator.js
+++ b/packages/block-editor/src/components/inserter/inserter-content-navigator.js
@@ -3,42 +3,65 @@
  */
 import { isRTL } from '@wordpress/i18n';
 import {
-	__experimentalItemGroup as ItemGroup,
-	__experimentalItem as Item,
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
 	__experimentalNavigatorButton as NavigatorButton,
-	FlexBlock,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const {
+	CompositeV2: Composite,
+	CompositeItemV2: CompositeItem,
+	useCompositeStoreV2: useCompositeStore,
+} = unlock( componentsPrivateApis );
+
 export default function InserterContentNavigator( { categories, children } ) {
+	const compositeStore = useCompositeStore( { orientation: 'vertical' } );
+
 	return (
 		<NavigatorProvider
 			initialPath="/"
 			className="block-editor-inserter__mobile-tab-navigation"
 		>
 			<NavigatorScreen path="/">
-				<ItemGroup>
-					{ categories.map( ( category ) => (
-						<NavigatorButton
-							key={ category.name }
-							path={ `/category/${ category.name }` }
-							as={ Item }
-							isAction
-						>
-							<HStack>
-								<FlexBlock>{ category.label }</FlexBlock>
-								<Icon
-									icon={
-										isRTL() ? chevronLeft : chevronRight
-									}
-								/>
-							</HStack>
-						</NavigatorButton>
-					) ) }
-				</ItemGroup>
+				<Composite
+					store={ compositeStore }
+					role="tree"
+					aria-label={ 'Categories' }
+				>
+					<VStack>
+						{ categories.map( ( category ) => (
+							<CompositeItem
+								key={ category.name }
+								render={
+									<NavigatorButton
+										path={ `/category/${ category.name }` }
+										role="treeitem"
+									>
+										<HStack>
+											<span>{ category.label }</span>
+											<Icon
+												icon={
+													isRTL()
+														? chevronLeft
+														: chevronRight
+												}
+											/>
+										</HStack>
+									</NavigatorButton>
+								}
+							/>
+						) ) }
+					</VStack>
+				</Composite>
 			</NavigatorScreen>
 			{ categories.map( ( category ) => (
 				<NavigatorScreen

--- a/packages/block-editor/src/components/inserter/inserter-content-navigator.js
+++ b/packages/block-editor/src/components/inserter/inserter-content-navigator.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 
-export default function MobileTabNavigation( { categories, children } ) {
+export default function InserterContentNavigator( { categories, children } ) {
 	return (
 		<NavigatorProvider
 			initialPath="/"

--- a/packages/block-editor/src/components/inserter/inserter-content-navigator.js
+++ b/packages/block-editor/src/components/inserter/inserter-content-navigator.js
@@ -37,7 +37,10 @@ export default function InserterContentNavigator( { categories, children } ) {
 					role="tree"
 					aria-label={ 'Categories' }
 				>
-					<VStack>
+					<VStack
+						spacing={ 1 }
+						className="block-editor-inserter__mobile-tab-navigation-buttons"
+					>
 						{ categories.map( ( category ) => (
 							<CompositeItem
 								key={ category.name }

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -32,32 +32,35 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const baseCssClass = 'block-editor-inserter__media-panel';
 	const searchLabel = category.labels.search_items || __( 'Search' );
 	return (
-		<VStack className={ baseCssClass }>
-			<HStack>
-				<NavigatorBackButton
-					icon={ isRTL() ? chevronRight : chevronLeft }
-					size="small"
-					label={ __( 'Back' ) }
+		<>
+			<VStack className={ baseCssClass }>
+				<HStack>
+					<NavigatorBackButton
+						icon={ isRTL() ? chevronRight : chevronLeft }
+						size="small"
+						label={ __( 'Back' ) }
+					/>
+					<FlexBlock>
+						<Heading level={ 4 } as="div">
+							{ category.label }
+						</Heading>
+					</FlexBlock>
+				</HStack>
+				<SearchControl
+					__nextHasNoMarginBottom
+					className="block-editor-inserter__search"
+					onChange={ setSearch }
+					value={ search }
+					label={ searchLabel }
+					placeholder={ searchLabel }
 				/>
-				<FlexBlock>
-					<Heading level={ 4 } as="div">
-						{ category.label }
-					</Heading>
-				</FlexBlock>
-			</HStack>
-			<SearchControl
-				className={ `${ baseCssClass }-search` }
-				onChange={ setSearch }
-				value={ search }
-				label={ searchLabel }
-				placeholder={ searchLabel }
-			/>
-			{ isLoading && (
-				<div className={ `${ baseCssClass }-spinner` }>
-					<Spinner />
-				</div>
-			) }
-			{ ! isLoading && ! mediaList?.length && <InserterNoResults /> }
+				{ isLoading && (
+					<div className={ `${ baseCssClass }-spinner` }>
+						<Spinner />
+					</div>
+				) }
+				{ ! isLoading && ! mediaList?.length && <InserterNoResults /> }
+			</VStack>
 			{ ! isLoading && !! mediaList?.length && (
 				<MediaList
 					rootClientId={ rootClientId }
@@ -66,6 +69,6 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 					category={ category }
 				/>
 			) }
-		</VStack>
+		</>
 	);
 }

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -1,9 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { Spinner, SearchControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import {
+	Spinner,
+	SearchControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
+	FlexBlock,
+	__experimentalNavigatorBackButton as NavigatorBackButton,
+} from '@wordpress/components';
+import { __, isRTL } from '@wordpress/i18n';
 import { useDebouncedInput } from '@wordpress/compose';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -23,7 +32,24 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const baseCssClass = 'block-editor-inserter__media-panel';
 	const searchLabel = category.labels.search_items || __( 'Search' );
 	return (
-		<div className={ baseCssClass }>
+		<VStack className={ baseCssClass }>
+			<HStack>
+				<NavigatorBackButton
+					style={
+						// TODO: This style override is also used in ToolsPanelHeader.
+						// It should be supported out-of-the-box by Button.
+						{ minWidth: 24, padding: 0 }
+					}
+					icon={ isRTL() ? chevronRight : chevronLeft }
+					size="small"
+					label={ __( 'Back' ) }
+				/>
+				<FlexBlock>
+					<Heading level={ 4 } as="div">
+						{ category.label }
+					</Heading>
+				</FlexBlock>
+			</HStack>
 			<SearchControl
 				className={ `${ baseCssClass }-search` }
 				onChange={ setSearch }
@@ -45,6 +71,6 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 					category={ category }
 				/>
 			) }
-		</div>
+		</VStack>
 	);
 }

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -35,11 +35,6 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 		<VStack className={ baseCssClass }>
 			<HStack>
 				<NavigatorBackButton
-					style={
-						// TODO: This style override is also used in ToolsPanelHeader.
-						// It should be supported out-of-the-box by Button.
-						{ minWidth: 24, padding: 0 }
-					}
 					icon={ isRTL() ? chevronRight : chevronLeft }
 					size="small"
 					label={ __( 'Back' ) }

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -8,7 +8,7 @@ import { useMemo } from '@wordpress/element';
  */
 import { MediaCategoryPanel } from './media-panel';
 import { useMediaCategories } from './hooks';
-import MobileTabNavigation from '../mobile-tab-navigation';
+import InserterContentNavigator from '../inserter-content-navigator';
 import InserterNoResults from '../no-results';
 
 function MediaTab( { rootClientId, onInsert } ) {
@@ -27,7 +27,7 @@ function MediaTab( { rootClientId, onInsert } ) {
 	}
 
 	return (
-		<MobileTabNavigation categories={ categories }>
+		<InserterContentNavigator categories={ categories }>
 			{ ( category ) => (
 				<MediaCategoryPanel
 					onInsert={ onInsert }
@@ -35,7 +35,7 @@ function MediaTab( { rootClientId, onInsert } ) {
 					category={ category }
 				/>
 			) }
-		</MobileTabNavigation>
+		</InserterContentNavigator>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -1,45 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useViewportMatch } from '@wordpress/compose';
-import { Button } from '@wordpress/components';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { MediaCategoryPanel } from './media-panel';
-import MediaUploadCheck from '../../media-upload/check';
-import MediaUpload from '../../media-upload';
 import { useMediaCategories } from './hooks';
-import { getBlockAndPreviewFromMedia } from './utils';
 import MobileTabNavigation from '../mobile-tab-navigation';
-import CategoryTabs from '../category-tabs';
 import InserterNoResults from '../no-results';
 
-const ALLOWED_MEDIA_TYPES = [ 'image', 'video', 'audio' ];
-
-function MediaTab( {
-	rootClientId,
-	selectedCategory,
-	onSelectCategory,
-	onInsert,
-	children,
-} ) {
+function MediaTab( { rootClientId, onInsert } ) {
 	const mediaCategories = useMediaCategories( rootClientId );
-	const isMobile = useViewportMatch( 'medium', '<' );
-	const baseCssClass = 'block-editor-inserter__media-tabs';
-	const onSelectMedia = useCallback(
-		( media ) => {
-			if ( ! media?.url ) {
-				return;
-			}
-			const [ block ] = getBlockAndPreviewFromMedia( media, media.type );
-			onInsert( block );
-		},
-		[ onInsert ]
-	);
 	const categories = useMemo(
 		() =>
 			mediaCategories.map( ( mediaCategory ) => ( {
@@ -54,56 +27,15 @@ function MediaTab( {
 	}
 
 	return (
-		<>
-			{ ! isMobile && (
-				<div className={ `${ baseCssClass }-container` }>
-					<CategoryTabs
-						categories={ categories }
-						selectedCategory={ selectedCategory }
-						onSelectCategory={ onSelectCategory }
-					>
-						{ children }
-					</CategoryTabs>
-					<MediaUploadCheck>
-						<MediaUpload
-							multiple={ false }
-							onSelect={ onSelectMedia }
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							render={ ( { open } ) => (
-								<Button
-									onClick={ ( event ) => {
-										// Safari doesn't emit a focus event on button elements when
-										// clicked and we need to manually focus the button here.
-										// The reason is that core's Media Library modal explicitly triggers a
-										// focus event and therefore a `blur` event is triggered on a different
-										// element, which doesn't contain the `data-unstable-ignore-focus-outside-for-relatedtarget`
-										// attribute making the Inserter dialog to close.
-										event.target.focus();
-										open();
-									} }
-									className="block-editor-inserter__media-library-button"
-									variant="secondary"
-									data-unstable-ignore-focus-outside-for-relatedtarget=".media-modal"
-								>
-									{ __( 'Open Media Library' ) }
-								</Button>
-							) }
-						/>
-					</MediaUploadCheck>
-				</div>
+		<MobileTabNavigation categories={ categories }>
+			{ ( category ) => (
+				<MediaCategoryPanel
+					onInsert={ onInsert }
+					rootClientId={ rootClientId }
+					category={ category }
+				/>
 			) }
-			{ isMobile && (
-				<MobileTabNavigation categories={ categories }>
-					{ ( category ) => (
-						<MediaCategoryPanel
-							onInsert={ onInsert }
-							rootClientId={ rootClientId }
-							category={ category }
-						/>
-					) }
-				</MobileTabNavigation>
-			) }
-		</>
+		</MobileTabNavigation>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -1,15 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useCallback, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import MediaUploadCheck from '../../media-upload/check';
+import MediaUpload from '../../media-upload';
 import { MediaCategoryPanel } from './media-panel';
 import { useMediaCategories } from './hooks';
 import InserterContentNavigator from '../inserter-content-navigator';
 import InserterNoResults from '../no-results';
+import { getBlockAndPreviewFromMedia } from './utils';
+
+const ALLOWED_MEDIA_TYPES = [ 'image', 'video', 'audio' ];
 
 function MediaTab( { rootClientId, onInsert } ) {
 	const mediaCategories = useMediaCategories( rootClientId );
@@ -21,21 +28,63 @@ function MediaTab( { rootClientId, onInsert } ) {
 			} ) ),
 		[ mediaCategories ]
 	);
+	const baseCssClass = 'block-editor-inserter__media-tabs';
+	const onSelectMedia = useCallback(
+		( media ) => {
+			if ( ! media?.url ) {
+				return;
+			}
+			const [ block ] = getBlockAndPreviewFromMedia( media, media.type );
+			onInsert( block );
+		},
+		[ onInsert ]
+	);
 
 	if ( ! categories.length ) {
 		return <InserterNoResults />;
 	}
 
 	return (
-		<InserterContentNavigator categories={ categories }>
-			{ ( category ) => (
-				<MediaCategoryPanel
-					onInsert={ onInsert }
-					rootClientId={ rootClientId }
-					category={ category }
+		<>
+			<InserterContentNavigator
+				className={ baseCssClass }
+				categories={ categories }
+			>
+				{ ( category ) => (
+					<MediaCategoryPanel
+						onInsert={ onInsert }
+						rootClientId={ rootClientId }
+						category={ category }
+					/>
+				) }
+			</InserterContentNavigator>
+			<MediaUploadCheck>
+				<MediaUpload
+					multiple={ false }
+					onSelect={ onSelectMedia }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					render={ ( { open } ) => (
+						<Button
+							onClick={ ( event ) => {
+								// Safari doesn't emit a focus event on button elements when
+								// clicked and we need to manually focus the button here.
+								// The reason is that core's Media Library modal explicitly triggers a
+								// focus event and therefore a `blur` event is triggered on a different
+								// element, which doesn't contain the `data-unstable-ignore-focus-outside-for-relatedtarget`
+								// attribute making the Inserter dialog to close.
+								event.target.focus();
+								open();
+							} }
+							className="block-editor-inserter__media-library-button"
+							variant="secondary"
+							data-unstable-ignore-focus-outside-for-relatedtarget=".media-modal"
+						>
+							{ __( 'Open Media Library' ) }
+						</Button>
+					) }
 				/>
-			) }
-		</InserterContentNavigator>
+			</MediaUploadCheck>
+		</>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -26,8 +26,7 @@ import Tips from './tips';
 import InserterPreviewPanel from './preview-panel';
 import BlockTypesTab from './block-types-tab';
 import BlockPatternsTab from './block-patterns-tab';
-import { PatternCategoryPreviewPanel } from './block-patterns-tab/pattern-category-preview-panel';
-import { MediaTab, MediaCategoryPanel } from './media-tab';
+import { MediaTab } from './media-tab';
 import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
@@ -133,13 +132,6 @@ function InserterMenu(
 		[ setSelectedPatternCategory, onPatternCategorySelection ]
 	);
 
-	const showPatternPanel =
-		selectedTab === 'patterns' &&
-		! delayedFilterValue &&
-		!! selectedPatternCategory;
-
-	const showMediaPanel = selectedTab === 'media' && !! selectedMediaCategory;
-
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {
 			return null;
@@ -233,18 +225,7 @@ function InserterMenu(
 				onInsert={ onInsertPattern }
 				onSelectCategory={ onClickPatternCategory }
 				selectedCategory={ selectedPatternCategory }
-			>
-				{ showPatternPanel && (
-					<PatternCategoryPreviewPanel
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsertPattern }
-						onHover={ onHoverPattern }
-						category={ selectedPatternCategory }
-						patternFilter={ patternFilter }
-						showTitlesAsTooltip
-					/>
-				) }
-			</BlockPatternsTab>
+			/>
 		);
 	}, [
 		destinationRootClientId,
@@ -253,7 +234,6 @@ function InserterMenu(
 		onClickPatternCategory,
 		patternFilter,
 		selectedPatternCategory,
-		showPatternPanel,
 	] );
 
 	const mediaTab = useMemo( () => {
@@ -263,22 +243,13 @@ function InserterMenu(
 				selectedCategory={ selectedMediaCategory }
 				onSelectCategory={ setSelectedMediaCategory }
 				onInsert={ onInsert }
-			>
-				{ showMediaPanel && (
-					<MediaCategoryPanel
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsert }
-						category={ selectedMediaCategory }
-					/>
-				) }
-			</MediaTab>
+			/>
 		);
 	}, [
 		destinationRootClientId,
 		onInsert,
 		selectedMediaCategory,
 		setSelectedMediaCategory,
-		showMediaPanel,
 	] );
 
 	const handleSetSelectedTab = ( value ) => {
@@ -304,7 +275,6 @@ function InserterMenu(
 	return (
 		<div
 			className={ clsx( 'block-editor-inserter__menu', {
-				'show-panel': showPatternPanel || showMediaPanel,
 				'is-zoom-out': isZoomOutMode,
 			} ) }
 			ref={ ref }

--- a/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
+++ b/packages/block-editor/src/components/inserter/mobile-tab-navigation.js
@@ -1,48 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { isRTL } from '@wordpress/i18n';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalSpacer as Spacer,
-	__experimentalHeading as Heading,
-	__experimentalView as View,
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
 	__experimentalNavigatorButton as NavigatorButton,
-	__experimentalNavigatorBackButton as NavigatorBackButton,
 	FlexBlock,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
-
-function ScreenHeader( { title } ) {
-	return (
-		<VStack spacing={ 0 }>
-			<View>
-				<Spacer marginBottom={ 0 } paddingX={ 4 } paddingY={ 3 }>
-					<HStack spacing={ 2 }>
-						<NavigatorBackButton
-							style={
-								// TODO: This style override is also used in ToolsPanelHeader.
-								// It should be supported out-of-the-box by Button.
-								{ minWidth: 24, padding: 0 }
-							}
-							icon={ isRTL() ? chevronRight : chevronLeft }
-							size="small"
-							label={ __( 'Back' ) }
-						/>
-						<Spacer>
-							<Heading level={ 5 }>{ title }</Heading>
-						</Spacer>
-					</HStack>
-				</Spacer>
-			</View>
-		</VStack>
-	);
-}
 
 export default function MobileTabNavigation( { categories, children } ) {
 	return (
@@ -76,7 +45,6 @@ export default function MobileTabNavigation( { categories, children } ) {
 					key={ category.name }
 					path={ `/category/${ category.name }` }
 				>
-					<ScreenHeader title={ __( 'Back' ) } />
 					{ children( category ) }
 				</NavigatorScreen>
 			) ) }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -337,15 +337,9 @@ $block-inserter-tabs-height: 44px;
 	left: 0;
 	height: calc(100% + #{$border-width});
 	width: 100%;
+	padding: 0 $grid-unit-20;
 	display: flex;
 	flex-direction: column;
-	
-	@include break-medium {
-		border-left: $border-width solid $gray-200;
-		padding: 0;
-		left: 100%;
-	}
-
 	.block-editor-inserter__media-list,
 	.block-editor-block-patterns-list {
 		padding: 0 $grid-unit-30 $grid-unit-20;
@@ -541,18 +535,9 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__media-panel {
 	min-height: 100%;
+	padding: $grid-unit-20 $grid-unit-20 0;
 	display: flex;
 	flex-direction: column;
-	position: absolute;
-	top: 0;
-	left: $block-inserter-width;
-	height: 100%;
-	width: 300px;
-	padding: 0;
-	overflow: hidden;
-	background: $gray-100;
-	border-left: $border-width solid $gray-200;
-	border-right: $border-width solid $gray-200;
 
 	.block-editor-inserter__media-panel-spinner {
 		height: 100%;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -542,13 +542,18 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__media-panel {
 	min-height: 100%;
-	padding: 0 $grid-unit-20;
 	display: flex;
 	flex-direction: column;
-
-	@include break-medium {
-		padding: 0;
-	}
+	position: absolute;
+	top: 0;
+	left: $block-inserter-width;
+	height: 100%;
+	width: 300px;
+	padding: 0;
+	overflow: hidden;
+	background: $gray-100;
+	border-left: $border-width solid $gray-200;
+	border-right: $border-width solid $gray-200;
 
 	.block-editor-inserter__media-panel-spinner {
 		height: 100%;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -344,7 +344,6 @@ $block-inserter-tabs-height: 44px;
 		border-left: $border-width solid $gray-200;
 		padding: 0;
 		left: 100%;
-		width: 300px;
 	}
 
 	.block-editor-inserter__media-list,
@@ -668,8 +667,7 @@ $block-inserter-tabs-height: 44px;
 
 
 .block-editor-inserter__mobile-tab-navigation {
-	padding: $grid-unit-20;
-	padding-top: 0;
+	padding: 0;
 	height: 100%;
 
 	> * {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -337,10 +337,9 @@ $block-inserter-tabs-height: 44px;
 	left: 0;
 	height: calc(100% + #{$border-width});
 	width: 100%;
-	padding: 0 $grid-unit-20;
 	display: flex;
 	flex-direction: column;
-
+	
 	@include break-medium {
 		border-left: $border-width solid $gray-200;
 		padding: 0;
@@ -535,9 +534,9 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__media-library-button {
 	&.components-button {
 		padding: $grid-unit-20;
+		margin: $grid-unit-20;
 		justify-content: center;
-		margin-top: $grid-unit-20;
-		width: 100%;
+		width: calc(100% - $grid-unit-20 * 2);
 	}
 }
 
@@ -665,6 +664,7 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__mobile-tab-navigation {
 	padding: $grid-unit-20;
+	padding-top: 0;
 	height: 100%;
 
 	> * {
@@ -722,17 +722,4 @@ $block-inserter-tabs-height: 44px;
 // Only relevant in zoom-out-mode
 .block-editor-inserter__pattern-panel-placeholder {
 	display: none;
-}
-
-.block-editor-inserter__menu.is-zoom-out {
-	display: flex;
-	&.show-panel::after {
-		// Makes space for the inserter flyout panel
-		@include break-medium {
-			content: "";
-			display: block;
-			width: 300px;
-			height: 100%;
-		}
-	}
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -106,7 +106,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__search {
-	padding: $grid-unit-20 $grid-unit-20 0 $grid-unit-20;
+	padding: $grid-unit-20;
 }
 
 .block-editor-inserter__tabs {
@@ -161,7 +161,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__panel-header {
 	display: inline-flex;
 	align-items: center;
-	padding: $grid-unit-20 $grid-unit-20 0;
+	padding: $grid-unit-10 $grid-unit-20 0;
 }
 
 .block-editor-inserter__panel-content {
@@ -337,7 +337,6 @@ $block-inserter-tabs-height: 44px;
 	left: 0;
 	height: calc(100% + #{$border-width});
 	width: 100%;
-	padding: 0 $grid-unit-20;
 	display: flex;
 	flex-direction: column;
 	.block-editor-inserter__media-list,
@@ -347,7 +346,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__patterns-category-panel-header {
-	padding: $grid-unit-10 $grid-unit-30;
+	padding: 0 $grid-unit-10;
 }
 
 .block-editor-inserter__patterns-category-no-results {
@@ -652,7 +651,7 @@ $block-inserter-tabs-height: 44px;
 
 
 .block-editor-inserter__mobile-tab-navigation {
-	padding: 0;
+	padding: 0 $grid-unit-10;
 	height: 100%;
 
 	> * {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -346,7 +346,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__patterns-category-panel-header {
-	padding: 0 $grid-unit-10;
+	padding: 0 $grid-unit-20;
 }
 
 .block-editor-inserter__patterns-category-no-results {
@@ -533,10 +533,8 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__media-panel {
-	min-height: 100%;
-	padding: $grid-unit-20 $grid-unit-20 0;
+	padding: $grid-unit-20;
 	display: flex;
-	flex-direction: column;
 
 	.block-editor-inserter__media-panel-spinner {
 		height: 100%;
@@ -651,7 +649,6 @@ $block-inserter-tabs-height: 44px;
 
 
 .block-editor-inserter__mobile-tab-navigation {
-	padding: 0 $grid-unit-10;
 	height: 100%;
 
 	> * {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -412,8 +412,8 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__quick-inserter-patterns {
 	.block-editor-block-patterns-list {
-		display: grid;
-		grid-template-columns: 1fr;
+		display: flex;
+		flex-direction: column;
 		grid-gap: $grid-unit-10;
 		.block-editor-block-patterns-list__list-item {
 			margin-bottom: 0;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -107,6 +107,7 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__search {
 	padding: $grid-unit-20;
+	padding-bottom: $grid-unit-10;
 }
 
 .block-editor-inserter__tabs {
@@ -346,7 +347,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__patterns-category-panel-header {
-	padding: 0 $grid-unit-20;
+	padding: $grid-unit-05 $grid-unit-20 $grid-unit-20;
 }
 
 .block-editor-inserter__patterns-category-no-results {
@@ -647,6 +648,9 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
+.block-editor-inserter__mobile-tab-navigation .components-button {
+	padding-right: $grid-unit-10;
+}
 
 .block-editor-inserter__mobile-tab-navigation {
 	height: 100%;
@@ -656,6 +660,9 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
+.block-editor-inserter__mobile-tab-navigation-buttons {
+	padding: $grid-unit-10;
+}
 
 .block-editor-inserter-media-tab-media-preview-inserter-external-image-modal {
 	@include break-small() {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -419,7 +419,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__quick-inserter-patterns {
 	.block-editor-block-patterns-list {
 		display: grid;
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: 1fr;
 		grid-gap: $grid-unit-10;
 		.block-editor-block-patterns-list__list-item {
 			margin-bottom: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Enables on large viewports the same drill down navigation we have in the site editor sidebar and in the small viewport for inserter categories, and in the process removes the preview pane.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The preview pane is not very useful: it creates another content area to skip for focus management, and it uses a lot of viewport area which is quite precious for assembling patterns (e.g. it should be possible on a large viewport to have both the inserter and the inspector open and assemble patterns). All that just to keep the category list available.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Copies over the component used for the small viewport and adjusts it to also work on larger viewports.
- Removes some zoom out layout tweaks.
- Enables the assembling in zoom out mode when the pattern tab of the inserter is accessed (as opposed to when a category is accessed)
- Tries to make the media and patterns behave the same on category navigation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to the site editor
2. Go to Pages and edit a page
3. Open the inserter
4. Open the patterns tab
5. **Notice zoom out mode is engaged**
6. **Notice the list of pattern categores**
7. Click a category
8. **Notice the patterns appear in the same panel**
9. Enable responsive mode
10. **Small viewport experience should be unchanged**


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/107534/ca660195-4876-4df4-8c12-180bab94ddbf

**Known Issues**

- [ ] There are some styling refinements required so that all panels look well spaced and similar
- [ ] There is a wild super scroll appearing when searching for patterns
- [ ] There is a sneaky disappearing scroll when the pattern list is rendering
- [ ] Somehow switching viewport size (?) may result in zoom out mode stuck to on
- [ ] We should move up the search in media if possible so that all tabs have the same UI structure
