### PR TITLE
theme.json schema: remove duplicate key

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2300,7 +2300,6 @@
 						},
 						"background": {},
 						"color": {},
-						"dimensions": {},
 						"layout": {},
 						"lightbox": {},
 						"spacing": {},


### PR DESCRIPTION

## What?
Removes the duplicate `settings.dimensions` key from the theme.json schema.

![image](https://github.com/WordPress/gutenberg/assets/54422211/242d408d-5ae4-4a8d-a432-9e1f63af2241)

## Why?
This key appears to have been added in #47271, but I think that's not what we intended.