### PR TITLE
Preserve controlled inner blocks on RESET_BLOCKS

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -592,16 +592,31 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 	if ( action.type === 'RESET_BLOCKS' ) {
 		const newState = {
 			...state,
-			byClientId: new Map(
-				getFlattenedBlocksWithoutAttributes( action.blocks )
-			),
-			attributes: new Map( getFlattenedBlockAttributes( action.blocks ) ),
-			order: mapBlockOrder( action.blocks ),
-			parents: new Map( mapBlockParents( action.blocks ) ),
-			controlledInnerBlocks: {},
+			byClientId: new Map( state?.byClientId ),
+			attributes: new Map( state?.attributes ),
+			order: new Map( state?.order ),
+			parents: new Map( state?.parents ),
+			tree: new Map( state?.tree ),
+			controlledInnerBlocks: state?.controlledInnerBlocks ?? {},
 		};
-
-		newState.tree = new Map( state?.tree );
+		for ( const [ key, value ] of getFlattenedBlocksWithoutAttributes(
+			action.blocks
+		) ) {
+			newState.byClientId.set( key, value );
+		}
+		for ( const [ key, value ] of getFlattenedBlockAttributes(
+			action.blocks
+		) ) {
+			newState.attributes.set( key, value );
+		}
+		for ( const [ key, value ] of mapBlockOrder( action.blocks ) ) {
+			if ( ! newState.controlledInnerBlocks[ key ] ) {
+				newState.order.set( key, value );
+			}
+		}
+		for ( const [ key, value ] of mapBlockParents( action.blocks ) ) {
+			newState.parents.set( key, value );
+		}
 		updateBlockTreeForBlocks( newState, action.blocks );
 		newState.tree.set( '', {
 			innerBlocks: action.blocks.map( ( subBlock ) =>


### PR DESCRIPTION
Experiment inspired by #61480. `RESET_BLOCKS` action destroys the `controlledInnerBlocks` state and also doesn't carry over the info about controlled inner blocks. `useBlockSync` then needs special code to quickly recover the controlled state and to set the controller inner blocks again.

This PR attempts to improve the `RESET_BLOCKS` action so that the controlled blocks state is carried over. That means:
- `state.controlledInnerBlocks` is preserved, and we continue to know that a block with certain `clientId` should be controlled.
- the state (`state.attributes`, `state.byClientId`, ...) for controlled inner blocks is preserved. Previously only the state for the new blocks and their uncontrolled children (`innerBlocks`) was part of the new state, the rest was forgotten.
- if block has controlled inner blocks, its `state.order` contains the controlled blocks, it's not reset to uncontrolled. These are still in `state.tree`, and will be written to `state.order` if the block switches to uncontrolled mode.

Let's see how this fares with the e2e tests.

Currently the `RESET_BLOCKS` reducer carries over too much info: it keeps everything that was in the previous state, and only adds info from `action.blocks`. This is harmless, but inefficient. If the experiment proves viable, I'll improve the code to carry over only the old controlled blocks + new blocks from `action.blocks`.