### PR TITLE
Background image: explicitly set background repeat value in user styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -346,15 +346,7 @@ function BackgroundSizeToolsPanelItem( {
 		inheritedValue?.background?.backgroundSize;
 	const repeatValue =
 		style?.background?.backgroundRepeat ||
-		/*
-		 * Edge case where theme.json has a backgroundSize value of 'cover'
-		 * and a backgroundRepeat value. If a user backgroundSize is set,
-		 * ignore the inherited backgroundRepeat value as style?.background?.backgroundRepeat
-		 * is deliberately set to undefined in updateBackgroundSize().
-		 */
-		( !! style?.background?.backgroundSize
-			? undefined
-			: inheritedValue?.background?.backgroundRepeat );
+		inheritedValue?.background?.backgroundRepeat;
 	const imageValue =
 		style?.background?.backgroundImage?.url ||
 		inheritedValue?.background?.backgroundImage?.url;
@@ -447,7 +439,7 @@ function BackgroundSizeToolsPanelItem( {
 			setImmutably(
 				style,
 				[ 'background', 'backgroundRepeat' ],
-				repeatCheckedValue === true ? 'no-repeat' : undefined
+				repeatCheckedValue === true ? 'no-repeat' : 'repeat'
 			)
 		);
 

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -346,7 +346,15 @@ function BackgroundSizeToolsPanelItem( {
 		inheritedValue?.background?.backgroundSize;
 	const repeatValue =
 		style?.background?.backgroundRepeat ||
-		inheritedValue?.background?.backgroundRepeat;
+		/*
+		 * Edge case where theme.json has a backgroundSize value of 'cover'
+		 * and a backgroundRepeat value. If a user backgroundSize is set,
+		 * ignore the inherited backgroundRepeat value as style?.background?.backgroundRepeat
+		 * is deliberately set to undefined in updateBackgroundSize().
+		 */
+		( !! style?.background?.backgroundSize
+			? undefined
+			: inheritedValue?.background?.backgroundRepeat );
 	const imageValue =
 		style?.background?.backgroundImage?.url ||
 		inheritedValue?.background?.backgroundImage?.url;

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -44,7 +44,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	backgroundRepeat: {
 		value: [ 'background', 'backgroundRepeat' ],
 		support: [ 'background', 'backgroundRepeat' ],
-		useEngine: false,
+		useEngine: true,
 	},
 	backgroundSize: {
 		value: [ 'background', 'backgroundSize' ],

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -44,11 +44,16 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	backgroundRepeat: {
 		value: [ 'background', 'backgroundRepeat' ],
 		support: [ 'background', 'backgroundRepeat' ],
-		useEngine: true,
+		useEngine: false,
 	},
 	backgroundSize: {
 		value: [ 'background', 'backgroundSize' ],
 		support: [ 'background', 'backgroundSize' ],
+		useEngine: true,
+	},
+	backgroundPosition: {
+		value: [ 'background', 'backgroundPosition' ],
+		support: [ 'background', 'backgroundPosition' ],
 		useEngine: true,
 	},
 	borderColor: {

--- a/packages/style-engine/src/styles/background/index.ts
+++ b/packages/style-engine/src/styles/background/index.ts
@@ -39,7 +39,7 @@ const backgroundImage = {
 };
 
 const backgroundPosition = {
-	name: 'backgroundRepeat',
+	name: 'backgroundPosition',
 	generate: ( style: Style, options: StyleOptions ) => {
 		return generateRule(
 			style,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Explicitly sets a "repeat" value for user background repeat styles.

Also adds/fixes some missing styles properties.


## Why?

This mainly fixes an edge case where theme.json defines background size of "cover" and "no-repeat".

```
"backgroundRepeat": "no-repeat",
"backgroundSize": "cover"
```

Now, these two properties don't really work together visually, but they're valid CSS. 

When setting `backgroundRepeat` to `undefined` in user styles, it seems as if the theme.json value will take precedence during the  global styles config merge of the two styles objects (theme.json and user).

This is of course undesirable as the user styles should take precedence, but since it we set it to undefined Gutenberg will go for the truthy value when merging.

## How?

The only fix I could come up with was setting the string value of "repeat" to ensure the user styles take precedence.


## Testing Instructions

Check that the global styles background image controls are still usable in the site editor with the follow theme.json.

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"color": {
			"text": "green"
		},
		"background": {
			"backgroundImage": {
				"url": "https://images.pexels.com/photos/20111605/pexels-photo-20111605/free-photo-of-surf-in-ericeira.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
			},
			"backgroundPosition": "center center",
			"backgroundRepeat": "no-repeat",
			"backgroundSize": "cover"
		}
	}
}
```

All other manifestations should work as expected, and their values should show up in the global styles background image controls, e.g., 

```
"backgroundRepeat": "no-repeat",
"backgroundSize": "contain"
```

```
"backgroundRepeat": "repeat",
"backgroundSize": "contain"
```

```
"backgroundRepeat": "no-repeat",
```

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/6458278/c9f2a438-992c-4d17-b247-34a1762546b2



### After

https://github.com/WordPress/gutenberg/assets/6458278/4e87ba9f-1c55-4e48-ae81-35ad2ebd6183







