### PR TITLE
Make `BlockPopover` component public

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -207,6 +207,10 @@ _Related_
 
 Undocumented declaration.
 
+### BlockPopover
+
+Undocumented declaration.
+
 ### BlockPreview
 
 BlockPreview renders a preview of a block or array of blocks.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -209,7 +209,9 @@ Undocumented declaration.
 
 ### BlockPopover
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-popover/README.md>
 
 ### BlockPreview
 

--- a/packages/block-editor/src/components/block-popover/README.md
+++ b/packages/block-editor/src/components/block-popover/README.md
@@ -30,7 +30,7 @@ This determines whether the block popover always shifts into the viewport or rem
 -	Required: No
 -	Default: `true`
 
-## BlockPopoverInbetween
+## BlockPopoverInbetween - Private Component
 
 ### Props
 

--- a/packages/block-editor/src/components/block-popover/cover.js
+++ b/packages/block-editor/src/components/block-popover/cover.js
@@ -7,7 +7,7 @@ import { useEffect, useState, useMemo, forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-block-props/use-block-refs';
-import BlockPopover from '.';
+import { PrivateBlockPopover } from '.';
 
 function BlockPopoverCover(
 	{ clientId, bottomClientId, children, shift = false, ...props },
@@ -18,7 +18,7 @@ function BlockPopoverCover(
 	const selectedElement = useBlockElement( clientId );
 
 	return (
-		<BlockPopover
+		<PrivateBlockPopover
 			ref={ ref }
 			clientId={ clientId }
 			bottomClientId={ bottomClientId }
@@ -32,7 +32,7 @@ function BlockPopoverCover(
 			) : (
 				children
 			) }
-		</BlockPopover>
+		</PrivateBlockPopover>
 	);
 }
 

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -160,7 +160,7 @@ const PublicBlockPopover = ( {
 	children,
 	...props
 } ) => (
-	<BlockPopover
+	<PrivateBlockPopover
 		{ ...props }
 		bottomClientId={ bottomClientId }
 		clientId={ clientId }
@@ -168,10 +168,10 @@ const PublicBlockPopover = ( {
 		__unstablePopoverSlot={ undefined }
 	>
 		{ children }
-	</BlockPopover>
+	</PrivateBlockPopover>
 );
 
 /**
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-popover/README.md
  */
-export default forwardRef( PublicBlockPopover );
+export default PublicBlockPopover;

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -154,18 +154,17 @@ function BlockPopover(
 
 export const PrivateBlockPopover = forwardRef( BlockPopover );
 
-const PublicBlockPopover = ( {
-	clientId,
-	bottomClientId,
-	children,
-	...props
-} ) => (
+const PublicBlockPopover = (
+	{ clientId, bottomClientId, children, ...props },
+	ref
+) => (
 	<PrivateBlockPopover
 		{ ...props }
 		bottomClientId={ bottomClientId }
 		clientId={ clientId }
 		__unstableContentRef={ undefined }
 		__unstablePopoverSlot={ undefined }
+		ref={ ref }
 	>
 		{ children }
 	</PrivateBlockPopover>
@@ -174,4 +173,4 @@ const PublicBlockPopover = ( {
 /**
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-popover/README.md
  */
-export default PublicBlockPopover;
+export default forwardRef( PublicBlockPopover );

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -152,4 +152,26 @@ function BlockPopover(
 	);
 }
 
-export default forwardRef( BlockPopover );
+export const PrivateBlockPopover = forwardRef( BlockPopover );
+
+const PublicBlockPopover = ( {
+	clientId,
+	bottomClientId,
+	children,
+	...props
+} ) => (
+	<BlockPopover
+		{ ...props }
+		bottomClientId={ bottomClientId }
+		clientId={ clientId }
+		__unstableContentRef={ undefined }
+		__unstablePopoverSlot={ undefined }
+	>
+		{ children }
+	</BlockPopover>
+);
+
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-popover/README.md
+ */
+export default forwardRef( PublicBlockPopover );

--- a/packages/block-editor/src/components/block-tools/block-toolbar-breadcrumb.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-breadcrumb.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * Internal dependencies
  */
 import BlockSelectionButton from './block-selection-button';
-import BlockPopover from '../block-popover';
+import { PrivateBlockPopover } from '../block-popover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
 
@@ -28,7 +28,7 @@ export default function BlockToolbarBreadcrumb( {
 	} );
 
 	return (
-		<BlockPopover
+		<PrivateBlockPopover
 			clientId={ capturingClientId || clientId }
 			bottomClientId={ lastClientId }
 			className={ clsx( 'block-editor-block-list__block-popover', {
@@ -41,6 +41,6 @@ export default function BlockToolbarBreadcrumb( {
 				clientId={ clientId }
 				rootClientId={ rootClientId }
 			/>
-		</BlockPopover>
+		</PrivateBlockPopover>
 	);
 }

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -160,6 +160,7 @@ export {
 export { default as __experimentalBlockPatternsList } from './block-patterns-list';
 export { default as __experimentalPublishDateTimePicker } from './publish-date-time-picker';
 export { default as __experimentalInspectorPopoverHeader } from './inspector-popover-header';
+export { default as BlockPopover } from './block-popover';
 export { useBlockEditingMode } from './block-editing-mode';
 
 /*

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -38,6 +38,7 @@ import {
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
 import { PrivateRichText } from './components/rich-text/';
+import { PrivateBlockPopover } from './components/block-popover';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -76,4 +77,5 @@ lock( privateApis, {
 	requiresWrapperOnCopy,
 	PrivateRichText,
 	reusableBlocksSelectKey,
+	PrivateBlockPopover,
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

> [!NOTE]  
> This PR is just a draft to get feedback. If making sense to make the `BlockPopover` component public, I would suggest marking it as an unstable API and improving the documentation.

This PR makes the `BlockPopover` component public. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, a consumer can add the Gutenberg toolbar block with the `BlockToolbar` component. Hoverwer, the `BlockToolbar` isn't flexible, and it is complex to hide/show different buttons and text. 

Making `BlockPopover` public allows a consumer to create a custom `BlockToolbar` and customize it according to application needs.

This PR could be part of https://github.com/WordPress/gutenberg/issues/53874.

You can check https://github.com/woocommerce/woocommerce/issues/47323 and https://github.com/woocommerce/woocommerce/pull/47322 for a real-use case.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
