### PR TITLE
build:package-types: Run silently to reduce user confusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,8 @@
 	"scripts": {
 		"build": "npm run build:packages && wp-scripts build",
 		"build:analyze-bundles": "npm run build -- --webpack-bundle-analyzer",
-		"build:package-types": "node ./bin/packages/validate-typescript-version.js && ( tsc --build || ( echo 'tsc failed. Try cleaning up first: `npm run clean:package-types`'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js",
+		"build:package-types": "npm run --silent build:package-types:verbose",
+		"build:package-types:verbose": "node ./bin/packages/validate-typescript-version.js && ( tsc --build || ( echo 'tsc failed. Try cleaning up first: `npm run clean:package-types`'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js",
 		"prebuild:packages": "npm run clean:packages && lerna run build",
 		"build:packages": "npm run build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",

--- a/package.json
+++ b/package.json
@@ -268,10 +268,9 @@
 	"scripts": {
 		"build": "npm run build:packages && wp-scripts build",
 		"build:analyze-bundles": "npm run build -- --webpack-bundle-analyzer",
-		"build:package-types": "npm run --silent build:package-types:verbose",
-		"build:package-types:verbose": "node ./bin/packages/validate-typescript-version.js && ( tsc --build || ( echo 'tsc failed. Try cleaning up first: `npm run clean:package-types`'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js",
+		"build:package-types": "node ./bin/packages/validate-typescript-version.js && ( tsc --build || ( echo 'tsc failed. Try cleaning up first: `npm run clean:package-types`'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js",
 		"prebuild:packages": "npm run clean:packages && lerna run build",
-		"build:packages": "npm run build:package-types && node ./bin/packages/build.js",
+		"build:packages": "npm run --silent build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
 		"clean:package-types": "tsc --build --clean",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",


### PR DESCRIPTION
Follows up on #61501.

The original PR, #61501, modified the `build:package-types` script to log a help message to developers if the `tsc --build` call failed. This message suggested a fix (to run `npm run clean:package-types`).

This works, but due to the way that NPM logs the execution of successive NPM scripts, the code that conditionally outputs the help message is, itself, always output. This is not only noisy, but could mislead developers into following the help message's instruction unnecessarily.

This PR fixes the problem by requiring the caller script (`build:packages`) to use NPM's `--silent` flag. The console output now looks like this:

> gutenberg@18.3.0 build:packages
> npm run --silent build:package-types && node ./bin/packages/build.js

Before | After
-|-
<img alt="before" src="https://private-user-images.githubusercontent.com/7753001/329169392-30a7bebb-a380-4ae9-ad2c-e582293e96d3.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTUyNjY0MjYsIm5iZiI6MTcxNTI2NjEyNiwicGF0aCI6Ii83NzUzMDAxLzMyOTE2OTM5Mi0zMGE3YmViYi1hMzgwLTRhZTktYWQyYy1lNTgyMjkzZTk2ZDMucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDUwOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA1MDlUMTQ0ODQ2WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YzU0YjYzNWM3OTE3NjRmNjJmYzYzNDQ5YjU1NGMzNjE3OTk3OTk3ZmRlZDFiZDc1Yzc4NDVkYmZjNDExM2YyOSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.Ec_RxAXjKaVbboe83ZKIDPzfyQmDAaTa8M5veDZKt9M"> | <img alt="build-package-types-silenced" src="https://github.com/WordPress/gutenberg/assets/150562/1f5ede7b-2e72-4901-b55e-dfb662bb68a4">