### PR TITLE
Added missing @global documentation

### DIFF
--- a/lib/compat/wordpress-6.4/script-loader.php
+++ b/lib/compat/wordpress-6.4/script-loader.php
@@ -11,6 +11,9 @@
  * @since 6.0.0
  * @access private
  *
+ * @global WP_Styles $wp_styles
+ * @global WP_Scripts $wp_scripts
+ *
  * @return array {
  *     The block editor assets.
  *


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/61536