### PR TITLE
Latest Posts: Fix video overflow in full content mode

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -116,5 +116,10 @@
 		}
 	},
 	"editorStyle": "wp-block-latest-posts-editor",
-	"style": "wp-block-latest-posts"
+	"style": [
+		"wp-block-latest-posts",
+		"wp-block-video",
+		"wp-block-cover",
+		"wp-block-media-text"
+	]
 }

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -30,6 +30,30 @@
 		}
 	}
 
+	.wp-block-video {
+		box-sizing: border-box;
+
+		video {
+			vertical-align: middle;
+			width: 100%;
+		}
+
+		&.aligncenter {
+			text-align: center;
+		}
+
+		figcaption {
+			margin-bottom: 1em;
+			margin-top: 0.5em;
+		}
+
+		@supports (position: sticky) {
+			[poster] {
+				object-fit: cover;
+			}
+		}
+	}
+
 	@include break-small {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } li {

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -30,30 +30,6 @@
 		}
 	}
 
-	.wp-block-video {
-		box-sizing: border-box;
-
-		video {
-			vertical-align: middle;
-			width: 100%;
-		}
-
-		&.aligncenter {
-			text-align: center;
-		}
-
-		figcaption {
-			margin-bottom: 1em;
-			margin-top: 0.5em;
-		}
-
-		@supports (position: sticky) {
-			[poster] {
-				object-fit: cover;
-			}
-		}
-	}
-
 	@include break-small {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } li {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: #61477 

## Why?
It makes videos contained within the allocated space in the latest posts block by setting appropriate width. Fixes overflow and overlap issues when 'Show full post' option is enabled, preventing horizontal scroll bars.

## How?
Enqueues the styles for video, cover and media-text block in Latest Posts block,

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add a latests posts block
2. Enable "Post content > Show full post" in the block settings panel of the latests post block.

### Testing Instructions for Keyboard
NIL

## Screenshots or screencast <!-- if applicable -->
<img width="1470" alt="image" src="https://github.com/WordPress/gutenberg/assets/77401999/38d9363b-6af5-420d-a3e4-3464102cb948">

---

<img width="1470" alt="image" src="https://github.com/WordPress/gutenberg/assets/77401999/14b8a46f-c676-457e-a7b5-905bc54825cc">
