### PR TITLE
Improve success messages of some post actions.

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -112,9 +112,17 @@ const trashPostAction = {
 										__( '"%s" moved to the Trash.' ),
 										getItemTitle( posts[ 0 ] )
 									);
+								} else if ( posts[ 0 ].type === 'page' ) {
+									successMessage = sprintf(
+										/* translators: The number of pages. */
+										__( '%s pages moved to the Trash.' ),
+										posts.length
+									);
 								} else {
-									successMessage = __(
-										'Pages moved to the Trash.'
+									successMessage = sprintf(
+										/* translators: The number of posts. */
+										__( '%s posts moved to the Trash.' ),
+										posts.length
 									);
 								}
 								createSuccessNotice( successMessage, {
@@ -343,23 +351,30 @@ function useRestorePostAction() {
 						( { status } ) => status === 'fulfilled'
 					)
 				) {
-					createSuccessNotice(
-						posts.length > 1
-							? sprintf(
-									/* translators: The number of posts. */
-									__( '%d posts have been restored.' ),
-									posts.length
-							  )
-							: sprintf(
-									/* translators: The number of posts. */
-									__( '"%s" has been restored.' ),
-									getItemTitle( posts[ 0 ] )
-							  ),
-						{
-							type: 'snackbar',
-							id: 'restore-post-action',
-						}
-					);
+					let successMessage;
+					if ( posts.length === 1 ) {
+						successMessage = sprintf(
+							/* translators: The number of posts. */
+							__( '"%s" has been restored.' ),
+							getItemTitle( posts[ 0 ] )
+						);
+					} else if ( posts[ 0 ].type === 'page' ) {
+						successMessage = sprintf(
+							/* translators: The number of posts. */
+							__( '%d pages have been restored.' ),
+							posts.length
+						);
+					} else {
+						successMessage = sprintf(
+							/* translators: The number of posts. */
+							__( '%d posts have been restored.' ),
+							posts.length
+						);
+					}
+					createSuccessNotice( successMessage, {
+						type: 'snackbar',
+						id: 'restore-post-action',
+					} );
 					if ( onActionPerformed ) {
 						onActionPerformed( posts );
 					}


### PR DESCRIPTION
This PR applies the suggestions by @jameskoster at https://github.com/WordPress/gutenberg/pull/59714#pullrequestreview-2048187594 and improves the success messages of trash and restore pages.


## Screenshots
<img width="273" alt="Screenshot 2024-05-09 at 19 11 00" src="https://github.com/WordPress/gutenberg/assets/11271197/65dcda53-013d-428c-8ebc-0b69585c79b4">
<img width="270" alt="Screenshot 2024-05-09 at 19 10 49" src="https://github.com/WordPress/gutenberg/assets/11271197/97d0ee25-6099-4387-ba1d-b8c6c52dc6e5">




## Testing Instructions
I moved two pages to the trash and verified the success message was "2 pages moved to the Trash.".
I restored the two pages and verified the success message was "2 pages have been restored.".
