### PR TITLE
Remove Post Template background override.

### DIFF
--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -5,10 +5,6 @@
 	list-style: none;
 	padding: 0;
 
-	// Unset background colors that can be inherited from Global Styles with extra specificity.
-	&.wp-block-post-template {
-		background: none;
-	}
 	// These rules no longer apply but should be kept for backwards compatibility.
 	&.is-flex-container {
 		flex-direction: row;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #59455.
Now that #56469 is merged, the override on background styles for the Post Template block is no longer needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In global styles, add a background color to the List block.
2. Check that Post Template block doesn't receive the List background color.
3. Add a background color to Post Template in global styles.
4. Check that Post Template block correctly reflects that background color in both editor and front end.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1341" alt="Screenshot 2024-05-10 at 11 33 42 AM" src="https://github.com/WordPress/gutenberg/assets/8096000/88fb1ec4-af42-44a7-affd-b44687ccb671">
