### PR TITLE
Fix double scrollbars in site editor with zoom out view enabled

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -21,6 +21,7 @@
 .edit-site-visual-editor {
 	position: relative;
 	height: 100%;
+	overflow: hidden;
 	display: block;
 	background-color: $gray-300;
 	// Centralize the editor horizontally (flex-direction is column).

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -5,8 +5,10 @@ html.interface-interface-skeleton__html-container {
 	width: 100%;
 
 	@include break-medium() {
-		position: initial;
-		width: initial;
+		&:not(:has(.is-zoom-out)) {
+			position: initial;
+			width: initial;
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Maybe fixes: https://github.com/WordPress/gutenberg/issues/61093

I'm not sure if it's the same double scrollbar issue mentioned in the issue, but at some cases depending on the viewport width you can have double scrollbar in site editor when having enabled the zoom out view.



## Testing Instructions
I can't reproduce this reliably, but here are some instructions:

1. Enable the zoom-out mode experiment.
2. Go the site editor and select a page to edit.
3. Trigger the zoom out mode by trying to insert a pattern from the inserter and after that resize the window width until you see the double scrollbar
5. This PR should fix that and introduce no other visual regression



## Screenshots before
<img width="1111" alt="Screenshot 2024-05-10 at 5 01 50 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/e7291437-a5a7-404a-8d9d-1a6b5930d5dd">

