### PR TITLE
Zoom out: try click through to disengage

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -21,8 +21,10 @@ function ZoomOutModeInserters() {
 		sectionRootClientId,
 		insertionPoint,
 		setInserterIsOpened,
+		selectedClientId,
 	} = useSelect( ( select ) => {
-		const { getSettings, getBlockOrder } = select( blockEditorStore );
+		const { getSettings, getBlockOrder, getSelectedBlockClientId } =
+			select( blockEditorStore );
 		const { sectionRootClientId: root } = unlock( getSettings() );
 		// To do: move ZoomOutModeInserters to core/editor.
 		// Or we perhaps we should move the insertion point state to the
@@ -37,10 +39,17 @@ function ZoomOutModeInserters() {
 			sectionRootClientId: root,
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
+			selectedClientId: getSelectedBlockClientId(),
 		};
 	}, [] );
 
 	const isMounted = useRef( false );
+
+	useEffect( () => {
+		if ( selectedClientId && ! blockOrder.includes( selectedClientId ) ) {
+			setInserterIsOpened( { tab: 'blocks' } );
+		}
+	}, [ selectedClientId, blockOrder, setInserterIsOpened ] );
 
 	useEffect( () => {
 		if ( ! isMounted.current ) {

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useRegistry, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
@@ -16,6 +16,7 @@ import { unlock } from '../../lock-unlock';
 
 function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
+	const registry = useRegistry();
 	const {
 		blockOrder,
 		sectionRootClientId,
@@ -47,9 +48,18 @@ function ZoomOutModeInserters() {
 
 	useEffect( () => {
 		if ( selectedClientId && ! blockOrder.includes( selectedClientId ) ) {
-			setInserterIsOpened( { tab: 'blocks' } );
+			const { tab } = unlock(
+				registry.select( 'core/editor' )
+			).getInsertionPoint();
+			if ( tab ) {
+				setInserterIsOpened( { tab: 'blocks' } );
+			} else {
+				registry
+					.dispatch( blockEditorStore )
+					.__unstableSetEditorMode( 'edit' );
+			}
 		}
-	}, [ selectedClientId, blockOrder, setInserterIsOpened ] );
+	}, [ selectedClientId, blockOrder, setInserterIsOpened, registry ] );
 
 	useEffect( () => {
 		if ( ! isMounted.current ) {

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -67,7 +67,7 @@ function ZoomOutModeInserters() {
 			return;
 		}
 		// reset insertion point when the block order changes
-		setInserterIsOpened( true );
+		setInserterIsOpened( { tab: 'patterns' } );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ blockOrder ] );
 

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -21,6 +21,7 @@ function InserterLibrary(
 		showMostUsedBlocks = false,
 		__experimentalInsertionIndex,
 		__experimentalInitialTab,
+		__experimentalSetTab,
 		__experimentalInitialCategory,
 		__experimentalFilterValue,
 		__experimentalOnPatternCategorySelection,
@@ -56,6 +57,7 @@ function InserterLibrary(
 				__experimentalOnPatternCategorySelection
 			}
 			__experimentalInitialTab={ __experimentalInitialTab }
+			__experimentalSetTab={ __experimentalSetTab }
 			__experimentalInitialCategory={ __experimentalInitialCategory }
 			shouldFocusBlock={ shouldFocusBlock }
 			ref={ ref }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -48,7 +48,8 @@ function InserterMenu(
 		shouldFocusBlock = true,
 		__experimentalOnPatternCategorySelection = NOOP,
 		onClose,
-		__experimentalInitialTab,
+		__experimentalInitialTab: selectedTab = 'blocks',
+		__experimentalSetTab: setSelectedTab,
 		__experimentalInitialCategory,
 	},
 	ref
@@ -67,9 +68,6 @@ function InserterMenu(
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
-	const [ selectedTab, setSelectedTab ] = useState(
-		__experimentalInitialTab
-	);
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -22,6 +22,10 @@ export function useZoomOut( zoomOut = true ) {
 	const mode = __unstableGetEditorMode();
 
 	useEffect( () => {
+		originalEditingMode.current = mode;
+	}, [ mode ] );
+
+	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.
 		if ( ! originalEditingMode.current ) {
 			originalEditingMode.current = mode;
@@ -42,5 +46,5 @@ export function useZoomOut( zoomOut = true ) {
 		} else if ( ! zoomOut && originalEditingMode.current !== mode ) {
 			__unstableSetEditorMode( originalEditingMode.current );
 		}
-	}, [ __unstableSetEditorMode, zoomOut, mode ] );
+	}, [ __unstableSetEditorMode, zoomOut ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -2,12 +2,14 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../store';
+
+let originalEditingMode = null;
 
 /**
  * A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
@@ -18,33 +20,25 @@ export function useZoomOut( zoomOut = true ) {
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
 
-	const originalEditingMode = useRef( null );
-	const mode = __unstableGetEditorMode();
-
-	useEffect( () => {
-		originalEditingMode.current = mode;
-	}, [ mode ] );
-
 	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.
-		if ( ! originalEditingMode.current ) {
-			originalEditingMode.current = mode;
-		}
+		originalEditingMode = __unstableGetEditorMode();
 
 		return () => {
 			// We need to use  __unstableGetEditorMode() here and not `mode`, as mode may not update on unmount
-			if ( __unstableGetEditorMode() !== originalEditingMode.current ) {
-				__unstableSetEditorMode( originalEditingMode.current );
+			if ( __unstableGetEditorMode() !== originalEditingMode ) {
+				__unstableSetEditorMode( originalEditingMode );
 			}
 		};
 	}, [] );
 
 	// The effect opens the zoom-out view if we want it open and it's not currently in zoom-out mode.
 	useEffect( () => {
+		const mode = __unstableGetEditorMode();
 		if ( zoomOut && mode !== 'zoom-out' ) {
 			__unstableSetEditorMode( 'zoom-out' );
-		} else if ( ! zoomOut && originalEditingMode.current !== mode ) {
-			__unstableSetEditorMode( originalEditingMode.current );
+		} else if ( ! zoomOut && originalEditingMode !== mode ) {
+			__unstableSetEditorMode( originalEditingMode );
 		}
 	}, [ __unstableSetEditorMode, zoomOut ] );
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2898,9 +2898,9 @@ export const getBlockEditingMode = createRegistrySelector(
 					sectionRootClientId
 				);
 				if ( ! sectionsClientIds?.includes( clientId ) ) {
-					return getBlockParents( state, clientId ).some(
-						( parentClientId ) =>
-							isBlockSelected( state, parentClientId )
+					return isBlockSelected(
+						state,
+						getBlockRootClientId( state, clientId )
 					)
 						? 'default'
 						: 'disabled';

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2898,12 +2898,14 @@ export const getBlockEditingMode = createRegistrySelector(
 					sectionRootClientId
 				);
 				if ( ! sectionsClientIds?.includes( clientId ) ) {
-					return isBlockSelected(
-						state,
-						getBlockRootClientId( state, clientId )
-					)
-						? 'default'
-						: 'disabled';
+					if (
+						! isBlockSelected(
+							state,
+							getBlockRootClientId( state, clientId )
+						)
+					) {
+						return 'disabled';
+					}
 				}
 			}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2800,7 +2800,7 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 				sectionRootClientId
 			);
 			if ( sectionClientIds?.includes( clientId ) ) {
-				return true;
+				return ! isBlockSelected( state, clientId );
 			}
 		} else if ( clientId && ! getBlockRootClientId( state, clientId ) ) {
 			return true;
@@ -2898,7 +2898,12 @@ export const getBlockEditingMode = createRegistrySelector(
 					sectionRootClientId
 				);
 				if ( ! sectionsClientIds?.includes( clientId ) ) {
-					return 'disabled';
+					return getBlockParents( state, clientId ).some(
+						( parentClientId ) =>
+							isBlockSelected( state, parentClientId )
+					)
+						? 'default'
+						: 'disabled';
 				}
 			}
 

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -63,6 +63,9 @@ export default function InserterSidebar( {
 						insertionPoint.insertionIndex
 					}
 					__experimentalInitialTab={ insertionPoint.tab }
+					__experimentalSetTab={ ( tab ) => {
+						setIsInserterOpened( { tab } );
+					} }
 					__experimentalInitialCategory={ insertionPoint.category }
 					__experimentalFilterValue={ insertionPoint.filterValue }
 					__experimentalOnPatternCategorySelection={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

To do: try maintaining grey padding when inserter is opened?

![zoom-out-click-through](https://github.com/WordPress/gutenberg/assets/4710635/e137c01f-3875-4b3e-8ddf-5e18b2905576)


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
