### PR TITLE
Only show grid resizer if grid block allows resizing on children.

### DIFF
--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -135,13 +135,17 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 
 function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 	const parentLayout = useLayout() || {};
+	const {
+		type: parentLayoutType = 'default',
+		allowSizingOnChildren = false,
+	} = parentLayout;
 	const rootClientId = useSelect(
 		( select ) => {
 			return select( blockEditorStore ).getBlockRootClientId( clientId );
 		},
 		[ clientId ]
 	);
-	if ( parentLayout.type !== 'grid' ) {
+	if ( parentLayoutType !== 'grid' ) {
 		return null;
 	}
 	if ( ! window.__experimentalEnableGridInteractivity ) {
@@ -150,21 +154,23 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 	return (
 		<>
 			<GridVisualizer clientId={ rootClientId } />
-			<GridItemResizer
-				clientId={ clientId }
-				onChange={ ( { columnSpan, rowSpan } ) => {
-					setAttributes( {
-						style: {
-							...style,
-							layout: {
-								...style?.layout,
-								columnSpan,
-								rowSpan,
+			{ allowSizingOnChildren && (
+				<GridItemResizer
+					clientId={ clientId }
+					onChange={ ( { columnSpan, rowSpan } ) => {
+						setAttributes( {
+							style: {
+								...style,
+								layout: {
+									...style?.layout,
+									columnSpan,
+									rowSpan,
+								},
 							},
-						},
-					} );
-				} }
-			/>
+						} );
+					} }
+				/>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The grid resizer should only appear when the parent block with grid layout explicitly sets `allowSizingOnChildren`. This PR adds a check to only render the resizer if that attribute is present.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the grid resizing experiment under Gutenberg > Experiments;
2. Add a non-empty Query block that contains a Post Template block to a post or template;
3. Set the Post Template to display as a grid;
4. Check that the child blocks of Post Template don't have resizing handles when selected.


## Screenshots or screencast <!-- if applicable -->

Trunk:


<img width="1210" alt="Screenshot 2024-05-10 at 2 24 47 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/990186f0-ff11-4fee-bd00-7b3d159f0117">


This branch:

<img width="1332" alt="Screenshot 2024-05-10 at 2 24 25 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/3f35c697-0844-4fc2-93a1-190012607ce7">

I opted to still display the grid visualiser because I personally like clearly seeing where each spot in the grid starts and ends, but it could also be removed; feedback welcome!