### PR TITLE
Add header title to list view sidebar

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -26,7 +26,6 @@ function InserterLibrary(
 		__experimentalOnPatternCategorySelection,
 		onSelect = noop,
 		shouldFocusBlock = false,
-		onClose,
 	},
 	ref
 ) {
@@ -59,7 +58,6 @@ function InserterLibrary(
 			__experimentalInitialCategory={ __experimentalInitialCategory }
 			shouldFocusBlock={ shouldFocusBlock }
 			ref={ ref }
-			onClose={ onClose }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -47,7 +47,6 @@ function InserterMenu(
 		__experimentalFilterValue = '',
 		shouldFocusBlock = true,
 		__experimentalOnPatternCategorySelection = NOOP,
-		onClose,
 		__experimentalInitialTab,
 		__experimentalInitialCategory,
 	},
@@ -302,7 +301,6 @@ function InserterMenu(
 				<InserterTabs
 					ref={ tabsRef }
 					onSelect={ handleSetSelectedTab }
-					onClose={ onClose }
 					selectedTab={ selectedTab }
 				>
 					{ inserterSearch }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -117,6 +117,8 @@ $block-inserter-tabs-height: 44px;
 
 	.block-editor-inserter__tablist {
 		width: 100%;
+		background-color: $gray-100;
+		border-bottom: $border-width solid $gray-300;
 
 		button[role="tab"] {
 			flex-grow: 1;

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -1,13 +1,9 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
-import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -33,33 +29,23 @@ const mediaTab = {
 	title: __( 'Media' ),
 };
 
-function InserterTabs( { onSelect, children, onClose, selectedTab }, ref ) {
+function InserterTabs( { onSelect, children, selectedTab }, ref ) {
 	const tabs = [ blocksTab, patternsTab, mediaTab ];
 
 	return (
 		<div className="block-editor-inserter__tabs" ref={ ref }>
 			<Tabs onSelect={ onSelect } selectedTabId={ selectedTab }>
-				<div className="block-editor-inserter-sidebar__header">
-					<Button
-						className="block-editor-inserter-sidebar__close-button"
-						icon={ closeSmall }
-						label={ __( 'Close block inserter' ) }
-						onClick={ () => onClose() }
-						size="small"
-					/>
-
-					<Tabs.TabList className="block-editor-inserter__tablist">
-						{ tabs.map( ( tab ) => (
-							<Tabs.Tab
-								key={ tab.name }
-								tabId={ tab.name }
-								className="block-editor-inserter__tab"
-							>
-								{ tab.title }
-							</Tabs.Tab>
-						) ) }
-					</Tabs.TabList>
-				</div>
+				<Tabs.TabList className="block-editor-inserter__tablist">
+					{ tabs.map( ( tab ) => (
+						<Tabs.Tab
+							key={ tab.name }
+							tabId={ tab.name }
+							className="block-editor-inserter__tab"
+						>
+							{ tab.title }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.TabList>
 				{ tabs.map( ( tab ) => (
 					<Tabs.TabPanel
 						key={ tab.name }

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -10,7 +10,9 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useCallback, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ESCAPE } from '@wordpress/keycodes';
-
+import { __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
@@ -73,6 +75,18 @@ export default function InserterSidebar( {
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div onKeyDown={ closeOnEscape } className="editor-inserter-sidebar">
+			<div className="block-editor-inserter-sidebar__header">
+				<span className="block-editor-inserter-sidebar__header-title">
+					{ __( 'Insert' ) }
+				</span>
+				<Button
+					className="block-editor-inserter-sidebar__close-button"
+					icon={ closeSmall }
+					label={ __( 'Close block inserter' ) }
+					onClick={ () => setIsInserterOpened( false ) }
+					size="small"
+				/>
+			</div>
 			<div className="editor-inserter-sidebar__content">
 				<Library
 					showMostUsedBlocks={ showMostUsedBlocks }
@@ -91,7 +105,6 @@ export default function InserterSidebar( {
 						isRightSidebarOpen ? closeGeneralSidebar : undefined
 					}
 					ref={ libraryRef }
-					onClose={ closeInserterSidebar }
 				/>
 			</div>
 		</div>

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -7,15 +7,26 @@
 }
 
 .block-editor-inserter-sidebar__header {
-	border-bottom: $border-width solid $gray-300;
-	padding-right: $grid-unit-10;
 	display: flex;
 	justify-content: space-between;
+	padding: $grid-unit-05 $grid-unit-05 0 $grid-unit-20;
+	background-color: $gray-100;
+}
 
-	.block-editor-inserter-sidebar__close-button {
-		order: 1;
-		align-self: center;
-	}
+.block-editor-inserter-sidebar__header-title {
+	font-size: 12px;
+	font-weight: 500;
+	color: $gray-600;
+	text-transform: uppercase;
+	position: relative;
+	top: $grid-unit-10;
+}
+
+.block-editor-inserter-sidebar__close-button {
+	background: transparent;
+	color: $gray-600;
+	position: relative;
+	z-index: 2; // allow the close button focus ring to be visible
 }
 
 .editor-inserter-sidebar__content {

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -16,7 +16,7 @@
 .block-editor-inserter-sidebar__header-title {
 	font-size: 12px;
 	font-weight: 500;
-	color: $gray-600;
+	color: #6b6b6b;
 	text-transform: uppercase;
 	position: relative;
 	top: $grid-unit-10;
@@ -24,7 +24,7 @@
 
 .block-editor-inserter-sidebar__close-button {
 	background: transparent;
-	color: $gray-600;
+	color: #6b6b6b;
 	position: relative;
 	z-index: 2; // allow the close button focus ring to be visible
 }

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -130,6 +130,9 @@ export default function ListViewSidebar() {
 				defaultTabId="list-view"
 			>
 				<div className="editor-list-view-sidebar__header">
+					<span className="editor-list-view-sidebar__header-title">
+						{ __( 'Document Overview' ) }
+					</span>
 					<Button
 						className="editor-list-view-sidebar__close-button"
 						icon={ closeSmall }
@@ -137,6 +140,8 @@ export default function ListViewSidebar() {
 						onClick={ closeListView }
 						size="small"
 					/>
+				</div>
+				<div className="editor-list-view-sidebar__tabs">
 					<Tabs.TabList
 						className="editor-list-view-sidebar__tabs-tablist"
 						ref={ tabsRef }

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -10,13 +10,29 @@
 	}
 	.editor-list-view-sidebar__header {
 		display: flex;
-		border-bottom: $border-width solid $gray-300;
+		justify-content: space-between;
+		padding: $grid-unit-05 $grid-unit-05 0 $grid-unit-20;
+		background-color: $gray-100;
 	}
+
+	.editor-list-view-sidebar__header-title {
+		font-size: 12px;
+		font-weight: 500;
+		color: $gray-600;
+		text-transform: uppercase;
+		position: relative;
+		top: $grid-unit-10;
+	}
+
 	.editor-list-view-sidebar__close-button {
-		background: $white;
-		order: 1;
-		align-self: center;
-		margin-right: $grid-unit-15;
+		background: transparent;
+		color: $gray-600;
+	}
+
+	.editor-list-view-sidebar__tabs {
+		display: flex;
+		background-color: $gray-100;
+		border-bottom: $border-width solid $gray-300;
 	}
 }
 

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -27,6 +27,8 @@
 	.editor-list-view-sidebar__close-button {
 		background: transparent;
 		color: $gray-600;
+		position: relative;
+		z-index: 2; // allow the close button focus ring to be visible
 	}
 
 	.editor-list-view-sidebar__tabs {

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -18,7 +18,7 @@
 	.editor-list-view-sidebar__header-title {
 		font-size: 12px;
 		font-weight: 500;
-		color: $gray-600;
+		color: #6b6b6b;
 		text-transform: uppercase;
 		position: relative;
 		top: $grid-unit-10;
@@ -26,7 +26,7 @@
 
 	.editor-list-view-sidebar__close-button {
 		background: transparent;
-		color: $gray-600;
+		color: #6b6b6b;
 		position: relative;
 		z-index: 2; // allow the close button focus ring to be visible
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Alternative to https://github.com/WordPress/gutenberg/pull/61514.
Fixes https://github.com/WordPress/gutenberg/issues/59013.

This code is not ready, but should give an idea of what the experience would be like. It is only implemented for the list view and inserter sidebars. The Styles and Settings sidebars have the old style so you can compare the behaviors more easily. Before merging a change like this, we would need to address all the sidebars.

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes accessibility issues where focus order must match visual order, and also not be between the tabs and tab panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Accessibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Moves Close button to before the tabs and add header title.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open inserter, test close button
- Open List view, test close button

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| - | - |
| ![image](https://github.com/WordPress/gutenberg/assets/27339341/7e7fbd6d-9534-4782-8823-e3445f49fcf5) | ![image](https://github.com/WordPress/gutenberg/assets/27339341/af111d92-3cfb-49e9-b04d-33429dbfafd9) |
