### PR TITLE
Show the inserters only when a section is selected

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -21,6 +21,7 @@ function ZoomOutModeInserters() {
 		sectionRootClientId,
 		insertionPoint,
 		setInserterIsOpened,
+		selectedSection,
 	} = useSelect( ( select ) => {
 		const { getSettings, getBlockOrder } = select( blockEditorStore );
 		const { sectionRootClientId: root } = unlock( getSettings() );
@@ -32,6 +33,7 @@ function ZoomOutModeInserters() {
 		// eslint-disable-next-line @wordpress/data-no-store-string-literals
 		const editor = select( 'core/editor' );
 		return {
+			selectedSection: editor.getSelectedBlock(),
 			blockOrder: getBlockOrder( root ),
 			insertionPoint: unlock( editor ).getInsertionPoint(),
 			sectionRootClientId: root,
@@ -62,7 +64,7 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
-	if ( ! isReady ) {
+	if ( ! isReady || ! selectedSection ) {
 		return null;
 	}
 

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -24,6 +24,12 @@ test.describe( 'Zoom Out', () => {
 		await page.getByRole( 'button', { name: 'Styles' } ).click();
 		await page.getByRole( 'button', { name: 'Browse styles' } ).click();
 
+		// select the 1st pattern
+		await page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.locator( 'header' )
+			.click();
+
 		await expect( page.getByLabel( 'Add pattern' ) ).toHaveCount( 3 );
 		await page.getByLabel( 'Add pattern' ).first().click();
 		await expect( page.getByLabel( 'Add pattern' ) ).toHaveCount( 2 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Show the pattern in between inserters only when a pattern is selected.
Closes https://github.com/WordPress/gutenberg/issues/61546. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To allow deselection to actually clear the layout of visual artefacts.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Don't show inserters if there is no selection.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to the site editor
2. Open a page
3. Open the inserter
4. Go to patterns
5. Open a category
6. Insert some patterns
7. Click on a pattern in the canvas
8. Notice the plus button inserters
9. Click on the grey area around the canvas
10. Notice there are not plus button inserters 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1813435/005c53e4-dabe-4965-8408-f67846d0ce6c


