### PR TITLE
Adjust the icons and text of the binding connected blocks

### DIFF
--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
@@ -85,7 +85,7 @@ export default function BlockBindingsToolbarIndicator( { clientIds } ) {
 			? sprintf(
 					/* translators: %1s: The block type's name; %2s: The block's user-provided name. */
 					__( 'This %1$s is editable using the "%2$s" override.' ),
-					firstBlockTitle,
+					firstBlockTitle.toLowerCase(),
 					firstBlockName
 			  )
 			: __( 'These blocks are editable using overrides.' );

--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
@@ -106,12 +106,6 @@ export default function BlockBindingsToolbarIndicator( { clientIds } ) {
 									className="block-editor-block-bindings-toolbar-indicator-icon"
 									showColors
 								/>
-								{ isSingleBlockSelected &&
-									!! firstBlockName && (
-										<span className="block-editor-block-switcher__toggle-text">
-											{ firstBlockName }
-										</span>
-									) }
 							</>
 						}
 						toggleProps={ {

--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
@@ -83,7 +83,7 @@ export default function BlockBindingsToolbarIndicator( { clientIds } ) {
 	if ( isConnectedToPatternOverrides && firstBlockName ) {
 		blockDescription = isSingleBlockSelected
 			? sprintf(
-					/* translators: %1s: The block type's name; %2s: The block's user-provided name. */
+					/* translators: %1s: The block type's name; %2s: The block's user-provided name (the same as the override name). */
 					__( 'This %1$s is editable using the "%2$s" override.' ),
 					firstBlockTitle.toLowerCase(),
 					firstBlockName

--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
@@ -83,7 +83,7 @@ export default function BlockBindingsToolbarIndicator( { clientIds } ) {
 					firstBlockTitle,
 					firstBlockName
 			  )
-			: __( 'These blocks are using the multiple overrides.' );
+			: __( 'These blocks are using multiple overrides.' );
 	}
 	const descriptionId = useId();
 

--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
@@ -3,7 +3,12 @@
  */
 import { useId } from '@wordpress/element';
 import { __, sprintf, _x } from '@wordpress/i18n';
-import { DropdownMenu, ToolbarGroup, ToolbarItem } from '@wordpress/components';
+import {
+	DropdownMenu,
+	ToolbarGroup,
+	ToolbarItem,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { copy } from '@wordpress/icons';
@@ -79,11 +84,11 @@ export default function BlockBindingsToolbarIndicator( { clientIds } ) {
 		blockDescription = isSingleBlockSelected
 			? sprintf(
 					/* translators: %1s: The block type's name; %2s: The block's user-provided name. */
-					__( 'This %1$s is using the "%2$s" override.' ),
+					__( 'This %1$s is editable using the "%2$s" override.' ),
 					firstBlockTitle,
 					firstBlockName
 			  )
-			: __( 'These blocks are using multiple overrides.' );
+			: __( 'These blocks are editable using overrides.' );
 	}
 	const descriptionId = useId();
 
@@ -118,9 +123,9 @@ export default function BlockBindingsToolbarIndicator( { clientIds } ) {
 						} }
 					>
 						{ () => (
-							<span id={ descriptionId }>
+							<Text id={ descriptionId }>
 								{ blockDescription }
-							</span>
+							</Text>
 						) }
 					</DropdownMenu>
 				) }

--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
@@ -1,19 +1,135 @@
 /**
  * WordPress dependencies
  */
-import { ToolbarItem, ToolbarGroup, Icon } from '@wordpress/components';
-import { connection } from '@wordpress/icons';
-import { _x } from '@wordpress/i18n';
+import { useId } from '@wordpress/element';
+import { __, sprintf, _x } from '@wordpress/i18n';
+import { DropdownMenu, ToolbarGroup, ToolbarItem } from '@wordpress/components';
+import { store as blocksStore } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { copy } from '@wordpress/icons';
 
-export default function BlockBindingsToolbarIndicator() {
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import BlockIcon from '../block-icon';
+import useBlockDisplayTitle from '../block-title/use-block-display-title';
+
+export default function BlockBindingsToolbarIndicator( { clientIds } ) {
+	const isSingleBlockSelected = clientIds.length === 1;
+	const { icon, firstBlockName, isConnectedToPatternOverrides } = useSelect(
+		( select ) => {
+			const {
+				getBlockAttributes,
+				getBlockNamesByClientId,
+				getBlocksByClientId,
+			} = select( blockEditorStore );
+			const { getBlockType, getActiveBlockVariation } =
+				select( blocksStore );
+			const blockTypeNames = getBlockNamesByClientId( clientIds );
+			const _firstBlockTypeName = blockTypeNames[ 0 ];
+			const firstBlockType = getBlockType( _firstBlockTypeName );
+			let _icon;
+			if ( isSingleBlockSelected ) {
+				const match = getActiveBlockVariation(
+					_firstBlockTypeName,
+					getBlockAttributes( clientIds[ 0 ] )
+				);
+				// Take into account active block variations.
+				_icon = match?.icon || firstBlockType.icon;
+			} else {
+				const isSelectionOfSameType =
+					new Set( blockTypeNames ).size === 1;
+				// When selection consists of blocks of multiple types, display an
+				// appropriate icon to communicate the non-uniformity.
+				_icon = isSelectionOfSameType ? firstBlockType.icon : copy;
+			}
+
+			return {
+				icon: _icon,
+				firstBlockName: getBlockAttributes( clientIds[ 0 ] ).metadata
+					.name,
+				isConnectedToPatternOverrides: getBlocksByClientId(
+					clientIds
+				).some( ( block ) =>
+					Object.values( block?.attributes.metadata?.bindings ).some(
+						( binding ) =>
+							binding.source === 'core/pattern-overrides'
+					)
+				),
+			};
+		},
+		[ clientIds, isSingleBlockSelected ]
+	);
+	const firstBlockTitle = useBlockDisplayTitle( {
+		clientId: clientIds[ 0 ],
+		maximumLength: 35,
+	} );
+
+	let blockDescription = isSingleBlockSelected
+		? _x(
+				'This block is connected.',
+				'block toolbar button label and description'
+		  )
+		: _x(
+				'These blocks are connected.',
+				'block toolbar button label and description'
+		  );
+	if ( isConnectedToPatternOverrides && firstBlockName ) {
+		blockDescription = isSingleBlockSelected
+			? sprintf(
+					/* translators: %1s: The block type's name; %2s: The block's user-provided name. */
+					__( 'This %1$s is using the "%2$s" override.' ),
+					firstBlockTitle,
+					firstBlockName
+			  )
+			: __( 'These blocks are using the multiple overrides.' );
+	}
+	const descriptionId = useId();
+
 	return (
 		<ToolbarGroup>
-			<ToolbarItem
-				as="div"
-				aria-label={ _x( 'Connected', 'block toolbar button label' ) }
-				className="block-editor-block-bindings-toolbar-indicator"
-			>
-				<Icon icon={ connection } size={ 24 } />
+			<ToolbarItem>
+				{ ( toggleProps ) => (
+					<DropdownMenu
+						className="block-editor-block-bindings-toolbar-indicator"
+						label={ firstBlockTitle }
+						popoverProps={ {
+							placement: 'bottom-start',
+							className:
+								'block-editor-block-bindings-toolbar-indicator__popover',
+						} }
+						icon={
+							<>
+								<BlockIcon
+									icon={ icon }
+									className="block-editor-block-bindings-toolbar-indicator-icon"
+									showColors
+								/>
+								{ isSingleBlockSelected &&
+									!! firstBlockName && (
+										<span className="block-editor-block-switcher__toggle-text">
+											{ firstBlockName }
+										</span>
+									) }
+							</>
+						}
+						toggleProps={ {
+							describedBy: blockDescription,
+							...toggleProps,
+						} }
+						menuProps={ {
+							orientation: 'both',
+							'aria-describedby': descriptionId,
+						} }
+					>
+						{ () => (
+							<span id={ descriptionId }>
+								{ blockDescription }
+							</span>
+						) }
+					</DropdownMenu>
+				) }
 			</ToolbarItem>
 		</ToolbarGroup>
 	);

--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/style.scss
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/style.scss
@@ -1,11 +1,9 @@
-.block-editor-block-bindings-toolbar-indicator {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	padding: 6px;
-	svg {
-		fill: var(--wp-block-synced-color);
-	}
+.block-editor-block-bindings-toolbar-indicator__popover .components-popover__content {
+	min-width: 300px;
+}
+
+.block-editor-block-bindings-toolbar-indicator .block-editor-block-bindings-toolbar-indicator-icon.has-colors svg {
+	fill: var(--wp-block-synced-color);
 }
 
 .editor-collapsible-block-toolbar .block-editor-block-bindings-toolbar-indicator {

--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/style.scss
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/style.scss
@@ -1,5 +1,6 @@
 .block-editor-block-bindings-toolbar-indicator__popover .components-popover__content {
-	min-width: 300px;
+	min-width: 260px;
+	padding: $grid-unit-20;
 }
 
 .block-editor-block-bindings-toolbar-indicator .block-editor-block-bindings-toolbar-indicator-icon.has-colors svg {

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -168,7 +168,7 @@ export function PrivateBlockToolbar( {
 					isLargeViewport &&
 					isDefaultEditingMode && <BlockParentSelector /> }
 				{ isUsingBindings && canBindBlock( blockName ) && (
-					<BlockBindingsIndicator />
+					<BlockBindingsIndicator clientIds={ blockClientIds } />
 				) }
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
 					( isDefaultEditingMode || isSynced ) && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close https://github.com/WordPress/gutenberg/issues/61515 and https://github.com/WordPress/gutenberg/issues/61547.

Adjust the icons and the text descriptions of the binding connected blocks (pattern overrides, connected post meta, etc.)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The generic connection icon is not that helpful and the block type names should be helpful.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adjust `<BlockBindingsToolbarIndicator>`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Create some patterns with overrides and some post meta connected blocks.

You can paste the markup here to create an empty post-meta connected paragraph.
```html
<!-- wp:paragraph {"metadata":{"name":"connect","bindings":{"content":{"source":"core/post-meta","args":{}}}}} -->
<p>Connected</p>
<!-- /wp:paragraph -->
```

## Screenshots or screencast <!-- if applicable -->
**A pattern overrides block**
<img width="480" alt="image" src="https://github.com/WordPress/gutenberg/assets/7753001/11d24470-bd69-4b3e-b7af-5875d089fce8">

**Multiple pattern overrides blocks**
<img width="480" alt="image" src="https://github.com/WordPress/gutenberg/assets/7753001/98627296-4ec5-4048-a251-520048677e58">

**A post-meta connected block**
<img width="480" alt="image" src="https://github.com/WordPress/gutenberg/assets/7753001/5c2b8499-d71d-4a1a-9ab0-718aa5b3827b">

**Multiple post-meta connected blocks**
<img width="480" alt="image" src="https://github.com/WordPress/gutenberg/assets/7753001/21b444ef-3fa3-441e-b8ff-ab4d24a4166c">
