### PR TITLE
Fix being unable to switch modes while inserter is open

### DIFF
--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -29,7 +29,10 @@ export function useZoomOut( zoomOut = true ) {
 
 		return () => {
 			// We need to use  __unstableGetEditorMode() here and not `mode`, as mode may not update on unmount
-			if ( __unstableGetEditorMode() !== originalEditingMode.current ) {
+			if (
+				__unstableGetEditorMode() === 'zoom-out' &&
+				__unstableGetEditorMode() !== originalEditingMode.current
+			) {
 				__unstableSetEditorMode( originalEditingMode.current );
 			}
 		};
@@ -39,7 +42,11 @@ export function useZoomOut( zoomOut = true ) {
 	useEffect( () => {
 		if ( zoomOut && mode !== 'zoom-out' ) {
 			__unstableSetEditorMode( 'zoom-out' );
-		} else if ( ! zoomOut && originalEditingMode.current !== mode ) {
+		} else if (
+			! zoomOut &&
+			__unstableGetEditorMode() === 'zoom-out' &&
+			originalEditingMode.current !== mode
+		) {
 			__unstableSetEditorMode( originalEditingMode.current );
 		}
 	}, [ __unstableSetEditorMode, zoomOut, mode ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
[Bug reported](https://github.com/WordPress/gutenberg/pull/61472#issuecomment-2101959925) by @alexstine 

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes a bug where when the inserter was open, you could not switch modes. This was due to the useZoomOut hook switching modes. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix being unable to switch modes while inserter is open.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a check to only switch away from 'zoom-out' mode if we are indeed in zoom out mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Switch between edit/navigation modes using Escape
- Open the inserter
- Switch between edit/navigation modes using Escape
- Open the pattern tab
- Select a pattern category
- Zoom out mode should activate
- Select a new pattern category
- Should still be in zoom out mode
- Switch to Media tab
- Should exit zoom out mode


## Screenshots or screencast <!-- if applicable -->
