### PR TITLE
PHP load: move rest template controller 6.6 import to "REST" area :)

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -46,6 +46,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php';
 	require_once __DIR__ . '/compat/wordpress-6.5/rest-api.php';
 
+	//WordPress 6.6 compat.
+	require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';
+	require __DIR__ . '/compat/wordpress-6.6/rest-api.php';
+
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';
 	require_once __DIR__ . '/rest-api.php';
@@ -130,8 +134,6 @@ require __DIR__ . '/compat/wordpress-6.6/resolve-patterns.php';
 require __DIR__ . '/compat/wordpress-6.6/block-bindings/pattern-overrides.php';
 require __DIR__ . '/compat/wordpress-6.6/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.6/option.php';
-require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';
-require __DIR__ . '/compat/wordpress-6.6/rest-api.php';
 require __DIR__ . '/compat/wordpress-6.6/post.php';
 
 // Experimental features.

--- a/lib/load.php
+++ b/lib/load.php
@@ -46,7 +46,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php';
 	require_once __DIR__ . '/compat/wordpress-6.5/rest-api.php';
 
-	//WordPress 6.6 compat.
+	// WordPress 6.6 compat.
 	require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';
 	require __DIR__ . '/compat/wordpress-6.6/rest-api.php';
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`WP_REST_Templates_Controller` extends `WP_REST_Controller` so it's probably best if it's loaded with the rest of the REST controllers.


## Testing Instructions

There are no functional changes here.

CI should pass and also templates should work/appear as you'd expected in the site editor.

Check PHP logs just in case.
