### PR TITLE
Upgrade framer-motion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4227,9 +4227,9 @@
 			}
 		},
 		"node_modules/@emotion/memoize": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+			"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
 		},
 		"node_modules/@emotion/native": {
 			"version": "11.0.0",
@@ -58706,9 +58706,9 @@
 			}
 		},
 		"@emotion/memoize": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+			"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
 		},
 		"@emotion/native": {
 			"version": "11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4201,15 +4201,6 @@
 			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
 			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
 		},
-		"node_modules/@emotion/is-prop-valid": {
-			"version": "0.8.8",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-			"optional": true,
-			"dependencies": {
-				"@emotion/memoize": "0.7.4"
-			}
-		},
 		"node_modules/@emotion/jest": {
 			"version": "11.7.1",
 			"resolved": "https://registry.npmjs.org/@emotion/jest/-/jest-11.7.1.tgz",
@@ -28614,6 +28605,30 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/framer-motion": {
+			"version": "11.1.9",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.1.9.tgz",
+			"integrity": "sha512-flECDIPV4QDNcOrDafVFiIazp8X01HFpzc01eDKJsdNH/wrATcYydJSH9JbPWMS8UD5lZlw+J1sK8LG2kICgqw==",
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/fresh": {
@@ -53538,7 +53553,7 @@
 				"deepmerge": "^4.3.0",
 				"downshift": "^6.0.15",
 				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^10.13.0",
+				"framer-motion": "^11.1.9",
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
@@ -53574,17 +53589,6 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
-		},
-		"packages/components/node_modules/framer-motion": {
-			"version": "10.13.0",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.13.0.tgz",
-			"integrity": "sha512-xKhw9VCizmwEHbopOfluaoVunGHSZyMztGbTvsgOYqCjaKu6qtlwWY1J+6GhL41NY1P157JgEikjDm67XCFnvQ==",
-			"dependencies": {
-				"tslib": "^2.4.0"
-			},
-			"optionalDependencies": {
-				"@emotion/is-prop-valid": "^0.8.2"
-			}
 		},
 		"packages/components/node_modules/path-to-regexp": {
 			"version": "6.2.2",
@@ -58687,15 +58691,6 @@
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
 			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
-		},
-		"@emotion/is-prop-valid": {
-			"version": "0.8.8",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-			"optional": true,
-			"requires": {
-				"@emotion/memoize": "0.7.4"
-			}
 		},
 		"@emotion/jest": {
 			"version": "11.7.1",
@@ -68805,7 +68800,7 @@
 				"deepmerge": "^4.3.0",
 				"downshift": "^6.0.15",
 				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^10.13.0",
+				"framer-motion": "^11.1.9",
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
@@ -68829,15 +68824,6 @@
 					"version": "0.1.3",
 					"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 					"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
-				},
-				"framer-motion": {
-					"version": "10.13.0",
-					"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.13.0.tgz",
-					"integrity": "sha512-xKhw9VCizmwEHbopOfluaoVunGHSZyMztGbTvsgOYqCjaKu6qtlwWY1J+6GhL41NY1P157JgEikjDm67XCFnvQ==",
-					"requires": {
-						"@emotion/is-prop-valid": "^0.8.2",
-						"tslib": "^2.4.0"
-					}
 				},
 				"path-to-regexp": {
 					"version": "6.2.2",
@@ -78220,6 +78206,14 @@
 			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
+			}
+		},
+		"framer-motion": {
+			"version": "11.1.9",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.1.9.tgz",
+			"integrity": "sha512-flECDIPV4QDNcOrDafVFiIazp8X01HFpzc01eDKJsdNH/wrATcYydJSH9JbPWMS8UD5lZlw+J1sK8LG2kICgqw==",
+			"requires": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"fresh": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Replaced `classnames` package with the faster and smaller `clsx` package ([#61138](https://github.com/WordPress/gutenberg/pull/61138)).
 -   Upgrade `@use-gesture/react` package to `^10.3.1` ([#61503](https://github.com/WordPress/gutenberg/pull/61503)).
+-   Upgrade `framer-motion` package to version `^11.1.9` ([#61572](https://github.com/WordPress/gutenberg/pull/61572)).
 
 ### Enhancements
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,7 +66,7 @@
 		"deepmerge": "^4.3.0",
 		"downshift": "^6.0.15",
 		"fast-deep-equal": "^3.1.3",
-		"framer-motion": "^10.13.0",
+		"framer-motion": "^11.1.9",
 		"gradient-parser": "^0.1.5",
 		"highlight-words-core": "^1.2.2",
 		"is-plain-object": "^5.0.0",

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -278,7 +278,6 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             <div
               class="emotion-15"
               role="presentation"
-              style="opacity: 1;"
             />
           </div>
         </div>
@@ -824,7 +823,6 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
             <div
               class="emotion-15"
               role="presentation"
-              style="opacity: 1;"
             />
           </div>
         </div>

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -7,7 +7,7 @@ exports[`DotTip should render correctly 1`] = `
   data-wp-c16t="true"
   data-wp-component="Popover"
   role="dialog"
-  style="position: absolute; top: 0px; left: 0px; opacity: 1; transform: none; transform-origin: 0% 50% 0;"
+  style="position: absolute; top: 0px; left: 0px; opacity: 1; transform: translateX(0px) translateY(0px) translateX(0em) scale(1) translateZ(0); transform-origin: 0% 50% 0;"
   tabindex="-1"
 >
   <div


### PR DESCRIPTION
## What?

Upgrade framer-motion package.

This is a significant diff, although I see no [release notes to speak of](https://github.com/framer/motion/blob/main/CHANGELOG.md#1100-2024-01-23) on why it's a major (potentially breaking) version change.

> [11.0.0] 2024-01-23
> Changed
> Replaced velocity-check jobs in favour of passive detection.
> Post-commit render moved to a microtask.

```sh
npm diff --diff=framer-motion@10.13.0 --diff=framer-motion@11.1.9
```

Includes https://github.com/WordPress/gutenberg/pull/61532
Extracted from https://github.com/WordPress/gutenberg/pull/61486

## Why?

This package has type conflicts with recent types, these can manifest causing build issues. https://github.com/framer/motion/pull/2587https://github.com/framer/motion/pull/2587

## How?

Upgrade the package to include the fix.

## Testing Instructions

I'm not sure where or how this is used.