### PR TITLE
Convert autop package to TypeScript

### DIFF
--- a/packages/autop/src/index.ts
+++ b/packages/autop/src/index.ts
@@ -3,7 +3,7 @@
  *
  * @type {RegExp}
  */
-const htmlSplitRegex = ( () => {
+const htmlSplitRegex: RegExp = ( () => {
 	/* eslint-disable no-multi-spaces */
 	const comments =
 		'!' + // Start of comment, after the <.
@@ -55,7 +55,7 @@ const htmlSplitRegex = ( () => {
  *
  * @return {string[]} The formatted text.
  */
-function htmlSplit( input ) {
+function htmlSplit( input: string ): string[] {
 	const parts = [];
 	let workingInput = input;
 
@@ -65,7 +65,7 @@ function htmlSplit( input ) {
 		// If the `g` flag is omitted, `index` is included.
 		// `htmlSplitRegex` does not have the `g` flag so we can assert it will have an index number.
 		// Assert `match.index` is a number.
-		const index = /** @type {number} */ ( match.index );
+		const index = match.index!;
 
 		parts.push( workingInput.slice( 0, index ) );
 		parts.push( match[ 0 ] );
@@ -87,7 +87,10 @@ function htmlSplit( input ) {
  *
  * @return {string} The formatted text.
  */
-function replaceInHtmlTags( haystack, replacePairs ) {
+function replaceInHtmlTags(
+	haystack: string,
+	replacePairs: Record< string, string >
+): string {
 	// Find all elements.
 	const textArr = htmlSplit( haystack );
 	let changed = false;
@@ -137,8 +140,8 @@ function replaceInHtmlTags( haystack, replacePairs ) {
  *
  * @return {string} Text which has been converted into paragraph tags.
  */
-export function autop( text, br = true ) {
-	const preTags = [];
+export function autop( text: string, br: boolean = true ): string {
+	const preTags: Array< [ string, string ] > = [];
 
 	if ( text.trim() === '' ) {
 		return '';
@@ -340,13 +343,12 @@ export function autop( text, br = true ) {
  *
  * @return {string} The content with stripped paragraph tags.
  */
-export function removep( html ) {
+export function removep( html: string ) {
 	const blocklist =
 		'blockquote|ul|ol|li|dl|dt|dd|table|thead|tbody|tfoot|tr|th|td|h[1-6]|fieldset|figure';
 	const blocklist1 = blocklist + '|div|p';
 	const blocklist2 = blocklist + '|pre';
-	/** @type {string[]} */
-	const preserve = [];
+	const preserve: string[] = [];
 	let preserveLinebreaks = false;
 	let preserveBr = false;
 
@@ -480,7 +482,7 @@ export function removep( html ) {
 	// Restore preserved tags.
 	if ( preserve.length ) {
 		html = html.replace( /<wp-preserve>/g, () => {
-			return /** @type {string} */ ( preserve.shift() );
+			return preserve.shift()!;
 		} );
 	}
 

--- a/packages/autop/src/index.ts
+++ b/packages/autop/src/index.ts
@@ -343,7 +343,7 @@ export function autop( text: string, br: boolean = true ): string {
  *
  * @return {string} The content with stripped paragraph tags.
  */
-export function removep( html: string ) {
+export function removep( html: string ): string {
 	const blocklist =
 		'blockquote|ul|ol|li|dl|dt|dd|table|thead|tbody|tfoot|tr|th|td|h[1-6]|fieldset|figure';
 	const blocklist1 = blocklist + '|div|p';

--- a/packages/autop/src/test/index.test.ts
+++ b/packages/autop/src/test/index.test.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { autop, removep } from '../';
+import { autop, removep } from '..';
 
 test( 'empty string', () => {
 	expect( autop( '' ) ).toBe( '' );
@@ -311,7 +311,7 @@ test( 'that_autop_treats_block_level_elements_as_blocks', () => {
 	];
 
 	// Check whitespace normalization.
-	let content = [];
+	let content: string[] = [];
 
 	blocks.forEach( ( block ) => {
 		content.push( `<${ block }>foo</${ block }>` );
@@ -388,18 +388,18 @@ test( 'that autop treats inline elements as inline', () => {
 		'select',
 	];
 
-	let content = [];
-	let expected = [];
+	const content: string[] = [];
+	const expected: string[] = [];
 
 	inlines.forEach( ( inline ) => {
 		content.push( `<${ inline }>foo</${ inline }>` );
 		expected.push( `<p><${ inline }>foo</${ inline }></p>` );
 	} );
 
-	content = content.join( '\n\n' );
-	expected = expected.join( '\n' );
+	const contentString = content.join( '\n\n' );
+	const expectedString = expected.join( '\n' );
 
-	expect( autop( content ).trim() ).toBe( expected );
+	expect( autop( contentString ).trim() ).toBe( expectedString );
 } );
 
 test( 'element sanity', () => {

--- a/packages/autop/src/test/index.test.ts
+++ b/packages/autop/src/test/index.test.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { autop, removep } from '..';
+import { autop, removep } from '../';
 
 test( 'empty string', () => {
 	expect( autop( '' ) ).toBe( '' );


### PR DESCRIPTION
## What?
This PR converts the `autop` package to TypeScript.

## Why?
Ensures package is fully type checked.

## How?
- converted files to `.ts`
- added explicit return types for functions `.ts` files
- explicitly typed variables that would otherwise be implicit `any`

## Testing Instructions
`npm run test:unit -- packages/autop` tests pass
`npm run build:package-types` returns a zero exit code