### PR TITLE
Fix: Post Template block: 'List view' display setting should be selected by default

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -248,7 +248,10 @@ export default function PostTemplateEdit( {
 			icon: list,
 			title: __( 'List view' ),
 			onClick: () => setDisplayLayout( { type: 'default' } ),
-			isActive: layoutType === 'default' || layoutType === 'constrained',
+			isActive:
+				'undefined' === typeof layout ||
+				layoutType === 'default' ||
+				layoutType === 'constrained',
 		},
 		{
 			icon: grid,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/61569

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - https://github.com/WordPress/gutenberg/issues/61569

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- This PR adds the `List View` as default for the post template block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- On checking, we identified that, `Layout` is coming as an attribute inside the post template block. We checked if that is `undefined`, set it as the default list view.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open, any page.
- Add the `query loop` block and select any pattern.
- You would see now the `list view` is by default selected for that pattern.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NIL

## Screenshots or screencast <!-- if applicable -->

<img width="1426" alt="Screenshot 2024-05-10 at 5 45 46 PM" src="https://github.com/WordPress/gutenberg/assets/58802366/18bc717e-b4d6-4d06-91ed-4b40f2ace5b5">
- You can see that, list type is selected by default.
