### PR TITLE
Fix the RRS block placeholder labeling and improve spacing

### DIFF
--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -59,10 +59,18 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 
 	const blockProps = useBlockProps();
 
+	const label = __( 'RSS URL' );
+
 	if ( isEditing ) {
 		return (
 			<div { ...blockProps }>
-				<Placeholder icon={ rss } label="RSS">
+				<Placeholder
+					icon={ rss }
+					label={ label }
+					instructions={ __(
+						'Display entries from any RSS or Atom feed.'
+					) }
+				>
 					<form
 						onSubmit={ onSubmitURL }
 						className="wp-block-rss__placeholder-form"
@@ -70,6 +78,8 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 						<HStack wrap>
 							<InputControl
 								__next40pxDefaultSize
+								label={ label }
+								hideLabelFromVision
 								placeholder={ __( 'Enter URL here…' ) }
 								value={ feedURL }
 								onChange={ ( value ) =>
@@ -82,7 +92,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 								variant="primary"
 								type="submit"
 							>
-								{ __( 'Use URL' ) }
+								{ __( 'Apply' ) }
 							</Button>
 						</HStack>
 					</form>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -14,7 +14,6 @@ import {
 	RangeControl,
 	ToggleControl,
 	ToolbarGroup,
-	__experimentalHStack as HStack,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
@@ -75,26 +74,24 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 						onSubmit={ onSubmitURL }
 						className="wp-block-rss__placeholder-form"
 					>
-						<HStack wrap>
-							<InputControl
-								__next40pxDefaultSize
-								label={ label }
-								hideLabelFromVision
-								placeholder={ __( 'Enter URL here…' ) }
-								value={ feedURL }
-								onChange={ ( value ) =>
-									setAttributes( { feedURL: value } )
-								}
-								className="wp-block-rss__placeholder-input"
-							/>
-							<Button
-								__next40pxDefaultSize
-								variant="primary"
-								type="submit"
-							>
-								{ __( 'Apply' ) }
-							</Button>
-						</HStack>
+						<InputControl
+							__next40pxDefaultSize
+							label={ label }
+							hideLabelFromVision
+							placeholder={ __( 'Enter URL here…' ) }
+							value={ feedURL }
+							onChange={ ( value ) =>
+								setAttributes( { feedURL: value } )
+							}
+							className="wp-block-rss__placeholder-input"
+						/>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							type="submit"
+						>
+							{ __( 'Apply' ) }
+						</Button>
 					</form>
 				</Placeholder>
 			</div>

--- a/packages/block-library/src/rss/editor.scss
+++ b/packages/block-library/src/rss/editor.scss
@@ -14,8 +14,8 @@
 	}
 
 	.wp-block-rss__placeholder-input {
-		flex: 1;
-		min-width: 80%;
+		margin: 0 8px 0 0;
+		flex: 1 1 auto;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/61571

## What?
<!-- In a few words, what is the PR actually doing? -->
While the RSS block isn't exactly an 'embed' block, user interaction and styling of the block placeholder are very similar with other embed-related blocks. As such it should be consistent with these blocks in terms of labeling and styling.

From an a11y perspective, the input field isn't labeled in an appropriate way, as the accessible name is only given by the HTML `placeholder` attribute. The input misses any associated `<label>` element or `aria-label` or `aria-labelledby` attributes.

The button text 'Use URL' feels a little weird. A simpler, more intuitive text would be better.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All interactive controls should be labeled in an accessible and meaningful way. The placeholder attribute isn't a replacement for labeling.
Labeling and styling should be consistent.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds a missing `label` prop to the InputControl. The rendered label is visually hidden. The label text is 'RSS URL'.
- Changes the visual label at the top of the block placeholder to 'RSS URL' so that:
  - It's consistent with other blocks e.g. Embed, YouTube, etc.
  - The visual label matches the visually hidden label of the input.
- Changes the button text from 'Use URL' to 'Apply'. 
- Adds a description with instructions: `Display entries from any RSS or Atom feed.` for two reasons:
  - Hep users understand the block accepts RSS and also _Atom_ feeds. Previously, Atom feeds weren't mentioned anywhere in the placeholder UI.
  - Consistency with other block placeholders.
- Removes an unnecessary `HStack` component and adjusts the spacing between the input and the button, for consistency with similar block placeholders.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- For comparison: add an RSS block, an Embed block, and an YouTube block.
- Compare the padding between the input fields and the buttons to submit, observe the padding is consistent.
- Note: the size of the inputs and buttons should be made consistent separately in an ohter issue and PR.
- Inspect the RSS block placeholder with your browser dev tools.
- Observe the input field is now associated with a `<label>` element with text 'RSS URL'.
- Observe the visual label at the top of the placeholder is now 'RSS URL'.
- Observe the button text is now 'Apply'.
- Observe the placeholder now shows instructions text `Display entries from any RSS or Atom feed.`


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/WordPress/gutenberg/assets/1682452/0a9abb7b-fd66-4818-a05c-12e521758950)


After:


![after](https://github.com/WordPress/gutenberg/assets/1682452/a65e7952-affd-4d04-b7bd-91c8f5b7f221)
