### PR TITLE
Site Editor Hub: Simplify

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -189,8 +189,6 @@ $z-layers: (
 	".customize-widgets__block-toolbar": 7,
 
 	// Site editor layout
-	".edit-site-layout__header-container": 4,
-	".edit-site-layout__hub": 3,
 	".edit-site-page-header": 2,
 	".edit-site-page-content": 1,
 	".edit-site-patterns__dataviews-list-pagination": 2,

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -4,3 +4,16 @@
 		outline-offset: calc(-2 * var(--wp-admin-border-width-focus));
 	}
 }
+
+/* stylelint-disable */
+::view-transition-old(frame),
+::view-transition-new(frame) {
+  animation-duration: 0;
+}
+/* stylelint-enable */
+
+.edit-site-visual-editor__editor-canvas {
+	/* stylelint-disable */
+	view-transition-name: frame;
+	/* stylelint-enable */
+}

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -1,10 +1,3 @@
-.edit-site-visual-editor__editor-canvas {
-	&.is-focused {
-		outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
-		outline-offset: calc(-2 * var(--wp-admin-border-width-focus));
-	}
-}
-
 /* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 ::view-transition-old(frame),
 ::view-transition-new(frame) {
@@ -16,4 +9,9 @@
 	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 	view-transition-name: frame;
 	/* stylelint-enable */
+
+	&.is-focused {
+		outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
+		outline-offset: calc(-2 * var(--wp-admin-border-width-focus));
+	}
 }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -5,7 +5,7 @@
 	}
 }
 
-/* stylelint-disable */
+/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 ::view-transition-old(frame),
 ::view-transition-new(frame) {
   animation-duration: 0;
@@ -13,7 +13,7 @@
 /* stylelint-enable */
 
 .edit-site-visual-editor__editor-canvas {
-	/* stylelint-disable */
+	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 	view-transition-name: frame;
 	/* stylelint-enable */
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -216,14 +216,16 @@ export default function EditSiteEditor( { isLoading } ) {
 						! isEditingPage && <PluginTemplateSettingPanel.Slot />
 					}
 				>
-					<BackButton>
-						<Button
-							className="edit-site-layout__view-mode-toggle"
-							onClick={ () => setCanvasMode( 'view' ) }
-						>
-							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-						</Button>
-					</BackButton>
+					{ isEditMode && (
+						<BackButton>
+							<Button
+								className="edit-site-layout__view-mode-toggle"
+								onClick={ () => setCanvasMode( 'view' ) }
+							>
+								<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+							</Button>
+						</BackButton>
+					) }
 					<SiteEditorMoreMenu />
 					{ supportsGlobalStyles && <GlobalStylesSidebar /> }
 				</Editor>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -221,6 +221,7 @@ export default function EditSiteEditor( { isLoading } ) {
 							{ ( { length } ) =>
 								length <= 1 && (
 									<Button
+										label={ __( 'Open Navigation' ) }
 										className="edit-site-layout__view-mode-toggle"
 										onClick={ () =>
 											setCanvasMode( 'view' )

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -7,6 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
+import { Button } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
 	EditorKeyboardShortcutsRegister,
@@ -40,10 +41,11 @@ import {
 } from '../editor-canvas-container';
 import SaveButton from '../save-button';
 import SiteEditorMoreMenu from '../more-menu';
+import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
 import useEditorTitle from './use-editor-title';
 
-const { Editor } = unlock( editorPrivateApis );
+const { Editor, BackButton } = unlock( editorPrivateApis );
 const { useHistory } = unlock( routerPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
 
@@ -125,6 +127,7 @@ export default function EditSiteEditor( { isLoading } ) {
 		],
 		[ settings.styles, canvasMode, currentPostIsTrashed ]
 	);
+	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const history = useHistory();
 	const onActionPerformed = useCallback(
@@ -213,6 +216,14 @@ export default function EditSiteEditor( { isLoading } ) {
 						! isEditingPage && <PluginTemplateSettingPanel.Slot />
 					}
 				>
+					<BackButton>
+						<Button
+							className="edit-site-layout__view-mode-toggle"
+							onClick={ () => setCanvasMode( 'view' ) }
+						>
+							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+						</Button>
+					</BackButton>
 					<SiteEditorMoreMenu />
 					{ supportsGlobalStyles && <GlobalStylesSidebar /> }
 				</Editor>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -218,12 +218,18 @@ export default function EditSiteEditor( { isLoading } ) {
 				>
 					{ isEditMode && (
 						<BackButton>
-							<Button
-								className="edit-site-layout__view-mode-toggle"
-								onClick={ () => setCanvasMode( 'view' ) }
-							>
-								<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-							</Button>
+							{ ( { length } ) =>
+								length <= 1 && (
+									<Button
+										className="edit-site-layout__view-mode-toggle"
+										onClick={ () =>
+											setCanvasMode( 'view' )
+										}
+									>
+										<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+									</Button>
+								)
+							}
 						</BackButton>
 					) }
 					<SiteEditorMoreMenu />

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -17,7 +17,3 @@
 	display: flex;
 	justify-content: center;
 }
-
-.editor-header {
-	padding-left: $header-height;
-}

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -16,9 +16,10 @@ import {
 	useReducedMotion,
 	useViewportMatch,
 	useResizeObserver,
+	usePrevious,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import {
 	CommandMenu,
@@ -72,7 +73,7 @@ export default function Layout() {
 	useCommonCommands();
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-
+	const toggleRef = useRef();
 	const {
 		isDistractionFree,
 		hasFixedToolbar,
@@ -133,6 +134,14 @@ export default function Layout() {
 
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
+	const previousCanvaMode = usePrevious( canvasMode );
+	useEffect( () => {
+		if ( previousCanvaMode === 'edit' ) {
+			toggleRef.current?.focus();
+		}
+		// Should not depend on the previous canvas mode value but the next.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ canvasMode ] );
 
 	// Synchronizing the URL with the store value of canvasMode happens in an effect
 	// This condition ensures the component is only rendered after the synchronization happens
@@ -191,6 +200,7 @@ export default function Layout() {
 										className="edit-site-layout__sidebar"
 									>
 										<SiteHub
+											ref={ toggleRef }
 											isTransparent={
 												isResizableFrameOversized
 											}

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -120,27 +120,6 @@ export default function Layout() {
 		triggerAnimationOnChange: canvasMode + '__' + routeKey,
 	} );
 
-	// This determines which animation variant should apply to the header.
-	// There is also a `isDistractionFreeHovering` state that gets priority
-	// when hovering the `edit-site-layout__header-container` in distraction
-	// free mode. It's set via framer and trickles down to all the children
-	// so they can use this variant state too.
-	//
-	// TODO: The issue with this is we want to have the hover state stick when hovering
-	// a popover opened via the header. We'll probably need to lift this state to
-	// handle it ourselves. Also, focusWithin the header needs to be handled.
-	let headerAnimationState;
-
-	if ( canvasMode === 'view' ) {
-		// We need 'view' to always take priority so 'isDistractionFree'
-		// doesn't bleed over into the view (sidebar) state
-		headerAnimationState = 'view';
-	} else if ( isDistractionFree ) {
-		headerAnimationState = 'isDistractionFree';
-	} else {
-		headerAnimationState = canvasMode; // edit, view, init
-	}
-
 	// Sets the right context for the command palette
 	let commandContext = 'site-editor';
 
@@ -183,41 +162,6 @@ export default function Layout() {
 					}
 				) }
 			>
-				<motion.div
-					className="edit-site-layout__header-container"
-					variants={ {
-						isDistractionFree: {
-							opacity: 0,
-							transition: {
-								type: 'tween',
-								delay: 0.8,
-								delayChildren: 0.8,
-							}, // How long to wait before the header exits
-						},
-						isDistractionFreeHovering: {
-							opacity: 1,
-							transition: {
-								type: 'tween',
-								delay: 0.2,
-								delayChildren: 0.2,
-							}, // How long to wait before the header shows
-						},
-						view: { opacity: 1 },
-						edit: { opacity: 1 },
-					} }
-					whileHover={
-						isDistractionFree
-							? 'isDistractionFreeHovering'
-							: undefined
-					}
-					animate={ headerAnimationState }
-				>
-					<SiteHub
-						isTransparent={ isResizableFrameOversized }
-						className="edit-site-layout__hub"
-					/>
-				</motion.div>
-
 				<div className="edit-site-layout__content">
 					{ /*
 						The NavigableRegion must always be rendered and not use
@@ -246,6 +190,11 @@ export default function Layout() {
 										} }
 										className="edit-site-layout__sidebar"
 									>
+										<SiteHub
+											isTransparent={
+												isResizableFrameOversized
+											}
+										/>
 										<SidebarContent routeKey={ routeKey }>
 											{ areas.sidebar }
 										</SidebarContent>

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -140,6 +140,9 @@
 	view-transition-name: toggle;
 }
 /* stylelint-enable */
+.edit-site-layout.is-full-canvas .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
+	display: none;
+}
 
 .edit-site-layout__view-mode-toggle.components-button {
 	position: relative;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -132,9 +132,11 @@
 	height: 100%;
 }
 
-/* stylelint-disable */
-::view-transition-group(toggle) {
-  animation-delay: 250ms;
+/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
+html:active-view-transition-type(canvas-mode-edit) {
+	&::view-transition-group(toggle) {
+		animation-delay: 250ms;
+	}
 }
 .edit-site-layout:not(.is-full-canvas) .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
 	view-transition-name: toggle;
@@ -142,7 +144,8 @@
 .edit-site-layout.is-full-canvas .edit-site-layout__canvas .edit-site-layout__view-mode-toggle {
 	view-transition-name: toggle;
 }
-/* stylelint-enable */
+/* stylelint-enable  */
+
 .edit-site-layout.is-full-canvas .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
 	display: none;
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -135,7 +135,7 @@
 /* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 html:active-view-transition-type(canvas-mode-edit) {
 	&::view-transition-group(toggle) {
-		animation-delay: 250ms;
+		animation-delay: 255ms;
 	}
 }
 .edit-site-layout:not(.is-full-canvas) .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -138,12 +138,6 @@ html:active-view-transition-type(canvas-mode-edit) {
 		animation-delay: 255ms;
 	}
 }
-.edit-site-layout:not(.is-full-canvas) .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
-	view-transition-name: toggle;
-}
-.edit-site-layout.is-full-canvas .edit-site-layout__canvas .edit-site-layout__view-mode-toggle {
-	view-transition-name: toggle;
-}
 /* stylelint-enable  */
 
 .edit-site-layout.is-full-canvas .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
@@ -151,6 +145,9 @@ html:active-view-transition-type(canvas-mode-edit) {
 }
 
 .edit-site-layout__view-mode-toggle.components-button {
+	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
+	view-transition-name: toggle;
+	/* stylelint-enable  */
 	position: relative;
 	color: $white;
 	height: $header-height;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -133,6 +133,9 @@
 }
 
 /* stylelint-disable */
+::view-transition-group(toggle) {
+  animation-delay: 250ms;
+}
 .edit-site-layout:not(.is-full-canvas) .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
 	view-transition-name: toggle;
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -158,6 +158,7 @@
 	align-items: center;
 	justify-content: center;
 	background: $gray-900;
+	border-radius: 0;
 
 	&:hover,
 	&:active {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -11,37 +11,6 @@
 	}
 }
 
-.edit-site-layout__hub {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: calc(100vw - #{$canvas-padding * 2});
-	height: $header-height;
-	z-index: z-index(".edit-site-layout__hub");
-
-	@include break-medium {
-		width: calc(#{$nav-sidebar-width} - #{$grid-unit-15});
-	}
-
-	.edit-site-layout.is-full-canvas & {
-		padding-right: 0;
-		border-radius: 0;
-		width: $header-height;
-		box-shadow: none;
-	}
-}
-
-.edit-site-layout__header-container:has(+ .edit-site-layout__content > .edit-site-layout__mobile>.edit-site-page) {
-	margin-bottom: $header-height;
-	@include break-medium {
-		margin-bottom: 0;
-	}
-}
-
-.edit-site-layout__header-container {
-	z-index: z-index(".edit-site-layout__header-container");
-}
-
 .edit-site-layout__content {
 	height: 100%;
 	flex-grow: 1;
@@ -241,33 +210,6 @@
 
 	@include break-medium {
 		border-left: $border-width solid $gray-300;
-	}
-}
-
-.edit-site-layout.is-distraction-free {
-	.edit-site-layout__header-container {
-		height: $header-height;
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		z-index: z-index(".edit-site-layout__header-container");
-		width: 100%;
-
-		// We need ! important because we override inline styles
-		// set by the motion component.
-		&:focus-within {
-			opacity: 1 !important;
-			div {
-				transform: translateX(0) translateY(0) translateZ(0) !important;
-			}
-		}
-	}
-
-	.edit-site-site-hub {
-		position: absolute;
-		top: 0;
-		z-index: z-index(".edit-site-layout__hub");
 	}
 }
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -133,10 +133,8 @@
 }
 
 /* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
-html:active-view-transition-type(canvas-mode-edit) {
-	&::view-transition-group(toggle) {
-		animation-delay: 255ms;
-	}
+html.canvas-mode-edit-transition::view-transition-group(toggle) {
+	animation-delay: 255ms;
 }
 /* stylelint-enable  */
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -143,6 +143,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	background: $gray-900;
 
 	&:hover,
 	&:active {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -132,6 +132,15 @@
 	height: 100%;
 }
 
+/* stylelint-disable */
+.edit-site-layout:not(.is-full-canvas) .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
+	view-transition-name: toggle;
+}
+.edit-site-layout.is-full-canvas .edit-site-layout__canvas .edit-site-layout__view-mode-toggle {
+	view-transition-name: toggle;
+}
+/* stylelint-enable */
+
 .edit-site-layout__view-mode-toggle.components-button {
 	position: relative;
 	color: $white;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -147,7 +147,6 @@
 .edit-site-layout__view-mode-toggle.components-button {
 	position: relative;
 	color: $white;
-	border-radius: 0;
 	height: $header-height;
 	width: $header-height;
 	overflow: hidden;
@@ -189,7 +188,6 @@
 
 	.edit-site-layout__view-mode-toggle-icon {
 		display: flex;
-		border-radius: $radius-block-ui;
 		height: $grid-unit-80;
 		width: $grid-unit-80;
 		justify-content: center;

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -59,7 +59,7 @@
 	position: sticky;
 	top: 0;
 	background: $gray-900;
-	padding-top: $grid-unit-60 + $header-height;
+	padding-top: $grid-unit-60;
 	margin-bottom: $grid-unit-10;
 	padding-bottom: $grid-unit-10;
 	z-index: z-index(".edit-site-sidebar-navigation-screen__title-icon");

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -60,7 +60,7 @@ const SiteHub = memo( ( { isTransparent } ) => {
 						href={ dashboardLink }
 						label={ __( 'Go to the Dashboard' ) }
 						className="edit-site-layout__view-mode-toggle"
-						style={ { transform: 'scale(0.5)' } }
+						style={ { transform: 'scale(0.5)', borderRadius: 4 } }
 					>
 						<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
 					</Button>

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { memo, forwardRef } from '@wordpress/element';
-import { search, external } from '@wordpress/icons';
+import { search } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 import { filterURLForDisplay } from '@wordpress/url';
@@ -73,22 +73,20 @@ const SiteHub = memo(
 
 					<HStack>
 						<div className="edit-site-site-hub__title">
-							{ decodeEntities( siteTitle ) }
+							<Button
+								variant="link"
+								href={ homeUrl }
+								target="_blank"
+								label={ __( 'View site (opens in a new tab)' ) }
+							>
+								{ decodeEntities( siteTitle ) }
+							</Button>
 						</div>
 						<HStack
 							spacing={ 0 }
 							expanded={ false }
 							className="edit-site-site-hub__actions"
 						>
-							<Button
-								variant="link"
-								href={ homeUrl }
-								target="_blank"
-								label={ __( 'View site (opens in a new tab)' ) }
-								icon={ external }
-								className="edit-site-site-hub__site-view-link"
-							/>
-
 							<Button
 								className="edit-site-site-hub_toggle-command-center"
 								icon={ search }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -7,17 +7,9 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	Button,
-	__unstableMotion as motion,
-	__unstableAnimatePresence as AnimatePresence,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
-import { useReducedMotion } from '@wordpress/compose';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { memo } from '@wordpress/element';
 import { search } from '@wordpress/icons';
@@ -32,164 +24,79 @@ import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
 
-const HUB_ANIMATION_DURATION = 0.3;
+const SiteHub = memo( ( { isTransparent } ) => {
+	const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
 
-const SiteHub = memo( ( { isTransparent, className } ) => {
-	const { canvasMode, dashboardLink, homeUrl, siteTitle } = useSelect(
-		( select ) => {
-			const { getCanvasMode, getSettings } = unlock(
-				select( editSiteStore )
-			);
-
-			const {
-				getSite,
-				getUnstableBase, // Site index.
-			} = select( coreStore );
-			const _site = getSite();
-			return {
-				canvasMode: getCanvasMode(),
-				dashboardLink:
-					getSettings().__experimentalDashboardLink || 'index.php',
-				homeUrl: getUnstableBase()?.home,
-				siteTitle:
-					! _site?.title && !! _site?.url
-						? filterURLForDisplay( _site?.url )
-						: _site?.title,
-			};
-		},
-		[]
-	);
+		const {
+			getSite,
+			getUnstableBase, // Site index.
+		} = select( coreStore );
+		const _site = getSite();
+		return {
+			dashboardLink:
+				getSettings().__experimentalDashboardLink || 'index.php',
+			homeUrl: getUnstableBase()?.home,
+			siteTitle:
+				! _site?.title && !! _site?.url
+					? filterURLForDisplay( _site?.url )
+					: _site?.title,
+		};
+	}, [] );
 	const { open: openCommandCenter } = useDispatch( commandsStore );
 
-	const disableMotion = useReducedMotion();
-	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
-	const { clearSelectedBlock } = useDispatch( blockEditorStore );
-	const { setDeviceType } = useDispatch( editorStore );
-	const isBackToDashboardButton = canvasMode === 'view';
-	const siteIconButtonProps = isBackToDashboardButton
-		? {
-				href: dashboardLink,
-				label: __( 'Go to the Dashboard' ),
-		  }
-		: {
-				href: dashboardLink, // We need to keep the `href` here so the component doesn't remount as a `<button>` and break the animation.
-				role: 'button',
-				label: __( 'Open Navigation' ),
-				onClick: ( event ) => {
-					event.preventDefault();
-					if ( canvasMode === 'edit' ) {
-						clearSelectedBlock();
-						setDeviceType( 'Desktop' );
-						setCanvasMode( 'view' );
-					}
-				},
-		  };
-
 	return (
-		<motion.div
-			className={ clsx( 'edit-site-site-hub', className ) }
-			variants={ {
-				isDistractionFree: { x: '-100%' },
-				isDistractionFreeHovering: { x: 0 },
-				view: { x: 0 },
-				edit: { x: 0 },
-			} }
-			initial={ false }
-			transition={ {
-				type: 'tween',
-				duration: disableMotion ? 0 : HUB_ANIMATION_DURATION,
-				ease: 'easeOut',
-			} }
-		>
+		<div className="edit-site-site-hub">
 			<HStack justify="flex-start" spacing="0">
-				<motion.div
+				<div
 					className={ clsx(
 						'edit-site-site-hub__view-mode-toggle-container',
 						{
 							'has-transparent-background': isTransparent,
 						}
 					) }
-					layout
-					transition={ {
-						type: 'tween',
-						duration: disableMotion ? 0 : HUB_ANIMATION_DURATION,
-						ease: 'easeOut',
-					} }
 				>
 					<Button
-						{ ...siteIconButtonProps }
+						href={ dashboardLink }
+						label={ __( 'Go to the Dashboard' ) }
 						className="edit-site-layout__view-mode-toggle"
 					>
-						<motion.div
-							initial={ false }
-							animate={ {
-								scale: canvasMode === 'view' ? 0.5 : 1,
-							} }
-							whileHover={ {
-								scale: canvasMode === 'view' ? 0.5 : 0.96,
-							} }
-							transition={ {
-								type: 'tween',
-								duration: disableMotion
-									? 0
-									: HUB_ANIMATION_DURATION,
-								ease: 'easeOut',
-							} }
-						>
+						<div style={ { transform: 'scale(0.5)' } }>
 							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-						</motion.div>
+						</div>
 					</Button>
-				</motion.div>
+				</div>
 
-				<AnimatePresence initial={ false }>
-					{ canvasMode === 'view' && (
-						<HStack
-							as={ motion.div }
-							initial={ { opacity: 0 } }
-							animate={ {
-								opacity: isTransparent ? 0 : 1,
-							} }
-							exit={ { opacity: 0 } }
-							transition={ {
-								type: 'tween',
-								duration: disableMotion ? 0 : 0.2,
-								ease: 'easeOut',
-								delay: canvasMode === 'view' ? 0.1 : 0,
-							} }
+				<HStack>
+					<div className="edit-site-site-hub__title">
+						{ decodeEntities( siteTitle ) }
+					</div>
+					<HStack
+						spacing={ 0 }
+						expanded={ false }
+						className="edit-site-site-hub__actions"
+					>
+						<Button
+							className="edit-site-site-hub__site-view-link"
+							variant="link"
+							href={ homeUrl }
+							target="_blank"
+							label={ __( 'View site (opens in a new tab)' ) }
 						>
-							<div className="edit-site-site-hub__title">
-								<Button
-									variant="link"
-									href={ homeUrl }
-									target="_blank"
-									label={ __(
-										'View site (opens in a new tab)'
-									) }
-									aria-label={ __(
-										'View site (opens in a new tab)'
-									) }
-								>
-									{ decodeEntities( siteTitle ) }
-								</Button>
-							</div>
-							<HStack
-								spacing={ 0 }
-								expanded={ false }
-								className="edit-site-site-hub__actions"
-							>
-								<Button
-									className="edit-site-site-hub_toggle-command-center"
-									icon={ search }
-									onClick={ () => openCommandCenter() }
-									label={ __( 'Open command palette' ) }
-									shortcut={ displayShortcut.primary( 'k' ) }
-								/>
-							</HStack>
-						</HStack>
-					) }
-				</AnimatePresence>
+							{ decodeEntities( siteTitle ) }
+						</Button>
+
+						<Button
+							className="edit-site-site-hub_toggle-command-center"
+							icon={ search }
+							onClick={ () => openCommandCenter() }
+							label={ __( 'Open command palette' ) }
+							shortcut={ displayShortcut.primary( 'k' ) }
+						/>
+					</HStack>
+				</HStack>
 			</HStack>
-		</motion.div>
+		</div>
 	);
 } );
 

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -60,10 +60,9 @@ const SiteHub = memo( ( { isTransparent } ) => {
 						href={ dashboardLink }
 						label={ __( 'Go to the Dashboard' ) }
 						className="edit-site-layout__view-mode-toggle"
+						style={ { transform: 'scale(0.5)' } }
 					>
-						<div style={ { transform: 'scale(0.5)' } }>
-							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-						</div>
+						<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
 					</Button>
 				</div>
 

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -11,8 +11,8 @@ import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { memo } from '@wordpress/element';
-import { search } from '@wordpress/icons';
+import { memo, forwardRef } from '@wordpress/element';
+import { search, external } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 import { filterURLForDisplay } from '@wordpress/url';
@@ -24,79 +24,84 @@ import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
 
-const SiteHub = memo( ( { isTransparent } ) => {
-	const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
-		const { getSettings } = unlock( select( editSiteStore ) );
+const SiteHub = memo(
+	forwardRef( ( { isTransparent }, ref ) => {
+		const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
+			const { getSettings } = unlock( select( editSiteStore ) );
 
-		const {
-			getSite,
-			getUnstableBase, // Site index.
-		} = select( coreStore );
-		const _site = getSite();
-		return {
-			dashboardLink:
-				getSettings().__experimentalDashboardLink || 'index.php',
-			homeUrl: getUnstableBase()?.home,
-			siteTitle:
-				! _site?.title && !! _site?.url
-					? filterURLForDisplay( _site?.url )
-					: _site?.title,
-		};
-	}, [] );
-	const { open: openCommandCenter } = useDispatch( commandsStore );
+			const {
+				getSite,
+				getUnstableBase, // Site index.
+			} = select( coreStore );
+			const _site = getSite();
+			return {
+				dashboardLink:
+					getSettings().__experimentalDashboardLink || 'index.php',
+				homeUrl: getUnstableBase()?.home,
+				siteTitle:
+					! _site?.title && !! _site?.url
+						? filterURLForDisplay( _site?.url )
+						: _site?.title,
+			};
+		}, [] );
+		const { open: openCommandCenter } = useDispatch( commandsStore );
 
-	return (
-		<div className="edit-site-site-hub">
-			<HStack justify="flex-start" spacing="0">
-				<div
-					className={ clsx(
-						'edit-site-site-hub__view-mode-toggle-container',
-						{
-							'has-transparent-background': isTransparent,
-						}
-					) }
-				>
-					<Button
-						href={ dashboardLink }
-						label={ __( 'Go to the Dashboard' ) }
-						className="edit-site-layout__view-mode-toggle"
-						style={ { transform: 'scale(0.5)', borderRadius: 4 } }
-					>
-						<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-					</Button>
-				</div>
-
-				<HStack>
-					<div className="edit-site-site-hub__title">
-						{ decodeEntities( siteTitle ) }
-					</div>
-					<HStack
-						spacing={ 0 }
-						expanded={ false }
-						className="edit-site-site-hub__actions"
+		return (
+			<div className="edit-site-site-hub">
+				<HStack justify="flex-start" spacing="0">
+					<div
+						className={ clsx(
+							'edit-site-site-hub__view-mode-toggle-container',
+							{
+								'has-transparent-background': isTransparent,
+							}
+						) }
 					>
 						<Button
-							className="edit-site-site-hub__site-view-link"
-							variant="link"
-							href={ homeUrl }
-							target="_blank"
-							label={ __( 'View site (opens in a new tab)' ) }
+							ref={ ref }
+							href={ dashboardLink }
+							label={ __( 'Go to the Dashboard' ) }
+							className="edit-site-layout__view-mode-toggle"
+							style={ {
+								transform: 'scale(0.5)',
+								borderRadius: 4,
+							} }
 						>
-							{ decodeEntities( siteTitle ) }
+							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
 						</Button>
+					</div>
 
-						<Button
-							className="edit-site-site-hub_toggle-command-center"
-							icon={ search }
-							onClick={ () => openCommandCenter() }
-							label={ __( 'Open command palette' ) }
-							shortcut={ displayShortcut.primary( 'k' ) }
-						/>
+					<HStack>
+						<div className="edit-site-site-hub__title">
+							{ decodeEntities( siteTitle ) }
+						</div>
+						<HStack
+							spacing={ 0 }
+							expanded={ false }
+							className="edit-site-site-hub__actions"
+						>
+							<Button
+								variant="link"
+								href={ homeUrl }
+								target="_blank"
+								label={ __( 'View site (opens in a new tab)' ) }
+								icon={ external }
+								className="edit-site-site-hub__site-view-link"
+							/>
+
+							<Button
+								className="edit-site-site-hub_toggle-command-center"
+								icon={ search }
+								onClick={ () => openCommandCenter() }
+								label={ __( 'Open command palette' ) }
+								shortcut={ displayShortcut.primary( 'k' ) }
+							/>
+						</HStack>
 					</HStack>
 				</HStack>
-			</HStack>
-		</div>
-	);
-} );
+			</div>
+		);
+	} )
+);
 
 export default SiteHub;

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -3,6 +3,7 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: $grid-unit-10;
+	margin-right: $grid-unit-15;
 }
 
 .edit-site-site-hub__actions {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -15,10 +15,6 @@
 	width: $header-height;
 	flex-shrink: 0;
 
-	.edit-site-layout__view-mode-toggle-icon {
-		background: $gray-900;
-	}
-
 	&.has-transparent-background .edit-site-layout__view-mode-toggle-icon {
 		background: transparent;
 	}

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -13,7 +13,6 @@
 .edit-site-site-icon__image {
 	width: 100%;
 	height: 100%;
-	border-radius: $radius-block-ui * 2;
 	object-fit: cover;
 	background: #333;
 

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -1,8 +1,5 @@
 .edit-site-site-icon__icon {
 	fill: currentColor;
-	// Matches SiteIcon motion, smoothing out the transition.
-	transition: padding 0.3s ease-out;
-	@include reduce-motion("transition");
 
 	.edit-site-layout.is-full-canvas & {
 		// Make the WordPress icon not so big in full canvas.

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -14,43 +14,49 @@ export const setCanvasMode =
 	( mode ) =>
 	( { registry, dispatch } ) => {
 		const switchCanvasMode = () => {
-			const isMediumOrBigger =
-				window.matchMedia( '(min-width: 782px)' ).matches;
-			registry.dispatch( blockEditorStore ).clearSelectedBlock();
-			registry.dispatch( editorStore ).setDeviceType( 'Desktop' );
-			registry
-				.dispatch( blockEditorStore )
-				.__unstableSetEditorMode( 'edit' );
-			const isPublishSidebarOpened = registry
-				.select( editorStore )
-				.isPublishSidebarOpened();
-			dispatch( {
-				type: 'SET_CANVAS_MODE',
-				mode,
-			} );
-			const isEditMode = mode === 'edit';
-			if ( isPublishSidebarOpened && ! isEditMode ) {
-				registry.dispatch( editorStore ).closePublishSidebar();
-			}
-
-			// Check if the block list view should be open by default.
-			// If `distractionFree` mode is enabled, the block list view should not be open.
-			// This behavior is disabled for small viewports.
-			if (
-				isMediumOrBigger &&
-				isEditMode &&
+			registry.batch( () => {
+				const isMediumOrBigger =
+					window.matchMedia( '(min-width: 782px)' ).matches;
+				registry.dispatch( blockEditorStore ).clearSelectedBlock();
+				registry.dispatch( editorStore ).setDeviceType( 'Desktop' );
 				registry
-					.select( preferencesStore )
-					.get( 'core', 'showListViewByDefault' ) &&
-				! registry
-					.select( preferencesStore )
-					.get( 'core', 'distractionFree' )
-			) {
-				registry.dispatch( editorStore ).setIsListViewOpened( true );
-			} else {
-				registry.dispatch( editorStore ).setIsListViewOpened( false );
-			}
-			registry.dispatch( editorStore ).setIsInserterOpened( false );
+					.dispatch( blockEditorStore )
+					.__unstableSetEditorMode( 'edit' );
+				const isPublishSidebarOpened = registry
+					.select( editorStore )
+					.isPublishSidebarOpened();
+				dispatch( {
+					type: 'SET_CANVAS_MODE',
+					mode,
+				} );
+				const isEditMode = mode === 'edit';
+				if ( isPublishSidebarOpened && ! isEditMode ) {
+					registry.dispatch( editorStore ).closePublishSidebar();
+				}
+
+				// Check if the block list view should be open by default.
+				// If `distractionFree` mode is enabled, the block list view should not be open.
+				// This behavior is disabled for small viewports.
+				if (
+					isMediumOrBigger &&
+					isEditMode &&
+					registry
+						.select( preferencesStore )
+						.get( 'core', 'showListViewByDefault' ) &&
+					! registry
+						.select( preferencesStore )
+						.get( 'core', 'distractionFree' )
+				) {
+					registry
+						.dispatch( editorStore )
+						.setIsListViewOpened( true );
+				} else {
+					registry
+						.dispatch( editorStore )
+						.setIsListViewOpened( false );
+				}
+				registry.dispatch( editorStore ).setIsInserterOpened( false );
+			} );
 		};
 
 		if ( ! document.startViewTransition ) {

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -54,8 +54,11 @@ export const setCanvasMode =
 		if ( ! document.startViewTransition ) {
 			switchCanvasMode();
 		} else {
-			document.startViewTransition( () => {
-				switchCanvasMode();
+			document.startViewTransition( {
+				update: () => {
+					switchCanvasMode();
+				},
+				types: [ 'canvas-mode-' + mode ],
 			} );
 		}
 	};

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -56,11 +56,16 @@ export const setCanvasMode =
 		if ( ! document.startViewTransition ) {
 			switchCanvasMode();
 		} else {
-			document.startViewTransition( {
-				update: () => {
-					switchCanvasMode();
-				},
-				types: [ 'canvas-mode-' + mode ],
+			document.documentElement.classList.add(
+				`canvas-mode-${ mode }-transition`
+			);
+			const transition = document.startViewTransition( () =>
+				switchCanvasMode()
+			);
+			transition.finished.finally( () => {
+				document.documentElement.classList.remove(
+					`canvas-mode-${ mode }-transition`
+				);
 			} );
 		}
 	};

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -13,39 +13,51 @@ import { store as editorStore } from '@wordpress/editor';
 export const setCanvasMode =
 	( mode ) =>
 	( { registry, dispatch } ) => {
-		const isMediumOrBigger =
-			window.matchMedia( '(min-width: 782px)' ).matches;
-		registry.dispatch( blockEditorStore ).__unstableSetEditorMode( 'edit' );
-		const isPublishSidebarOpened = registry
-			.select( editorStore )
-			.isPublishSidebarOpened();
-		dispatch( {
-			type: 'SET_CANVAS_MODE',
-			mode,
-		} );
-		const isEditMode = mode === 'edit';
-		if ( isPublishSidebarOpened && ! isEditMode ) {
-			registry.dispatch( editorStore ).closePublishSidebar();
-		}
-
-		// Check if the block list view should be open by default.
-		// If `distractionFree` mode is enabled, the block list view should not be open.
-		// This behavior is disabled for small viewports.
-		if (
-			isMediumOrBigger &&
-			isEditMode &&
+		const switchCanvasMode = () => {
+			const isMediumOrBigger =
+				window.matchMedia( '(min-width: 782px)' ).matches;
 			registry
-				.select( preferencesStore )
-				.get( 'core', 'showListViewByDefault' ) &&
-			! registry
-				.select( preferencesStore )
-				.get( 'core', 'distractionFree' )
-		) {
-			registry.dispatch( editorStore ).setIsListViewOpened( true );
+				.dispatch( blockEditorStore )
+				.__unstableSetEditorMode( 'edit' );
+			const isPublishSidebarOpened = registry
+				.select( editorStore )
+				.isPublishSidebarOpened();
+			dispatch( {
+				type: 'SET_CANVAS_MODE',
+				mode,
+			} );
+			const isEditMode = mode === 'edit';
+			if ( isPublishSidebarOpened && ! isEditMode ) {
+				registry.dispatch( editorStore ).closePublishSidebar();
+			}
+
+			// Check if the block list view should be open by default.
+			// If `distractionFree` mode is enabled, the block list view should not be open.
+			// This behavior is disabled for small viewports.
+			if (
+				isMediumOrBigger &&
+				isEditMode &&
+				registry
+					.select( preferencesStore )
+					.get( 'core', 'showListViewByDefault' ) &&
+				! registry
+					.select( preferencesStore )
+					.get( 'core', 'distractionFree' )
+			) {
+				registry.dispatch( editorStore ).setIsListViewOpened( true );
+			} else {
+				registry.dispatch( editorStore ).setIsListViewOpened( false );
+			}
+			registry.dispatch( editorStore ).setIsInserterOpened( false );
+		};
+
+		if ( ! document.startViewTransition ) {
+			switchCanvasMode();
 		} else {
-			registry.dispatch( editorStore ).setIsListViewOpened( false );
+			document.startViewTransition( () => {
+				switchCanvasMode();
+			} );
 		}
-		registry.dispatch( editorStore ).setIsInserterOpened( false );
 	};
 
 /**

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -16,6 +16,8 @@ export const setCanvasMode =
 		const switchCanvasMode = () => {
 			const isMediumOrBigger =
 				window.matchMedia( '(min-width: 782px)' ).matches;
+			registry.dispatch( blockEditorStore ).clearSelectedBlock();
+			registry.dispatch( editorStore ).setDeviceType( 'Desktop' );
 			registry
 				.dispatch( blockEditorStore )
 				.__unstableSetEditorMode( 'edit' );

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -57,8 +57,7 @@ test.describe( 'Template Part', () => {
 		page,
 	} ) => {
 		// Visit the index.
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
+		await admin.visitSiteEditor( { canvas: 'edit' } );
 		const headerTemplateParts = editor.canvas.locator(
 			'[data-type="core/template-part"]'
 		);
@@ -84,8 +83,7 @@ test.describe( 'Template Part', () => {
 	} ) => {
 		const paragraphText = 'Test 2';
 
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
+		await admin.visitSiteEditor( { canvas: 'edit' } );
 		// Add a block and select it.
 		await editor.insertBlock( {
 			name: 'core/paragraph',
@@ -124,8 +122,7 @@ test.describe( 'Template Part', () => {
 		const paragraphText1 = 'Test 3';
 		const paragraphText2 = 'Test 4';
 
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
+		await admin.visitSiteEditor( { canvas: 'edit' } );
 		// Add a block and select it.
 		await editor.insertBlock( {
 			name: 'core/paragraph',
@@ -199,8 +196,7 @@ test.describe( 'Template Part', () => {
 		} );
 
 		// Visit the index.
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
+		await admin.visitSiteEditor( { canvas: 'edit' } );
 		// Check that the header contains the paragraph added earlier.
 		const paragraph = editor.canvas.locator(
 			`p >> text="${ paragraphText }"`
@@ -303,8 +299,7 @@ test.describe( 'Template Part', () => {
 		editor,
 		page,
 	} ) => {
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
+		await admin.visitSiteEditor( { canvas: 'edit' } );
 
 		// Add a block and select it.
 		await editor.insertBlock( {
@@ -344,8 +339,7 @@ test.describe( 'Template Part', () => {
 		editor,
 		page,
 	} ) => {
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
+		await admin.visitSiteEditor( { canvas: 'edit' } );
 
 		// Select existing header template part.
 		await editor.selectBlocks(

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -20,10 +20,9 @@ test.describe( 'Template Revert', () => {
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
-	test.beforeEach( async ( { admin, requestUtils, editor } ) => {
+	test.beforeEach( async ( { admin, requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
+		await admin.visitSiteEditor( { canvas: 'edit' } );
 	} );
 
 	test( 'should delete the template after saving the reverted template', async ( {


### PR DESCRIPTION
## What and Why?

Currently the site editor renders a "hub" with a site logo, site title and some actions. That hub is persistent and rendered as "fixed" on top of everything.

I think the main reason it's implemented that way is to be able to animate the site logo with go in and out of view mode. That said, I personally believe this is way too complex to accommodate for a small animation.

So this PR is kind of a provocation, how simple can it be if we don't have to implement the animation of the logo. It's not necessarily meant to be merged but at least I want to raise this discussion.

Also, coincidentally, this fixes #60875

Let me know what you think.