### PR TITLE
Convert data-controls test to TypeScript

### DIFF
--- a/packages/data-controls/src/test/index.ts
+++ b/packages/data-controls/src/test/index.ts
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import type { APIFetchOptions } from '@wordpress/api-fetch';
 import triggerFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
@@ -13,14 +14,14 @@ import { controls } from '../index';
 describe( 'controls', () => {
 	describe( 'API_FETCH', () => {
 		afterEach( () => {
-			triggerFetch.mockClear();
+			( triggerFetch as unknown as jest.Mock ).mockClear();
 		} );
 		it( 'invokes the triggerFetch function', () => {
-			controls.API_FETCH( { request: '' } );
+			controls.API_FETCH( { request: '' as APIFetchOptions } );
 			expect( triggerFetch ).toHaveBeenCalledTimes( 1 );
 		} );
 		it( 'invokes the triggerFetch function with the passed in request', () => {
-			controls.API_FETCH( { request: 'foo' } );
+			controls.API_FETCH( { request: 'foo' as APIFetchOptions } );
 			expect( triggerFetch ).toHaveBeenCalledWith( 'foo' );
 		} );
 	} );


### PR DESCRIPTION
## What?
This PR converts the tests for the `data-controls` package to TypeScript.

## Why?
Ensures package is fully type checked.

## How?
- converted files to `.ts`
- cast dummy requests in tests to  `APIFetchOptions`
- explicitly cast mocked `triggerFetch` to `jest.Mock`

## Testing Instructions
`npm run test:unit -- packages/data-controls` tests pass
`npm run build:package-types` returns a zero exit code
