### PR TITLE
List View: Account for text fields in shortcut handler

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -30,6 +30,7 @@ import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { speak } from '@wordpress/a11y';
+import { isTextField } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -178,6 +179,11 @@ function ListViewBlock( {
 	 */
 	async function onKeyDown( event ) {
 		if ( event.defaultPrevented ) {
+			return;
+		}
+
+		// Retain the default behavior for text fields.
+		if ( isTextField( event.target ) ) {
 			return;
 		}
 

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -36,26 +36,10 @@ test.describe( 'Block Renaming', () => {
 			page,
 			pageUtils,
 		} ) => {
-			// Turn on block list view by default.
-			await editor.setPreferences( 'core', {
-				showListViewByDefault: true,
-			} );
-
-			const listView = page.getByRole( 'treegrid', {
-				name: 'Block navigation structure',
-			} );
-
-			await editor.insertBlock( {
-				name: 'core/group',
-				attributes: { content: 'First Paragraph' },
-			} );
+			await editor.insertBlock( { name: 'core/group' } );
 
 			// Select via keyboard.
 			await pageUtils.pressKeys( 'primary+a' );
-
-			// Convert to a Group block which supports renaming.
-			await editor.clickBlockOptionsMenuItem( 'Group' );
-
 			await editor.clickBlockOptionsMenuItem( 'Rename' );
 
 			const renameMenuItem = page.getByRole( 'menuitem', {
@@ -107,10 +91,17 @@ test.describe( 'Block Renaming', () => {
 				'false'
 			);
 
-			// Check custom name reflected in List View.
-			listView.getByRole( 'link', {
-				name: 'My new name',
+			await pageUtils.pressKeys( 'access+o' );
+			const listView = page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
 			} );
+
+			await expect(
+				listView.getByRole( 'link', {
+					name: 'My new name',
+				} ),
+				'should reflect custom name in List View'
+			).toBeVisible();
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
@@ -123,7 +114,8 @@ test.describe( 'Block Renaming', () => {
 				},
 			] );
 
-			// Re-trigger the rename dialog.
+			// Re-trigger the rename dialog from the List View.
+			await listView.getByRole( 'button', { name: 'Options' } ).click();
 			await renameMenuItem.click();
 
 			// Expect modal input to contain the custom name.
@@ -142,10 +134,12 @@ test.describe( 'Block Renaming', () => {
 
 			await saveButton.click();
 
-			// Check the original block name to reflected in List View.
-			listView.getByRole( 'link', {
-				name: 'Group',
-			} );
+			await expect(
+				listView.getByRole( 'link', {
+					name: 'Group',
+				} ),
+				'should reflect original name in List View'
+			).toBeVisible();
 
 			// Expect block to have no custom name (i.e. it should be reset to the original block name).
 			await expect.poll( editor.getBlocks ).toMatchObject( [


### PR DESCRIPTION
## What?
Fixes #61544.

PR fixes a bug when pressing <kbd>Delete</kbd> in modals opened from the List View was causing block deletion.

## Todo
- [x] Add e2e test to avoid similar regression in the future.

## Why?
This fixes a regression introduced in #61130. The list view shortcut handler now captures events propagated from modals.

## Testing Instructions
1. Open a post or page.
2. Add a group block.
3. Open the List View.
4. Rename the group block via List View options.
5. Confirm you can delete the new block name.

### Testing Instructions for Keyboard
Same.
