### PR TITLE
Fix: The issue of appender button not clickable in row/stack group.

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -48,7 +48,8 @@
 
 	// Let the parent be selectable in the placeholder area.
 	pointer-events: none;
-	.block-editor-inserter {
+	.block-editor-inserter,
+	.block-editor-button-block-appender {
 		pointer-events: all;
 	}
 }


### PR DESCRIPTION
## What?
Fixes #56438 

## Why?
For core/group block that:
- Has the layout attribute value of {"type": "flex"}, i.e. a Row or Column variation.
- Has no inner blocks.
- Has a single value in its allowedBlocks attribute.

One cannot click on the button appender component to insert a block.

## How?
The issue was caused as the pointer-events were restricted on the `.block-list-appender`, So this PR allows the pointer event on the button inside so user can insert the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Create a new Page.
2. Paste the group code provided further below.
```
<!-- wp:group {"allowedBlocks":["core/paragraph"],"layout":{"type":"flex"}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->
```
3. In visual mode, attempt to click on the block appender button. Now, the block should be inserted.

### Testing Instructions for Keyboard
Nil

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/55375170/8fc470ea-dd9f-4211-a192-83959cbbba97


