### PR TITLE
LinkControl: Provides better way to see the full URLs

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -24,6 +24,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import { ViewerSlot } from './viewer-slot';
+import trimLongURL from './trim-long-url';
 
 import useRichUrlData from './use-rich-url-data';
 
@@ -51,6 +52,8 @@ export default function LinkPreview( {
 	const displayURL =
 		( value && filterURLForDisplay( safeDecodeURI( value.url ), 24 ) ) ||
 		'';
+
+	const trimmedURL = trimLongURL( displayURL );
 
 	// url can be undefined if the href attribute is unset
 	const isEmptyURL = ! value?.url?.length;
@@ -114,8 +117,8 @@ export default function LinkPreview( {
 								</ExternalLink>
 								{ value?.url && displayTitle !== displayURL && (
 									<span className="block-editor-link-control__search-item-info">
-										<Truncate numberOfLines={ 1 }>
-											{ displayURL }
+										<Truncate numberOfLines={ 4 }>
+											{ trimmedURL }
 										</Truncate>
 									</span>
 								) }

--- a/packages/block-editor/src/components/link-control/trim-long-url.js
+++ b/packages/block-editor/src/components/link-control/trim-long-url.js
@@ -1,0 +1,66 @@
+/**
+ * Trims a long URL to a more concise format for display.
+ *
+ * This function intelligently handles long URLs by removing unnecessary parts such as protocol, www prefix,
+ * query string, fragment, index.html, and trailing slash. If the URL is longer than 40 characters,
+ * it shortens it by showing relevant parts of the URL.
+ *
+ * @param {string} url - The URL to be trimmed.
+ *
+ * @return {string} The trimmed URL.
+ */
+export default function trimLongURL( url ) {
+	let trimmedURL = url;
+
+	// Decode URL
+	trimmedURL = decodeURIComponent( trimmedURL );
+
+	// Remove protocol and www prefix
+	trimmedURL = trimmedURL.replace( /^(?:https?:)?\/\/(?:www\.)?/, '' );
+
+	// Remove query string
+	const queryStringIndex = trimmedURL.indexOf( '?' );
+	if ( queryStringIndex !== -1 ) {
+		trimmedURL = trimmedURL.slice( 0, queryStringIndex );
+	}
+
+	// Remove fragment
+	const fragmentIndex = trimmedURL.indexOf( '#' );
+	if ( fragmentIndex !== -1 ) {
+		trimmedURL = trimmedURL.slice( 0, fragmentIndex );
+	}
+
+	// Remove index.html
+	trimmedURL = trimmedURL.replace( /(?:index)?\.html$/, '' );
+
+	// Remove trailing slash
+	if ( trimmedURL.charAt( trimmedURL.length - 1 ) === '/' ) {
+		trimmedURL = trimmedURL.slice( 0, -1 );
+	}
+
+	// Shorten URL if longer than 40 characters
+	if ( trimmedURL.length > 40 ) {
+		const firstSlashIndex = trimmedURL.indexOf( '/' );
+		const lastSlashIndex = trimmedURL.lastIndexOf( '/' );
+		if (
+			firstSlashIndex !== -1 &&
+			lastSlashIndex !== -1 &&
+			lastSlashIndex !== firstSlashIndex
+		) {
+			// If beginning + ending are shorter than 40 chars, show more of the ending
+			if ( firstSlashIndex + trimmedURL.length - lastSlashIndex < 40 ) {
+				trimmedURL =
+					trimmedURL.slice( 0, firstSlashIndex + 1 ) +
+					'\u2026' +
+					trimmedURL.slice( -( 40 - ( firstSlashIndex + 1 ) ) );
+			} else {
+				trimmedURL =
+					trimmedURL.slice( 0, firstSlashIndex + 1 ) +
+					'\u2026' +
+					trimmedURL.slice( lastSlashIndex );
+			}
+		}
+	}
+
+	return trimmedURL;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: #61158 

## Why?
Using the 'Copy link' button tooltip to display the full URL of the link is a no-go for accessibility. Fir example, a very long URL displayed within a tooltip isn't a great user experience.

## How?
This PR introduces a new function, trimLongURL, which employs various URL processing techniques which is similar to Classic Permalink editing UI. It intelligently shortens long URLs for improved display.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Edit it and add the navigation block.
3. Within the navigation block, click on any of the page link
4. Click on the `Links` which is available in Block Toolbar

## Screenshots or screencast <!-- if applicable -->
Earlier to see the full URL, we have to use the tooltip:
<img width="1470" alt="image" src="https://github.com/WordPress/gutenberg/assets/77401999/6bf71160-fd07-4928-bc0a-7f539e88b071">

---

After:
<img width="1091" alt="image" src="https://github.com/WordPress/gutenberg/assets/77401999/4da686e8-279c-4ac8-bdb9-5b72d36c117f">

