### PR TITLE
Placeholder: Tweak placeholder style

### DIFF
--- a/packages/block-library/src/rss/editor.scss
+++ b/packages/block-library/src/rss/editor.scss
@@ -2,20 +2,6 @@
 	display: inline;
 }
 
-.wp-block-rss__placeholder-form {
-	> * {
-		margin-bottom: $grid-unit-10;
-	}
-
-	@include break-medium() {
-		> * {
-			margin-bottom: 0;
-		}
-	}
-
-	.wp-block-rss__placeholder-input {
-		margin: 0 8px 0 0;
-		flex: 1 1 auto;
-	}
+.wp-block-rss__placeholder-form .wp-block-rss__placeholder-input {
+	flex: 1 1 auto;
 }
-

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `PaletteEdit`: Use consistent spacing and metrics. ([#61368](https://github.com/WordPress/gutenberg/pull/61368)).
 -   `FormTokenField`: Hide label when not defined ([#61336](https://github.com/WordPress/gutenberg/pull/61336)).
 -   Upgraded the @types/react and @types/react-dom packages ([#60796](https://github.com/WordPress/gutenberg/pull/60796)).
+-   `Placeholder`: Tweak placeholder style ([#61590](https://github.com/WordPress/gutenberg/pull/61590)).
 
 ### Bug Fix
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -67,7 +67,7 @@
 	flex-direction: row;
 	width: 100%;
 	flex-wrap: wrap;
-	gap: $grid-unit-15;
+	gap: $grid-unit-20;
 	justify-content: flex-start;
 
 	p {
@@ -83,7 +83,6 @@
 
 .components-placeholder__input[type="url"] {
 	@include input-control;
-	margin: 0 8px 0 0;
 	flex: 1 1 auto;
 }
 


### PR DESCRIPTION
Part of #41961
Related to #59275

## What?

This PR adjusts the placeholder layout for RSS and Embed blocks.

With this PR, the following two things apply:

- The spacing between the input field and button is unified to 16px regardless of the viewport size.
- In mobile layouts, the right margin of the text field is removed.
- Remove unnecessary styles from the RSS block.

## Why?

To make placeholder styles more consistent.

## How?

This PR changes the gap and margin of the Placeholder component itself, but this component already has a flex layout applied, so the impact on developers should be minor.

## Testing Instructions

- Insert RS and Embed blocks.
- Check the desktop view and mobile layout.

> [!Note]
>You may notice that when you paste text into a text field, unintended behavior occurs. This is a known issue and has been reported on #61377.

## Screenshots or screencast <!-- if applicable -->

### Desktop

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/73262837-70d7-4438-bac0-18201fa0a4bd) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/93350a09-b904-4ad3-8619-57cbb04689e7) | 

### Mobile

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/91ec298b-8f39-42aa-bf53-0bec9b516dea) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/8ea34d55-281b-4699-b061-f37ef0980dd9) | 
