### PR TITLE
Block Editor: Remove `multiline` prop from `Richtext` doc

### DIFF
--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -29,10 +29,6 @@ _Optional._ Placeholder text to show when the field is empty, similar to the
 
 _Optional._  Disables inserting line breaks on `Enter` when it is set to `true`
 
-### `multiline: Boolean | String`
-
-_Optional._ By default, a line break will be inserted on <kbd>Enter</kbd>. If the editable field can contain multiple paragraphs, this property can be set to create new paragraphs on <kbd>Enter</kbd>.
-
 ### `onReplace( blocks: Array ): Function`
 
 _Optional._ Called when the `RichText` instance can be replaced with the given blocks.


### PR DESCRIPTION
Closes #61580

## What?

The `multiline` prop for `RichText` components is now deprecated, so I removed it from the README.

I thought about marking this prop as deprecated and keeping it, but just like [when `onSplit` was deprecated](https://github.com/WordPress/gutenberg/pull/54543/files#diff-c7f1fa97855ed23061eacc8c8fe0771c34d049f5ced0fbc10f2eb4aa43c23643L36-L39), I removed the prop itself from the documentation.