### PR TITLE
Bug: False positives for `react-hooks/exhaustive-deps`

### DIFF
--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -37,7 +37,7 @@ module.exports = {
 		'react-hooks/exhaustive-deps': [
 			'warn',
 			{
-				additionalHooks: '(useSelect|useSuspenseSelect)',
+				additionalHooks: '^(useSelect|useSuspenseSelect)$',
 			},
 		],
 		'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
Closes #61598

## How?
Improves the regex pattern to match only the specific hooks, e.g. matching the whole word instead of matching part of it

