### PR TITLE
Zoom Out: The patterns tab behind a new experiment.

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -28,6 +28,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-page-client-side-navigation' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalFullPageClientSideNavigation = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-zoomed-out-patterns-tab', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomedOutPatternsTab = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -127,6 +127,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-zoomed-out-patterns-tab',
+		__( 'Enable zoomed out view when patterns in the inserter', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable zoomed out view when selecting a pattern category in the main inserter.', 'gutenberg' ),
+			'id'    => 'gutenberg-zoomed-out-patterns-tab',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -129,7 +129,7 @@ function gutenberg_initialize_experiments_settings() {
 
 	add_settings_field(
 		'gutenberg-zoomed-out-patterns-tab',
-		__( 'Enable zoomed out view when patterns in the inserter', 'gutenberg' ),
+		__( 'Enable zoomed out view when patterns are browsed in the inserter', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-preview-panel.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-preview-panel.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { PatternCategoryPreviews } from './pattern-category-previews';
+import { useZoomOut } from '../../../hooks/use-zoom-out';
 
-export function PatternCategoryPreviewPanel( {
+function PatternCategoryPreviewPanelInner( {
 	rootClientId,
 	onInsert,
 	onHover,
@@ -23,4 +23,18 @@ export function PatternCategoryPreviewPanel( {
 			patternFilter={ patternFilter }
 		/>
 	);
+}
+
+function PatternCategoryPreviewPanelWithZoomOut( props ) {
+	useZoomOut();
+	return <PatternCategoryPreviewPanelInner { ...props } />;
+}
+
+export function PatternCategoryPreviewPanel( props ) {
+	// When the pattern panel is showing, we want to use zoom out mode
+	if ( window.__experimentalEnableZoomedOutPatternsTab ) {
+		return <PatternCategoryPreviewPanelWithZoomOut { ...props } />;
+	}
+
+	return <PatternCategoryPreviewPanelInner { ...props } />;
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -31,7 +31,6 @@ import { MediaTab, MediaCategoryPanel } from './media-tab';
 import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
-import { useZoomOut } from '../../hooks/use-zoom-out';
 import { store as blockEditorStore } from '../../store';
 
 const NOOP = () => {};
@@ -266,9 +265,6 @@ function InserterMenu(
 		setSelectedMediaCategory,
 		showMediaPanel,
 	] );
-
-	// When the pattern panel is showing, we want to use zoom out mode
-	useZoomOut( showPatternPanel );
 
 	const handleSetSelectedTab = ( value ) => {
 		// If no longer on patterns tab remove the category setting.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In trunk we zoom out the canvas when you open the patterns tab. This PR hides that behaviour behind an experimental flag.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I don't think the current zoom out experience is good enough to be useful yet, so we should remove this from the next version of Gutenberg until it's ready.

## How?
Put the hook behind an experimental flag.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor
3. Open the inserter
4. Open the patterns tab
5. Select a category
6. Confirm that the view does not zoom out
0. Open the Gutenberg experiments settings page
1. Set the new experiment flag to be true
2. Open the site editor
3. Open the inserter
4. Open the patterns tab
5. Select a category
6. Confirm that the view does zoom out

## Note
Zoom out can still be accessed from Global Styles > Browse Styles.
