### PR TITLE
Make sure to replace all instances of `:where(body)` instead of just …

### DIFF
--- a/packages/block-editor/src/utils/test/__snapshots__/transform-styles.js.snap
+++ b/packages/block-editor/src/utils/test/__snapshots__/transform-styles.js.snap
@@ -24,6 +24,12 @@ exports[`transformStyles URL rewrite should rewrite relative paths 1`] = `
 ]
 `;
 
+exports[`transformStyles error handling should handle multiple instances of \`:where(body)\` 1`] = `
+[
+  ".my-namespace { color: pink; } .my-namespace { color: orange; }",
+]
+`;
+
 exports[`transformStyles selector wrap should ignore font-face selectors 1`] = `
 [
   "

--- a/packages/block-editor/src/utils/test/transform-styles.js
+++ b/packages/block-editor/src/utils/test/transform-styles.js
@@ -51,6 +51,20 @@ describe( 'transformStyles', () => {
 				//                                                        ^^^^ In PostCSS, a tab is equal four spaces
 			);
 		} );
+
+		it( 'should handle multiple instances of `:where(body)`', () => {
+			const input = `:where(body) { color: pink; } :where(body) { color: orange; }`;
+			const output = transformStyles(
+				[
+					{
+						css: input,
+					},
+				],
+				'.my-namespace'
+			);
+
+			expect( output ).toMatchSnapshot();
+		} );
 	} );
 
 	describe( 'selector wrap', () => {

--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -18,8 +18,7 @@ function transformStyle(
 	if ( ! wrapperSelector && ! baseURL ) {
 		return css;
 	}
-
-	const postcssFriendlyCSS = css.replace( ':where(body)', 'body' );
+	const postcssFriendlyCSS = css.replace( /:where\(body\)/g, 'body' );
 	try {
 		return postcss(
 			[


### PR DESCRIPTION
…the first.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #61565 and possibly also #61582.

The non-iframed editor all instances of `body` with `.editor-styles-wrapper` in the editor styles. It also checks for `:where(body)`, but because it was using `replace` with a string instead of a regex, only the first instance was being replaced.

This PR adds a regex with the global flag, so all instances of `:where(body)` will be replaced.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the post editor, under Preferences, enable Custom Fields.
2. Reload the editor and check that base color and font styles still apply to editor content.
3. Blocks should have something like the following rule applied:

```
.editor-styles-wrapper {
    background-color: var(--wp--preset--color--base);
    color: var(--wp--preset--color--contrast);
    font-family: var(--wp--preset--font-family--body);
    font-size: var(--wp--preset--font-size--medium);
    font-style: normal;
    font-weight: 400;
    line-height: 1.55;
    --wp--style--root--padding-top: 0px;
    --wp--style--root--padding-right: 37px;
    --wp--style--root--padding-bottom: 0px;
    --wp--style--root--padding-left: 37px;
}
```
