### PR TITLE
Hide Image block resizer when inside a grid layout.

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -103,6 +103,7 @@ export function ImageEdit( {
 	onReplace,
 	context,
 	clientId,
+	__unstableParentLayout: parentLayout,
 } ) {
 	const {
 		url = '',
@@ -385,6 +386,7 @@ export function ImageEdit( {
 				context={ context }
 				clientId={ clientId }
 				blockEditingMode={ blockEditingMode }
+				parentLayoutType={ parentLayout?.type }
 			/>
 			<MediaPlaceholder
 				icon={ <BlockIcon icon={ icon } /> }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -106,6 +106,7 @@ export default function Image( {
 	context,
 	clientId,
 	blockEditingMode,
+	parentLayoutType,
 } ) {
 	const {
 		url = '',
@@ -181,7 +182,8 @@ export default function Image( {
 		allowResize &&
 		hasNonContentControls &&
 		! isWideAligned &&
-		isLargeViewport;
+		isLargeViewport &&
+		parentLayoutType !== 'grid';
 	const imageSizeOptions = imageSizes
 		.filter(
 			( { slug } ) => image?.media_details?.sizes?.[ slug ]?.source_url


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #57478. Makes sure that if an Image block is inside a block with grid layout, the Image resizing handles don't show. This is so that the grid resizer can take precedence.

This should be the last thing left to address before the grid visualizer/resizer experiment is stabilised.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the grid resizing experiment in Gutenberg > Experiments;
2. Add a Grid block to a post and add some Image blocks inside it;
3. Check that the only resize handles that appear around the Image blocks are the grid resizer ones.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="338" alt="Screenshot 2024-05-13 at 1 36 22 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/bfeb6983-b726-4277-a83c-285402b4aac1">

After:

<img width="338" alt="Screenshot 2024-05-13 at 1 36 51 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/8e5157dd-568b-4bdf-9bb5-b82ce5d7cc00">


