### PR TITLE
List View: Add a special case for shortcuts coming from modals

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -30,7 +30,6 @@ import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { speak } from '@wordpress/a11y';
-import { isTextField } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -182,10 +181,7 @@ function ListViewBlock( {
 			return;
 		}
 
-		// Retain the default behavior for text fields.
-		if ( isTextField( event.target ) ) {
-			return;
-		}
+		const isDeleteKey = [ BACKSPACE, DELETE ].includes( event.keyCode );
 
 		// If multiple blocks are selected, deselect all blocks when the user
 		// presses the escape key.
@@ -197,10 +193,15 @@ function ListViewBlock( {
 			event.preventDefault();
 			selectBlock( event, undefined );
 		} else if (
-			event.keyCode === BACKSPACE ||
-			event.keyCode === DELETE ||
+			isDeleteKey ||
 			isMatch( 'core/block-editor/remove', event )
 		) {
+			// Do not handle single-key block deletion shortcuts when events come from modals;
+			// retain the default behavior for these keys.
+			if ( isDeleteKey && event.target.closest( '[role=dialog]' ) ) {
+				return;
+			}
+
 			const {
 				blocksToUpdate: blocksToDelete,
 				firstBlockClientId,


### PR DESCRIPTION
## What?
An alternative to #61583

Avoid handling single-key block deletion shortcuts when events come from the modals while preserving the main shortcut for the action. This matches the canvas behavior.

## Why?
See https://github.com/WordPress/gutenberg/pull/61583#pullrequestreview-2051637643.

## Testing Instructions
1. Open a post or page.
2. Add a group block.
3. Open the List View.
4. Rename the group block via List View options.
5. Confirm you can delete the new block name.
6. Move focus to the modal buttons.
7. Press <kbd>Delete</kbd> confirm that block isn't deleted.

### Testing Instructions for Keyboard
Same.
## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/f1817493-7ee3-447f-ba19-e880cbea14a8

