### PR TITLE
chore: convert escape-html package to typescript

### DIFF
--- a/packages/escape-html/src/escape-greater.ts
+++ b/packages/escape-html/src/escape-greater.ts
@@ -10,6 +10,6 @@
  *
  * @return {string} Escaped string.
  */
-export default function __unstableEscapeGreaterThan( value ) {
+export default function __unstableEscapeGreaterThan( value: string ): string {
 	return value.replace( />/g, '&gt;' );
 }

--- a/packages/escape-html/src/index.ts
+++ b/packages/escape-html/src/index.ts
@@ -14,7 +14,8 @@ import __unstableEscapeGreaterThan from './escape-greater';
  *
  * @type {RegExp}
  */
-const REGEXP_INVALID_ATTRIBUTE_NAME = /[\u007F-\u009F "'>/="\uFDD0-\uFDEF]/;
+const REGEXP_INVALID_ATTRIBUTE_NAME: RegExp =
+	/[\u007F-\u009F "'>/="\uFDD0-\uFDEF]/;
 
 /**
  * Returns a string with ampersands escaped. Note that this is an imperfect
@@ -30,7 +31,7 @@ const REGEXP_INVALID_ATTRIBUTE_NAME = /[\u007F-\u009F "'>/="\uFDD0-\uFDEF]/;
  *
  * @return {string} Escaped string.
  */
-export function escapeAmpersand( value ) {
+export function escapeAmpersand( value: string ): string {
 	return value.replace( /&(?!([a-z0-9]+|#[0-9]+|#x[a-f0-9]+);)/gi, '&amp;' );
 }
 
@@ -41,7 +42,7 @@ export function escapeAmpersand( value ) {
  *
  * @return {string} Escaped string.
  */
-export function escapeQuotationMark( value ) {
+export function escapeQuotationMark( value: string ): string {
 	return value.replace( /"/g, '&quot;' );
 }
 
@@ -52,7 +53,7 @@ export function escapeQuotationMark( value ) {
  *
  * @return {string} Escaped string.
  */
-export function escapeLessThan( value ) {
+export function escapeLessThan( value: string ): string {
 	return value.replace( /</g, '&lt;' );
 }
 
@@ -76,7 +77,7 @@ export function escapeLessThan( value ) {
  *
  * @return {string} Escaped attribute value.
  */
-export function escapeAttribute( value ) {
+export function escapeAttribute( value: string ): string {
 	return __unstableEscapeGreaterThan(
 		escapeQuotationMark( escapeAmpersand( value ) )
 	);
@@ -94,7 +95,7 @@ export function escapeAttribute( value ) {
  *
  * @return {string} Escaped HTML element value.
  */
-export function escapeHTML( value ) {
+export function escapeHTML( value: string ): string {
 	return escapeLessThan( escapeAmpersand( value ) );
 }
 
@@ -107,7 +108,7 @@ export function escapeHTML( value ) {
  *
  * @return {string} Escaped HTML element value.
  */
-export function escapeEditableHTML( value ) {
+export function escapeEditableHTML( value: string ): string {
 	return escapeLessThan( value.replace( /&/g, '&amp;' ) );
 }
 
@@ -118,6 +119,6 @@ export function escapeEditableHTML( value ) {
  *
  * @return {boolean} Whether attribute is valid.
  */
-export function isValidAttributeName( name ) {
+export function isValidAttributeName( name: string ): boolean {
 	return ! REGEXP_INVALID_ATTRIBUTE_NAME.test( name );
 }

--- a/packages/escape-html/src/test/index.ts
+++ b/packages/escape-html/src/test/index.ts
@@ -9,17 +9,19 @@ import {
 	escapeHTML,
 	isValidAttributeName,
 	escapeEditableHTML,
-} from '../';
+} from '..';
 import __unstableEscapeGreaterThan from '../escape-greater';
 
-function testUnstableEscapeGreaterThan( implementation ) {
+type Implementation = ( str: string ) => string;
+
+function testUnstableEscapeGreaterThan( implementation: Implementation ) {
 	it( 'should escape greater than', () => {
 		const result = implementation( 'Chicken > Ribs' );
 		expect( result ).toBe( 'Chicken &gt; Ribs' );
 	} );
 }
 
-function testEscapeAmpersand( implementation ) {
+function testEscapeAmpersand( implementation: Implementation ) {
 	it( 'should escape ampersand', () => {
 		const result = implementation(
 			'foo & bar &amp; &AMP; baz &#931; &#bad; &#x3A3; &#X3a3; &#xevil;'
@@ -31,7 +33,7 @@ function testEscapeAmpersand( implementation ) {
 	} );
 }
 
-function testEscapeQuotationMark( implementation ) {
+function testEscapeQuotationMark( implementation: Implementation ) {
 	it( 'should escape quotation mark', () => {
 		const result = implementation( '"Be gone!"' );
 
@@ -39,7 +41,7 @@ function testEscapeQuotationMark( implementation ) {
 	} );
 }
 
-function testEscapeLessThan( implementation ) {
+function testEscapeLessThan( implementation: Implementation ) {
 	it( 'should escape less than', () => {
 		const result = implementation( 'Chicken < Ribs' );
 


### PR DESCRIPTION
## What?

This PR converts the `escape-html` package to TypeScript.

## Why?

Ensures package is fully type checked.

## How?

- converted files to `.ts`
- explicitly type functions and incorrectly-implied variables, based on `@type`, `@param` and `@return` comments

## Testing Instructions

- [x] `npm run test:unit -- packages/escape-html` tests pass
- [ ] `npm run build:package-types` returns a zero exit code