### PR TITLE
Make color variations fit in a bit better visually

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -7,7 +7,6 @@
 }
 
 .edit-site-global-styles-preview__iframe {
-	border-radius: $radius-block-ui + 1px; // Visually resembles the $radius-block-ui.
 	max-width: 100%;
 	display: block;
 	width: 100%;

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -14,8 +14,8 @@
 		@include reduce-motion("transition");
 
 		&.is-pill {
-			height: $button-size-next-default-40px;
-			border-radius: 100px;
+			height: $button-size-compact;
+			border-radius: $radius-block-ui;
 			overflow: hidden;
 		}
 	}

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -15,7 +15,6 @@
 
 		&.is-pill {
 			height: $button-size-compact;
-			border-radius: $radius-block-ui;
 			overflow: hidden;
 		}
 	}

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -15,7 +15,10 @@
 
 		&.is-pill {
 			height: $button-size-compact;
-			overflow: hidden;
+
+			.block-editor-iframe__scale-container {
+				overflow: hidden;
+			}
 		}
 	}
 

--- a/packages/edit-site/src/components/global-styles/variations/style.scss
+++ b/packages/edit-site/src/components/global-styles/variations/style.scss
@@ -8,6 +8,7 @@
 		border-radius: $radius-block-ui;
 		outline: $border-width solid rgba($black, 0.15);
 		outline-offset: -$border-width;
+		overflow: hidden;
 		position: relative;
 		// Add the same transition that block style variations and other buttons have.
 		transition: outline 0.1s linear;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Reduces the height to 32px and uses the ui border radius. Closes #61759. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. Open the global styles sidebar.
3. Select "Colors".
4. Select the color palette to edit it.
5. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-13 at 07 24 55](https://github.com/WordPress/gutenberg/assets/1813435/793c0d99-712b-4ef5-a6fc-0d1612241edf)|![CleanShot 2024-05-13 at 07 21 57](https://github.com/WordPress/gutenberg/assets/1813435/0390082d-6021-4f6b-94b6-0e39ac24e065)|
