### PR TITLE
Editor: Update and simplify the Post Summary and Post Card section in the document sidebar

### DIFF
--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -38,7 +38,6 @@ export default function PostCardPanel( { actions } ) {
 			__experimentalGetTemplateInfo( _record );
 		return {
 			title: _templateInfo?.title || getEditedPostAttribute( 'title' ),
-			id: _id,
 			icon: unlock( select( editorStore ) ).getPostIcon( _type, {
 				area: _record?.area,
 			} ),

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -1,17 +1,10 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import {
 	Icon,
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalText as Text,
-	PanelBody,
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -25,89 +18,51 @@ import { store as editorStore } from '../../store';
 import {
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
-	PATTERN_POST_TYPE,
 } from '../../store/constants';
-import { PrivatePostExcerptPanel } from '../post-excerpt/panel';
-import PostLastEditedPanel from '../post-last-edited-panel';
 import { unlock } from '../../lock-unlock';
-import TemplateAreas from '../template-areas';
 
-export default function PostCardPanel( { className, actions } ) {
-	const { title, showPostContentPanels, icon, postType } = useSelect(
-		( select ) => {
-			const {
-				getEditedPostAttribute,
-				getCurrentPostType,
-				getCurrentPostId,
-				__experimentalGetTemplateInfo,
-			} = select( editorStore );
-			const { getEditedEntityRecord } = select( coreStore );
-			const _type = getCurrentPostType();
-			const _id = getCurrentPostId();
-			const _record = getEditedEntityRecord( 'postType', _type, _id );
-			const _templateInfo =
-				[ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes(
-					_type
-				) && __experimentalGetTemplateInfo( _record );
-			return {
-				title:
-					_templateInfo?.title || getEditedPostAttribute( 'title' ),
-				id: _id,
-				postType: _type,
-				icon: unlock( select( editorStore ) ).getPostIcon( _type, {
-					area: _record?.area,
-				} ),
-				// Post excerpt panel and Last Edited info are rendered in different place depending on the post type.
-				// So we cannot make this check inside the PostExcerpt or PostLastEditedPanel component based on the current edited entity.
-				showPostContentPanels: [
-					TEMPLATE_POST_TYPE,
-					TEMPLATE_PART_POST_TYPE,
-					PATTERN_POST_TYPE,
-				].includes( _type ),
-			};
-		},
-		[]
-	);
+export default function PostCardPanel( { actions } ) {
+	const { title, icon } = useSelect( ( select ) => {
+		const {
+			getEditedPostAttribute,
+			getCurrentPostType,
+			getCurrentPostId,
+			__experimentalGetTemplateInfo,
+		} = select( editorStore );
+		const { getEditedEntityRecord } = select( coreStore );
+		const _type = getCurrentPostType();
+		const _id = getCurrentPostId();
+		const _record = getEditedEntityRecord( 'postType', _type, _id );
+		const _templateInfo =
+			[ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes( _type ) &&
+			__experimentalGetTemplateInfo( _record );
+		return {
+			title: _templateInfo?.title || getEditedPostAttribute( 'title' ),
+			id: _id,
+			icon: unlock( select( editorStore ) ).getPostIcon( _type, {
+				area: _record?.area,
+			} ),
+		};
+	}, [] );
 	return (
-		<PanelBody>
-			<div
-				className={ clsx( 'editor-post-card-panel', className, {
-					'has-description': showPostContentPanels,
-				} ) }
+		<div className="editor-post-card-panel">
+			<HStack
+				spacing={ 2 }
+				className="editor-post-card-panel__header"
+				align="flex-start"
 			>
-				<HStack
-					spacing={ 2 }
-					className="editor-post-card-panel__header"
-					align="flex-start"
+				<Icon className="editor-post-card-panel__icon" icon={ icon } />
+				<Text
+					numberOfLines={ 2 }
+					truncate
+					className="editor-post-card-panel__title"
+					weight={ 500 }
+					as="h2"
 				>
-					<Icon
-						className="editor-post-card-panel__icon"
-						icon={ icon }
-					/>
-					<Text
-						numberOfLines={ 2 }
-						truncate
-						className="editor-post-card-panel__title"
-						weight={ 500 }
-						as="h2"
-					>
-						{ title ? decodeEntities( title ) : __( 'No Title' ) }
-					</Text>
-					{ actions }
-				</HStack>
-				<VStack className="editor-post-card-panel__content">
-					{ showPostContentPanels && (
-						<VStack
-							className="editor-post-card-panel__description"
-							spacing={ 2 }
-						>
-							<PrivatePostExcerptPanel />
-							<PostLastEditedPanel />
-						</VStack>
-					) }
-					{ postType === TEMPLATE_POST_TYPE && <TemplateAreas /> }
-				</VStack>
-			</div>
-		</PanelBody>
+					{ title ? decodeEntities( title ) : __( 'No Title' ) }
+				</Text>
+				{ actions }
+			</HStack>
+		</div>
 	);
 }

--- a/packages/editor/src/components/post-panel-section/index.js
+++ b/packages/editor/src/components/post-panel-section/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __experimentalVStack as VStack } from '@wordpress/components';
+
+function PostPanelSection( { className, children } ) {
+	return (
+		<VStack className={ clsx( 'editor-post-panel__section', className ) }>
+			{ children }
+		</VStack>
+	);
+}
+
+export default PostPanelSection;

--- a/packages/editor/src/components/post-panel-section/style.scss
+++ b/packages/editor/src/components/post-panel-section/style.scss
@@ -1,0 +1,3 @@
+.editor-post-panel__section {
+	padding: $grid-unit-20;
+}

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -26,8 +26,6 @@ import PageAttributesPanel from '../page-attributes/panel';
 import PatternOverridesPanel from '../pattern-overrides-panel';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 import PluginSidebar from '../plugin-sidebar';
-import PostActions from '../post-actions';
-import PostCardPanel from '../post-card-panel';
 import PostDiscussionPanel from '../post-discussion/panel';
 import PostLastRevisionPanel from '../post-last-revision/panel';
 import PostSummary from './post-summary';
@@ -58,7 +56,6 @@ const SidebarContent = ( {
 	renderingMode,
 	onActionPerformed,
 	extraPanels,
-	showSummary = true,
 } ) => {
 	const tabListRef = useRef( null );
 	// Because `PluginSidebar` renders a `ComplementaryArea`, we
@@ -115,14 +112,7 @@ const SidebarContent = ( {
 		>
 			<Tabs.Context.Provider value={ tabsContextValue }>
 				<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
-					<PostCardPanel
-						actions={
-							<PostActions
-								onActionPerformed={ onActionPerformed }
-							/>
-						}
-					/>
-					{ showSummary && <PostSummary /> }
+					<PostSummary onActionPerformed={ onActionPerformed } />
 					<PluginDocumentSettingPanel.Slot />
 					{ renderingMode !== 'post-only' && (
 						<TemplateContentPanel />

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -59,7 +59,7 @@ export default function PostSummary( { onActionPerformed } ) {
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
 					<>
-						<VStack spacing={ 3 }>
+						<VStack spacing={ 4 }>
 							<PostCardPanel
 								actions={
 									<PostActions
@@ -74,7 +74,7 @@ export default function PostSummary( { onActionPerformed } ) {
 								<PostLastEditedPanel />
 							</VStack>
 							{ ! isRemovedPostStatusPanel && (
-								<>
+								<VStack spacing={ 2 }>
 									<VStack spacing={ 1 }>
 										<PostStatusPanel />
 										<PostSchedulePanel />
@@ -91,7 +91,7 @@ export default function PostSummary( { onActionPerformed } ) {
 										! isTemplate &&
 										! isTemplatePart &&
 										! isNavigation && <PostTrashPanel /> }
-								</>
+								</VStack>
 							) }
 						</VStack>
 					</>

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -1,26 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	PanelBody,
-} from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import PluginPostStatusInfo from '../plugin-post-status-info';
+import PostActions from '../post-actions';
 import PostAuthorPanel from '../post-author/panel';
+import PostCardPanel from '../post-card-panel';
 import PostContentInformation from '../post-content-information';
 import { PrivatePostExcerptPanel as PostExcerptPanel } from '../post-excerpt/panel';
 import PostFeaturedImagePanel from '../post-featured-image/panel';
 import PostFormatPanel from '../post-format/panel';
 import PostLastEditedPanel from '../post-last-edited-panel';
+import PostPanelSection from '../post-panel-section';
 import PostSchedulePanel from '../post-schedule/panel';
-import PostSlugPanel from '../post-slug/panel';
 import PostStatusPanel from '../post-status';
 import PostStickyPanel from '../post-sticky';
 import PostSyncStatus from '../post-sync-status';
@@ -28,89 +25,78 @@ import PostTemplatePanel from '../post-template/panel';
 import PostTrashPanel from '../post-trash/panel';
 import PostURLPanel from '../post-url/panel';
 import { store as editorStore } from '../../store';
-import { PATTERN_POST_TYPE } from '../../store/constants';
+import {
+	NAVIGATION_POST_TYPE,
+	PATTERN_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	TEMPLATE_POST_TYPE,
+} from '../../store/constants';
+import TemplateAreas from '../template-areas';
 
 /**
  * Module Constants
  */
 const PANEL_NAME = 'post-status';
 
-export default function PostSummary() {
-	const { isOpened, isRemoved, isPattern } = useSelect( ( select ) => {
+export default function PostSummary( { onActionPerformed } ) {
+	const { isRemovedPostStatusPannel, postType } = useSelect( ( select ) => {
 		// We use isEditorPanelRemoved to hide the panel if it was programatically removed. We do
 		// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
-		const {
-			isEditorPanelRemoved,
-			isEditorPanelOpened,
-			getCurrentPostType,
-		} = select( editorStore );
-		const postType = getCurrentPostType();
+		const { isEditorPanelRemoved, getCurrentPostType } =
+			select( editorStore );
 		return {
-			isRemoved: isEditorPanelRemoved( PANEL_NAME ),
-			isOpened: isEditorPanelOpened( PANEL_NAME ),
-			// Post excerpt panel is rendered in different place depending on the post type.
-			// So we cannot make this check inside the PostExcerpt component based on the current edited entity.
-			isPattern: postType === PATTERN_POST_TYPE,
+			isRemovedPostStatusPannel: isEditorPanelRemoved( PANEL_NAME ),
+			postType: getCurrentPostType(),
 		};
 	}, [] );
-	const { toggleEditorPanelOpened } = useDispatch( editorStore );
-
-	if ( isRemoved ) {
-		return null;
-	}
+	const isPattern = postType === PATTERN_POST_TYPE;
+	const isTemplate = postType === TEMPLATE_POST_TYPE;
+	const isTemplatePart = postType === TEMPLATE_PART_POST_TYPE;
+	const isNavigation = postType === NAVIGATION_POST_TYPE;
 
 	return (
-		<PanelBody
-			title={ __( 'Summary' ) }
-			opened={ isOpened }
-			onToggle={ () => toggleEditorPanelOpened( PANEL_NAME ) }
-		>
+		<PostPanelSection className="editor-post-summary">
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
 					<>
-						{ ! isPattern && (
-							<VStack
-								spacing={ 3 }
-								//  TODO: this needs to be consolidated with the panel in site editor, when we unify them.
-								style={ { marginBlockEnd: '24px' } }
-							>
-								<PostFeaturedImagePanel
-									withPanelBody={ false }
-								/>
-								<PostExcerptPanel />
-								<VStack spacing={ 1 }>
-									<PostContentInformation />
-									<PostLastEditedPanel />
-								</VStack>
+						<VStack spacing={ 3 }>
+							<PostCardPanel
+								actions={
+									<PostActions
+										onActionPerformed={ onActionPerformed }
+									/>
+								}
+							/>
+							<PostFeaturedImagePanel withPanelBody={ false } />
+							<PostExcerptPanel />
+							<VStack spacing={ 1 }>
+								<PostContentInformation />
+								<PostLastEditedPanel />
 							</VStack>
-						) }
-						<VStack
-							spacing={ 1 }
-							style={ { marginBlockEnd: '12px' } }
-						>
-							<PostStatusPanel />
-							<PostSchedulePanel />
-							<PostTemplatePanel />
-							<PostURLPanel />
-							<PostSyncStatus />
+							{ ! isRemovedPostStatusPannel && (
+								<>
+									<VStack spacing={ 1 }>
+										<PostStatusPanel />
+										<PostSchedulePanel />
+										<PostTemplatePanel />
+										<PostURLPanel />
+										<PostSyncStatus />
+									</VStack>
+									<PostStickyPanel />
+									<PostFormatPanel />
+									<PostAuthorPanel />
+									{ isTemplate && <TemplateAreas /> }
+									{ fills }
+									{ ! isPattern &&
+										! isTemplate &&
+										! isTemplatePart &&
+										! isNavigation && <PostTrashPanel /> }
+								</>
+							) }
 						</VStack>
-						<PostStickyPanel />
-						<PostFormatPanel />
-						<PostSlugPanel />
-						<PostAuthorPanel />
-						{ fills }
-						{ ! isPattern && (
-							<HStack
-								style={ {
-									marginTop: '16px',
-								} }
-							>
-								<PostTrashPanel />
-							</HStack>
-						) }
 					</>
 				) }
 			</PluginPostStatusInfo.Slot>
-		</PanelBody>
+		</PostPanelSection>
 	);
 }

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -39,13 +39,13 @@ import TemplateAreas from '../template-areas';
 const PANEL_NAME = 'post-status';
 
 export default function PostSummary( { onActionPerformed } ) {
-	const { isRemovedPostStatusPannel, postType } = useSelect( ( select ) => {
+	const { isRemovedPostStatusPanel, postType } = useSelect( ( select ) => {
 		// We use isEditorPanelRemoved to hide the panel if it was programatically removed. We do
 		// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
 		const { isEditorPanelRemoved, getCurrentPostType } =
 			select( editorStore );
 		return {
-			isRemovedPostStatusPannel: isEditorPanelRemoved( PANEL_NAME ),
+			isRemovedPostStatusPanel: isEditorPanelRemoved( PANEL_NAME ),
 			postType: getCurrentPostType(),
 		};
 	}, [] );
@@ -73,7 +73,7 @@ export default function PostSummary( { onActionPerformed } ) {
 								<PostContentInformation />
 								<PostLastEditedPanel />
 							</VStack>
-							{ ! isRemovedPostStatusPannel && (
+							{ ! isRemovedPostStatusPanel && (
 								<>
 									<VStack spacing={ 1 }>
 										<PostStatusPanel />

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -12,3 +12,7 @@
 		}
 	}
 }
+
+.editor-post-summary .components-v-stack:empty {
+	display: none;
+}

--- a/packages/editor/src/components/template-areas/style.scss
+++ b/packages/editor/src/components/template-areas/style.scss
@@ -1,5 +1,4 @@
 .editor-template-areas {
-	margin-top: $grid-unit-20;
 	&__list {
 		margin: 0;
 		> li {

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -25,6 +25,7 @@
 @import "./components/post-last-revision/style.scss";
 @import "./components/post-locked-modal/style.scss";
 @import "./components/post-panel-row/style.scss";
+@import "./components/post-panel-section/style.scss";
 @import "./components/post-publish-panel/style.scss";
 @import "./components/post-saved-state/style.scss";
 @import "./components/post-schedule/style.scss";

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -112,7 +112,6 @@ test.describe( 'Sidebar', () => {
 
 		await expect( documentSettingsPanels ).toHaveText( [
 			'No Title',
-			'Summary',
 			'Categories',
 			'Tags',
 			'Discussion',
@@ -124,8 +123,13 @@ test.describe( 'Sidebar', () => {
 		const postFeaturedImagePanel = page.getByRole( 'button', {
 			name: 'Set featured image',
 		} );
-		await expect( postExcerptPanel ).toHaveCount( 1 );
-		await expect( postFeaturedImagePanel ).toHaveCount( 1 );
+		const postSummarySection = page.getByRole( 'checkbox', {
+			name: 'Stick to the top of the blog',
+		} );
+
+		await expect( postExcerptPanel ).toBeVisible();
+		await expect( postFeaturedImagePanel ).toBeVisible();
+		await expect( postSummarySection ).toBeVisible();
 
 		await page.evaluate( () => {
 			const { removeEditorPanel } =
@@ -140,7 +144,8 @@ test.describe( 'Sidebar', () => {
 		} );
 
 		await expect( documentSettingsPanels ).toHaveCount( 1 );
-		await expect( postExcerptPanel ).toHaveCount( 0 );
-		await expect( postFeaturedImagePanel ).toHaveCount( 0 );
+		await expect( postExcerptPanel ).toBeHidden();
+		await expect( postFeaturedImagePanel ).toBeHidden();
+		await expect( postSummarySection ).toBeHidden();
 	} );
 } );

--- a/test/e2e/specs/site-editor/settings-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/settings-sidebar.spec.js
@@ -55,12 +55,9 @@ test.describe( 'Settings sidebar', () => {
 			const templateTitle = settingsSideber.locator(
 				'.editor-post-card-panel__title'
 			);
-			const templateDescription = settingsSideber.locator(
-				'.editor-post-card-panel__description'
-			);
 
 			await expect( templateTitle ).toHaveText( 'Index' );
-			await expect( templateDescription ).toHaveText(
+			await expect( settingsSideber ).toContainText(
 				'Used as a fallback template for all pages when a more specific template is not defined.'
 			);
 
@@ -71,7 +68,7 @@ test.describe( 'Settings sidebar', () => {
 			} );
 
 			await expect( templateTitle ).toHaveText( 'Single Entries' );
-			await expect( templateDescription ).toHaveText(
+			await expect( settingsSideber ).toContainText(
 				'Displays any single entry, such as a post or a page. This template will serve as a fallback when a more specific template (e.g. Single Post, Page, or Attachment) cannot be found.'
 			);
 		} );


### PR DESCRIPTION
Related to #59689 

## What?

This PR iterates towards the designs shared in #59689 
It's not meant to solve everything yet but it does a few things that moves us in the right direction:

 - All the summary controls are rendered within the PostSummary component.
 - Tweaks spacing a little bit.
 - Removes collapsible panel from the summary panel.
 - Removes separator between the PostCard and PostSummary by rendering the PostCard within PostSummary.

## Testing Instructions

Open the post or site editor for the following post types:

 - Post, page, navigation, template part, template, pattern.

Ensure the summary looks correct and is consistent.

## Screenshots or screencast <!-- if applicable -->
<img width="285" alt="Screenshot 2024-05-13 at 2 43 54 PM" src="https://github.com/WordPress/gutenberg/assets/272444/03e9bc98-1d81-4530-a40c-c08237f0646f">
