### PR TITLE
Post Actions: Correctly disable dropdown trigger

### DIFF
--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -52,6 +52,7 @@ export default function PostActions( { onActionPerformed, buttonProps } ) {
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
 					disabled={ ! actions.length }
+					__experimentalIsFocusable
 					className="editor-all-actions-button"
 					onClick={ () =>
 						setIsActionsMenuOpen( ! isActionsMenuOpen )


### PR DESCRIPTION
## What?
PR makes sure that the "Post Actions" dropdown trigger is focusable even when disabled.

## Why?
See #56547.

## Testing Instructions
1. Open a post.
2. Edit the post template.
3. Confirm that the "Actions" button is disabled but still focusable.

### Testing Instructions for Keyboard
Same.

### Screenshot
![CleanShot 2024-05-13 at 17 47 10](https://github.com/WordPress/gutenberg/assets/240569/653bd74b-fccb-49cc-b210-b4206661107f)

