### PR TITLE
E2E: Ensure SE canvas loader appears before waiting for it to disappear

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -37,7 +37,31 @@ export async function visitSiteEditor(
 		query.set( 'canvas', canvas );
 	}
 
+	const canvasLoader = this.page.locator(
+		// Spinner was used instead of the progress bar in an earlier version of
+		// the site editor.
+		'.edit-site-canvas-loader, .edit-site-canvas-spinner'
+	);
+
 	await this.visitAdminPage( 'site-editor.php', query.toString() );
+
+	// Try waiting for the canvas loader to appear first, so that the locator
+	// that waits for it to disappear doesn't resolve prematurely.
+	await canvasLoader.waitFor().catch( () => {} );
+
+	/**
+	 * @todo This is a workaround for the fact that the editor canvas is seen as
+	 * ready and visible before the loading spinner is hidden. Ideally, the
+	 * content underneath the loading overlay should be marked inert until the
+	 * loading is done.
+	 */
+	await canvasLoader.waitFor( {
+		state: 'hidden',
+		// Bigger timeout is needed for larger entities, like the Large Post
+		// HTML fixture that we load for performance tests, which often doesn't
+		// make it under the default timeout value.
+		timeout: 60_000,
+	} );
 
 	if ( ! options.showWelcomeGuide ) {
 		await this.editor.setPreferences( 'core/edit-site', {
@@ -47,19 +71,4 @@ export async function visitSiteEditor(
 			welcomeGuideTemplate: false,
 		} );
 	}
-
-	/**
-	 * @todo This is a workaround for the fact that the editor canvas is seen as
-	 * ready and visible before the loading spinner is hidden. Ideally, the
-	 * content underneath the loading overlay should be marked inert until the
-	 * loading is done.
-	 */
-	await this.page
-		// Spinner was used instead of the progress bar in an earlier version of
-		// the site editor.
-		.locator( '.edit-site-canvas-loader, .edit-site-canvas-spinner' )
-		// Bigger timeout is needed for larger entities, for example the large
-		// post html fixture that we load for performance tests, which often
-		// doesn't make it under the default 10 seconds.
-		.waitFor( { state: 'hidden', timeout: 60_000 } );
 }


### PR DESCRIPTION
## What?
When the Site Editor takes longer to load (e.g., due to large canvas content), the `visitSiteEditor` promise resolves prematurely as it incorrectly assumes the canvas loader has already disappeared. In reality, it hasn't even appeared yet. It can lead to, e.g., subsequent locator assertions timing out as their 10s timeout gets eaten up by the canvas loading time. This PR fixes that by attempting to wait for the loader element immediately after the page is loaded so that we can reliably wait for it to disappear.

**Failure example**: [trace.zip](https://github.com/WordPress/gutenberg/files/15306958/trace.zip) (from WooCommerce Blocks)

## Testing Instructions

All tests should pass.