### PR TITLE
WP-ENV: Fix return type and tests

### DIFF
--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -108,7 +108,7 @@ const DEFAULT_ENVIRONMENT_CONFIG = {
  * @param {string} configDirectoryPath A path to the directory we are parsing the config for.
  * @param {string} cacheDirectoryPath  Path to the work directory located in ~/.wp-env.
  *
- * @return {WPRootConfig} Parsed config.
+ * @return {Promise<WPRootConfig>} Parsed config.
  */
 async function parseConfig( configDirectoryPath, cacheDirectoryPath ) {
 	// The local config will be used to override any defaults.

--- a/packages/env/lib/config/test/parse-config.js
+++ b/packages/env/lib/config/test/parse-config.js
@@ -1,5 +1,4 @@
 'use strict';
-/* eslint-disable jest/no-conditional-expect */
 /**
  * Internal dependencies
  */
@@ -319,16 +318,13 @@ describe( 'parseConfig', () => {
 	it( 'throws when latest WordPress version needed but not found', async () => {
 		getLatestWordPressVersion.mockResolvedValue( null );
 
-		expect.assertions( 1 );
-		try {
-			await parseConfig( '/test/gutenberg', '/cache' );
-		} catch ( error ) {
-			expect( error ).toEqual(
-				new ValidationError(
-					'Could not find the latest WordPress version. There may be a network issue.'
-				)
-			);
-		}
+		await expect(
+			parseConfig( '/test/gutenberg', '/cache' )
+		).rejects.toEqual(
+			new ValidationError(
+				'Could not find the latest WordPress version. There may be a network issue.'
+			)
+		);
 	} );
 
 	it( 'throws for unknown config options', async () => {
@@ -346,16 +342,13 @@ describe( 'parseConfig', () => {
 			throw new Error( 'Invalid File: ' + configFile );
 		} );
 
-		expect.assertions( 1 );
-		try {
-			await parseConfig( '/test/gutenberg', '/cache' );
-		} catch ( error ) {
-			expect( error ).toEqual(
-				new ValidationError(
-					`Invalid /test/gutenberg/.wp-env.json: "test" is not a configuration option.`
-				)
-			);
-		}
+		await expect(
+			parseConfig( '/test/gutenberg', '/cache' )
+		).rejects.toEqual(
+			new ValidationError(
+				`Invalid /test/gutenberg/.wp-env.json: "test" is not a configuration option.`
+			)
+		);
 	} );
 
 	it( 'throws for root-only config options', async () => {
@@ -378,16 +371,12 @@ describe( 'parseConfig', () => {
 			throw new Error( 'Invalid File: ' + configFile );
 		} );
 
-		expect.assertions( 1 );
-		try {
-			await parseConfig( '/test/gutenberg', '/cache' );
-		} catch ( error ) {
-			expect( error ).toEqual(
-				new ValidationError(
-					`Invalid /test/gutenberg/.wp-env.json: "development.env" is not a configuration option.`
-				)
-			);
-		}
+		await expect(
+			parseConfig( '/test/gutenberg', '/cache' )
+		).rejects.toEqual(
+			new ValidationError(
+				`Invalid /test/gutenberg/.wp-env.json: "development.env" is not a configuration option.`
+			)
+		);
 	} );
 } );
-/* eslint-enable jest/no-conditional-expect */


### PR DESCRIPTION
## What?

This is a fix in test and type for wp-env. I noticed it while working on #61486 and extracted it here.

## Why?

- There are some unnecessary lint disables around test expectations. The tests can be refactored to remove conditional expects and enable the lint.
- A return type is wrong.

## How?

Fix the things!

## Testing Instructions

CI should be sufficient.
