### PR TITLE
Fix grid item resizing in non-iframed editor.

### DIFF
--- a/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
@@ -63,6 +63,8 @@ function GridItemResizerInner( {
 	 * This ref is necessary get the bounding client rect of the resizer,
 	 * because it exists outside of the iframe, so its bounding client
 	 * rect isn't the same as the block element's.
+	 * It needs to be added to a dummy element because we can't be sure if
+	 * the popover or the resizer are on the page when we need them.
 	 */
 	const resizerRef = useRef( null );
 
@@ -131,7 +133,6 @@ function GridItemResizerInner( {
 			clientId={ clientId }
 			__unstablePopoverSlot="block-toolbar"
 			additionalStyles={ styles }
-			__unstableContentRef={ resizerRef }
 		>
 			<ResizableBox
 				className="block-editor-grid-item-resizer__box"
@@ -164,8 +165,9 @@ function GridItemResizerInner( {
 					 * isn't directly above the handle, so we try to detect if it happens
 					 * outside the grid and dispatch a mouseup event on the handle.
 					 */
-					const rootElementParent =
-						rootBlockElement.closest( 'body' );
+					const rootElementParent = rootBlockElement.closest(
+						'.editor-styles-wrapper'
+					);
 					rootElementParent.addEventListener(
 						'mouseup',
 						() => {
@@ -221,6 +223,10 @@ function GridItemResizerInner( {
 					controller.abort();
 				} }
 			/>
+			<div
+				className="block-editor-grid-item-resizer__dummy"
+				ref={ resizerRef }
+			></div>
 		</BlockPopoverCover>
 	);
 }

--- a/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
@@ -165,10 +165,8 @@ function GridItemResizerInner( {
 					 * isn't directly above the handle, so we try to detect if it happens
 					 * outside the grid and dispatch a mouseup event on the handle.
 					 */
-					const rootElementParent = rootBlockElement.closest(
-						'.editor-styles-wrapper'
-					);
-					rootElementParent.addEventListener(
+					controller.abort();
+					event.target.ownerDocument.addEventListener(
 						'mouseup',
 						() => {
 							event.target.dispatchEvent(

--- a/packages/block-editor/src/components/grid-visualizer/style.scss
+++ b/packages/block-editor/src/components/grid-visualizer/style.scss
@@ -32,3 +32,10 @@
 	}
 }
 
+.block-editor-grid-item-resizer__dummy {
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	z-index: -1;
+}
+


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes one of the issues described in #61633: the non-iframed editor crashing when using the grid resizer, by moving the mouseup event listener that was added to `body` (which was meant to target the iframe body element) to `.editor-styles-wrapper` which will target the root editor canvas element in both iframed and non-iframed scenarios.

Also fixes a discrepancy in the grid resizing bounds for the non-iframed editor by reintroducing a dummy div to attach the resizer ref to, which was originally removed in https://github.com/WordPress/gutenberg/pull/60986#discussion_r1591816580. The problem is that attaching the ref to any of the child components of `GridItemResizerInner` doesn't guarantee it'll actually be in the DOM when we need it. For context, the ref is needed to calculate the height discrepancy between the grid item and its resizer, in the scenario where the editor is iframed and they belong to different documents.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the post editor, enable Custom Fields under Preferences.
2. Add a Grid block with some children to the canvas.
3. Try resizing the children, pulling the resize handles and bringing them back to the original position, and verify the editor doesn't crash.
4. Try resizing up or down to the boundaries of the grid, and verify the resizer doesn't go beyond those boundaries.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
