### PR TITLE
Stabilise grid layout visualiser and resizer.

### DIFF
--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -154,10 +154,6 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 		return null;
 	}
 
-	if ( ! window.__experimentalEnableGridInteractivity ) {
-		return null;
-	}
-
 	return (
 		<>
 			<GridVisualizer

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -93,9 +93,6 @@ export default {
 		);
 	},
 	toolBarControls: function GridLayoutToolbarControls( { clientId } ) {
-		if ( ! window.__experimentalEnableGridInteractivity ) {
-			return null;
-		}
 		return <GridVisualizer clientId={ clientId } />;
 	},
 	getLayoutStyle: function getLayoutStyle( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Furthers #57478.

Pending the last little bit of #61633 being solved, the grid visualizer and resizer can be brought out of experimental status.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Disable the grid experiment under Gutenberg > Experiments if it's enabled;
2. Add a Grid block to a post, with some children in it;
3. Check that the visualizer appears and the children can be resized with the resizers.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="724" alt="Screenshot 2024-05-14 at 3 37 34 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/1de40e92-2ada-4017-af41-cc3b0524e06a">

