### PR TITLE
Grid Visualizer: Fix grid item resizing in site editor

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -58,7 +58,7 @@
 		}
 	}
 
-	.components-resizable-box__container {
+	& > .components-resizable-box__container {
 		margin: 0 auto;
 	}
 


### PR DESCRIPTION
## What?

Fixes bug documented in https://github.com/WordPress/gutenberg/issues/61633.

Using the resize handles to make a grid item in the site editor smaller made both the left and right sides of the resizable box shrink towards the middle. Only the side you're dragging should move.


## How?
A `margin: 0 auto` rule that's used by the site editor to keep the resizable canvas centred was conflicting with `GridItemResizer`. The fix is to make that rule more specific.

## Testing Instructions
1. Open the site editor and edit a page or template.
2. Insert a grid block and insert a block into the grid.
4. Grab the left or right resize handle and resize the grid item to be _smaller_.
5. Only the handle that you're grabbing should move. Not the opposite handle.

## Screenshots or screencast 

Before:

https://github.com/WordPress/gutenberg/assets/612155/858d43cf-9036-44fd-884e-411c8956108a

After:

https://github.com/WordPress/gutenberg/assets/612155/a3b0faac-2861-4035-9daa-c6c043c787b2