### PR TITLE
Update block-transforms.md to have a copyable code block.

### DIFF
--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -246,7 +246,7 @@ We want to tell the editor to allow the inner `h2` and `p` elements. We do this 
 a `<RichText />` component is a good place to allow phrasing content otherwise we'll lose all text formatting on conversion.
 
 ```js
-schema : ({ phrasingContentSchema }) => ({
+schema: ( { phrasingContentSchema } ) => ( {
     div: {
         required: true,
         attributes: [ 'data-post-id' ],
@@ -255,7 +255,7 @@ schema : ({ phrasingContentSchema }) => ({
             p: { children: phrasingContentSchema }
         }
     }
-})
+} )
 ```
 
 When we successfully match this content every HTML attribute will be stripped away except for `data-post-id` and if we have other arrangements of HTML inside of a given `div` then it won't match our transformer. Likewise we'd fail to match if we found an `<h3>` in there instead of an `<h2>`.

--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -246,7 +246,7 @@ We want to tell the editor to allow the inner `h2` and `p` elements. We do this 
 a `<RichText />` component is a good place to allow phrasing content otherwise we'll lose all text formatting on conversion.
 
 ```js
-schema = ({ phrasingContentSchema }) => {
+schema : ({ phrasingContentSchema }) => ({
     div: {
         required: true,
         attributes: [ 'data-post-id' ],
@@ -255,7 +255,7 @@ schema = ({ phrasingContentSchema }) => {
             p: { children: phrasingContentSchema }
         }
     }
-}
+})
 ```
 
 When we successfully match this content every HTML attribute will be stripped away except for `data-post-id` and if we have other arrangements of HTML inside of a given `div` then it won't match our transformer. Likewise we'd fail to match if we found an `<h3>` in there instead of an `<h2>`.


### PR DESCRIPTION
## What?
Looking at the [documentation for "Raw" transforms](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-transforms/#raw), the schema example isn't a copyable example.

This PR updates the example so users can immediately copy it and use it for their own block transforms.

## How?

**Current**
```js
schema = ({ phrasingContentSchema }) => {
    div: {
        required: true,
        attributes: [ 'data-post-id' ],
        children: {
            h2: { children: phrasingContentSchema },
            p: { children: phrasingContentSchema }
        }
    }
}
```
**Proposal**
```js
schema: ( { phrasingContentSchema } ) => ( {
    div: {
        required: true,
        attributes: [ 'data-post-id' ],
        children: {
            h2: { children: phrasingContentSchema },
            p: { children: phrasingContentSchema }
        }
    }
} )
```

## Testing Instructions
N/A

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
