### PR TITLE
GridItemResizer: Fix resizing when List View is open

### DIFF
--- a/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { ResizableBox } from '@wordpress/components';
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-
 import BlockPopoverCover from '../block-popover/cover';
 import { getComputedCSS } from './utils';
 
-export function GridItemResizer( { clientId, onChange } ) {
+export function GridItemResizer( { clientId, bounds, onChange } ) {
 	const blockElement = useBlockElement( clientId );
 	const rootBlockElement = blockElement?.parentElement;
 
@@ -22,6 +22,7 @@ export function GridItemResizer( { clientId, onChange } ) {
 	return (
 		<GridItemResizerInner
 			clientId={ clientId }
+			bounds={ bounds }
 			blockElement={ blockElement }
 			rootBlockElement={ rootBlockElement }
 			onChange={ onChange }
@@ -31,6 +32,7 @@ export function GridItemResizer( { clientId, onChange } ) {
 
 function GridItemResizerInner( {
 	clientId,
+	bounds,
 	blockElement,
 	rootBlockElement,
 	onChange,
@@ -59,19 +61,6 @@ function GridItemResizerInner( {
 		return () => observer.disconnect();
 	}, [ blockElement, rootBlockElement ] );
 
-	/*
-	 * This ref is necessary get the bounding client rect of the resizer,
-	 * because it exists outside of the iframe, so its bounding client
-	 * rect isn't the same as the block element's.
-	 * It needs to be added to a dummy element because we can't be sure if
-	 * the popover or the resizer are on the page when we need them.
-	 */
-	const resizerRef = useRef( null );
-
-	if ( ! blockElement ) {
-		return null;
-	}
-
 	const justification = {
 		right: 'flex-start',
 		left: 'flex-end',
@@ -92,36 +81,6 @@ function GridItemResizerInner( {
 		...( alignment[ resizeDirection ] && {
 			alignItems: alignment[ resizeDirection ],
 		} ),
-	};
-
-	/*
-	 * The bounding element is equivalent to the root block element, but
-	 * its bounding client rect is modified to account for the resizer
-	 * being outside of the editor iframe.
-	 */
-	const boundingElement = {
-		offsetWidth: rootBlockElement.offsetWidth,
-		offsetHeight: rootBlockElement.offsetHeight,
-		getBoundingClientRect: () => {
-			const blockClientRect = blockElement.getBoundingClientRect();
-			const rootBlockClientRect =
-				rootBlockElement.getBoundingClientRect();
-			const resizerTop = resizerRef.current?.getBoundingClientRect()?.top;
-			// Fallback value of 60 to account for editor top bar height.
-			const heightDifference = resizerTop
-				? resizerTop - blockClientRect.top
-				: 60;
-			return {
-				bottom: rootBlockClientRect.bottom + heightDifference,
-				height: rootBlockElement.offsetHeight,
-				left: rootBlockClientRect.left,
-				right: rootBlockClientRect.right,
-				top: rootBlockClientRect.top + heightDifference,
-				width: rootBlockClientRect.width,
-				x: rootBlockClientRect.x,
-				y: rootBlockClientRect.y + heightDifference,
-			};
-		},
 	};
 
 	// Controller to remove event listener on resize stop.
@@ -150,7 +109,7 @@ function GridItemResizerInner( {
 					topLeft: false,
 					topRight: false,
 				} }
-				bounds={ boundingElement }
+				bounds={ bounds }
 				boundsByDirection
 				onResizeStart={ ( event, direction ) => {
 					/*
@@ -221,10 +180,6 @@ function GridItemResizerInner( {
 					controller.abort();
 				} }
 			/>
-			<div
-				className="block-editor-grid-item-resizer__dummy"
-				ref={ resizerRef }
-			></div>
 		</BlockPopoverCover>
 	);
 }

--- a/packages/block-editor/src/components/grid-visualizer/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-visualizer.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, forwardRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -12,7 +12,7 @@ import BlockPopoverCover from '../block-popover/cover';
 import { store as blockEditorStore } from '../../store';
 import { getComputedCSS } from './utils';
 
-export function GridVisualizer( { clientId } ) {
+export function GridVisualizer( { clientId, contentRef } ) {
 	const isDistractionFree = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings().isDistractionFree,
@@ -30,12 +30,15 @@ export function GridVisualizer( { clientId } ) {
 			clientId={ clientId }
 			__unstablePopoverSlot="block-toolbar"
 		>
-			<GridVisualizerGrid blockElement={ blockElement } />
+			<GridVisualizerGrid
+				ref={ contentRef }
+				blockElement={ blockElement }
+			/>
 		</BlockPopoverCover>
 	);
 }
 
-function GridVisualizerGrid( { blockElement } ) {
+const GridVisualizerGrid = forwardRef( ( { blockElement }, ref ) => {
 	const [ gridInfo, setGridInfo ] = useState( () =>
 		getGridInfo( blockElement )
 	);
@@ -56,6 +59,7 @@ function GridVisualizerGrid( { blockElement } ) {
 	}, [ blockElement ] );
 	return (
 		<div
+			ref={ ref }
 			className="block-editor-grid-visualizer__grid"
 			style={ gridInfo.style }
 		>
@@ -64,7 +68,7 @@ function GridVisualizerGrid( { blockElement } ) {
 			) ) }
 		</div>
 	);
-}
+} );
 
 function getGridInfo( blockElement ) {
 	const gridTemplateColumns = getComputedCSS(

--- a/packages/block-editor/src/components/grid-visualizer/style.scss
+++ b/packages/block-editor/src/components/grid-visualizer/style.scss
@@ -31,11 +31,3 @@
 		pointer-events: all !important;
 	}
 }
-
-.block-editor-grid-item-resizer__dummy {
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	z-index: -1;
-}
-

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -162,7 +162,7 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 		<>
 			<GridVisualizer
 				clientId={ rootClientId }
-				contentRef={ ( instance ) => setResizerBounds( instance ) }
+				contentRef={ setResizerBounds }
 			/>
 			{ allowSizingOnChildren && (
 				<GridItemResizer

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -3,6 +3,7 @@
  */
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -134,29 +135,40 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 }
 
 function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
-	const parentLayout = useLayout() || {};
 	const {
 		type: parentLayoutType = 'default',
 		allowSizingOnChildren = false,
-	} = parentLayout;
+	} = useLayout() || {};
+
 	const rootClientId = useSelect(
 		( select ) => {
 			return select( blockEditorStore ).getBlockRootClientId( clientId );
 		},
 		[ clientId ]
 	);
+
+	// Use useState() instead of useRef() so that GridItemResizer updates when ref is set.
+	const [ resizerBounds, setResizerBounds ] = useState();
+
 	if ( parentLayoutType !== 'grid' ) {
 		return null;
 	}
+
 	if ( ! window.__experimentalEnableGridInteractivity ) {
 		return null;
 	}
+
 	return (
 		<>
-			<GridVisualizer clientId={ rootClientId } />
+			<GridVisualizer
+				clientId={ rootClientId }
+				contentRef={ ( instance ) => setResizerBounds( instance ) }
+			/>
 			{ allowSizingOnChildren && (
 				<GridItemResizer
 					clientId={ clientId }
+					// Don't allow resizing beyond the grid visualizer.
+					bounds={ resizerBounds }
 					onChange={ ( { columnSpan, rowSpan } ) => {
 						setAttributes( {
 							style: {


### PR DESCRIPTION
## What?
Fixes a bug noticed in https://github.com/WordPress/gutenberg/pull/61641 (which is in turn part of https://github.com/WordPress/gutenberg/issues/61633) where the grid item resizes behaves funnily when the List View is opened.

## How?
Opening the List View changes the origin that `getBoundingClientRect()` uses which means that the bounds rectangle we pass to `ResizableBox` is no longer correct.

We could update our logic that calculate `bounds` to accomodate the List View, but I think this is too complicated.

So instead I replaced the logic we use for calculating bounds with something that I think is simpler which is setting `ResizableBox`'s `bounds` prop to be `.block-editor-grid-visualizer__grid` which we know will be on screen, not in the iframe, and the correct size and position to act as bounds.

I'm doing some ref passing instead of `querySelector` because I think it makes the relationship more explicit.

## Testing Instructions
1. Open the site editor and edit a page or template.
2. Insert a grid block and insert a block or two into the grid.
3. Make the grid item have a >1 column span.
4. Open the List View.
5. Resize the grid item vertically.
6. The resize box should not shrink all of a sudden.