### PR TITLE
Post Actions: Pass entity permission to the 'isEligible' method

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -43,8 +43,8 @@ const trashPostAction = {
 	label: __( 'Move to Trash' ),
 	isPrimary: true,
 	icon: trash,
-	isEligible( { status } ) {
-		return status !== 'trash';
+	isEligible( item, permissions ) {
+		return item.status !== 'trash' && !! permissions?.canDelete;
 	},
 	supportsBulk: true,
 	hideModalHeader: true,


### PR DESCRIPTION
## What?
🚧 PoC for introducing entity permission to the "Post Actions"

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Create a test use with a Contributor role.
2. Remove `delete_posts` capability - `wp cap remove 'contributor' 'delete_posts'`
3. Create a post and save it as a draft.
4. The big red "Move to Trash" button shouldn't be visible
5. The "Move to Trash" action shouldn't be visible.


### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-14 at 12 49 27](https://github.com/WordPress/gutenberg/assets/240569/48798db6-5e0f-4adc-aa92-508711f40195)
