### PR TITLE
Polish external link, avoid CSS bleed.

### DIFF
--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -7,6 +7,10 @@
 }
 
 .components-external-link__icon {
-	margin-left: 0.5ch;
-	font-weight: 400;
+	// These styles exist to override plugins that incorrectly style this component.
+	&.components-external-link__icon {
+		vertical-align: initial;
+		margin: 0;
+		margin-left: 0.5ch;
+	}
 }


### PR DESCRIPTION
## What?

The ExternalLink component is subject to CSS bleed from plugins that also style this same classname.

![css bleed from jetpack](https://github.com/WordPress/gutenberg/assets/1204802/ba5481c4-eff1-4a99-b454-76cab26c46ef)

This PR increases specificity and unstyles some pieces that break the core component. It also removes the font-weight so that the weight of the glyph is the same as adjacent text:

![after](https://github.com/WordPress/gutenberg/assets/1204802/22495e2b-c49e-4550-bca6-fdebf5bbe2c5)

The font weight change is mainly motivated by leveraging the fact that the unicode glyph is the same font and size as the surrounding text, so by keeping the weight in sync gels with that. 

## Testing Instructions

* Activate the Jetpack plugin
* Observe the external link glyph being vertically pushed down.
* Check out this PR
* Observe that the glyph should be correctly positioned.