### PR TITLE
Update plugin-document-setting-panel.md bad import reference

### DIFF
--- a/docs/reference-guides/slotfills/plugin-document-setting-panel.md
+++ b/docs/reference-guides/slotfills/plugin-document-setting-panel.md
@@ -13,7 +13,7 @@ This SlotFill allows registering a UI to edit Document settings.
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 
 const PluginDocumentSettingPanelDemo = () => (
 	<PluginDocumentSettingPanel
@@ -49,7 +49,7 @@ To programmatically toggle panels, use the following:
 
 ```js
 import { useDispatch } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
+import { store as editorStore } from '@wordpress/edit-post';
 
 const Example = () => {
 	const { toggleEditorPanelOpened } = useDispatch( editorStore );
@@ -76,7 +76,7 @@ It is also possible to remove panels from the admin using the `removeEditorPanel
 
 ```js
 import { useDispatch } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
+import { store as editorStore } from '@wordpress/edit-post';
 
 const Example = () => {
 	const { removeEditorPanel } = useDispatch( editorStore );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix reference error found in documentation on [PluginDocumentSettingPanel](https://developer.wordpress.org/block-editor/reference-guides/slotfills/plugin-document-setting-panel/)

## Why?
When you follow the code examples you get non-compiling code as `PluginDocumentSettingPanel` is `undefined` when using the editor library instead of edit-post

## How?
Updates the documentation to use the correct library where `PluginDocumentSettingPanel` can be found

Changes imports from `@wordpress/editor` to `@wordpress/edit-post`

## Testing Instructions
Tested on WP 6.5.3
Built with node packages: 
@wordpress/scripts 27.8.0
@wordpress/components 27.5.0

Create a simple WP Block and use the demo code. Compile using `npm run build`. Include the block or built JavaScript, there should be no undefined `PluginDocumentSettingPanel` now. 
```
import { registerPlugin } from '@wordpress/plugins';
import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
const PluginDocumentSettingPanelDemo = () => (
    <PluginDocumentSettingPanel
        name="lime-custom-panel"
        title="Custom Panel"
        className="lime-custom-panel"
    >
        Custom Panel Contents
    </PluginDocumentSettingPanel>
);

registerPlugin('plugin-document-setting-panel-demo', {
    render: PluginDocumentSettingPanelDemo,
    icon: 'palmtree',
});
```

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
