### PR TITLE
Add script module data implementation

### DIFF
--- a/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
@@ -196,7 +196,7 @@ if ( ! class_exists( 'WP_Interactivity_API' ) ) {
 		 * @since 6.5.0
 		 */
 		public function add_hooks() {
-			add_filter( 'gb_scriptmoduledata_@wordpress/interactivity', array( $this, 'print_client_interactivity_data' ) );
+			add_filter( 'scriptmoduledata_@wordpress/interactivity', array( $this, 'print_client_interactivity_data' ) );
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
@@ -196,6 +196,7 @@ if ( ! class_exists( 'WP_Interactivity_API' ) ) {
 		 * @since 6.5.0
 		 */
 		public function add_hooks() {
+			add_action( 'wp_enqueue_scripts', array( $this, 'register_script_modules' ) );
 			add_filter( 'scriptmoduledata_@wordpress/interactivity', array( $this, 'print_client_interactivity_data' ) );
 		}
 

--- a/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
@@ -167,18 +167,7 @@ if ( ! class_exists( 'WP_Interactivity_API' ) ) {
 				$interactivity_data['state'] = $state;
 			}
 
-			if ( ! empty( $interactivity_data ) ) {
-				wp_print_inline_script_tag(
-					wp_json_encode(
-						$interactivity_data,
-						JSON_HEX_TAG | JSON_HEX_AMP
-					),
-					array(
-						'type' => 'application/json',
-						'id'   => 'wp-interactivity-data',
-					)
-				);
-			}
+			return $interactivity_data;
 		}
 
 		/**
@@ -207,8 +196,7 @@ if ( ! class_exists( 'WP_Interactivity_API' ) ) {
 		 * @since 6.5.0
 		 */
 		public function add_hooks() {
-			add_action( 'wp_enqueue_scripts', array( $this, 'register_script_modules' ) );
-			add_action( 'wp_footer', array( $this, 'print_client_interactivity_data' ) );
+			add_filter( 'gb_scriptmoduledata_@wordpress/interactivity', array( $this, 'print_client_interactivity_data' ) );
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
@@ -131,21 +131,20 @@ if ( ! class_exists( 'WP_Interactivity_API' ) ) {
 		}
 
 		/**
-		 * Prints the serialized client-side interactivity data.
+		 * Adds interactivity data to filtered data to be passed to the client.
 		 *
-		 * Encodes the config and initial state into JSON and prints them inside a
-		 * script tag of type "application/json". Once in the browser, the state will
-		 * be parsed and used to hydrate the client-side interactivity stores and the
-		 * configuration will be available using a `getConfig` utility.
+		 * Once in the browser, the state will be parsed and used to hydrate the client-side
+		 * interactivity stores and the configuration will be available using a `getConfig` utility.
 		 *
 		 * @since 6.5.0
+		 *
+		 * @param array $interactivity_data Interactivity data.
+		 * @return array $interactivity_data Interactivity data with store data added (if it exists).
 		 */
-		public function print_client_interactivity_data() {
+		public function print_client_interactivity_data( $interactivity_data ) {
 			if ( empty( $this->state_data ) && empty( $this->config_data ) ) {
-				return;
+				return $interactivity_data;
 			}
-
-			$interactivity_data = array();
 
 			$config = array();
 			foreach ( $this->config_data as $key => $value ) {

--- a/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
+++ b/lib/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php
@@ -131,20 +131,21 @@ if ( ! class_exists( 'WP_Interactivity_API' ) ) {
 		}
 
 		/**
-		 * Adds interactivity data to filtered data to be passed to the client.
+		 * Prints the serialized client-side interactivity data.
 		 *
-		 * Once in the browser, the state will be parsed and used to hydrate the client-side
-		 * interactivity stores and the configuration will be available using a `getConfig` utility.
+		 * Encodes the config and initial state into JSON and prints them inside a
+		 * script tag of type "application/json". Once in the browser, the state will
+		 * be parsed and used to hydrate the client-side interactivity stores and the
+		 * configuration will be available using a `getConfig` utility.
 		 *
 		 * @since 6.5.0
-		 *
-		 * @param array $interactivity_data Interactivity data.
-		 * @return array $interactivity_data Interactivity data with store data added (if it exists).
 		 */
-		public function print_client_interactivity_data( $interactivity_data ) {
+		public function print_client_interactivity_data() {
 			if ( empty( $this->state_data ) && empty( $this->config_data ) ) {
-				return $interactivity_data;
+				return;
 			}
+
+			$interactivity_data = array();
 
 			$config = array();
 			foreach ( $this->config_data as $key => $value ) {
@@ -166,7 +167,18 @@ if ( ! class_exists( 'WP_Interactivity_API' ) ) {
 				$interactivity_data['state'] = $state;
 			}
 
-			return $interactivity_data;
+			if ( ! empty( $interactivity_data ) ) {
+				wp_print_inline_script_tag(
+					wp_json_encode(
+						$interactivity_data,
+						JSON_HEX_TAG | JSON_HEX_AMP
+					),
+					array(
+						'type' => 'application/json',
+						'id'   => 'wp-interactivity-data',
+					)
+				);
+			}
 		}
 
 		/**
@@ -196,7 +208,7 @@ if ( ! class_exists( 'WP_Interactivity_API' ) ) {
 		 */
 		public function add_hooks() {
 			add_action( 'wp_enqueue_scripts', array( $this, 'register_script_modules' ) );
-			add_filter( 'scriptmoduledata_@wordpress/interactivity', array( $this, 'print_client_interactivity_data' ) );
+			add_action( 'wp_footer', array( $this, 'print_client_interactivity_data' ) );
 		}
 
 		/**

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -215,7 +215,7 @@ function gutenberg_print_script_module_data(): void {
 	}
 
 	foreach ( array_keys( $modules ) as $module_id ) {
-		$data = apply_filters( 'scriptmoduledata_' . $module_id, array() );
+		$data = apply_filters( "scriptmoduledata_{$module_id}", array() );
 		if ( ! empty( $data ) ) {
 			/*
 			 * This data will be printed as JSON inside a script tag like this:

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -215,7 +215,7 @@ function gutenberg_print_script_module_data(): void {
 	}
 
 	foreach ( array_keys( $modules ) as $module_id ) {
-		$data = apply_filters( 'gb_scriptmoduledata_' . $module_id, array() );
+		$data = apply_filters( 'scriptmoduledata_' . $module_id, array() );
 		if ( ! empty( $data ) ) {
 					/*
 			 * This data will be printed as JSON inside a script tag like this:
@@ -264,7 +264,7 @@ function gutenberg_print_script_module_data(): void {
 				wp_json_encode( $data, $json_encode_flags ),
 				array(
 					'type' => 'application/json',
-					'id'   => 'gb-scriptmodule-data_' . $module_id,
+					'id'   => 'wp-scriptmodule-data_' . $module_id,
 				)
 			);
 		}

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -200,7 +200,15 @@ function gutenberg_dequeue_module( $module_identifier ) {
 
 
 /**
- * @since 18.4.0
+ * Print data associated with Script Modules in Script tags.
+ *
+ * This embeds data in the page HTML so that it is available on page load.
+ *
+ * Data can be associated with a given Script Module by using the
+ * `scriptmoduledata_{$module_id}` filter.
+ *
+ * The data for a given Script Module will be JSON serialized in a script tag with an ID
+ * like `wp-scriptmodule-data_{$module_id}`.
  */
 function gutenberg_print_script_module_data(): void {
 	$get_marked_for_enqueue = new ReflectionMethod( 'WP_Script_Modules', 'get_marked_for_enqueue' );
@@ -215,7 +223,26 @@ function gutenberg_print_script_module_data(): void {
 	}
 
 	foreach ( array_keys( $modules ) as $module_id ) {
+		/**
+		 * Filters data associated with a given Script Module.
+		 *
+		 * Script Modules may require data that is required for initialization or is essential to
+		 * have immediately available on page load. These are suitable use cases for this data.
+		 *
+		 * This is best suited to a minimal set of data and is not intended to replace the REST API.
+		 *
+		 * If the filter returns no data (an empty array), nothing will be embedded in the page.
+		 *
+		 * The data for a given Script Module, if provided, will be JSON serialized in a script tag
+		 * with an ID like `wp-scriptmodule-data_{$module_id}`.
+		 *
+		 * The dynamic portion of the hook name, `$module_id`, refers to the Script Module ID that
+		 * the data is associated with.
+		 *
+		 * @param array $data The data that should be associated with the array.
+		 */
 		$data = apply_filters( "scriptmoduledata_{$module_id}", array() );
+
 		if ( ! empty( $data ) ) {
 			/*
 			 * This data will be printed as JSON inside a script tag like this:
@@ -264,7 +291,7 @@ function gutenberg_print_script_module_data(): void {
 				wp_json_encode( $data, $json_encode_flags ),
 				array(
 					'type' => 'application/json',
-					'id'   => 'wp-scriptmodule-data_' . $module_id,
+					'id'   => "wp-scriptmodule-data_{$module_id}",
 				)
 			);
 		}

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -255,36 +255,24 @@ function gutenberg_print_script_module_data(): void {
 			 *   - JSON_HEX_TAG: All < and > are converted to \u003C and \u003E.
 			 *   - JSON_UNESCAPED_SLASHES: Don't escape /.
 			 *
+			 * If the page will use UTF-8 encoding, it's safe to print unescaped unicode:
+			 *
+			 *   - JSON_UNESCAPED_UNICODE: Encode multibyte Unicode characters literally (instead of as `\uXXXX`).
+			 *   - JSON_UNESCAPED_LINE_TERMINATORS: The line terminators are kept unescaped when
+			 *     JSON_UNESCAPED_UNICODE is supplied. It uses the same behaviour as it was
+			 *     before PHP 7.1 without this constant. Available as of PHP 7.1.0.
+			 *
+			 * The JSON specification requires encoding in UTF-8, so if the generated HTML page
+			 * is not encoded in UTF-8 then it's not safe to include those literals. They must
+			 * be escaped to avoid encoding issues.
+			 *
+			 * @see https://www.rfc-editor.org/rfc/rfc8259.html for details on encoding requirements.
 			 * @see https://www.php.net/manual/en/json.constants.php for details on these constants.
-			 * @see https://html.spec.whatwg.org/#script-data-state for details on script
-			 *      tag parsing.
+			 * @see https://html.spec.whatwg.org/#script-data-state for details on script tag parsing.
 			 */
-			$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
-			if ( 'UTF-8' === get_option( 'blog_charset' ) ) {
-				/*
-				 * If the page will use UTF-8 encoding, it's safe to print unescaped unicode in
-				 * JSON. Set the following flags:
-				 *
-				 * - JSON_UNESCAPED_UNICODE: Encode multibyte Unicode characters literally
-				 *   (default is to escape as \uXXXX).
-				 * - JSON_UNESCAPED_LINE_TERMINATORS: The line terminators are kept unescaped when
-				 *   JSON_UNESCAPED_UNICODE is supplied. It uses the same behaviour as it was
-				 *   before PHP 7.1 without this constant. Available as of PHP 7.1.0.
-				 *
-				 * The JSON specification does not specify a character encoding, RFC-8259
-				 * suggests that UTF-8 be used everywhere. It's risky to print unicode if the page
-				 * uses any other encoding.
-				 *
-				 * > JSON text exchanged between systems that are not part of a closed ecosystem
-				 * > MUST be encoded using UTF-8. Previous specifications of JSON have not required
-				 * > the use of UTF-8 when transmitting JSON text.  However, the vast majority of
-				 * > JSON- based software implementations have chosen to use the UTF-8 encoding,
-				 * > to the extent that it is the only encoding that achieves interoperability.
-				 *
-				 * @see https://www.rfc-editor.org/rfc/rfc8259.html
-				 *
-				 */
-				$json_encode_flags |= JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
+			$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
+			if ( 'UTF-8' !== get_option( 'blog_charset' ) ) {
+				$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
 			}
 
 			wp_print_inline_script_tag(

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -215,10 +215,53 @@ function gutenberg_print_script_module_data(): void {
 	}
 
 	foreach ( array_keys( $modules ) as $module_id ) {
-		$config = apply_filters( 'gb_scriptmoduledata_' . $module_id, array() );
-		if ( ! empty( $config ) ) {
+		$data = apply_filters( 'gb_scriptmoduledata_' . $module_id, array() );
+		if ( ! empty( $data ) ) {
+					/*
+			 * This data will be printed as JSON inside a script tag like this:
+			 *   <script type="application/json"></script>
+			 *
+			 * A script tag must be closed by a sequence beginning with `</`. It's impossible to
+			 * close a script tag without using `<`. We ensure that `<` is escaped and `/` can
+			 * remain unescaped, so `</script>` will be printed as `\u003C/script\u00E3`.
+			 *
+			 *   - JSON_HEX_TAG: All < and > are converted to \u003C and \u003E.
+			 *   - JSON_UNESCAPED_SLASHES: Don't escape /.
+			 *
+			 * @see https://www.php.net/manual/en/json.constants.php for details on these constants.
+			 * @see https://html.spec.whatwg.org/#script-data-state for details on script
+			 *      tag parsing.
+			 */
+			$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
+			if ( 'UTF-8' === get_option( 'blog_charset' ) ) {
+				/*
+				 * If the page will use UTF-8 encoding, it's safe to print unescaped unicode in
+				 * JSON. Set the following flags:
+				 *
+				 * - JSON_UNESCAPED_UNICODE: Encode multibyte Unicode characters literally
+				 *   (default is to escape as \uXXXX).
+				 * - JSON_UNESCAPED_LINE_TERMINATORS: The line terminators are kept unescaped when
+				 *   JSON_UNESCAPED_UNICODE is supplied. It uses the same behaviour as it was
+				 *   before PHP 7.1 without this constant. Available as of PHP 7.1.0.
+				 *
+				 * The JSON specification does not specify a character encoding, RFC-8259
+				 * suggests that UTF-8 be used everywhere. It's risky to print unicode if the page
+				 * uses any other encoding.
+				 *
+				 * > JSON text exchanged between systems that are not part of a closed ecosystem
+				 * > MUST be encoded using UTF-8. Previous specifications of JSON have not required
+				 * > the use of UTF-8 when transmitting JSON text.  However, the vast majority of
+				 * > JSON- based software implementations have chosen to use the UTF-8 encoding,
+				 * > to the extent that it is the only encoding that achieves interoperability.
+				 *
+				 * @see https://www.rfc-editor.org/rfc/rfc8259.html
+				 *
+				 */
+				$json_encode_flags |= JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
+			}
+
 			wp_print_inline_script_tag(
-				wp_json_encode( $config, JSON_HEX_TAG | JSON_HEX_AMP ),
+				wp_json_encode( $data, $json_encode_flags ),
 				array(
 					'type' => 'application/json',
 					'id'   => 'gb-scriptmodule-data_' . $module_id,

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -217,7 +217,7 @@ function gutenberg_print_script_module_data(): void {
 	foreach ( array_keys( $modules ) as $module_id ) {
 		$data = apply_filters( 'scriptmoduledata_' . $module_id, array() );
 		if ( ! empty( $data ) ) {
-					/*
+			/*
 			 * This data will be printed as JSON inside a script tag like this:
 			 *   <script type="application/json"></script>
 			 *

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -243,7 +243,7 @@ function gutenberg_print_script_module_data(): void {
 		 */
 		$data = apply_filters( "scriptmoduledata_{$module_id}", array() );
 
-		if ( ! empty( $data ) ) {
+		if ( is_array( $data ) && ! empty( $data ) ) {
 			/*
 			 * This data will be printed as JSON inside a script tag like this:
 			 *   <script type="application/json"></script>

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -319,9 +319,11 @@ export function store(
 }
 
 export const parseInitialData = ( dom = document ) => {
-	const jsonDataScriptTag = dom.getElementById(
-		'wp-scriptmodule-data_@wordpress/interactivity'
-	);
+	const jsonDataScriptTag =
+		// Preferred Script Module data passing form
+		dom.getElementById( 'wp-scriptmodule-data_@wordpress/interactivity' ) ??
+		// Legacy form
+		dom.getElementById( 'wp-interactivity-data' );
 	if ( jsonDataScriptTag?.textContent ) {
 		try {
 			return JSON.parse( jsonDataScriptTag.textContent );

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -319,15 +319,13 @@ export function store(
 }
 
 export const parseInitialData = ( dom = document ) => {
-	const storeTag = dom.querySelector(
-		`script[type="application/json"]#wp-interactivity-data`
+	const jsonDataScriptTag = dom.getElementById(
+		'gb-scriptmodule-data_@wordpress/interactivity'
 	);
-	if ( storeTag?.textContent ) {
+	if ( jsonDataScriptTag?.textContent ) {
 		try {
-			return JSON.parse( storeTag.textContent );
-		} catch ( e ) {
-			// Do nothing.
-		}
+			return JSON.parse( jsonDataScriptTag.textContent );
+		} catch {}
 	}
 	return {};
 };

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -320,7 +320,7 @@ export function store(
 
 export const parseInitialData = ( dom = document ) => {
 	const jsonDataScriptTag = dom.getElementById(
-		'gb-scriptmodule-data_@wordpress/interactivity'
+		'wp-scriptmodule-data_@wordpress/interactivity'
 	);
 	if ( jsonDataScriptTag?.textContent ) {
 		try {


### PR DESCRIPTION
## What?

Add a filter that allows data to be embedded in the page HTML for use by Script Modules.

Use the system to pass Interactivity API data.

Adds a new filter: `scriptmoduledata_{ MODULE_ID }`. If the filter returns non-empty data, it will be embedded in a script tag in the page HTML.

```php
add_filter(
  'scriptmoduledata_@wordpress/interactivity',
  function ( $data ) {
    $data['my-added-data'] = 'it works';
    return $data;
  }
);
```

If this moves into Core, we should be able to use the same filter name and disable the filter based on the presence of the core function name.

See this proposal for details: [Proposal: Server to client data sharing for Script Modules](https://make.wordpress.org/core/2024/05/06/proposal-server-to-client-data-sharing-for-script-modules/)

## Why?

All the details are in the proposal.


## Testing Instructions

This can be tested by anything using the Interactivity API with a server-provided store or configuration. The data should be embedded in an HTML tag on the page.

It should be covered by Interactivity e2e tests.
