### PR TITLE
Remove `onActionPerformed` & `onActionStart` from the ActionModal API

### DIFF
--- a/packages/dataviews/src/item-actions.tsx
+++ b/packages/dataviews/src/item-actions.tsx
@@ -44,8 +44,6 @@ interface ActionModalProps {
 	action: ActionModalType;
 	items: Item[];
 	closeModal?: () => void;
-	onActionStart?: ( items: Item[] ) => void;
-	onActionPerformed?: ( items: Item[] ) => void;
 }
 
 interface ActionWithModalProps extends ActionModalProps {
@@ -97,13 +95,7 @@ function DropdownMenuItemTrigger( {
 	);
 }
 
-export function ActionModal( {
-	action,
-	items,
-	closeModal,
-	onActionStart,
-	onActionPerformed,
-}: ActionModalProps ) {
+export function ActionModal( { action, items, closeModal }: ActionModalProps ) {
 	return (
 		<Modal
 			title={ action.modalHeader || action.label }
@@ -116,8 +108,8 @@ export function ActionModal( {
 			<action.RenderModal
 				items={ items }
 				closeModal={ closeModal }
-				onActionStart={ onActionStart }
-				onActionPerformed={ onActionPerformed }
+				onActionStart={ action.onActionStart }
+				onActionPerformed={ action.onActionPerformed }
 			/>
 		</Modal>
 	);
@@ -127,8 +119,6 @@ export function ActionWithModal( {
 	action,
 	items,
 	ActionTrigger,
-	onActionStart,
-	onActionPerformed,
 	isBusy,
 }: ActionWithModalProps ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -148,8 +138,6 @@ export function ActionWithModal( {
 					action={ action }
 					items={ items }
 					closeModal={ () => setIsModalOpen( false ) }
-					onActionStart={ onActionStart }
-					onActionPerformed={ onActionPerformed }
 				/>
 			) }
 		</>

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -206,6 +206,16 @@ interface ActionBase {
 
 export interface ActionModal extends ActionBase {
 	/**
+	 * The callback to execute when the action has finished.
+	 */
+	onActionPerformed: ( ( items: Item[] ) => void ) | undefined;
+
+	/**
+	 * The callback to execute when the action is triggered.
+	 */
+	onActionStart: ( ( items: Item[] ) => void ) | undefined;
+
+	/**
 	 * Modal to render when the action is triggered.
 	 */
 	RenderModal: ( {

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -229,8 +229,6 @@ function ListItem( {
 											closeModal={ () =>
 												setIsModalOpen( false )
 											}
-											onActionStart={ () => {} }
-											onActionPerformed={ () => {} }
 										/>
 									) }
 								</CompositeItem>


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/60805/files#r1599815188

## What?

Removes `onActionPerformed` and `onActionStart` from the `ActionModal` API.

## Why?

Those are properties available at the action, so it's not necessary to pass them to the modal as well.
