### PR TITLE
Block bindings: Remove not needed breaks in `gutenberg_block_bindings_replace_html`

### DIFF
--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -99,13 +99,10 @@ function gutenberg_block_bindings_replace_html( $block_content, $block_name, str
 			}
 			$amended_content->set_attribute( $block_type->attributes[ $attribute_name ]['attribute'], $source_value );
 			return $amended_content->get_updated_html();
-		break;
 
 		default:
 			return $block_content;
-		break;
 	}
-	return;
 }
 
 /**
@@ -114,6 +111,7 @@ function gutenberg_block_bindings_replace_html( $block_content, $block_name, str
  * @param string   $block_content Block Content.
  * @param array    $parsed_block  The full block, including name and attributes.
  * @param WP_Block $block_instance The block instance.
+ * @return string  The modified block content.
  */
 function gutenberg_process_block_bindings( $block_content, $parsed_block, $block_instance ) {
 	$supported_block_attrs = array(

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -111,7 +111,7 @@ function gutenberg_block_bindings_replace_html( $block_content, $block_name, str
  * @param string   $block_content Block Content.
  * @param array    $parsed_block  The full block, including name and attributes.
  * @param WP_Block $block_instance The block instance.
- * @return string  The modified block content.
+ * @return string  Block content with the bind applied.
  */
 function gutenberg_process_block_bindings( $block_content, $parsed_block, $block_instance ) {
 	$supported_block_attrs = array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Quick PR that removes unreachable code. 

We can include this too in https://github.com/WordPress/gutenberg/pull/61236 backport @SantosGuillamot 