### PR TITLE
Several Typo Corrections in Inline Documentations

### DIFF
--- a/lib/compat/wordpress-6.5/block-bindings/block-bindings.php
+++ b/lib/compat/wordpress-6.5/block-bindings/block-bindings.php
@@ -53,7 +53,7 @@ if ( ! function_exists( 'register_block_bindings_source' ) ) {
  * @since 6.5.0
  *
  * @param string $source_name Block bindings source name including namespace.
- * @return WP_Block_Bindings_Source|false The unregistred block bindings source on success and `false` otherwise.
+ * @return WP_Block_Bindings_Source|false The unregistered block bindings source on success and `false` otherwise.
  */
 if ( ! function_exists( 'unregister_block_bindings_source' ) ) {
 	function unregister_block_bindings_source( string $source_name ) {

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -755,7 +755,7 @@ export function renderAttributes( props ) {
 
 		let value = getNormalAttributeValue( key, props[ key ] );
 
-		// If value is not of serializeable type, skip.
+		// If value is not of serializable type, skip.
 		if ( ! ATTRIBUTES_TYPES.has( typeof value ) ) {
 			continue;
 		}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/61661