### PR TITLE
Add additional styles for Guide component

### DIFF
--- a/packages/components/src/guide/stories/index.story.tsx
+++ b/packages/components/src/guide/stories/index.story.tsx
@@ -52,6 +52,11 @@ const Template: StoryFn< typeof Guide > = ( { onFinish, ...props } ) => {
 export const Default = Template.bind( {} );
 Default.args = {
 	pages: Array.from( { length: 3 } ).map( ( _, page ) => ( {
-		content: <p>{ `Page ${ page + 1 }` }</p>,
+		content: (
+			<>
+				<h1>{ `Title ${ page + 1 }` }</h1>
+				<p>{ `Page ${ page + 1 }` }</p>
+			</>
+		),
 	} ) ),
 };

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -41,6 +41,7 @@
 		justify-content: space-between;
 		margin-top: -$header-height;
 		min-height: 100%;
+		max-width: 400px;
 	}
 
 	&__page {

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -53,6 +53,22 @@
 		@include break-small() {
 			min-height: $image-height;
 		}
+
+		h1 {
+			margin: $grid-unit-20 0 $grid-unit-20 0;
+			padding: 0 $grid-unit-40;
+		}
+
+		p {
+			margin: 0 0 $grid-unit-30 0;
+			padding: 0 $grid-unit-40;
+		}
+
+		img {
+			display: block;
+			max-width: 100%;
+			object-fit: cover;
+		}
 	}
 
 	&__footer {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This add additional styles for Guide component for img, p, and h1 elements.

## Why?
This can reduce the amount of CSS needed for basic uses of this component, since it is very likely that any text will need margins.

## Testing Instructions
1. Run `npm run storybook:dev`
2. Open the Guide storybook (?path=/docs/components-guide--docs)
3. Click 'Open Guide'
4. Check that the heading and paragraph have margin and additional styles.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
