### PR TITLE
Editor: Move the starter template options to the editor package.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -205,7 +205,7 @@ $z-layers: (
 	".edit-site-sidebar-navigation-screen__title-icon": 1,
 
 	// Ensure modal footer actions appear above modal contents
-	".edit-site-start-template-options__modal__actions": 1,
+	".editor-start-template-options__modal__actions": 1,
 
 	// Ensure checkbox + actions don't overlap table header
 	".dataviews-view-table thead": 1,

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -43,7 +43,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 	const [ hasRecursionError, setHasRecursionError ] = useState( false );
 	const parsePatternDependencies = useParsePatternDependencies();
 
-	// Duplicated in packages/edit-site/src/components/start-template-options/index.js.
+	// Duplicated in packages/editor/src/components/start-template-options/index.js.
 	function injectThemeAttributeInBlockTemplateContent( block ) {
 		if (
 			block.innerBlocks.find(

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -44,7 +44,6 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import CodeEditor from '../code-editor';
 import Header from '../header-edit-mode';
 import WelcomeGuide from '../welcome-guide';
-import StartTemplateOptions from '../start-template-options';
 import { store as editSiteStore } from '../../store';
 import { GlobalStylesRenderer } from '../global-styles-renderer';
 import useTitle from '../routes/use-title';
@@ -289,7 +288,6 @@ export default function Editor( { isLoading, onClick } ) {
 					settings={ settings }
 					useSubRegistry={ false }
 				>
-					{ isEditMode && <StartTemplateOptions /> }
 					<InterfaceSkeleton
 						isDistractionFree={ isDistractionFree }
 						enableRegionNavigation={ false }

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -16,7 +16,6 @@
 @import "./components/editor/style.scss";
 @import "./components/create-template-part-modal/style.scss";
 @import "./components/welcome-guide/style.scss";
-@import "./components/start-template-options/style.scss";
 @import "./components/layout/style.scss";
 @import "./components/save-hub/style.scss";
 @import "./components/save-panel/style.scss";

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -29,6 +29,7 @@ import BlockRemovalWarnings from '../block-removal-warnings';
 import StartPageOptions from '../start-page-options';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
 import ContentOnlySettingsMenu from '../block-settings-menu/content-only-settings-menu';
+import StartTemplateOptions from '../start-template-options';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -275,6 +276,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 									<KeyboardShortcutHelpModal />
 									<BlockRemovalWarnings />
 									<StartPageOptions />
+									<StartTemplateOptions />
 								</>
 							) }
 						</BlockEditorProviderComponent>

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -17,6 +17,7 @@ import { __unstableSerializeAndClean } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { TEMPLATE_POST_TYPE } from '../../store/constants';
 
 function useStartPatterns() {
 	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
@@ -116,10 +117,14 @@ export default function StartPageOptions() {
 			getCurrentPostType,
 			getCurrentPostId,
 		} = select( editorStore );
+		const _postType = getCurrentPostType();
 
 		return {
-			shouldEnableModal: ! isEditedPostDirty() && isEditedPostEmpty(),
-			postType: getCurrentPostType(),
+			shouldEnableModal:
+				! isEditedPostDirty() &&
+				isEditedPostEmpty() &&
+				TEMPLATE_POST_TYPE !== _postType,
+			postType: _postType,
 			postId: getCurrentPostId(),
 		};
 	}, [] );

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -115,13 +115,10 @@ export default function StartPageOptions() {
 			isEditedPostEmpty,
 			getCurrentPostType,
 			getCurrentPostId,
-			getEditorSettings,
 		} = select( editorStore );
-		const { __unstableIsPreviewMode: isPreviewMode } = getEditorSettings();
 
 		return {
-			shouldEnableModal:
-				! isPreviewMode && ! isEditedPostDirty() && isEditedPostEmpty(),
+			shouldEnableModal: ! isEditedPostDirty() && isEditedPostEmpty(),
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
 		};

--- a/packages/editor/src/components/start-template-options/style.scss
+++ b/packages/editor/src/components/start-template-options/style.scss
@@ -1,7 +1,7 @@
 $actions-height: 92px;
 
-.edit-site-start-template-options__modal {
-	.edit-site-start-template-options__modal__actions {
+.editor-start-template-options__modal {
+	.editor-start-template-options__modal__actions {
 		position: absolute;
 		bottom: 0;
 		width: 100%;
@@ -12,7 +12,7 @@ $actions-height: 92px;
 		padding-left: $grid-unit-40;
 		padding-right: $grid-unit-40;
 		border-top: 1px solid $gray-300;
-		z-index: z-index(".edit-site-start-template-options__modal__actions");
+		z-index: z-index(".editor-start-template-options__modal__actions");
 	}
 
 	.block-editor-block-patterns-list {
@@ -25,7 +25,7 @@ $actions-height: 92px;
 	}
 }
 
-.edit-site-start-template-options__modal-content .block-editor-block-patterns-list {
+.editor-start-template-options__modal-content .block-editor-block-patterns-list {
 	column-count: 2;
 	column-gap: $grid-unit-30;
 

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -43,6 +43,7 @@
 @import "./components/preview-dropdown/style.scss";
 @import "./components/save-publish-panels/style.scss";
 @import "./components/start-page-options/style.scss";
+@import "./components/start-template-options/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/table-of-contents/style.scss";
 @import "./components/template-areas/style.scss";


### PR DESCRIPTION
Related #52632 

## What?

This PR just moves the StartTemplateOptions to the editor package. In theory this should have enabled the "starter modal" when creating templates from the post editor but for the moment it doesn't because there's a small difference between the "create template" button of the site editor and the post editor.

 - In the site editor: create template creates templates with empty content.
 - In the post editor: the dropdown creates a template with default content that can be provided using a block editor setting.

Aligning these two is harder and I'm not sure which path is the best or if they should be aligned (because they are triggered in two different places so I'm leaving that out of this PR.

## Testing Instructions

1- Go to the "templates" page in the site editor
2- Create a custom template
3- you should be provided with a modal to choose from template starters.