### PR TITLE
DataViews: Add types to the ViewGrid component

### DIFF
--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -191,7 +191,33 @@ export interface ViewList extends ViewBase {
 	};
 }
 
-export type View = ViewList | ViewBase;
+export interface ViewGrid extends ViewBase {
+	type: 'grid';
+
+	layout: {
+		/**
+		 * The field to use as the primary field.
+		 */
+		primaryField: string;
+
+		/**
+		 * The field to use as the media field.
+		 */
+		mediaField: string;
+
+		/**
+		 * The fields to use as columns.
+		 */
+		columnFields: string[];
+
+		/**
+		 * The fields to use as badge fields.
+		 */
+		badgeFields: string[];
+	};
+}
+
+export type View = ViewList | ViewGrid | ViewBase;
 
 interface ActionBase< Item extends AnyItem > {
 	/**

--- a/packages/dataviews/src/view-grid.tsx
+++ b/packages/dataviews/src/view-grid.tsx
@@ -21,8 +21,39 @@ import { __ } from '@wordpress/i18n';
  */
 import ItemActions from './item-actions';
 import SingleSelectionCheckbox from './single-selection-checkbox';
-
 import { useHasAPossibleBulkAction } from './bulk-actions';
+import type {
+	Action,
+	Data,
+	Item,
+	NormalizedField,
+	ViewGrid as ViewGridType,
+} from './types';
+
+interface GridItemProps {
+	selection: string[];
+	data: Data;
+	onSelectionChange: ( items: Item[] ) => void;
+	getItemId: ( item: Item ) => string;
+	item: Item;
+	actions: Action[];
+	mediaField?: NormalizedField;
+	primaryField?: NormalizedField;
+	visibleFields: NormalizedField[];
+	badgeFields: NormalizedField[];
+	columnFields: string[];
+}
+
+interface ViewGridProps {
+	actions: Action[];
+	data: Data;
+	fields: NormalizedField[];
+	getItemId: ( item: Item ) => string;
+	isLoading: boolean;
+	onSelectionChange: ( items: Item[] ) => void;
+	selection: string[];
+	view: ViewGridType;
+}
 
 function GridItem( {
 	selection,
@@ -36,7 +67,7 @@ function GridItem( {
 	visibleFields,
 	badgeFields,
 	columnFields,
-} ) {
+}: GridItemProps ) {
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
@@ -86,7 +117,6 @@ function GridItem( {
 				className="dataviews-view-grid__title-actions"
 			>
 				<SingleSelectionCheckbox
-					id={ id }
 					item={ item }
 					selection={ selection }
 					onSelectionChange={ onSelectionChange }
@@ -105,7 +135,7 @@ function GridItem( {
 					className="dataviews-view-grid__badge-fields"
 					spacing={ 2 }
 					wrap
-					align="top"
+					alignment="top"
 					justify="flex-start"
 				>
 					{ badgeFields.map( ( field ) => {
@@ -183,7 +213,7 @@ export default function ViewGrid( {
 	onSelectionChange,
 	selection,
 	view,
-} ) {
+}: ViewGridProps ) {
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField
 	);
@@ -191,7 +221,7 @@ export default function ViewGrid( {
 		( field ) => field.id === view.layout.primaryField
 	);
 	const { visibleFields, badgeFields } = fields.reduce(
-		( accumulator, field ) => {
+		( accumulator: Record< string, NormalizedField[] >, field ) => {
 			if (
 				view.hiddenFields.includes( field.id ) ||
 				[ view.layout.mediaField, view.layout.primaryField ].includes(

--- a/packages/dataviews/src/view-grid.tsx
+++ b/packages/dataviews/src/view-grid.tsx
@@ -24,30 +24,29 @@ import SingleSelectionCheckbox from './single-selection-checkbox';
 import { useHasAPossibleBulkAction } from './bulk-actions';
 import type {
 	Action,
-	Data,
-	Item,
+	AnyItem,
 	NormalizedField,
 	ViewGrid as ViewGridType,
 } from './types';
 
-interface GridItemProps {
+interface GridItemProps< Item extends AnyItem > {
 	selection: string[];
-	data: Data;
+	data: Item[];
 	onSelectionChange: ( items: Item[] ) => void;
 	getItemId: ( item: Item ) => string;
 	item: Item;
-	actions: Action[];
-	mediaField?: NormalizedField;
-	primaryField?: NormalizedField;
-	visibleFields: NormalizedField[];
-	badgeFields: NormalizedField[];
+	actions: Action< Item >[];
+	mediaField?: NormalizedField< Item >;
+	primaryField?: NormalizedField< Item >;
+	visibleFields: NormalizedField< Item >[];
+	badgeFields: NormalizedField< Item >[];
 	columnFields: string[];
 }
 
-interface ViewGridProps {
-	actions: Action[];
-	data: Data;
-	fields: NormalizedField[];
+interface ViewGridProps< Item extends AnyItem > {
+	actions: Action< Item >[];
+	data: Item[];
+	fields: NormalizedField< Item >[];
 	getItemId: ( item: Item ) => string;
 	isLoading: boolean;
 	onSelectionChange: ( items: Item[] ) => void;
@@ -55,7 +54,7 @@ interface ViewGridProps {
 	view: ViewGridType;
 }
 
-function GridItem( {
+function GridItem< Item extends AnyItem >( {
 	selection,
 	data,
 	onSelectionChange,
@@ -67,7 +66,7 @@ function GridItem( {
 	visibleFields,
 	badgeFields,
 	columnFields,
-}: GridItemProps ) {
+}: GridItemProps< Item > ) {
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
@@ -204,7 +203,7 @@ function GridItem( {
 	);
 }
 
-export default function ViewGrid( {
+export default function ViewGrid< Item extends AnyItem >( {
 	actions,
 	data,
 	fields,
@@ -213,7 +212,7 @@ export default function ViewGrid( {
 	onSelectionChange,
 	selection,
 	view,
-}: ViewGridProps ) {
+}: ViewGridProps< Item > ) {
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField
 	);
@@ -221,7 +220,7 @@ export default function ViewGrid( {
 		( field ) => field.id === view.layout.primaryField
 	);
 	const { visibleFields, badgeFields } = fields.reduce(
-		( accumulator: Record< string, NormalizedField[] >, field ) => {
+		( accumulator: Record< string, NormalizedField< Item >[] >, field ) => {
 			if (
 				view.hiddenFields.includes( field.id ) ||
 				[ view.layout.mediaField, view.layout.primaryField ].includes(


### PR DESCRIPTION
Related #55083 
Follow-up to #61185

## What?

The DataViews package is a types heavy package. There's a lot of structures that need to be documented properly. So this continues the effort to add explicit types to the package. This PR focuses on typing the ViewGrid component.

## Testing instructions

There's no functional change, it's essentially a code quality + documentation change.