### PR TITLE
Grid Visualizer: Fix resize not ending when mouse is released outside grid's bounds

### DIFF
--- a/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid-visualizer/grid-item-resizer.js
@@ -83,9 +83,6 @@ function GridItemResizerInner( {
 		} ),
 	};
 
-	// Controller to remove event listener on resize stop.
-	const controller = new AbortController();
-
 	return (
 		<BlockPopoverCover
 			className="block-editor-grid-item-resizer"
@@ -124,15 +121,14 @@ function GridItemResizerInner( {
 					 * isn't directly above the handle, so we try to detect if it happens
 					 * outside the grid and dispatch a mouseup event on the handle.
 					 */
-					controller.abort();
-					event.target.ownerDocument.addEventListener(
+					blockElement.ownerDocument.addEventListener(
 						'mouseup',
 						() => {
 							event.target.dispatchEvent(
 								new Event( 'mouseup', { bubbles: true } )
 							);
 						},
-						{ signal: controller.signal, capture: true }
+						{ once: true }
 					);
 				} }
 				onResizeStop={ ( event, direction, boxElement ) => {
@@ -176,8 +172,6 @@ function GridItemResizerInner( {
 						columnSpan: columnEnd - columnStart + 1,
 						rowSpan: rowEnd - rowStart + 1,
 					} );
-					// Removes event listener added in onResizeStart.
-					controller.abort();
 				} }
 			/>
 		</BlockPopoverCover>


### PR DESCRIPTION
## What?
Fixes an outstanding bug related to https://github.com/WordPress/gutenberg/issues/61633. In trunk if you start resizing a grid item and let go of the mouse when the mouse it outside of the grid block, the resize action doesn't end.

## How?
The problem is twofold:

1. We're targeting `event.target.ownerDocument` which is the editor's document. We actually want to be targeting the editor `iframe`'s document because the `mouseup` event doesn't leave the iframe when the user releases the mouse over an element in the iframe.
2. We're aborting the `AbortController` _before_ we add an event listener that uses it which means that it never fires. We can use `once: true` instead which is much simpler.

## Testing Instructions
1. Open the site editor and edit a page or template.
2. Insert a grid block and insert a block or two into the grid.
3. Resize the grid item and release your mouse outside of the grid block.