### PR TITLE
Post Actions: Display a notice after moving a post into the trash

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -281,9 +281,10 @@ function Layout( { initialPost } ) {
 			switch ( actionId ) {
 				case 'move-to-trash':
 					{
-						const postType = items[ 0 ].type;
 						document.location.href = addQueryArgs( 'edit.php', {
-							post_type: postType,
+							trashed: 1,
+							post_type: items[ 0 ].type,
+							ids: items[ 0 ].id,
 						} );
 					}
 					break;


### PR DESCRIPTION
## What?
This is a follow-up for https://github.com/WordPress/gutenberg/pull/61507#discussion_r1598175873.

PR updates the 'move-to-trash' redirection to display a notice on the post list page.

## Why?
It matches the behavior of the big red trash button.

## Testing Instructions
1. Open a Post.
2. Delete it via Post Actions
3. Confirm that notice is displayed after the deletion.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/881afcb4-f725-4d93-90ac-29b1cd88419d