### PR TITLE
Docs: Fix parentheses in Markdown link URL

### DIFF
--- a/docs/how-to-guides/feature-flags.md
+++ b/docs/how-to-guides/feature-flags.md
@@ -74,7 +74,7 @@ if ( undefined ) {
 
 ### Dead code elimination
 
-For production builds, webpack ['minifies'](https://en.wikipedia.org/wiki/Minification_(programming)) the code, removing as much unnecessary JavaScript as it can. 
+For production builds, webpack ['minifies'](https://en.wikipedia.org/wiki/Minification_%28programming%29) the code, removing as much unnecessary JavaScript as it can.
 
 One of the steps involves something known as 'dead code elimination'. For example, when the following code is encountered, webpack determines that the surrounding `if` statement is unnecessary:
 


### PR DESCRIPTION
## What?

Parentheses in Markdown link URLs can be confusing, some tooling will attempt to fix them (https://github.com/prettier/prettier/issues/15340):

Original: `['minifies'](https://en.wikipedia.org/wiki/Minification_(programming))`
"fixed": `['minifies'](<https://en.wikipedia.org/wiki/Minification_(programming)>)`

I believe both formats are technically valid, but the simplest fix is to URL encode the parens [like this page recommends](https://www.markdownguide.org/basic-syntax/#link-best-practices):

> Parentheses in the middle of a URL can also be problematic. For compatibility, try to URL encode the opening parenthesis (`(`) with `%28` and the closing parenthesis (`)`) with `%29`.

I've applied that suggestion here.

Extracted from https://github.com/WordPress/gutenberg/pull/61486 (my editor ran prettier and "fixed" the link).

## Why?

The markdown link is more likely to be treated correctly by all markdown parsers.

## Testing Instructions

Look at the rendered markdown in the diff and confirm the link works correctly.
