### PR TITLE
Editor: Avoid rendering snackbar notices twice in list data views

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -345,7 +345,7 @@ export default function Editor( { isLoading, onClick } ) {
 								}
 							/>
 						}
-						notices={ <EditorSnackbars /> }
+						notices={ isEditMode && <EditorSnackbars /> }
 						content={
 							<>
 								<GlobalStylesRenderer />


### PR DESCRIPTION
closes #60457 

## What?

When manipulating the pages in the "list view", it can result in snackbar notices showing up twice: outside and inside the frame. This PR only shows the notices inside the frame in "edit" mode.

## Testing Instructions

1- Open the "pages" menu in the site editor
2- Rename a page from the actions menu
3- Notice that a snackbar shows up (but only once)
