### PR TITLE
Fix problem with gradient-parser types

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug Fix
 
 -   `ToolsPanel`: Fix sticking “Reset” option ([#60621](https://github.com/WordPress/gutenberg/pull/60621)).
+-   Fix an issue where types used a synthetic default import ([#61679](https://github.com/WordPress/gutenberg/pull/61679)).
 
 ## 27.5.0 (2024-05-02)
 

--- a/packages/components/src/custom-gradient-picker/index.tsx
+++ b/packages/components/src/custom-gradient-picker/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type gradientParser from 'gradient-parser';
+import { type LinearGradientNode } from 'gradient-parser';
 
 /**
  * WordPress dependencies
@@ -79,7 +79,7 @@ const GradientTypePicker = ( {
 					? undefined
 					: HORIZONTAL_GRADIENT_ORIENTATION,
 				type: 'linear-gradient',
-			} as gradientParser.LinearGradientNode )
+			} satisfies LinearGradientNode )
 		);
 	};
 


### PR DESCRIPTION

## What?

Fixes an issue where gradient-parser types were used as a "synthetic default import". This is a default import of a package that [only has named exports](https://unpkg.com/browse/@types/gradient-parser@0.1.5/index.d.ts).

Extracted from https://github.com/WordPress/gutenberg/pull/61486

## Why?

This can cause some type errors we don't want.

## How?

Instead of the synthetic default export, use a named import.

## Testing Instructions

This is a type-only change. CI passing is sufficient.
