### PR TITLE
Interactivity API: Add build configuration for a standalone package 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ test/gutenberg-test-themes/twentytwentyone
 test/gutenberg-test-themes/twentytwentythree
 test/gutenberg-test-themes/twentytwentyfour
 packages/react-native-editor/src/setup-local.js
+
+# Interactivity API
+build-cdn

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,5 @@ test/gutenberg-test-themes/twentytwentythree
 test/gutenberg-test-themes/twentytwentyfour
 packages/react-native-editor/src/setup-local.js
 
-# Interactivity API
-standalone
+# Interactivity API standalone build
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ test/gutenberg-test-themes/twentytwentyfour
 packages/react-native-editor/src/setup-local.js
 
 # Interactivity API
-build-cdn
+standalone

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -32,5 +32,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"scripts": {
+		"build": "webpack --config webpack.config.js"
 	}
 }

--- a/packages/interactivity/webpack.config.js
+++ b/packages/interactivity/webpack.config.js
@@ -1,5 +1,6 @@
 /*
- * THIS FILE IS USED ONLY FOR BUILDING THE INTERACTIVITY PACKAGE FOR CDN.
+ * THIS FILE IS USED ONLY FOR BUILDING THE STANDALONE VERSION OF THE
+ * INTERACTIVITY PACKAGE FOR USE ON A CDN OR IN A NON-WP ENVIRONMENT.
  */
 
 /**
@@ -14,7 +15,7 @@ const { baseConfig } = require( '../../tools/webpack/shared' );
 
 module.exports = {
 	...baseConfig,
-	name: 'interactivity-cdn',
+	name: 'interactivity-standalone',
 	entry: {
 		index: './src/index',
 		debug: './src/debug',
@@ -24,7 +25,8 @@ module.exports = {
 	},
 	output: {
 		devtoolNamespace: 'wp',
-		filename: './packages/interactivity/build-cdn/[name]-standalone.min.js',
+		filename:
+			'./packages/interactivity/standalone/[name]-standalone.min.js',
 		library: {
 			type: 'module',
 		},

--- a/packages/interactivity/webpack.config.js
+++ b/packages/interactivity/webpack.config.js
@@ -25,8 +25,7 @@ module.exports = {
 	},
 	output: {
 		devtoolNamespace: 'wp',
-		filename:
-			'./packages/interactivity/standalone/[name]-standalone.min.js',
+		filename: './packages/interactivity/dist/[name]-standalone.min.js',
 		library: {
 			type: 'module',
 		},

--- a/packages/interactivity/webpack.config.js
+++ b/packages/interactivity/webpack.config.js
@@ -1,0 +1,66 @@
+/*
+ * THIS FILE IS USED ONLY FOR BUILDING THE INTERACTIVITY PACKAGE FOR CDN.
+ */
+
+/**
+ * External dependencies
+ */
+const { join } = require( 'path' );
+
+/**
+ * Internal dependencies
+ */
+const { baseConfig } = require( '../../tools/webpack/shared' );
+
+module.exports = {
+	...baseConfig,
+	name: 'interactivity-cdn',
+	entry: {
+		index: './src/index',
+		debug: './src/debug',
+	},
+	experiments: {
+		outputModule: true,
+	},
+	output: {
+		devtoolNamespace: 'wp',
+		filename: './packages/interactivity/build-cdn/[name]-standalone.min.js',
+		library: {
+			type: 'module',
+		},
+		path: join( __dirname, '..', '..' ),
+		environment: { module: true },
+		module: true,
+		chunkFormat: 'module',
+	},
+	resolve: {
+		extensions: [ '.js', '.ts', '.tsx' ],
+	},
+	module: {
+		rules: [
+			{
+				test: /\.(j|t)sx?$/,
+				exclude: /node_modules/,
+				use: [
+					{
+						loader: require.resolve( 'babel-loader' ),
+						options: {
+							cacheDirectory:
+								process.env.BABEL_CACHE_DIRECTORY || true,
+							babelrc: false,
+							configFile: false,
+							presets: [
+								'@babel/preset-typescript',
+								'@babel/preset-react',
+							],
+						},
+					},
+				],
+			},
+		],
+	},
+	watchOptions: {
+		ignored: [ '**/node_modules' ],
+		aggregateTimeout: 500,
+	},
+};


### PR DESCRIPTION
## What?
Configure webpack in the Gutenberg repo so that a minified and bundled version of the Interactivity API is also available inside of the built `@wordpress/interactivity` npm package.

## Why?
1. [A few people](https://github.com/WordPress/gutenberg/discussions/60979) asked to use Interactivity API without WordPress and without a build system. they would like to be able to import the package from a CDN and "just use" the Interactivity API.

2. With this configuration in place, we could then submit `@wordpress/interactivity` to [cdn.js](https://cdnjs.com/) and have it [always pull the latest version](https://github.com/cdnjs/packages/blob/master/CONTRIBUTING.md#configuring-library-auto-update)

3. It is a very common pattern among JS libraries to provide a standalone build. e.g. `petite-vue` and `alpine.js` both provide it. We should follow suit. It's **not** a very important feature in and of itself but **having it contributes to the perception that the Interactivity API is easy to use and easy to get started with**.

## How?
Adding a new webpack config and a `build` script to the `package.json` of `@wordpress/interactivity`. This build script is then run by `lerna` before the packages are published (see the `"prebuild:packages"` in the `package.json` at the root of the repo).


## Testing Instructions
1. Run `npm run build:packages` and make sure that the Interactivity API builds `build-cdn`
2. Use the built `index-standalone.min.js` file and on a page that uses the interactivity API and make sure that it works.
3. Make sure that the `packages/interactivity/build-cdn` folder is ignored by the editor and `git`.

