### PR TITLE
Components:  Introduce support custom suggestions filter for the FormTokenField component

### DIFF
--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -74,6 +74,9 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		__next40pxDefaultSize = false,
 		__experimentalAutoSelectFirstMatch = false,
 		__nextHasNoMarginBottom = false,
+		__filterSuggestions,
+		__onSuggestionClick,
+		__forceSuggestionFocus = false,
 		tokenizeOnBlur = false,
 	} = useDeprecated36pxDefaultSizeProp< FormTokenFieldProps >( props );
 
@@ -449,16 +452,34 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			speak( messages.__experimentalInvalid, 'assertive' );
 			return;
 		}
+
 		addNewTokens( [ token ] );
 		speak( messages.added, 'assertive' );
 
 		setIncompleteTokenValue( '' );
-		setSelectedSuggestionIndex( -1 );
-		setSelectedSuggestionScroll( false );
 		setIsExpanded( ! __experimentalExpandOnFocus );
 
 		if ( isActive && ! tokenizeOnBlur ) {
 			focus();
+		}
+
+		/*
+		 * If a __filterSuggestions is provided,
+		 * it's possible that the token has been already added.
+		 */
+		const isTokenTaken = value.some( ( item ) => {
+			return getTokenValue( item ) === token;
+		} );
+
+		__onSuggestionClick?.( token, isTokenTaken );
+
+		if ( __forceSuggestionFocus ) {
+			const index = getMatchingSuggestions().indexOf( token );
+			setSelectedSuggestionIndex( index );
+			setSelectedSuggestionScroll( true );
+		} else {
+			setSelectedSuggestionScroll( false );
+			setSelectedSuggestionIndex( -1 );
 		}
 	}
 
@@ -514,6 +535,11 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			} );
 
 			_suggestions = startsWithMatch.concat( containsMatch );
+		}
+
+		// Apply custom filter if provided.
+		if ( __filterSuggestions ) {
+			_suggestions = __filterSuggestions( _suggestions, match );
 		}
 
 		return _suggestions.slice( 0, _maxSuggestions );

--- a/packages/components/src/form-token-field/stories/index.story.tsx
+++ b/packages/components/src/form-token-field/stories/index.story.tsx
@@ -3,6 +3,8 @@
  */
 import type { Meta, StoryFn } from '@storybook/react';
 import type { ComponentProps } from 'react';
+import styled from '@emotion/styled';
+
 /**
  * WordPress dependencies
  */
@@ -12,6 +14,8 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import FormTokenField from '../';
+import CheckboxControl from '../../checkbox-control';
+import Label from '../../input-control/label';
 
 const meta: Meta< typeof FormTokenField > = {
 	component: FormTokenField,
@@ -134,4 +138,93 @@ WithValidatedInput.args = {
 	...Default.args,
 	__experimentalValidateInput: ( input: string ) =>
 		continents.includes( input ),
+};
+
+const fruits = [
+	'Apple',
+	'Apricot',
+	'Avocado',
+	'Banana',
+	'Blackberry',
+	'Blueberry',
+];
+
+const CheckboxLabelWrapper = styled.div`
+	.suggestion-checkbox-label {
+		display: flex !important;
+		align-items: center;
+		color: inherit;
+	}
+`;
+
+export const WithSuggestionCheckbox: StoryFn< typeof FormTokenField > = ( {
+	suggestions,
+	...args
+} ) => {
+	const [ selectedFruits, setSelectedFruits ] = useState<
+		ComponentProps< typeof FormTokenField >[ 'value' ]
+	>( [] );
+
+	/*
+	 * Combine the suggested fruits with
+	 */
+	let allFruits = suggestions ? [ ...suggestions ] : [];
+
+	if ( selectedFruits ) {
+		allFruits = allFruits.concat(
+			selectedFruits.map( ( fruit ) => String( fruit ) )
+		);
+
+		// Remove duplicates
+		allFruits = [ ...new Set( allFruits ) ];
+
+		// Sort the values
+		allFruits.sort();
+	}
+
+	return (
+		<FormTokenField
+			{ ...args }
+			value={ selectedFruits }
+			suggestions={ allFruits }
+			onChange={ setSelectedFruits }
+			__filterSuggestions={ ( _filteredSuggestions, value ) => {
+				return allFruits.filter( ( suggestion ) =>
+					suggestion.toLowerCase().includes( value.toLowerCase() )
+				);
+			} }
+			__onSuggestionClick={ ( suggestion, isSuggestionTaken ) => {
+				// If the suggestion is taken, filter the selected continents
+				if ( isSuggestionTaken ) {
+					const filteredContinents = selectedFruits?.filter(
+						( continent ) => continent !== suggestion
+					);
+					setSelectedFruits( filteredContinents );
+				}
+			} }
+			__experimentalRenderItem={ ( { item } ) => {
+				const itemTaken = selectedFruits?.includes( item );
+				return (
+					<CheckboxLabelWrapper>
+						<Label className="suggestion-checkbox-label">
+							<CheckboxControl
+								checked={ itemTaken }
+								onChange={ () => {} }
+							/>
+							{ item }
+						</Label>
+					</CheckboxLabelWrapper>
+				);
+			} }
+		/>
+	);
+};
+
+WithSuggestionCheckbox.args = {
+	label: 'Pick or create a fruit',
+	suggestions: fruits,
+	__nextHasNoMarginBottom: true,
+	__experimentalExpandOnFocus: true,
+	__experimentalAutoSelectFirstMatch: true,
+	__forceSuggestionFocus: true,
 };

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -183,6 +183,27 @@ export interface FormTokenFieldProps
 	 * @default false
 	 */
 	__nextHasNoMarginBottom?: boolean;
+
+	/**
+	 * Use this prop to filter the suggestions list.
+	 * It receives the list of suggestions and the current input value.
+	 * It should return a filtered list of suggestions.
+	 */
+	__filterSuggestions?: ( suggestions: string[], value: string ) => string[];
+
+	/**
+	 * Callback to be called when a suggestion is clicked.
+	 */
+	__onSuggestionClick?: (
+		suggestion: string,
+		isSuggestionTaken: boolean
+	) => void;
+
+	/**
+	 * If true, the suggestion item will be focused when the suggestions list is opened.
+	 */
+	__forceSuggestionFocus?: boolean;
+
 	/**
 	 * If true, add any incompleteTokenValue as a new token when the field loses focus.
 	 *


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds a few new properties to the FormTokenField component to enable more complex implementations. For instance, select/unselect a suggestion from the suggestions list:

https://github.com/WordPress/gutenberg/assets/77539/6edfd998-6a32-45c5-babb-3157f9ce8a8c


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To be able to create more complex components based on it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding a few new properties:

```ts
	/**
	 * Use this prop to filter the suggestions list.
	 * It receives the list of suggestions and the current input value.
	 * It should return a filtered list of suggestions.
	 */
	__filterSuggestions?: ( suggestions: string[], value: string ) => string[];

	/**
	 * Callback to be called when a suggestion is clicked.
	 */
	__onSuggestionClick?: (
		suggestion: string,
		isSuggestionTaken: boolean
	) => void;

	/**
	 * If true, the suggestion item will be focused when the suggestions list is opened.
	 */
	__forceSuggestionFocus?: boolean;
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Tes by suing the storybook story

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
