### PR TITLE
Performance tests: fix results file path

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -20,7 +20,8 @@ const config = require( '../config' );
 
 const ARTIFACTS_PATH =
 	process.env.WP_ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
-const RESULTS_FILE_SUFFIX = '.performance-results.raw.json';
+const RAW_RESULTS_FILE_SUFFIX = '.performance-results.raw.json';
+const RESULTS_FILE_SUFFIX = '.performance-results.json';
 
 /**
  * @typedef WPPerformanceCommandOptions
@@ -492,7 +493,7 @@ async function runPerformanceTests( branches, options ) {
 	logAtIndent( 0, 'Calculating results' );
 
 	const resultFiles = getFilesFromDir( ARTIFACTS_PATH ).filter( ( file ) =>
-		file.endsWith( RESULTS_FILE_SUFFIX )
+		file.endsWith( RAW_RESULTS_FILE_SUFFIX )
 	);
 	/** @type {Record<string,Record<string, Record<string, Record<string, number>>>>} */
 	const results = {};


### PR DESCRIPTION
#60950 broke performance tests in `trunk`, because it writes results to wrong file: `.raw.json` instead of `.json`. The original intent was merely to _read_ from `.raw.json`, but I overlooked that the `RESULTS_FILE_SUFFIX` constant is used for two purposes.
