### PR TITLE
Fix editor view mode canvas shadow

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -61,10 +61,6 @@
 	& > .components-resizable-box__container {
 		margin: 0 auto;
 	}
-
-	&.is-view-mode {
-		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
-	}
 }
 
 .resizable-editor__drag-handle {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -118,7 +118,7 @@
 		justify-content: flex-end;
 	}
 
-	& > div {
+	.edit-site-resizable-frame__inner {
 		color: $gray-900;
 	}
 
@@ -143,10 +143,6 @@
 		top: 0;
 		bottom: 0;
 		width: 100%;
-
-		& > div {
-			border-radius: 0;
-		}
 	}
 }
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -128,6 +128,7 @@
 		width: calc(100% - #{$canvas-padding});
 
 		.edit-site-resizable-frame__inner-content {
+			box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
 			transition: border-radius 0.4s;
 			// This ensure the radius work properly.
 			overflow: hidden;


### PR DESCRIPTION
## What?
Fixes a apparent regression of the canvas shadow in view mode of the editor. I didn’t label it regression because the label says that’s for latest release and I don’t know when this regressed.

## Why?
The shadow is supposed to be there? I'd be just as happy to remove it as restore it but perhaps it would be more important were the editor to respect user admin themes (or become otherwise themeable).

## How?
Moves the shadow to an element where it can be seen (if your eyesight and monitor are super good 😄).

## Testing Instructions
1. Visit the editor.
2. Note the shadow of the canvas (you might have to change a background color).
```css
.edit-site-layout {
    background: papayawhip;
}
```

## Screenshots or screencast <!-- if applicable -->

_Background color applied to make the difference easy to see._

### Before
<img width="783" alt="image" src="https://github.com/WordPress/gutenberg/assets/9000376/d3c365b9-c8ca-4cea-a119-0fc95f3947d1">

### After
<img width="783" alt="image" src="https://github.com/WordPress/gutenberg/assets/9000376/145673b0-c010-4bef-92f2-3020df0e5139">
