### PR TITLE
Editor: Fix the 'DocumentBar' position for long titles

### DIFF
--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -43,6 +43,7 @@
 	flex-grow: 1;
 	display: flex;
 	justify-content: center;
+	min-width: 0;
 
 	&.is-collapsed {
 		display: none;

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -43,6 +43,10 @@
 	flex-grow: 1;
 	display: flex;
 	justify-content: center;
+	// Flex items will, by default, refuse to shrink below a minimum
+	// intrinsic width. In order to shrink this flexbox item, and
+	// subsequently truncate child text, we set an explicit min-width.
+	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 	min-width: 0;
 
 	&.is-collapsed {


### PR DESCRIPTION
## What?
Resolves #61677.

PR fixes the `DocumentBar` position when an entity has a long title.

## Why?
The component renders the title fully and truncates it via CSS. By default, flex items won't shrink below their minimum content size. Setting `min-width: 0` changes this behavior.

## Testing Instructions
1. Create a post.
2. Enter a short post title.
3. Confirm that the document bar is positioned correctly.
4. Make the title much longer.
5. Confirm that the document bar is still positioned correctly.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-15 at 22 10 06](https://github.com/WordPress/gutenberg/assets/240569/800a9ca5-9c37-4e2e-b630-eb02cb32fba9)
