### PR TITLE
ToolsPanel: Trigger `onDeselect`/`onSelect` callbacks directly

### DIFF
--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -44,7 +44,6 @@ export function useToolsPanelItem(
 		registerPanelItem,
 		deregisterPanelItem,
 		flagItemCustomization,
-		isResetting,
 		shouldRenderPlaceholderItems: shouldRenderPlaceholder,
 		firstDisplayedItem,
 		lastDisplayedItem,
@@ -78,6 +77,8 @@ export function useToolsPanelItem(
 				isShownByDefault,
 				label,
 				panelId,
+				onDeselect,
+				onSelect,
 			} );
 		}
 
@@ -99,6 +100,8 @@ export function useToolsPanelItem(
 		previousPanelId,
 		registerPanelItem,
 		deregisterPanelItem,
+		onDeselect,
+		onSelect,
 	] );
 
 	useEffect( () => {
@@ -121,7 +124,6 @@ export function useToolsPanelItem(
 	// `ToolsPanel`.
 	const menuGroup = isShownByDefault ? 'default' : 'optional';
 	const isMenuItemChecked = menuItems?.[ menuGroup ]?.[ label ];
-	const wasMenuItemChecked = usePrevious( isMenuItemChecked );
 	const isRegistered = menuItems?.[ menuGroup ]?.[ label ] !== undefined;
 
 	const isValueSet = hasValue();
@@ -141,40 +143,10 @@ export function useToolsPanelItem(
 		isShownByDefault,
 	] );
 
-	// Determine if the panel item's corresponding menu is being toggled and
-	// trigger appropriate callback if it is.
-	useEffect( () => {
-		// We check whether this item is currently registered as items rendered
-		// via fills can persist through the parent panel being remounted.
-		// See: https://github.com/WordPress/gutenberg/pull/45673
-		if ( ! isRegistered || isResetting || ! hasMatchingPanel ) {
-			return;
-		}
-
-		if ( isMenuItemChecked && ! isValueSet && ! wasMenuItemChecked ) {
-			onSelect?.();
-		}
-
-		if ( ! isMenuItemChecked && isValueSet && wasMenuItemChecked ) {
-			onDeselect?.();
-		}
-	}, [
-		hasMatchingPanel,
-		isMenuItemChecked,
-		isRegistered,
-		isResetting,
-		isValueSet,
-		wasMenuItemChecked,
-		onSelect,
-		onDeselect,
-	] );
-
 	// The item is shown if it is a default control regardless of whether it
 	// has a value. Optional items are shown when they are checked or have
 	// a value.
-	const isShown = isShownByDefault
-		? menuItems?.[ menuGroup ]?.[ label ] !== undefined
-		: isMenuItemChecked;
+	const isShown = isShownByDefault ? isRegistered : isMenuItemChecked;
 
 	const cx = useCx();
 	const classes = useMemo( () => {

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { usePrevious } from '@wordpress/compose';
+import { useEvent, usePrevious } from '@wordpress/compose';
 import {
 	useCallback,
 	useEffect,
@@ -31,8 +31,8 @@ export function useToolsPanelItem(
 		label,
 		panelId,
 		resetAllFilter = noop,
-		onDeselect,
-		onSelect,
+		onDeselect: onDeselectProp,
+		onSelect: onSelectProp,
 		...otherProps
 	} = useContextSystem( props, 'ToolsPanelItem' );
 
@@ -59,6 +59,8 @@ export function useToolsPanelItem(
 	// dependency to the useCallback hook! If needed, we should use a ref.
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const resetAllFilterCallback = useCallback( resetAllFilter, [ panelId ] );
+	const onDeselect = useEvent( onDeselectProp );
+	const onSelect = useEvent( onSelectProp );
 	const previousPanelId = usePrevious( currentPanelId );
 
 	const hasMatchingPanel =

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -357,9 +357,22 @@ export function useToolsPanel(
 
 	// Toggle the checked state of a menu item which is then used to determine
 	// display of the item within the panel.
-	const toggleItem = useCallback( ( label: string ) => {
-		panelDispatch( { type: 'TOGGLE_VALUE', label } );
-	}, [] );
+	const toggleItem = useCallback(
+		( label: string ) => {
+			panelDispatch( { type: 'TOGGLE_VALUE', label } );
+			const currentItem = panelItems.find(
+				( item ) => item.label === label
+			);
+			if ( currentItem ) {
+				const { isShownByDefault, onDeselect, onSelect } = currentItem;
+				const menuGroup = isShownByDefault ? 'default' : 'optional';
+				const hasValue = menuItems[ menuGroup ][ label ];
+				const callback = hasValue ? onDeselect : onSelect;
+				callback?.();
+			}
+		},
+		[ menuItems, panelItems ]
+	);
 
 	// Resets display of children and executes resetAll callback if available.
 	const resetAllItems = useCallback( () => {

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -133,13 +133,6 @@ export type ToolsPanelItem = {
 	 * from a shared source.
 	 */
 	panelId?: string | null;
-};
-
-export type ToolsPanelItemProps = ToolsPanelItem & {
-	/**
-	 * The child elements.
-	 */
-	children?: ReactNode;
 	/**
 	 * Called when this item is deselected in the `ToolsPanel` menu. This is
 	 * normally used to reset the panel item control's value.
@@ -150,6 +143,13 @@ export type ToolsPanelItemProps = ToolsPanelItem & {
 	 * menu.
 	 */
 	onSelect?: () => void;
+};
+
+export type ToolsPanelItemProps = ToolsPanelItem & {
+	/**
+	 * The child elements.
+	 */
+	children?: ReactNode;
 
 	/**
 	 * A `ToolsPanel` will collect each item's `resetAllFilter` and pass an


### PR DESCRIPTION
## What?
Instead of using an effect hook to run some callbacks runs them from an event.

## Why?
Simplification for maintainability. I noticed this while working on #60621.

## How?
- Puts the `onDeselect` and `onSelect` callbacks into state accessible by `toggleItem`.
- Runs the callbacks from `toggleItem` which is the event handler for menu item clicks.
- Removes the effect hook that previously used for the above.

## Automated tests
Currently, with the effect being responsible for triggering the callbacks, I wasn’t sure if `onSelect` or `onDeselect` might be triggered from controlled updates to an item’s value or interactions with the item’s actual control. I made some unit tests for such and according to these, it was never a thing (they pass on trunk or this branch). I'm not sure if these tests are actually worth adding.

```diff
diff --git a/packages/components/src/tools-panel/test/index.tsx b/packages/components/src/tools-panel/test/index.tsx
index 8d2c4f17a8..e40a470b06 100644
--- a/packages/components/src/tools-panel/test/index.tsx
+++ b/packages/components/src/tools-panel/test/index.tsx
@@ -797,6 +797,81 @@ describe( 'ToolsPanel', () => {
 		} );
 	} );
 
+	describe( 'menu item callbacks on item interaction', () => {
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		const onDeselect = jest.fn();
+		const onSelect = jest.fn();
+		const ToolsPanelControllable = ( {
+			toolsPanelItemValue,
+			isOptional = false,
+		}: {
+			toolsPanelItemValue?: boolean;
+			isOptional?: boolean;
+		} ) => {
+			const itemProps = {
+				attributes: { value: toolsPanelItemValue },
+				hasValue: () => toolsPanelItemValue !== undefined,
+				label: isOptional ? 'Optional' : 'Standard',
+				onDeselect,
+				onSelect,
+			};
+
+			// The null panelId below simulates the panel prop when there
+			// are multiple blocks selected.
+			return (
+				<ToolsPanel { ...defaultProps } panelId={ null }>
+					<ToolsPanelItem { ...itemProps }>
+						<input
+							type="checkbox"
+							defaultChecked={ !! toolsPanelItemValue }
+							onChange={ ( event ) => {
+								controlValue = event.target.checked;
+							} }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			);
+		};
+
+		it( 'default item’s value changes should not trigger menu item callbacks', async () => {
+			const { rerender } = render(
+				<ToolsPanelControllable toolsPanelItemValue={ false } />
+			);
+
+			const control = screen.getByRole( 'checkbox' );
+			const user = userEvent.setup();
+			await user.click( control );
+			expect( controlProps.onSelect ).not.toHaveBeenCalled();
+			await user.click( control );
+			expect( controlProps.onDeselect ).not.toHaveBeenCalled();
+
+			rerender( <ToolsPanelControllable /> );
+			expect( controlProps.onDeselect ).not.toHaveBeenCalled();
+		} );
+
+		it( 'optional item’s value changes should not trigger menu item callbacks', async () => {
+			const { rerender } = render(
+				<ToolsPanelControllable
+					isOptional
+					toolsPanelItemValue={ false }
+				/>
+			);
+
+			const control = screen.getByRole( 'checkbox' );
+			const user = userEvent.setup();
+			await user.click( control );
+			expect( controlProps.onSelect ).not.toHaveBeenCalled();
+			await user.click( control );
+			expect( controlProps.onDeselect ).not.toHaveBeenCalled();
+
+			rerender( <ToolsPanelControllable isOptional /> );
+			expect( controlProps.onDeselect ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	describe( 'grouped panel items within custom components', () => {
 		it( 'should render grouped items correctly', () => {
 			renderGroupedItemsInPanel();

```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
