### PR TITLE
Enable parallel processing for PHPCS sniffs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -42,6 +42,9 @@
 	<!-- Cache the scan results and re-use those for unchanged files on the next scan. -->
 	<arg name="cache" value=".cache/phpcs.json"/>
 
+	<!-- Check up to 20 files simultaneously. -->
+	<arg name="parallel" value="1"/>
+
 	<file>./bin</file>
 	<file>./gutenberg.php</file>
 	<file>./lib</file>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -43,7 +43,7 @@
 	<arg name="cache" value=".cache/phpcs.json"/>
 
 	<!-- Check up to 20 files simultaneously. -->
-	<arg name="parallel" value="1"/>
+	<arg name="parallel" value="20"/>
 
 	<file>./bin</file>
 	<file>./gutenberg.php</file>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds parallel processing for PHPCS sniffs.
Fixes https://github.com/WordPress/gutenberg/issues/61699.

## Why?
Parallel processing significantly improves speed by using multiple processes to run the PHPCS linters (300% speed increase in my tests).

## How?
It's a matter of adding a single line to the `phpcs.xml.dist` file.
That's it.
I'm not able to find any documentation on that setting, but it seems to work great.

## Testing Instructions
Make sure that GitHub CI jobs pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
