### PR TITLE
Editor: Don't apply purple accent to the unsynced pattern title

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -103,6 +103,7 @@ export default function DocumentBar() {
 	const isGlobalEntity = GLOBAL_POST_TYPES.includes( postType );
 	const hasBackButton = !! onNavigateToPreviousEntityRecord;
 	const title = isTemplate ? templateTitle : document.title;
+	const isUnsyncedPattern = document?.wp_pattern_sync_status === 'unsynced';
 
 	const mounted = useRef( false );
 	useEffect( () => {
@@ -113,7 +114,7 @@ export default function DocumentBar() {
 		<div
 			className={ clsx( 'editor-document-bar', {
 				'has-back-button': hasBackButton,
-				'is-global': isGlobalEntity,
+				'is-global': isGlobalEntity && ! isUnsyncedPattern,
 			} ) }
 		>
 			<AnimatePresence>


### PR DESCRIPTION
## What?
Fixes #61609.

PR updates the condition for the `is-global` class in the `DocumentBar` component. It's no longer applied to the unsynced patterns.

## Testing Instructions
1. Open Site Editor > Patterns.
2. Open any unsynced pattern.
3. Confirm that the title in the document bar doesn't have a purple accent.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-16 at 10 48 49](https://github.com/WordPress/gutenberg/assets/240569/3c6fdd4c-c261-439b-af07-1493d141e506)
