### PR TITLE
Components: introduce Combobox `expandOnFocus` property

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `ComboboxControl`: supports disabled items ([#61294](https://github.com/WordPress/gutenberg/pull/61294)).
 -   Upgraded the @types/react and @types/react-dom packages ([#60796](https://github.com/WordPress/gutenberg/pull/60796)).
 -   `Placeholder`: Tweak placeholder style ([#61590](https://github.com/WordPress/gutenberg/pull/61590)).
+-   `Combobox`: Introduce Combobox expandOnFocus property ([#61705](https://github.com/WordPress/gutenberg/pull/61705)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,7 +1,10 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
--   `Combobox`: Introduce Combobox expandOnFocus property ([#61705](https://github.com/WordPress/gutenberg/pull/61705)).
+
+### Enhancements
+
+-   `ComboboxControl`: Introduce Combobox expandOnFocus prop ([#61705](https://github.com/WordPress/gutenberg/pull/61705)).
 
 ## 27.6.0 (2024-05-16)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+-   `Combobox`: Introduce Combobox expandOnFocus property ([#61705](https://github.com/WordPress/gutenberg/pull/61705)).
 
 ## 27.6.0 (2024-05-16)
 
@@ -17,7 +18,6 @@
 -   `ComboboxControl`: supports disabled items ([#61294](https://github.com/WordPress/gutenberg/pull/61294)).
 -   Upgraded the @types/react and @types/react-dom packages ([#60796](https://github.com/WordPress/gutenberg/pull/60796)).
 -   `Placeholder`: Tweak placeholder style ([#61590](https://github.com/WordPress/gutenberg/pull/61590)).
--   `Combobox`: Introduce Combobox expandOnFocus property ([#61705](https://github.com/WordPress/gutenberg/pull/61705)).
 
 ### Bug Fix
 

--- a/packages/components/src/combobox-control/README.md
+++ b/packages/components/src/combobox-control/README.md
@@ -101,6 +101,15 @@ The current value of the control.
 -   Type: `string | null`
 -   Required: No
 
+#### expandOnFocus
+
+Automatically expand the dropdown when the control is focused.
+If the control is clicked, the dropdown will expand regardless of this prop.
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `true`
+
 #### __experimentalRenderItem
 
 Custom renderer invoked for each option in the suggestion list. The render prop receives as its argument an object containing, under the `item` key, the single option's data (directly from the array of data passed to the `options` prop).

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -127,6 +127,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 			selected: __( 'Item selected.' ),
 		},
 		__experimentalRenderItem,
+		expandOnFocus = true,
 	} = useDeprecated36pxDefaultSizeProp( props );
 
 	const [ value, setValue ] = useControlledValue( {
@@ -236,9 +237,16 @@ function ComboboxControl( props: ComboboxControlProps ) {
 
 	const onFocus = () => {
 		setInputHasFocus( true );
-		setIsExpanded( true );
+		if ( expandOnFocus ) {
+			setIsExpanded( true );
+		}
+
 		onFilterValueChange( '' );
 		setInputValue( '' );
+	};
+
+	const onClick = () => {
+		setIsExpanded( true );
 	};
 
 	const onFocusOutside = () => {
@@ -324,6 +332,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 								value={ isExpanded ? inputValue : currentLabel }
 								onFocus={ onFocus }
 								onBlur={ onBlur }
+								onClick={ onClick }
 								isExpanded={ isExpanded }
 								selectedSuggestionIndex={ getIndexOfMatchingSuggestion(
 									selectedSuggestion,

--- a/packages/components/src/combobox-control/stories/index.story.tsx
+++ b/packages/components/src/combobox-control/stories/index.story.tsx
@@ -139,3 +139,17 @@ WithDisabledOptions.args = {
 	label: 'Select a country',
 	options: optionsWithDisabledOptions,
 };
+
+/**
+ * By default, the combobox expands when focused.
+ * You can disable this behavior by setting the `expandOnFocus` prop to `false`.
+ * This is useful when you want to show the suggestions only when the user interacts with the input.
+ */
+export const NotExpandOnFocus = Template.bind( {} );
+
+NotExpandOnFocus.args = {
+	allowReset: false,
+	label: 'Select a country',
+	options: countryOptions,
+	expandOnFocus: false,
+};

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -74,4 +74,11 @@ export type ComboboxControlProps = Pick<
 	 * The current value of the control.
 	 */
 	value?: string | null;
+
+	/**
+	 * Automatically expand the dropdown when the control is focused.
+	 *
+	 * @default true
+	 */
+	expandOnFocus?: boolean;
 };

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -46,6 +46,13 @@ export type ComboboxControlProps = Pick<
 	 */
 	allowReset?: boolean;
 	/**
+	 * Automatically expand the dropdown when the control is focused.
+	 * If the control is clicked, the dropdown will expand regardless of this prop.
+	 *
+	 * @default true
+	 */
+	expandOnFocus?: boolean;
+	/**
 	 * Customizable UI messages.
 	 */
 	messages?: {
@@ -74,12 +81,4 @@ export type ComboboxControlProps = Pick<
 	 * The current value of the control.
 	 */
 	value?: string | null;
-
-	/**
-	 * Automatically expand the dropdown when the control is focused.
-	 * If the control is clicked, the dropdown will expand regardless of this prop.
-	 *
-	 * @default true
-	 */
-	expandOnFocus?: boolean;
 };

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -77,6 +77,7 @@ export type ComboboxControlProps = Pick<
 
 	/**
 	 * Automatically expand the dropdown when the control is focused.
+	 * If the control is clicked, the dropdown will expand regardless of this prop.
 	 *
 	 * @default true
 	 */

--- a/packages/components/src/form-token-field/token-input.tsx
+++ b/packages/components/src/form-token-field/token-input.tsx
@@ -27,6 +27,7 @@ export function UnForwardedTokenInput(
 		className,
 		onChange,
 		onFocus,
+		onClick,
 		onBlur,
 		...restProps
 	} = props;
@@ -53,6 +54,10 @@ export function UnForwardedTokenInput(
 		onBlur?.( e );
 	};
 
+	const onClickHandler: any = ( event: any ) => {
+		onClick?.( event );
+	};
+
 	return (
 		<input
 			ref={ ref }
@@ -62,6 +67,7 @@ export function UnForwardedTokenInput(
 			value={ value || '' }
 			onChange={ onChangeHandler }
 			onFocus={ onFocusHandler }
+			onClick={ onClickHandler }
 			onBlur={ onBlurHandler }
 			size={ size }
 			className={ clsx(

--- a/packages/components/src/form-token-field/token-input.tsx
+++ b/packages/components/src/form-token-field/token-input.tsx
@@ -27,7 +27,6 @@ export function UnForwardedTokenInput(
 		className,
 		onChange,
 		onFocus,
-		onClick,
 		onBlur,
 		...restProps
 	} = props;
@@ -54,10 +53,6 @@ export function UnForwardedTokenInput(
 		onBlur?.( e );
 	};
 
-	const onClickHandler: any = ( event: any ) => {
-		onClick?.( event );
-	};
-
 	return (
 		<input
 			ref={ ref }
@@ -67,7 +62,6 @@ export function UnForwardedTokenInput(
 			value={ value || '' }
 			onChange={ onChangeHandler }
 			onFocus={ onFocusHandler }
-			onClick={ onClickHandler }
 			onBlur={ onBlurHandler }
 			size={ size }
 			className={ clsx(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This property introduces the `expandOnFocus` property to the Combobox control component.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Sometimes, auto-expanding the combo box dropdown is not a desired behavior and could even be considered intrusive.
For instance, AriaKit combobox never auto-expands the dropdown in the focus event.

https://github.com/WordPress/gutenberg/assets/77539/9a2636a6-75b6-4f4c-bebf-a072e867015c

The dropdown opens only when the user types in the input field or clicks on it.

Note: it doesn't change the current behavior to ensure backward compatibilities, which we would consider it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* It adds the `onClick` property to the `<TokenInput />` component, since it's mandatory to differetiate the `onFocus` and the `onClick` event in the `<ComboboxControl />` component context
* When focusing the element, it sets `isExpanded` as true only when the `expandOnFocus` property is true as well.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Run storybook
2. Compare the ComboboxControl stories
3. Confirm that `Not Expand On Focus` does not auto-expand the dropdown when the user focuses on the input element. It's required to type or click on it to open the dropdown:

https://github.com/WordPress/gutenberg/assets/77539/ce7bb078-876a-4c0e-bdb1-2ff7a0828467


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


