### PR TITLE
DocumentBar: Only selected data needed for rendering

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -53,7 +53,7 @@ export default function DocumentBar() {
 	const {
 		postType,
 		documentTitle,
-		isResolving,
+		isNotFound,
 		isUnsyncedPattern,
 		templateIcon,
 		templateTitle,
@@ -78,12 +78,14 @@ export default function DocumentBar() {
 		return {
 			postType: _postType,
 			documentTitle: _document.title,
-			isResolving: isResolvingSelector(
-				'getEditedEntityRecord',
-				'postType',
-				_postType,
-				_postId
-			),
+			isNotFound:
+				! _document &&
+				! isResolvingSelector(
+					'getEditedEntityRecord',
+					'postType',
+					_postType,
+					_postId
+				),
 			isUnsyncedPattern: _document?.wp_pattern_sync_status === 'unsynced',
 			templateIcon: unlock( select( editorStore ) ).getPostIcon(
 				_postType,
@@ -100,7 +102,6 @@ export default function DocumentBar() {
 	const { open: openCommandCenter } = useDispatch( commandsStore );
 	const isReducedMotion = useReducedMotion();
 
-	const isNotFound = ! documentTitle && ! isResolving;
 	const isTemplate = TEMPLATE_POST_TYPES.includes( postType );
 	const isGlobalEntity = GLOBAL_POST_TYPES.includes( postType );
 	const hasBackButton = !! onNavigateToPreviousEntityRecord;

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -52,8 +52,9 @@ const MotionButton = motion( Button );
 export default function DocumentBar() {
 	const {
 		postType,
-		document,
+		documentTitle,
 		isResolving,
+		isUnsyncedPattern,
 		templateIcon,
 		templateTitle,
 		onNavigateToPreviousEntityRecord,
@@ -76,13 +77,14 @@ export default function DocumentBar() {
 		const _templateInfo = getTemplateInfo( _document );
 		return {
 			postType: _postType,
-			document: _document,
+			documentTitle: _document.title,
 			isResolving: isResolvingSelector(
 				'getEditedEntityRecord',
 				'postType',
 				_postType,
 				_postId
 			),
+			isUnsyncedPattern: _document?.wp_pattern_sync_status === 'unsynced',
 			templateIcon: unlock( select( editorStore ) ).getPostIcon(
 				_postType,
 				{
@@ -98,12 +100,11 @@ export default function DocumentBar() {
 	const { open: openCommandCenter } = useDispatch( commandsStore );
 	const isReducedMotion = useReducedMotion();
 
-	const isNotFound = ! document && ! isResolving;
+	const isNotFound = ! documentTitle && ! isResolving;
 	const isTemplate = TEMPLATE_POST_TYPES.includes( postType );
 	const isGlobalEntity = GLOBAL_POST_TYPES.includes( postType );
 	const hasBackButton = !! onNavigateToPreviousEntityRecord;
-	const title = isTemplate ? templateTitle : document.title;
-	const isUnsyncedPattern = document?.wp_pattern_sync_status === 'unsynced';
+	const title = isTemplate ? templateTitle : documentTitle;
 
 	const mounted = useRef( false );
 	useEffect( () => {


### PR DESCRIPTION
## What?
PR updates the `DocumentBar` component to only selected data needed for rendering.

## Why?
This prevents the component from re-rendering when the user is typing on canvas.

## Testing Instructions
1. Open a post or page.
2. Add a text block.
3. Enabled "Highlight updates when components render." from React DevTools.
4. Start typing in a block.
5. Confirm that the document bar doesn't re-render with every keystroke.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/240569/230df47a-fa44-4a24-a2fd-6a1a289e2cf5

**After**

https://github.com/WordPress/gutenberg/assets/240569/e178a428-a26e-46f8-b0c4-6123eaf350a9

