### PR TITLE
Close publish sidebar if not in `edit` mode

### DIFF
--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -16,16 +16,24 @@ export const setCanvasMode =
 		const isMediumOrBigger =
 			window.matchMedia( '(min-width: 782px)' ).matches;
 		registry.dispatch( blockEditorStore ).__unstableSetEditorMode( 'edit' );
+		const isPublishSidebarOpened = registry
+			.select( editorStore )
+			.isPublishSidebarOpened();
 		dispatch( {
 			type: 'SET_CANVAS_MODE',
 			mode,
 		} );
+		const isEditMode = mode === 'edit';
+		if ( isPublishSidebarOpened && ! isEditMode ) {
+			registry.dispatch( editorStore ).closePublishSidebar();
+		}
+
 		// Check if the block list view should be open by default.
 		// If `distractionFree` mode is enabled, the block list view should not be open.
 		// This behavior is disabled for small viewports.
 		if (
 			isMediumOrBigger &&
-			mode === 'edit' &&
+			isEditMode &&
 			registry
 				.select( preferencesStore )
 				.get( 'core', 'showListViewByDefault' ) &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Observed by @jameskoster here: https://github.com/WordPress/gutenberg/pull/61676#issuecomment-2112947915.

In site editor when we have opened the publish sidebar and go back to view mode, the sidebar remains open. This PR closes it when we go to view mode.

## Testing Instructions
1. In site editor go to a draft page and open the publish sidebar panels
2. Go to view mode and observe the sidebar panels are closed.
