### PR TITLE
Clarify `date` value in Pages

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -345,10 +345,11 @@ export default function PagePages() {
 						return createInterpolateElement(
 							sprintf(
 								/* translators: %s: page creation date */
-								__( 'Modified: <time>%s</time>' ),
+								__( '<span>Modified: <time>%s</time></span>' ),
 								getFormattedDate( item.date )
 							),
 							{
+								span: <span />,
 								time: <time />,
 							}
 						);
@@ -359,10 +360,11 @@ export default function PagePages() {
 						return createInterpolateElement(
 							sprintf(
 								/* translators: %s: page creation date */
-								__( 'Scheduled: <time>%s</time>' ),
+								__( '<span>Scheduled: <time>%s</time></span>' ),
 								getFormattedDate( item.date )
 							),
 							{
+								span: <span />,
 								time: <time />,
 							}
 						);
@@ -379,10 +381,11 @@ export default function PagePages() {
 						return createInterpolateElement(
 							sprintf(
 								/* translators: %s: the newest of created or modified date for the page */
-								__( 'Modified: <time>%s</time>' ),
+								__( '<span>Modified: <time>%s</time></span>' ),
 								getFormattedDate( dateToDisplay )
 							),
 							{
+								span: <span />,
 								time: <time />,
 							}
 						);
@@ -393,10 +396,11 @@ export default function PagePages() {
 						return createInterpolateElement(
 							sprintf(
 								/* translators: %s: the newest of created or modified date for the page */
-								__( 'Published: <time>%s</time>' ),
+								__( '<span>Published: <time>%s</time></span>' ),
 								getFormattedDate( dateToDisplay )
 							),
 							{
+								span: <span />,
 								time: <time />,
 							}
 						);

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -2,10 +2,16 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useState,
+	useMemo,
+	useCallback,
+	useEffect,
+} from '@wordpress/element';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -336,21 +342,29 @@ export default function PagePages() {
 						item.status
 					);
 					if ( isDraftOrPrivate ) {
-						return (
-							<>
-								{ __( 'Modified: ' ) }
-								<time>{ getFormattedDate( item.date ) }</time>
-							</>
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: page creation date */
+								__( 'Modified: <time>%s</time>' ),
+								getFormattedDate( item.date )
+							),
+							{
+								time: <time />,
+							}
 						);
 					}
 
 					const isScheduled = item.status === 'future';
 					if ( isScheduled ) {
-						return (
-							<>
-								{ __( 'Scheduled: ' ) }
-								<time>{ getFormattedDate( item.date ) }</time>
-							</>
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: page creation date */
+								__( 'Scheduled: <time>%s</time>' ),
+								getFormattedDate( item.date )
+							),
+							{
+								time: <time />,
+							}
 						);
 					}
 
@@ -362,25 +376,29 @@ export default function PagePages() {
 
 					const isPending = item.status === 'pending';
 					if ( isPending ) {
-						return (
-							<>
-								{ __( 'Modified: ' ) }
-								<time>
-									{ getFormattedDate( dateToDisplay ) }
-								</time>
-							</>
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: the newest of created or modified date for the page */
+								__( 'Modified: <time>%s</time>' ),
+								getFormattedDate( dateToDisplay )
+							),
+							{
+								time: <time />,
+							}
 						);
 					}
 
 					const isPublished = item.status === 'publish';
 					if ( isPublished ) {
-						return (
-							<>
-								{ __( 'Published: ' ) }
-								<time>
-									{ getFormattedDate( dateToDisplay ) }
-								</time>
-							</>
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: the newest of created or modified date for the page */
+								__( 'Published: <time>%s</time>' ),
+								getFormattedDate( dateToDisplay )
+							),
+							{
+								time: <time />,
+							}
 						);
 					}
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -332,16 +332,31 @@ export default function PagePages() {
 				header: __( 'Date' ),
 				id: 'date',
 				render: ( { item } ) => {
-					const isNotPublished = [
-						'draft',
-						'pending',
-						'private',
-					].some( ( status ) => status === item.status );
-					if ( isNotPublished ) {
+					const isDraftOrPrivate = [ 'draft', 'private' ].some(
+						( status ) => status === item.status
+					);
+					if ( isDraftOrPrivate ) {
 						return (
 							<>
 								{ __( 'Modified: ' ) }
 								<time>{ getFormattedDate( item.date ) }</time>
+							</>
+						);
+					}
+
+					const isPending = item.status === 'pending';
+					if ( isPending ) {
+						const isModified =
+							getDate( item.modified ) > getDate( item.date );
+						const dateToDisplay = isModified
+							? item.modified
+							: item.date;
+						return (
+							<>
+								{ __( 'Modified: ' ) }
+								<time>
+									{ getFormattedDate( dateToDisplay ) }
+								</time>
 							</>
 						);
 					}
@@ -357,25 +372,24 @@ export default function PagePages() {
 					}
 
 					const isPublished = item.status === 'publish';
-					const isModified =
-						getDate( item.date ) < getDate( item.modified );
-					if ( isPublished && isModified ) {
+					if ( isPublished ) {
+						const isModified =
+							getDate( item.modified ) > getDate( item.modified );
+						const dateToDisplay = isModified
+							? item.modified
+							: item.date;
 						return (
 							<>
 								{ __( 'Published: ' ) }
 								<time>
-									{ getFormattedDate( item.modified ) }
+									{ getFormattedDate( dateToDisplay ) }
 								</time>
 							</>
 						);
 					}
 
-					return (
-						<>
-							{ __( 'Published: ' ) }
-							<time>{ getFormattedDate( item.date ) }</time>
-						</>
-					);
+					// Unknow status.
+					return <time>{ getFormattedDate( item.date ) }</time>;
 				},
 			},
 		],

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -332,20 +332,16 @@ export default function PagePages() {
 				header: __( 'Date' ),
 				id: 'date',
 				render: ( { item } ) => {
-					const isModified =
-						getDate( item.date ) < getDate( item.modified );
 					const isNotPublished = [
 						'draft',
 						'pending',
 						'private',
 					].some( ( status ) => status === item.status );
-					if ( isModified || isNotPublished ) {
+					if ( isNotPublished ) {
 						return (
 							<>
 								{ __( 'Modified: ' ) }
-								<time>
-									{ getFormattedDate( item.modified ) }
-								</time>
+								<time>{ getFormattedDate( item.date ) }</time>
 							</>
 						);
 					}
@@ -356,6 +352,20 @@ export default function PagePages() {
 							<>
 								{ __( 'Scheduled: ' ) }
 								<time>{ getFormattedDate( item.date ) }</time>
+							</>
+						);
+					}
+
+					const isPublished = item.status === 'publish';
+					const isModified =
+						getDate( item.date ) < getDate( item.modified );
+					if ( isPublished && isModified ) {
+						return (
+							<>
+								{ __( 'Modified: ' ) }
+								<time>
+									{ getFormattedDate( item.modified ) }
+								</time>
 							</>
 						);
 					}

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -332,31 +332,14 @@ export default function PagePages() {
 				header: __( 'Date' ),
 				id: 'date',
 				render: ( { item } ) => {
-					const isDraftOrPrivate = [ 'draft', 'private' ].some(
-						( status ) => status === item.status
+					const isDraftOrPrivate = [ 'draft', 'private' ].includes(
+						item.status
 					);
 					if ( isDraftOrPrivate ) {
 						return (
 							<>
 								{ __( 'Modified: ' ) }
 								<time>{ getFormattedDate( item.date ) }</time>
-							</>
-						);
-					}
-
-					const isPending = item.status === 'pending';
-					if ( isPending ) {
-						const isModified =
-							getDate( item.modified ) > getDate( item.date );
-						const dateToDisplay = isModified
-							? item.modified
-							: item.date;
-						return (
-							<>
-								{ __( 'Modified: ' ) }
-								<time>
-									{ getFormattedDate( dateToDisplay ) }
-								</time>
 							</>
 						);
 					}
@@ -371,13 +354,26 @@ export default function PagePages() {
 						);
 					}
 
-					const isPublished = item.status === 'publish';
-					if ( isPublished ) {
-						const isModified =
-							getDate( item.modified ) > getDate( item.modified );
-						const dateToDisplay = isModified
+					// Pending & Published posts show the modified date if it's newer.
+					const dateToDisplay =
+						getDate( item.modified ) > getDate( item.date )
 							? item.modified
 							: item.date;
+
+					const isPending = item.status === 'pending';
+					if ( isPending ) {
+						return (
+							<>
+								{ __( 'Modified: ' ) }
+								<time>
+									{ getFormattedDate( dateToDisplay ) }
+								</time>
+							</>
+						);
+					}
+
+					const isPublished = item.status === 'publish';
+					if ( isPublished ) {
 						return (
 							<>
 								{ __( 'Published: ' ) }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -334,32 +334,33 @@ export default function PagePages() {
 				render: ( { item } ) => {
 					const isModified =
 						getDate( item.date ) < getDate( item.modified );
-					if ( isModified ) {
+					const isDraft = item.status === 'draft';
+					if ( isModified || isDraft ) {
 						return (
-							<p>
+							<>
 								{ __( 'Modified: ' ) }
 								<time>
 									{ getFormattedDate( item.modified ) }
 								</time>
-							</p>
+							</>
 						);
 					}
 
 					const isScheduled = isInTheFuture( item.date );
 					if ( isScheduled ) {
 						return (
-							<p>
+							<>
 								{ __( 'Scheduled: ' ) }
 								<time>{ getFormattedDate( item.date ) }</time>
-							</p>
+							</>
 						);
 					}
 
 					return (
-						<p>
+						<>
 							{ __( 'Published: ' ) }
 							<time>{ getFormattedDate( item.date ) }</time>
-						</p>
+						</>
 					);
 				},
 			},

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -330,7 +330,12 @@ export default function PagePages() {
 						getSettings().formats.datetimeAbbreviated,
 						getDate( item.date )
 					);
-					return <time>{ formattedDate }</time>;
+					return (
+						<p>
+							{ 'Published: ' }
+							<time>{ formattedDate }</time>
+						</p>
+					);
 				},
 			},
 		],

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -362,7 +362,7 @@ export default function PagePages() {
 					if ( isPublished && isModified ) {
 						return (
 							<>
-								{ __( 'Modified: ' ) }
+								{ __( 'Published: ' ) }
 								<time>
 									{ getFormattedDate( item.modified ) }
 								</time>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -326,13 +326,29 @@ export default function PagePages() {
 				header: __( 'Date' ),
 				id: 'date',
 				render: ( { item } ) => {
+					const isModified =
+						getDate( item.date ) < getDate( item.modified );
+					const dateToDisplay = isModified
+						? item.modified
+						: item.date;
+
 					const formattedDate = dateI18n(
 						getSettings().formats.datetimeAbbreviated,
-						getDate( item.date )
+						getDate( dateToDisplay )
 					);
+
+					if ( isModified ) {
+						return (
+							<p>
+								{ __( 'Modified: ' ) }
+								<time>{ formattedDate }</time>
+							</p>
+						);
+					}
+
 					return (
 						<p>
-							{ 'Published: ' }
+							{ __( 'Published: ' ) }
 							<time>{ formattedDate }</time>
 						</p>
 					);

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
-import { dateI18n, getDate, getSettings, isInTheFuture } from '@wordpress/date';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
@@ -334,9 +334,12 @@ export default function PagePages() {
 				render: ( { item } ) => {
 					const isModified =
 						getDate( item.date ) < getDate( item.modified );
-					const isDraft = item.status === 'draft';
-					const isPending = item.status === 'pending';
-					if ( isModified || isDraft || isPending ) {
+					const isNotPublished = [
+						'draft',
+						'pending',
+						'private',
+					].some( ( status ) => status === item.status );
+					if ( isModified || isNotPublished ) {
 						return (
 							<>
 								{ __( 'Modified: ' ) }
@@ -347,7 +350,7 @@ export default function PagePages() {
 						);
 					}
 
-					const isScheduled = isInTheFuture( item.date );
+					const isScheduled = item.status === 'future';
 					if ( isScheduled ) {
 						return (
 							<>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -335,7 +335,8 @@ export default function PagePages() {
 					const isModified =
 						getDate( item.date ) < getDate( item.modified );
 					const isDraft = item.status === 'draft';
-					if ( isModified || isDraft ) {
+					const isPending = item.status === 'pending';
+					if ( isModified || isDraft || isPending ) {
 						return (
 							<>
 								{ __( 'Modified: ' ) }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/60477

## What?

Enhances the information displayed in the `date` field.

## Why?

We aim to get parity with wp-admin:

<img width="1307" alt="Screenshot 2024-04-04 at 18 25 04" src="https://github.com/WordPress/gutenberg/assets/846565/ff9a43f2-a3ff-4bac-841e-9e3281a8edc5">

Target design for dataviews:

<img width="1113" alt="Screenshot 2024-04-12 at 13 49 24" src="https://github.com/WordPress/gutenberg/assets/846565/90d20fba-4685-4ab3-be57-0f2334cff487">

## How?

Adds logic to the `date` field rendering depending on the post status:

- Published: show the latest of created (`item.date`) or modified (`item.modified`).
- Scheduled: show always the created (`item.date`) date, which is in the future.
- Private & Draft: show always the created (`item.date`), even if it has been modified.
- Pending: show the latest of created (`item.date`) or modified (`item.modified`).

| wp-admin | dataviews |
| --- | --- |
| <img width="1251" alt="Captura de ecrã 2024-05-16, às 13 42 47" src="https://github.com/WordPress/gutenberg/assets/583546/b008d263-4d9c-4309-8399-4fa239caabc4"> | <img width="908" alt="Captura de ecrã 2024-05-16, às 13 42 33" src="https://github.com/WordPress/gutenberg/assets/583546/17bd9147-5023-4ef3-ad7a-89ea0d6997d3"> |

## Testing Instructions

- Create pages with different status (draft, private, etc.). For each, create one that is modified after being first created and one that is not.
- Visit the pages page and verify the dates look the same as in wp-admin.