### PR TITLE
Data views: Fix pagination position on pages with short lists

### DIFF
--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -85,62 +85,60 @@ export default function DataViews( {
 	);
 	return (
 		<div className="dataviews-wrapper">
-			<div className="dataviews-records">
+			<HStack
+				alignment="top"
+				justify="start"
+				className="dataviews-filters__view-actions"
+			>
 				<HStack
-					alignment="top"
 					justify="start"
-					className="dataviews-filters__view-actions"
+					className="dataviews-filters__container"
+					wrap
 				>
-					<HStack
-						justify="start"
-						className="dataviews-filters__container"
-						wrap
-					>
-						{ search && (
-							<Search
-								label={ searchLabel }
-								view={ view }
-								onChangeView={ onChangeView }
-							/>
-						) }
-						<Filters
-							fields={ _fields }
+					{ search && (
+						<Search
+							label={ searchLabel }
 							view={ view }
 							onChangeView={ onChangeView }
-							openedFilter={ openedFilter }
-							setOpenedFilter={ setOpenedFilter }
 						/>
-					</HStack>
-					{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
-						hasPossibleBulkAction && (
-							<BulkActions
-								actions={ actions }
-								data={ data }
-								onSelectionChange={ onSetSelection }
-								selection={ selection }
-								getItemId={ getItemId }
-							/>
-						) }
-					<ViewActions
+					) }
+					<Filters
 						fields={ _fields }
 						view={ view }
 						onChangeView={ onChangeView }
-						supportedLayouts={ supportedLayouts }
+						openedFilter={ openedFilter }
+						setOpenedFilter={ setOpenedFilter }
 					/>
 				</HStack>
-				<ViewComponent
-					actions={ actions }
-					data={ data }
+				{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
+					hasPossibleBulkAction && (
+						<BulkActions
+							actions={ actions }
+							data={ data }
+							onSelectionChange={ onSetSelection }
+							selection={ selection }
+							getItemId={ getItemId }
+						/>
+					) }
+				<ViewActions
 					fields={ _fields }
-					getItemId={ getItemId }
-					isLoading={ isLoading }
-					onChangeView={ onChangeView }
-					onSelectionChange={ onSetSelection }
-					selection={ selection }
-					setOpenedFilter={ setOpenedFilter }
 					view={ view }
+					onChangeView={ onChangeView }
+					supportedLayouts={ supportedLayouts }
 				/>
-			</div>
+			</HStack>
+			<ViewComponent
+				actions={ actions }
+				data={ data }
+				fields={ _fields }
+				getItemId={ getItemId }
+				isLoading={ isLoading }
+				onChangeView={ onChangeView }
+				onSelectionChange={ onSetSelection }
+				selection={ selection }
+				setOpenedFilter={ setOpenedFilter }
+				view={ view }
+			/>
 			<Pagination
 				view={ view }
 				onChangeView={ onChangeView }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -85,60 +85,62 @@ export default function DataViews( {
 	);
 	return (
 		<div className="dataviews-wrapper">
-			<HStack
-				alignment="top"
-				justify="start"
-				className="dataviews-filters__view-actions"
-			>
+			<div className="dataviews-records">
 				<HStack
+					alignment="top"
 					justify="start"
-					className="dataviews-filters__container"
-					wrap
+					className="dataviews-filters__view-actions"
 				>
-					{ search && (
-						<Search
-							label={ searchLabel }
+					<HStack
+						justify="start"
+						className="dataviews-filters__container"
+						wrap
+					>
+						{ search && (
+							<Search
+								label={ searchLabel }
+								view={ view }
+								onChangeView={ onChangeView }
+							/>
+						) }
+						<Filters
+							fields={ _fields }
 							view={ view }
 							onChangeView={ onChangeView }
+							openedFilter={ openedFilter }
+							setOpenedFilter={ setOpenedFilter }
 						/>
-					) }
-					<Filters
+					</HStack>
+					{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
+						hasPossibleBulkAction && (
+							<BulkActions
+								actions={ actions }
+								data={ data }
+								onSelectionChange={ onSetSelection }
+								selection={ selection }
+								getItemId={ getItemId }
+							/>
+						) }
+					<ViewActions
 						fields={ _fields }
 						view={ view }
 						onChangeView={ onChangeView }
-						openedFilter={ openedFilter }
-						setOpenedFilter={ setOpenedFilter }
+						supportedLayouts={ supportedLayouts }
 					/>
 				</HStack>
-				{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
-					hasPossibleBulkAction && (
-						<BulkActions
-							actions={ actions }
-							data={ data }
-							onSelectionChange={ onSetSelection }
-							selection={ selection }
-							getItemId={ getItemId }
-						/>
-					) }
-				<ViewActions
+				<ViewComponent
+					actions={ actions }
+					data={ data }
 					fields={ _fields }
-					view={ view }
+					getItemId={ getItemId }
+					isLoading={ isLoading }
 					onChangeView={ onChangeView }
-					supportedLayouts={ supportedLayouts }
+					onSelectionChange={ onSetSelection }
+					selection={ selection }
+					setOpenedFilter={ setOpenedFilter }
+					view={ view }
 				/>
-			</HStack>
-			<ViewComponent
-				actions={ actions }
-				data={ data }
-				fields={ _fields }
-				getItemId={ getItemId }
-				isLoading={ isLoading }
-				onChangeView={ onChangeView }
-				onSelectionChange={ onSetSelection }
-				selection={ selection }
-				setOpenedFilter={ setOpenedFilter }
-				view={ view }
-			/>
+			</div>
 			<Pagination
 				view={ view }
 				onChangeView={ onChangeView }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -3,6 +3,8 @@
 	overflow: auto;
 	box-sizing: border-box;
 	scroll-padding-bottom: $grid-unit-80;
+	display: flex;
+	flex-direction: column;
 }
 
 .dataviews-filters__view-actions {
@@ -68,6 +70,7 @@
 	border-collapse: collapse;
 	position: relative;
 	color: $gray-700;
+	margin-bottom: auto;
 
 	a {
 		text-decoration: none;
@@ -278,10 +281,10 @@
 }
 
 .dataviews-view-grid {
-	margin-bottom: $grid-unit-30;
+	margin-bottom: auto;
 	grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
 	grid-template-rows: max-content;
-	padding: 0 $grid-unit-40;
+	padding: 0 $grid-unit-40 $grid-unit-30;
 
 	@include break-xlarge() {
 		grid-template-columns: repeat(3, minmax(0, 1fr)) !important; // Todo: eliminate !important dependency
@@ -396,7 +399,7 @@
 }
 
 .dataviews-view-list {
-	margin: 0;
+	margin: 0 0 auto;
 
 	li {
 		margin: 0;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -3,9 +3,6 @@
 	overflow: auto;
 	box-sizing: border-box;
 	scroll-padding-bottom: $grid-unit-80;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
 }
 
 .dataviews-filters__view-actions {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -3,6 +3,9 @@
 	overflow: auto;
 	box-sizing: border-box;
 	scroll-padding-bottom: $grid-unit-80;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
 }
 
 .dataviews-filters__view-actions {


### PR DESCRIPTION
## What?
Ensure the pagination row is always positioned at the bottom of the frame.

## Why?
Pagination arrows changing position as you navigate between pages is a bit annoying for mouse users.

## How?
I needed to add an extra div to accomplish this. I feel as though there must be a way to avoid this, but I couldn't think of one. Ideas welcome.

## Testing Instructions
1. Navigate to a data views page with a small number of records.
2. Ensure the pagination row is positioned at the bottom of the frame.
3. Check there are no regressions in the wider data views UI.

| Before | After |
| --- | --- |
| <img width="402" alt="Screenshot 2024-05-16 at 11 15 29" src="https://github.com/WordPress/gutenberg/assets/846565/3a7fabea-7c0e-425b-86fd-e20d0b35e9e0"> | <img width="471" alt="Screenshot 2024-05-16 at 11 21 39" src="https://github.com/WordPress/gutenberg/assets/846565/c2f6995f-aac7-433f-b256-e9fccd970f69"> |


