### PR TITLE
Fix: Update "Link Text" label to "Text" on Social Icons block #60966

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -117,9 +117,9 @@ const SocialLinkEdit = ( {
 					<PanelRow>
 						<TextControl
 							__nextHasNoMarginBottom
-							label={ __( 'Link text' ) }
+							label={ __( 'Text' ) }
 							help={ __(
-								'The link text is visible when enabled from the parent Social Icons block.'
+								'The text is visible when enabled from the parent Social Icons block.'
 							) }
 							value={ label }
 							onChange={ ( value ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - https://github.com/WordPress/gutenberg/issues/60966

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- This is need to make consistent and polish the blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR change the label and help text by removing the link word.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open any post/page.
2. Add the social icons block and add the icons.
3. For single icon, on the settings bar you can see the label is now changed to `text`, instead of `link text`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NIL

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| :-------------: | :-------------: |
| <img width="1426" alt="Screenshot 2024-05-16 at 4 20 44 PM" src="https://github.com/WordPress/gutenberg/assets/58802366/b9757623-810e-4a33-a2ac-934c974abc8f"> | <img width="1426" alt="Screenshot 2024-05-16 at 4 14 20 PM" src="https://github.com/WordPress/gutenberg/assets/58802366/eb82b551-f332-411e-84a1-74e46719c732"> |
