### PR TITLE
Add badge to title for posts & front pages

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -300,6 +300,23 @@ export default function PagePages() {
 				id: 'title',
 				getValue: ( { item } ) => item.title?.rendered,
 				render: ( { item } ) => {
+					let suffix = '';
+					if ( item.id === frontPageId ) {
+						suffix = (
+							<span className="edit-site-page-pages__title-badge">
+								{ __( 'Front Page' ) }
+							</span>
+						);
+					}
+
+					if ( item.id === postsPageId ) {
+						suffix = (
+							<span className="edit-site-page-pages__title-badge">
+								{ __( 'Posts Page' ) }
+							</span>
+						);
+					}
+
 					const addLink =
 						[ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
 						item.status !== 'trash';
@@ -313,33 +330,15 @@ export default function PagePages() {
 						>
 							{ decodeEntities( item.title?.rendered ) ||
 								__( '(no title)' ) }
+							{ suffix }
 						</Link>
 					) : (
-						decodeEntities( item.title?.rendered ) ||
-						__( '(no title)' )
+						<>
+							{ decodeEntities( item.title?.rendered ) ||
+								__( '(no title)' ) }
+							{ suffix }
+						</>
 					);
-
-					if ( item.id === frontPageId ) {
-						return (
-							<>
-								{ title }
-								<span className="edit-site-page-pages__title-badge">
-									{ __( 'Front Page' ) }
-								</span>
-							</>
-						);
-					}
-
-					if ( item.id === postsPageId ) {
-						return (
-							<>
-								{ title }
-								<span className="edit-site-page-pages__title-badge">
-									{ __( 'Posts Page' ) }
-								</span>
-							</>
-						);
-					}
 
 					return title;
 				},

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -273,6 +273,16 @@ export default function PagePages() {
 		[ totalItems, totalPages ]
 	);
 
+	const { frontPageId, postsPageId } = useSelect( ( select ) => {
+		const { getEntityRecord } = select( coreStore );
+		const siteSettings = getEntityRecord( 'root', 'site' );
+
+		return {
+			frontPageId: siteSettings?.page_on_front,
+			postsPageId: siteSettings?.page_for_posts,
+		};
+	} );
+
 	const fields = useMemo(
 		() => [
 			{
@@ -293,7 +303,7 @@ export default function PagePages() {
 					const addLink =
 						[ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
 						item.status !== 'trash';
-					return addLink ? (
+					const title = addLink ? (
 						<Link
 							params={ {
 								postId: item.id,
@@ -306,8 +316,32 @@ export default function PagePages() {
 						</Link>
 					) : (
 						decodeEntities( item.title?.rendered ) ||
-							__( '(no title)' )
+						__( '(no title)' )
 					);
+
+					if ( item.id === frontPageId ) {
+						return (
+							<>
+								{ title }
+								<span className="edit-site-page-pages__title-badge">
+									{ __( 'Front Page' ) }
+								</span>
+							</>
+						);
+					}
+
+					if ( item.id === postsPageId ) {
+						return (
+							<>
+								{ title }
+								<span className="edit-site-page-pages__title-badge">
+									{ __( 'Posts Page' ) }
+								</span>
+							</>
+						);
+					}
+
+					return title;
 				},
 				maxWidth: 300,
 				enableHiding: false,
@@ -411,7 +445,7 @@ export default function PagePages() {
 				},
 			},
 		],
-		[ authors, view.type ]
+		[ authors, view.type, frontPageId, postsPageId ]
 	);
 
 	const postTypeActions = usePostActions( 'page' );

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -315,8 +315,10 @@ export default function PagePages() {
 								__( '(no title)' ) }
 						</Link>
 					) : (
-						decodeEntities( item.title?.rendered ) ||
-						__( '(no title)' )
+						<span>
+							{ decodeEntities( item.title?.rendered ) ||
+								__( '(no title)' ) }
+						</span>
 					);
 
 					let suffix = '';
@@ -335,7 +337,10 @@ export default function PagePages() {
 					}
 
 					return (
-						<HStack justify="stretch">
+						<HStack
+							className="edit-site-page-pages-title"
+							justify="stretch"
+						>
 							{ title }
 							{ suffix }
 						</HStack>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -339,7 +339,8 @@ export default function PagePages() {
 					return (
 						<HStack
 							className="edit-site-page-pages-title"
-							justify="stretch"
+							alignment="center"
+							justify="flex-start"
 						>
 							{ title }
 							{ suffix }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -300,23 +300,6 @@ export default function PagePages() {
 				id: 'title',
 				getValue: ( { item } ) => item.title?.rendered,
 				render: ( { item } ) => {
-					let suffix = '';
-					if ( item.id === frontPageId ) {
-						suffix = (
-							<span className="edit-site-page-pages__title-badge">
-								{ __( 'Front Page' ) }
-							</span>
-						);
-					}
-
-					if ( item.id === postsPageId ) {
-						suffix = (
-							<span className="edit-site-page-pages__title-badge">
-								{ __( 'Posts Page' ) }
-							</span>
-						);
-					}
-
 					const addLink =
 						[ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
 						item.status !== 'trash';
@@ -330,17 +313,33 @@ export default function PagePages() {
 						>
 							{ decodeEntities( item.title?.rendered ) ||
 								__( '(no title)' ) }
-							{ suffix }
 						</Link>
 					) : (
-						<>
-							{ decodeEntities( item.title?.rendered ) ||
-								__( '(no title)' ) }
-							{ suffix }
-						</>
+						decodeEntities( item.title?.rendered ) ||
+						__( '(no title)' )
 					);
 
-					return title;
+					let suffix = '';
+					if ( item.id === frontPageId ) {
+						suffix = (
+							<span className="edit-site-page-pages__title-badge">
+								{ __( 'Front Page' ) }
+							</span>
+						);
+					} else if ( item.id === postsPageId ) {
+						suffix = (
+							<span className="edit-site-page-pages__title-badge">
+								{ __( 'Posts Page' ) }
+							</span>
+						);
+					}
+
+					return (
+						<HStack justify="stretch">
+							{ title }
+							{ suffix }
+						</HStack>
+					);
 				},
 				maxWidth: 300,
 				enableHiding: false,

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -51,3 +51,13 @@
 		outline: 2px solid transparent;
 	}
 }
+
+.edit-site-page-pages__title-badge {
+	background: $gray-100;
+	margin-left: $grid-unit-05;
+	padding: $grid-unit-10;
+	border-radius: $radius-block-ui;
+	font-size: 12px;
+	font-weight: 400;
+	width: fit-content;
+}

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -52,6 +52,11 @@
 	}
 }
 
+.edit-site-page-pages-title span {
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
 .edit-site-page-pages__title-badge {
 	background: $gray-100;
 	color: $gray-700;
@@ -60,5 +65,5 @@
 	border-radius: $radius-block-ui;
 	font-size: 12px;
 	font-weight: 400;
-	width: fit-content;
+	min-width: 80px !important; // Override HStack min-width: 0
 }

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -54,6 +54,7 @@
 
 .edit-site-page-pages__title-badge {
 	background: $gray-100;
+	color: $gray-700;
 	margin-left: $grid-unit-05;
 	padding: $grid-unit-10;
 	border-radius: $radius-block-ui;

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -60,10 +60,9 @@
 .edit-site-page-pages__title-badge {
 	background: $gray-100;
 	color: $gray-700;
-	margin-left: $grid-unit-05;
-	padding: $grid-unit-10;
+	padding: $grid-unit-05 $grid-unit-10;
 	border-radius: $radius-block-ui;
 	font-size: 12px;
 	font-weight: 400;
-	min-width: 80px !important; // Override HStack min-width: 0
+	flex-shrink: 0;
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/57763

## What?

Adds a badge to indicate that a page is the `Front Page` or the `Posts Page`.

## Why?

This is the target design we want:

<img width="1391" alt="page marking" src="https://github.com/WordPress/gutenberg/assets/846565/422f80f0-ec06-4a81-9a91-4e9bc52d8119">

## How?

Update the `title` rendering function to check whether the item is one of the special pages. If so, add a badge.

## Testing Instructions

- Go to Settings > Reading and set the "Homepage" and "Posts page".
- Visit the Pages page and verify the badge is there in all layouts.
