### PR TITLE
Fix read only post status styles

### DIFF
--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -281,7 +281,9 @@ export default function PostStatus() {
 					) }
 				/>
 			) : (
-				<div className="editor-post-status">{ labels[ status ] }</div>
+				<div className="editor-post-status is-read-only">
+					{ labels[ status ] }
+				</div>
 			) }
 		</PostPanelRow>
 	);

--- a/packages/editor/src/components/post-status/style.scss
+++ b/packages/editor/src/components/post-status/style.scss
@@ -1,5 +1,9 @@
 .editor-post-status {
 	max-width: 100%;
+
+	&.is-read-only {
+		padding: 6px 12px;
+	}
 }
 
 .editor-change-status__password-fieldset {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/61645

This PR updates the styles of Post Status component when the user cannot edit it.


Before               |  After
-----------------------------------------|-------------------------
<img width="280" alt="Screenshot 2024-05-16 at 4 12 12 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/4c824c76-d76a-419f-aa8f-409851dceed8"> |  <img width="280" alt="Screenshot 2024-05-16 at 4 11 51 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/733f602b-1454-4af0-942d-b9caa8556e1c">

<!-- In a few words, what is the PR actually doing? -->



## Testing Instructions
1. Check post status with a `contributor` user
