### PR TITLE
Improve link conrol preview when show button text label is enabled.

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -36,7 +36,7 @@ $block-editor-link-control-number-of-actions: 1;
 		}
 
 		.block-editor-link-control__search-item-top {
-			gap: $grid-unit-10;
+			gap: $grid-unit-05;
 			flex-wrap: wrap;
 			justify-content: flex-end;
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -37,11 +37,18 @@ $block-editor-link-control-number-of-actions: 1;
 
 		.block-editor-link-control__search-item-top {
 			gap: $grid-unit-10;
+			flex-wrap: wrap;
+			justify-content: flex-end;
 
 			.components-button.has-icon {
-				min-width: inherit;
-				width: min-content;
+				width: auto;
+				padding: $grid-unit-05;
 			}
+		}
+
+		.is-preview .block-editor-link-control__search-item-header {
+			min-width: 100%;
+			margin-right: 0;
 		}
 	}
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -38,7 +38,6 @@ $block-editor-link-control-number-of-actions: 1;
 		.block-editor-link-control__search-item-top {
 			gap: $grid-unit-05;
 			flex-wrap: wrap;
-			justify-content: flex-end;
 
 			.components-button.has-icon {
 				width: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
See https://github.com/WordPress/gutenberg/issues/61158

## What?
<!-- In a few words, what is the PR actually doing? -->
When the 'Show button text labels' preference is enabled, the LInkControl preview has very limited horizontal space to show its content, especially with some languages. See screenshots at https://github.com/WordPress/gutenberg/issues/61158#issuecomment-2115407705

Both the link preview and the buttons with visible text need more horizontal space.

When 'Show button text labels' is enabled, there is no need to show the preview and the buttons on the same line. IN a way, 'Show button text labels' already changes the UI and it is reasonable to accomodate a different layout for the buttons with visible text. Laying out the buttons on a new line appears to be the simplest and more effective solution.

Pinging a few people who worked on this UI or are familiar with non-westeren languages:
@richtabor @MaggieCabrera @scruffian @getdave @t-hamano 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- The link preview may be so narrow to be mostly useless, as it shows a very limited portion of the preview and URL.
- The buttons text may be even not fully readable, see for example the screnshot with the admin language set to Japanese



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Makes the buttons go in a new line, only when the `Show button text labels` preference is enabled. There should be no visual changes for the default layout with icon buttons.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post, add a paragraph with some text and a link.
- Observe the UI to _add_ the link has no visual changes.
- Once the link is added, click the link again to make the popover with the link preview appear.
- Observe there are no visual changes.
- Go to Options > Preferences > Accessibility, and enable the 'Show button text labels' preference.
- Click again the link in the Paragraph.
- Observe the Link preview is on one line and the buttons with visible text are on a second line, right aligned.
- Test with languages other than English e.g. Spanish, French, German, Japanese, and an RTL language.
- Observe the button text is always fully visible.
- Note: the worst thing can happen is the buttons wrap to a second line see for example Spanish.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before 

![Screenshot 2024-05-16 at 16 10 42](https://github.com/WordPress/gutenberg/assets/1682452/8b84c745-b7e6-4bee-9fe7-95718d92a535)

![Screenshot 2024-05-16 at 15 53 51](https://github.com/WordPress/gutenberg/assets/1682452/da753d05-cca7-4b02-a371-dd66ac71afa8)

![Screenshot 2024-05-16 at 15 54 44](https://github.com/WordPress/gutenberg/assets/1682452/641c0015-a7b3-47ca-ad66-67e1869b192f)

### After

Default is unchanged:

![default](https://github.com/WordPress/gutenberg/assets/1682452/cc2e3216-65be-4fe0-afa4-e1143f04a8e7)

'Show button text labels' enabled, English:

![english](https://github.com/WordPress/gutenberg/assets/1682452/15bec359-d7e9-4212-a78d-a833bbd49992)

'Show button text labels' enabled, Spanish:

![spanish](https://github.com/WordPress/gutenberg/assets/1682452/e7d34fee-421f-49c9-beaa-9aed2817ccd3)


'Show button text labels' enabled, Japanese:

![japanee](https://github.com/WordPress/gutenberg/assets/1682452/42ab7fac-6779-478e-9ae3-108446b4e979)
