### PR TITLE
Interactivity API: Turn named capturing groups back into numbered ones inside `toVdom`

### DIFF
--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -96,10 +96,9 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 				if ( attributeName === ignoreAttr ) {
 					ignore = true;
 				} else {
-					const namespaceAndPath =
-						nsPathRegExp.exec( attributeValue );
-					const namespace = namespaceAndPath?.[ 1 ] ?? null;
-					let value: any = namespaceAndPath?.[ 2 ] ?? attributeValue;
+					const regexResult = nsPathRegExp.exec( attributeValue );
+					const namespace = regexResult?.[ 1 ] ?? null;
+					let value: any = regexResult?.[ 2 ] ?? attributeValue;
 					try {
 						value = value && JSON.parse( value );
 					} catch ( e ) {}

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -88,6 +88,7 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 
 		for ( let i = 0; i < attributes.length; i++ ) {
 			const attributeName = attributes[ i ].name;
+			const attributeValue = attributes[ i ].value;
 			if (
 				attributeName[ fullPrefix.length ] &&
 				attributeName.slice( 0, fullPrefix.length ) === fullPrefix
@@ -95,7 +96,6 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 				if ( attributeName === ignoreAttr ) {
 					ignore = true;
 				} else {
-					const attributeValue = attributes[ i ].value;
 					const namespaceAndPath =
 						nsPathRegExp.exec( attributeValue );
 					const namespace = namespaceAndPath?.[ 1 ] ?? null;
@@ -120,7 +120,7 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 			} else if ( attributeName === 'ref' ) {
 				continue;
 			}
-			props[ attributeName ] = attributes[ i ].value;
+			props[ attributeName ] = attributeValue;
 		}
 
 		if ( ignore && ! island ) {

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -32,7 +32,7 @@ const directiveParser = new RegExp(
 // the reference, separated by `::`, like `some-namespace::state.somePath`.
 // Namespaces can contain any alphanumeric characters, hyphens, underscores or
 // forward slashes. References don't have any restrictions.
-const nsPathRegExp = /^(?<namespace>[\w_\/-]+)::(?<value>.+)$/;
+const nsPathRegExp = /^([\w_\/-]+)::(.+)$/;
 
 export const hydratedIslands = new WeakSet();
 
@@ -95,12 +95,10 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 				if ( attributeName === ignoreAttr ) {
 					ignore = true;
 				} else {
-					const regexCaptureGroups = nsPathRegExp.exec(
-						attributes[ i ].value
-					)?.groups;
-					const namespace = regexCaptureGroups?.namespace ?? null;
-					let value: any =
-						regexCaptureGroups?.value ?? attributes[ i ].value;
+					const attrValue = attributes[ i ].value;
+					const namespaceAndPath = nsPathRegExp.exec( attrValue );
+					const namespace = namespaceAndPath?.[ 1 ] ?? null;
+					let value: any = namespaceAndPath?.[ 2 ] ?? attrValue;
 					try {
 						value = value && JSON.parse( value );
 					} catch ( e ) {}

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -95,10 +95,11 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 				if ( attributeName === ignoreAttr ) {
 					ignore = true;
 				} else {
-					const attrValue = attributes[ i ].value;
-					const namespaceAndPath = nsPathRegExp.exec( attrValue );
+					const attributeValue = attributes[ i ].value;
+					const namespaceAndPath =
+						nsPathRegExp.exec( attributeValue );
 					const namespace = namespaceAndPath?.[ 1 ] ?? null;
-					let value: any = namespaceAndPath?.[ 2 ] ?? attrValue;
+					let value: any = namespaceAndPath?.[ 2 ] ?? attributeValue;
 					try {
 						value = value && JSON.parse( value );
 					} catch ( e ) {}


### PR DESCRIPTION
## What?

Reverts a recent change in https://github.com/WordPress/gutenberg/pull/59865/commits/dbf231aae35054d962a8aa5b8293f19130c95857 that introduced named capturing groups in the RegExp used to parse directive values.

https://github.com/WordPress/gutenberg/blob/dbf231aae35054d962a8aa5b8293f19130c95857/packages/interactivity/src/vdom.ts#L98-L103

## Why?

According to [caniuse.com](https://caniuse.com), named capturing groups have global support of [95.62%](https://caniuse.com/mdn-javascript_regular_expressions_named_capturing_group). Although the value is quite high, there could be users for whom the Interactivity API does not work just by using this feature.

For instance, global support of Proxy objects is [97.28%](https://caniuse.com/proxy).

## How?

Using numbered capturing groups instead.
