### PR TITLE
Add documentation for DocumentBar

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -254,7 +254,19 @@ _Returns_
 
 ### DocumentBar
 
-Undocumented declaration.
+DocumentBar component.
+
+This component renders a navigation bar at the top of the editor. It displays the title of the current document, a back button (if applicable), and a command center button. It also handles different states of the document, such as "not found" or "unsynced".
+
+_Usage_
+
+```jsx
+<DocumentBar />
+```
+
+_Returns_
+
+-   `JSX.Element`: The rendered DocumentBar component.
 
 ### DocumentOutline
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -254,8 +254,6 @@ _Returns_
 
 ### DocumentBar
 
-DocumentBar component.
-
 This component renders a navigation bar at the top of the editor. It displays the title of the current document, a back button (if applicable), and a command center button. It also handles different states of the document, such as "not found" or "unsynced".
 
 _Usage_

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -49,6 +49,20 @@ const GLOBAL_POST_TYPES = [
 
 const MotionButton = motion( Button );
 
+/**
+ * DocumentBar component.
+ *
+ * This component renders a navigation bar at the top of the editor. It displays the title of the current document,
+ * a back button (if applicable), and a command center button. It also handles different states of the document,
+ * such as "not found" or "unsynced".
+ *
+ * @example
+ * ```jsx
+ * <DocumentBar />
+ * ```
+ *
+ * @return {JSX.Element} The rendered DocumentBar component.
+ */
 export default function DocumentBar() {
 	const {
 		postType,

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -50,8 +50,6 @@ const GLOBAL_POST_TYPES = [
 const MotionButton = motion( Button );
 
 /**
- * DocumentBar component.
- *
  * This component renders a navigation bar at the top of the editor. It displays the title of the current document,
  * a back button (if applicable), and a command center button. It also handles different states of the document,
  * such as "not found" or "unsynced".


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/60358

Added JSDoc to DocumentBar component and rendered documentation for the readme.

## How?
Added JSDocs formatted doc blocks to existing DocumentBar component.
Ran `npm run docs:build` to render new README.md