### PR TITLE
Add JSDoc to PostVisibility, PostVisibilityCheck, and PostVisibilityLabel

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1154,13 +1154,11 @@ Undocumented declaration.
 
 ### PostVisibility
 
-PostVisibility component.
-
 Allows users to set the visibility of a post.
 
 _Parameters_
 
--   _props_ `Object`: Component properties.
+-   _props_ `Object`: The component props.
 -   _props.onClose_ `Function`: Function to call when the popover is closed.
 
 _Returns_
@@ -1169,22 +1167,18 @@ _Returns_
 
 ### PostVisibilityCheck
 
-PostVisibilityCheck component.
-
 Determines if the current post can be edited (published) and passes this information to the provided render function.
 
 _Parameters_
 
--   _props_ `Object`: - Component properties.
--   _props.render_ `Function`: - Function to render the component. Receives an object with a `canEdit` property.
+-   _props_ `Object`: The component props.
+-   _props.render_ `Function`: Function to render the component. Receives an object with a `canEdit` property.
 
 _Returns_
 
--   `JSX.Element`: Rendered component.
+-   `JSX.Element`: The rendered component.
 
 ### PostVisibilityLabel
-
-PostVisibilityLabel component.
 
 Returns the label for the current post visibility setting.
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1154,15 +1154,43 @@ Undocumented declaration.
 
 ### PostVisibility
 
-Undocumented declaration.
+PostVisibility component.
+
+Allows users to set the visibility of a post.
+
+_Parameters_
+
+-   _props_ `Object`: Component properties.
+-   _props.onClose_ `Function`: Function to call when the popover is closed.
+
+_Returns_
+
+-   `JSX.Element`: The rendered component.
 
 ### PostVisibilityCheck
 
-Undocumented declaration.
+PostVisibilityCheck component.
+
+Determines if the current post can be edited (published) and passes this information to the provided render function.
+
+_Parameters_
+
+-   _props_ `Object`: - Component properties.
+-   _props.render_ `Function`: - Function to render the component. Receives an object with a `canEdit` property.
+
+_Returns_
+
+-   `JSX.Element`: Rendered component.
 
 ### PostVisibilityLabel
 
-Undocumented declaration.
+PostVisibilityLabel component.
+
+Returns the label for the current post visibility setting.
+
+_Returns_
+
+-   `string`: Post visibility label.
 
 ### privateApis
 
@@ -1266,7 +1294,11 @@ Undocumented declaration.
 
 ### usePostVisibilityLabel
 
-Undocumented declaration.
+Get the label for the current post visibility setting.
+
+_Returns_
+
+-   `string`: Post visibility label.
 
 ### userAutocompleter
 

--- a/packages/editor/src/components/post-visibility/check.js
+++ b/packages/editor/src/components/post-visibility/check.js
@@ -9,15 +9,13 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '../../store';
 
 /**
- * PostVisibilityCheck component.
- *
  * Determines if the current post can be edited (published)
  * and passes this information to the provided render function.
  *
- * @param {Object}   props        - Component properties.
- * @param {Function} props.render - Function to render the component.
+ * @param {Object}   props        The component props.
+ * @param {Function} props.render Function to render the component.
  *                                Receives an object with a `canEdit` property.
- * @return {JSX.Element} Rendered component.
+ * @return {JSX.Element} The rendered component.
  */
 export default function PostVisibilityCheck( { render } ) {
 	const canEdit = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-visibility/check.js
+++ b/packages/editor/src/components/post-visibility/check.js
@@ -8,6 +8,17 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * PostVisibilityCheck component.
+ *
+ * Determines if the current post can be edited (published)
+ * and passes this information to the provided render function.
+ *
+ * @param {Object}   props        - Component properties.
+ * @param {Function} props.render - Function to render the component.
+ *                                Receives an object with a `canEdit` property.
+ * @return {JSX.Element} Rendered component.
+ */
 export default function PostVisibilityCheck( { render } ) {
 	const canEdit = useSelect( ( select ) => {
 		return (

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -18,11 +18,9 @@ import { visibilityOptions } from './utils';
 import { store as editorStore } from '../../store';
 
 /**
- * PostVisibility component.
- *
  * Allows users to set the visibility of a post.
  *
- * @param {Object}   props         Component properties.
+ * @param {Object}   props         The component props.
  * @param {Function} props.onClose Function to call when the popover is closed.
  * @return {JSX.Element} The rendered component.
  */
@@ -142,18 +140,6 @@ export default function PostVisibility( { onClose } ) {
 	);
 }
 
-/**
- * PostVisibilityChoice component.
- *
- * Renders a visibility choice option.
- *
- * @param {Object} props            - Component properties.
- * @param {number} props.instanceId - Unique instance ID for the component.
- * @param {string} props.value      - The value of the visibility option.
- * @param {string} props.label      - The label for the visibility option.
- * @param {string} props.info       - Additional information about the visibility option.
- * @return {JSX.Element} The rendered component.
- */
 function PostVisibilityChoice( { instanceId, value, label, info, ...props } ) {
 	return (
 		<div className="editor-post-visibility__choice">

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -17,6 +17,15 @@ import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '
 import { visibilityOptions } from './utils';
 import { store as editorStore } from '../../store';
 
+/**
+ * PostVisibility component.
+ *
+ * Allows users to set the visibility of a post.
+ *
+ * @param {Object}   props         Component properties.
+ * @param {Function} props.onClose Function to call when the popover is closed.
+ * @return {JSX.Element} The rendered component.
+ */
 export default function PostVisibility( { onClose } ) {
 	const instanceId = useInstanceId( PostVisibility );
 
@@ -133,6 +142,18 @@ export default function PostVisibility( { onClose } ) {
 	);
 }
 
+/**
+ * PostVisibilityChoice component.
+ *
+ * Renders a visibility choice option.
+ *
+ * @param {Object} props            - Component properties.
+ * @param {number} props.instanceId - Unique instance ID for the component.
+ * @param {string} props.value      - The value of the visibility option.
+ * @param {string} props.label      - The label for the visibility option.
+ * @param {string} props.info       - Additional information about the visibility option.
+ * @return {JSX.Element} The rendered component.
+ */
 function PostVisibilityChoice( { instanceId, value, label, info, ...props } ) {
 	return (
 		<div className="editor-post-visibility__choice">

--- a/packages/editor/src/components/post-visibility/label.js
+++ b/packages/editor/src/components/post-visibility/label.js
@@ -9,10 +9,22 @@ import { useSelect } from '@wordpress/data';
 import { visibilityOptions } from './utils';
 import { store as editorStore } from '../../store';
 
+/**
+ * PostVisibilityLabel component.
+ *
+ * Returns the label for the current post visibility setting.
+ *
+ * @return {string} Post visibility label.
+ */
 export default function PostVisibilityLabel() {
 	return usePostVisibilityLabel();
 }
 
+/**
+ * Get the label for the current post visibility setting.
+ *
+ * @return {string} Post visibility label.
+ */
 export function usePostVisibilityLabel() {
 	const visibility = useSelect( ( select ) =>
 		select( editorStore ).getEditedPostVisibility()

--- a/packages/editor/src/components/post-visibility/label.js
+++ b/packages/editor/src/components/post-visibility/label.js
@@ -10,8 +10,6 @@ import { visibilityOptions } from './utils';
 import { store as editorStore } from '../../store';
 
 /**
- * PostVisibilityLabel component.
- *
  * Returns the label for the current post visibility setting.
  *
  * @return {string} Post visibility label.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of: https://github.com/WordPress/gutenberg/issues/60358

This PR adds JSDoc comments to the PostVisibility, PostVisibilityCheck, and PostVisibilityLabel to improve code documentation and maintainability.

