### PR TITLE
Add documentation for the EditorNotices component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -326,7 +326,19 @@ _Returns_
 
 ### EditorNotices
 
-Undocumented declaration.
+EditorNotices component.
+
+This component renders the notices displayed in the editor. It displays pinned notices first, followed by dismissible
+
+_Usage_
+
+```jsx
+<EditorNotices />
+```
+
+_Returns_
+
+-   `JSX.Element`: The rendered component.
 
 ### EditorProvider
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -326,8 +326,6 @@ _Returns_
 
 ### EditorNotices
 
-EditorNotices component.
-
 This component renders the notices displayed in the editor. It displays pinned notices first, followed by dismissible
 
 _Usage_
@@ -338,7 +336,7 @@ _Usage_
 
 _Returns_
 
--   `JSX.Element`: The rendered component.
+-   `JSX.Element`: The rendered EditorNotices component.
 
 ### EditorProvider
 

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -10,6 +10,18 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import TemplateValidationNotice from '../template-validation-notice';
 
+/**
+ * EditorNotices component.
+ *
+ * This component renders the notices displayed in the editor. It displays pinned notices first, followed by dismissible
+ *
+ * @example
+ * ```jsx
+ * <EditorNotices />
+ * ```
+ *
+ * @return {JSX.Element} The rendered component.
+ */
 export function EditorNotices() {
 	const { notices } = useSelect(
 		( select ) => ( {

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -11,8 +11,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import TemplateValidationNotice from '../template-validation-notice';
 
 /**
- * EditorNotices component.
- *
  * This component renders the notices displayed in the editor. It displays pinned notices first, followed by dismissible
  *
  * @example
@@ -20,7 +18,7 @@ import TemplateValidationNotice from '../template-validation-notice';
  * <EditorNotices />
  * ```
  *
- * @return {JSX.Element} The rendered component.
+ * @return {JSX.Element} The rendered EditorNotices component.
  */
 export function EditorNotices() {
 	const { notices } = useSelect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/60358

Added JSDoc to EditorNotices component and rendered documentation for the readme.

## How?
Added JSDocs formatted doc blocks to existing EditorNotices component.
Ran `npm run docs:build` to render new README.md
Ran `npm run lint:js packages/editor/src/components/editor-notices/index.js --fix` to ensure we wouldn't hit any linter issues in CI.