### PR TITLE
Documentation: Add PostURL component docs

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1138,7 +1138,15 @@ _Returns_
 
 ### PostURL
 
-Undocumented declaration.
+Renders the Post URL.
+
+_Parameters_
+
+-   _onClose_ `Function`: Callback function to be executed when the popover is closed.
+
+_Returns_
+
+-   `Component`: The component to be rendered.
 
 ### PostURLCheck
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1138,7 +1138,13 @@ _Returns_
 
 ### PostURL
 
-Renders the Post URL.
+Renders the `PostURL` component.
+
+_Usage_
+
+```jsx
+<PostURL />
+```
 
 _Parameters_
 
@@ -1146,19 +1152,36 @@ _Parameters_
 
 _Returns_
 
--   `Component`: The component to be rendered.
+-   `Component`: The rendered PostURL component.
 
 ### PostURLCheck
 
-Undocumented declaration.
+Check if the post URL is valid and visible.
+
+_Parameters_
+
+-   _props_ `Object`: The component props.
+-   _props.children_ `Element`: The child components.
+
+_Returns_
+
+-   `Component|null`: The child components if the post URL is valid and visible, otherwise null.
 
 ### PostURLLabel
 
-Undocumented declaration.
+Represents a label component for a post URL.
+
+_Returns_
+
+-   `Component`: The PostURLLabel component.
 
 ### PostURLPanel
 
-Undocumented declaration.
+Renders the `PostURLPanel` component.
+
+_Returns_
+
+-   `JSX.Element`: The rendered PostURLPanel component.
 
 ### PostVisibility
 
@@ -1270,7 +1293,11 @@ Undocumented declaration.
 
 ### usePostURLLabel
 
-Undocumented declaration.
+Custom hook to get the label for the post URL.
+
+_Returns_
+
+-   `string`: The filtered and decoded post URL label.
 
 ### usePostVisibilityLabel
 

--- a/packages/editor/src/components/post-url/check.js
+++ b/packages/editor/src/components/post-url/check.js
@@ -9,6 +9,14 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * Check if the post URL is valid and visible.
+ *
+ * @param {Object}  props          The component props.
+ * @param {Element} props.children The child components.
+ *
+ * @return {Component|null} The child components if the post URL is valid and visible, otherwise null.
+ */
 export default function PostURLCheck( { children } ) {
 	const isVisible = useSelect( ( select ) => {
 		const postTypeSlug = select( editorStore ).getCurrentPostType();

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -25,11 +25,16 @@ import { usePostURLLabel } from './label';
 import { store as editorStore } from '../../store';
 
 /**
- * Renders the Post URL.
+ * Renders the `PostURL` component.
+ *
+ * @example
+ * ```jsx
+ * <PostURL />
+ * ```
  *
  * @param {Function} onClose Callback function to be executed when the popover is closed.
  *
- * @return {Component} The component to be rendered.
+ * @return {Component} The rendered PostURL component.
  */
 export default function PostURL( { onClose } ) {
 	const { isEditable, postSlug, postLink, permalinkPrefix, permalinkSuffix } =

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -24,6 +24,13 @@ import { useCopyToClipboard } from '@wordpress/compose';
 import { usePostURLLabel } from './label';
 import { store as editorStore } from '../../store';
 
+/**
+ * Renders the Post URL.
+ *
+ * @param {Function} onClose Callback function to be executed when the popover is closed.
+ *
+ * @return {Component} The component to be rendered.
+ */
 export default function PostURL( { onClose } ) {
 	const { isEditable, postSlug, postLink, permalinkPrefix, permalinkSuffix } =
 		useSelect( ( select ) => {

--- a/packages/editor/src/components/post-url/label.js
+++ b/packages/editor/src/components/post-url/label.js
@@ -9,10 +9,20 @@ import { filterURLForDisplay, safeDecodeURIComponent } from '@wordpress/url';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * Represents a label component for a post URL.
+ *
+ * @return {Component} The PostURLLabel component.
+ */
 export default function PostURLLabel() {
 	return usePostURLLabel();
 }
 
+/**
+ * Custom hook to get the label for the post URL.
+ *
+ * @return {string} The filtered and decoded post URL label.
+ */
 export function usePostURLLabel() {
 	const postLink = useSelect(
 		( select ) => select( editorStore ).getPermalink(),

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -15,6 +15,11 @@ import PostURL from './index';
 import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
 
+/**
+ * Renders the `PostURLPanel` component.
+ *
+ * @return {JSX.Element} The rendered PostURLPanel component.
+ */
 export default function PostURLPanel() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.


### PR DESCRIPTION
## What? & Why?
Addresses one item in #60358 

Adding documentation to existing editor components can help with any of the following:

* encourages knowledge sharing and quicker onboarding for future devs
* supports maintenance and troubleshooting
* mitigates risk

## How?
Add JSDocs formatted doc blocks to the existing `PostURL` component.

## Testing Instructions
Add a JSDoc comment to the `PostURL` component and run npm run `docs:build` to populate the `README.md` file with the newly added documentation.
