### PR TITLE
Add docblock to PostTitle and PostTitleRaw component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1108,7 +1108,16 @@ Undocumented declaration.
 
 ### PostTitle
 
-Undocumented declaration.
+Renders the post title component.
+
+_Parameters_
+
+-   \_\_\_ `Object`: - Unused parameter.
+-   _forwardedRef_ `React.Ref`: - Reference to the component's DOM node.
+
+_Returns_
+
+-   `React.Element`: The rendered post title component which is able to receive a ref prop.
 
 ### PostTitleRaw
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1108,16 +1108,16 @@ Undocumented declaration.
 
 ### PostTitle
 
-Renders the post title component.
+Renders the `PostTitle` component.
 
 _Parameters_
 
--   \_\_\_ `Object`: - Unused parameter.
--   _forwardedRef_ `React.Ref`: - Reference to the component's DOM node.
+-   \_\_\_ `Object`: Unused parameter.
+-   _forwardedRef_ `Element`: Forwarded ref for the component.
 
 _Returns_
 
--   `React.Element`: The rendered post title component which is able to receive a ref prop.
+-   `Component`: The rendered PostTitle component.
 
 ### PostTitleRaw
 

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import clsx from 'clsx';
-
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { forwardRef, useState } from '@wordpress/element';
+import { React, forwardRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -210,5 +209,11 @@ function PostTitle( _, forwardedRef ) {
 		/* eslint-enable jsx-a11y/heading-has-content, jsx-a11y/no-noninteractive-element-to-interactive-role */
 	);
 }
-
+/**
+ * Renders the post title component.
+ *
+ * @param {Object}    _            - Unused parameter.
+ * @param {React.Ref} forwardedRef - Reference to the component's DOM node.
+ * @return	{React.Element} 	The rendered post title component which is able to receive a ref prop.
+ */
 export default forwardRef( PostTitle );

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { React, forwardRef, useState } from '@wordpress/element';
+import { forwardRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -209,11 +209,13 @@ function PostTitle( _, forwardedRef ) {
 		/* eslint-enable jsx-a11y/heading-has-content, jsx-a11y/no-noninteractive-element-to-interactive-role */
 	);
 }
+
 /**
- * Renders the post title component.
+ * Renders the `PostTitle` component.
  *
- * @param {Object}    _            - Unused parameter.
- * @param {React.Ref} forwardedRef - Reference to the component's DOM node.
- * @return	{React.Element} 	The rendered post title component which is able to receive a ref prop.
+ * @param {Object}  _            Unused parameter.
+ * @param {Element} forwardedRef Forwarded ref for the component.
+ *
+ * @return {Component} The rendered PostTitle component.
  */
 export default forwardRef( PostTitle );

--- a/packages/editor/src/components/post-title/post-title-raw.js
+++ b/packages/editor/src/components/post-title/post-title-raw.js
@@ -20,6 +20,14 @@ import { DEFAULT_CLASSNAMES, REGEXP_NEWLINES } from './constants';
 import usePostTitleFocus from './use-post-title-focus';
 import usePostTitle from './use-post-title';
 
+/**
+ * Renders a raw post title input field.
+ *
+ * @param {Object}  _            Unused parameter.
+ * @param {Element} forwardedRef Reference to the component's DOM node.
+ *
+ * @return {Component} The rendered component.
+ */
 function PostTitleRaw( _, forwardedRef ) {
 	const { placeholder, hasFixedToolbar } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );

--- a/packages/editor/src/components/post-title/use-post-title-focus.js
+++ b/packages/editor/src/components/post-title/use-post-title-focus.js
@@ -9,6 +9,13 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * Custom hook that manages the focus behavior of the post title input field.
+ *
+ * @param {Element} forwardedRef - The forwarded ref for the input field.
+ *
+ * @return {Object} - The ref object.
+ */
 export default function usePostTitleFocus( forwardedRef ) {
 	const ref = useRef();
 

--- a/packages/editor/src/components/post-title/use-post-title.js
+++ b/packages/editor/src/components/post-title/use-post-title.js
@@ -7,6 +7,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * Custom hook for managing the post title in the editor.
+ *
+ * @return {Object} An object containing the current title and a function to update the title.
+ */
 export default function usePostTitle() {
 	const { editPost } = useDispatch( editorStore );
 	const { title } = useSelect( ( select ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Addresses one item in https://github.com/WordPress/gutenberg/issues/60358

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Adding documentation to existing editor components can help with any of the following:

- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

This PR justs adds a JSDoc comment to the PostTitle component and populates the README with the new documents generated by running `npm run docs:build`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
