### PR TITLE
Update dependencies to fix exhaustive-deps linting issues

### DIFF
--- a/packages/block-directory/src/components/auto-block-uninstaller/index.js
+++ b/packages/block-directory/src/components/auto-block-uninstaller/index.js
@@ -31,7 +31,7 @@ export default function AutoBlockUninstaller() {
 				unregisterBlockType( blockType.name );
 			} );
 		}
-	}, [ shouldRemoveBlockTypes ] );
+	}, [ shouldRemoveBlockTypes, uninstallBlockType, unusedBlockTypes ] );
 
 	return null;
 }

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -118,7 +118,7 @@ const BlockDraggableWrapper = ( { children, isRTL } ) => {
 				stopDraggingBlocks();
 			}
 		};
-	}, [] );
+	}, [ isDragging.value, stopDraggingBlocks ] );
 
 	const setDraggedBlockIconByClientId = ( clientId ) => {
 		const blockName = select( blockEditorStore ).getBlockName( clientId );

--- a/packages/block-editor/src/components/block-inspector/useBlockInspectorAnimationSettings.js
+++ b/packages/block-editor/src/components/block-inspector/useBlockInspectorAnimationSettings.js
@@ -8,10 +8,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
-export default function useBlockInspectorAnimationSettings(
-	blockType,
-	selectedBlockClientId
-) {
+export default function useBlockInspectorAnimationSettings( blockType ) {
 	return useSelect(
 		( select ) => {
 			if ( blockType ) {
@@ -48,6 +45,6 @@ export default function useBlockInspectorAnimationSettings(
 			}
 			return null;
 		},
-		[ selectedBlockClientId, blockType ]
+		[ blockType ]
 	);
 }

--- a/packages/block-editor/src/components/block-list/block-list-item-cell.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item-cell.native.js
@@ -32,7 +32,7 @@ function BlockListItemCell( { children, item: clientId, onLayout } ) {
 				shouldRemove: true,
 			} );
 		};
-	}, [] );
+	}, [ blocksLayouts, clientId, updateBlocksLayouts ] );
 
 	const onCellLayout = useCallback(
 		( event ) => {
@@ -49,7 +49,7 @@ function BlockListItemCell( { children, item: clientId, onLayout } ) {
 				onLayout( event );
 			}
 		},
-		[ clientId, rootClientId, updateBlocksLayouts, onLayout ]
+		[ updateBlocksLayouts, blocksLayouts, clientId, rootClientId, onLayout ]
 	);
 
 	return (

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -78,7 +78,7 @@ function Root( { className, ...settings } ) {
 					updates[ id ] = isIntersecting;
 				} );
 			setBlockVisibility( updates );
-		}, [ registry ] ),
+		}, [ registry, setBlockVisibility ] ),
 		300,
 		{
 			trailing: true,
@@ -103,7 +103,7 @@ function Root( { className, ...settings } ) {
 			}
 			delayedBlockVisibilityUpdates();
 		} );
-	}, [] );
+	}, [ delayedBlockVisibilityUpdates, registry ] );
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			ref: useMergeRefs( [

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -86,7 +86,13 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 			}
 		}
 		placeCaretAtHorizontalEdge( target, isReverse );
-	}, [ initialPosition, clientId ] );
+	}, [
+		initialPosition,
+		clientId,
+		isBlockSelected,
+		isMultiSelecting,
+		__unstableGetEditorMode,
+	] );
 
 	return ref;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Issue: https://github.com/WordPress/gutenberg/issues/47917

Fixing `react-hooks/exhaustive-deps` linting issues.  There are lots of these.   This doesn't solve all of them, but makes some progress.
