### PR TITLE
Copy custom CSS between variations when switching

### DIFF
--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -36,15 +36,17 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		);
 	} );
 
-	multiplePropertyVariations.unshift( {
-		title: __( 'Default' ),
-		settings: {},
-		styles: {},
-	} );
-
-	const withEmptyVariation = useMemo( () => {
+	const themeVariations = useMemo( () => {
+		const withEmptyVariation = [
+			{
+				title: __( 'Default' ),
+				settings: {},
+				styles: {},
+			},
+			...( multiplePropertyVariations ?? [] ),
+		];
 		return [
-			...( multiplePropertyVariations ?? [] ).map( ( variation ) => {
+			...withEmptyVariation.map( ( variation ) => {
 				const blockStyles = { ...variation?.styles?.blocks } || {};
 				// We need to copy any user custom CSS to the variation to prevent it being lost
 				// when switching variations.
@@ -95,7 +97,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 			className="edit-site-global-styles-style-variations-container"
 			gap={ gap }
 		>
-			{ withEmptyVariation.map( ( variation, index ) => (
+			{ themeVariations.map( ( variation, index ) => (
 				<Variation key={ index } variation={ variation }>
 					{ ( isFocused ) => (
 						<PreviewStyles

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -36,13 +36,14 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		);
 	} );
 
+	multiplePropertyVariations.unshift( {
+		title: __( 'Default' ),
+		settings: {},
+		styles: {},
+	} );
+
 	const withEmptyVariation = useMemo( () => {
 		return [
-			{
-				title: __( 'Default' ),
-				settings: {},
-				styles: {},
-			},
 			...( multiplePropertyVariations ?? [] ).map( ( variation ) => {
 				const blockStyles = { ...variation?.styles?.blocks } || {};
 				// We need to copy any user custom CSS to the variation to prevent it being lost
@@ -52,10 +53,11 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 						// First get any block specific custom CSS from the current user styles and merge with any custom CSS for
 						// that block in the variation.
 						if ( userStyles.blocks[ blockName ].css ) {
+							const variationBlockStyles =
+								blockStyles[ blockName ] || {};
+
 							blockStyles[ blockName ] = {
-								...( blockStyles[ blockName ]
-									? blockStyles[ blockName ]
-									: {} ),
+								...variationBlockStyles,
 								css: `${
 									blockStyles[ blockName ]?.css || ''
 								} ${ userStyles.blocks[ blockName ].css }`,
@@ -64,15 +66,16 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 					} );
 				}
 				// Now merge any global custom CSS from current user styles with global custom CSS in the variation.
+				const globalCustomCSS =
+					userStyles?.css || variation.styles?.css
+						? `${ variation.styles?.css || '' } ${
+								userStyles?.css || ''
+						  }`
+						: '';
+
 				const styles = {
 					...variation.styles,
-					...( userStyles?.css || variation.styles?.css
-						? {
-								css: `${ variation.styles?.css || '' } ${
-									userStyles?.css
-								}`,
-						  }
-						: {} ),
+					css: globalCustomCSS,
 					blocks: {
 						...blockStyles,
 					},

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -3,7 +3,7 @@
  */
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useContext, useMemo, useState } from '@wordpress/element';
+import { useContext, useEffect, useMemo, useState } from '@wordpress/element';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -20,8 +20,13 @@ const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
 export default function StyleVariationsContainer( { gap = 2 } ) {
 	const { user } = useContext( GlobalStylesContext );
-	const [ currentUserStyles ] = useState( { ...user } );
+	const [ currentUserStyles, setCurrentUserStyles ] = useState( { ...user } );
 	const userStyles = currentUserStyles?.styles;
+
+	useEffect( () => {
+		setCurrentUserStyles( { ...user } );
+	}, [ user ] );
+
 	const variations = useSelect( ( select ) => {
 		return select(
 			coreStore

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -20,11 +20,11 @@ const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
 export default function StyleVariationsContainer( { gap = 2 } ) {
 	const { user } = useContext( GlobalStylesContext );
-	const [ currentUserStyles, setCurrentUserStyles ] = useState( { ...user } );
+	const [ currentUserStyles, setCurrentUserStyles ] = useState( user );
 	const userStyles = currentUserStyles?.styles;
 
 	useEffect( () => {
-		setCurrentUserStyles( { ...user } );
+		setCurrentUserStyles( user );
 	}, [ user ] );
 
 	const variations = useSelect( ( select ) => {
@@ -53,6 +53,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		return [
 			...withEmptyVariation.map( ( variation ) => {
 				const blockStyles = { ...variation?.styles?.blocks } || {};
+
 				// We need to copy any user custom CSS to the variation to prevent it being lost
 				// when switching variations.
 				if ( userStyles?.blocks ) {
@@ -62,20 +63,14 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 						if ( userStyles.blocks[ blockName ].css ) {
 							const variationBlockStyles =
 								blockStyles[ blockName ] || {};
-							const customCSS =
-								blockStyles[ blockName ]?.css ||
-								userStyles.blocks[ blockName ].css
-									? {
-											css: `${
-												blockStyles[ blockName ]?.css ||
-												''
-											} ${
-												userStyles.blocks[ blockName ]
-													.css || ''
-											}`,
-									  }
-									: {};
-
+							const customCSS = {
+								css: `${
+									blockStyles[ blockName ]?.css || ''
+								} ${
+									userStyles.blocks[ blockName ].css.trim() ||
+									''
+								}`,
+							};
 							blockStyles[ blockName ] = {
 								...variationBlockStyles,
 								...customCSS,
@@ -110,7 +105,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				};
 			} ),
 		];
-	}, [ multiplePropertyVariations, userStyles.blocks, userStyles?.css ] );
+	}, [ multiplePropertyVariations, userStyles?.blocks, userStyles?.css ] );
 
 	return (
 		<Grid

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -57,12 +57,23 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 						if ( userStyles.blocks[ blockName ].css ) {
 							const variationBlockStyles =
 								blockStyles[ blockName ] || {};
+							const customCSS =
+								blockStyles[ blockName ]?.css ||
+								userStyles.blocks[ blockName ].css
+									? {
+											css: `${
+												blockStyles[ blockName ]?.css ||
+												''
+											} ${
+												userStyles.blocks[ blockName ]
+													.css || ''
+											}`,
+									  }
+									: {};
 
 							blockStyles[ blockName ] = {
 								...variationBlockStyles,
-								css: `${
-									blockStyles[ blockName ]?.css || ''
-								} ${ userStyles.blocks[ blockName ].css }`,
+								...customCSS,
 							};
 						}
 					} );

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -79,19 +79,24 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 					} );
 				}
 				// Now merge any global custom CSS from current user styles with global custom CSS in the variation.
-				const globalCustomCSS =
+				const css =
 					userStyles?.css || variation.styles?.css
-						? `${ variation.styles?.css || '' } ${
-								userStyles?.css || ''
-						  }`
-						: '';
+						? {
+								css: `${ variation.styles?.css || '' } ${
+									userStyles?.css || ''
+								}`,
+						  }
+						: {};
+
+				const blocks =
+					Object.keys( blockStyles ).length > 0
+						? { blocks: blockStyles }
+						: {};
 
 				const styles = {
 					...variation.styles,
-					css: globalCustomCSS,
-					blocks: {
-						...blockStyles,
-					},
+					...css,
+					...blocks,
 				};
 				return {
 					...variation,

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -101,7 +101,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				return {
 					...variation,
 					settings: variation.settings ?? {},
-					styles: styles ?? {},
+					styles,
 				};
 			} ),
 		];


### PR DESCRIPTION
## What?
Copies any user custom CSS between variations when the user if switching between theme variations

## Why?
Currently, if a user switches theme variations all their custom CSS is lost. It has been decided that this should move between variations by default. See background discussion on https://github.com/WordPress/gutenberg/pull/56623

## How?
Checks if there us any user custom CSS, either global or block level, and if so this is copied to the new variation.

## Testing Instructions

- Set some global and block level custom CSS on a site
- Go to the Styles section in site editor and move between variations and check that the custom CSS is still applied
- Also test from the Variation picker in the right global styles menu and make sure the css is cleared from the variations when global styles are reset

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/b4afeb07-358f-4434-b5d6-a0b4d135025a

After:

https://github.com/WordPress/gutenberg/assets/3629020/9ead57ed-e595-49fb-adf9-083561cb6789

From right global styles menu:

https://github.com/WordPress/gutenberg/assets/3629020/4df1dc10-42ea-4dfd-849a-4c4d5e385764


