### PR TITLE
Site Editor: Use a consistent snackbar position

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -27,7 +27,6 @@ import {
 	EditorKeyboardShortcutsRegister,
 	EditorKeyboardShortcuts,
 	EditorNotices,
-	EditorSnackbars,
 	privateApis as editorPrivateApis,
 	store as editorStore,
 } from '@wordpress/editor';
@@ -345,7 +344,6 @@ export default function Editor( { isLoading, onClick } ) {
 								}
 							/>
 						}
-						notices={ <EditorSnackbars /> }
 						content={
 							<>
 								<GlobalStylesRenderer />

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -17,18 +17,3 @@
 	display: flex;
 	justify-content: center;
 }
-
-// Adjust the position of the notices when breadcrumbs are present
-.edit-site .has-block-breadcrumbs.is-full-canvas .components-editor-notices__snackbar {
-	bottom: 40px;
-}
-
-// Adjust the position of the notices
-.edit-site .components-editor-notices__snackbar {
-	position: absolute;
-	right: 0;
-	bottom: 16px;
-	padding-left: 16px;
-	padding-right: 16px;
-}
-@include editor-left(".edit-site .components-editor-notices__snackbar")

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -30,7 +30,10 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { privateApis as coreCommandsPrivateApis } from '@wordpress/core-commands';
-import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import {
+	EditorSnackbars,
+	privateApis as editorPrivateApis,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -261,6 +264,8 @@ export default function Layout() {
 							</AnimatePresence>
 						</NavigableRegion>
 					) }
+
+					<EditorSnackbars />
 
 					{ isMobileViewport && areas.mobile && (
 						<div className="edit-site-layout__mobile">

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -277,3 +277,11 @@
 		margin: $canvas-padding $canvas-padding $canvas-padding 0;
 	}
 }
+
+.edit-site .components-editor-notices__snackbar {
+	position: fixed;
+	right: 0;
+	bottom: 16px;
+	padding-left: 16px;
+	padding-right: 16px;
+}

--- a/packages/edit-site/src/components/page/index.js
+++ b/packages/edit-site/src/components/page/index.js
@@ -6,10 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	EditorSnackbars,
-	privateApis as editorPrivateApis,
-} from '@wordpress/editor';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -41,7 +38,6 @@ export default function Page( {
 				) }
 				{ children }
 			</div>
-			<EditorSnackbars />
 		</NavigableRegion>
 	);
 }


### PR DESCRIPTION
closes #60457 
Alternative to #61676

## What?

When manipulating the pages in the "list view", it can result in snackbar notices showing up twice: outside and inside the frame. This PR renders the snackbars in a fixed position in the site editor, regardless of which page is being rendered.

## Testing Instructions

1- Open the "pages" menu in the site editor
2- Rename a page from the actions menu
3- Notice that a snackbar shows up (but only once)
