### PR TITLE
Templates: only resolve patterns for REST API endpoints

### DIFF
--- a/backport-changelog/6.6/6559.md
+++ b/backport-changelog/6.6/6559.md
@@ -1,0 +1,6 @@
+https://github.com/WordPress/wordpress-develop/pull/6559
+
+* https://github.com/WordPress/gutenberg/pull/60349
+* https://github.com/WordPress/gutenberg/pull/60464
+* https://github.com/WordPress/gutenberg/pull/60491
+* https://github.com/WordPress/gutenberg/pull/61757

--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
@@ -117,4 +117,14 @@ class Gutenberg_REST_Templates_Controller_6_6 extends Gutenberg_REST_Templates_C
 
 		return rest_ensure_response( $response );
 	}
+
+	/**
+	 * See WP_REST_Templates_Controller::prepare_item_for_response
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$blocks        = parse_blocks( $item->content );
+		$blocks        = gutenberg_replace_pattern_blocks( $blocks );
+		$item->content = serialize_blocks( $blocks );
+		return parent::prepare_item_for_response( $item, $request );
+	}
 }

--- a/lib/compat/wordpress-6.6/resolve-patterns.php
+++ b/lib/compat/wordpress-6.6/resolve-patterns.php
@@ -61,25 +61,6 @@ function gutenberg_replace_pattern_blocks( $blocks, &$inner_content = null ) {
 	return $blocks;
 }
 
-function gutenberg_replace_pattern_blocks_get_block_templates( $templates ) {
-	foreach ( $templates as $template ) {
-		$blocks            = parse_blocks( $template->content );
-		$blocks            = gutenberg_replace_pattern_blocks( $blocks );
-		$template->content = serialize_blocks( $blocks );
-	}
-	return $templates;
-}
-
-function gutenberg_replace_pattern_blocks_get_block_template( $template ) {
-	if ( null === $template ) {
-		return $template;
-	}
-	$blocks            = parse_blocks( $template->content );
-	$blocks            = gutenberg_replace_pattern_blocks( $blocks );
-	$template->content = serialize_blocks( $blocks );
-	return $template;
-}
-
 function gutenberg_replace_pattern_blocks_patterns_endpoint( $result, $server, $request ) {
 	if ( $request->get_route() !== '/wp/v2/block-patterns/patterns' ) {
 		return $result;
@@ -98,10 +79,6 @@ function gutenberg_replace_pattern_blocks_patterns_endpoint( $result, $server, $
 	return $result;
 }
 
-// For core merge, we should avoid the double parse and replace the patterns in templates here:
-// https://github.com/WordPress/wordpress-develop/blob/02fb53498f1ce7e63d807b9bafc47a7dba19d169/src/wp-includes/block-template-utils.php#L558
-add_filter( 'get_block_templates', 'gutenberg_replace_pattern_blocks_get_block_templates' );
-add_filter( 'get_block_template', 'gutenberg_replace_pattern_blocks_get_block_template' );
 // Similarly, for patterns, we can avoid the double parse here:
 // https://github.com/WordPress/wordpress-develop/blob/02fb53498f1ce7e63d807b9bafc47a7dba19d169/src/wp-includes/class-wp-block-patterns-registry.php#L175
 add_filter( 'rest_post_dispatch', 'gutenberg_replace_pattern_blocks_patterns_endpoint', 10, 3 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR resolves patterns more conservatively in templates. Instead of always resolving all patterns when getting templates, it only resolves them when accessing templates through the REST API endpoints.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This fixes #61454: people might be relying on filters when _rendering_ templates server side.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For REST API endpoints, these templates were never _rendered_ anyway, they are raw block markup, to be render in the editor. For the endpoints, these filters never ran anyway. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
