### PR TITLE
Inserter: Encapsulate styles for tablist and close button

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -115,17 +115,17 @@ $block-inserter-tabs-height: 44px;
 	flex-direction: column;
 	overflow: hidden;
 
-	.block-editor-inserter-sidebar__header {
+	.block-editor-inserter__tablist-and-close {
 		border-bottom: $border-width solid $gray-300;
 		padding-right: $grid-unit-10;
 		display: flex;
 		justify-content: space-between;
+	}
 
-		.block-editor-inserter-sidebar__close-button {
-			/* stylelint-disable-next-line property-disallowed-list -- This should be refactored to avoid order if possible */
-			order: 1;
-			align-self: center;
-		}
+	.block-editor-inserter__close-button {
+		/* stylelint-disable-next-line property-disallowed-list -- This should be refactored to avoid order if possible */
+		order: 1;
+		align-self: center;
 	}
 
 	.block-editor-inserter__tablist {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -115,6 +115,19 @@ $block-inserter-tabs-height: 44px;
 	flex-direction: column;
 	overflow: hidden;
 
+	.block-editor-inserter-sidebar__header {
+		border-bottom: $border-width solid $gray-300;
+		padding-right: $grid-unit-10;
+		display: flex;
+		justify-content: space-between;
+
+		.block-editor-inserter-sidebar__close-button {
+			/* stylelint-disable-next-line property-disallowed-list -- This should be refactored to avoid order if possible */
+			order: 1;
+			align-self: center;
+		}
+	}
+
 	.block-editor-inserter__tablist {
 		width: 100%;
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -115,9 +115,9 @@ $block-inserter-tabs-height: 44px;
 	flex-direction: column;
 	overflow: hidden;
 
-	.block-editor-inserter__tablist-and-close {
+	.block-editor-inserter__tablist-and-close-button {
 		border-bottom: $border-width solid $gray-300;
-		padding-right: $grid-unit-10;
+		padding-right: $grid-unit-15;
 		display: flex;
 		justify-content: space-between;
 	}

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -39,7 +39,7 @@ function InserterTabs( { onSelect, children, onClose, selectedTab }, ref ) {
 	return (
 		<div className="block-editor-inserter__tabs" ref={ ref }>
 			<Tabs onSelect={ onSelect } selectedTabId={ selectedTab }>
-				<div className="block-editor-inserter__tablist-and-close">
+				<div className="block-editor-inserter__tablist-and-close-button">
 					<Button
 						className="block-editor-inserter__close-button"
 						icon={ closeSmall }

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -39,9 +39,9 @@ function InserterTabs( { onSelect, children, onClose, selectedTab }, ref ) {
 	return (
 		<div className="block-editor-inserter__tabs" ref={ ref }>
 			<Tabs onSelect={ onSelect } selectedTabId={ selectedTab }>
-				<div className="block-editor-inserter-sidebar__header">
+				<div className="block-editor-inserter__tablist-and-close">
 					<Button
-						className="block-editor-inserter-sidebar__close-button"
+						className="block-editor-inserter__close-button"
 						icon={ closeSmall }
 						label={ __( 'Close block inserter' ) }
 						onClick={ () => onClose() }

--- a/packages/edit-widgets/src/components/layout/style.scss
+++ b/packages/edit-widgets/src/components/layout/style.scss
@@ -18,7 +18,7 @@
 	// Leave space for the close button
 	height: calc(100% - #{$button-size} - #{$grid-unit-10});
 
-	.block-editor-inserter-sidebar__header {
+	.block-editor-inserter__tablist-and-close {
 		display: none;
 	}
 

--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -6,19 +6,6 @@
 	flex-direction: column;
 }
 
-.block-editor-inserter-sidebar__header {
-	border-bottom: $border-width solid $gray-300;
-	padding-right: $grid-unit-15;
-	display: flex;
-	justify-content: space-between;
-
-	.block-editor-inserter-sidebar__close-button {
-		/* stylelint-disable-next-line property-disallowed-list -- This should be refactored to avoid order if possible */
-		order: 1;
-		align-self: center;
-	}
-}
-
 .editor-inserter-sidebar__content {
 	// Leave space for the close button
 	height: calc(100% - #{$button-size} - #{$grid-unit-10});


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR moves the CSS for the tabllist and close button layout into the inserter itself.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #61421, the close button was added, and the CSS styling was added to the `InserterSidebar` instead of the `Inserter` itself.

This broke the styling for consumers using the `Inserter` directly (or `__experimentalLibrary`), such as the new product editor in WooCommerce (see https://github.com/woocommerce/woocommerce/pull/47561).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The CSS is moved to the `Inserter` itself.

In addition, the CSS class names are changed to be more accurate to what they actually are, which will help with maintainability and also allow for a temporary workaround to be applied by those using `Inserter`/`__experimentalLibrary` directly while allowing them to automatically get future styling changes without having to remove the workaround.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open the inserter
2. Verify styling is correct.

(Testing instructions for WooCommerce specifically will be part of https://github.com/woocommerce/woocommerce/pull/47561)

## Screenshots or screencast <!-- if applicable -->

### Broken (in WooCommerce)

<img width="349" alt="Screenshot 2024-05-17 at 07 07 04" src="https://github.com/WordPress/gutenberg/assets/2098816/ae3861b7-372e-49f5-ba0a-603b2277d59c">

### Fixed (no change in core Gutenberg styling)

<img width="347" alt="Screenshot 2024-05-17 at 07 08 04" src="https://github.com/WordPress/gutenberg/assets/2098816/23363793-f95d-4eb1-830b-7287a90cff66">

