### PR TITLE
Playwright E2E Utils: add fullscreenMode option to createNewPost

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.ts
@@ -9,7 +9,7 @@ interface NewPostOptions {
 	content?: string;
 	excerpt?: string;
 	showWelcomeGuide?: boolean;
-	fullscreenMode?: boolean
+	fullscreenMode?: boolean;
 }
 
 /**

--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.ts
@@ -9,6 +9,7 @@ interface NewPostOptions {
 	content?: string;
 	excerpt?: string;
 	showWelcomeGuide?: boolean;
+	fullscreenMode?: boolean
 }
 
 /**
@@ -41,6 +42,6 @@ export async function createNewPost(
 
 	await this.editor.setPreferences( 'core/edit-post', {
 		welcomeGuide: options.showWelcomeGuide ?? false,
-		fullscreenMode: false,
+		fullscreenMode: options.fullscreenMode ?? false,
 	} );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
 Introduces `fullscreenMode` optional property to `NewPostOptions` and updates `createNewPost` function to set `fullscreenMode` preference based on the provided property if set, fallbacks to `fullscreenMode: false` otherwise.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Gives more flexibility allowing to configure preferences with fullscreenMode: true 
 

