### PR TITLE
A page attributes panel slot now exists

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -669,7 +669,7 @@ _Returns_
 
 ### PluginPageAttributesPanel
 
-Renders a row in the Summary panel of the Document sidebar. It should be noted that this is named and implemented around the function it serves and not its location, which may change in future iterations.
+Renders a row in the Page Attributes panel of the Document sidebar.
 
 _Usage_
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -667,6 +667,50 @@ _Returns_
 
 -   `Component`: The component to be rendered.
 
+### PluginPageAttributesPanel
+
+Renders a row in the Summary panel of the Document sidebar. It should be noted that this is named and implemented around the function it serves and not its location, which may change in future iterations.
+
+_Usage_
+
+```js
+// Using ES5 syntax
+var __ = wp.i18n.__;
+var PluginPageAttributesPanel = wp.editPost.PluginPageAttributesPanel;
+
+function MyPluginPageAttributes() {
+	return React.createElement(
+		PluginPageAttributesPanel,
+		{
+			className: 'my-plugin-page-attributes',
+		},
+		__( 'My page attributes' )
+	);
+}
+```
+
+```jsx
+// Using ESNext syntax
+import { __ } from '@wordpress/i18n';
+import { PluginPageAttributesPanel } from '@wordpress/edit-post';
+
+const MyPluginPageAttributes = () => (
+	<PluginPageAttributesPanel className="my-plugin-page-attributes">
+		{ __( 'My page attributes' ) }
+	</PluginPageAttributesPanel>
+);
+```
+
+_Parameters_
+
+-   _props_ `Object`: Component properties.
+-   _props.className_ `[string]`: An optional class name added to the row.
+-   _props.children_ `Element`: Children to be rendered.
+
+_Returns_
+
+-   `Component`: The component to be rendered.
+
 ### PluginPostPublishPanel
 
 Renders provided content to the post-publish panel in the publish flow (side panel that opens after a user publishes the post).

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -29,6 +29,7 @@ export { default as PageTemplate } from './post-template/classic-theme';
 export { default as PluginDocumentSettingPanel } from './plugin-document-setting-panel';
 export { default as PluginBlockSettingsMenuItem } from './block-settings-menu/plugin-block-settings-menu-item';
 export { default as PluginMoreMenuItem } from './plugin-more-menu-item';
+export { default as PluginPageAttributesPanel } from './plugin-page-attributes-panel';
 export { default as PluginPostPublishPanel } from './plugin-post-publish-panel';
 export { default as PluginPostStatusInfo } from './plugin-post-status-info';
 export { default as PluginPrePublishPanel } from './plugin-pre-publish-panel';

--- a/packages/editor/src/components/page-attributes/panel.js
+++ b/packages/editor/src/components/page-attributes/panel.js
@@ -14,6 +14,7 @@ import { store as editorStore } from '../../store';
 import PageAttributesCheck from './check';
 import PageAttributesOrder from './order';
 import PageAttributesParent from './parent';
+import PluginPageAttributesPanel from '../plugin-page-attributes-panel';
 
 const PANEL_NAME = 'page-attributes';
 
@@ -48,6 +49,7 @@ function AttributesPanel() {
 			<PanelRow>
 				<PageAttributesOrder />
 			</PanelRow>
+			<PluginPageAttributesPanel.Slot />
 		</PanelBody>
 	);
 }

--- a/packages/editor/src/components/plugin-page-attributes-panel/index.js
+++ b/packages/editor/src/components/plugin-page-attributes-panel/index.js
@@ -1,5 +1,5 @@
 /**
- * Defines as extensibility slot for the Summary panel.
+ * Defines as extensibility slot for the Page Attributes panel.
  */
 
 /**
@@ -10,9 +10,7 @@ import { createSlotFill, PanelRow } from '@wordpress/components';
 const { Fill, Slot } = createSlotFill( 'PluginPageAttributesPanel' );
 
 /**
- * Renders a row in the Summary panel of the Document sidebar.
- * It should be noted that this is named and implemented around the function it serves
- * and not its location, which may change in future iterations.
+ * Renders a row in the Page Attributes panel of the Document sidebar.
  *
  * @param {Object}  props             Component properties.
  * @param {string}  [props.className] An optional class name added to the row.

--- a/packages/editor/src/components/plugin-page-attributes-panel/index.js
+++ b/packages/editor/src/components/plugin-page-attributes-panel/index.js
@@ -1,0 +1,63 @@
+/**
+ * Defines as extensibility slot for the Summary panel.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill, PanelRow } from '@wordpress/components';
+
+const { Fill, Slot } = createSlotFill( 'PluginPageAttributesPanel' );
+
+/**
+ * Renders a row in the Summary panel of the Document sidebar.
+ * It should be noted that this is named and implemented around the function it serves
+ * and not its location, which may change in future iterations.
+ *
+ * @param {Object}  props             Component properties.
+ * @param {string}  [props.className] An optional class name added to the row.
+ * @param {Element} props.children    Children to be rendered.
+ *
+ * @example
+ * ```js
+ * // Using ES5 syntax
+ * var __ = wp.i18n.__;
+ * var PluginPageAttributesPanel = wp.editPost.PluginPageAttributesPanel;
+ *
+ * function MyPluginPageAttributes() {
+ * 	return React.createElement(
+ * 		PluginPageAttributesPanel,
+ * 		{
+ * 			className: 'my-plugin-page-attributes',
+ * 		},
+ * 		__( 'My page attributes' )
+ * 	)
+ * }
+ * ```
+ *
+ * @example
+ * ```jsx
+ * // Using ESNext syntax
+ * import { __ } from '@wordpress/i18n';
+ * import { PluginPageAttributesPanel } from '@wordpress/edit-post';
+ *
+ * const MyPluginPageAttributes = () => (
+ * 	<PluginPageAttributesPanel
+ * 		className="my-plugin-page-attributes"
+ * 	>
+ * 		{ __( 'My page attributes' ) }
+ * 	</PluginPageAttributesPanel>
+ * );
+ * ```
+ *
+ * @return {Component} The component to be rendered.
+ */
+const PluginPageAttributesPanel = ( { children, className } ) => (
+	<Fill>
+		<PanelRow className={ className }>{ children }</PanelRow>
+	</Fill>
+);
+
+PluginPageAttributesPanel.Slot = Slot;
+
+export default PluginPageAttributesPanel;

--- a/packages/editor/src/components/plugin-page-attributes-panel/test/index.js
+++ b/packages/editor/src/components/plugin-page-attributes-panel/test/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PluginPageAttributesPanel from '../';
+
+describe( 'PluginPageAttributesPanel', () => {
+	test( 'renders fill properly', () => {
+		render(
+			<SlotFillProvider>
+				<PluginPageAttributesPanel className="my-plugin-page-attributes-panel">
+					My page attributes panel content
+				</PluginPageAttributesPanel>
+				<PluginPageAttributesPanel.Slot />
+			</SlotFillProvider>
+		);
+
+		expect(
+			screen.getByText( 'My page attributes panel content' )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adding a Slot on the Page Attributes Panel 
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This resolves #31888 and allows plugin authors to extend that panel with additional information.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added a new Slot `PluginPageAttributesPanel` which adds a new `panelRow`  below the panel items from core. This is essentially mimicking the behavior provided by the `page_attributes_misc_attributes` hook. 
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Register a plugin
```
const MyPageAttributes = () => {
    return (
        <PluginPageAttributesPanel className="different">
			<p>
				{ __(
					'Add some page attributes',
					'gutenberg-slot-fill-system'
				) }
			</p>
		</PluginPageAttributesPanel>
    );
}
// Register the plugin.
registerPlugin( 'my-page-attributes', { render: MyPageAttributes } );
```
2. See that it appears in the page attributes panel in the editor while editing a page.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-05-17 at 11 56 28 AM](https://github.com/WordPress/gutenberg/assets/5949352/9afcd25e-76e3-4191-9c11-eb19e094aaa1)
