### PR TITLE
fix make dimensions.aspectRatios key of theme.json files translatable

### DIFF
--- a/backport-changelog/6.6/6567.md
+++ b/backport-changelog/6.6/6567.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/6567
+
+* https://github.com/WordPress/gutenberg/pull/47271
+* https://github.com/WordPress/gutenberg/pull/61774

--- a/lib/theme-i18n.json
+++ b/lib/theme-i18n.json
@@ -38,6 +38,13 @@
 				}
 			]
 		},
+		"dimensions": {
+			"aspectRatios": [
+				{
+					"Name": "Aspect ratio name"
+				}
+			]
+		},
 		"blocks": {
 			"*": {
 				"typography": {

--- a/lib/theme-i18n.json
+++ b/lib/theme-i18n.json
@@ -41,7 +41,7 @@
 		"dimensions": {
 			"aspectRatios": [
 				{
-					"Name": "Aspect ratio name"
+					"name": "Aspect ratio name"
 				}
 			]
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Make Aspect Ratio preset names in `theme.json` translatable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Closing #61767

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding the schema to the `theme-i18n.json` file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
