### PR TITLE
Update class-wp-theme-json-schema-test.php

### DIFF
--- a/phpunit/class-wp-theme-json-schema-test.php
+++ b/phpunit/class-wp-theme-json-schema-test.php
@@ -202,7 +202,7 @@ class WP_Theme_JSON_Schema_Gutenberg_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$this->assertEqualSetsWithIndex( $expected, $actual );
+		$this->assertEquals( $expected, $actual );
 	}
 
 	public function test_migrate_v2_to_latest() {
@@ -249,6 +249,6 @@ class WP_Theme_JSON_Schema_Gutenberg_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$this->assertEqualSetsWithIndex( $expected, $actual );
+		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
replace assertEqualSetsWithIndex with assertEquals, as this is the standard PHPUnit method for comparing arrays, including their order and structure.

