### PR TITLE
Update child layout selector to match core.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -577,7 +577,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	// Child layout specific logic.
 	if ( $child_layout ) {
-		$container_content_class   = wp_unique_id( 'wp-container-content-' );
+		$container_content_class   = wp_unique_prefixed_id( 'wp-container-content-' );
 		$child_layout_declarations = array();
 		$child_layout_styles       = array();
 

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -501,7 +501,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_output' => '<p class="wp-container-content-1">Some text.</p>', // The generated classname number assumes `wp_unique_id` will not have run previously in this test.
+				'expected_output' => '<p class="wp-container-content-1">Some text.</p>', // The generated classname number assumes `wp_unique_prefixed_id( 'wp-container-content-' )` will not have run previously in this test.
 			),
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Syncing a change that was made in the [core sync PR](https://github.com/WordPress/wordpress-develop/pull/6493) for grid and column spans.

Using `wp_unique_id` to generate the child layout classname number means that number will vary depending on how many times `wp_unique_id` has been used on the page before. This was causing the results of the test added in #61392 to be unpredictable, and also the classname of any given block on a page to be unpredictable, which could affect things like dynamic loading (see #55416).

This PR changes the child layout classname to use `wp_unique_prefixed_id` instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Nothing should have visibly changed, but if you

1. Create a post with:
    * an Image block with a custom duotone filter applied (choose the colors yourself, don't use the preset);
    *  a Row block with a few children, and set one of the children to "Fill" under Dimensions;
2. Create a custom template for that post that contains only the Post Content block;
3. Save and view on the front end. The classname for the Row child set to Fill should be `wp-container-content-1` (in trunk it'll be `wp-container-content-2` because the duotone filter also uses `wp_unique_id`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
