### PR TITLE
wp-env: Allow Cache directory value WP_ENV_HOME to Access from .wp-env.json and .wp-env-override.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn.lock
 # Operating system specific files
 .DS_Store
 Thumbs.db
+.idea/
 
 # Report generated from jest-junit
 junit.xml

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -490,7 +490,9 @@ You can customize the WordPress installation, plugins and themes that the develo
 | `"config"`     | `Object`       | See below.                             | Mapping of wp-config.php constants to their desired values.                                                                      |
 | `"mappings"`   | `Object`       | `"{}"`                                 | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                                   |
 
-_Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
+Note:
+1. The port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values.
+2. When set, the `WP_ENV_HOME` environment variable will initially prioritize value from the `.wp-env.json` configuration file.
 
 Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mappings` fields.
 

--- a/packages/env/lib/config/get-cache-directory.js
+++ b/packages/env/lib/config/get-cache-directory.js
@@ -7,14 +7,33 @@ const fs = require( 'fs' ).promises;
 const os = require( 'os' );
 
 /**
+ * Internal dependencies
+ */
+const readRawConfigFile = require( './read-raw-config-file' );
+
+/**
  * Gets the directory in which generated files are created.
  *
  * By default: '~/.wp-env/'. On Linux with snap packages: '~/wp-env/'. Can be
  * overridden with the WP_ENV_HOME environment variable.
  *
+ * @param {string|null} configFilePath Config Path for .wp-env.json file if exists.
+ *
  * @return {Promise<string>} The absolute path to the `wp-env` home directory.
  */
-module.exports = async function getCacheDirectory() {
+module.exports = async function getCacheDirectory( configFilePath = null ) {
+	/**
+	 * Allows user to override download location from .wp-env.json|.wp-env-override.json file.
+	 * Moving this variable allows us not only move from node environment variables, but
+	 * allows us to keep all our WP config at one place neat and tidy.
+	 */
+	if ( configFilePath ) {
+		const rawConfig = await readRawConfigFile( configFilePath );
+		if ( rawConfig.config.WP_ENV_HOME ) {
+			return path.resolve( rawConfig.config.WP_ENV_HOME );
+		}
+	}
+
 	// Allow user to override download location.
 	if ( process.env.WP_ENV_HOME ) {
 		return path.resolve( process.env.WP_ENV_HOME );
@@ -22,7 +41,7 @@ module.exports = async function getCacheDirectory() {
 
 	/**
 	 * Installing docker with Snap Packages on Linux is common, but does not
-	 * support hidden directories. Therefore we use a public directory when
+	 * support hidden directories. Therefore, we use a public directory when
 	 * snap packages exist.
 	 *
 	 * @see https://github.com/WordPress/gutenberg/issues/20180#issuecomment-587046325

--- a/packages/env/lib/config/get-cache-directory.js
+++ b/packages/env/lib/config/get-cache-directory.js
@@ -29,7 +29,7 @@ module.exports = async function getCacheDirectory( configFilePath = null ) {
 	 */
 	if ( configFilePath ) {
 		const rawConfig = await readRawConfigFile( configFilePath );
-		if ( rawConfig.config.WP_ENV_HOME ) {
+		if ( rawConfig?.config?.WP_ENV_HOME ) {
 			return path.resolve( rawConfig.config.WP_ENV_HOME );
 		}
 	}

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -43,7 +43,7 @@ module.exports = async function loadConfig( configDirectoryPath ) {
 	const configFilePath = getConfigFilePath( configDirectoryPath );
 
 	const cacheDirectoryPath = path.resolve(
-		await getCacheDirectory(),
+		await getCacheDirectory( configFilePath ),
 		md5( configFilePath )
 	);
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Description
Allows users to override the cache directory when WP_ENV_HOME set in .wp-env.json and .wp-env-override.json.

## How?
```
{
  "core": null,
  "plugins": [ "." ],
  "config": {
    "WP_ENV_HOME" : "/PATH/TO/YOUR/DIRECTORY"
  }
}
```

## Testing

1. I used the WP_ENV_HOME variable locally in my .wp-env.json file  and verified generated files were placed there. 
2. I also checked that the default location and Environment Variable is still used if the environment variable is not specified.
3. I also tested that, if the container is running, the start command works successfully after deleting the wp-env home directory.

## Types of changes
New Feature

Checklist:

- [x] My code is tested
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x]  I've included developer documentation if appropriate.
