### PR TITLE
Command Palette: Remove unused url parameter

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -26,7 +26,7 @@ import { useIsBlockBasedTheme } from './hooks';
 import { unlock } from './lock-unlock';
 import { orderEntityRecordsBySearch } from './utils/order-entity-records-by-search';
 
-const { useHistory, useLocation } = unlock( routerPrivateApis );
+const { useHistory } = unlock( routerPrivateApis );
 
 const icons = {
 	post,
@@ -160,14 +160,6 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 	function useNavigationCommandLoader( { search } ) {
 		const history = useHistory();
-		const location = useLocation();
-
-		const isPatternsPage =
-			location?.params?.path === '/patterns' ||
-			location?.params?.postType === 'wp_block';
-		const didAccessPatternsPage =
-			!! location?.params?.didAccessPatternsPage;
-
 		const isBlockBasedTheme = useIsBlockBasedTheme();
 		const { records, isLoading } = useSelect( ( select ) => {
 			const { getEntityRecords } = select( coreStore );
@@ -223,11 +215,6 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 							const args = {
 								postType: templateType,
 								postId: record.id,
-								didAccessPatternsPage:
-									! isBlockBasedTheme &&
-									( isPatternsPage || didAccessPatternsPage )
-										? 1
-										: undefined,
 								...extraArgs,
 							};
 							const targetUrl = addQueryArgs(


### PR DESCRIPTION
Related to #54422

## What?

This PR removes the `didAccessPatternsPage` parameter added to the URL when a hybrid theme accesses the Patterns page via the command palette.

## Why?

From #54422:

> If a classic theme that supports block template parts goes directly to the Patterns page in the Site Editor, the back button link on the All Template Parts page should always go to the Patterns page instead of the Dashboard.
> 
> To control this, I introduce a URL parameter called `didAccessPatternsPage`.

This parameter was previously introduced to control the back button link from All Template Parts page when classic themes accessed the Patterns page in the Site Editor directly.

However, now that the Patterns page is officially exposed for all themes, this parameter is no longer used anywhere.

## Testing Instructions

- Access `http://localhost:8889/wp-admin/`
- Activate the Emptyhybrid theme
- Access Appearance > Patterns
- Launch the command palette and open the header template part
- Check the URL and make sure there is no `didAccessPatternsPage` parameter.
  - trunk: `http://localhost:8889/wp-admin/site-editor.php?postType=wp_template_part&postId=gutenberg-test-themes%2Femptyhybrid%2F%2Fheader&didAccessPatternsPage=1`
  - This PR: 

### Before

https://github.com/WordPress/gutenberg/assets/54422211/5d061592-ac77-479f-a1e8-7d8477e6d703


### After

https://github.com/WordPress/gutenberg/assets/54422211/c48231fd-ea95-48c4-bca5-46da6b417c9b




