### PR TITLE
Playwright E2E Utils: editPost options

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/edit-post.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/edit-post.ts
@@ -12,10 +12,14 @@ interface EditPostOptions {
  * Open the post with given ID in the editor.
  *
  * @param this
- * @param postId Post ID to visit.
+ * @param postId  Post ID to visit.
  * @param options Editor options for edit post.
  */
-export async function editPost( this: Admin, postId: string | number, options: EditPostOptions = {}) {
+export async function editPost(
+	this: Admin,
+	postId: string | number,
+	options: EditPostOptions = {}
+) {
 	const query = new URLSearchParams();
 
 	query.set( 'post', String( postId ) );

--- a/packages/e2e-test-utils-playwright/src/admin/edit-post.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/edit-post.ts
@@ -3,13 +3,18 @@
  */
 import type { Admin } from '.';
 
+interface EditPostOptions {
+	showWelcomeGuide?: boolean;
+	fullscreenMode?: boolean;
+}
+
 /**
  * Open the post with given ID in the editor.
  *
  * @param this
  * @param postId Post ID to visit.
  */
-export async function editPost( this: Admin, postId: string | number ) {
+export async function editPost( this: Admin, postId: string | number, options: EditPostOptions = {}) {
 	const query = new URLSearchParams();
 
 	query.set( 'post', String( postId ) );
@@ -18,7 +23,7 @@ export async function editPost( this: Admin, postId: string | number ) {
 	await this.visitAdminPage( 'post.php', query.toString() );
 
 	await this.editor.setPreferences( 'core/edit-post', {
-		welcomeGuide: false,
-		fullscreenMode: false,
+		welcomeGuide: options.showWelcomeGuide ?? false,
+		fullscreenMode: options.fullscreenMode ?? false,
 	} );
 }

--- a/packages/e2e-test-utils-playwright/src/admin/edit-post.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/edit-post.ts
@@ -13,6 +13,7 @@ interface EditPostOptions {
  *
  * @param this
  * @param postId Post ID to visit.
+ * @param options Editor options for edit post.
  */
 export async function editPost( this: Admin, postId: string | number, options: EditPostOptions = {}) {
 	const query = new URLSearchParams();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Introduces optional `EditPostOptions` to `admin.editPost()` function. 
Backward compatible. 

## Why?
 <!--Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Provides flexibility to set editor's preferences, similarly to the `NewPostOptions` for the  `admin.createNewPost()` function 

<!-- ## How?
How is your PR addressing the issue at hand? What are the implementation details? -->

<!--## Testing Instructions
 Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

<!--### Testing Instructions for Keyboard
 How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

