### PR TITLE
ESLint: Enable `eslint-plugin-react-compiler`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -551,14 +551,12 @@ module.exports = {
 		{
 			files: [ 'packages/interactivity*/src/**' ],
 			rules: {
+				'react-compiler/react-compiler': 'off',
 				'react/react-in-jsx-scope': 'error',
 			},
 		},
 		{
-			files: [
-				'packages/interactivity-router/src/index.js',
-				...developmentFiles,
-			],
+			files: [ ...developmentFiles ],
 			rules: {
 				'react-compiler/react-compiler': 'off',
 			},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -236,6 +236,7 @@ module.exports = {
 				'import/no-unresolved': 'off',
 				'import/named': 'off',
 				'@wordpress/data-no-store-string-literals': 'off',
+				'react-compiler/react-compiler': 'off',
 			},
 		},
 		{
@@ -553,12 +554,6 @@ module.exports = {
 			rules: {
 				'react-compiler/react-compiler': 'off',
 				'react/react-in-jsx-scope': 'error',
-			},
-		},
-		{
-			files: [ ...developmentFiles ],
-			rules: {
-				'react-compiler/react-compiler': 'off',
 			},
 		},
 	],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -554,5 +554,14 @@ module.exports = {
 				'react/react-in-jsx-scope': 'error',
 			},
 		},
+		{
+			files: [
+				'packages/dependency-extraction-webpack-plugin/test/**',
+				'packages/interactivity-router/src/index.js',
+			],
+			rules: {
+				'react-compiler/react-compiler': 'off',
+			},
+		},
 	],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -556,8 +556,8 @@ module.exports = {
 		},
 		{
 			files: [
-				'packages/dependency-extraction-webpack-plugin/test/**',
 				'packages/interactivity-router/src/index.js',
+				...developmentFiles,
 			],
 			rules: {
 				'react-compiler/react-compiler': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -156,6 +156,7 @@ module.exports = {
 		'plugin:eslint-comments/recommended',
 		'plugin:storybook/recommended',
 	],
+	plugins: [ 'react-compiler' ],
 	globals: {
 		wp: 'off',
 		globalThis: 'readonly',
@@ -220,6 +221,15 @@ module.exports = {
 			'error',
 			{
 				definedTags: [ 'jest-environment' ],
+			},
+		],
+		'react-compiler/react-compiler': [
+			'error',
+			{
+				environment: {
+					enableTreatRefLikeIdentifiersAsRefs: true,
+					validateRefAccessDuringRender: false,
+				},
 			},
 		],
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
 				"eslint-plugin-jest": "27.2.3",
 				"eslint-plugin-jest-dom": "5.0.2",
 				"eslint-plugin-prettier": "5.0.0",
+				"eslint-plugin-react-compiler": "19.0.0-beta-8a03594-20241020",
 				"eslint-plugin-ssr-friendly": "1.0.6",
 				"eslint-plugin-storybook": "0.6.13",
 				"eslint-plugin-testing-library": "6.0.2",
@@ -2470,6 +2471,23 @@
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-proposal-private-methods": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+			"integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
+			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^7.18.6",
+				"@babel/helper-plugin-utils": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -25344,6 +25362,41 @@
 			},
 			"peerDependencies": {
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+			}
+		},
+		"node_modules/eslint-plugin-react-compiler": {
+			"version": "19.0.0-beta-8a03594-20241020",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-8a03594-20241020.tgz",
+			"integrity": "sha512-bYg1COih1s3r14IV/AKdQs/SN7CQmNI0ZaMtPdgZ6gp1S1Q/KGP9P43w7R6dHJ4wYpuMBvekNJHQdVu+x6UM+A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.24.4",
+				"@babel/parser": "^7.24.4",
+				"@babel/plugin-proposal-private-methods": "^7.18.6",
+				"hermes-parser": "^0.20.1",
+				"zod": "^3.22.4",
+				"zod-validation-error": "^3.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=7"
+			}
+		},
+		"node_modules/eslint-plugin-react-compiler/node_modules/hermes-estree": {
+			"version": "0.20.1",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
+			"integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+			"dev": true
+		},
+		"node_modules/eslint-plugin-react-compiler/node_modules/hermes-parser": {
+			"version": "0.20.1",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
+			"integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+			"dev": true,
+			"dependencies": {
+				"hermes-estree": "0.20.1"
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
@@ -51819,6 +51872,18 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-validation-error": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+			"integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"zod": "^3.18.0"
 			}
 		},
 		"packages/a11y": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"eslint-plugin-jest": "27.2.3",
 		"eslint-plugin-jest-dom": "5.0.2",
 		"eslint-plugin-prettier": "5.0.0",
+		"eslint-plugin-react-compiler": "19.0.0-beta-8a03594-20241020",
 		"eslint-plugin-ssr-friendly": "1.0.6",
 		"eslint-plugin-storybook": "0.6.13",
 		"eslint-plugin-testing-library": "6.0.2",

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -10,7 +10,12 @@ module.exports = {
 			version: 'detect',
 		},
 	},
-	plugins: [ '@wordpress', 'react', 'react-hooks' ],
+	plugins: [
+		'@wordpress',
+		'eslint-plugin-react-compiler',
+		'react',
+		'react-hooks',
+	],
 	rules: {
 		'@wordpress/no-unused-vars-before-return': [
 			'error',
@@ -34,6 +39,7 @@ module.exports = {
 		'react/no-children-prop': 'off',
 		'react/prop-types': 'off',
 		'react/react-in-jsx-scope': 'off',
+		'react-compiler/react-compiler': 'error',
 		'react-hooks/exhaustive-deps': [
 			'warn',
 			{

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -10,12 +10,7 @@ module.exports = {
 			version: 'detect',
 		},
 	},
-	plugins: [
-		'@wordpress',
-		'react-compiler',
-		'react',
-		'react-hooks',
-	],
+	plugins: [ '@wordpress', 'react-compiler', 'react', 'react-hooks' ],
 	rules: {
 		'@wordpress/no-unused-vars-before-return': [
 			'error',

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -39,6 +39,7 @@ module.exports = {
 			{
 				environment: {
 					enableTreatRefLikeIdentifiersAsRefs: true,
+					validateRefAccessDuringRender: false,
 				},
 			},
 		],

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -12,7 +12,7 @@ module.exports = {
 	},
 	plugins: [
 		'@wordpress',
-		'eslint-plugin-react-compiler',
+		'react-compiler',
 		'react',
 		'react-hooks',
 	],

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -34,7 +34,14 @@ module.exports = {
 		'react/no-children-prop': 'off',
 		'react/prop-types': 'off',
 		'react/react-in-jsx-scope': 'off',
-		'react-compiler/react-compiler': 'error',
+		'react-compiler/react-compiler': [
+			'error',
+			{
+				environment: {
+					enableTreatRefLikeIdentifiersAsRefs: true,
+				},
+			},
+		],
 		'react-hooks/exhaustive-deps': [
 			'warn',
 			{

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -10,7 +10,7 @@ module.exports = {
 			version: 'detect',
 		},
 	},
-	plugins: [ '@wordpress', 'react-compiler', 'react', 'react-hooks' ],
+	plugins: [ '@wordpress', 'react', 'react-hooks' ],
 	rules: {
 		'@wordpress/no-unused-vars-before-return': [
 			'error',
@@ -34,15 +34,6 @@ module.exports = {
 		'react/no-children-prop': 'off',
 		'react/prop-types': 'off',
 		'react/react-in-jsx-scope': 'off',
-		'react-compiler/react-compiler': [
-			'error',
-			{
-				environment: {
-					enableTreatRefLikeIdentifiersAsRefs: true,
-					validateRefAccessDuringRender: false,
-				},
-			},
-		],
 		'react-hooks/exhaustive-deps': [
 			'warn',
 			{


### PR DESCRIPTION
## What?
This PR introduces the `eslint-plugin-react-compiler` ESLint plugin to the repo.

Even if the plugin is still beta, it will help us to have it in the repo in order to maintain a friendlier environment for React 19 and the React Compiler.

We're experimenting with adopting React Compiler through the Babel plugin in #66361.

## Why?

[It's recommended](https://react.dev/learn/react-compiler) that this ESLint plugin is used to help improve the quality of your codebase.

## How?
The `eslint-plugin-react-compiler` plugin can be used without the React Compiler itself. We're installing it and enabling it. Also ignoring a few files that include top-level `await` which seems to break the linter right now.

## Testing Instructions
Verify there are no ESLint errors and the static analysis check passes. 

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None