### PR TITLE
Block Editor: Fix wrapper props mutation in BlockListBlock

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -216,12 +216,14 @@ function BlockListBlock( {
 	}
 
 	const { 'data-align': dataAlign, ...restWrapperProps } = wrapperProps ?? {};
-
-	restWrapperProps.className = clsx(
-		restWrapperProps.className,
-		dataAlign && themeSupportsLayout && `align${ dataAlign }`,
-		! ( dataAlign && isSticky ) && className
-	);
+	const updatedWrapperProps = {
+		...restWrapperProps,
+		className: clsx(
+			restWrapperProps.className,
+			dataAlign && themeSupportsLayout && `align${ dataAlign }`,
+			! ( dataAlign && isSticky ) && className
+		),
+	};
 
 	// We set a new context with the adjusted and filtered wrapperProps (through
 	// `editor.BlockListBlock`), which the `BlockListBlockProvider` did not have
@@ -234,7 +236,7 @@ function BlockListBlock( {
 	return (
 		<PrivateBlockContext.Provider
 			value={ {
-				wrapperProps: restWrapperProps,
+				wrapperProps: updatedWrapperProps,
 				isAligned,
 				...context,
 			} }


### PR DESCRIPTION
## What?
This PR fixes a mutation that we're performing in `BlockListBlock` and updates to use a new object instead.

## Why?
Mutating objects could lead to subtle bugs.
In this particular case, I'm fixing it to resolve an ESLint error that was raised by the React Compiler ESLint plugin in https://github.com/WordPress/gutenberg/pull/61788

## How?
Using a new object instead of mutating the existing one.

## Testing Instructions
Smoke test the editor and verify alignment classnames are still passed to the blocks.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None