### PR TITLE
Shadows: Unlock private components and hooks at the file level

### DIFF
--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -33,9 +33,9 @@ import { unlock } from '../../lock-unlock';
  */
 const EMPTY_ARRAY = [];
 const {
+	CompositeItemV2: CompositeItem,
 	CompositeV2: Composite,
 	useCompositeStoreV2: useCompositeStore,
-	CompositeItemV2: CompositeItem,
 } = unlock( componentsPrivateApis );
 
 export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -32,6 +32,11 @@ import { unlock } from '../../lock-unlock';
  * @type {Array}
  */
 const EMPTY_ARRAY = [];
+const {
+	CompositeV2: Composite,
+	useCompositeStoreV2: useCompositeStore,
+	CompositeItemV2: CompositeItem,
+} = unlock( componentsPrivateApis );
 
 export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
 	const shadows = useShadowPresets( settings );
@@ -59,8 +64,6 @@ export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
 }
 
 export function ShadowPresets( { presets, activeShadow, onSelect } ) {
-	const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
-		unlock( componentsPrivateApis );
 	const compositeStore = useCompositeStore();
 	return ! presets ? null : (
 		<Composite
@@ -86,7 +89,6 @@ export function ShadowPresets( { presets, activeShadow, onSelect } ) {
 }
 
 export function ShadowIndicator( { type, label, isActive, onSelect, shadow } ) {
-	const { CompositeItemV2: CompositeItem } = unlock( componentsPrivateApis );
 	return (
 		<CompositeItem
 			role="option"


### PR DESCRIPTION
## What?
A micro-optimization moves the private `Composite` component and hook unlocking outside the components, at the file level.

## Why?
Resolving an error reported by `eslint-plugin-react-compiler`. See #61788.
This is similar to #55809.

## Testing Instructions
1. Open the Site Editor.
2. Navigate to Global Styles -> Blocks -> Button.
3. Enable "Shadow"
4. Confirm modal is rendered without an error and works as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-20 at 16 43 08](https://github.com/WordPress/gutenberg/assets/240569/8071608e-bed2-4e33-8dba-daa9e4da61f7)
