### PR TITLE
PaletteEdit: Fix flaky test

### DIFF
--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -170,11 +170,13 @@ describe( 'PaletteEdit', () => {
 			} )
 		);
 
-		expect(
-			screen.getByRole( 'button', {
-				name: 'Remove all colors',
-			} )
-		).toBeVisible();
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Remove all colors',
+				} )
+			).toBeVisible();
+		} );
 	} );
 
 	it( 'shows a reset option when the `canReset` prop is enabled', async () => {


### PR DESCRIPTION
## What?
Fixes a flaky `PaletteEdit` test 

## Why?
Because it's flaky. Example: 
* https://github.com/WordPress/gutenberg/actions/runs/9158832871/job/25178298698?pr=61789

## How?
We're now explicitly waiting for the "Remove all colors" button to appear.

## Testing Instructions
All tests should pass. Make sure to do multiple runs of this one to ensure it's no longer flaky:

```
npm run test:unit:watch packages/components/src/palette-edit/test/index.tsx
```

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None