### PR TITLE
Block Library: Avoid using component naming conventions for non-component code

### DIFF
--- a/packages/block-library/src/form-submit-button/save.js
+++ b/packages/block-library/src/form-submit-button/save.js
@@ -3,12 +3,11 @@
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
-const Save = () => {
+export default function save() {
 	const blockProps = useBlockProps.save();
 	return (
 		<div className="wp-block-form-submit-wrapper" { ...blockProps }>
 			<InnerBlocks.Content />
 		</div>
 	);
-};
-export default Save;
+}

--- a/packages/block-library/src/form/save.js
+++ b/packages/block-library/src/form/save.js
@@ -3,7 +3,7 @@
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-const Save = ( { attributes } ) => {
+export default function save( { attributes } ) {
 	const blockProps = useBlockProps.save();
 	const { submissionMethod } = attributes;
 
@@ -16,5 +16,4 @@ const Save = ( { attributes } ) => {
 			<InnerBlocks.Content />
 		</form>
 	);
-};
-export default Save;
+}

--- a/packages/block-library/src/query-no-results/save.js
+++ b/packages/block-library/src/query-no-results/save.js
@@ -3,6 +3,6 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function QueryNoResultsSave() {
+export default function save() {
 	return <InnerBlocks.Content />;
 }

--- a/packages/block-library/src/query/save.js
+++ b/packages/block-library/src/query/save.js
@@ -3,7 +3,7 @@
  */
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
-export default function QuerySave( { attributes: { tagName: Tag = 'div' } } ) {
+export default function save( { attributes: { tagName: Tag = 'div' } } ) {
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return <Tag { ...innerBlocksProps } />;


### PR DESCRIPTION
## What?
Change names of `save` functions in the block library and avoid using React's function component naming conventions.

## Why?
These pure functions aren't components and shouldn't be treated as such.

Resolves errors reported by `eslint-plugin-react-compiler`. See #61788.

## Testing Instructions
It's a simple renaming operation. Simple smoke testing should suffice.

### Testing Instructions for Keyboard
Same.
