### PR TITLE
Search Block: Fix `borderRadius` mutation

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -112,13 +112,19 @@ export default function SearchEdit( {
 	] );
 
 	const borderRadius = style?.border?.radius;
-	const borderProps = useBorderProps( attributes );
+	let borderProps = useBorderProps( attributes );
 
 	// Check for old deprecated numerical border radius. Done as a separate
 	// check so that a borderRadius style won't overwrite the longhand
 	// per-corner styles.
 	if ( typeof borderRadius === 'number' ) {
-		borderProps.style.borderRadius = `${ borderRadius }px`;
+		borderProps = {
+			...borderProps,
+			style: {
+				...borderProps.style,
+				borderRadius: `${ borderRadius }px`,
+			},
+		};
 	}
 
 	const colorProps = useColorProps( attributes );


### PR DESCRIPTION
## What?
This PR fixes a mutation that we're performing in the Search block and updates to use a new object instead.

## Why?
Mutating objects could lead to subtle bugs.
In this particular case, I'm fixing it to resolve an ESLint error that was raised by the React Compiler ESLint plugin in https://github.com/WordPress/gutenberg/pull/61788

## How?
Using a new object instead of mutating the existing one.

## Testing Instructions
Verify the border-radius specified to a Search block still works if set as a number and with a unit.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None