### PR TITLE
Stop Patterns data view header shrinking

### DIFF
--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -104,6 +104,7 @@
 		position: sticky;
 		top: 0;
 		z-index: 2;
+		flex-shrink: 0;
 	}
 
 	.edit-site-patterns__pattern-title {


### PR DESCRIPTION
On Patterns data views, the header will fractionally shrink / grow based on viewport height. Video demo below (you may need to zoom in to see it):

https://github.com/WordPress/gutenberg/assets/846565/587ad6ba-aaaa-476d-b6cd-d14ef55eb77e

This PR fixes that by applying `flex-shrink: 0` to `.edit-site-patterns__section-header`.