### PR TITLE
SlotFills: Use state for registry initialization

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.tsx
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { observableMap } from '@wordpress/compose';
 
@@ -98,7 +98,7 @@ function createSlotRegistry(): SlotFillBubblesVirtuallyContext {
 export default function SlotFillProvider( {
 	children,
 }: SlotFillProviderProps ) {
-	const registry = useMemo( createSlotRegistry, [] );
+	const [ registry ] = useState( createSlotRegistry );
 	return (
 		<SlotFillContext.Provider value={ registry }>
 			{ children }

--- a/packages/components/src/slot-fill/provider.tsx
+++ b/packages/components/src/slot-fill/provider.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import type { Component } from '@wordpress/element';
-import { useMemo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -118,7 +118,7 @@ function createSlotRegistry(): BaseSlotFillContext {
 }
 
 export function SlotFillProvider( { children }: SlotFillProviderProps ) {
-	const contextValue = useMemo( createSlotRegistry, [] );
+	const [ contextValue ] = useState( createSlotRegistry );
 	return (
 		<SlotFillContext.Provider value={ contextValue }>
 			{ children }


### PR DESCRIPTION
## What?
PR updates SlotFill providers to initialize context values via `useState` lazily. The code used the same initialization method but changed during TS refactoring - 821f4d4344f630b337fed4c5beb10eee346899b0.

## Why?
* Fixes `react-compiler/react-compiler` [error](https://github.com/WordPress/gutenberg/actions/runs/9158471368/job/25176908344?pr=61788#step:5:625) - `Expected the first argument to be an inline function expression`.
* This is a valid pattern for initializing values. See https://tkdodo.eu/blog/use-state-for-one-time-initializations and https://x.com/dan_abramov2/status/1792555601106551229.

## Testing Instructions
CI checks should be green.

### Testing Instructions for Keyboard
Same.
