### PR TITLE
Update actions order in site editor for template and template parts

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1189,11 +1189,7 @@ export function usePostActions( postType, onActionPerformed ) {
 		}
 
 		const actions = [
-			isTemplateOrTemplatePart && resetTemplateAction,
 			postTypeObject?.viewable && viewPostAction,
-			! isTemplateOrTemplatePart && restorePostAction,
-			isTemplateOrTemplatePart && deleteTemplateAction,
-			! isTemplateOrTemplatePart && permanentlyDeletePostAction,
 			postRevisionsAction,
 			process.env.IS_GUTENBERG_PLUGIN
 				? ! isTemplateOrTemplatePart &&
@@ -1203,6 +1199,10 @@ export function usePostActions( postType, onActionPerformed ) {
 			! isTemplateOrTemplatePart && renamePostAction,
 			isTemplateOrTemplatePart && renameTemplateAction,
 			isPattern && exportPatternAsJSONAction,
+			isTemplateOrTemplatePart && resetTemplateAction,
+			! isTemplateOrTemplatePart && restorePostAction,
+			isTemplateOrTemplatePart && deleteTemplateAction,
+			! isTemplateOrTemplatePart && permanentlyDeletePostAction,
 			isPattern && deletePatternAction,
 			! isTemplateOrTemplatePart && trashPostAction,
 		].filter( Boolean );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This pull request reorders the destructive action to the end.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Destructive actions should be the last items on the actions list.

## Screenshots or screencast <!-- if applicable -->
<img width="282" alt="image" src="https://github.com/WordPress/gutenberg/assets/43412958/27f83b81-fa8e-4195-b58c-a9ae957337b2">
<img width="280" alt="image" src="https://github.com/WordPress/gutenberg/assets/43412958/6549cec0-4b42-4e11-8fc4-ed9b63cb1a5b">

Closes #61798