### PR TITLE
Global styles: send theme object to setUserConfig

### DIFF
--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -89,10 +89,7 @@ export const useGlobalStylesReset = () => {
 	const canReset = !! config && ! fastDeepEqual( config, EMPTY_CONFIG );
 	return [
 		canReset,
-		useCallback(
-			() => setUserConfig( () => EMPTY_CONFIG ),
-			[ setUserConfig ]
-		),
+		useCallback( () => setUserConfig( EMPTY_CONFIG ), [ setUserConfig ] ),
 	];
 };
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -81,11 +81,7 @@ function ScreenRevisions() {
 	};
 
 	const restoreRevision = ( revision ) => {
-		setUserConfig( () => ( {
-			styles: revision?.styles,
-			settings: revision?.settings,
-			_links: revision?._links,
-		} ) );
+		setUserConfig( () => revision );
 		setIsLoadingRevisionWithUnsavedChanges( false );
 		onCloseRevisions();
 	};
@@ -134,11 +130,7 @@ function ScreenRevisions() {
 		 * See: https://github.com/WordPress/gutenberg/issues/55866
 		 */
 		if ( shouldSelectFirstItem ) {
-			setCurrentlySelectedRevision( {
-				styles: firstRevision?.styles || {},
-				settings: firstRevision?.settings || {},
-				id: firstRevision?.id,
-			} );
+			setCurrentlySelectedRevision( firstRevision );
 		}
 	}, [ shouldSelectFirstItem, firstRevision ] );
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -86,19 +86,6 @@ function ScreenRevisions() {
 		onCloseRevisions();
 	};
 
-	const selectRevision = ( revision ) => {
-		setCurrentlySelectedRevision( {
-			/*
-			 * The default must be an empty object so that
-			 * `mergeBaseAndUserConfigs()` can merge them correctly.
-			 */
-			styles: revision?.styles || {},
-			settings: revision?.settings || {},
-			_links: revision?._links || {},
-			id: revision?.id,
-		} );
-	};
-
 	useEffect( () => {
 		if (
 			! editorCanvasContainerView ||
@@ -178,7 +165,7 @@ function ScreenRevisions() {
 					/>
 				) ) }
 			<RevisionsButtons
-				onChange={ selectRevision }
+				onChange={ setCurrentlySelectedRevision }
 				selectedRevisionId={ currentlySelectedRevisionId }
 				userRevisions={ currentRevisions }
 				canApplyRevision={ isLoadButtonEnabled }

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -27,11 +27,7 @@ export default function Variation( { variation, children, isPill } ) {
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
 	const context = useMemo(
 		() => ( {
-			user: {
-				settings: variation.settings ?? {},
-				styles: variation.styles ?? {},
-				_links: variation._links ?? {},
-			},
+			user: variation,
 			base,
 			merged: mergeBaseAndUserConfigs( base, variation ),
 			setUserConfig: () => {},
@@ -39,13 +35,7 @@ export default function Variation( { variation, children, isPill } ) {
 		[ variation, base ]
 	);
 
-	const selectVariation = () => {
-		setUserConfig( () => ( {
-			settings: variation.settings,
-			styles: variation.styles,
-			_links: variation._links,
-		} ) );
-	};
+	const selectVariation = () => setUserConfig( () => variation );
 
 	const selectOnEnter = ( event ) => {
 		if ( event.keyCode === ENTER ) {

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -35,7 +35,7 @@ export default function Variation( { variation, children, isPill } ) {
 		[ variation, base ]
 	);
 
-	const selectVariation = () => setUserConfig( () => variation );
+	const selectVariation = () => setUserConfig( variation );
 
 	const selectOnEnter = ( event ) => {
 		if ( event.keyCode === ENTER ) {

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -287,7 +287,7 @@ function PushChangesToGlobalStylesControl( {
 			// notification.
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( newBlockAttributes );
-			setUserConfig( () => newUserConfig, { undoIgnore: true } );
+			setUserConfig( newUserConfig, { undoIgnore: true } );
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: Title of the block e.g. 'Heading'.
@@ -302,7 +302,7 @@ function PushChangesToGlobalStylesControl( {
 							onClick() {
 								__unstableMarkNextChangeAsNotPersistent();
 								setAttributes( attributes );
-								setUserConfig( () => userConfig, {
+								setUserConfig( userConfig, {
 									undoIgnore: true,
 								} );
 							},

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -163,7 +163,13 @@ function useGlobalStylesUserConfig() {
 	}, [ settings, styles, _links ] );
 
 	const setConfig = useCallback(
-		( callback, options = {} ) => {
+		/**
+		 * Set the global styles config.
+		 * @param {Function|Object} callbackOrObject If the callbackOrObject is a function, pass the current config to the callback so the consumer can merge values.
+		 *                                           Otherwise, overwrite the current config with the incoming object.
+		 * @param {Object}          options          Options for editEntityRecord Core selector.
+		 */
+		( callbackOrObject, options = {} ) => {
 			const record = getEditedEntityRecord(
 				'root',
 				'globalStyles',
@@ -175,7 +181,11 @@ function useGlobalStylesUserConfig() {
 				settings: record?.settings ?? {},
 				_links: record?._links ?? {},
 			};
-			const updatedConfig = callback( currentConfig );
+
+			const updatedConfig =
+				typeof callbackOrObject === 'function'
+					? callbackOrObject( currentConfig )
+					: callbackOrObject;
 
 			editEntityRecord(
 				'root',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow up to https://github.com/WordPress/gutenberg/pull/61271

Instead of destructuring object, just send it to the global styles provider callback via `setUserConfig`.

Props to @noisysocks for [catching it](https://github.com/WordPress/gutenberg/pull/61271#pullrequestreview-2064964677), and for giving me pause to discover how trivial the change is.

~~Should `setUserConfig` accept a function and an object?~~ 

Also, `setUserConfig` now accept a function and an object to update user global styles. So,

1. a callback function where the consumer needs the current config to merge changes (or whatever), and 
2. an object where the consumer just wants to overwrite the user config object completely

```js
const { setUserConfig } = useContext( GlobalStylesContext );

const newValue = {
    styles: { color: 'red' },
    settings: { test: 1 },
};

// With callback (merging)
setUserConfig( ( currentConfig ) => ( {
   styles: {
        ....currentConfig.styles,
        color: newValue.styles.color,
    },
    settings: newValue.settings,
} ) );

// Without (overwrite)
setUserConfig( newValue );
```

## Why?

The [global styles provider does the work](https://github.com/WordPress/gutenberg/blob/18e2d5c3f86eb2c00c5cb821d95957b45f0d9070/packages/editor/src/components/global-styles-provider/index.js#L84-L84) of splitting the properties into `styles`, `settings` and `_links`.


## Testing Instructions

There should be no regressions in the way global style variations or revisions work.

I'm using Twenty Twenty Four to test.

1. Fire up the site editor and open the global styles sidebar. Under "Browse styles", you'll find the theme variations. Apply a few theme variations and save each time.
2. Then open up the global styles revisions panel and apply some of your recently-created revisions.

There should be no JS errors, and the theme styles should apply to the canvas.

https://github.com/WordPress/gutenberg/assets/6458278/902a74da-53bf-41a9-87e3-bb898b3bd1dc

To test the `setUserConfig` arguments:

1. Switch and save various theme style variations
2. Fiddle with an individual block's styles and push them to global styles (in the advance panel of the block's settings)
3. Change global styles, then reset them. 

There should be no regressions.


