### PR TITLE
Workflows: test to check for label and skip backport changelog

### DIFF
--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -31,7 +31,7 @@ jobs:
             - name: 'Fetch relevant history from origin'
               run: git fetch origin ${{ github.event.pull_request.base.ref }}
             - name: Check CHANGELOG status
-              if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Core sync required') }}
+              if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Core sync required') && !contains(github.event.pull_request.labels.*.name, 'Backport from WordPress Core') }}
               env:
                   PR_NUMBER: ${{ github.event.number }}
               run: |

--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -2,7 +2,7 @@ name: Verify Core Backport Changlog
 
 on:
     pull_request:
-        types: [opened, synchronize]
+        types: [opened, synchronize, labeled, unlabeled]
         paths:
             - 'lib/**'
             - '!lib/load.php'
@@ -31,6 +31,7 @@ jobs:
             - name: 'Fetch relevant history from origin'
               run: git fetch origin ${{ github.event.pull_request.base.ref }}
             - name: Check CHANGELOG status
+              if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Core sync required') }}
               env:
                   PR_NUMBER: ${{ github.event.number }}
               run: |

--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -31,7 +31,7 @@ jobs:
             - name: 'Fetch relevant history from origin'
               run: git fetch origin ${{ github.event.pull_request.base.ref }}
             - name: Check CHANGELOG status
-              if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Core sync required') && !contains(github.event.pull_request.labels.*.name, 'Backport from WordPress Core') }}
+              if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Core Sync Required') && !contains(github.event.pull_request.labels.*.name, 'Backport from WordPress Core') }}
               env:
                   PR_NUMBER: ${{ github.event.number }}
               run: |

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API: Try: bundle WP_Theme_JSON class instead of inheriting per WordPress version class
+ * REST API: Bundle WP_Theme_JSON class instead of inheriting per WordPress version class
  *
  * Changes to this class should be synced to the corresponding class
  * in WordPress core: src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow up to:

- https://github.com/WordPress/gutenberg/pull/61785

Skips the backport changelog check in CI if the "No Core sync required" label is applied to a PR.

## Why?
Folks might want to add changes that do not require a Core backport, e.g., syncing from Core to Gutenberg.

## How?
Add an `if` condition to the action.

## Testing Instructions


Make a PHP change in a new branch. 

The check should fail.

Now add the "No Core sync required" or "Backport from WordPress Core" label

The CI should refresh and the check will not fail.