### PR TITLE
Change media-text block placeholder buttons size

### DIFF
--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -40,3 +40,9 @@
 .wp-block-media-text--placeholder-image {
 	min-height: 205px;
 }
+
+@media screen and (min-width: 600px) {
+	.wp-block-media-text .components-placeholder__fieldset {
+		width: auto;
+	}
+}

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -42,7 +42,13 @@
 }
 
 @media screen and (min-width: 600px) {
-	.wp-block-media-text .components-placeholder__fieldset {
-		width: auto;
+	.wp-block-media-text {
+		.components-placeholder__fieldset {
+			.components-form-file-upload,
+			.components-button.is-secondary,
+			.block-editor-media-placeholder__url-input-container {
+				width: min-content;
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixed: #61812
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When you place a media & text block, before selecting a media, there is a placeholder with three buttons.
With Gutenberg active, there is an unexpected change in the styling of the buttons, which are wider than in other placeholders.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In the CSS of media text block I added width for the button as auto when screen size greater than 600px
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post
2. Insert Media Text block
3. Check the placeholder buttons size
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="690" alt="Screenshot 2024-05-21 at 3 01 15 PM" src="https://github.com/WordPress/gutenberg/assets/40138190/f7118203-f293-44db-a91e-622da2ffd870">
