### PR TITLE
Inspector summary rows: Make tooltips appear middle-left

### DIFF
--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -72,6 +72,7 @@ export default function PostSchedulePanel() {
 							size="compact"
 							className="editor-post-schedule__dialog-toggle"
 							variant="tertiary"
+							tooltipPosition="middle left"
 							onClick={ onToggle }
 							aria-label={ sprintf(
 								// translators: %s: Current post date.

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -78,6 +78,7 @@ export default function BlockThemeControl( { id } ) {
 			toggleProps={ {
 				size: 'compact',
 				variant: 'tertiary',
+				tooltipPosition: 'middle left',
 			} }
 			label={ __( 'Template options' ) }
 			text={ decodeEntities( template.title ) }


### PR DESCRIPTION
## What?
Update the Buttons in Inspector summary rows so that tooltips appear to the left of the button.

## Why?
There exists a small usability issue with the current placement. As you cursor up and down the list of buttons, the tooltips can annoyingly obscure the other buttons. Video demo:


https://github.com/WordPress/gutenberg/assets/846565/c258245f-f85b-4a41-b0d6-e24cfb84ae6d

Note that when the date tooltip is visible the template button becomes inaccessible until you cursor away.

## Result
The tooltips now appear left of the button so that you can cursor up and down the list without distraction.

<img width="374" alt="Screenshot 2024-05-21 at 10 08 55" src="https://github.com/WordPress/gutenberg/assets/846565/ae284ccb-abc4-4968-85df-035935c126f6">


## Testing Instructions
1. Edit a post or page
2. Cursor over buttons in the summary panel
3. Ensure all tooltips appear middle-left

