### PR TITLE
E2E: Fix canvas waiter in visitSiteEditor

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -45,7 +45,7 @@ export async function visitSiteEditor(
 	 * content underneath the loading overlay should be marked inert until the
 	 * loading is done.
 	 */
-	if ( postId || canvas === 'edit' ) {
+	if ( ! query.size || postId || canvas === 'edit' ) {
 		const canvasLoader = this.page.locator(
 			// Spinner was used instead of the progress bar in an earlier
 			// version of the site editor.

--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -37,17 +37,7 @@ export async function visitSiteEditor(
 		query.set( 'canvas', canvas );
 	}
 
-	const canvasLoader = this.page.locator(
-		// Spinner was used instead of the progress bar in an earlier version of
-		// the site editor.
-		'.edit-site-canvas-loader, .edit-site-canvas-spinner'
-	);
-
 	await this.visitAdminPage( 'site-editor.php', query.toString() );
-
-	// Try waiting for the canvas loader to appear first, so that the locator
-	// that waits for it to disappear doesn't resolve prematurely.
-	await canvasLoader.waitFor().catch( () => {} );
 
 	/**
 	 * @todo This is a workaround for the fact that the editor canvas is seen as
@@ -55,13 +45,24 @@ export async function visitSiteEditor(
 	 * content underneath the loading overlay should be marked inert until the
 	 * loading is done.
 	 */
-	await canvasLoader.waitFor( {
-		state: 'hidden',
-		// Bigger timeout is needed for larger entities, like the Large Post
-		// HTML fixture that we load for performance tests, which often doesn't
-		// make it under the default timeout value.
-		timeout: 60_000,
-	} );
+	if ( postId || canvas === 'edit' ) {
+		const canvasLoader = this.page.locator(
+			// Spinner was used instead of the progress bar in an earlier
+			// version of the site editor.
+			'.edit-site-canvas-loader, .edit-site-canvas-spinner'
+		);
+
+		// Wait for the canvas loader to appear first, so that the locator that
+		// waits for the hidden state doesn't resolve prematurely.
+		await canvasLoader.waitFor( { state: 'visible' } );
+		await canvasLoader.waitFor( {
+			state: 'hidden',
+			// Bigger timeout is needed for larger entities, like the Large Post
+			// HTML fixture that we load for performance tests, which often
+			// doesn't make it under the default timeout value.
+			timeout: 60_000,
+		} );
+	}
 
 	if ( ! options.showWelcomeGuide ) {
 		await this.editor.setPreferences( 'core/edit-site', {


### PR DESCRIPTION
Reported in: https://github.com/WordPress/gutenberg/pull/61629#issuecomment-2120893082
Related convo: https://wordpress.slack.com/archives/C02QB2JS7/p1716226087226579

## What?
Fix the canvas loading bar waiter step so that it only applies when we open a page for editing, e.g., by passing the `pageId` param.

## Why?
The [current implementation](https://github.com/WordPress/gutenberg/pull/61629) adds 2 minutes to each performance test that visits the site editor's page that doesn't load the canvas, e.g., the `All Templates` view. It also does that for E2E tests, only there the `actionTimeout` is 5 seconds instead of 2 minutes, so we don't really notice that.

## How?
By checking if the `pageId` or the `canvas` query params are present, so that we know the intent is to actually edit content.

## Testing Instructions
All E2E tests should pass, and the total time of the performance tests should be reduced from ~50 to ~30 minutes.