### PR TITLE
PaletteEdit: Fix another flaky test

### DIFF
--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -189,11 +189,13 @@ describe( 'PaletteEdit', () => {
 				name: 'Color options',
 			} )
 		);
-		expect(
-			screen.getByRole( 'button', {
-				name: 'Reset colors',
-			} )
-		).toBeVisible();
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Reset colors',
+				} )
+			).toBeVisible();
+		} );
 	} );
 
 	it( 'does not show a reset colors option when `canReset` is disabled', async () => {


### PR DESCRIPTION
## What?
Fixes another flaky `PaletteEdit` test. Follow-up to #61791.

## Why?
Because it's flaky. Example: 
https://github.com/WordPress/gutenberg/actions/runs/9171026029/job/25214476473?pr=61813#step:6:200

## How?
We're now explicitly waiting for the "Reset colors" button to appear.

## Testing Instructions
All tests should pass. Make sure to do multiple runs of this one to ensure it's no longer flaky:

```
npm run test:unit:watch packages/components/src/palette-edit/test/index.tsx
```

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None