### PR TITLE
Data views: Update grid layout on small screens

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -277,9 +277,13 @@
 
 .dataviews-view-grid {
 	margin-bottom: auto;
-	grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+	grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
 	grid-template-rows: max-content;
 	padding: 0 $grid-unit-40 $grid-unit-30;
+
+	@include break-mobile() {
+		grid-template-columns: repeat(2, minmax(0, 1fr)) !important; // Todo: eliminate !important dependency
+	}
 
 	@include break-xlarge() {
 		grid-template-columns: repeat(3, minmax(0, 1fr)) !important; // Todo: eliminate !important dependency
@@ -557,6 +561,11 @@
 	}
 
 	line-height: 0;
+	flex-shrink: 0;
+
+	.components-checkbox-control__input-container {
+		margin: 0;
+	}
 }
 
 .dataviews-filters__custom-menu-radio-item-prefix {


### PR DESCRIPTION
## What?
Reduce the minimum number of columns a grid can be arranged into to 1.

## Why?
With the addition of bulk actions (checkbox) and the lock icon for patterns, a 2 column layout doesn't work so well at small screen sizes.

## Screenshots

| Before | After |
| --- | --- |
| <img width="372" alt="Screenshot 2024-05-21 at 14 14 00" src="https://github.com/WordPress/gutenberg/assets/846565/e66c1f54-71b0-4e80-9865-b1589ddf2563"> | <img width="373" alt="Screenshot 2024-05-21 at 14 14 17" src="https://github.com/WordPress/gutenberg/assets/846565/910ecd09-467f-443a-a888-5b61a4aaa88a"> |

## Testing Instructions
1. Open a data view e.g. Patterns and ensure Grid layout is selected
2. Resize window to <480px
3. See grid arranged into single column

Note: This PR also includes a small fix to stop checkboxes shrinking and breaking the layout at smaller screen sizes.
