### PR TITLE
useBlockInspectorAnimationSettings: Remove unnecessary deps

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -111,10 +111,8 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	// displays based on the relationship between the selected block
 	// and its parent, and only enable it if the parent is controlling
 	// its children blocks.
-	const blockInspectorAnimationSettings = useBlockInspectorAnimationSettings(
-		blockType,
-		selectedBlockClientId
-	);
+	const blockInspectorAnimationSettings =
+		useBlockInspectorAnimationSettings( blockType );
 
 	const borderPanelLabel = useBorderPanelLabel( {
 		blockName: selectedBlockName,

--- a/packages/block-editor/src/components/block-inspector/useBlockInspectorAnimationSettings.js
+++ b/packages/block-editor/src/components/block-inspector/useBlockInspectorAnimationSettings.js
@@ -8,10 +8,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
-export default function useBlockInspectorAnimationSettings(
-	blockType,
-	selectedBlockClientId
-) {
+export default function useBlockInspectorAnimationSettings( blockType ) {
 	return useSelect(
 		( select ) => {
 			if ( blockType ) {
@@ -48,6 +45,6 @@ export default function useBlockInspectorAnimationSettings(
 			}
 			return null;
 		},
-		[ selectedBlockClientId, blockType ]
+		[ blockType ]
 	);
 }


### PR DESCRIPTION
## What?
PR remove unnecessary dependency for `useBlockInspectorAnimationSettings` hook and fixes ESLint warning.

```
React Hook useSelect has an unnecessary dependency: 'selectedBlockClientId'. Either exclude it or remove the dependency array
```

## Testing Instructions
1. Open a post or page.
2. Insert a Navigation block.
3. Confirm that inspector control animations work as before.

### Testing Instructions for Keyboard
Same.
