### PR TITLE
Fix positioning of close icons in panels to be consistent

### DIFF
--- a/packages/editor/src/components/inserter-sidebar/style.scss
+++ b/packages/editor/src/components/inserter-sidebar/style.scss
@@ -8,7 +8,7 @@
 
 .block-editor-inserter-sidebar__header {
 	border-bottom: $border-width solid $gray-300;
-	padding-right: $grid-unit-10;
+	padding-right: $grid-unit-15;
 	display: flex;
 	justify-content: space-between;
 

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -1,6 +1,6 @@
 .components-panel__header.editor-sidebar__panel-tabs {
 	padding-left: 0;
-	padding-right: $grid-unit-20;
+	padding-right: $grid-unit-15;
 
 	.components-button.has-icon {
 		padding: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow-up to https://github.com/WordPress/gutenberg/pull/61421, making all the close buttons positioned the same across the Inserter, List View, and the Inspector. 

## How?
Minor style change. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Open the Inserter. 
3. See the close icon. 
4. Open List View. 
5. See the close icon does not change position. 
6. Open the Inspector. 
7. See the close icon is positioned the same as it is within List View. 

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-21 at 14 43 43](https://github.com/WordPress/gutenberg/assets/1813435/fc817302-1fcc-4243-9340-9ccadbb2306b)
