### PR TITLE
Shadows instead of borders on interface skeleton

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -14,10 +14,9 @@
 		background: $gray-900;
 		color: $white;
 		border-radius: 0;
-		height: $header-height + $border-width;
+		height: $header-height;
 		width: $header-height;
 		position: relative;
-		margin-bottom: - $border-width;
 
 		&:active {
 			color: $white;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -162,15 +162,13 @@
 	position: relative;
 	color: $white;
 	border-radius: 0;
-	height: $header-height +  $border-width;
+	height: $header-height;
 	width: $header-height;
-	margin-bottom: -  $border-width;
 	overflow: hidden;
 	padding: 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	border-bottom: 1px solid transparent;
 
 	&:hover,
 	&:active {

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -129,7 +129,7 @@ html.interface-interface-skeleton__html-container {
 	overflow: hidden;
 
 	@include break-medium() {
-		box-shadow: -$border-width 0 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+		box-shadow: -$border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 	}
 }
 
@@ -138,7 +138,7 @@ html.interface-interface-skeleton__html-container {
 	right: 0;
 
 	@include break-medium() {
-		box-shadow: $border-width 0 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+		box-shadow: $border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 	}
 }
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -125,24 +125,27 @@ html.interface-interface-skeleton__html-container {
 }
 
 .interface-interface-skeleton__sidebar {
+	border-top: $border-width solid $gray-200;
 	overflow: hidden;
 
 	@include break-medium() {
-		border-left: $border-width solid $gray-200;
+		box-shadow: -$border-width 0 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 	}
 }
 
 .interface-interface-skeleton__secondary-sidebar {
+	border-top: $border-width solid $gray-200;
 	right: 0;
+
 	@include break-medium() {
-		border-right: $border-width solid $gray-200;
+		box-shadow: $border-width 0 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 	}
 }
 
 .interface-interface-skeleton__header {
 	flex-shrink: 0;
 	height: auto;  // Keep the height flexible.
-	border-bottom: $border-width solid $gray-200;
+	box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 	z-index: z-index(".interface-interface-skeleton__header");
 	color: $gray-900;
 }

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -130,6 +130,7 @@ html.interface-interface-skeleton__html-container {
 
 	@include break-medium() {
 		box-shadow: -$border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+		outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 	}
 }
 
@@ -139,6 +140,7 @@ html.interface-interface-skeleton__html-container {
 
 	@include break-medium() {
 		box-shadow: $border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+		outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 	}
 }
 
@@ -148,6 +150,7 @@ html.interface-interface-skeleton__html-container {
 	box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 	z-index: z-index(".interface-interface-skeleton__header");
 	color: $gray-900;
+	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 }
 
 .interface-interface-skeleton__footer {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of the exploration in #60286 and an alternate to https://github.com/WordPress/gutenberg/pull/42282, attempting to reduce visual conflicts when viewing sites with background colors that are not lighter than $gray-200. Currently if the background color of the site is darker than the border, you end up with a slight distortion around the edges of the interface.

Also fixes a 1px offset when the Inspector is closed, from the animation adjusting the canvas based on the width of the sidebar (not accounting for the 1px border) in https://github.com/WordPress/gutenberg/pull/60561. 

## How?
Replace borders with box shadows. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page.
2. View the interface skeleton

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-21 at 15 50 58](https://github.com/WordPress/gutenberg/assets/1813435/7aa8f2cb-dd02-424e-a24f-337e9b10c497)|![CleanShot 2024-05-21 at 15 44 34](https://github.com/WordPress/gutenberg/assets/1813435/e235f41b-b18c-4507-839d-040f5186ab27)|