### PR TITLE
Tweak contextual block toolbar position

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -182,8 +182,8 @@
 	.block-editor-block-list__block-selection-button,
 	.block-editor-block-contextual-toolbar {
 		pointer-events: all;
-		margin-top: $grid-unit-15;
-		margin-bottom: $grid-unit-15;
+		margin-top: $grid-unit-10;
+		margin-bottom: $grid-unit-10;
 	}
 
 	.block-editor-block-contextual-toolbar {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Moves the toolbar a closer to the content selected. Originally explored as part of https://github.com/WordPress/gutenberg/pull/60286. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert an image block.
3. See change.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-21 at 16 01 29](https://github.com/WordPress/gutenberg/assets/1813435/2e6ce008-ff90-4ce0-8a57-b1bfcd24f634)|![CleanShot 2024-05-21 at 16 02 15](https://github.com/WordPress/gutenberg/assets/1813435/4c23beb3-d9dc-41b7-8ea8-c234520c520e)|