### PR TITLE
Docs: Fix missing braces into code snippet

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -926,13 +926,13 @@ import { useBlockProps } from '@wordpress/block-editor';
 
 export default function Edit() {
 
-  const blockProps = useBlockProps(
+  const blockProps = useBlockProps( {
     className: 'my-custom-class',
     style: {
       color: '#222222',
       backgroundColor: '#eeeeee'
     }
-  )
+  } );
 
   return (
     <div { ...blockProps }>


### PR DESCRIPTION
The parameters of useBlockProps should be an object otherwise it generates error.

## What?
<!-- In a few words, what is the PR actually doing? -->
It adds the missing braces to code snippets using the `useBlockProps` hook.

## Why?
The parameters of the useBlockProps hook must be an object; otherwise, it will throw an error in the console. I've seen another code snippet [in this doc](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#block-wrapper-props passed) passed an object which is the right way.