### PR TITLE
Helper Text to No-follow Links

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -55,6 +55,9 @@ const LINK_SETTINGS = [
 	{
 		id: 'nofollow',
 		title: __( 'Mark as nofollow' ),
+		help: __(
+			'A "no follow" link tells search engines not to pass SEO value to the linked site.'
+		),
 	},
 ];
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -35,6 +35,9 @@ const LINK_SETTINGS = [
 	{
 		id: 'nofollow',
 		title: __( 'Mark as nofollow' ),
+		help: __(
+			'A "no follow" link tells search engines not to pass SEO value to the linked site.'
+		),
 	},
 ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Help users understand the purpose of "nofollow" links.
https://github.com/WordPress/gutenberg/issues/61838

## How?
Add a helper text to the link format and button block for the nofollow links.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to editor
2. Add a link to the paragraph block or button block
3. Go to the Link Advanced settings
4. Check "No follow" checkbox

## Screenshots or screencast <!-- if applicable -->
<img width="457" alt="image" src="https://github.com/WordPress/gutenberg/assets/43412958/2f045681-d9be-43f0-b971-c70a10cc40c7">

