### PR TITLE
Add a lock snackbar for modifying content lock blocks

### DIFF
--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -4,12 +4,13 @@
 import { ToolbarButton, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../store';
+import { getModifyContentLockSnackbarId } from '../store/utils';
 import { BlockControls, BlockSettingsMenuControls } from '../components';
 import { unlock } from '../lock-unlock';
 
@@ -36,15 +37,19 @@ function ContentLockControlsPure( { clientId, isSelected } ) {
 		[ clientId ]
 	);
 
-	const { stopEditingAsBlocks, modifyContentLockBlock } = unlock(
+	const { stopEditingAsBlocks, modifyContentLockBlock, selectBlock } = unlock(
 		useDispatch( blockEditorStore )
 	);
+	const { removeNotice } = useDispatch( noticesStore );
 	const isContentLocked =
 		! isLockedByParent && templateLock === 'contentOnly';
 
-	const stopEditingAsBlockCallback = useCallback( () => {
+	const stopEditingAsBlockCallback = () => {
 		stopEditingAsBlocks( clientId );
-	}, [ clientId, stopEditingAsBlocks ] );
+		removeNotice( getModifyContentLockSnackbarId( clientId ) );
+		// Move focus back to the block to prevent focus-loss.
+		selectBlock( clientId, -1 );
+	};
 
 	if ( ! isContentLocked && ! isEditingAsBlocks ) {
 		return null;

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { Platform } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -9,6 +11,7 @@ import { Platform } from '@wordpress/element';
 import { undoIgnoreBlocks } from './undo-ignore';
 import { store as blockEditorStore } from './index';
 import { unlock } from '../lock-unlock';
+import { getModifyContentLockSnackbarId } from './utils';
 
 const castArray = ( maybeArray ) =>
 	Array.isArray( maybeArray ) ? maybeArray : [ maybeArray ];
@@ -399,7 +402,7 @@ export function expandBlock( clientId ) {
  */
 export const modifyContentLockBlock =
 	( clientId ) =>
-	( { select, dispatch } ) => {
+	( { registry, select, dispatch } ) => {
 		dispatch.__unstableMarkNextChangeAsNotPersistent();
 		dispatch.updateBlockAttributes( clientId, {
 			templateLock: undefined,
@@ -414,4 +417,22 @@ export const modifyContentLockBlock =
 			clientId,
 			focusModeToRevert
 		);
+		const snackbarId = getModifyContentLockSnackbarId( clientId );
+		registry
+			.dispatch( noticesStore )
+			.createSuccessNotice( __( 'Done editing?' ), {
+				type: 'snackbar',
+				id: snackbarId,
+				actions: [
+					{
+						label: __( 'Lock' ),
+						onClick: () => {
+							dispatch.stopEditingAsBlocks( clientId );
+							// Move focus back to the block to prevent focus-loss.
+							dispatch.selectBlock( clientId, -1 );
+						},
+					},
+				],
+			} );
+		return snackbarId;
 	};

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -67,3 +67,7 @@ export function getInsertBlockTypeDependants( state, rootClientId ) {
 		state.blockEditingModes,
 	];
 }
+
+export function getModifyContentLockSnackbarId( clientId ) {
+	return `modify-content-lock-${ clientId }`;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close #61554.

Add a "Done editing? Lock" snackbar for easier access to re-lock a modifying content-locked block.

> [!NOTE]
> This UI is still TBD. This PR is created to help with testing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #61554. This is a UI enhancement to improve the discoverability of the feature.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a snackbar once users enter the temporary modifying mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add a template-locked block or insert the content below.
```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>template lock</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
2. Go to the list view and select the Group block.
3. Open the "More" menu.
4. Click on "Modify".
5. The snackbar should appear and announce the message.
6. Clicking on the "Lock" action in the snackbar should re-lock the group and return the focus to the block.
7. Repeat steps 2~4. Clicking on the "Done" menu item on the block toolbar should behave the same, and it should dismiss the snackbar.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/d21e9a8f-438f-483a-8dde-a765f0b0a522

