### PR TITLE
Data views: Always show Actions table header

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -107,7 +107,8 @@
 		th:first-child {
 			padding-left: $grid-unit-40;
 
-			.dataviews-view-table-header-button {
+			.dataviews-view-table-header-button,
+			.dataviews-view-table-header {
 				margin-left: - #{$grid-unit-10};
 			}
 		}
@@ -221,6 +222,10 @@
 				display: none;
 			}
 		}
+	}
+
+	.dataviews-view-table-header {
+		padding-left: $grid-unit-05;
 	}
 
 	.dataviews-view-table__actions-column {

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -15,7 +15,6 @@ import {
 	privateApis as componentsPrivateApis,
 	CheckboxControl,
 	Spinner,
-	VisuallyHidden,
 } from '@wordpress/components';
 import {
 	forwardRef,
@@ -552,9 +551,9 @@ function ViewTable< Item extends AnyItem >( {
 								data-field-id="actions"
 								className="dataviews-view-table__actions-column"
 							>
-								<VisuallyHidden>
+								<span className="dataviews-view-table-header">
 									{ __( 'Actions' ) }
-								</VisuallyHidden>
+								</span>
 							</th>
 						) }
 					</tr>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
See https://github.com/WordPress/gutenberg/pull/61710#issuecomment-2124002994
Reverts https://github.com/WordPress/gutenberg/pull/61710

## What?
<!-- In a few words, what is the PR actually doing? -->
Makes the 'Actions' table header in the data views always visible.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Hiding table heders is less than ideal for the reasons explained in https://github.com/WordPress/gutenberg/pull/61710#issuecomment-2124002994
Previously: https://github.com/WordPress/gutenberg/issues/42505

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Reverts the changes from https://github.com/WordPress/gutenberg/pull/61710

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site editor > Pages > View options > Layout > Table
- Observe the 'Actions' table header is always visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
