### PR TITLE
Style Book: Use state to initialize examples

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -190,7 +190,7 @@ function StyleBook( {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ textColor ] = useGlobalStyle( 'color.text' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
-	const examples = useMemo( getExamples, [] );
+	const [ examples ] = useState( getExamples );
 	const tabs = useMemo(
 		() =>
 			getCategories()


### PR DESCRIPTION
## What?
PR updates method for initializing examples for the `StyleBook` component.

This is similar to #61802.

## Why?

- Fixes `react-compiler/react-compiler` [error](https://github.com/WordPress/gutenberg/actions/runs/9173492334/job/25222306709?pr=61788#step:5:779) - `Expected the first argument to be an inline function expression.`
- This is a valid pattern for initializing values. See https://tkdodo.eu/blog/use-state-for-one-time-initializations and https://x.com/dan_abramov2/status/1792555601106551229.

## Testing Instructions
1. Open the Site Editor.
2. Navigate to the Style Book.
3. It should work as before.

### Testing Instructions for Keyboard
Same.
