### PR TITLE
Tooltip: Fix Ariakit tooltip store usage

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Internal
 
 -   Remove usage of deprecated spreading of `key` prop in JSX in CustomSelectControl and FormTokenField components ([#61692](https://github.com/WordPress/gutenberg/pull/61692)).
+-   Tooltip: Fix Ariakit tooltip store usage ([#61858](https://github.com/WordPress/gutenberg/pull/61858)).
 
 ## 27.6.0 (2024-05-16)
 

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -87,10 +87,7 @@ function UnforwardedTooltip(
 	}
 	computedPlacement = computedPlacement || 'bottom';
 
-	// Removing the `Ariakit` namespace from the hook name allows ESLint to
-	// properly identify the hook, and apply the correct linting rules.
-	const useAriakitTooltipStore = Ariakit.useTooltipStore;
-	const tooltipStore = useAriakitTooltipStore( {
+	const tooltipStore = Ariakit.useTooltipStore( {
 		placement: computedPlacement,
 		showTimeout: delay,
 	} );


### PR DESCRIPTION
## What?
This PR fixes how we use the `Ariakit.useTooltipStore` hook in the `Tooltip` component.

## Why?
Previously, we were circumventing an ESLint error because the hook was conditionally called. I recall I suggested this workaround, so I'm glad I'm the one to suggest removing it now (see https://github.com/WordPress/gutenberg/pull/57202#discussion_r1443170682).

The workaround is no longer necessary since the hook is no longer called conditionally.

The motivation is that I'm fixing it to resolve a couple of ESLint errors that were raised by the React Compiler ESLint plugin in https://github.com/WordPress/gutenberg/pull/61788

## How?
Just using the hook directly.

## Testing Instructions
Verify the static analysis check is still green. 

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None