### PR TITLE
Global Styles: Move type presets below elements

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -31,10 +31,10 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen">
 				<VStack spacing={ 7 }>
-					<TypographyVariations title={ __( 'Presets' ) } />
 					{ ! window.__experimentalDisableFontLibrary &&
 						fontLibraryEnabled && <FontFamilies /> }
 					<TypographyElements />
+					<TypographyVariations title={ __( 'Presets' ) } />
 				</VStack>
 			</div>
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Moves the type presets lower in the global styles sidebar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It is possible for there to be a lot presets - having them at the top would push down all the other settings, so it's better to have them lower so that they can scroll.

## How?
Just move the component.

## Testing Instructions
0. Using TT4...
1. Open the Site Editor
2. Open Global Styles
3. Open Typography
4. Check that the presets are at the bottom of the list.

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|---|----|
|<img width="317" alt="Screenshot 2024-05-22 at 14 11 44" src="https://github.com/WordPress/gutenberg/assets/275961/18db94bd-e0f9-4fa1-a39f-e38b8240d564">|<img width="321" alt="Screenshot 2024-05-22 at 14 10 46" src="https://github.com/WordPress/gutenberg/assets/275961/dff39d88-12a9-4691-9d52-a9ea2bb40fe2">|