### PR TITLE
Post Actions: Hide the trash action for auto-drafts

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -49,8 +49,8 @@ const trashPostAction = {
 	label: __( 'Move to Trash' ),
 	isPrimary: true,
 	icon: trash,
-	isEligible( { status } ) {
-		return status !== 'trash';
+	isEligible( item ) {
+		return ! [ 'auto-draft', 'trash' ].includes( item.status );
 	},
 	supportsBulk: true,
 	hideModalHeader: true,


### PR DESCRIPTION
## What?
PR updates the post status check condition for the "Move to Trash" action and hides it for freshly created posts.

## Why?
It matches the condition from the legacy `PostTrash` component, which used the `isEditedPostNew` selector for this check.

## Testing Instructions
1. Create a new post.
2. Confirm that the trash action is hidden.
3. Add a title to the post and save it.
4. Confirm that the trash action is available.

### Testing Instructions for Keyboard
Same.
