### PR TITLE
Zoom Out: Hide inserters behind the experiment flag

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -231,11 +231,12 @@ export default function BlockTools( {
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
 				/>
-				{ isZoomOutMode && (
-					<ZoomOutModeInserters
-						__unstableContentRef={ __unstableContentRef }
-					/>
-				) }
+				{ window.__experimentalEnableZoomedOutPatternsTab &&
+					isZoomOutMode && (
+						<ZoomOutModeInserters
+							__unstableContentRef={ __unstableContentRef }
+						/>
+					) }
 			</InsertionPointOpenRef.Provider>
 		</div>
 	);

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -8,9 +8,29 @@ test.describe( 'Zoom Out', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.beforeEach( async ( { admin, editor } ) => {
+	test.beforeEach( async ( { admin, editor, page } ) => {
+		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
+
+		const zoomedOutCheckbox = page.getByLabel(
+			'Enable zoomed out view when selecting a pattern category in the main inserter.'
+		);
+
+		await zoomedOutCheckbox.setChecked( true );
+		await expect( zoomedOutCheckbox ).toBeChecked();
+		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+
 		await admin.visitSiteEditor();
 		await editor.canvas.locator( 'body' ).click();
+	} );
+
+	test.afterEach( async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
+		const zoomedOutCheckbox = page.getByLabel(
+			'Enable zoomed out view when selecting a pattern category in the main inserter.'
+		);
+		await zoomedOutCheckbox.setChecked( false );
+		await expect( zoomedOutCheckbox ).not.toBeChecked();
+		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Hides the zoom out inserters behind the next experiment flag.

## Why?
Until zoom out mode works well with the patterns tab we should disable these inserters. You still should be able to access them by enabling the experiment for testing purposes.

## How?
Only outputs the inserters when the experiment is enabled.

## Testing Instructions
1. Open the Site Editor
2. Open Global Styles
3. Open Browse Styles
4. Confirm that the view zooms out
5. Confirm that no inserters are visible
6. Enable the zoom out experiment from Gutenberg > Experiments
1. Open the Site Editor
2. Open Global Styles
3. Open Browse Styles
4. Confirm that the view zooms out
5. Confirm that inserters are now visible

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="899" alt="Screenshot 2024-05-22 at 15 04 01" src="https://github.com/WordPress/gutenberg/assets/275961/be322b28-391a-4324-9c48-14b965dc35a1">|<img width="820" alt="Screenshot 2024-05-22 at 15 05 11" src="https://github.com/WordPress/gutenberg/assets/275961/730f1b19-525c-4e9a-8cb0-c0a96a1ddd7c">|
