### PR TITLE
Inspector: Remove revisions panel

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1108,6 +1108,7 @@ export function usePostActions( postType, onActionPerformed ) {
 	].includes( postType );
 	const isPattern = postType === PATTERN_POST_TYPE;
 	const isLoaded = !! postTypeObject;
+	const supportsRevisions = !! postTypeObject?.supports?.revisions;
 	return useMemo( () => {
 		if ( ! isLoaded ) {
 			return [];
@@ -1115,7 +1116,7 @@ export function usePostActions( postType, onActionPerformed ) {
 
 		const actions = [
 			postTypeObject?.viewable && viewPostAction,
-			postRevisionsAction,
+			supportsRevisions && postRevisionsAction,
 			globalThis.IS_GUTENBERG_PLUGIN
 				? ! isTemplateOrTemplatePart &&
 				  ! isPattern &&
@@ -1181,5 +1182,6 @@ export function usePostActions( postType, onActionPerformed ) {
 		restorePostAction,
 		onActionPerformed,
 		isLoaded,
+		supportsRevisions,
 	] );
 }

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -26,7 +26,6 @@ import PageAttributesPanel from '../page-attributes/panel';
 import PatternOverridesPanel from '../pattern-overrides-panel';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 import PluginSidebar from '../plugin-sidebar';
-import PostLastRevisionPanel from '../post-last-revision/panel';
 import PostSummary from './post-summary';
 import PostTaxonomiesPanel from '../post-taxonomies/panel';
 import PostTransformPanel from '../post-transform-panel';
@@ -117,7 +116,6 @@ const SidebarContent = ( {
 						<TemplateContentPanel />
 					) }
 					<PostTransformPanel />
-					<PostLastRevisionPanel />
 					<PostTaxonomiesPanel />
 					<PageAttributesPanel />
 					<PatternOverridesPanel />

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -363,11 +363,15 @@ test.describe( 'Footnotes', () => {
 
 		// Open revisions.
 		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await editorSettings.getByRole( 'tab', { name: 'Post' } ).click();
+		await editorSettings.getByRole( 'button', { name: 'Actions' } ).click();
 		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'tab', { name: 'Post' } )
+			.getByRole( 'menu' )
+			.getByRole( 'menuitem', { name: 'View revisions' } )
 			.click();
-		await page.locator( 'a:text("Revisions (2)")' ).click();
 		await page.locator( '.revisions-controls .ui-slider-handle' ).focus();
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.locator( 'input:text("Restore This Revision")' ).click();


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/issues/59689.

## What?
Remove the revisions panel from the document inspector.

## Why?
Revisions are now accessible from the ellipsis menu which offers more appropriate prominence.

## Testing Instructions
1. Edit documents like pages, posts, templates, etc.
2. Observe the 'View revisions' action in the ellipsis menu
3. Notice the 'Revisions' panel is no longer visible in the Inspector

| Before | After |
| --- | --- |
| <img width="280" alt="Screenshot 2024-05-22 at 15 17 14" src="https://github.com/WordPress/gutenberg/assets/846565/2735fd0f-3e7a-4e06-8c6d-f3bf918de548"> | <img width="279" alt="Screenshot 2024-05-22 at 15 17 42" src="https://github.com/WordPress/gutenberg/assets/846565/9cd46075-6e52-4e62-98d8-414a5ab4eac5"> |


