### PR TITLE
DataViews: Remove unnecessary dependency for pattern fields memo

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -336,7 +336,7 @@ export default function DataviewsPatterns() {
 		}
 
 		return _fields;
-	}, [ view.type, categoryId, type, authors ] );
+	}, [ view.type, type, authors ] );
 
 	// Reset the page number when the category changes.
 	useEffect( () => {


### PR DESCRIPTION
## What?
PR removes unnecessary dependency for the `fields` memo in the `DataviewsPatterns` component. Fixes ESLint warning:

```
React Hook useMemo has an unnecessary dependency: 'categoryId'. Either exclude it or remove the dependency array.
```

## Testing Instructions
CI checks should be green.
