### PR TITLE
Automatically select group variation if there is only one available

### DIFF
--- a/packages/block-library/src/group/placeholder.js
+++ b/packages/block-library/src/group/placeholder.js
@@ -139,6 +139,13 @@ function GroupPlaceHolder( { name, onSelect } ) {
 	const blockProps = useBlockProps( {
 		className: 'wp-block-group__placeholder',
 	} );
+
+	useEffect( () => {
+		if ( variations && variations.length === 1 ) {
+			onSelect( variations[ 0 ] );
+		}
+	}, [ onSelect, variations ] );
+
 	return (
 		<div { ...blockProps }>
 			<Placeholder


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When a core/group block has only one variation available, let's skip the placeholder step and select the variation.

## Why?
We are building an email editor, but many email clients don't support modern grids or flex layouts. Therefore, we've disabled most variations, leaving us only with one. It feels weird to display the placeholder step with only one option.

## How?
I added an effect into the placeholder component in which I select the variation if there is only one available. I was thinking about adding this logic directly to the Edit component, but it would require calling select for variants for every Edit render so I rather added the change directly into the Placeholder. I'm happy to change it based on the feedback.

## Testing Instructions
### Default state (multiple variations)
1. Insert a group block via inserter
2. See placeholder with multiple variations

### With only one variation

1. Disable all group variations but one:
```js
addFilter(
    'blocks.registerBlockType',
    'mailpoet-email-editor/disable-group-variations',
    ( settings, name ) => {
      if ( name === 'core/group' ) {
        return {
          ...settings,
          variations: settings.variations.filter(
            ( variation ) => variation.name === 'group',
          ),
        };
      }
      return settings;
    },
  );
```
2. Insert the group block via the inserter
3. See that the placeholder step was skipped

### Testing Instructions for Keyboard
The appender in the empty group block is accessible using arrows in the canvas

## Screenshots or screencast <!-- if applicable -->

### Before
![Screen Capture on 2024-05-22 at 16-50-25](https://github.com/WordPress/gutenberg/assets/1082140/d3cc6165-6aeb-4e07-a813-d83f45396f87)

### After
![Screen Capture on 2024-05-22 at 16-52-43](https://github.com/WordPress/gutenberg/assets/1082140/1779cc59-2b6a-4399-84a3-b25d0d66adce)

Closes #62239