### PR TITLE
Show all blocks all the times to avoid confusing UX

### DIFF
--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -31,15 +31,6 @@ export function BlockTypesTab(
 	{ rootClientId, onInsert, onHover, showMostUsedBlocks },
 	ref
 ) {
-	// Find the root of what we _can_ insert into for this block.
-	// const { rootContentBlockId } = useSelect( ( select ) => {
-	// 	// Try the empty root first.
-	// 	const { getAllowedBlockTypes } = select( 'core/block-editor' );
-
-	// 	select( 'core/block-editor' ).getInserterItems( rootClientId );
-
-	// }, [] );
-
 	const [ allItems, items, categories, collections, onSelectItem ] =
 		useBlockTypesState( rootClientId, onInsert );
 

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -3,20 +3,17 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { useMemo, useEffect, forwardRef } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { pipe, useAsyncList } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../../store';
 import BlockTypesList from '../block-types-list';
 import InserterPanel from './panel';
 import useBlockTypesState from './hooks/use-block-types-state';
 import InserterListbox from '../inserter-listbox';
 import { orderBy } from '../../utils/sorting';
 import InserterNoResults from './no-results';
-import useInsertionPoint from './hooks/use-insertion-point';
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
@@ -34,38 +31,8 @@ export function BlockTypesTab(
 	{ rootClientId, onInsert, onHover, showMostUsedBlocks },
 	ref
 ) {
-	const [
-		items,
-		categories,
-		collections,
-		onSelectItem,
-		allItems,
-		createNewBlock,
-	] = useBlockTypesState( rootClientId, onInsert );
-
-	const insertionIndex = useSelect( ( select ) => {
-		const { getBlockOrder } = select( blockEditorStore );
-
-		// Last item.
-		return getBlockOrder().length;
-	} );
-
-	const [ , onInsertBlocks ] = useInsertionPoint( { insertionIndex } );
-
-	const onSelectGeneralItem = (
-		{ name, initialAttributes, innerBlocks, syncStatus, content },
-		shouldFocusBlock
-	) => {
-		const newBlock = createNewBlock( {
-			content,
-			name,
-			initialAttributes,
-			innerBlocks,
-			syncStatus,
-		} );
-
-		onInsertBlocks( newBlock, undefined, shouldFocusBlock );
-	};
+	const [ items, categories, collections, onSelectItem, allItems ] =
+		useBlockTypesState( rootClientId, onInsert );
 
 	const suggestedItems = useMemo( () => {
 		return orderBy( items, 'frecency', 'desc' ).slice(
@@ -223,7 +190,7 @@ export function BlockTypesTab(
 						<InserterPanel title={ _x( 'All blocks', 'blocks' ) }>
 							<BlockTypesList
 								items={ allItems }
-								onSelect={ onSelectGeneralItem }
+								onSelect={ onSelectItem }
 								onHover={ onHover }
 								label={ _x( 'All blocks', 'blocks' ) }
 							/>

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -14,6 +14,7 @@ import useBlockTypesState from './hooks/use-block-types-state';
 import InserterListbox from '../inserter-listbox';
 import { orderBy } from '../../utils/sorting';
 import InserterNoResults from './no-results';
+import useInsertionPoint from './hooks/use-insertion-point';
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
@@ -31,10 +32,14 @@ export function BlockTypesTab(
 	{ rootClientId, onInsert, onHover, showMostUsedBlocks },
 	ref
 ) {
-	const [ items, categories, collections, onSelectItem ] = useBlockTypesState(
-		rootClientId,
-		onInsert
-	);
+	const [ items, categories, collections, onSelectItem, allItems ] =
+		useBlockTypesState( rootClientId, onInsert );
+
+	const [ , onInsertBlocks ] = useInsertionPoint( {} );
+
+	const onSelectGeneralItem = ( blocks, meta, shouldForceFocusBlock ) => {
+		onInsertBlocks( blocks, meta, shouldForceFocusBlock );
+	};
 
 	const suggestedItems = useMemo( () => {
 		return orderBy( items, 'frecency', 'desc' ).slice(
@@ -104,6 +109,14 @@ export function BlockTypesTab(
 	if ( ! items.length ) {
 		return <InserterNoResults />;
 	}
+
+	const availableCategories = categories.filter( ( category ) => {
+		const categoryItems = itemsPerCategory[ category.slug ];
+		if ( ! categoryItems || ! categoryItems.length ) {
+			return false;
+		}
+		return category;
+	} );
 
 	return (
 		<InserterListbox>
@@ -176,6 +189,20 @@ export function BlockTypesTab(
 							</InserterPanel>
 						);
 					}
+				) }
+
+				{ ( items.length === 0 ||
+					availableCategories.length === 1 ) && (
+					<div className="block-editor-inserter__tips">
+						<InserterPanel title={ _x( 'All blocks', 'blocks' ) }>
+							<BlockTypesList
+								items={ allItems }
+								onSelect={ onSelectGeneralItem }
+								onHover={ onHover }
+								label={ _x( 'All blocks', 'blocks' ) }
+							/>
+						</InserterPanel>
+					</div>
 				) }
 			</div>
 		</InserterListbox>

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -14,6 +14,8 @@ import useBlockTypesState from './hooks/use-block-types-state';
 import InserterListbox from '../inserter-listbox';
 import { orderBy } from '../../utils/sorting';
 import InserterNoResults from './no-results';
+import { select } from '@wordpress/data';
+import { store as blockEditorStore } from '../../store';
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
@@ -31,6 +33,7 @@ export function BlockTypesTab(
 	{ rootClientId, onInsert, onHover, showMostUsedBlocks },
 	ref
 ) {
+	const { getBlockName } = select( blockEditorStore );
 	const [ items, categories, collections, onSelectItem, allItems ] =
 		useBlockTypesState( rootClientId, onInsert );
 
@@ -99,6 +102,13 @@ export function BlockTypesTab(
 	// Hide block preview on unmount.
 	useEffect( () => () => onHover( null ), [] );
 
+	const getRootBlockTitle = () => {
+		const blockName = getBlockName( rootClientId );
+		// Find the title within the list of all possible blocks.
+		const block = allItems.find( ( item ) => item.name === blockName );
+		return block ? block.title : __( 'Allowed' );
+	};
+
 	/**
 	 * The inserter contains a big number of blocks and opening it is a costful operation.
 	 * The rendering is the most costful part of it, in order to improve the responsiveness
@@ -150,7 +160,7 @@ export function BlockTypesTab(
 							key={ category.slug }
 							title={
 								categoryItems.length === 1
-									? __( 'Allowed' ) // Maybe check the parent block name and use that instead, like "List Block"?
+									? getRootBlockTitle()
 									: category.title
 							}
 							icon={ category.icon }

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -31,7 +31,7 @@ export function BlockTypesTab(
 	{ rootClientId, onInsert, onHover, showMostUsedBlocks },
 	ref
 ) {
-	const [ allItems, items, categories, collections, onSelectItem ] =
+	const [ items, categories, collections, onSelectItem, allItems ] =
 		useBlockTypesState( rootClientId, onInsert );
 
 	const allItemsPerCategory = useMemo( () => {

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -31,13 +31,17 @@ export function BlockTypesTab(
 	{ rootClientId, onInsert, onHover, showMostUsedBlocks },
 	ref
 ) {
-	const [ items, categories, collections, onSelectItem ] = useBlockTypesState(
-		rootClientId,
-		onInsert
-	);
+	// Find the root of what we _can_ insert into for this block.
+	// const { rootContentBlockId } = useSelect( ( select ) => {
+	// 	// Try the empty root first.
+	// 	const { getAllowedBlockTypes } = select( 'core/block-editor' );
 
-	// TODO: Split this into its own component that has all items?
-	const [ allItems, allCategories ] = useBlockTypesState( '', () => {} );
+	// 	select( 'core/block-editor' ).getInserterItems( rootClientId );
+
+	// }, [] );
+
+	const [ allItems, items, categories, collections, onSelectItem ] =
+		useBlockTypesState( rootClientId, onInsert );
 
 	const allItemsPerCategory = useMemo( () => {
 		return pipe(
@@ -122,10 +126,6 @@ export function BlockTypesTab(
 		didRenderAllCategories ? collectionEntries : EMPTY_ARRAY
 	);
 
-	if ( ! items.length ) {
-		return <InserterNoResults />;
-	}
-
 	const availableCategories = categories.filter( ( category ) => {
 		const categoryItems = itemsPerCategory[ category.slug ];
 		if ( ! categoryItems || ! categoryItems.length ) {
@@ -137,6 +137,7 @@ export function BlockTypesTab(
 	return (
 		<InserterListbox>
 			<div ref={ ref }>
+				{ ! items.length && ! allItems.length && <InserterNoResults /> }
 				{ showMostUsedBlocks && !! suggestedItems.length && (
 					<InserterPanel title={ _x( 'Most used', 'blocks' ) }>
 						<BlockTypesList
@@ -214,7 +215,7 @@ export function BlockTypesTab(
 				{ ( items.length === 0 ||
 					availableCategories.length === 1 ) && (
 					<div className="block-editor-inserter__all-blocks">
-						{ allCategories.map( ( category ) => {
+						{ categories.map( ( category ) => {
 							const categoryItems =
 								allItemsPerCategory[ category.slug ];
 							return (

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useMemo, useEffect, forwardRef } from '@wordpress/element';
 import { pipe, useAsyncList } from '@wordpress/compose';
 
@@ -106,7 +106,13 @@ export function BlockTypesTab(
 		const blockName = getBlockName( rootClientId );
 		// Find the title within the list of all possible blocks.
 		const block = allItems.find( ( item ) => item.name === blockName );
-		return block ? block.title : __( 'Allowed' );
+		return block
+			? sprintf(
+					// translators: %s: Block title, e.g: "List", "Buttons", "Group"
+					__( '%s Block' ),
+					block.title
+			  )
+			: __( 'Allowed' );
 	};
 
 	/**

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -30,6 +30,20 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 		[ rootClientId ]
 	);
 
+	const [ allItems ] = useSelect(
+		( select ) => {
+			// get top most block client id
+			const rootBlockClientId =
+				select( blockEditorStore ).getBlockRootClientId( rootClientId );
+			return [
+				select( blockEditorStore ).getInserterItems(
+					rootBlockClientId
+				),
+			];
+		},
+		[ rootClientId ]
+	);
+
 	const [ categories, collections ] = useSelect( ( select ) => {
 		const { getCategories, getCollections } = select( blocksStore );
 		return [ getCategories(), getCollections() ];
@@ -56,7 +70,7 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 		[ onInsert ]
 	);
 
-	return [ items, categories, collections, onSelectItem ];
+	return [ items, categories, collections, onSelectItem, allItems ];
 };
 
 export default useBlockTypesState;

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -76,7 +76,7 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 		[ onInsert ]
 	);
 
-	return [ allItems, items, categories, collections, onSelectItem ];
+	return [ items, categories, collections, onSelectItem, allItems ];
 };
 
 export default useBlockTypesState;

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -49,52 +49,28 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 		return [ getCategories(), getCollections() ];
 	}, [] );
 
-	const createNewBlock = ( {
-		content,
-		name,
-		initialAttributes,
-		innerBlocks,
-		syncStatus,
-	} ) => {
-		return syncStatus === 'unsynced'
-			? parse( content, {
-					__unstableSkipMigrationLogs: true,
-			  } )
-			: createBlock(
-					name,
-					initialAttributes,
-					createBlocksFromInnerBlocksTemplate( innerBlocks )
-			  );
-	};
-
 	const onSelectItem = useCallback(
 		(
 			{ name, initialAttributes, innerBlocks, syncStatus, content },
 			shouldFocusBlock
 		) => {
-			onInsert(
-				createNewBlock( {
-					content,
-					name,
-					initialAttributes,
-					innerBlocks,
-					syncStatus,
-				} ),
-				undefined,
-				shouldFocusBlock
-			);
+			const insertedBlock =
+				syncStatus === 'unsynced'
+					? parse( content, {
+							__unstableSkipMigrationLogs: true,
+					  } )
+					: createBlock(
+							name,
+							initialAttributes,
+							createBlocksFromInnerBlocksTemplate( innerBlocks )
+					  );
+
+			onInsert( insertedBlock, undefined, shouldFocusBlock );
 		},
 		[ onInsert ]
 	);
 
-	return [
-		items,
-		categories,
-		collections,
-		onSelectItem,
-		allItems,
-		createNewBlock,
-	];
+	return [ items, categories, collections, onSelectItem, allItems ];
 };
 
 export default useBlockTypesState;

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -23,6 +23,26 @@ import { store as blockEditorStore } from '../../../store';
  * @return {Array} Returns the block types state. (block types, categories, collections, onSelect handler)
  */
 const useBlockTypesState = ( rootClientId, onInsert ) => {
+	const [ allItems ] = useSelect( ( select ) => {
+		const { getBlocksByName, getInserterItems } =
+			select( blockEditorStore );
+
+		// Try the empty root first.
+		const rootInserterItems = getInserterItems( '' );
+		if ( rootInserterItems.length ) {
+			return [ rootInserterItems ];
+		}
+
+		const postContentBlock = getBlocksByName( 'core/post-content' );
+
+		if ( postContentBlock.length ) {
+			return [ getInserterItems( postContentBlock[ 0 ] ) ];
+		}
+
+		// Failsafe
+		return [ [] ];
+	}, [] );
+
 	const [ items ] = useSelect(
 		( select ) => [
 			select( blockEditorStore ).getInserterItems( rootClientId ),
@@ -57,7 +77,7 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 		[ onInsert ]
 	);
 
-	return [ items, categories, collections, onSelectItem ];
+	return [ allItems, items, categories, collections, onSelectItem ];
 };
 
 export default useBlockTypesState;

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -24,24 +24,23 @@ import { store as blockEditorStore } from '../../../store';
  */
 const useBlockTypesState = ( rootClientId, onInsert ) => {
 	const [ allItems ] = useSelect( ( select ) => {
-		const { getBlocksByName, getInserterItems } =
-			select( blockEditorStore );
+		let availableItems = select( blockEditorStore ).getInserterItems( '' );
 
-		// Try the empty root first.
-		const rootInserterItems = getInserterItems( '' );
-		if ( rootInserterItems.length ) {
-			return [ rootInserterItems ];
+		// use current selection as root for situations like
+		// template locked mode
+		const rootBlocks = select( blockEditorStore ).getBlocks();
+		while ( availableItems.length === 0 ) {
+			for ( const block of rootBlocks ) {
+				availableItems = select( blockEditorStore ).getInserterItems(
+					block.clientId
+				);
+				if ( availableItems.length ) {
+					break;
+				}
+			}
 		}
-
-		const postContentBlock = getBlocksByName( 'core/post-content' );
-
-		if ( postContentBlock.length ) {
-			return [ getInserterItems( postContentBlock[ 0 ] ) ];
-		}
-
-		// Failsafe
-		return [ [] ];
-	}, [] );
+		return [ availableItems ];
+	} );
 
 	const [ items ] = useSelect(
 		( select ) => [

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -30,22 +30,9 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 		[ rootClientId ]
 	);
 
-	const [ allItems ] = useSelect(
-		( select ) => {
-			// get top most block client id
-			const rootBlockClientId =
-				select( blockEditorStore ).getBlockRootClientId( rootClientId );
-			return [
-				select( blockEditorStore ).getInserterItems(
-					rootBlockClientId
-				),
-			];
-		},
-		[ rootClientId ]
-	);
-
 	const [ categories, collections ] = useSelect( ( select ) => {
 		const { getCategories, getCollections } = select( blocksStore );
+
 		return [ getCategories(), getCollections() ];
 	}, [] );
 
@@ -70,7 +57,7 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 		[ onInsert ]
 	);
 
-	return [ items, categories, collections, onSelectItem, allItems ];
+	return [ items, categories, collections, onSelectItem ];
 };
 
 export default useBlockTypesState;

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -49,28 +49,52 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 		return [ getCategories(), getCollections() ];
 	}, [] );
 
+	const createNewBlock = ( {
+		content,
+		name,
+		initialAttributes,
+		innerBlocks,
+		syncStatus,
+	} ) => {
+		return syncStatus === 'unsynced'
+			? parse( content, {
+					__unstableSkipMigrationLogs: true,
+			  } )
+			: createBlock(
+					name,
+					initialAttributes,
+					createBlocksFromInnerBlocksTemplate( innerBlocks )
+			  );
+	};
+
 	const onSelectItem = useCallback(
 		(
 			{ name, initialAttributes, innerBlocks, syncStatus, content },
 			shouldFocusBlock
 		) => {
-			const insertedBlock =
-				syncStatus === 'unsynced'
-					? parse( content, {
-							__unstableSkipMigrationLogs: true,
-					  } )
-					: createBlock(
-							name,
-							initialAttributes,
-							createBlocksFromInnerBlocksTemplate( innerBlocks )
-					  );
-
-			onInsert( insertedBlock, undefined, shouldFocusBlock );
+			onInsert(
+				createNewBlock( {
+					content,
+					name,
+					initialAttributes,
+					innerBlocks,
+					syncStatus,
+				} ),
+				undefined,
+				shouldFocusBlock
+			);
 		},
 		[ onInsert ]
 	);
 
-	return [ items, categories, collections, onSelectItem, allItems ];
+	return [
+		items,
+		categories,
+		collections,
+		onSelectItem,
+		allItems,
+		createNewBlock,
+	];
 };
 
 export default useBlockTypesState;

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -119,6 +119,7 @@ function useInsertionPoint( {
 					meta
 				);
 			} else {
+				// Check here to see if we _can_ insert the block in the location?
 				insertBlocks(
 					blocks,
 					destinationIndex,

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -51,10 +51,7 @@ function useInsertionPoint( {
 	} = useSelect( blockEditorStore );
 	const { destinationRootClientId, destinationIndex } = useSelect(
 		( select ) => {
-			const {
-				getSelectedBlockClientId,
-				getBlockRootClientId: _getBlockRootClientId,
-			} = select( blockEditorStore );
+			const { getSelectedBlockClientId } = select( blockEditorStore );
 			const selectedBlockClientId = getSelectedBlockClientId();
 
 			let _destinationRootClientId = rootClientId;
@@ -67,7 +64,7 @@ function useInsertionPoint( {
 				// Insert after a specific client ID.
 				_destinationIndex = getBlockIndex( clientId );
 			} else if ( ! isAppender && selectedBlockClientId ) {
-				_destinationRootClientId = _getBlockRootClientId(
+				_destinationRootClientId = getBlockRootClientId(
 					selectedBlockClientId
 				);
 				_destinationIndex = getBlockIndex( selectedBlockClientId ) + 1;
@@ -81,7 +78,6 @@ function useInsertionPoint( {
 			return {
 				destinationRootClientId: _destinationRootClientId,
 				destinationIndex: _destinationIndex,
-				getBlockRootClientId: _getBlockRootClientId,
 			};
 		},
 		[ rootClientId, insertionIndex, clientId, isAppender ]

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -44,6 +44,7 @@ function useInsertionPoint( {
 } ) {
 	const {
 		getSelectedBlock,
+		getBlocksByName,
 		getBlockIndex,
 		getBlockRootClientId,
 		getBlockOrder,
@@ -142,9 +143,17 @@ function useInsertionPoint( {
 						_destinationRootClientId
 					);
 
-					// If we are at the root, there's nothing more to check
 					if ( _destinationRootClientId === null ) {
-						break;
+						// If we are at the root, try to find a post content block
+						const postContentBlock =
+							getBlocksByName( 'core/post-content' );
+						if ( postContentBlock.length ) {
+							_destinationRootClientId = postContentBlock[ 0 ];
+							// Insert at the end of the post content block.
+							_destinationIndex = getBlockOrder(
+								postContentBlock[ 0 ]
+							).length;
+						}
 					}
 				}
 
@@ -181,6 +190,10 @@ function useInsertionPoint( {
 			onSelect,
 			shouldFocusBlock,
 			selectBlockOnInsert,
+			setLastFocus,
+			canInsertBlockType,
+			getBlockOrder,
+			getBlocksByName,
 		]
 	);
 

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -135,6 +135,35 @@ function useInsertionPoint( {
 							_destinationRootClientId
 						)
 					);
+				if ( ! canInsertBlocks && normalizedBlocks.length === 1 ) {
+					// If it's not possible to insert the block in the current location, try to find a new location up the tree
+					while (
+						! canInsertBlockType(
+							normalizedBlocks[ 0 ].name,
+							_destinationRootClientId
+						)
+					) {
+						// save the index of the previous destination root client ID
+						const _previousDestinationRootClientId =
+							_destinationRootClientId;
+						_destinationIndex =
+							getBlockIndex( _previousDestinationRootClientId ) +
+							1;
+
+						// get the parent of the current destination root client ID
+						_destinationRootClientId = getBlockRootClientId(
+							_destinationRootClientId
+						);
+
+						// Break the loop if we searched the whole tree
+						if (
+							_previousDestinationRootClientId ===
+							_destinationRootClientId
+						) {
+							break;
+						}
+					}
+				}
 
 				while ( ! canInsertBlocks() ) {
 					_destinationIndex =

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -82,18 +82,23 @@ function useInsertionPoint( {
 				).length;
 			}
 
+			// When we're using the appender or an insertion index has been passed directly,
+			// we want to use that over our "best guess" block insertion point
+			const isDirectInsert = insertionIndex !== undefined || isAppender;
+			const shouldUseBlockInsertionPoint =
+				! isDirectInsert &&
+				blockInsertionPoint?.rootClientId !== undefined &&
+				blockInsertionPoint?.index !== undefined;
+
 			return {
 				destinationRootClientId: _destinationRootClientId,
 				destinationIndex: _destinationIndex,
-				blockInsertionRootClientId:
-					blockInsertionPoint?.rootClientId !== undefined &&
-					! isAppender
-						? blockInsertionPoint.rootClientId
-						: _destinationRootClientId,
-				blockInsertionIndex:
-					blockInsertionPoint?.index !== undefined && ! isAppender
-						? blockInsertionPoint.index
-						: _destinationIndex,
+				blockInsertionRootClientId: shouldUseBlockInsertionPoint
+					? blockInsertionPoint.rootClientId
+					: _destinationRootClientId,
+				blockInsertionIndex: shouldUseBlockInsertionPoint
+					? blockInsertionPoint.index
+					: _destinationIndex,
 			};
 		},
 		[ rootClientId, insertionIndex, clientId, isAppender ]

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -86,11 +86,12 @@ function useInsertionPoint( {
 				destinationRootClientId: _destinationRootClientId,
 				destinationIndex: _destinationIndex,
 				blockInsertionRootClientId:
-					blockInsertionPoint?.rootClientId !== undefined
+					blockInsertionPoint?.rootClientId !== undefined &&
+					! isAppender
 						? blockInsertionPoint.rootClientId
 						: _destinationRootClientId,
 				blockInsertionIndex:
-					blockInsertionPoint?.index !== undefined
+					blockInsertionPoint?.index !== undefined && ! isAppender
 						? blockInsertionPoint.index
 						: _destinationIndex,
 			};

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -48,6 +48,7 @@ function useInsertionPoint( {
 		getBlockIndex,
 		getBlockRootClientId,
 		getBlockOrder,
+		getBlocks,
 		canInsertBlockType,
 	} = useSelect( blockEditorStore );
 	const { destinationRootClientId, destinationIndex } = useSelect(
@@ -135,8 +136,10 @@ function useInsertionPoint( {
 							_destinationRootClientId
 						)
 					);
-				if ( ! canInsertBlocks && normalizedBlocks.length === 1 ) {
+				if ( ! canInsertBlocks() && normalizedBlocks.length === 1 ) {
 					// If it's not possible to insert the block in the current location, try to find a new location up the tree
+					const rootBlocks = getBlocks();
+					const currentRootBlock = 0;
 					while (
 						! canInsertBlockType(
 							normalizedBlocks[ 0 ].name,
@@ -160,28 +163,12 @@ function useInsertionPoint( {
 							_previousDestinationRootClientId ===
 							_destinationRootClientId
 						) {
-							break;
-						}
-					}
-				}
-
-				while ( ! canInsertBlocks() ) {
-					_destinationIndex =
-						getBlockIndex( _destinationRootClientId ) + 1;
-					_destinationRootClientId = getBlockRootClientId(
-						_destinationRootClientId
-					);
-
-					if ( _destinationRootClientId === null ) {
-						// If we are at the root, try to find a post content block
-						const postContentBlock =
-							getBlocksByName( 'core/post-content' );
-						if ( postContentBlock.length ) {
-							_destinationRootClientId = postContentBlock[ 0 ];
-							// Insert at the end of the post content block.
-							_destinationIndex = getBlockOrder(
-								postContentBlock[ 0 ]
-							).length;
+							if ( currentRootBlock === rootBlocks.length ) {
+								break;
+							}
+							// also try to find an insertable block top down
+							const rootBlock = rootBlocks[ currentRootBlock ];
+							_destinationRootClientId = rootBlock.clientId;
 						}
 					}
 				}

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -126,23 +126,25 @@ function useInsertionPoint( {
 
 				let _destinationIndex = destinationIndex;
 				let _destinationRootClientId = destinationRootClientId;
-				// Check if it's possible to insert the block in the current location
-				const canInsertBlocks = normalizedBlocks.every( ( block ) =>
-					canInsertBlockType( block.name, _destinationRootClientId )
-				);
 
-				if ( ! canInsertBlocks && normalizedBlocks.length === 1 ) {
-					while (
-						! canInsertBlockType(
-							normalizedBlocks[ 0 ].name,
+				const canInsertBlocks = () =>
+					normalizedBlocks.every( ( block ) =>
+						canInsertBlockType(
+							block.name,
 							_destinationRootClientId
 						)
-					) {
-						_destinationIndex =
-							getBlockIndex( _destinationRootClientId ) + 1;
-						_destinationRootClientId = getBlockRootClientId(
-							_destinationRootClientId
-						);
+					);
+
+				while ( ! canInsertBlocks() ) {
+					_destinationIndex =
+						getBlockIndex( _destinationRootClientId ) + 1;
+					_destinationRootClientId = getBlockRootClientId(
+						_destinationRootClientId
+					);
+
+					// If we are at the root, there's nothing more to check
+					if ( _destinationRootClientId === null ) {
+						break;
 					}
 				}
 
@@ -170,6 +172,8 @@ function useInsertionPoint( {
 		[
 			isAppender,
 			getSelectedBlock,
+			getBlockIndex,
+			getBlockRootClientId,
 			replaceBlocks,
 			insertBlocks,
 			destinationRootClientId,

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -12,6 +12,7 @@ import {
 	useCallback,
 	useMemo,
 	useRef,
+	useEffect,
 	useLayoutEffect,
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
@@ -77,6 +78,7 @@ function InserterMenu(
 			isAppender,
 			insertionIndex: __experimentalInsertionIndex,
 			shouldFocusBlock,
+			blockToInsert: hoveredItem,
 		} );
 	const blockTypesTabRef = useRef();
 
@@ -111,11 +113,14 @@ function InserterMenu(
 
 	const onHover = useCallback(
 		( item ) => {
-			onToggleInsertionPoint( !! item );
 			setHoveredItem( item );
 		},
-		[ onToggleInsertionPoint, setHoveredItem ]
+		[ setHoveredItem ]
 	);
+
+	useEffect( () => {
+		onToggleInsertionPoint( !! hoveredItem );
+	}, [ onToggleInsertionPoint, hoveredItem ] );
 
 	const onHoverPattern = useCallback(
 		( item ) => {

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -76,15 +76,19 @@ function InserterSearchResults( {
 		selectBlockOnInsert,
 	} );
 	const [
-		blockTypes,
+		availableBlockTypes,
 		blockTypeCategories,
 		blockTypeCollections,
 		onSelectBlockType,
+		allBlockTypes,
 	] = useBlockTypesState( destinationRootClientId, onInsertBlocks );
 	const [ patterns, , onClickPattern ] = usePatternsState(
 		onInsertBlocks,
 		destinationRootClientId
 	);
+
+	const blockTypes =
+		availableBlockTypes.length < 2 ? allBlockTypes : availableBlockTypes;
 
 	const filteredBlockPatterns = useMemo( () => {
 		if ( maxBlockPatterns === 0 ) {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -200,6 +200,10 @@ $block-inserter-tabs-height: 44px;
 	width: 100%;
 }
 
+.block-editor-inserter__all-blocks {
+	border-top: $border-width solid $gray-400;
+}
+
 .block-editor-inserter__no-results,
 .block-editor-inserter__patterns-loading {
 	padding: $grid-unit-40;

--- a/packages/block-editor/src/components/inserter/test/block-types-tab.native.js
+++ b/packages/block-editor/src/components/inserter/test/block-types-tab.native.js
@@ -25,6 +25,7 @@ const selectMock = {
 	getBlockType: jest.fn(),
 	getClipboard: jest.fn(),
 	getSettings: jest.fn( () => ( { impressions: {} } ) ),
+	getBlocks: jest.fn().mockReturnValue( [] ),
 };
 
 describe( 'BlockTypesTab component', () => {

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -513,9 +513,37 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'showInsertionPoint', () => {
-		it( 'should return the SHOW_INSERTION_POINT action', () => {
-			expect( showInsertionPoint() ).toEqual( {
+		it( 'should dispatch the SHOW_INSERTION_POINT action', () => {
+			const select = {};
+
+			const dispatch = jest.fn();
+
+			showInsertionPoint()( { select, dispatch } );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'SHOW_INSERTION_POINT',
+				rootClientId: undefined,
+				index: undefined,
+				__unstableWithInserter: undefined,
+				operation: undefined,
+				nearestSide: undefined,
+			} );
+		} );
+
+		it( 'should dispatch the SHOW_INSERTION_POINT action with passed rootClientId and index', () => {
+			const select = {};
+
+			const dispatch = jest.fn();
+
+			showInsertionPoint( '', 0 )( { select, dispatch } );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: 'SHOW_INSERTION_POINT',
+				rootClientId: '',
+				index: 0,
+				__unstableWithInserter: undefined,
+				operation: undefined,
+				nearestSide: undefined,
 			} );
 		} );
 	} );

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -14,6 +14,7 @@ test.describe( 'Columns', () => {
 
 	test( 'restricts all blocks inside the columns block', async ( {
 		page,
+		pageUtils,
 		editor,
 	} ) => {
 		// Open Columns
@@ -39,11 +40,12 @@ test.describe( 'Columns', () => {
 			.click();
 
 		// Verify Column
-		const inserterOptions = page.locator(
-			'role=region[name="Block Library"i] >> role=option'
-		);
-		await expect( inserterOptions ).toHaveCount( 1 );
-		await expect( inserterOptions ).toHaveText( 'Column' );
+		const columnOption = page.getByRole( 'option', {
+			name: 'Column',
+			exact: true,
+		} );
+		await pageUtils.pressKeys( 'Tab', { times: 2 } );
+		await expect( columnOption ).toBeFocused();
 	} );
 
 	test( 'prevent the removal of locked column block from the column count change UI', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Explores #60991 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Too often the inserter is empty, for instance when opening the inserter while a list block list item is selected or a button in a buttons block, the only available block is the list item , or the button respectively.

This is confusing because it's unclear why the other blocks are not available.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Try to show all the blocks all the time and insert blocks in the nearest possible location.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the site editor or the post editor add a list block
2. Add a list item
3. Open the inserter
4. **Notice all blocks are listed**
5. Insert a block that is _not_ the list item block, e.g. an image block
6. **Notice the image block is inserted right after the parent list block of the currently selected list item block**


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/107534/ffd8aa77-f1fe-4be2-a3f3-77134bc5904a

# Known limitations

- the inserter is still empty when a block in a pattern with overrides is selected and no insertion is possible
- https://github.com/WordPress/gutenberg/pull/61873/files#r1611877561
