### PR TITLE
Try having less of the tree within `EditorProvider`

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -283,14 +283,7 @@ export default function Editor( { isLoading, onClick } ) {
 				</Notice>
 			) }
 			{ isReady && (
-				<EditorProvider
-					post={ postWithTemplate ? contextPost : editedPost }
-					__unstableTemplate={
-						postWithTemplate ? editedPost : undefined
-					}
-					settings={ settings }
-					useSubRegistry={ false }
-				>
+				<>
 					<InterfaceSkeleton
 						isDistractionFree={ isDistractionFree }
 						enableRegionNavigation={ false }
@@ -349,7 +342,16 @@ export default function Editor( { isLoading, onClick } ) {
 							/>
 						}
 						content={
-							<>
+							<EditorProvider
+								post={
+									postWithTemplate ? contextPost : editedPost
+								}
+								__unstableTemplate={
+									postWithTemplate ? editedPost : undefined
+								}
+								settings={ settings }
+								useSubRegistry={ false }
+							>
 								{ isEditMode && <EditorNotices /> }
 								{ editorMode === 'text' && isEditMode && (
 									<CodeEditor />
@@ -360,7 +362,7 @@ export default function Editor( { isLoading, onClick } ) {
 								{ showVisualEditor && (
 									<SiteEditorCanvas onClick={ onClick } />
 								) }
-							</>
+							</EditorProvider>
 						}
 						secondarySidebar={
 							isEditMode &&
@@ -399,7 +401,7 @@ export default function Editor( { isLoading, onClick } ) {
 						}
 					/>
 					{ supportsGlobalStyles && <GlobalStylesSidebar /> }
-				</EditorProvider>
+				</>
 			) }
 		</>
 	);


### PR DESCRIPTION
## What?
Trys a naive fix for some animations that are currently broken. It probably can generally make parts of the interface a teeny bit more snappy (less re-renders).

## Why?
Fixes #60875 and fixes #61875.

## How?
Moves `EditorProvider` to wrap less of the interface—just the content.

## Testing Instructions
- See the linked issues and try reproducing them
- Try finding something else this may break
