### PR TITLE
EntityProvider: Avoid remounts and simplify

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -20,39 +20,7 @@ import { updateFootnotesFromMeta } from './footnotes';
 
 const EMPTY_ARRAY = [];
 
-/**
- * Internal dependencies
- */
-import { rootEntitiesConfig, additionalEntityConfigLoaders } from './entities';
-
-const entityContexts = {
-	...rootEntitiesConfig.reduce( ( acc, loader ) => {
-		if ( ! acc[ loader.kind ] ) {
-			acc[ loader.kind ] = {};
-		}
-		acc[ loader.kind ][ loader.name ] = {
-			context: createContext( undefined ),
-		};
-		return acc;
-	}, {} ),
-	...additionalEntityConfigLoaders.reduce( ( acc, loader ) => {
-		acc[ loader.kind ] = {};
-		return acc;
-	}, {} ),
-};
-const getEntityContext = ( kind, name ) => {
-	if ( ! entityContexts[ kind ] ) {
-		throw new Error( `Missing entity config for kind: ${ kind }.` );
-	}
-
-	if ( ! entityContexts[ kind ][ name ] ) {
-		entityContexts[ kind ][ name ] = {
-			context: createContext( undefined ),
-		};
-	}
-
-	return entityContexts[ kind ][ name ].context;
-};
+const EntityContext = createContext( {} );
 
 /**
  * Context provider component for providing
@@ -68,8 +36,22 @@ const getEntityContext = ( kind, name ) => {
  *                   the entity's context provider.
  */
 export default function EntityProvider( { kind, type: name, id, children } ) {
-	const Provider = getEntityContext( kind, name ).Provider;
-	return <Provider value={ id }>{ children }</Provider>;
+	const parent = useContext( EntityContext );
+	const childContext = useMemo(
+		() => ( {
+			...parent,
+			[ kind ]: {
+				...parent?.[ kind ],
+				[ name ]: id,
+			},
+		} ),
+		[ parent, kind, name, id ]
+	);
+	return (
+		<EntityContext.Provider value={ childContext }>
+			{ children }
+		</EntityContext.Provider>
+	);
 }
 
 /**
@@ -80,7 +62,8 @@ export default function EntityProvider( { kind, type: name, id, children } ) {
  * @param {string} name The entity name.
  */
 export function useEntityId( kind, name ) {
-	return useContext( getEntityContext( kind, name ) );
+	const context = useContext( EntityContext );
+	return context?.[ kind ]?.[ name ];
 }
 
 /**


### PR DESCRIPTION
closes #61875 
Alternative to #61874 

## What?

While debugging #61875 I noticed that the EditorProvider remounts its children when the "entity" changes (for instance when moving from a template to a template part). The reason for this is a poor implementation of the `EntityProvider` component. It was basically using some complex code to use a separate React context per entity.

The current PR simplifies things a bit by using the same provider and hold all the "entity providers" in it. Personally, I think ultimately, we should seek to deprecate the EntityProviders entirely in favor of Block Context. It was a bad idea that stuck but that's for another time.

## Testing Instructions

1- Open the site editor
2- Select a template part and click "edit"
3- The document bar should animate forward
4- Click "back" on the document bar and it should animate backwards.