### PR TITLE
Enable shadow support for cover block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -245,7 +245,7 @@ Add an image or video with a text overlay. ([Source](https://github.com/WordPres
 
 -	**Name:** core/cover
 -	**Category:** media
--	**Supports:** align, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), interactivity (clientNavigation), layout (~~allowJustification~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, tagName, templateLock, url, useFeaturedImage
 
 ## Details

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -85,6 +85,7 @@
 		"anchor": true,
 		"align": true,
 		"html": false,
+		"shadow": true,
 		"spacing": {
 			"padding": true,
 			"margin": [ "top", "bottom" ],


### PR DESCRIPTION
## What?
On previous attempts to do this, the cover block was displaying inconsistencies between how it was rendered in the editor vs the frontend; that doesn't seem to be the case anymore, so we should be enable shadow support without any modifications to the block itself.

I'd still appreciate some eyes on this, because I don't know what exactly has changed since the first time I attempted this.

## Testing Instructions
1. Add a cover block
2. Add a shadow to it
3. Modify the block's border radius and size; modifications should be consistent between frontend and editor.


## Screenshots or screencast <!-- if applicable -->
<img width="1777" alt="image" src="https://github.com/WordPress/gutenberg/assets/1157901/72b19527-5449-4b12-ae4f-9b330c94fadf">

