### PR TITLE
Introduce `wp-on-async` directive as performant alternative over synchronous `wp-on` directive

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -188,12 +188,12 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// Image.
 	$p->next_tag( 'img' );
 	$p->set_attribute( 'data-wp-init', 'callbacks.setButtonStyles' );
-	$p->set_attribute( 'data-wp-on--load', 'callbacks.setButtonStyles' );
-	$p->set_attribute( 'data-wp-on-window--resize', 'callbacks.setButtonStyles' );
+	$p->set_attribute( 'data-wp-on-async--load', 'callbacks.setButtonStyles' );
+	$p->set_attribute( 'data-wp-on-async-window--resize', 'callbacks.setButtonStyles' );
 	// Sets an event callback on the `img` because the `figure` element can also
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.
-	$p->set_attribute( 'data-wp-on--click', 'actions.showLightbox' );
+	$p->set_attribute( 'data-wp-on-async--click', 'actions.showLightbox' );
 
 	$body_content = $p->get_updated_html();
 
@@ -209,7 +209,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			aria-haspopup="dialog"
 			aria-label="' . esc_attr( $aria_label ) . '"
 			data-wp-init="callbacks.initTriggerButton"
-			data-wp-on--click="actions.showLightbox"
+			data-wp-on-async--click="actions.showLightbox"
 			data-wp-style--right="context.imageButtonRight"
 			data-wp-style--top="context.imageButtonTop"
 		>
@@ -258,12 +258,12 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-class--show-closing-animation="state.showClosingAnimation"
 			data-wp-watch="callbacks.setOverlayFocus"
 			data-wp-on--keydown="actions.handleKeydown"
-			data-wp-on--touchstart="actions.handleTouchStart"
+			data-wp-on-async--touchstart="actions.handleTouchStart"
 			data-wp-on--touchmove="actions.handleTouchMove"
-			data-wp-on--touchend="actions.handleTouchEnd"
-			data-wp-on--click="actions.hideLightbox"
-			data-wp-on-window--resize="callbacks.setOverlayStyles"
-			data-wp-on-window--scroll="actions.handleScroll"
+			data-wp-on-async--touchend="actions.handleTouchEnd"
+			data-wp-on-async--click="actions.hideLightbox"
+			data-wp-on-async-window--resize="callbacks.setOverlayStyles"
+			data-wp-on-async-window--scroll="actions.handleScroll"
 			tabindex="-1"
 			>
 				<button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button">

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 ## Unreleased
 
-### Bug fixes
+### New Features
 
--	Fix null and number strings as namespaces runtime error. ([#61960](https://github.com/WordPress/gutenberg/pull/61960/))
+-   Introduce `wp-on-async` directive as performant alternative over synchronous `wp-on` directive. ([#61885](https://github.com/WordPress/gutenberg/pull/61885))
 
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
 -   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
+### Bug fixes
+
+-	Fix null and number strings as namespaces runtime error. ([#61960](https://github.com/WordPress/gutenberg/pull/61960/))
 
 ## 5.7.0 (2024-05-16)
 

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -214,10 +214,10 @@ const getGlobalEventDirective = ( type: 'window' | 'document' ) => {
 	return ( { directives, evaluate } ) => {
 		directives[ `on-${ type }` ]
 			.filter( ( { suffix } ) => suffix !== 'default' )
-			.forEach( ( entry ) => {
+			.forEach( ( entry: DirectiveEntry ) => {
 				const eventName = entry.suffix.split( '--', 1 )[ 0 ];
 				useInit( () => {
-					const cb = ( event ) => evaluate( entry, event );
+					const cb = ( event: Event ) => evaluate( entry, event );
 					const globalVar = type === 'window' ? window : document;
 					globalVar.addEventListener( eventName, cb );
 					return () => globalVar.removeEventListener( eventName, cb );

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -12,6 +12,7 @@ import { deepSignal, peek, type DeepSignal } from 'deepsignal';
  * Internal dependencies
  */
 import { useWatch, useInit, kebabToCamelCase, warn } from './utils';
+import type { DirectiveEntry } from './hooks';
 import { directive, getScope, getEvaluate } from './hooks';
 
 // Assigned objects should be ignore during proxification.
@@ -281,19 +282,19 @@ export default () => {
 
 	// data-wp-on--[event]
 	directive( 'on', ( { directives: { on }, element, evaluate } ) => {
-		const events = new Map();
+		const events = new Map< string, Set< DirectiveEntry > >();
 		on.filter( ( { suffix } ) => suffix !== 'default' ).forEach(
 			( entry ) => {
 				const event = entry.suffix.split( '--' )[ 0 ];
 				if ( ! events.has( event ) ) {
-					events.set( event, new Set() );
+					events.set( event, new Set< DirectiveEntry >() );
 				}
-				events.get( event ).add( entry );
+				events.get( event )!.add( entry );
 			}
 		);
 
 		events.forEach( ( entries, eventType ) => {
-			element.props[ `on${ eventType }` ] = ( event ) => {
+			element.props[ `on${ eventType }` ] = ( event: Event ) => {
 				entries.forEach( ( entry ) => {
 					evaluate( entry, event );
 				} );

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -21,7 +21,7 @@ import {
 import type { DirectiveEntry } from './hooks';
 import { directive, getScope, getEvaluate } from './hooks';
 
-// Assigned objects should be ignore during proxification.
+// Assigned objects should be ignored during proxification.
 const contextAssignedObjects = new WeakMap();
 
 // Store the context proxy and fallback for each object in the context.

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -19,7 +19,7 @@ import type { VNode, Context, RefObject } from 'preact';
  */
 import { store, stores, universalUnlock } from './store';
 import { warn } from './utils';
-interface DirectiveEntry {
+export interface DirectiveEntry {
 	value: string | object;
 	namespace: string;
 	suffix: string;

--- a/packages/interactivity/src/init.ts
+++ b/packages/interactivity/src/init.ts
@@ -6,7 +6,7 @@ import { hydrate, type ContainerNode, type ComponentChild } from 'preact';
  * Internal dependencies
  */
 import { toVdom, hydratedIslands } from './vdom';
-import { createRootFragment } from './utils';
+import { createRootFragment, yieldToMain } from './utils';
 import { directivePrefix } from './constants';
 
 // Keep the same root fragment for each interactive region node.
@@ -23,13 +23,6 @@ export const getRegionRootFragment = ( region: Element ): ContainerNode => {
 	}
 	return regionRootFragments.get( region );
 };
-
-function yieldToMain() {
-	return new Promise( ( resolve ) => {
-		// TODO: Use scheduler.yield() when available.
-		setTimeout( resolve, 0 );
-	} );
-}
 
 // Initial vDOM regions associated with its DOM element.
 export const initialVdom = new WeakMap< Element, ComponentChild[] >();

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -50,6 +50,18 @@ const afterNextFrame = ( callback: () => void ) => {
 };
 
 /**
+ * Returns a promise that resolves after yielding to main.
+ *
+ * @return Promise
+ */
+export const yieldToMain = () => {
+	return new Promise( ( resolve ) => {
+		// TODO: Use scheduler.yield() when available.
+		setTimeout( resolve, 0 );
+	} );
+};
+
+/**
  * Creates a Flusher object that can be used to flush computed values and notify listeners.
  *
  * Using the mangled properties:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #61634.

## What?

This adds an alternative async variation to the `data-wp-on` directives by tagging on an `-async` to the directive name. So instead of `data-wp-on--click` it can be `data-wp-on-async--click`. This is also done for the `data-wp-on-window` and `data-wp-on-document` directives with `data-wp-on-async-window` and`data-wp-on-async-document` respectively (which here can also be made `passive`).

## Why?

This ensures that when there are multiple directives for the same event, they do not add up to a long task.

## How?

This directive yields to the main thread immediately before invoking the action/callback.

This is implemented for the eligible directives in the Image block. 

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Install and activate this [Try Slow Events](https://gist.github.com/westonruter/59f7c58230bd5d1e82733e5b87d245dc) plugin which adds 10 click event directives to the `img` in an Image block.
2. Add an Image to a post and enable the click-to-expand feature.
3. Navigate to the post on the frontend.
4. First add `?try-slow-events=sync` to the URL and try opening the image in a lightbox. Notice the latency.
5. Second, try `?try-slow-events=async` to the URL and try opening the image in a lightbox. Notice the latency goes away.

## Screenshots or screencast <!-- if applicable -->

### Before (`?try-slow-events=sync`)

[Screen recording 2024-05-22 17.34.29.webm](https://github.com/WordPress/gutenberg/assets/134745/5ffb9ab4-1706-44f7-989f-812b8c8a35d2)

![image](https://github.com/WordPress/gutenberg/assets/134745/a14c546f-210b-4a9a-a884-91eab25bd8d2)

### After (`?try-slow-events=async`)

[Screen recording 2024-05-22 17.34.52.webm](https://github.com/WordPress/gutenberg/assets/134745/19457cf1-a9d0-43a3-8f8e-731007be6cf4)

![image](https://github.com/WordPress/gutenberg/assets/134745/a35633e4-ae03-44e9-979d-e452696da84a)

(Aside: The `yieldToMain()` seems it could be improved yet further since a long task is still sneaking in, even though it is much better.)