### PR TITLE
Global styles: relocate Background Image controls to sit under Layout

### DIFF
--- a/packages/edit-site/src/components/global-styles/background-panel.js
+++ b/packages/edit-site/src/components/global-styles/background-panel.js
@@ -59,7 +59,7 @@ export default function BackgroundPanel() {
 			value={ style }
 			onChange={ setStyle }
 			settings={ settings }
-			headerLabel={ __( 'Image' ) }
+			headerLabel={ __( 'Background' ) }
 			defaultValues={ BACKGROUND_DEFAULT_VALUES }
 			defaultControls={ defaultControls }
 			themeFileURIs={ _links?.[ 'wp:theme-file' ] }

--- a/packages/edit-site/src/components/global-styles/root-menu.js
+++ b/packages/edit-site/src/components/global-styles/root-menu.js
@@ -6,7 +6,6 @@ import {
 	typography,
 	color,
 	layout,
-	image,
 	shadow as shadowIcon,
 } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -24,7 +23,6 @@ const {
 	useHasColorPanel,
 	useGlobalSetting,
 	useSettingsForBlockElement,
-	useHasBackgroundPanel,
 } = unlock( blockEditorPrivateApis );
 
 function RootMenu() {
@@ -35,7 +33,6 @@ function RootMenu() {
 	const hasShadowPanel = true; // useHasShadowPanel( settings );
 	const hasDimensionsPanel = useHasDimensionsPanel( settings );
 	const hasLayoutPanel = hasDimensionsPanel;
-	const hasBackgroundPanel = useHasBackgroundPanel( settings );
 
 	return (
 		<>
@@ -74,15 +71,6 @@ function RootMenu() {
 						aria-label={ __( 'Layout styles' ) }
 					>
 						{ __( 'Layout' ) }
-					</NavigationButtonAsItem>
-				) }
-				{ hasBackgroundPanel && (
-					<NavigationButtonAsItem
-						icon={ image }
-						path="/background"
-						aria-label={ __( 'Background image styles' ) }
-					>
-						{ __( 'Background image' ) }
 					</NavigationButtonAsItem>
 				) }
 			</ItemGroup>

--- a/packages/edit-site/src/components/global-styles/screen-layout.js
+++ b/packages/edit-site/src/components/global-styles/screen-layout.js
@@ -8,20 +8,27 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import DimensionsPanel from './dimensions-panel';
+import BackgroundPanel from './background-panel';
 import ScreenHeader from './header';
 import { unlock } from '../../lock-unlock';
 
-const { useHasDimensionsPanel, useGlobalSetting, useSettingsForBlockElement } =
-	unlock( blockEditorPrivateApis );
+const {
+	useHasBackgroundPanel,
+	useHasDimensionsPanel,
+	useGlobalSetting,
+	useSettingsForBlockElement,
+} = unlock( blockEditorPrivateApis );
 
 function ScreenLayout() {
 	const [ rawSettings ] = useGlobalSetting( '' );
 	const settings = useSettingsForBlockElement( rawSettings );
 	const hasDimensionsPanel = useHasDimensionsPanel( settings );
+	const hasBackgroundPanel = useHasBackgroundPanel( settings );
 	return (
 		<>
 			<ScreenHeader title={ __( 'Layout' ) } />
 			{ hasDimensionsPanel && <DimensionsPanel /> }
+			{ hasBackgroundPanel && <BackgroundPanel /> }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -41,7 +41,6 @@ import ScreenStyleVariations from './screen-style-variations';
 import StyleBook from '../style-book';
 import ScreenCSS from './screen-css';
 import ScreenRevisions from './screen-revisions';
-import ScreenBackground from './screen-background';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 
@@ -356,10 +355,6 @@ function GlobalStylesUI() {
 
 			<GlobalStylesNavigationScreen path={ '/revisions' }>
 				<ScreenRevisions />
-			</GlobalStylesNavigationScreen>
-
-			<GlobalStylesNavigationScreen path={ '/background' }>
-				<ScreenBackground />
 			</GlobalStylesNavigationScreen>
 
 			{ blocks.map( ( block ) => (


### PR DESCRIPTION
## What?

This PR relocates the Background Image controls to sit under Layout in the global styles sidebar.

It also removes the Background image top-level navigation item.

Background image controls were originally added to global styles in https://github.com/WordPress/gutenberg/pull/59454

There are no modifications to functionality.


## Why?

The global styles taxonomy is under review and will likely change between now and WordPress 6.7.

See discussion:

- https://github.com/WordPress/gutenberg/issues/61494#issuecomment-2116865577


The ambition in this PR is to make a low-impact change to the global styles taxonomy until these changes are implemented.


## How?
Just movin' stuff around. 

## Testing Instructions

The main concern here is whether the location of Background controls, despite it being temporary, is a reasonable step and won't introduce too much confusion.

Furthermore, as no functionality is being introduced, it would be great to smoke test that the background controls work as they should, e.g., 

- you should be able to add and edit a site-wide background image by heading to **Global styles > Layout > Background**
- you should still be able to set a background image in your theme.json and have it appear in the controls



## Screenshots or screencast <!-- if applicable -->

<img width="279" alt="Screenshot 2024-05-23 at 10 36 48 am" src="https://github.com/WordPress/gutenberg/assets/6458278/d3d00476-44ce-4658-bf1b-e595e7006524">

<img width="269" alt="Screenshot 2024-05-23 at 10 37 30 am" src="https://github.com/WordPress/gutenberg/assets/6458278/c0ba6589-a186-47db-a49b-f465591f2885">

