### PR TITLE
Fix Post Excerpt length when there's no excerpt and post content is used instead

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -37,7 +37,10 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	add_filter( 'excerpt_length', function ( $length ) use ( $excerpt_length ) {
 		return isset( $excerpt_length ) ? $excerpt_length : $length;
 	}, 10, 1 );
-
+	
+	$excerpt        = get_the_excerpt( $block->context['postId'] );
+	if ( isset( $excerpt_length ) ) {
+		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -39,7 +39,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	};
 	add_filter( 'excerpt_length', $filter_excerpt_length );
 
-	$excerpt        = get_the_excerpt( $block->context['postId'] );
+	$excerpt = get_the_excerpt( $block->context['postId'] );
 	if ( isset( $excerpt_length ) ) {
 		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
 	}

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -27,9 +27,17 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	* wp_trim_words is used instead.
 	*/
 	$excerpt_length = $attributes['excerptLength'];
-	$excerpt        = get_the_excerpt( $block->context['postId'] );
-	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
+
+	/*
+	* If the post doesn’t have a custom excerpt, get_the_excerpt function function
+	* will use wp_trim_excerpt() to generate an excerpt. wp_trim_excerpt returns
+	* a maximum of 55 words with an ellipsis appended if necessary. That means we
+	* need to override it with excerpt_length
+	*/
+	add_filter( 'excerpt_length', function ( $length ) use ( $excerpt_length ) {
+		return isset( $excerpt_length ) ? $excerpt_length : $length;
+	}, 10, 1 );
+
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -34,13 +34,11 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	* a maximum of 55 words with an ellipsis appended if necessary. That means we
 	* need to override it with excerpt_length
 	*/
-	add_filter( 'excerpt_length', function ( $length ) use ( $excerpt_length ) {
+	$filter_excerpt_length = static function ( $length ) use ( $excerpt_length ) {
 		return isset( $excerpt_length ) ? $excerpt_length : $length;
-	}, 10, 1 );
-	
-	$excerpt        = get_the_excerpt( $block->context['postId'] );
-	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
+	};
+	add_filter( 'excerpt_length', $filter_excerpt_length );
+
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
@@ -73,8 +71,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	} else {
 		$content .= " $more_text</p>";
 	}
-	remove_filter( 'excerpt_more', $filter_excerpt_more );
-	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );
+	remove_filter( 'excerpt_length', $filter_excerpt_length );
 }
 
 /**

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -39,6 +39,9 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	};
 	add_filter( 'excerpt_length', $filter_excerpt_length );
 
+	$excerpt        = get_the_excerpt( $block->context['postId'] );
+	if ( isset( $excerpt_length ) ) {
+		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
@@ -72,6 +75,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		$content .= " $more_text</p>";
 	}
 	remove_filter( 'excerpt_length', $filter_excerpt_length );
+	remove_filter( 'excerpt_more', $filter_excerpt_more );
+	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Post Excerpt allows users to set the excerpt length in Editor (10 - 100 words). If a post has no excerpt, the post content is taken as a fallback. Post Content is truncated internally before reaching the Excerpt block to 55 words with default WordPress ellipsis: `[…]` instead of Excerpts ellipsis `…`.

Check the screenshot below, the excerpt (pink background) length is set to 100 words:

Before | After
-- | --
<img width="1038" alt="image" src="https://github.com/WordPress/gutenberg/assets/20098064/aae9cc41-df98-4553-8229-0baf051a85d7"> | <img width="1106" alt="image" src="https://github.com/WordPress/gutenberg/assets/20098064/5d083848-c999-487f-a402-186ddbc663d6">

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In [get_post_excerpt](https://developer.wordpress.org/reference/functions/get_the_excerpt/) we read:

> If this function is used outside The Loop and the post doesn’t have a custom excerpt, this function will use [wp_trim_excerpt()](https://developer.wordpress.org/reference/functions/wp_trim_excerpt/) to generate an excerpt.

then in [wp_trim_excerpt](https://developer.wordpress.org/reference/functions/wp_trim_excerpt/):

> Returns a maximum of 55 words with an ellipsis appended if necessary.
> The 55-word limit can be modified by plugins/themes using the [‘excerpt_length’](https://developer.wordpress.org/reference/hooks/excerpt_length/) filter.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Before calling `get_post_excerpt` we call a `excerpt_length` filter and pass `$excerpt_length` attribute if set.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Create new post
2. Insert content that is longer than 100 words

<details>
  <summary>Example content</summary>
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed nibh blandit, sodales enim aliquet, ultricies ligula. Praesent enim lectus, gravida a sapien eget, venenatis tempor ligula. Etiam cursus, nisl id molestie rutrum, ex velit volutpat arcu, at blandit quam lectus ut urna. Sed at venenatis turpis, convallis laoreet ante. Nulla lobortis odio non est eleifend, eu vulputate arcu pharetra. Pellentesque porta ante non mauris rutrum consectetur. Quisque nulla neque, vestibulum sed consectetur eget, pellentesque quis felis. Nullam maximus felis neque, a efficitur velit venenatis vitae. Praesent elit sem, bibendum id malesuada sit amet, tristique non turpis. Vivamus varius venenatis sem auctor semper. Cras imperdiet risus diam, sit amet tincidunt dui dictum posuere.

Duis ut tellus fermentum arcu efficitur posuere. Sed tincidunt, nulla a porttitor sagittis, felis felis condimentum felis, ut bibendum augue lacus eu orci. Vestibulum consequat condimentum viverra. Duis pharetra turpis vel varius malesuada. Quisque id velit id.
</details>

3. Insert Excerpt block
4. Set `MAX NUMBER OF WORDS` to 100
5. Save and go to frontend
6. Expected: Excerpt is indeed 100 words long, not 55 (no need to count words, asses the "volume" of the text based on below screenshots 🙌 )

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before | After
-- | --
<img width="1038" alt="image" src="https://github.com/WordPress/gutenberg/assets/20098064/aae9cc41-df98-4553-8229-0baf051a85d7"> | <img width="1106" alt="image" src="https://github.com/WordPress/gutenberg/assets/20098064/5d083848-c999-487f-a402-186ddbc663d6">

