### PR TITLE
Writing flow: split heading into default block

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1002,6 +1002,9 @@ export const __unstableSplitSelection =
 		// the default block type cannot be inserted.
 		const defaultBlockName = getDefaultBlockName();
 		if (
+			// A block is only split when the selection is within the same
+			// block.
+			blockA.clientId === blockB.clientId &&
 			defaultBlockName &&
 			tail.name !== defaultBlockName &&
 			select.canInsertBlockType( defaultBlockName, anchorRootClientId )

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -982,7 +982,7 @@ export const __unstableSplitSelection =
 			},
 		};
 
-		const tail = {
+		let tail = {
 			...blockB,
 			// Only preserve the original client ID if the end is different.
 			clientId:
@@ -994,6 +994,23 @@ export const __unstableSplitSelection =
 				[ attributeKeyB ]: toHTMLString( { value: valueB } ),
 			},
 		};
+
+		// When splitting a block, attempt to convert the tail block to the
+		// default block type. For example, when splitting a heading block, the
+		// tail block will be converted to a paragraph block. Note that for
+		// blocks such as a list item and button, this will be skipped because
+		// the default block type cannot be inserted.
+		const defaultBlockName = getDefaultBlockName();
+		if (
+			defaultBlockName &&
+			tail.name !== defaultBlockName &&
+			select.canInsertBlockType( defaultBlockName, anchorRootClientId )
+		) {
+			const switched = switchToBlockType( tail, defaultBlockName );
+			if ( switched?.length === 1 ) {
+				tail = switched[ 0 ];
+			}
+		}
 
 		if ( ! blocks.length ) {
 			dispatch.replaceBlocks( select.getSelectedBlockClientIds(), [

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -695,10 +695,9 @@ test.describe( 'Copy/cut/paste', () => {
 				},
 			},
 			{
-				name: 'core/heading',
+				name: 'core/paragraph',
 				attributes: {
 					content: 'bB',
-					level: 2,
 				},
 			},
 		] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

|Before|After|
|-|-|
|![split-before](https://github.com/WordPress/gutenberg/assets/4710635/0eeed945-e61c-407e-ac9a-1ba60ec95438)|![split-after](https://github.com/WordPress/gutenberg/assets/4710635/a822e987-7505-423a-b241-2d8f7f12dcd0)|

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

* Headings can have an anchor that shouldn't be duplicated.
* It never makes sense to split an h1 in two, there should be no two h1 tags.
* Most likely other headings should not be duplicated either.

One can always switch it back to a heading.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
