### PR TITLE
Editor: Fix canvas padding in post editor

### DIFF
--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -3,6 +3,7 @@ iframe[name="editor-canvas"] {
 	height: 100%;
 	display: block;
 	background-color: $gray-300;
+	box-sizing: border-box;
 }
 
 


### PR DESCRIPTION
## What?

I noticed a small regression in the post editor where the width of the canvas is not correct (no padding on the right) when you move to "template mode". This PR fixes the issue but I'm not entirely sure when this regression happened.

<img width="1470" alt="Screenshot 2024-05-23 at 9 32 09 AM" src="https://github.com/WordPress/gutenberg/assets/272444/5cc154d2-8750-4724-95ec-7661633d5a3c">

## Testing Instructions

1- Open the post editor
2- Click "Template" on the sidebar and "Edit template"
3- There should be a padding around the canvas.