### PR TITLE
Navigation Focus Mode: Remove leftover code

### DIFF
--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -6,7 +6,6 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { useState, useEffect, useMemo } from '@wordpress/element';
@@ -21,32 +20,15 @@ import {
  */
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
-import {
-	FOCUSABLE_ENTITIES,
-	NAVIGATION_POST_TYPE,
-} from '../../utils/constants';
 
 const { EditorCanvas: EditorCanvasRoot } = unlock( editorPrivateApis );
 
 function EditorCanvas( { settings, children } ) {
-	const {
-		hasBlocks,
-		isFocusMode,
-		templateType,
-		canvasMode,
-		currentPostIsTrashed,
-	} = useSelect( ( select ) => {
-		const { getBlockCount } = select( blockEditorStore );
-		const { getEditedPostType, getCanvasMode } = unlock(
-			select( editSiteStore )
-		);
-		const _templateType = getEditedPostType();
+	const { canvasMode, currentPostIsTrashed } = useSelect( ( select ) => {
+		const { getCanvasMode } = unlock( select( editSiteStore ) );
 
 		return {
-			templateType: _templateType,
-			isFocusMode: FOCUSABLE_ENTITIES.includes( _templateType ),
 			canvasMode: getCanvasMode(),
-			hasBlocks: !! getBlockCount(),
 			currentPostIsTrashed:
 				select( editorStore ).getCurrentPostAttribute( 'status' ) ===
 				'trash',
@@ -92,15 +74,6 @@ function EditorCanvas( { settings, children } ) {
 		},
 		readonly: true,
 	};
-	const isTemplateTypeNavigation = templateType === NAVIGATION_POST_TYPE;
-	const isNavigationFocusMode = isTemplateTypeNavigation && isFocusMode;
-	// Hide the appender when:
-	// - In navigation focus mode (should only allow the root Nav block).
-	// - In view mode (i.e. not editing).
-	const showBlockAppender =
-		( isNavigationFocusMode && hasBlocks ) || canvasMode === 'view'
-			? false
-			: undefined;
 
 	const styles = useMemo(
 		() => [
@@ -123,10 +96,6 @@ function EditorCanvas( { settings, children } ) {
 
 	return (
 		<EditorCanvasRoot
-			className={ clsx( 'edit-site-editor-canvas__block-list', {
-				'is-navigation-block': isTemplateTypeNavigation,
-			} ) }
-			renderAppender={ showBlockAppender }
 			styles={ styles }
 			iframeProps={ {
 				className: clsx( 'edit-site-visual-editor__editor-canvas', {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -12,12 +12,6 @@
 	}
 }
 
-// Navigation focus mode requires padding around the root Navigation block
-// for presentational purposes.
-.edit-site-editor-canvas__block-list.is-navigation-block {
-	padding: $grid-unit-30;
-}
-
 .edit-site-visual-editor {
 	position: relative;
 	height: 100%;

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -100,7 +100,6 @@ function EditorCanvas( {
 	// Ideally as we unify post and site editors, we won't need these props.
 	autoFocus,
 	className,
-	renderAppender,
 	styles,
 	disableIframe = false,
 	iframeProps,
@@ -469,7 +468,6 @@ function EditorCanvas( {
 									? localRef.current
 									: localRef.current?.parentNode
 							}
-							renderAppender={ renderAppender }
 							__unstableDisableDropZone={
 								// In template preview mode, disable drop zones at the root of the template.
 								renderingMode === 'template-locked'

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -99,7 +99,6 @@ function checkForPostContentAtRootLevel( blocks ) {
 function EditorCanvas( {
 	// Ideally as we unify post and site editors, we won't need these props.
 	autoFocus,
-	className,
 	styles,
 	disableIframe = false,
 	iframeProps,
@@ -453,7 +452,6 @@ function EditorCanvas( {
 					>
 						<BlockList
 							className={ clsx(
-								className,
 								'is-' + deviceType.toLowerCase() + '-preview',
 								renderingMode !== 'post-only' ||
 									isDesignPostType


### PR DESCRIPTION
## What?

When trying to align post and site editors, I noticed that the Navigation block focus mode has a lot of specific custom code to make it work as it should. But after digging a little bit more, I found that most of that code is actually useless and already handled elsewhere. This PR just cleans these things a little bit:

 - No specific className to add padding (this is already handled by the editor package)
 - No specific code to disable the appender (it was already disabled at the root level for me)

This code was first introduced in the initial PR that introduced Navigation focus mode #39286 

## Testing Instructions

1- Open the site editor
2- Click navigation
3- Click the "edit" link in the dropdown in the sidebar
4- You should be able to edit the navigation menu properly, a padding is visible around the canvas and there's no root level appender. 