### PR TITLE
Global Styles: Don't apply the background and text colors to typography previews

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview-iframe.js
+++ b/packages/edit-site/src/components/global-styles/preview-iframe.js
@@ -38,6 +38,7 @@ export default function PreviewIframe( {
 	label,
 	isFocused,
 	withHoverView,
+	previewStyles,
 } ) {
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
@@ -109,6 +110,15 @@ export default function PreviewIframe( {
 	}, [ styles ] );
 	const isReady = !! width;
 
+	const calculatedStyles = {
+		height: normalizedHeight * ratio,
+		width: '100%',
+		background: gradientValue ?? backgroundColor,
+		cursor: withHoverView ? 'pointer' : undefined,
+		// Override these styles with the previewStyles prop.
+		...previewStyles,
+	};
+
 	return (
 		<>
 			<div style={ { position: 'relative' } }>
@@ -126,12 +136,7 @@ export default function PreviewIframe( {
 				>
 					<EditorStyles styles={ editorStyles } />
 					<motion.div
-						style={ {
-							height: normalizedHeight * ratio,
-							width: '100%',
-							background: gradientValue ?? backgroundColor,
-							cursor: withHoverView ? 'pointer' : undefined,
-						} }
+						style={ calculatedStyles }
 						initial="start"
 						animate={
 							( isHovered || isFocused ) &&

--- a/packages/edit-site/src/components/global-styles/preview-iframe.js
+++ b/packages/edit-site/src/components/global-styles/preview-iframe.js
@@ -110,7 +110,7 @@ export default function PreviewIframe( {
 	}, [ styles ] );
 	const isReady = !! width;
 
-	const calculatedStyles = {
+	const computedStyles = {
 		height: normalizedHeight * ratio,
 		width: '100%',
 		background: gradientValue ?? backgroundColor,
@@ -136,7 +136,7 @@ export default function PreviewIframe( {
 				>
 					<EditorStyles styles={ editorStyles } />
 					<motion.div
-						style={ calculatedStyles }
+						style={ computedStyles }
 						initial="start"
 						animate={
 							( isHovered || isFocused ) &&

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -40,6 +40,10 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 								<PreviewIframe
 									label={ variation?.title }
 									isFocused={ isFocused }
+									previewStyles={ {
+										background: '#ffffff',
+										color: '#000000',
+									} }
 								>
 									{ ( { ratio, key } ) => (
 										<HStack


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This overrides the site text and background colors on typography previews. Fixes #61217

## Why?
It's easier to preview the typography without the additional color information.

## How?
Pass styles to the Iframe Preview component.

## Testing Instructions
1. Open Global Styles
2. Open Typography and check that the background color is white and text color is black
3. Also check this on the site view.

## Screenshots or screencast <!-- if applicable -->
<img width="313" alt="Screenshot 2024-05-23 at 13 04 29" src="https://github.com/WordPress/gutenberg/assets/275961/142720f6-6fb5-478d-a108-c2789467a47e">
<img width="368" alt="Screenshot 2024-05-23 at 13 04 17" src="https://github.com/WordPress/gutenberg/assets/275961/1888b2a6-a13e-4f7c-be6e-77b551e777a1">

