### PR TITLE
Global Styles: Restore the default variation to the color and typography style tiles

### DIFF
--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -160,8 +160,12 @@ export default function useThemeStyleVariationsByProperty( {
 					cloneDeep( variation ),
 					property
 				);
+
 				// Remove variations that are empty once the property is filtered out.
-				if ( Object.keys( variationFilteredByProperty ).length === 0 ) {
+				if (
+					variation.title !== 'Default' &&
+					Object.keys( variationFilteredByProperty ).length === 0
+				) {
 					return accumulator;
 				}
 

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -163,7 +163,7 @@ export default function useThemeStyleVariationsByProperty( {
 
 				// Remove variations that are empty once the property is filtered out.
 				if (
-					variation.title !== 'Default' &&
+					variation.title !== __( 'Default' ) &&
 					Object.keys( variationFilteredByProperty ).length === 0
 				) {
 					return accumulator;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This restores the default variation to the style tiles for color and typography sets.

## Why?
This is necessary to allow users to put their color and typography settings back to how they were before they made changes.

## How?
Don't filter out Default as an empty variation - treat it as an exception.

## Testing Instructions
1. Open the Site Editor
2. Open Global Styles
3. Go to Typography
4. Confirm that the default styles are first in the list
3. Go to Colors
4. Confirm that the default styles are first in the list
5. Also confirm at the default styles are visible on the site view

## Screenshots or screencast <!-- if applicable -->
<img width="380" alt="Screenshot 2024-05-23 at 13 28 27" src="https://github.com/WordPress/gutenberg/assets/275961/6571059e-386b-4134-b08f-22eb640d886e">
<img width="314" alt="Screenshot 2024-05-23 at 13 28 12" src="https://github.com/WordPress/gutenberg/assets/275961/7f747a23-6d66-466d-a3be-b1aedc12111b">
<img width="305" alt="Screenshot 2024-05-23 at 13 27 57" src="https://github.com/WordPress/gutenberg/assets/275961/506003a1-3632-4d96-b62b-569bae11f384">

