### PR TITLE
Site Editor: Remove useless onClick handler

### DIFF
--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -28,13 +28,7 @@ import {
 
 const { EditorCanvas: EditorCanvasRoot } = unlock( editorPrivateApis );
 
-function EditorCanvas( {
-	enableResizing,
-	settings,
-	children,
-	onClick,
-	...props
-} ) {
+function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 	const {
 		hasBlocks,
 		isFocusMode,
@@ -88,11 +82,7 @@ function EditorCanvas( {
 			}
 		},
 		onClick: () => {
-			if ( !! onClick ) {
-				onClick();
-			} else {
-				setCanvasMode( 'edit' );
-			}
+			setCanvasMode( 'edit' );
 		},
 		onClickCapture: ( event ) => {
 			if ( currentPostIsTrashed ) {

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -27,7 +27,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 const { useLocation } = unlock( routerPrivateApis );
 
-export default function SiteEditorCanvas( { onClick } ) {
+export default function SiteEditorCanvas() {
 	const location = useLocation();
 	const { templateType, isFocusableEntity, isViewMode, isZoomOutMode } =
 		useSelect( ( select ) => {
@@ -89,7 +89,6 @@ export default function SiteEditorCanvas( { onClick } ) {
 							<EditorCanvas
 								enableResizing={ enableResizing }
 								settings={ settings }
-								onClick={ onClick }
 							>
 								{
 									// Avoid resize listeners when not needed,

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -83,7 +83,7 @@ const interfaceLabels = {
 
 const ANIMATION_DURATION = 0.25;
 
-export default function Editor( { isLoading, onClick } ) {
+export default function Editor( { isLoading } ) {
 	const {
 		record: editedPost,
 		getTitle,
@@ -351,9 +351,7 @@ export default function Editor( { isLoading, onClick } ) {
 								{ ! isLargeViewport && showVisualEditor && (
 									<BlockToolbar hideDragHandle />
 								) }
-								{ showVisualEditor && (
-									<SiteEditorCanvas onClick={ onClick } />
-								) }
+								{ showVisualEditor && <SiteEditorCanvas /> }
 							</>
 						}
 						secondarySidebar={

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -75,7 +75,6 @@ function useRedirectOldPaths() {
 
 export default function useLayoutAreas() {
 	const isSiteEditorLoading = useIsSiteEditorLoading();
-	const history = useHistory();
 	const { params } = useLocation();
 	const { postType, postId, path, layout, isCustom, canvas } = params;
 	useRedirectOldPaths();
@@ -95,16 +94,7 @@ export default function useLayoutAreas() {
 				),
 				content: <PagePages />,
 				preview: ( isListLayout || canvas === 'edit' ) && (
-					<Editor
-						isLoading={ isSiteEditorLoading }
-						onClick={ () =>
-							history.push( {
-								postType: 'page',
-								postId,
-								canvas: 'edit',
-							} )
-						}
-					/>
+					<Editor isLoading={ isSiteEditorLoading } />
 				),
 				mobile:
 					canvas === 'edit' ? (


### PR DESCRIPTION
## What?

This onClick handler for the Editor component was I think needed when we had the "manage all pages" page and we had to navigate away from there. But now that we simplified everything, it's not needed anymore, it's equivalent to the default onClick handler of the preview, so I'm just removing it.
 
## Testing Instructions

Try opening pages from the pages list of the site editor, there should be no functional change in this PR.