### PR TITLE
Navigation block: Check for update_ignored_hooked_blocks_postmeta in core

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1620,7 +1620,7 @@ $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ig
  * Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
  * that are not present in Gutenberg's WP 6.5 compatibility layer.
  */
-if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) ) {
+if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ( ! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) && ! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' ) ) ) {
 	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta' );
 }
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1621,10 +1621,9 @@ $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ig
  * that are not present in Gutenberg's WP 6.5 compatibility layer.
  */
 if (
-	function_exists( 'set_ignored_hooked_blocks_metadata' ) && (
-		! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) ||
-		! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' )
-	)
+	! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' ) &&
+	function_exists( 'set_ignored_hooked_blocks_metadata' ) &&
+	! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback )
 ) {
 	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta' );
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1620,7 +1620,7 @@ $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ig
  * Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
  * that are not present in Gutenberg's WP 6.5 compatibility layer.
  */
-if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ( ! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) && ! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' ) ) ) {
+if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ( ! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) || ! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' ) ) ) {
 	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta' );
 }
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1620,7 +1620,12 @@ $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ig
  * Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
  * that are not present in Gutenberg's WP 6.5 compatibility layer.
  */
-if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ( ! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) || ! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' ) ) ) {
+if (
+	function_exists( 'set_ignored_hooked_blocks_metadata' ) && (
+		! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) ||
+		! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' )
+	)
+) {
 	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta' );
 }
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1617,8 +1617,10 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ignore_hooked_blocks_meta'; // phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found
 
 /*
- * Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
- * that are not present in Gutenberg's WP 6.5 compatibility layer.
+ * Do not add the `block_core_navigation_update_ignore_hooked_blocks_meta` filter in the following cases:
+ * - If Core has added the `update_ignored_hooked_blocks_postmeta` filter already (WP >= 6);
+ * - or if the `set_ignored_hooked_blocks_metadata` function is unavailable (which is required for the filter to work. It was introduced by WP 6.5 but is not present in Gutenberg's WP 6.5 compatibility layer);
+ * - or if the `$rest_insert_wp_navigation_core_callback` filter has already been added.
  */
 if (
 	! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' ) &&

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1618,7 +1618,7 @@ $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ig
 
 /*
  * Do not add the `block_core_navigation_update_ignore_hooked_blocks_meta` filter in the following cases:
- * - If Core has added the `update_ignored_hooked_blocks_postmeta` filter already (WP >= 6);
+ * - If Core has added the `update_ignored_hooked_blocks_postmeta` filter already (WP >= 6.6);
  * - or if the `set_ignored_hooked_blocks_metadata` function is unavailable (which is required for the filter to work. It was introduced by WP 6.5 but is not present in Gutenberg's WP 6.5 compatibility layer);
  * - or if the `$rest_insert_wp_navigation_core_callback` filter has already been added.
  */


### PR DESCRIPTION
Related PR: https://github.com/WordPress/wordpress-develop/pull/6604

## What?
<!-- In a few words, what is the PR actually doing? -->
Adding another `has_filter` check before adding the Navigation blocks filter to store `ignoredHookedBlocks` metadata as this functionality is being moved into WP core.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The logic to add the `ignoredHookedBlocks` metadata has been moved to core to consolidate and haromise the functionality.