### PR TITLE
Block Editor: Fix `ZoomOutModeInserters` dependencies

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -51,8 +51,7 @@ function ZoomOutModeInserters() {
 		}
 		// reset insertion point when the block order changes
 		setInserterIsOpened( true );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ blockOrder ] );
+	}, [ blockOrder, setInserterIsOpened ] );
 
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {


### PR DESCRIPTION
## What?
This PR fixes the dependencies of one of `ZoomOutModeInserters`'s `useEffect` calls.

## Why?
From what I understand, there is no good reason not to provide `setInserterIsOpened` as a dependency:

- The effect will be called only once because of the mounted check
- The `setInserterIsOpened` reference is a stable reference to a block editor store action function. 

The motivation is resolving an ESLint error that was raised by the React Compiler ESLint plugin in https://github.com/WordPress/gutenberg/pull/61788

## How?
By adding `setInserterIsOpened` as a dependency and removing the ESLint rule disabling.

## Testing Instructions
* Enable the "Enable zoomed out view when patterns are browsed in the inserter" experiment
* Open the post editor
* Open the inserter and go to Patterns
* Select a pattern and verify that the inserters still look and work the same way as in `trunk` (they look broken btw, but I'm not 100% sure how they are expected to look and work, cc @youknowriad) 

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None