### PR TITLE
Consolidate and fix `delete` and `edit` post actions

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -277,7 +277,7 @@ function Layout( { initialPost } ) {
 	const onActionPerformed = useCallback(
 		( actionId, items ) => {
 			switch ( actionId ) {
-				case 'move-to-trash':
+				case 'delete-post':
 					{
 						document.location.href = addQueryArgs( 'edit.php', {
 							trashed: 1,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -277,7 +277,7 @@ function Layout( { initialPost } ) {
 	const onActionPerformed = useCallback(
 		( actionId, items ) => {
 			switch ( actionId ) {
-				case 'delete-post':
+				case 'move-to-trash':
 					{
 						document.location.href = addQueryArgs( 'edit.php', {
 							trashed: 1,

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -26,16 +26,8 @@ export const useEditPostAction = () => {
 				if ( post.status === 'trash' ) {
 					return false;
 				}
-				// It's eligible for all post types except patterns.
-				if (
-					! [ ...Object.values( PATTERN_TYPES ) ].includes(
-						post.type
-					)
-				) {
-					return true;
-				}
-				// We can only edit user patterns.
-				return post.type === PATTERN_TYPES.user;
+				// It's eligible for all post types except theme patterns.
+				return post.type !== PATTERN_TYPES.theme;
 			},
 			callback( items ) {
 				const post = items[ 0 ];

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -9,6 +9,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
+import { PATTERN_TYPES } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
@@ -21,8 +22,20 @@ export const useEditPostAction = () => {
 			label: __( 'Edit' ),
 			isPrimary: true,
 			icon: edit,
-			isEligible( { status } ) {
-				return status !== 'trash';
+			isEligible( post ) {
+				if ( post.status === 'trash' ) {
+					return false;
+				}
+				// It's eligible for all post types except patterns.
+				if (
+					! [ ...Object.values( PATTERN_TYPES ) ].includes(
+						post.type
+					)
+				) {
+					return true;
+				}
+				// We can only edit user patterns.
+				return post.type === PATTERN_TYPES.user;
 			},
 			callback( items ) {
 				const post = items[ 0 ];

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -212,7 +212,7 @@ export default function Editor( { isLoading } ) {
 	const onActionPerformed = useCallback(
 		( actionId, items ) => {
 			switch ( actionId ) {
-				case 'move-to-trash':
+				case 'delete-post':
 					{
 						history.push( {
 							postType: items[ 0 ].type,

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -212,6 +212,7 @@ export default function Editor( { isLoading } ) {
 	const onActionPerformed = useCallback(
 		( actionId, items ) => {
 			switch ( actionId ) {
+				case 'move-to-trash':
 				case 'delete-post':
 					{
 						history.push( {

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -38,10 +38,9 @@ const { PATTERN_TYPES } = unlock( patternsPrivateApis );
 
 /**
  * Check if a template is removable.
- * Copy from packages/edit-site/src/utils/is-template-removable.js.
  *
  * @param {Object} template The template entity to check.
- * @return {boolean} Whether the template is revertable.
+ * @return {boolean} Whether the template is removable.
  */
 function isTemplateRemovable( template ) {
 	if ( ! template ) {

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -9,7 +9,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __, _n, sprintf, _x } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from '@wordpress/element';
-import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 
 import {
@@ -110,19 +109,6 @@ const deletePostAction = {
 		const { createSuccessNotice, createErrorNotice } =
 			useDispatch( noticesStore );
 		const { deleteEntityRecord } = useDispatch( coreStore );
-		const { __experimentalDeleteReusableBlock } =
-			useDispatch( reusableBlocksStore );
-		const isPattern = items[ 0 ].type === PATTERN_POST_TYPE;
-		const deleteItem = isPattern
-			? ( item ) => __experimentalDeleteReusableBlock( item.id )
-			: ( item ) =>
-					deleteEntityRecord(
-						'postType',
-						item.type,
-						item.id,
-						{},
-						{ throwOnError: true }
-					);
 		return (
 			<VStack spacing="5">
 				<Text>
@@ -159,7 +145,15 @@ const deletePostAction = {
 								onActionStart( items );
 							}
 							const promiseResult = await Promise.allSettled(
-								items.map( deleteItem )
+								items.map( ( item ) =>
+									deleteEntityRecord(
+										'postType',
+										item.type,
+										item.id,
+										{},
+										{ throwOnError: true }
+									)
+								)
 							);
 							// If all the promises were fulfilled with success.
 							if (

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -15,7 +15,6 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import isTemplateRevertable from './utils/is-template-revertable';
-import { TEMPLATE_POST_TYPE } from './constants';
 
 /**
  * Returns an action object used to set which template is currently being used/edited.
@@ -363,14 +362,13 @@ export const revertTemplate =
 	};
 
 /**
- * Action that removes an array of templates.
+ * Action that removes an array of templates, template parts or patterns.
  *
- * @param {Array} items An array of template or template part objects to remove.
+ * @param {Array} items An array of template,template part or pattern objects to remove.
  */
 export const removeTemplates =
 	( items ) =>
 	async ( { registry } ) => {
-		const isTemplate = items[ 0 ].type === TEMPLATE_POST_TYPE;
 		const promiseResult = await Promise.allSettled(
 			items.map( ( item ) => {
 				return registry
@@ -402,16 +400,14 @@ export const removeTemplates =
 					decodeEntities( title )
 				);
 			} else {
-				successMessage = isTemplate
-					? __( 'Templates deleted.' )
-					: __( 'Template parts deleted.' );
+				successMessage = __( 'Items deleted.' );
 			}
 
 			registry
 				.dispatch( noticesStore )
 				.createSuccessNotice( successMessage, {
 					type: 'snackbar',
-					id: 'site-editor-template-deleted-success',
+					id: 'editor-template-deleted-success',
 				} );
 		} else {
 			// If there was at lease one failure.
@@ -421,11 +417,9 @@ export const removeTemplates =
 				if ( promiseResult[ 0 ].reason?.message ) {
 					errorMessage = promiseResult[ 0 ].reason.message;
 				} else {
-					errorMessage = isTemplate
-						? __( 'An error occurred while deleting the template.' )
-						: __(
-								'An error occurred while deleting the template part.'
-						  );
+					errorMessage = __(
+						'An error occurred while deleting the item.'
+					);
 				}
 				// If we were trying to delete a multiple templates
 			} else {
@@ -439,45 +433,23 @@ export const removeTemplates =
 					}
 				}
 				if ( errorMessages.size === 0 ) {
-					errorMessage = isTemplate
-						? __(
-								'An error occurred while deleting the templates.'
-						  )
-						: __(
-								'An error occurred while deleting the template parts.'
-						  );
+					errorMessage = __(
+						'An error occurred while deleting the items.'
+					);
 				} else if ( errorMessages.size === 1 ) {
-					errorMessage = isTemplate
-						? sprintf(
-								/* translators: %s: an error message */
-								__(
-									'An error occurred while deleting the templates: %s'
-								),
-								[ ...errorMessages ][ 0 ]
-						  )
-						: sprintf(
-								/* translators: %s: an error message */
-								__(
-									'An error occurred while deleting the template parts: %s'
-								),
-								[ ...errorMessages ][ 0 ]
-						  );
+					errorMessage = sprintf(
+						/* translators: %s: an error message */
+						__( 'An error occurred while deleting the items: %s' ),
+						[ ...errorMessages ][ 0 ]
+					);
 				} else {
-					errorMessage = isTemplate
-						? sprintf(
-								/* translators: %s: a list of comma separated error messages */
-								__(
-									'Some errors occurred while deleting the templates: %s'
-								),
-								[ ...errorMessages ].join( ',' )
-						  )
-						: sprintf(
-								/* translators: %s: a list of comma separated error messages */
-								__(
-									'Some errors occurred while deleting the template parts: %s'
-								),
-								[ ...errorMessages ].join( ',' )
-						  );
+					sprintf(
+						/* translators: %s: a list of comma separated error messages */
+						__(
+							'Some errors occurred while deleting the items: %s'
+						),
+						[ ...errorMessages ].join( ',' )
+					);
 				}
 			}
 			registry

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -416,11 +416,11 @@ test.describe( 'Change detection', () => {
 			.click();
 		await page
 			.getByRole( 'menu' )
-			.getByRole( 'menuitem', { name: 'Delete' } )
+			.getByRole( 'menuitem', { name: 'Move to Trash' } )
 			.click();
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Delete' } )
+			.getByRole( 'button', { name: 'Trash' } )
 			.click();
 
 		await expect( page ).toHaveURL( '/wp-admin/edit.php?post_type=post' );

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -416,7 +416,7 @@ test.describe( 'Change detection', () => {
 			.click();
 		await page
 			.getByRole( 'menu' )
-			.getByRole( 'menuitem', { name: 'Move to Trash' } )
+			.getByRole( 'menuitem', { name: 'Delete' } )
 			.click();
 		await page
 			.getByRole( 'dialog' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/61787
Similar to: https://github.com/WordPress/gutenberg/pull/61857

This PR does two things:
1. Fix the `edit` action in site editor to be shown only in user patterns.
2. Fixes some logic of `delete` post action and keep one `delete` action for templates, template parts and patterns, and one `move to trash` action for the rest post types.

## Notes
I've updated the messages when removing a template, template part, pattern to have the generic `item` label, to simplify the logic there. For single item deletions nothing changes because we use the name of the item. It changes though for multiple items and for example the `An error occurred while deleting the templates.` is now `An error occurred while deleting the items.`

## Testing Instructions
1. Try the edit action in list views of `patterns, pages and templates`. In patterns it should be shown only for user created patterns and all template parts
2. Test that the delete action is working properly and that is shown only when it should(for example you cannot delete a theme template)
    - in site editor in all list views with single and multiple selection
    - in both editors for all post types(post, page, template, pattern, template part) in inspector controls

