### PR TITLE
Update: Implement new parent and order design.

### DIFF
--- a/packages/editor/src/components/page-attributes/order.js
+++ b/packages/editor/src/components/page-attributes/order.js
@@ -43,7 +43,7 @@ function PageAttributesOrder() {
 					label={ __( 'Order' ) }
 					value={ value }
 					onChange={ setUpdatedOrder }
-					labelPosition="side"
+					hideLabelFromVision
 					onBlur={ () => {
 						setOrderInput( null );
 					} }

--- a/packages/editor/src/components/page-attributes/order.js
+++ b/packages/editor/src/components/page-attributes/order.js
@@ -1,18 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
+	Button,
+	Dropdown,
 	Flex,
 	FlexBlock,
 	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
+import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import PostPanelRow from '../post-panel-row';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
 
@@ -64,5 +68,66 @@ export default function PageAttributesOrderWithChecks() {
 		<PostTypeSupportCheck supportKeys="page-attributes">
 			<PageAttributesOrder />
 		</PostTypeSupportCheck>
+	);
+}
+
+function PostOrderToggle( { isOpen, onClick } ) {
+	const order = useSelect(
+		( select ) =>
+			select( editorStore ).getEditedPostAttribute( 'menu_order' ) ?? 0,
+		[]
+	);
+	return (
+		<Button
+			size="compact"
+			className="editor-post-order__panel-toggle"
+			variant="tertiary"
+			aria-expanded={ isOpen }
+			// translators: %s: Current post parent.
+			aria-label={ sprintf( __( 'Change order: %s' ), order ) }
+			onClick={ onClick }
+		>
+			{ order }
+		</Button>
+	);
+}
+
+export function OrderRow() {
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the popover's anchor updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	// Memoize popoverProps to avoid returning a new object every time.
+	const popoverProps = useMemo(
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
+		[ popoverAnchor ]
+	);
+	return (
+		<PostPanelRow label={ __( 'Order' ) } ref={ setPopoverAnchor }>
+			<Dropdown
+				popoverProps={ popoverProps }
+				className="editor-post-order__panel-dropdown"
+				contentClassName="editor-post-order__panel-dialog"
+				focusOnMount
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<PostOrderToggle isOpen={ isOpen } onClick={ onToggle } />
+				) }
+				renderContent={ ( { onClose } ) => (
+					<div className="editor-post-order">
+						<InspectorPopoverHeader
+							title={ __( 'Order' ) }
+							onClose={ onClose }
+						/>
+						<PageAttributesOrder />
+					</div>
+				) }
+			/>
+		</PostPanelRow>
 	);
 }

--- a/packages/editor/src/components/page-attributes/order.js
+++ b/packages/editor/src/components/page-attributes/order.js
@@ -45,6 +45,7 @@ function PageAttributesOrder() {
 				<NumberControl
 					__next40pxDefaultSize
 					label={ __( 'Order' ) }
+					help={ __( 'Set the page order.' ) }
 					value={ value }
 					onChange={ setUpdatedOrder }
 					hideLabelFromVision
@@ -130,7 +131,7 @@ export function OrderRow() {
 							) }
 							<p>
 								{ __(
-									'Pages with the same order value will sorted alphabetically. Negative order values can be used.'
+									'Pages with the same order value will sorted alphabetically. Negative order values are also supported.'
 								) }
 							</p>
 						</div>

--- a/packages/editor/src/components/page-attributes/order.js
+++ b/packages/editor/src/components/page-attributes/order.js
@@ -124,6 +124,16 @@ export function OrderRow() {
 							title={ __( 'Order' ) }
 							onClose={ onClose }
 						/>
+						<div>
+							{ __(
+								'This attribute determines the order of pages in the Pages List block.'
+							) }
+							<p>
+								{ __(
+									'Pages with the same order value will sorted alphabetically. Negative order values can be used.'
+								) }
+							</p>
+						</div>
 						<PageAttributesOrder />
 					</div>
 				) }

--- a/packages/editor/src/components/page-attributes/panel.js
+++ b/packages/editor/src/components/page-attributes/panel.js
@@ -1,161 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { Dropdown, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useMemo, useState } from '@wordpress/element';
-import { decodeEntities } from '@wordpress/html-entities';
-import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
-
 /**
  * Internal dependencies
  */
-import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
 import PageAttributesCheck from './check';
-import PageAttributesOrder from './order';
-import PageAttributesParent from './parent';
+import { OrderRow } from './order';
+import { ParentRow } from './parent';
 
 const PANEL_NAME = 'page-attributes';
-
-function getTitle( post ) {
-	return post?.title?.rendered
-		? decodeEntities( post.title.rendered )
-		: `#${ post.id } (${ __( 'no title' ) })`;
-}
-
-function PostParentToggle( { isOpen, onClick } ) {
-	const parentPost = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( editorStore );
-		const parentPostId = getEditedPostAttribute( 'parent' );
-		if ( ! parentPostId ) {
-			return null;
-		}
-		const { getEntityRecord } = select( coreStore );
-		const postTypeSlug = getEditedPostAttribute( 'type' );
-		return getEntityRecord( 'postType', postTypeSlug, parentPostId );
-	}, [] );
-	const parentTitle = useMemo(
-		() => ( ! parentPost ? __( 'None' ) : getTitle( parentPost ) ),
-		[ parentPost ]
-	);
-	return (
-		<Button
-			size="compact"
-			className="editor-post-parent__panel-toggle"
-			variant="tertiary"
-			aria-expanded={ isOpen }
-			// translators: %s: Current post parent.
-			aria-label={ sprintf( __( 'Change parent: %s' ), parentTitle ) }
-			onClick={ onClick }
-		>
-			{ parentTitle }
-		</Button>
-	);
-}
-
-function PostOrderToggle( { isOpen, onClick } ) {
-	const order = useSelect(
-		( select ) =>
-			select( editorStore ).getEditedPostAttribute( 'menu_order' ) ?? 0,
-		[]
-	);
-	return (
-		<Button
-			size="compact"
-			className="editor-post-order__panel-toggle"
-			variant="tertiary"
-			aria-expanded={ isOpen }
-			// translators: %s: Current post parent.
-			aria-label={ sprintf( __( 'Change order: %s' ), order ) }
-			onClick={ onClick }
-		>
-			{ order }
-		</Button>
-	);
-}
-
-function ParentRow() {
-	// Use internal state instead of a ref to make sure that the component
-	// re-renders when the popover's anchor updates.
-	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
-	// Memoize popoverProps to avoid returning a new object every time.
-	const popoverProps = useMemo(
-		() => ( {
-			// Anchor the popover to the middle of the entire row so that it doesn't
-			// move around when the label changes.
-			anchor: popoverAnchor,
-			placement: 'left-start',
-			offset: 36,
-			shift: true,
-		} ),
-		[ popoverAnchor ]
-	);
-	return (
-		<PostPanelRow label={ __( 'Parent' ) } ref={ setPopoverAnchor }>
-			<Dropdown
-				popoverProps={ popoverProps }
-				className="editor-post-parent__panel-dropdown"
-				contentClassName="editor-post-parent__panel-dialog"
-				focusOnMount
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<PostParentToggle isOpen={ isOpen } onClick={ onToggle } />
-				) }
-				renderContent={ ( { onClose } ) => (
-					<div className="editor-post-parent">
-						<InspectorPopoverHeader
-							title={ __( 'Parent' ) }
-							onClose={ onClose }
-						/>
-						<PageAttributesParent />
-					</div>
-				) }
-			/>
-		</PostPanelRow>
-	);
-}
-
-function OrderRow() {
-	// Use internal state instead of a ref to make sure that the component
-	// re-renders when the popover's anchor updates.
-	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
-	// Memoize popoverProps to avoid returning a new object every time.
-	const popoverProps = useMemo(
-		() => ( {
-			// Anchor the popover to the middle of the entire row so that it doesn't
-			// move around when the label changes.
-			anchor: popoverAnchor,
-			placement: 'left-start',
-			offset: 36,
-			shift: true,
-		} ),
-		[ popoverAnchor ]
-	);
-	return (
-		<PostPanelRow label={ __( 'Order' ) } ref={ setPopoverAnchor }>
-			<Dropdown
-				popoverProps={ popoverProps }
-				className="editor-post-order__panel-dropdown"
-				contentClassName="editor-post-order__panel-dialog"
-				focusOnMount
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<PostOrderToggle isOpen={ isOpen } onClick={ onToggle } />
-				) }
-				renderContent={ ( { onClose } ) => (
-					<div className="editor-post-order">
-						<InspectorPopoverHeader
-							title={ __( 'Order' ) }
-							onClose={ onClose }
-						/>
-						<PageAttributesOrder />
-					</div>
-				) }
-			/>
-		</PostPanelRow>
-	);
-}
 
 function AttributesPanel() {
 	const { isEnabled, postType } = useSelect( ( select ) => {

--- a/packages/editor/src/components/page-attributes/panel.js
+++ b/packages/editor/src/components/page-attributes/panel.js
@@ -1,15 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { PanelBody, PanelRow } from '@wordpress/components';
-
-import { useSelect, useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { Dropdown, Button, PanelRow } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { useMemo, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
 import PageAttributesCheck from './check';
 import PageAttributesOrder from './order';
@@ -17,38 +20,163 @@ import PageAttributesParent from './parent';
 
 const PANEL_NAME = 'page-attributes';
 
+function getTitle( post ) {
+	return post?.title?.rendered
+		? decodeEntities( post.title.rendered )
+		: `#${ post.id } (${ __( 'no title' ) })`;
+}
+
+function PostParentToggle( { isOpen, onClick } ) {
+	const parentPost = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( editorStore );
+		const parentPostId = getEditedPostAttribute( 'parent' );
+		if ( ! parentPostId ) {
+			return null;
+		}
+		const { getEntityRecord } = select( coreStore );
+		const postTypeSlug = getEditedPostAttribute( 'type' );
+		return getEntityRecord( 'postType', postTypeSlug, parentPostId );
+	}, [] );
+	const parentTitle = useMemo(
+		() => ( ! parentPost ? __( 'None' ) : getTitle( parentPost ) ),
+		[ parentPost ]
+	);
+	return (
+		<Button
+			size="compact"
+			className="editor-post-author__panel-toggle"
+			variant="tertiary"
+			aria-expanded={ isOpen }
+			// translators: %s: Current post parent.
+			aria-label={ sprintf( __( 'Change parent: %s' ), parentTitle ) }
+			onClick={ onClick }
+		>
+			{ parentTitle }
+		</Button>
+	);
+}
+
+function PostOrderToggle( { isOpen, onClick } ) {
+	const order = useSelect(
+		( select ) =>
+			select( editorStore ).getEditedPostAttribute( 'menu_order' ) ?? 0,
+		[]
+	);
+	return (
+		<Button
+			size="compact"
+			className="editor-post-author__panel-toggle"
+			variant="tertiary"
+			aria-expanded={ isOpen }
+			// translators: %s: Current post parent.
+			aria-label={ sprintf( __( 'Change order: %s' ), order ) }
+			onClick={ onClick }
+		>
+			{ order }
+		</Button>
+	);
+}
+
+function ParentRow() {
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the popover's anchor updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	// Memoize popoverProps to avoid returning a new object every time.
+	const popoverProps = useMemo(
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
+		[ popoverAnchor ]
+	);
+	return (
+		<PostPanelRow label={ __( 'Parent' ) } ref={ setPopoverAnchor }>
+			<Dropdown
+				popoverProps={ popoverProps }
+				className="editor-post-parent__panel-dropdown"
+				contentClassName="editor-post-parent__panel-dialog"
+				focusOnMount
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<PostParentToggle isOpen={ isOpen } onClick={ onToggle } />
+				) }
+				renderContent={ ( { onClose } ) => (
+					<div className="editor-post-parent">
+						<InspectorPopoverHeader
+							title={ __( 'Parent' ) }
+							onClose={ onClose }
+						/>
+						<PageAttributesParent />
+					</div>
+				) }
+			/>
+		</PostPanelRow>
+	);
+}
+
+function OrderRow() {
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the popover's anchor updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	// Memoize popoverProps to avoid returning a new object every time.
+	const popoverProps = useMemo(
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
+		[ popoverAnchor ]
+	);
+	return (
+		<PostPanelRow label={ __( 'Order' ) } ref={ setPopoverAnchor }>
+			<Dropdown
+				popoverProps={ popoverProps }
+				className="editor-post-order__panel-dropdown"
+				contentClassName="editor-post-order__panel-dialog"
+				focusOnMount
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<PostOrderToggle isOpen={ isOpen } onClick={ onToggle } />
+				) }
+				renderContent={ ( { onClose } ) => (
+					<div className="editor-post-order">
+						<InspectorPopoverHeader
+							title={ __( 'Order' ) }
+							onClose={ onClose }
+						/>
+						<PageAttributesOrder />
+					</div>
+				) }
+			/>
+		</PostPanelRow>
+	);
+}
+
 function AttributesPanel() {
-	const { isEnabled, isOpened, postType } = useSelect( ( select ) => {
-		const {
-			getEditedPostAttribute,
-			isEditorPanelEnabled,
-			isEditorPanelOpened,
-		} = select( editorStore );
+	const { isEnabled, postType } = useSelect( ( select ) => {
+		const { getEditedPostAttribute, isEditorPanelEnabled } =
+			select( editorStore );
 		const { getPostType } = select( coreStore );
 		return {
 			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
-			isOpened: isEditorPanelOpened( PANEL_NAME ),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		};
 	}, [] );
-
-	const { toggleEditorPanelOpened } = useDispatch( editorStore );
 
 	if ( ! isEnabled || ! postType ) {
 		return null;
 	}
 
 	return (
-		<PanelBody
-			title={ postType?.labels?.attributes ?? __( 'Page attributes' ) }
-			opened={ isOpened }
-			onToggle={ () => toggleEditorPanelOpened( PANEL_NAME ) }
-		>
-			<PageAttributesParent />
-			<PanelRow>
-				<PageAttributesOrder />
-			</PanelRow>
-		</PanelBody>
+		<>
+			<ParentRow />
+			<OrderRow />
+		</>
 	);
 }
 

--- a/packages/editor/src/components/page-attributes/panel.js
+++ b/packages/editor/src/components/page-attributes/panel.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Dropdown, Button, PanelRow } from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
@@ -44,7 +44,7 @@ function PostParentToggle( { isOpen, onClick } ) {
 	return (
 		<Button
 			size="compact"
-			className="editor-post-author__panel-toggle"
+			className="editor-post-parent__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			// translators: %s: Current post parent.
@@ -65,7 +65,7 @@ function PostOrderToggle( { isOpen, onClick } ) {
 	return (
 		<Button
 			size="compact"
-			className="editor-post-author__panel-toggle"
+			className="editor-post-order__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			// translators: %s: Current post parent.

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -7,7 +7,12 @@ import removeAccents from 'remove-accents';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Dropdown, ComboboxControl } from '@wordpress/components';
+import {
+	Button,
+	Dropdown,
+	ComboboxControl,
+	ExternalLink,
+} from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -242,6 +247,23 @@ export function ParentRow() {
 							title={ __( 'Parent' ) }
 							onClose={ onClose }
 						/>
+						<div>
+							{ __(
+								'Child pages inherit characteristics from their parent, like URL structure. For instance, if "Web Design" is a child of "Services," its URL would be mysite.com/services/web-design.'
+							) }
+							<p>
+								{ __(
+									'They also show up as sub-items in the default navigation menu. '
+								) }
+								<ExternalLink
+									href={ __(
+										'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
+									) }
+								>
+									{ __( 'Learn more.' ) }
+								</ExternalLink>
+							</p>
+						</div>
 						<PageAttributesParent />
 					</div>
 				) }

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -176,6 +176,7 @@ export function PageAttributesParent() {
 			__next40pxDefaultSize
 			className="editor-page-attributes__parent"
 			label={ __( 'Parent' ) }
+			help={ __( 'Choose a parent page.' ) }
 			value={ parentPostId }
 			options={ parentOptions }
 			onFilterValueChange={ debounce( handleKeydown, 300 ) }
@@ -249,7 +250,7 @@ export function ParentRow() {
 						/>
 						<div>
 							{ __(
-								'Child pages inherit characteristics from their parent, like URL structure. For instance, if "Web Design" is a child of "Services," its URL would be mysite.com/services/web-design.'
+								"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services,' its URL would be mysite.com/services/web-design."
 							) }
 							<p>
 								{ __(
@@ -257,10 +258,10 @@ export function ParentRow() {
 								) }
 								<ExternalLink
 									href={ __(
-										'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
+										'https://wordpress.org/documentation/article/page-post-settings-sidebar/#page-attributes'
 									) }
 								>
-									{ __( 'Learn more.' ) }
+									{ __( 'Learn more' ) }
 								</ExternalLink>
 							</p>
 						</div>

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -173,6 +173,7 @@ export function PageAttributesParent() {
 			options={ parentOptions }
 			onFilterValueChange={ debounce( handleKeydown, 300 ) }
 			onChange={ handleChange }
+			hideLabelFromVision
 		/>
 	);
 }

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -6,17 +6,19 @@ import removeAccents from 'remove-accents';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { ComboboxControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Dropdown, ComboboxControl } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
+import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import PostPanelRow from '../post-panel-row';
 import { buildTermsTree } from '../../utils/terms';
 import { store as editorStore } from '../../store';
 
@@ -175,6 +177,76 @@ export function PageAttributesParent() {
 			onChange={ handleChange }
 			hideLabelFromVision
 		/>
+	);
+}
+
+function PostParentToggle( { isOpen, onClick } ) {
+	const parentPost = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( editorStore );
+		const parentPostId = getEditedPostAttribute( 'parent' );
+		if ( ! parentPostId ) {
+			return null;
+		}
+		const { getEntityRecord } = select( coreStore );
+		const postTypeSlug = getEditedPostAttribute( 'type' );
+		return getEntityRecord( 'postType', postTypeSlug, parentPostId );
+	}, [] );
+	const parentTitle = useMemo(
+		() => ( ! parentPost ? __( 'None' ) : getTitle( parentPost ) ),
+		[ parentPost ]
+	);
+	return (
+		<Button
+			size="compact"
+			className="editor-post-parent__panel-toggle"
+			variant="tertiary"
+			aria-expanded={ isOpen }
+			// translators: %s: Current post parent.
+			aria-label={ sprintf( __( 'Change parent: %s' ), parentTitle ) }
+			onClick={ onClick }
+		>
+			{ parentTitle }
+		</Button>
+	);
+}
+
+export function ParentRow() {
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the popover's anchor updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	// Memoize popoverProps to avoid returning a new object every time.
+	const popoverProps = useMemo(
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
+		[ popoverAnchor ]
+	);
+	return (
+		<PostPanelRow label={ __( 'Parent' ) } ref={ setPopoverAnchor }>
+			<Dropdown
+				popoverProps={ popoverProps }
+				className="editor-post-parent__panel-dropdown"
+				contentClassName="editor-post-parent__panel-dialog"
+				focusOnMount
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<PostParentToggle isOpen={ isOpen } onClick={ onToggle } />
+				) }
+				renderContent={ ( { onClose } ) => (
+					<div className="editor-post-parent">
+						<InspectorPopoverHeader
+							title={ __( 'Parent' ) }
+							onClose={ onClose }
+						/>
+						<PageAttributesParent />
+					</div>
+				) }
+			/>
+		</PostPanelRow>
 	);
 }
 

--- a/packages/editor/src/components/page-attributes/style.scss
+++ b/packages/editor/src/components/page-attributes/style.scss
@@ -1,14 +1,13 @@
-.editor-post-parent__panel, .editor-post-order__panel {
+.editor-post-parent__panel,
+.editor-post-order__panel {
 	padding-top: $grid-unit-10;
+	.editor-post-panel__row-control > div {
+		width: 100%;
+	}
 }
 
-.editor-post-parent__panel, .editor-post-order__panel {
-    .editor-post-panel__row-control > div {
-        width: 100%;
-    }
-}
-
-.editor-post-parent__panel-dialog .editor-post-parent, .editor-post-order__panel-dialog .editor-post-order {
+.editor-post-parent__panel-dialog .editor-post-parent,
+.editor-post-order__panel-dialog .editor-post-order {
 	// sidebar width - popover padding - form margin
 	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;
 	margin: $grid-unit-10;

--- a/packages/editor/src/components/page-attributes/style.scss
+++ b/packages/editor/src/components/page-attributes/style.scss
@@ -6,9 +6,14 @@
 	}
 }
 
-.editor-post-parent__panel-dialog .editor-post-parent,
-.editor-post-order__panel-dialog .editor-post-order {
-	// sidebar width - popover padding - form margin
-	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;
-	margin: $grid-unit-10;
+.editor-post-parent__panel-dialog,
+.editor-post-order__panel-dialog {
+	.editor-post-parent,
+	.editor-post-order {
+		margin: $grid-unit-10;
+	}
+
+	.components-popover__content {
+		min-width: 320px;
+	}
 }

--- a/packages/editor/src/components/page-attributes/style.scss
+++ b/packages/editor/src/components/page-attributes/style.scss
@@ -1,0 +1,15 @@
+.editor-post-parent__panel, .editor-post-order__panel {
+	padding-top: $grid-unit-10;
+}
+
+.editor-post-parent__panel, .editor-post-order__panel {
+    .editor-post-panel__row-control > div {
+        width: 100%;
+    }
+}
+
+.editor-post-parent__panel-dialog .editor-post-parent, .editor-post-order__panel-dialog .editor-post-order {
+	// sidebar width - popover padding - form margin
+	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;
+	margin: $grid-unit-10;
+}

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -22,7 +22,6 @@ import { store as interfaceStore } from '@wordpress/interface';
 /**
  * Internal dependencies
  */
-import PageAttributesPanel from '../page-attributes/panel';
 import PatternOverridesPanel from '../pattern-overrides-panel';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 import PluginSidebar from '../plugin-sidebar';
@@ -117,7 +116,6 @@ const SidebarContent = ( {
 					) }
 					<PostTransformPanel />
 					<PostTaxonomiesPanel />
-					<PageAttributesPanel />
 					<PatternOverridesPanel />
 					{ extraPanels }
 				</Tabs.TabPanel>

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -12,6 +12,7 @@ import PostActions from '../post-actions';
 import PostAuthorPanel from '../post-author/panel';
 import PostCardPanel from '../post-card-panel';
 import PostContentInformation from '../post-content-information';
+import PageAttributesPanel from '../page-attributes/panel';
 import PostDiscussionPanel from '../post-discussion/panel';
 import { PrivatePostExcerptPanel as PostExcerptPanel } from '../post-excerpt/panel';
 import PostFeaturedImagePanel from '../post-featured-image/panel';
@@ -75,6 +76,7 @@ export default function PostSummary( { onActionPerformed } ) {
 										<PostAuthorPanel />
 										<PostTemplatePanel />
 										<PostDiscussionPanel />
+										<PageAttributesPanel />
 										<PostSyncStatus />
 										<BlogTitle />
 										<PostsPerPage />

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -16,6 +16,7 @@
 @import "./components/inserter-sidebar/style.scss";
 @import "./components/keyboard-shortcut-help-modal/style.scss";
 @import "./components/list-view-sidebar/style.scss";
+@import "./components/page-attributes/style.scss";
 @import "./components/post-author/style.scss";
 @import "./components/post-actions/style.scss";
 @import "./components/post-card-panel/style.scss";

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -36,16 +36,7 @@ test.describe( 'Test Custom Post Types', () => {
 			} )
 			.click();
 
-		// Open the Document -> Page Attributes panel.
-		const pageAttributes = page.getByRole( 'button', {
-			name: 'Page Attributes',
-		} );
-		const isClosed =
-			( await pageAttributes.getAttribute( 'aria-expanded' ) ) ===
-			'false';
-		if ( isClosed ) {
-			await pageAttributes.click();
-		}
+		await page.locator( '.editor-post-parent__panel-toggle' ).click();
 
 		const parentPageLocator = page.getByRole( 'combobox', {
 			name: 'Parent',
@@ -61,6 +52,8 @@ test.describe( 'Test Custom Post Types', () => {
 		await page.keyboard.type( 'Child Post' );
 		await editor.publishPost();
 		await page.reload();
+
+		await page.locator( '.editor-post-parent__panel-toggle' ).click();
 
 		// Confirm parent page selection matches after reloading.
 		await expect( parentPageLocator ).toHaveValue( parentPage );


### PR DESCRIPTION
This PR implements the new parent and order design.
Related https://github.com/WordPress/gutenberg/issues/60291, https://github.com/WordPress/gutenberg/issues/59689.

## Screenshot
<img width="350" alt="Screenshot 2024-05-23 at 19 48 35" src="https://github.com/WordPress/gutenberg/assets/11271197/053526aa-ac25-49e1-b804-444c39767061">



## Testing Instructions
Verified I could still change the parent and order of a page.
