### PR TITLE
Add prefix / suffix to Post Date block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -625,7 +625,7 @@ Display the publish date for an entry such as a post or page. ([Source](https://
 -	**Name:** core/post-date
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayType, format, isLink, textAlign
+-	**Attributes:** displayType, format, isLink, prefix, suffix, textAlign
 
 ## Excerpt
 

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -10,8 +10,16 @@
 		"textAlign": {
 			"type": "string"
 		},
+		"prefix": {
+			"type": "string",
+			"default": ""
+		},
 		"format": {
 			"type": "string"
+		},
+		"suffix": {
+			"type": "string",
+			"default": ""
 		},
 		"isLink": {
 			"type": "boolean",

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -13,6 +13,7 @@ import {
 	AlignmentControl,
 	BlockControls,
 	InspectorControls,
+	RichText,
 	useBlockProps,
 	__experimentalDateFormatPicker as DateFormatPicker,
 	__experimentalPublishDateTimePicker as PublishDateTimePicker,
@@ -30,7 +31,7 @@ import { DOWN } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 
 export default function PostDateEdit( {
-	attributes: { textAlign, format, isLink, displayType },
+	attributes: { textAlign, format, prefix, suffix, isLink, displayType },
 	context: { postId, postType: postTypeSlug, queryId },
 	setAttributes,
 } ) {
@@ -148,7 +149,6 @@ export default function PostDateEdit( {
 						</ToolbarGroup>
 					) }
 			</BlockControls>
-
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<DateFormatPicker
@@ -188,7 +188,27 @@ export default function PostDateEdit( {
 				</PanelBody>
 			</InspectorControls>
 
-			<div { ...blockProps }>{ postDate }</div>
+			<div { ...blockProps }>
+				<RichText
+					className="wp-block-post-date__prefix"
+					multiline={ false }
+					aria-label={ __( 'Prefix' ) }
+					placeholder={ __( 'Prefix' ) + ' ' }
+					value={ prefix }
+					onChange={ ( value ) => setAttributes( { prefix: value } ) }
+					tagName="span"
+				/>
+				{ postDate }
+				<RichText
+					className="wp-block-post-terms__suffix"
+					multiline={ false }
+					aria-label={ __( 'Suffix' ) }
+					placeholder={ ' ' + __( 'Suffix' ) }
+					value={ suffix }
+					onChange={ ( value ) => setAttributes( { suffix: value } ) }
+					tagName="span"
+				/>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -50,7 +50,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 
 	$prefix = '';
 	if ( isset( $attributes['prefix'] ) && $attributes['prefix'] ) {
-		$prefix = '<span class="wp-block-post-date__prefix">' . $attributes['prefix'] . '</span>';
+		$prefix = wp_kses_post( '<span class="wp-block-post-date__prefix">' . $attributes['prefix'] . '</span>' );
 	}
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
@@ -59,7 +59,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 
 	$suffix = '';
 	if ( isset( $attributes['suffix'] ) && $attributes['suffix'] ) {
-		$suffix = '<span class="wp-block-post-date__suffix">' . $attributes['suffix'] . '</span>';
+		$suffix = wp_kses_post( '<span class="wp-block-post-date__suffix">' . $attributes['suffix'] . '</span>' );
 	}
 
 	return sprintf(

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -48,15 +48,27 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
+	$prefix = '';
+	if ( isset( $attributes['prefix'] ) && $attributes['prefix'] ) {
+		$prefix = '<span class="wp-block-post-date__prefix">' . $attributes['prefix'] . '</span>';
+	}
+
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$formatted_date = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $post_ID ), $formatted_date );
 	}
 
+	$suffix = '';
+	if ( isset( $attributes['suffix'] ) && $attributes['suffix'] ) {
+		$suffix = '<span class="wp-block-post-date__suffix">' . $attributes['suffix'] . '</span>';
+	}
+
 	return sprintf(
-		'<div %1$s><time datetime="%2$s">%3$s</time></div>',
+		'<div %1$s>%2$s<time datetime="%3$s">%4$s</time>%5$s</div>',
 		$wrapper_attributes,
+		$prefix,
 		$unformatted_date,
-		$formatted_date
+		$formatted_date,
+		$suffix
 	);
 }
 

--- a/test/integration/fixtures/blocks/core__post-date.json
+++ b/test/integration/fixtures/blocks/core__post-date.json
@@ -4,7 +4,9 @@
 		"isValid": true,
 		"attributes": {
 			"isLink": false,
-			"displayType": "date"
+			"displayType": "date",
+			"prefix": "",
+			"suffix": ""
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add prefix / suffix to Post Date block

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

https://github.com/WordPress/gutenberg/issues/47738

The [Post Date](https://wordpress.org/documentation/article/post-date-block/) block doesn't let you add a prefix or suffix. You can manually add a text before the block but you are using the Last Modified Date and it is empty then the text you added will appear with no date output.

This would allow using 2 Post Date blocks on the same post, which may solve https://github.com/WordPress/gutenberg/issues/46645 :

> Published on : 2 Febuary 2023
> Last Modified : 3 Febuary 2023

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This pull request adds an optional prefix / suffix to Post Date, the same way the Category block does (see PR https://github.com/WordPress/gutenberg/pull/40559).

> prefix date suffix

For instance :

> Published on : 2 Febuary 2023

This would allow to use 2 Post Date blocks on the same post, which may solve https://github.com/WordPress/gutenberg/issues/46645 :

Published on : 2 Febuary 2023
Last Modified : 3 Febuary 2023

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a new blog post
2. Add a Post Date block with the "Display last modified date" toggle disabled
3. Enter a prefix. example "Posted On: "
4. Enter a suffix. example "."
2. Add a Post Date block with the "Display last modified date" toggle enabled
5. Enter a prefix. example "Updated On: "
6. Enter a suffix. example "." 
7. Save the post and view the post. As it is a new post it should show the "Posted On: 'Date'." and **Not** the "Updated On: 'Date'." as they are the same.
8. Update the publish date to be in the past to trigger the Published and Last Modified date to be different. This will allow the Post Date block output to pass the follow statement.  https://github.com/dsas/gutenberg/blob/5b95e96a90aac522c6df73349930144b89b53dfa/packages/block-library/src/post-date/index.php#L38
9. Save the post and view the post.  It should show the "Posted On: 'Date'." and  the "Updated On: 'Date'."
10. Party

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/2807433/a8d047b6-8a50-49c1-a224-b8a47d3a48d6)
![image](https://github.com/WordPress/gutenberg/assets/2807433/4b73125a-289d-470d-ad75-51e257e4b5c6)
![image](https://github.com/WordPress/gutenberg/assets/2807433/f6101301-d079-488c-b776-d6c71c522ad1)
![image](https://github.com/WordPress/gutenberg/assets/2807433/b1d01fc3-73c9-4787-b696-eb88280c8bd4)
![image](https://github.com/WordPress/gutenberg/assets/2807433/bf53283b-7850-4ddc-9502-e685deb185c9)


