### PR TITLE
Template Actions: Fix console error when resetting template

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -835,8 +835,8 @@ const resetTemplateAction = {
 							}
 							await onConfirm( items );
 							onActionPerformed?.( items );
+							setIsBusy( false );
 							closeModal();
-							isBusy( false );
 						} }
 						isBusy={ isBusy }
 						disabled={ isBusy }


### PR DESCRIPTION

## What?
This PR fixes console error when resetting template.

https://github.com/WordPress/gutenberg/assets/54422211/f9e2623c-619f-45b9-adfa-a2b18f2ef29c

## Why?

`isBusy` is not a function.

## How?

As in the following two places, execute `setIsBusy( false )` before `closeModal()`.

https://github.com/WordPress/gutenberg/blob/de9a53a44464cb0fa8f9e8a0c8c0e76b0991142c/packages/editor/src/components/post-actions/actions.js#L198-L199

https://github.com/WordPress/gutenberg/blob/de9a53a44464cb0fa8f9e8a0c8c0e76b0991142c/packages/editor/src/components/post-actions/actions.js#L926-L927

## Testing Instructions

- Make changes to the template.
- Reset template.
- There are no console errors.