### PR TITLE
Remove lock icons from Content blocks inner blocks when editing a page in the site editor

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1759,16 +1759,13 @@ export function canMoveBlock( state, clientId, rootClientId = null ) {
 	if ( attributes === null ) {
 		return true;
 	}
-	if ( getBlockEditingMode( state, rootClientId ) !== 'default' ) {
-		return false;
-	}
 	if ( attributes.lock?.move !== undefined ) {
 		return ! attributes.lock.move;
 	}
 	if ( getTemplateLock( state, rootClientId ) === 'all' ) {
 		return false;
 	}
-	return true;
+	return getBlockEditingMode( state, rootClientId ) !== 'disabled';
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
It was mentioned in https://github.com/WordPress/gutenberg/pull/61127#issuecomment-2127615997 that there was a regression around how lock icons are shown when editing a page in the site editor.

Previously, blocks within the 'Content' block were shown without the lock icon as they can be freely edited, but after #61127 they show a lock icon.

## Why?
The regression seems to have happened because of a change to the `canMoveBlock` selector, which is called as part of the logic for displaying the lock icon. The change considered any block with a parent that has `blockEditingMode === 'contentOnly'` as not moveable, but that's not the case.

My understanding is there are some differences between `blockEditingMode === 'contentOnly'` and `templateLock === 'contentOnly'` that can be hard to understand. `blockEditingMode` doesn't affect inner blocks, while `templateLock` does.

The selector is probably missing some logic for `templateLock === 'contentOnly'`, but I'd consider that for a different PR.

## How?
Revert the changes to the selector. This may bring back some other issues that the change was intended to solve.

## Testing Instructions

In addition to the steps below, it's also worth smoke testing other editing modes (editing template, template parts, posts etc.)

#### Page editing
1. Edit a page
2. Open List View

Expected: The lock icons shouldn't be displayed on the inner blocks of the 'Content' block. The templated blocks (Title, Featured Image, Content) are also not expected to show a lock icon since #61127, the block options dropdown menu explains why those blocks can't be moved.

#### Synced patterns with overrides
1. Insert a synced pattern that has overrides
2. Open List View

Expected: The lock icons are not displayed on overriden block with a synced pattern. The block options dropdown menu explains why those blocks can't be moved.

#### contentOnly locked groups
1. Insert a group that has inner blocks (easiest way is to insert an unsynced pattern that has a group as the wrapping block)
2. Switch to code editor mode and add the `"templateLock":"contentOnly"` attribute to the group block
3. Switch back to visual mode and open list view

Expected: The lock icons are not displayed on the inner blocks of the group. The block options dropdown menu explains why those blocks can't be moved.

## Screenshots or screencast <!-- if applicable -->
#### Page editing in the site editor
![Screenshot 2024-05-24 at 12 38 48 pm](https://github.com/WordPress/gutenberg/assets/677833/a188d752-1f59-4f44-9b41-770a0a34192b)

#### Synced patterns with overrides
![Screenshot 2024-05-24 at 12 42 40 pm](https://github.com/WordPress/gutenberg/assets/677833/9d7468d5-1a8a-4a65-ad19-f06996aa7266)

#### Groups with `templateLock === 'contentOnly'`
![Screenshot 2024-05-24 at 12 41 20 pm](https://github.com/WordPress/gutenberg/assets/677833/6c4d9ad2-49be-499a-9ef1-51370a0999f8)
