### PR TITLE
fix: Inconsistent Padding in Post Template Block

### DIFF
--- a/packages/block-library/src/post-template/editor.scss
+++ b/packages/block-library/src/post-template/editor.scss
@@ -1,6 +1,6 @@
 .editor-styles-wrapper {
 	ul.wp-block-post-template {
-		padding-left: 0;
+		padding: 0;
 		margin-left: 0;
 		list-style: none;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #61655


## What?
- If you add background color to the Post Template block, it inherits padding from [the styles](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/list/style.scss) from the List block in the Editor.
- see https://github.com/WordPress/gutenberg/issues/61655 for more
- It inherently only has padding-left: 0 applied ([here](https://github.com/WordPress/gutenberg/blob/f9df151ab91b74e2b787bba579275e3a258ab29d/packages/block-library/src/post-template/editor.scss#L3)).
- This PR adds Padding: 0; therefore, making it same as what is displayed in the front-end.
<img width="1470" alt="Screenshot 2024-05-24 at 12 01 05 PM" src="https://github.com/WordPress/gutenberg/assets/71006004/77b8ab00-ee56-48ca-b159-2191feb4a07c">

## Why?
Editor only had left padding aplied and the post-template ul was taking padding from [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/list/style.scss).
```
ol.has-background,ul.has-background {
    padding: 1.25em 2.375em
}
```

## How
By adding padding: 0 instead of just padding-left: 0, it will add padding same as the front-end see [here](https://github.com/WordPress/gutenberg/blob/f9df151ab91b74e2b787bba579275e3a258ab29d/packages/block-library/src/post-template/style.scss#L6).

## Testing Instructions

1. Open a new Playground instance and navigate to the Post Editor
2. Using a Pattern, add one of the Posts options
3. Inside the Post Template block, wrap all internal blocks in a Group and see the background color on the Group to any color.
4. Then set the background color on the Post Template block to a different color. Notice how the padding is applied and that it does not show up on the frontend.
5. Now do the same with this branch and see that the front-end & editor looks the same

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots

|--------| Editor | Front-End |
|--------|--------|--------|
| BEFORE |<img width="836" alt="Screenshot 2024-05-24 at 12 14 16 PM" src="https://github.com/WordPress/gutenberg/assets/71006004/d18b0e67-e846-42ce-998d-5315273d6b8a">|<img width="836" alt="Screenshot 2024-05-24 at 12 07 41 PM" src="https://github.com/WordPress/gutenberg/assets/71006004/05f8eb42-472c-43b6-882a-fc8dde4045c7">|
| AFTER |<img width="836" alt="Screenshot 2024-05-24 at 12 07 24 PM" src="https://github.com/WordPress/gutenberg/assets/71006004/954318b4-51f6-47be-8926-243e5daca3f1">|<img width="836" alt="Screenshot 2024-05-24 at 12 07 41 PM" src="https://github.com/WordPress/gutenberg/assets/71006004/05f8eb42-472c-43b6-882a-fc8dde4045c7">|
