### PR TITLE
Skip flaky 'Zoom out' e2e test

### DIFF
--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -3,7 +3,10 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'Zoom Out', () => {
+// The test is flaky and fails almost consistently.
+// See: https://github.com/WordPress/gutenberg/issues/61806.
+// eslint-disable-next-line playwright/no-skipped-test
+test.describe.skip( 'Zoom Out', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );


### PR DESCRIPTION
## What?
See #61806.

Skipping the flaky "Zoom out" e2e test. It has failed 200+ times just in few days.

## Testing Instructions
CI checks should be green.
