### PR TITLE
Fixed table block border issue in various theme #61491

### DIFF
--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -30,10 +30,12 @@
 	.has-fixed-layout {
 		table-layout: fixed;
 		width: 100%;
+		border-color: inherit;
 
 		td,
 		th {
 			word-break: break-word;
+			border: 1px solid;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The table block border is not displaying same on editor side and front-end side when we changed its text color. So, I have resolved the issue.

[Resolved the Issue:](https://www.awesomescreenshot.com/video/27983194?key=1f0d8c9e80a75ca79136f628f46fa2bf)

## Why?
- I have reviewed the "table block" and found that table block border is not displaying same on editor side and front-end side when we changed its text color.
- I think that it should be on both side(Editor & Front-end)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding border-color to table and adding border to th/td. Now it will work as expected.

## Testing Instructions
- Type / to choose a block
- Select Table block
- Add demo text for header, footer, and columns
- Change text color
- Save the changes and publish the page.
- View front-view.
- Change theme and follow the same steps.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
I have provided video in above.