### PR TITLE
Try: Enable script debug for the test env

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,6 +4,9 @@
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {
+			"config": {
+				"SCRIPT_DEBUG": true
+			},
 			"mappings": {
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",


### PR DESCRIPTION
## What?
🚧  DO NOT MERGE! 🚧

PR enables `SCRIPT_DEBUG` for the testing environment to catch any warnings triggered by new JSX runtime. See: #61917.