### PR TITLE
Packages: Increase the minimum required Node.js version to v18.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53072,7 +53072,8 @@
 				"@wordpress/i18n": "file:../i18n"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/annotations": {
@@ -53088,7 +53089,8 @@
 				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -53112,7 +53114,8 @@
 				"@wordpress/url": "file:../url"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/autop": {
@@ -53123,7 +53126,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/babel-plugin-import-jsx-pragma": {
@@ -53132,7 +53136,8 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.12.9"
@@ -53149,7 +53154,8 @@
 				"is-plain-object": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.12.9"
@@ -53174,14 +53180,19 @@
 				"react": "^18.3.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/base-styles": {
 			"name": "@wordpress/base-styles",
 			"version": "4.49.0",
 			"dev": true,
-			"license": "GPL-2.0-or-later"
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
 		},
 		"packages/blob": {
 			"name": "@wordpress/blob",
@@ -53191,7 +53202,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/block-directory": {
@@ -53222,7 +53234,8 @@
 				"change-case": "^4.1.2"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -53282,7 +53295,8 @@
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -53392,7 +53406,8 @@
 				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -53415,7 +53430,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/block-serialization-spec-parser": {
@@ -53427,7 +53443,8 @@
 				"phpegjs": "^1.0.0-beta7"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/blocks": {
@@ -53464,7 +53481,8 @@
 				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -53489,7 +53507,8 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/commands": {
@@ -53509,7 +53528,8 @@
 				"cmdk": "^0.2.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -53570,7 +53590,8 @@
 				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -53627,7 +53648,8 @@
 				"use-memo-one": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -53662,7 +53684,8 @@
 				"@wordpress/url": "file:../url"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -53697,7 +53720,8 @@
 				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -53744,7 +53768,11 @@
 			"name": "@wordpress/create-block-tutorial-template",
 			"version": "3.12.0",
 			"dev": true,
-			"license": "GPL-2.0-or-later"
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
 		},
 		"packages/customize-widgets": {
 			"name": "@wordpress/customize-widgets",
@@ -53776,7 +53804,8 @@
 				"fast-deep-equal": "^3.1.3"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -53805,7 +53834,8 @@
 				"use-memo-one": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -53822,7 +53852,8 @@
 				"@wordpress/deprecated": "file:../deprecated"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -53848,7 +53879,8 @@
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -53900,7 +53932,8 @@
 				"moment-timezone": "^0.5.40"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/dependency-extraction-webpack-plugin": {
@@ -53912,7 +53945,8 @@
 				"json2php": "^0.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
@@ -53927,7 +53961,8 @@
 				"@wordpress/hooks": "file:../hooks"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/docgen": {
@@ -53946,6 +53981,10 @@
 			},
 			"bin": {
 				"docgen": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/dom": {
@@ -53957,7 +53996,8 @@
 				"@wordpress/deprecated": "file:../deprecated"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/dom-ready": {
@@ -53968,7 +54008,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/e2e-test-utils": {
@@ -53986,7 +54027,8 @@
 				"node-fetch": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"jest": ">=29",
@@ -54010,7 +54052,8 @@
 				"web-vitals": "^3.5.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"@playwright/test": ">=1"
@@ -54037,7 +54080,8 @@
 				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"jest": ">=29",
@@ -54094,7 +54138,8 @@
 				"memize": "^2.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54156,7 +54201,8 @@
 				"react-autosize-textarea": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54198,7 +54244,8 @@
 				"clsx": "^2.1.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54255,7 +54302,8 @@
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54277,7 +54325,8 @@
 				"react-dom": "^18.3.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/env": {
@@ -54301,6 +54350,10 @@
 			},
 			"bin": {
 				"wp-env": "bin/wp-env"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/env/node_modules/cliui": {
@@ -54425,7 +54478,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/eslint-plugin": {
@@ -54453,8 +54507,8 @@
 				"requireindex": "^1.2.0"
 			},
 			"engines": {
-				"node": ">=14",
-				"npm": ">=6.14.4"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"@babel/core": ">=7",
@@ -54491,7 +54545,8 @@
 				"@wordpress/url": "file:../url"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54506,7 +54561,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/html-entities": {
@@ -54517,7 +54573,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/i18n": {
@@ -54536,7 +54593,8 @@
 				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/icons": {
@@ -54549,7 +54607,8 @@
 				"@wordpress/primitives": "file:../primitives"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/interactivity": {
@@ -54562,7 +54621,8 @@
 				"preact": "^10.19.3"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/interactivity-router": {
@@ -54573,7 +54633,8 @@
 				"@wordpress/interactivity": "file:../interactivity"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/interactivity/node_modules/@preact/signals": {
@@ -54646,7 +54707,8 @@
 				"clsx": "^2.1.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54661,7 +54723,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/jest-console": {
@@ -54674,7 +54737,8 @@
 				"jest-matcher-utils": "^29.6.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"jest": ">=29"
@@ -54690,7 +54754,8 @@
 				"babel-jest": "^29.6.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"@babel/core": ">=7",
@@ -54707,7 +54772,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"jest": ">=29",
@@ -54730,7 +54796,8 @@
 				"@wordpress/keycodes": "file:../keycodes"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -54745,7 +54812,8 @@
 				"@wordpress/i18n": "file:../i18n"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/lazy-import": {
@@ -54759,7 +54827,8 @@
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"npm": ">=6.9.0"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/list-reusable-blocks": {
@@ -54777,7 +54846,8 @@
 				"change-case": "^4.1.2"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54796,7 +54866,8 @@
 				"@wordpress/i18n": "file:../i18n"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/notices": {
@@ -54809,7 +54880,8 @@
 				"@wordpress/data": "file:../data"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -54821,7 +54893,8 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"npm-package-json-lint": ">=6.0.0"
@@ -54842,7 +54915,8 @@
 				"@wordpress/icons": "file:../icons"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54871,7 +54945,8 @@
 				"@wordpress/url": "file:../url"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54893,7 +54968,8 @@
 				"memize": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54910,7 +54986,8 @@
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
@@ -54922,7 +54999,8 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
@@ -54946,7 +55024,8 @@
 				"clsx": "^2.1.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -54962,7 +55041,8 @@
 				"@wordpress/api-fetch": "file:../api-fetch"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/prettier-config": {
@@ -54971,7 +55051,8 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"prettier": ">=3"
@@ -54987,7 +55068,8 @@
 				"clsx": "^2.1.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/priority-queue": {
@@ -54999,7 +55081,8 @@
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/private-apis": {
@@ -55010,7 +55093,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/project-management-automation": {
@@ -55024,6 +55108,10 @@
 				"@babel/runtime": "^7.16.0",
 				"@octokit/request-error": "^2.1.0",
 				"@octokit/webhooks": "7.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/react-i18n": {
@@ -55037,7 +55125,8 @@
 				"utility-types": "^3.10.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/react-native-aztec": {
@@ -55047,6 +55136,10 @@
 			"dependencies": {
 				"@wordpress/element": "file:../element",
 				"@wordpress/keycodes": "file:../keycodes"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "*",
@@ -55059,6 +55152,10 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/react-native-aztec": "file:../react-native-aztec"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react-native": "*"
@@ -55114,8 +55211,8 @@
 				"react-native-webview": "13.6.1"
 			},
 			"engines": {
-				"node": ">=12",
-				"npm": ">=6.9"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/react-native-editor/node_modules/buffer": {
@@ -55179,7 +55276,8 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=14.0"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"webpack": "^4.8.3 || ^5.0.0"
@@ -55196,7 +55294,8 @@
 				"rungen": "^0.3.2"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"redux": ">=4"
@@ -55213,8 +55312,8 @@
 				"jest-message-util": "^29.6.2"
 			},
 			"engines": {
-				"node": ">=14",
-				"npm": ">=6.9"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/report-flaky-tests/node_modules/@actions/github": {
@@ -55248,7 +55347,8 @@
 				"@wordpress/url": "file:../url"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -55272,7 +55372,8 @@
 				"memize": "^2.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -55290,7 +55391,8 @@
 				"history": "^5.3.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -55365,8 +55467,8 @@
 				"wp-scripts": "bin/wp-scripts.js"
 			},
 			"engines": {
-				"node": ">=18",
-				"npm": ">=6.14.4"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"@playwright/test": "^1.43.0",
@@ -55700,7 +55802,8 @@
 				"fast-deep-equal": "^3.1.3"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -55716,7 +55819,8 @@
 				"memize": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/style-engine": {
@@ -55728,7 +55832,8 @@
 				"change-case": "^4.1.2"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/stylelint-config": {
@@ -55741,7 +55846,8 @@
 				"stylelint-config-recommended-scss": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"stylelint": "^14.2"
@@ -55764,7 +55870,8 @@
 				"yjs": "~13.6.6"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/token-list": {
@@ -55775,7 +55882,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/undo-manager": {
@@ -55787,7 +55895,8 @@
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/url": {
@@ -55799,7 +55908,8 @@
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/viewport": {
@@ -55813,7 +55923,8 @@
 				"@wordpress/element": "file:../element"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
@@ -55824,7 +55935,8 @@
 			"version": "2.58.0",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/widgets": {
@@ -55846,6 +55958,10 @@
 				"@wordpress/notices": "file:../notices",
 				"clsx": "^2.1.1"
 			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
@@ -55859,7 +55975,8 @@
 				"@babel/runtime": "^7.16.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		}
 	},

--- a/packages/a11y/CHANGELOG.md
+++ b/packages/a11y/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/31270)). Learn more at https://nodejs.org/en/about/previous-releases.
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/a11y/CHANGELOG.md
+++ b/packages/a11y/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   Increase the minimum Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/31270)). Learn more at https://nodejs.org/en/about/previous-releases.
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 3.58.0 (2024-05-16)
 

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/annotations/CHANGELOG.md
+++ b/packages/annotations/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 2.58.0 (2024-05-16)
 
 ## 2.57.0 (2024-05-02)

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 6.55.0 (2024-05-16)
 
 ## 6.54.0 (2024-05-02)
@@ -116,7 +120,7 @@
 
 ### Breaking changes
 
-   `OPTIONS` requests handled by the preloading middleware are now resolved as `window.Response` objects if you explicitly set `parse: false` (for consistency with how GET requests are resolved). They used to be resolved as `Plain Old JavaScript Objects`.
+`OPTIONS` requests handled by the preloading middleware are now resolved as `window.Response` objects if you explicitly set `parse: false` (for consistency with how GET requests are resolved). They used to be resolved as `Plain Old JavaScript Objects`.
 
 ## 5.2.5 (2021-11-07)
 

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.41.0 (2024-05-16)
 
 ## 4.40.0 (2024-05-02)

--- a/packages/babel-plugin-import-jsx-pragma/README.md
+++ b/packages/babel-plugin-import-jsx-pragma/README.md
@@ -14,7 +14,7 @@ Install the module to your project using [npm](https://www.npmjs.com/).
 npm install @wordpress/babel-plugin-import-jsx-pragma
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Usage
 

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -24,7 +24,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"index.js"

--- a/packages/babel-plugin-makepot/CHANGELOG.md
+++ b/packages/babel-plugin-makepot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 5.42.0 (2024-05-16)
 
 ## 5.41.0 (2024-05-02)

--- a/packages/babel-plugin-makepot/README.md
+++ b/packages/babel-plugin-makepot/README.md
@@ -21,7 +21,7 @@ Install the module:
 npm install @wordpress/babel-plugin-makepot --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Contributing to this package
 

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"index.js"

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 7.42.0 (2024-05-16)
 

--- a/packages/babel-preset-default/README.md
+++ b/packages/babel-preset-default/README.md
@@ -12,7 +12,7 @@ Install the module
 npm install @wordpress/babel-preset-default --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ### Usage
 

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"build",

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.49.0 (2024-05-16)
 
 ## 4.48.0 (2024-05-02)

--- a/packages/base-styles/package.json
+++ b/packages/base-styles/package.json
@@ -20,6 +20,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/blob/CHANGELOG.md
+++ b/packages/blob/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/block-directory/CHANGELOG.md
+++ b/packages/block-directory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.35.0 (2024-05-16)
 
 ## 4.34.0 (2024-05-02)

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 12.26.0 (2024-05-16)
 
 ### Internal

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 8.35.0 (2024-05-16)
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/block-serialization-default-parser/CHANGELOG.md
+++ b/packages/block-serialization-default-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.58.0 (2024-05-16)
 
 ## 4.57.0 (2024-05-02)

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/block-serialization-spec-parser/CHANGELOG.md
+++ b/packages/block-serialization-spec-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.58.0 (2024-05-16)
 
 ## 4.57.0 (2024-05-02)

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "parser.js",
 	"sideEffects": false,

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 12.35.0 (2024-05-16)
 

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/browserslist-config/CHANGELOG.md
+++ b/packages/browserslist-config/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 5.41.0 (2024-05-16)
 
 ## 5.40.0 (2024-05-02)

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -10,7 +10,7 @@ Install the module
 $ npm install browserslist @wordpress/browserslist-config --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Usage
 

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"index.js"

--- a/packages/commands/CHANGELOG.md
+++ b/packages/commands/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 0.29.0 (2024-05-16)
 
 ### Internal

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ### Enhancements
 
@@ -32,7 +33,7 @@
 
 ### Enhancements
 
--   `FontSizePicker`: Add `vw` and `vh` units to the default units in the font size picker ([#60507]((https://github.com/WordPress/gutenberg/pull/60607)).
+-   `FontSizePicker`: Add `vw` and `vh` units to the default units in the font size picker ([#60507](<(https://github.com/WordPress/gutenberg/pull/60607)>).
 -   `PaletteEdit`: Use consistent spacing and metrics. ([#61368](https://github.com/WordPress/gutenberg/pull/61368)).
 -   `FormTokenField`: Hide label when not defined ([#61336](https://github.com/WordPress/gutenberg/pull/61336)).
 -   `ComboboxControl`: supports disabled items ([#61294](https://github.com/WordPress/gutenberg/pull/61294)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 6.35.0 (2024-05-16)
 
 ## 6.34.0 (2024-05-02)

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/core-commands/CHANGELOG.md
+++ b/packages/core-commands/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 0.27.0 (2024-05-16)
 
 ## 0.26.0 (2024-05-02)

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 6.35.0 (2024-05-16)
 

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 1.21.0 (2024-05-16)
 
 ## 1.20.0 (2024-05-02)

--- a/packages/create-block-interactive-template/package.json
+++ b/packages/create-block-interactive-template/package.json
@@ -19,6 +19,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/create-block-tutorial-template/CHANGELOG.md
+++ b/packages/create-block-tutorial-template/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.12.0 (2024-05-16)
 
 ## 3.11.0 (2024-05-02)

--- a/packages/create-block-tutorial-template/package.json
+++ b/packages/create-block-tutorial-template/package.json
@@ -19,6 +19,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/customize-widgets/CHANGELOG.md
+++ b/packages/customize-widgets/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 4.35.0 (2024-05-16)
 

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -17,7 +17,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/data-controls/CHANGELOG.md
+++ b/packages/data-controls/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.27.0 (2024-05-16)
 
 ## 3.26.0 (2024-05-02)

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,19 +2,23 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 9.28.0 (2024-05-16)
 
 ## 9.27.0 (2024-05-02)
 
 ## 9.26.0 (2024-04-19)
 
-- Add new `createSelector` function for creating memoized store selectors ([#60370](https://github.com/WordPress/gutenberg/pull/60370)).
+-   Add new `createSelector` function for creating memoized store selectors ([#60370](https://github.com/WordPress/gutenberg/pull/60370)).
 
 ## 9.25.0 (2024-04-03)
 
 ## 9.24.0 (2024-03-21)
 
--  Deprecate the `getIsResolved` meta-selector ([#59679](https://github.com/WordPress/gutenberg/pull/59679)).
+-   Deprecate the `getIsResolved` meta-selector ([#59679](https://github.com/WordPress/gutenberg/pull/59679)).
 
 ## 9.23.0 (2024-03-06)
 
@@ -40,13 +44,13 @@
 
 ### Bug Fix
 
--  Fix `combineReducers()` types ([#55321](https://github.com/WordPress/gutenberg/pull/55321)).
+-   Fix `combineReducers()` types ([#55321](https://github.com/WordPress/gutenberg/pull/55321)).
 
 ## 9.13.0 (2023-10-05)
 
 ### Enhancements
 
--  Change implementation of `combineReducers` so that it doesn't use `eval` internally, and can run with a CSP policy that doesn't allow `unsafe-eval` ([#54606](https://github.com/WordPress/gutenberg/pull/54606)).
+-   Change implementation of `combineReducers` so that it doesn't use `eval` internally, and can run with a CSP policy that doesn't allow `unsafe-eval` ([#54606](https://github.com/WordPress/gutenberg/pull/54606)).
 
 ## 9.12.0 (2023-09-20)
 
@@ -56,7 +60,7 @@
 
 ### Enhancements
 
--  Warn if the `useSelect` hook returns different values when called with the same state and parameters ([#53666](https://github.com/WordPress/gutenberg/pull/53666)).
+-   Warn if the `useSelect` hook returns different values when called with the same state and parameters ([#53666](https://github.com/WordPress/gutenberg/pull/53666)).
 
 ## 9.9.0 (2023-08-10)
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 1.2.0 (2024-05-16)
 

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.58.0 (2024-05-16)
 
 ## 4.57.0 (2024-05-02)

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 5.9.0 (2024-05-16)
 
 ## 5.8.0 (2024-05-02)

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -21,7 +21,7 @@ Install the module
 npm install @wordpress/dependency-extraction-webpack-plugin --save-dev
 ```
 
-**Note**: This package requires Node.js 18.0.0 or later. It also requires webpack 5.0.0 or newer. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It also requires webpack 5.0.0 or newer. It is not compatible with older versions.
 
 ## Usage
 

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=18"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"lib",

--- a/packages/deprecated/CHANGELOG.md
+++ b/packages/deprecated/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 1.67.0 (2024-05-16)
 
 ## 1.66.0 (2024-05-02)
@@ -88,7 +92,7 @@
 
 ### Bug Fixes
 
--	Fix getting param annotations for default exported functions. ([#31603](https://github.com/WordPress/gutenberg/pull/31603))
+-   Fix getting param annotations for default exported functions. ([#31603](https://github.com/WordPress/gutenberg/pull/31603))
 
 ## 1.17.0 (2021-04-29)
 

--- a/packages/docgen/README.md
+++ b/packages/docgen/README.md
@@ -16,6 +16,8 @@ Install the module
 npm install @wordpress/docgen --save-dev
 ```
 
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
+
 ## Usage
 
 ```bash

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -19,6 +19,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"files": [
 		"bin",
 		"lib"

--- a/packages/dom-ready/CHANGELOG.md
+++ b/packages/dom-ready/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)
@@ -10,7 +14,7 @@
 
 ## 3.55.0 (2024-04-03)
 
-- fix return types of `focus.tabbable` methods to be `HTMLElement` instead of `Element`.
+-   fix return types of `focus.tabbable` methods to be `HTMLElement` instead of `Element`.
 
 ## 3.54.0 (2024-03-21)
 
@@ -94,7 +98,7 @@
 
 ## 3.14.0 (2022-07-27)
 
-- `getRectangleFromRange` may now return `null`.
+-   `getRectangleFromRange` may now return `null`.
 
 ## 3.13.0 (2022-07-13)
 
@@ -108,7 +112,7 @@
 
 ### Deprecation
 
-- Deprecate `isNumberInput`, as it is no longer used internally ([#40896](https://github.com/WordPress/gutenberg/pull/40896)).
+-   Deprecate `isNumberInput`, as it is no longer used internally ([#40896](https://github.com/WordPress/gutenberg/pull/40896)).
 
 ## 3.8.0 (2022-05-04)
 

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 0.26.0 (2024-05-16)
 
 ## 0.25.0 (2024-05-02)
@@ -54,4 +58,4 @@
 
 ## 0.1.0 (2023-05-10)
 
-- Initial version of the package.
+-   Initial version of the package.

--- a/packages/e2e-test-utils-playwright/README.md
+++ b/packages/e2e-test-utils-playwright/README.md
@@ -16,7 +16,7 @@ Install the module
 npm install @wordpress/e2e-test-utils-playwright --save-dev
 ```
 
-**Note**: This package requires Node.js 12.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## API
 
@@ -42,6 +42,7 @@ await admin.visitAdminPage( 'options-general.php' );
 End to end test utilities for the WordPress Block Editor.
 
 To use these utilities, instantiate them within each test file:
+
 ```js
 test.use( {
 	editor: async ( { page }, use ) => {
@@ -53,7 +54,7 @@ test.use( {
 Within a test or test utility, use the `canvas` property to select elements within the iframe canvas:
 
 ```js
-await editor.canvas.locator( 'role=document[name="Paragraph block"i]' )
+await editor.canvas.locator( 'role=document[name="Paragraph block"i]' );
 ```
 
 ### PageUtils

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"build",

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 10.29.0 (2024-05-16)
 
 ## 10.28.0 (2024-05-02)
@@ -38,9 +42,9 @@
 
 ### Enhancement
 
--    Update promise order in `loginUser` to avoid any flakiness in the tests.
--    Update `activateTheme` to redirect to `themes.php` after theme activation, if theme redirects to some other page.
--    Update `activatePlugin` to redirect to `plugins.php` after plugin activation, if plugin redirects to some other page.
+-   Update promise order in `loginUser` to avoid any flakiness in the tests.
+-   Update `activateTheme` to redirect to `themes.php` after theme activation, if theme redirects to some other page.
+-   Update `activatePlugin` to redirect to `plugins.php` after plugin activation, if plugin redirects to some other page.
 
 ## 10.12.0 (2023-08-31)
 
@@ -70,7 +74,7 @@
 
 ### Breaking Changes
 
--  Started requiring Jest v29 instead of v27 as a peer dependency. See [breaking changes in Jest 28](https://jestjs.io/blog/2022/04/25/jest-28) and [in jest 29](https://jestjs.io/blog/2022/08/25/jest-29) ([#47388](https://github.com/WordPress/gutenberg/pull/47388))
+-   Started requiring Jest v29 instead of v27 as a peer dependency. See [breaking changes in Jest 28](https://jestjs.io/blog/2022/04/25/jest-28) and [in jest 29](https://jestjs.io/blog/2022/08/25/jest-29) ([#47388](https://github.com/WordPress/gutenberg/pull/47388))
 
 ## 9.5.0 (2023-03-01)
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -14,7 +14,7 @@ Install the module
 npm install @wordpress/e2e-test-utils --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## API
 

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"build",

--- a/packages/e2e-tests/CHANGELOG.md
+++ b/packages/e2e-tests/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 7.29.0 (2024-05-16)
 

--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -80,7 +80,7 @@ Debugging in a Chrome browser can be replaced with `vscode`'s debugger by adding
 
 This will run jest, targetting the spec file currently open in the editor. `vscode`'s debugger can now be used to add breakpoints and inspect tests as you would in Chrome DevTools.
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Contributing to this package
 

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"dependencies": {
 		"@wordpress/e2e-test-utils": "file:../e2e-test-utils",

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 7.35.0 (2024-05-16)
 

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 5.35.0 (2024-05-16)
 

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/edit-widgets/CHANGELOG.md
+++ b/packages/edit-widgets/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 5.35.0 (2024-05-16)
 

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 13.35.0 (2024-05-16)
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 5.35.0 (2024-05-16)
 
 ## 5.34.0 (2024-05-02)
@@ -136,7 +140,7 @@
 
 ### Bug Fix
 
-- Serialize will now keep correct casing for SVG attributes ([#38936](https://github.com/WordPress/gutenberg/pull/38936)).
+-   Serialize will now keep correct casing for SVG attributes ([#38936](https://github.com/WordPress/gutenberg/pull/38936)).
 
 ## 4.1.0 (2022-01-27)
 

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 9.10.0 (2024-05-16)
 
 ## 9.9.0 (2024-05-02)
@@ -30,7 +34,7 @@
 
 ### Breaking Change
 
-- Update Docker usage to `docker compose` V2 following [deprecation](https://docs.docker.com/compose/migrate/) of `docker-compose` V1.
+-   Update Docker usage to `docker compose` V2 following [deprecation](https://docs.docker.com/compose/migrate/) of `docker-compose` V1.
 
 ## 8.13.0 (2023-11-29)
 

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -19,6 +19,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"directories": {
 		"lib": "lib",
 		"test": "tests"

--- a/packages/escape-html/CHANGELOG.md
+++ b/packages/escape-html/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 2.58.0 (2024-05-16)
 
 ## 2.57.0 (2024-05-02)

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `@wordpress/is-gutenberg-plugin` rule has been replaced by `@wordpress/wp-global-usage` ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
 -   `@wordpress/wp-process-env` rule has been added and included in the recommended configurations ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
 -   `@wordpress/gutenberg-phase` rule has been removed (deprecated in v10.0.0) ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 18.1.0 (2024-05-16)
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/eslint-plugin --save-dev
 ```
 
-**Note**: This package requires `node` 14.0.0 or later, and `npm` 6.14.4 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Usage
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -20,8 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14",
-		"npm": ">=6.14.4"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"configs",

--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.35.0 (2024-05-16)
 
 ## 4.34.0 (2024-05-02)

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/html-entities/CHANGELOG.md
+++ b/packages/html-entities/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.58.0 (2024-05-16)
 
 ## 4.57.0 (2024-05-02)
@@ -114,7 +118,7 @@
 
 ## 4.3.0 (2022-01-27)
 
-- Add new `addLocaleData` method to merge locale data into the Tannin instance by domain.
+-   Add new `addLocaleData` method to merge locale data into the Tannin instance by domain.
 
 ## 4.2.0 (2021-07-21)
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 9.49.0 (2024-05-16)
 
 ## 9.48.0 (2024-05-02)
@@ -10,7 +14,7 @@
 
 ## 9.46.0 (2024-04-03)
 
-- Add new `chevronDownSmall` icon.
+-   Add new `chevronDownSmall` icon.
 
 ## 9.45.0 (2024-03-21)
 
@@ -32,7 +36,7 @@
 
 ### New features
 
-- Add new `funnel` icon.
+-   Add new `funnel` icon.
 
 ## 9.36.0 (2023-11-02)
 
@@ -123,14 +127,17 @@
 ## 9.0.0 (2022-05-18)
 
 ### Breaking Changes
+
 -   Removed icons no longer used by the UI: `commentTitle`, `postTitle`, `queryTitle`, `archiveTitle`.
 
 ### Enhancement
+
 -   Update the `title` icon to match g2 design language. ([#40596](https://github.com/WordPress/gutenberg/pull/40596))
 
 ## 8.4.0 (2022-05-04)
 
 ## 8.3.0 (2022-04-21)
+
 ### New Features
 
 -   Add new `filter` icon. ([#40435](https://github.com/WordPress/gutenberg/pull/40435))

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 1.8.0 (2024-05-16)
 

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/labels/%5BFeature%5D%20Interactivity%20API"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 5.7.0 (2024-05-16)
 

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/labels/%5BFeature%5D%20Interactivity%20API"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 5.35.0 (2024-05-16)
 
 ### Internal

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/is-shallow-equal/CHANGELOG.md
+++ b/packages/is-shallow-equal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.58.0 (2024-05-16)
 
 ## 4.57.0 (2024-05-02)

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"build",

--- a/packages/jest-console/CHANGELOG.md
+++ b/packages/jest-console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 7.29.0 (2024-05-16)
 
 ## 7.28.0 (2024-05-02)

--- a/packages/jest-console/README.md
+++ b/packages/jest-console/README.md
@@ -18,7 +18,7 @@ Install the module:
 npm install @wordpress/jest-console --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ### Setup
 

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"build",

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 11.29.0 (2024-05-16)
 

--- a/packages/jest-preset-default/README.md
+++ b/packages/jest-preset-default/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/jest-preset-default --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Setup
 
@@ -89,7 +89,7 @@ Finally, you should add `enzyme-to-json/serializer` to the array of [`snapshotSe
 
 ```javascript
 {
-	snapshotSerializers: [ 'enzyme-to-json/serializer' ]
+	snapshotSerializers: [ 'enzyme-to-json/serializer' ];
 }
 ```
 

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"scripts",

--- a/packages/jest-puppeteer-axe/CHANGELOG.md
+++ b/packages/jest-puppeteer-axe/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 6.29.0 (2024-05-16)
 
 ## 6.28.0 (2024-05-02)
@@ -64,7 +68,7 @@
 
 ### Breaking Changes
 
--  Started requiring Jest v29 instead of v27 as a peer dependency. See [breaking changes in Jest 28](https://jestjs.io/blog/2022/04/25/jest-28) and [in jest 29](https://jestjs.io/blog/2022/08/25/jest-29) ([#47388](https://github.com/WordPress/gutenberg/pull/47388))
+-   Started requiring Jest v29 instead of v27 as a peer dependency. See [breaking changes in Jest 28](https://jestjs.io/blog/2022/04/25/jest-28) and [in jest 29](https://jestjs.io/blog/2022/08/25/jest-29) ([#47388](https://github.com/WordPress/gutenberg/pull/47388))
 
 ## 5.11.0 (2023-03-01)
 

--- a/packages/jest-puppeteer-axe/README.md
+++ b/packages/jest-puppeteer-axe/README.md
@@ -12,7 +12,7 @@ Install the module
 npm install @wordpress/jest-puppeteer-axe --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ### Setup
 

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -22,7 +22,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"build",

--- a/packages/keyboard-shortcuts/CHANGELOG.md
+++ b/packages/keyboard-shortcuts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.35.0 (2024-05-16)
 
 ## 4.34.0 (2024-05-02)

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/lazy-import/CHANGELOG.md
+++ b/packages/lazy-import/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 1.45.0 (2024-05-16)
 
 ## 1.44.0 (2024-05-02)

--- a/packages/lazy-import/package.json
+++ b/packages/lazy-import/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"npm": ">=6.9.0"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "lib/index.js",
 	"types": "build-types",

--- a/packages/list-reusable-blocks/CHANGELOG.md
+++ b/packages/list-reusable-blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.35.0 (2024-05-16)
 
 ## 4.34.0 (2024-05-02)

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.49.0 (2024-05-16)
 
 ## 4.48.0 (2024-05-02)

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.26.0 (2024-05-16)
 
 ## 4.25.0 (2024-05-02)

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/npm-package-json-lint-config/CHANGELOG.md
+++ b/packages/npm-package-json-lint-config/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.43.0 (2024-05-16)
 
 ## 4.42.0 (2024-05-02)

--- a/packages/npm-package-json-lint-config/README.md
+++ b/packages/npm-package-json-lint-config/README.md
@@ -10,7 +10,7 @@ Install the module
 $ npm install @wordpress/npm-package-json-lint-config
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Usage
 

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"index.js"

--- a/packages/nux/CHANGELOG.md
+++ b/packages/nux/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 8.20.0 (2024-05-16)
 
 ## 8.19.0 (2024-05-02)

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 1.19.0 (2024-05-16)
 
 ## 1.18.0 (2024-05-02)

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=16.0.0"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/plugins/CHANGELOG.md
+++ b/packages/plugins/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 6.26.0 (2024-05-16)
 

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/postcss-plugins-preset/CHANGELOG.md
+++ b/packages/postcss-plugins-preset/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.42.0 (2024-05-16)
 
 ## 4.41.0 (2024-05-02)

--- a/packages/postcss-plugins-preset/README.md
+++ b/packages/postcss-plugins-preset/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/postcss-plugins-preset --save
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Contributing to this package
 

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -22,7 +22,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"lib"

--- a/packages/postcss-themes/CHANGELOG.md
+++ b/packages/postcss-themes/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 5.41.0 (2024-05-16)
 
 ## 5.40.0 (2024-05-02)

--- a/packages/postcss-themes/README.md
+++ b/packages/postcss-themes/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/postcss-themes --save
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Contributing to this package
 

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -24,7 +24,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"index.js"

--- a/packages/preferences-persistence/CHANGELOG.md
+++ b/packages/preferences-persistence/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 1.50.0 (2024-05-16)
 
 ## 1.49.0 (2024-05-02)

--- a/packages/preferences-persistence/package.json
+++ b/packages/preferences-persistence/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/preferences/CHANGELOG.md
+++ b/packages/preferences/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.35.0 (2024-05-16)
 
 ### Internal

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.15.0 (2024-05-16)
 
 ## 3.14.0 (2024-05-02)

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -10,7 +10,7 @@ Install the module
 $ npm install @wordpress/prettier-config --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Usage
 

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"lib/index.js"

--- a/packages/primitives/CHANGELOG.md
+++ b/packages/primitives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.56.0 (2024-05-16)
 
 ### Internal

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/priority-queue/CHANGELOG.md
+++ b/packages/priority-queue/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 2.58.0 (2024-05-16)
 
 ## 2.57.0 (2024-05-02)
@@ -108,7 +112,7 @@
 
 ### New features
 
--  Add a new `cancel` method that removes scheduled callbacks without executing them.
+-   Add a new `cancel` method that removes scheduled callbacks without executing them.
 
 ## 2.6.0 (2022-04-08)
 

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/private-apis/CHANGELOG.md
+++ b/packages/private-apis/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 0.40.0 (2024-05-16)
 

--- a/packages/private-apis/package.json
+++ b/packages/private-apis/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 1.57.0 (2024-05-16)
 
 ## 1.56.0 (2024-05-02)

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -19,6 +19,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"main": "lib/index.js",
 	"types": "build-types",
 	"dependencies": {

--- a/packages/react-i18n/CHANGELOG.md
+++ b/packages/react-i18n/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.56.0 (2024-05-16)
 
 ## 3.55.0 (2024-05-02)

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -18,6 +18,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"dependencies": {
 		"@wordpress/element": "file:../element",
 		"@wordpress/keycodes": "file:../keycodes"

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -17,6 +17,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"main": "index.js",
 	"react-native": "index",
 	"dependencies": {

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -23,8 +23,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12",
-		"npm": ">=6.9"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "src/index.js",
 	"react-native": "src/index",

--- a/packages/readable-js-assets-webpack-plugin/CHANGELOG.md
+++ b/packages/readable-js-assets-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 2.41.0 (2024-05-16)
 
 ## 2.40.0 (2024-05-02)

--- a/packages/readable-js-assets-webpack-plugin/README.md
+++ b/packages/readable-js-assets-webpack-plugin/README.md
@@ -14,7 +14,7 @@ Install the module
 npm install @wordpress/readable-js-assets-webpack-plugin --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It also requires webpack 4.8.3 and newer. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Usage
 

--- a/packages/readable-js-assets-webpack-plugin/package.json
+++ b/packages/readable-js-assets-webpack-plugin/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14.0"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"index.js"

--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.58.0 (2024-05-16)
 
 ## 4.57.0 (2024-05-02)

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/report-flaky-tests/package.json
+++ b/packages/report-flaky-tests/package.json
@@ -20,8 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14",
-		"npm": ">=6.9"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"types": "build-types",

--- a/packages/reusable-blocks/CHANGELOG.md
+++ b/packages/reusable-blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.35.0 (2024-05-16)
 
 ## 4.34.0 (2024-05-02)

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 6.35.0 (2024-05-16)
 
 ## 6.34.0 (2024-05-02)

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 0.27.0 (2024-05-16)
 
 ## 0.26.0 (2024-05-02)

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)).
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 27.9.0 (2024-05-16)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -16,7 +16,7 @@ You only need to install one npm module:
 npm install @wordpress/scripts --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later, and `npm` 6.14.4 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Setup
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -19,8 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=18",
-		"npm": ">=6.14.4"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"bin",

--- a/packages/server-side-render/CHANGELOG.md
+++ b/packages/server-side-render/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 4.35.0 (2024-05-16)
 
 ## 4.34.0 (2024-05-02)

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/shortcode/CHANGELOG.md
+++ b/packages/shortcode/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/style-engine/CHANGELOG.md
+++ b/packages/style-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 1.41.0 (2024-05-16)
 
 ## 1.40.0 (2024-05-02)
@@ -43,6 +47,7 @@
 ## 1.22.0 (2023-08-10)
 
 ### Bug Fixes
+
 -   Style engine: switch off optimize by default [#53085](https://github.com/WordPress/gutenberg/pull/53085).
 
 ## 1.21.0 (2023-07-20)
@@ -84,24 +89,29 @@
 ## 1.3.0 (2022-10-19)
 
 ### Internal
+
 -   Style Engine: move PHP unit tests to Gutenberg [#44722](https://github.com/WordPress/gutenberg/pull/44722)
 
 ## 1.2.0 (2022-10-05)
 
 ### Internal
+
 -   Script loader: remove 6.1 wp actions ([#44519](https://github.com/WordPress/gutenberg/pull/44519))
 
 ## 1.1.0 (2022-09-21)
 
 ### Enhancement
+
 -   Allow for prettified output ([#42909](https://github.com/WordPress/gutenberg/pull/42909)).
 -   Enqueue block supports styles in Gutenberg ([#42880](https://github.com/WordPress/gutenberg/pull/42880)).
 
 ### Internal
+
 -   Move backend scripts to package ([#39736](https://github.com/WordPress/gutenberg/pull/39736)).
 -   Updating docs, formatting, and separating global functions from the main class file ([#43840](https://github.com/WordPress/gutenberg/pull/43840)).
 
 ### New Features
+
 -   Add a WP_Style_Engine_Processor object ([#42463](https://github.com/WordPress/gutenberg/pull/42463)).
 -   Add a WP_Style_Engine_CSS_Declarations object ([#42043](https://github.com/WordPress/gutenberg/pull/42043)).
 -   Add Rules and Store objects ([#42222](https://github.com/WordPress/gutenberg/pull/42222)).

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -21,7 +21,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 21.41.0 (2024-05-16)
 
 ## 21.40.0 (2024-05-02)

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -8,7 +8,7 @@
 $ npm install @wordpress/stylelint-config --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It is not compatible with older versions.
+**Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Usage
 

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"files": [
 		"CHANGELOG.md",

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 0.20.0 (2024-05-16)
 
 ## 0.19.0 (2024-05-02)

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/token-list/CHANGELOG.md
+++ b/packages/token-list/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 2.58.0 (2024-05-16)
 
 ## 2.57.0 (2024-05-02)

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/undo-manager/CHANGELOG.md
+++ b/packages/undo-manager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 0.18.0 (2024-05-16)
 
 ## 0.17.0 (2024-05-02)
@@ -35,4 +39,3 @@
 ## 0.3.0 (2023-10-05)
 
 ## 0.2.0 (2023-09-20)
-

--- a/packages/undo-manager/package.json
+++ b/packages/undo-manager/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.59.0 (2024-05-16)
 
 ## 3.58.0 (2024-05-02)

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/viewport/CHANGELOG.md
+++ b/packages/viewport/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 5.35.0 (2024-05-16)
 
 ## 5.34.0 (2024-05-02)

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/warning/CHANGELOG.md
+++ b/packages/warning/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 2.58.0 (2024-05-16)
 

--- a/packages/warning/package.json
+++ b/packages/warning/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/widgets/CHANGELOG.md
+++ b/packages/widgets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.35.0 (2024-05-16)
 
 ### Internal

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -16,6 +16,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",

--- a/packages/wordcount/CHANGELOG.md
+++ b/packages/wordcount/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+
 ## 3.58.0 (2024-05-16)
 
 ## 3.57.0 (2024-05-02)

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Node.js v18.12.0 was the first long-term supported version introduced in v18.x line (https://nodejs.org/en/blog/release/v18.12.0). It is now the lowest version that is listed as Maintenance LTS release at https://nodejs.org/en/about/previous-releases. The same version is bundled with npm 8.19.2. This PR tries to unify the minimum required Node.js version defined in all npm packages published to npm.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We are approaching another major WordPress release - 6.6.0. It's a good opportunity to ship all the breaking changes batched together with some other changes that landed recently:
- https://github.com/WordPress/gutenberg/pull/61486
- https://github.com/WordPress/gutenberg/pull/61692

While Gutenberg and WordPress core are more strict in defining the minimum required Node.js and npm versions:

```json
"engines": {
	"node": ">=20.10.0",
	"npm": ">=10.2.3"
},
```

I propose we also allow the 18.x line for WordPress packages, which will be actively maintained until the middle of 2025. This will give more time to folks who might still be using Node.js 18 in their projects.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I ensured that all non-private packages have the minimum version defined with the following:

```json
"engines": {
	"node": ">=18.12.0",
	"npm": ">=8.19.2"
},
```

I also updated all corresponding documentation and add changelog entries.

The only exception is `@wordpress/create-block,` which aligns more closely with the versions that WordPress and Gutenberg use, as decided separately some time ago.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

There isn't that much to test because `engines` works mostly as a hint for Node.js, unless the strict check is explicitly enabled in `.npmrc`. More in https://docs.npmjs.com/cli/v8/using-npm/config#engine-strict.

