### PR TITLE
Components: Fix remaining warning in ColorPanelDropdown

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -272,14 +272,17 @@ function ColorPanelDropdown( {
 									</Tabs.TabList>
 
 									{ tabs.map( ( tab ) => {
+										const { key: tabKey, ...restTabProps } =
+											tab;
 										return (
 											<Tabs.TabPanel
-												key={ tab.key }
-												tabId={ tab.key }
+												key={ tabKey }
+												tabId={ tabKey }
 												focusable={ false }
 											>
 												<ColorPanelTab
-													{ ...tab }
+													key={ tabKey }
+													{ ...restTabProps }
 													colorGradientControlSettings={
 														colorGradientControlSettings
 													}


### PR DESCRIPTION
## What?
This is similar to #61917.

PR updates `ColorPanelDropdown` to prevent triggering a warning when multiple color tabs are rendered.

## Testing Instructions
1. Open a post or page. 
2. Add a paragraph block.
3. Open the background color selector.
4. Warning shouldn't be logged in the console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-24 at 13 19 04](https://github.com/WordPress/gutenberg/assets/240569/917b17aa-ae50-4dab-a117-c31e42e170ef)
