### PR TITLE
E2E Tests: Fix React warnings triggered by test plugins

### DIFF
--- a/packages/e2e-tests/plugins/hooks-api/index.js
+++ b/packages/e2e-tests/plugins/hooks-api/index.js
@@ -17,7 +17,6 @@
 				{
 					className: 'e2e-reset-block-button',
 					variant: "secondary",
-					isLarge: true,
 					onClick() {
 						const emptyBlock = createBlock( props.name );
 						props.onReplace( emptyBlock );

--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -92,7 +92,7 @@
 
 		edit: function InnerBlocksUpdateLockedTemplateEdit( props ) {
 			const hasUpdatedTemplated = props.attributes.hasUpdatedTemplate;
-			return el( 'div', null, [
+			return el( 'div', null,
 				el(
 					'button',
 					{
@@ -108,7 +108,7 @@
 						: TEMPLATE,
 					templateLock: 'all',
 				} ) ),
-			] );
+			);
 		},
 
 		save,


### PR DESCRIPTION
## What?
PR fixes some of the React warnings logged by the e2e test plugins. See #61929.

## Why?
It reduces noise, and we can focus on actual issues.

## Testing Instructions
CI checks should be green.
