### PR TITLE
More block: Fix React warning when adding custom text

### DIFF
--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"customText": {
-			"type": "string"
+			"type": "string",
+			"default": ""
 		},
 		"noTeaser": {
 			"type": "boolean",

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -10,14 +10,13 @@ import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 const DEFAULT_TEXT = __( 'Read more' );
 
 export default function MoreEdit( {
-	attributes: { customText = '', noTeaser },
+	attributes: { customText, noTeaser },
 	insertBlocksAfter,
 	setAttributes,
 } ) {
 	const onChangeInput = ( event ) => {
 		setAttributes( {
-			customText:
-				event.target.value !== '' ? event.target.value : undefined,
+			customText: event.target.value,
 		} );
 	};
 

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -10,7 +10,7 @@ import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 const DEFAULT_TEXT = __( 'Read more' );
 
 export default function MoreEdit( {
-	attributes: { customText, noTeaser },
+	attributes: { customText = '', noTeaser },
 	insertBlocksAfter,
 	setAttributes,
 } ) {

--- a/test/integration/fixtures/blocks/core__more.json
+++ b/test/integration/fixtures/blocks/core__more.json
@@ -3,6 +3,7 @@
 		"name": "core/more",
 		"isValid": true,
 		"attributes": {
+			"customText": "",
 			"noTeaser": false
 		},
 		"innerBlocks": []


### PR DESCRIPTION
## What?
PR fixes a React warning triggered by the "More" block when updating the placeholder text.

```
Warning: A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen.
```

## Why?
This can happen when the value changes from `undefined` to other primitive values like string.

## How?
Set the default value to an empty string instead of `undefined`.

## Testing Instructions
1. Open a post or page.
2. Insert the "More" block.
3. Change the placeholder "Read More" text to something else.
4. Confirm that no React warnings are logged in the console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-24 at 14 11 17](https://github.com/WordPress/gutenberg/assets/240569/9d37814f-5c6f-41bd-b9c1-5bfe3b16ae3d)
