### PR TITLE
Clean up packages build-types when cleaning types

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
 		"build:packages": "npm run --silent build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
 		"clean:package-types": "tsc --build --clean; rimraf \"./packages/*/build-types\"",
-		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
+		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style|build-types)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",
 		"distclean": "rimraf node_modules packages/*/node_modules",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
 		"prebuild:packages": "npm run clean:packages && lerna run build",
 		"build:packages": "npm run --silent build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
-		"clean:package-types": "tsc --build --clean",
+		"clean:package-types": "tsc --build --clean; rm -rf packages/*/build-types",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
 		"prebuild:packages": "npm run clean:packages && lerna run build",
 		"build:packages": "npm run --silent build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
-		"clean:package-types": "tsc --build --clean; rm -rf packages/*/build-types",
+		"clean:package-types": "tsc --build --clean; rimraf \"./packages/*/build-types\"",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
 		"prebuild:packages": "npm run clean:packages && lerna run build",
 		"build:packages": "npm run --silent build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
-		"clean:package-types": "tsc --build --clean ; rimraf \"./packages/*/build-types\"",
+		"clean:package-types": "tsc --build --clean && rimraf \"./packages/*/build-types\"",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style|build-types)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
 		"prebuild:packages": "npm run clean:packages && lerna run build",
 		"build:packages": "npm run --silent build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
-		"clean:package-types": "tsc --build --clean; rimraf \"./packages/*/build-types\"",
+		"clean:package-types": "tsc --build --clean ; rimraf \"./packages/*/build-types\"",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style|build-types)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Stale generated types can be left sitting around the repo which can cause build issues. Gutenberg recommends using the `clean:package-types` command to clean types and fix this problem, but the generated declaration files remain.

This can cause issues with builds that are resolved by removing the stale declaration files (put in the `build-types` directories) and getting a fresh build.

## Why?

It can break the types builds.

## How?

By removing all the stale generated files.

## Testing Instructions

After running

```sh
npm run clean:package-types
```

No packages should have `build-types` directories.
