### PR TITLE
Add postcss-modules to support local selectors

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -23,6 +23,10 @@
 		],
 		"rule-empty-line-before": null,
 		"selector-class-pattern": null,
+		"selector-pseudo-class-no-unknown": [
+			true,
+			{ "ignorePseudoClasses": [ "local" ] }
+		],
 		"value-keyword-case": null,
 		"scss/operator-no-unspaced": null,
 		"scss/selector-no-redundant-nesting-selector": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29068,6 +29068,24 @@
 				"node": "^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/generic-names": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/generic-names/-/generic-names-4.0.0.tgz",
+			"integrity": "sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==",
+			"dev": true,
+			"dependencies": {
+				"loader-utils": "^3.2.0"
+			}
+		},
+		"node_modules/generic-names/node_modules/loader-utils": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+			"integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -35832,6 +35850,12 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
+		"node_modules/lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+			"dev": true
+		},
 		"node_modules/lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -42550,6 +42574,25 @@
 				"postcss": "^8.2.15"
 			}
 		},
+		"node_modules/postcss-modules": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-6.0.0.tgz",
+			"integrity": "sha512-7DGfnlyi/ju82BRzTIjWS5C4Tafmzl3R79YP/PASiocj+aa6yYphHhhKUOEoXQToId5rgyFgJ88+ccOUydjBXQ==",
+			"dev": true,
+			"dependencies": {
+				"generic-names": "^4.0.0",
+				"icss-utils": "^5.1.0",
+				"lodash.camelcase": "^4.3.0",
+				"postcss-modules-extract-imports": "^3.0.0",
+				"postcss-modules-local-by-default": "^4.0.0",
+				"postcss-modules-scope": "^3.0.0",
+				"postcss-modules-values": "^4.0.0",
+				"string-hash": "^1.1.1"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
 		"node_modules/postcss-modules-extract-imports": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
@@ -47789,6 +47832,12 @@
 			"engines": {
 				"node": ">=0.6.19"
 			}
+		},
+		"node_modules/string-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
+			"dev": true
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -54907,7 +54956,8 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
-				"autoprefixer": "^10.2.5"
+				"autoprefixer": "^10.2.5",
+				"postcss-modules": "^6.0.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -69691,7 +69741,8 @@
 			"version": "file:packages/postcss-plugins-preset",
 			"requires": {
 				"@wordpress/base-styles": "file:../base-styles",
-				"autoprefixer": "^10.2.5"
+				"autoprefixer": "^10.2.5",
+				"postcss-modules": "^6.0.0"
 			}
 		},
 		"@wordpress/postcss-themes": {
@@ -78565,6 +78616,23 @@
 				}
 			}
 		},
+		"generic-names": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/generic-names/-/generic-names-4.0.0.tgz",
+			"integrity": "sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^3.2.0"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+					"integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
+					"dev": true
+				}
+			}
+		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -83623,6 +83691,12 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+			"dev": true
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
@@ -88786,6 +88860,22 @@
 				"postcss-selector-parser": "^6.0.5"
 			}
 		},
+		"postcss-modules": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-6.0.0.tgz",
+			"integrity": "sha512-7DGfnlyi/ju82BRzTIjWS5C4Tafmzl3R79YP/PASiocj+aa6yYphHhhKUOEoXQToId5rgyFgJ88+ccOUydjBXQ==",
+			"dev": true,
+			"requires": {
+				"generic-names": "^4.0.0",
+				"icss-utils": "^5.1.0",
+				"lodash.camelcase": "^4.3.0",
+				"postcss-modules-extract-imports": "^3.0.0",
+				"postcss-modules-local-by-default": "^4.0.0",
+				"postcss-modules-scope": "^3.0.0",
+				"postcss-modules-values": "^4.0.0",
+				"string-hash": "^1.1.1"
+			}
+		},
 		"postcss-modules-extract-imports": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
@@ -92815,6 +92905,12 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
 			"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+			"dev": true
+		},
+		"string-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+			"integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
 			"dev": true
 		},
 		"string-length": {

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -3,7 +3,7 @@
 	overflow-y: auto;
 }
 
-@keyframes slide-from-right {
+@keyframes :local(slide-from-right) {
 	from {
 		transform: translateX(50px);
 		opacity: 0;
@@ -14,7 +14,7 @@
 	}
 }
 
-@keyframes slide-from-left {
+@keyframes :local(slide-from-left) {
 	from {
 		transform: translateX(-50px);
 		opacity: 0;
@@ -46,11 +46,11 @@
 		animation-duration: 0s;
 	}
 
-	&.slide-from-left {
+	&.slide-from-left :local {
 		animation-name: slide-from-left;
 	}
 
-	&.slide-from-right {
+	&.slide-from-right :local {
 		animation-name: slide-from-right;
 	}
 

--- a/packages/postcss-plugins-preset/lib/index.js
+++ b/packages/postcss-plugins-preset/lib/index.js
@@ -1,1 +1,7 @@
-module.exports = [ require( 'autoprefixer' )( { grid: true } ) ];
+module.exports = [
+	require( 'autoprefixer' )( { grid: true } ),
+	require( 'postcss-modules' )( {
+		scopeBehaviour: 'global',
+		getJSON: () => {},
+	} ),
+];

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -30,7 +30,8 @@
 	"main": "lib/index.js",
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",
-		"autoprefixer": "^10.2.5"
+		"autoprefixer": "^10.2.5",
+		"postcss-modules": "^6.0.0"
 	},
 	"peerDependencies": {
 		"postcss": "^8.0.0"


### PR DESCRIPTION
Adds support for marking selectors or keyframes as `:local`, and preventing them from conflicting with other global CSS definitions.

See how I'm using it to locally scope the `slide-from-right` sidebar animations in Site Editor. The animation names no longer pollute the global namespace. They are mangled into names like `_slide-from-left_1uetc_2516`.

There are still open problems. Stylelint doesn't understand the `:local` syntax and complains:
```
49:20  ✖  Unexpected unknown pseudo-class selector ":local"  selector-pseudo-class-no-unknown
```

Also, VSCode complains about the syntax:

<img width="519" alt="Screenshot 2024-05-24 at 13 22 36" src="https://github.com/WordPress/gutenberg/assets/664258/c6d9abbb-10ff-4c4a-9d42-253e13765468">

Here I'm not even sure where the error comes from. Is it a built-in VSCode SCSS syntax checker? Or is it a lint plugin that the Gutenberg repo can configure?

**How to test:**
Go to Site Editor and verify that the sidebar animations (sliding as you navigate back and forth) still work:

<img width="360" alt="Screenshot 2024-05-24 at 13 26 29" src="https://github.com/WordPress/gutenberg/assets/664258/f73f8838-027e-41a1-9270-84e6f0fa98dd">
