### PR TITLE
Update: Improve overrides modal for enabling and disabling

### DIFF
--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -63,7 +63,7 @@ export function AllowOverridesModal( {
 				<VStack spacing="6">
 					<Text id={ descriptionId }>
 						{ __(
-							'Overrides are changes you make to a block within a synced pattern instance. Use overrides to customize a synced pattern instance to suit its new context. Name this block to specify an override.'
+							'Adding an override will allow this block to be edited within any instance of this synced pattern. To set an override, name this block.'
 						) }
 					</Text>
 					<TextControl
@@ -121,7 +121,7 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 				<VStack spacing="6">
 					<Text id={ descriptionId }>
 						{ __(
-							'Are you sure you want to disable overrides? Disabling overrides will revert all applied overrides for this block throughout instances of this pattern.'
+							'Are you sure you want to disable an override for this block? By disabling, any custom content for this block throughout every instance of this pattern will be reverted to the original content of the synced pattern.'
 						) }
 					</Text>
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This update enhances the text descriptions in the `Enable Overrides` and `Disable Overrides` modals.

Closes #61542

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The previous descriptions in the modals were concise but could lead to confusion about what exactly happens when overrides are enabled or disabled. The updated text is intended to provide a clearer, more direct explanation suitable for all users, helping them make informed decisions while managing block overrides.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Updated the text in the `Enable Overrides` modal to more explicitly describe the impact of enabling an override on a block within any synced pattern instance.
- Revised the `Disable Overrides` modal text to clarify the consequences of disabling an override, including how it affects the content across instances.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Ensure any full site editing (FSE) theme is active.
2. Navigate to the site editor.
3. Add a synced block pattern.
4. Insert a heading block.
5. Open the right-side inspector controls.
6. Expand the `Advanced` section.
7. Click on the "Enable Overrides" button; the modal will display the updated message.
8. Enter a name for the block and click `Enable`.
9. After enabling, select the heading block again and click on `Disable Overrides`,  the modal with the updated message about disabling will appear.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Enable

![enable](https://github.com/WordPress/gutenberg/assets/78657883/d4a23722-24dd-4a07-a0a0-14f18bd63a45)


### Disable

![disable](https://github.com/WordPress/gutenberg/assets/78657883/c24d2115-839d-4270-83b7-ce407326bf9f)


