### PR TITLE
InspectorControls: Text not displayed when "Show button text labels" is enabled

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -5,6 +5,8 @@ import {
 	Button,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -24,6 +26,10 @@ export default function InspectorControlsTabs( {
 	hasBlockStyles,
 	tabs,
 } ) {
+	const showIconLabels = useSelect( ( select ) => {
+		return select( preferencesStore ).get( 'core', 'showIconLabels' );
+	}, [] );
+
 	// The tabs panel will mount before fills are rendered to the list view
 	// slot. This means the list view tab isn't initially included in the
 	// available tabs so the panel defaults selection to the settings tab
@@ -43,10 +49,16 @@ export default function InspectorControlsTabs( {
 							tabId={ tab.name }
 							render={
 								<Button
-									icon={ tab.icon }
-									label={ tab.title }
+									icon={
+										! showIconLabels ? tab.icon : undefined
+									}
+									label={
+										! showIconLabels ? tab.title : undefined
+									}
 									className={ tab.className }
-								/>
+								>
+									{ showIconLabels && tab.title }
+								</Button>
 							}
 						/>
 					) ) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/style.scss
+++ b/packages/block-editor/src/components/inspector-controls-tabs/style.scss
@@ -6,8 +6,7 @@
 				display: none;
 			}
 			// ... and display labels.
-			// Uses ::before as ::after is already used for active tab styling.
-			&::before {
+			&::after {
 				content: attr(aria-label);
 			}
 		}

--- a/packages/block-editor/src/components/inspector-controls-tabs/style.scss
+++ b/packages/block-editor/src/components/inspector-controls-tabs/style.scss
@@ -1,14 +1,7 @@
 .show-icon-labels {
 	.block-editor-block-inspector__tabs [role="tablist"] {
-		.components-button.has-icon {
-			// Hide the button icons when labels are set to display...
-			svg {
-				display: none;
-			}
-			// ... and display labels.
-			&::after {
-				content: attr(aria-label);
-			}
+		.components-button {
+			justify-content: center;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #61947
Seems to be caused by #60560

## What?

This PR fixes an issue where tab text in InspectorControls is not displayed when "Show button text labels" is enabled.

![image](https://github.com/WordPress/gutenberg/assets/54422211/9723bcc5-572d-46cd-8da9-a7f10ee2c333)


## Why?

When "Show button text labels" is enabled, text is often displayed using the following approach:

```scss
.show-icon-labels {
	.some-element {
		.components-button.has-icon {
			// Hide the button icons when labels are set to display...
			svg {
				display: none;
			}
			// ... and display labels.
			&::before { // Or `&::after`
				content: attr(aria-label);
			}
		}
	}
}
```

However, #60560 applied `opacity: 0;` to the `before` pseudo-element, so the text is no longer visible.

## How?

Fortunately #60560 removed the `after` pseudo-element, so I changed `before` to `after`. But this is _a temporary fix_ for WP6.6. It may not be an ideal approach as it may be affected by changes to the `Tab` component in the future. Overall, we will need to consider the implementation itself if "Show button text labels" is enabled, as discussed in #61763.

## Testing Instructions

- Enable "Show button text labels".
- Select some block.
- Make sure the tab text is visible.