### PR TITLE
Documentation: EditorBoundary editor component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -366,7 +366,7 @@ Undocumented declaration.
 
 ### ErrorBoundary
 
-Undocumented declaration.
+ErrorBoundary component.
 
 ### FontSizePicker
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -366,7 +366,11 @@ Undocumented declaration.
 
 ### ErrorBoundary
 
-ErrorBoundary component.
+ErrorBoundary is used to catch JavaScript errors anywhere in a child component tree, log those errors, and display a fallback UI.
+
+It uses the lifecycle methods getDerivedStateFromError and componentDidCatch to catch errors in a child component tree.
+
+getDerivedStateFromError is used to render a fallback UI after an error has been thrown, and componentDidCatch is used to log error information.
 
 ### FontSizePicker
 

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -75,4 +75,10 @@ class ErrorBoundary extends Component {
 	}
 }
 
+/**
+ * ErrorBoundary component.
+ *
+ * @class ErrorBoundary
+ * @augments Component
+ */
 export default ErrorBoundary;

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -76,7 +76,11 @@ class ErrorBoundary extends Component {
 }
 
 /**
- * ErrorBoundary component.
+ * ErrorBoundary is used to catch JavaScript errors anywhere in a child component tree, log those errors, and display a fallback UI.
+ *
+ * It uses the lifecycle methods getDerivedStateFromError and componentDidCatch to catch errors in a child component tree.
+ *
+ * getDerivedStateFromError is used to render a fallback UI after an error has been thrown, and componentDidCatch is used to log error information.
  *
  * @class ErrorBoundary
  * @augments Component


### PR DESCRIPTION
## What? & Why?
Addresses one item in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `EditorBoundary` component and run `npm run docs:build` to populate the `README` with the newly added documents.
