### PR TITLE
Documentation: LocalAutosaveMonitor editor component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -422,7 +422,14 @@ _Returns_
 
 ### LocalAutosaveMonitor
 
-LocalAutosaveMonitor component. The component is conditionally exported based on the presence of sessionStorage support.
+Monitors local autosaves of a post in the editor. It uses several hooks and functions to manage autosave behavior:
+
+-   `useAutosaveNotice` hook: Manages the creation of a notice prompting the user to restore a local autosave, if one exists.
+-   `useAutosavePurge` hook: Ejects a local autosave after a successful save occurs.
+-   `hasSessionStorageSupport` function: Checks if the current environment supports browser sessionStorage.
+-   `LocalAutosaveMonitor` component: Uses the `AutosaveMonitor` component to perform autosaves at a specified interval.
+
+The module also checks for sessionStorage support and conditionally exports the `LocalAutosaveMonitor` component based on that.
 
 ### MediaPlaceholder
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -422,7 +422,7 @@ _Returns_
 
 ### LocalAutosaveMonitor
 
-Undocumented declaration.
+LocalAutosaveMonitor component. The component is conditionally exported based on the presence of sessionStorage support.
 
 ### MediaPlaceholder
 

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -192,4 +192,10 @@ function LocalAutosaveMonitor() {
 	);
 }
 
+/**
+ * LocalAutosaveMonitor component.
+ * The component is conditionally exported based on the presence of sessionStorage support.
+ *
+ * @module LocalAutosaveMonitor
+ */
 export default ifCondition( hasSessionStorageSupport )( LocalAutosaveMonitor );

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -193,8 +193,14 @@ function LocalAutosaveMonitor() {
 }
 
 /**
- * LocalAutosaveMonitor component.
- * The component is conditionally exported based on the presence of sessionStorage support.
+ * Monitors local autosaves of a post in the editor.
+ * It uses several hooks and functions to manage autosave behavior:
+ * - `useAutosaveNotice` hook: Manages the creation of a notice prompting the user to restore a local autosave, if one exists.
+ * - `useAutosavePurge` hook: Ejects a local autosave after a successful save occurs.
+ * - `hasSessionStorageSupport` function: Checks if the current environment supports browser sessionStorage.
+ * - `LocalAutosaveMonitor` component: Uses the `AutosaveMonitor` component to perform autosaves at a specified interval.
+ *
+ * The module also checks for sessionStorage support and conditionally exports the `LocalAutosaveMonitor` component based on that.
  *
  * @module LocalAutosaveMonitor
  */


### PR DESCRIPTION
## What? & Why?
Addresses one item in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `LocalAutosaveMonitor` component and run `npm run docs:build` to populate the `README` with the newly added documents.
