### PR TITLE
Post Date block always show the accurate Last Modified Date

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -181,9 +181,7 @@ export default function PostDateEdit( {
 							} )
 						}
 						checked={ displayType === 'modified' }
-						help={ __(
-							'Only shows if the post has been modified'
-						) }
+						help={ __( "Show the post's last modified date" ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -33,17 +33,12 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	}
 
 	/*
-	 * If the "Display last modified date" setting is enabled,
-	 * only display the modified date if it is later than the publishing date.
+	 * If the "Display last modified date" setting is enabled.
 	 */
 	if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
-		if ( get_the_modified_date( 'Ymdhi', $post_ID ) > get_the_date( 'Ymdhi', $post_ID ) ) {
-			$formatted_date   = get_the_modified_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $post_ID );
-			$unformatted_date = esc_attr( get_the_modified_date( 'c', $post_ID ) );
-			$classes[]        = 'wp-block-post-date__modified-date';
-		} else {
-			return '';
-		}
+		$formatted_date   = get_the_modified_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $post_ID );
+		$unformatted_date = esc_attr( get_the_modified_date( 'c', $post_ID ) );
+		$classes[]        = 'wp-block-post-date__modified-date';
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );


### PR DESCRIPTION
## What?
Remove the if statement preventing the Post Date block from returning an empty value when the Last Modified Date is used and it matches the Published Date.

## Why?
If you add a label before the [Post Date](https://wordpress.org/documentation/article/post-date-block/) block and you are using the Last Modified Date if is the same as the publish date then it doesn't display on the front end despite being shown in the editor on the back end.

This is another alternative solution to the issue mentioned above and the other pull request I made here: https://github.com/WordPress/gutenberg/pull/61920
For this issue: https://github.com/WordPress/gutenberg/issues/47738

This being subtractive should be simpler to merge and act as a temporary solution until a Bit solution can be created.
https://github.com/WordPress/gutenberg/discussions/39831
https://github.com/WordPress/gutenberg/pull/61920#issuecomment-2128136026

**This does cause an issue...**
If the publish date is set in the future to schedule the post the Publish Date and Last Modified Date will show the post was last modified prior to being published. While this is true it may not be ideal for UX/UI.

## How?
Removed the if statement here: https://github.com/dsas/gutenberg/blob/5b95e96a90aac522c6df73349930144b89b53dfa/packages/block-library/src/post-date/index.php#L38

## Testing Instructions

1. Create a new blog post
2. Add a Group block to create a Row
3. Add a Paragraph block with the text: "Posted On:"
4. Add a Post Date block with the "Display last modified date" toggle disabled
3. Add a Paragraph block with the text: "Updated On:"
6. Add a Post Date block with the "Display last modified date" toggle enabled
9. Save the post and view the post. Both should appear with the same date.
10. Update the publish date to the past. Both should appear with the same date.
11. Update the publish date to the future will schedule the post. Both should appear with the same date.
12. Update your test servers system clock to past the future date. Both should appear with the same date, but _this might be seen as an issue with the Publish date is after the Modified date._ 

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/2807433/3950b0e2-01a5-443f-a1c2-61f9ac50a1ca)
![image](https://github.com/WordPress/gutenberg/assets/2807433/e9a56a02-011f-45b2-9aca-3401caab62ed)
![image](https://github.com/WordPress/gutenberg/assets/2807433/9b10e7d8-e227-442b-89d7-a65fac9e7987)
![image](https://github.com/WordPress/gutenberg/assets/2807433/3a744e1f-5955-4d0c-a10c-22cedc8d2af6)
![image](https://github.com/WordPress/gutenberg/assets/2807433/94afebde-b12f-458f-90d2-0953ef4de9c9)
![image](https://github.com/WordPress/gutenberg/assets/2807433/517bc468-35b3-4447-ad9f-ec1800a05de3)
![image](https://github.com/WordPress/gutenberg/assets/2807433/48dfff0c-e9c6-4458-8698-a182594ce0bc)

Example of potential issue:
![image](https://github.com/WordPress/gutenberg/assets/2807433/fee3b8d5-5baa-45a7-b9a4-32b49dcd978f)








