### PR TITLE
Make post meta row button treatment consistent

### DIFF
--- a/packages/editor/src/components/post-discussion/panel.js
+++ b/packages/editor/src/components/post-discussion/panel.js
@@ -6,7 +6,6 @@ import {
 	Dropdown,
 	Button,
 	__experimentalVStack as VStack,
-	__experimentalText as Text,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
@@ -81,7 +80,7 @@ function PostDiscussionToggle( { isOpen, onClick } ) {
 			aria-expanded={ isOpen }
 			onClick={ onClick }
 		>
-			<Text>{ label }</Text>
+			{ label }
 		</Button>
 	);
 }

--- a/packages/editor/src/components/post-discussion/style.scss
+++ b/packages/editor/src/components/post-discussion/style.scss
@@ -13,9 +13,7 @@
 	}
 }
 .editor-post-discussion__panel-toggle {
-	&.components-button {
-		height: auto;
-	}
+
 	.components-text {
 		color: inherit;
 	}

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -11,6 +11,8 @@
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
+	padding: 6px 0; // Matches button to ensure alignment
+	line-height: $grid-unit-05 * 5;
 }
 
 .editor-post-panel__row-control {

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -29,8 +29,7 @@
 		min-height: $button-size-compact;
 	}
 
-	.components-dropdown,
-	.editor-post-author__panel-dropdown {
+	.components-dropdown {
 		max-width: 100%;
 	}
 }

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -13,6 +13,7 @@
 	align-items: center;
 	padding: 6px 0; // Matches button to ensure alignment
 	line-height: $grid-unit-05 * 5;
+	hyphens: auto;
 }
 
 .editor-post-panel__row-control {

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -20,11 +20,11 @@
 	align-items: center;
 
 	.components-button {
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		overflow: hidden;
-		display: inline-block;
 		max-width: 100%;
+		text-align: left;
+		text-wrap: pretty;
+		height: auto;
+		min-height: $button-size-compact;
 	}
 
 	.components-dropdown,

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -18,4 +18,17 @@
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
+
+	.components-button {
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+		display: inline-block;
+		max-width: 100%;
+	}
+
+	.components-dropdown,
+	.editor-post-author__panel-dropdown {
+		max-width: 100%;
+	}
 }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -8,14 +8,3 @@
 		padding: $grid-unit-20;
 	}
 }
-
-.editor-post-schedule__dialog-toggle.components-button {
-	overflow: hidden;
-	text-align: left;
-	white-space: unset;
-	height: auto;
-	min-height: $button-size-compact;
-
-	// The line height + the padding should be the same as the button size.
-	line-height: inherit;
-}

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -2,15 +2,6 @@
 	width: 100%;
 }
 
-.components-button.editor-post-url__panel-toggle {
-	display: block;
-	max-width: 100%;
-	overflow: hidden;
-	text-align: left;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
 .editor-post-url__panel-dialog .editor-post-url {
 	// sidebar width - popover padding - form margin
 	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/61492 and https://github.com/WordPress/gutenberg/pull/61703

## What?
Apply the same treatment to all buttons in `.editor-post-panel__row-control`. Specifically; truncate to one line, and use a tooltip to display the full value where helpful (IE the date field).

## Why?
Currently button treatments are inconsistent and in some cases broken. Here's a comparison between trunk and this branch:


| Trunk | This branch |
| --- | --- |
| <img width="320" alt="Screenshot 2024-05-24 at 16 27 13" src="https://github.com/WordPress/gutenberg/assets/846565/cb2f23b7-80ef-4f75-8d2d-e04201769986"> | <img width="379" alt="Screenshot 2024-05-24 at 16 24 56" src="https://github.com/WordPress/gutenberg/assets/846565/183b16c7-159b-4952-9187-523ae39028ee"> |

It's not uncommon for find long date strings, template names, slugs, author names etc. The UI should be better prepared to handle these scenarios.

Another option to try could be truncating to X number of lines so that details like the full date are always visible, but I prefer truncating to a single line as it keeps the panel neat. The full value is always accessible (either via tooltip, or by opening the associated panel).