### PR TITLE
Add 60 minute timeout to performance job

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
     performance:
+        timeout-minutes: 60
         name: Run performance tests
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Set a timeout on the performance CI workflow job.

## Why?

Here's an example that ran for over 5 hours:
https://github.com/WordPress/gutenberg/actions/runs/9223013362/job/25375360661?pr=61939

## How?

[Set `timeout-minutes` to 60.](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)

## Testing Instructions
None.