### PR TITLE
Fix: React compiler error on button.

### DIFF
--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -174,14 +174,16 @@ export function UnforwardedButton(
 	const anchorProps: ComponentPropsWithoutRef< 'a' > =
 		Tag === 'a' ? { href, target } : {};
 
+	const disableEventProps: {
+		[ key: string ]: ( event: MouseEvent ) => void;
+	} = {};
 	if ( disabled && isFocusable ) {
 		// In this case, the button will be disabled, but still focusable and
 		// perceivable by screen reader users.
 		buttonProps[ 'aria-disabled' ] = true;
 		anchorProps[ 'aria-disabled' ] = true;
-
 		for ( const disabledEvent of disabledEventsOnDisabledButton ) {
-			additionalProps[ disabledEvent ] = ( event: MouseEvent ) => {
+			disableEventProps[ disabledEvent ] = ( event: MouseEvent ) => {
 				if ( event ) {
 					event.stopPropagation();
 					event.preventDefault();
@@ -234,6 +236,7 @@ export function UnforwardedButton(
 			<a
 				{ ...anchorProps }
 				{ ...( additionalProps as HTMLAttributes< HTMLAnchorElement > ) }
+				{ ...disableEventProps }
 				{ ...commonProps }
 			>
 				{ elementChildren }
@@ -242,6 +245,7 @@ export function UnforwardedButton(
 			<button
 				{ ...buttonProps }
 				{ ...( additionalProps as HTMLAttributes< HTMLButtonElement > ) }
+				{ ...disableEventProps }
 				{ ...commonProps }
 			>
 				{ elementChildren }


### PR DESCRIPTION
Fixes a react compiler error on the button component.
Fixes the following error:
```
[2] /home/runner/work/gutenberg/gutenberg/packages/components/src/button/index.tsx
[2]   184:4  error  Mutating a value returned from a function whose return value should not be mutated  react-compiler/react-compiler
[2] 
```
Part of the work required to have React compiler on the codebase.
See https://github.com/WordPress/gutenberg/pull/61788.


## Testing Instructions
I staged my changes on https://github.com/WordPress/gutenberg/pull/61788 and verified the error disappeared.
