### PR TITLE
Documentation: PostComments editor component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -939,7 +939,11 @@ _Returns_
 
 ### PostComments
 
-Undocumented declaration.
+A form for managing comment status.
+
+_Returns_
+
+-   `JSX.Element`: The rendered PostComments component.
 
 ### PostDiscussionPanel
 

--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -71,4 +71,9 @@ function PostComments() {
 	);
 }
 
+/**
+ * A form for managing comment status.
+ *
+ * @return {JSX.Element} The rendered PostComments component.
+ */
 export default PostComments;


### PR DESCRIPTION
## What? & Why?
Addresses one item in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `PostComments` component and run `npm run docs:build` to populate the `README` with the newly added documents.
