### PR TITLE
Show shadow tools by default in global styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -90,7 +90,7 @@ const DEFAULT_CONTROLS = {
 	radius: true,
 	color: true,
 	width: true,
-	shadow: false,
+	shadow: true,
 };
 
 export default function BorderPanel( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fix keeps the shadow tool enabled by default under global styles.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In Global Styles, all tools should show up by default in tools panels, including the shadow tool.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Navigate to global styles -> blocks -> button
* Shadow tool should be visible by default

Global settings:

<img width="551" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/e62cdf70-718b-41a6-996a-d8ad865fa769">

Also, verify that it is not enabled/shown by default under block settings (of button block)

<img width="553" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/8f09703b-28db-490b-8ffa-7a6cdb7b2dcb">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

### Related issues:

Fixes: #61952
