### PR TITLE
DataViews Templates: Auto-hide description field for list view in template dataview page

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -192,6 +192,10 @@ export default function PageTemplates() {
 		return {
 			...DEFAULT_VIEW,
 			type: usedType,
+			hiddenFields:
+				LAYOUT_LIST === usedType
+					? [ ...DEFAULT_VIEW.hiddenFields, 'description' ]
+					: DEFAULT_VIEW.hiddenFields,
 			layout: defaultConfigPerViewType[ usedType ],
 			filters:
 				activeView !== 'all'
@@ -335,6 +339,10 @@ export default function PageTemplates() {
 			if ( newView.type !== view.type ) {
 				newView = {
 					...newView,
+					hiddenFields:
+						LAYOUT_LIST === newView.type
+							? [ ...newView.hiddenFields, 'description' ]
+							: newView.hiddenFields,
 					layout: {
 						...defaultConfigPerViewType[ newView.type ],
 					},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

In DataViews page for template -
Auto-hide the description field when the layout is switched to "List".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Closes: https://github.com/WordPress/gutenberg/issues/57596

As mentioned in the above issue, template descriptions can be quite long and in list layout, where the width is narrow due to the preview pannel, the layout might not look very good.
The layout does look good when description is turned off. And therefore its a good idea to auto-hide the description field when the layout is switched to "List".

<img width="1512" alt="Screenshot 2024-05-26 at 11 52 55 AM" src="https://github.com/WordPress/gutenberg/assets/39427067/b05bea02-96aa-4142-9892-f11a34484d6c">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR automatically adds the `description` field to the hidden fields when you -
- Switch the layout to "List".
- Load the page with layout set as "List".

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Please see the below screencast section or refer the steps below.

- Open site-editor.
- Go to "Templates".
- By default you will see the layout is "Grid".
- Make sure the "Description" field is visible, i.e not hidden.
- Now change the layout to "List".
- You will see as the layout field is changed to "List" the "Description" field automatically gets hidden.
- But if you want you can definitely go and manually enable the "Description" field, if you still want to see it in the "List" view. But everytime you switch to "List" view, it automatically gets hidden.
- You can also do one more test.
- Switch on the "Description" field while in the "List" layout.
- And now refresh the page.
- You will see that the "Description" fields gets again auto-hidden.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/39427067/b1c73248-5929-4ef3-b1eb-992bc96421ac



