### PR TITLE
Fix line height is not reflecting in editor

### DIFF
--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -75,3 +75,18 @@ ol.wp-block-latest-comments {
 		font-size: inherit;
 	}
 }
+
+// Enforce line-height when user has made selection at the individual block level.
+.wp-block-latest-comments {
+	&[style*="line-height"] {
+		line-height: inherit;
+
+		ol.wp-block-latest-comments {
+			// Apply parent's line-height to child.
+			line-height: inherit !important;
+
+			// Unset any previously set line-height to avoid conflicts.
+			line-height: unset !important;
+		}
+	}
+}


### PR DESCRIPTION
Fixes: [#61890](https://github.com/WordPress/gutenberg/issues/61890)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the issue where the line height in the Latest Comments block is not reflected in the editor side until the page is refreshed.

## Why?
This PR is necessary to ensure that changes to the line height in the Latest Comments block are immediately reflected in the editor. This addresses the problem of the editor not updating the line height dynamically, which can cause confusion and disrupt the editing workflow.

## How?
The PR addresses the issue by adding CSS to ensure that the Latest Comments block in the editor adopts the parent's line height immediately upon change. Specifically, the implementation updates the editor's rendering logic to apply the line height styles directly to the block's DOM elements without requiring a page refresh. This ensures that the line height changes are dynamically reflected in the editor as soon as they are made

## Testing Instructions
1. Open a post or page in the WordPress editor.
2. Insert the Latest Comments block.
3. Change the Line height value in the block settings.
4. Verify that the line height change is immediately reflected in the editor.
5. Confirm that the line height is also reflected correctly in the frontend.

### Testing Instructions for Keyboard
1. Open a post or page in the WordPress editor.
2. Use the keyboard to navigate to the Latest Comments block.
3. Use the keyboard to change the Line height value in the block settings.
4. Verify that the line height change is immediately reflected in the editor using only keyboard navigation.

## Screenshots or screencast
https://www.loom.com/share/7af36ed135b54425a74aa0fbe94f2638?sid=1a0d6fd2-6ce9-4069-8279-cb79fc94a68a
