### PR TITLE
Add: Display username in Post Author Sidebar Panel for Admins.

### DIFF
--- a/packages/editor/src/components/post-author/hook.js
+++ b/packages/editor/src/components/post-author/hook.js
@@ -15,10 +15,18 @@ import { AUTHORS_QUERY, BASE_QUERY } from './constants';
 export function useAuthorsQuery( search ) {
 	const { authorId, authors, postAuthor } = useSelect(
 		( select ) => {
-			const { getUser, getUsers } = select( coreStore );
+			const { getUser, getUsers, canUser } = select( coreStore );
 			const { getEditedPostAttribute } = select( editorStore );
 			const _authorId = getEditedPostAttribute( 'author' );
 			const query = { ...AUTHORS_QUERY };
+
+			const isCurrentUserAdmin = Boolean( canUser( 'create', 'users' ) );
+
+			// Get the authors with edit context if the current user is admin.
+			if ( isCurrentUserAdmin ) {
+				query.context = 'edit';
+				query._fields = query._fields + ',username';
+			}
 
 			if ( search ) {
 				query.search = search;
@@ -37,7 +45,8 @@ export function useAuthorsQuery( search ) {
 		const fetchedAuthors = ( authors ?? [] ).map( ( author ) => {
 			return {
 				value: author.id,
-				label: decodeEntities( author.name ),
+				label: `${ decodeEntities( author.name ) }
+				${ decodeEntities( `(${ author.username })` ?? '' ) }`,
 			};
 		} );
 


### PR DESCRIPTION
Fixes - #17364 
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds the username along with name to the Author List in Gutenberg Sidebar Panel.

## Why?
The major problem it solves is if there are more than 1 user that have same name then there can be confusion to decide which user does the post must be authored to. By displaying their username the admin can easily differentiate between the users.

## How?
This PR displays the username in brackets along side the name. eg - TestName (Username). So if the user that is in the editor is Admin ( It is deduced by checking if current user can create users) , then the request to get authors is made with the context of edit and username is added in return fields.

## Testing Instructions
1. Create a few test users on the site.
2. Now create a new Post.
3. Open the SideBar Panel and click on Author.
4. A ComboBox must appear with the list of authors in following format - Name (Username)


## Screenshot
<img width="1470" alt="Screenshot 2024-05-26 at 17 25 06" src="https://github.com/WordPress/gutenberg/assets/45504169/4991c185-9069-43df-a256-d99e66af4edf">
