### PR TITLE
Shadow Panel: Generates unique shadow slugs by finding max suffix and incrementing it

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -20,6 +20,7 @@ import { unlock } from '../../lock-unlock';
 import Subtitle from './subtitle';
 import { NavigationButtonAsItem } from './navigation-button';
 import ScreenHeader from './header';
+import { getNewIndexFromPresets } from './utils';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
@@ -79,34 +80,17 @@ export default function ShadowsPanel() {
 	);
 }
 
-export function getNameAndSlugForShadow( shadows, slugPrefix = 'shadow-' ) {
-	const nameRegex = new RegExp( `^${ slugPrefix }([\\d]+)$` );
-	const position = shadows.reduce( ( previousValue, currentValue ) => {
-		if ( typeof currentValue?.slug === 'string' ) {
-			const matches = currentValue?.slug.match( nameRegex );
-			if ( matches ) {
-				const id = parseInt( matches[ 1 ], 10 );
-				if ( id >= previousValue ) {
-					return id + 1;
-				}
-			}
-		}
-		return previousValue;
-	}, 1 );
-
-	return {
-		name: `Shadow ${ position }`,
-		slug: `${ slugPrefix }${ position }`,
-	};
-}
-
 function ShadowList( { label, shadows, category, canCreate, onCreate } ) {
 	const handleAddShadow = () => {
-		const { name, slug } = getNameAndSlugForShadow( shadows );
+		const newIndex = getNewIndexFromPresets( shadows, 'shadow-' );
 		onCreate( {
-			name,
+			name: sprintf(
+				/* translators: %s: is an index for a preset */
+				__( 'Shadow %s' ),
+				newIndex
+			),
 			shadow: defaultShadow,
-			slug,
+			slug: `shadow-${ newIndex }`,
 		} );
 	};
 

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -79,12 +79,34 @@ export default function ShadowsPanel() {
 	);
 }
 
+export function getNameAndSlugForShadow( shadows, slugPrefix = 'shadow-' ) {
+	const nameRegex = new RegExp( `^${ slugPrefix }([\\d]+)$` );
+	const position = shadows.reduce( ( previousValue, currentValue ) => {
+		if ( typeof currentValue?.slug === 'string' ) {
+			const matches = currentValue?.slug.match( nameRegex );
+			if ( matches ) {
+				const id = parseInt( matches[ 1 ], 10 );
+				if ( id >= previousValue ) {
+					return id + 1;
+				}
+			}
+		}
+		return previousValue;
+	}, 1 );
+
+	return {
+		name: `Shadow ${ position }`,
+		slug: `${ slugPrefix }${ position }`,
+	};
+}
+
 function ShadowList( { label, shadows, category, canCreate, onCreate } ) {
 	const handleAddShadow = () => {
+		const { name, slug } = getNameAndSlugForShadow( shadows );
 		onCreate( {
-			name: `Shadow ${ shadows.length + 1 }`,
+			name,
 			shadow: defaultShadow,
-			slug: `shadow-${ shadows.length + 1 }`,
+			slug,
 		} );
 	};
 

--- a/packages/edit-site/src/components/global-styles/test/utils.spec.js
+++ b/packages/edit-site/src/components/global-styles/test/utils.spec.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import { getNewIndexFromPresets } from '../utils';
+
+const validPresets = {
+	single: [ { slug: 'preset-1' } ],
+	multiple: [ { slug: 'preset-1' }, { slug: 'preset-2' } ],
+	withGaps: [ { slug: 'preset-1' }, { slug: 'preset-3' } ],
+	mixedPrefixes: [
+		{ slug: 'preset-1' },
+		{ slug: 'shadow-2' },
+		{ slug: 'preset-3' },
+	],
+	nonStringSlug: [ { slug: 'preset-1' }, { slug: 2 } ],
+	emptyArray: [],
+};
+
+const invalidPresets = {
+	noMatch: [ { slug: 'preset-alpha' }, { slug: 'preset-beta' } ],
+	emptySlug: [ { slug: '' } ],
+	nullSlug: [ { slug: null } ],
+	undefinedSlug: [ { slug: undefined } ],
+	nonObjectElements: [ 'preset-1' ],
+};
+
+const getExpectedIndex = ( presetKey, presets ) => {
+	if ( presetKey === 'withGaps' ) {
+		return 4;
+	}
+	if ( presetKey === 'mixedPrefixes' ) {
+		return 4;
+	}
+	if ( presetKey === 'nonStringSlug' ) {
+		return 2;
+	}
+	return presets.length + 1;
+};
+
+describe( 'getNewIndexFromPresets', () => {
+	Object.entries( validPresets ).forEach( ( [ presetKey, presets ] ) => {
+		describe( `test valid preset format: ${ presetKey }`, () => {
+			const newIndex = getNewIndexFromPresets( presets, 'preset-' );
+			it( `should return correct new index for ${ presetKey }`, () => {
+				const expectedIndex = getExpectedIndex( presetKey, presets );
+				expect( newIndex ).toBe( expectedIndex );
+			} );
+		} );
+	} );
+
+	Object.entries( invalidPresets ).forEach( ( [ presetKey, presets ] ) => {
+		describe( `test invalid preset format: ${ presetKey }`, () => {
+			const newIndex = getNewIndexFromPresets( presets, 'preset-' );
+			it( `should return 1 for ${ presetKey }`, () => {
+				expect( newIndex ).toBe( 1 );
+			} );
+		} );
+	} );
+} );

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -11,6 +11,22 @@ export function getVariationClassName( variation ) {
 	return `is-style-${ variation }`;
 }
 
+export function getNewIndexFromPresets( presets, slugPrefix ) {
+	const nameRegex = new RegExp( `^${ slugPrefix }([\\d]+)$` );
+	return presets.reduce( ( previousValue, currentValue ) => {
+		if ( typeof currentValue?.slug === 'string' ) {
+			const matches = currentValue?.slug.match( nameRegex );
+			if ( matches ) {
+				const id = parseInt( matches[ 1 ], 10 );
+				if ( id >= previousValue ) {
+					return id + 1;
+				}
+			}
+		}
+		return previousValue;
+	}, 1 );
+}
+
 function getFontFamilyFromSetting( fontFamilies, setting ) {
 	if ( ! Array.isArray( fontFamilies ) || ! setting ) {
 		return null;

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -11,6 +11,14 @@ export function getVariationClassName( variation ) {
 	return `is-style-${ variation }`;
 }
 
+/**
+ * Returns a new index based on the presets and slug prefix.
+ *
+ * @param {Array}  presets    The array of presets.
+ * @param {string} slugPrefix The prefix for the slug.
+ *
+ * @return {number} The new index.
+ */
 export function getNewIndexFromPresets( presets, slugPrefix ) {
 	const nameRegex = new RegExp( `^${ slugPrefix }([\\d]+)$` );
 	return presets.reduce( ( previousValue, currentValue ) => {

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -12,27 +12,30 @@ export function getVariationClassName( variation ) {
 }
 
 /**
- * Returns a new index based on the presets and slug prefix.
+ * Iterates through the presets array and searches for slugs that start with the specified
+ * slugPrefix followed by a numerical suffix. It identifies the highest numerical suffix found
+ * and returns one greater than the highest found suffix, ensuring that the new index is unique.
  *
- * @param {Array}  presets    The array of presets.
- * @param {string} slugPrefix The prefix for the slug.
+ * @param {Array}  presets    The array of preset objects, each potentially containing a slug property.
+ * @param {string} slugPrefix The prefix to look for in the preset slugs.
  *
- * @return {number} The new index.
+ * @return {number} The next available index for a preset with the specified slug prefix, or 1 if no matching slugs are found.
  */
 export function getNewIndexFromPresets( presets, slugPrefix ) {
 	const nameRegex = new RegExp( `^${ slugPrefix }([\\d]+)$` );
-	return presets.reduce( ( previousValue, currentValue ) => {
-		if ( typeof currentValue?.slug === 'string' ) {
-			const matches = currentValue?.slug.match( nameRegex );
+	const highestPresetValue = presets.reduce( ( currentHighest, preset ) => {
+		if ( typeof preset?.slug === 'string' ) {
+			const matches = preset?.slug.match( nameRegex );
 			if ( matches ) {
 				const id = parseInt( matches[ 1 ], 10 );
-				if ( id >= previousValue ) {
-					return id + 1;
+				if ( id > currentHighest ) {
+					return id;
 				}
 			}
 		}
-		return previousValue;
-	}, 1 );
+		return currentHighest;
+	}, 0 );
+	return highestPresetValue + 1;
 }
 
 function getFontFamilyFromSetting( fontFamilies, setting ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: #61989 

## Why?
Shadow slugs were getting duplicated when we try to delete any custom shadow and add a new. See [this](https://github.com/WordPress/gutenberg/issues/61989#issue-2317416856) for more details.

## How?
This PR adds a function to generate unique names and slugs for shadows by finding the highest suffix number used and incrementing it.

## Testing Instructions
1. Add three custom shadows. The labels are "Shadow 1", "Shadow 2", and "Shadow3" respectively.
2. Delete "Shadow 2".
3. Add a new shadow.
4. Now the new shadow will have unique slug and name.

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/77401999/d8ebb043-16e9-423b-a314-880606dafce6


