### PR TITLE
Global styles: add option to remove site-wide theme background image

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -83,6 +83,8 @@ export function hasBackgroundSizeValue( style ) {
 export function hasBackgroundImageValue( style ) {
 	return (
 		!! style?.background?.backgroundImage?.id ||
+		// Supports url() string values in theme.json.
+		'string' === typeof style?.background?.backgroundImage ||
 		!! style?.background?.backgroundImage?.url
 	);
 }
@@ -279,6 +281,23 @@ function BackgroundImageToolsPanelItem( {
 
 	const hasValue = hasBackgroundImageValue( style );
 
+	const closeAndFocus = () => {
+		const [ toggleButton ] = focus.tabbable.find(
+			replaceContainerRef.current
+		);
+		// Focus the toggle button and close the dropdown menu.
+		// This ensures similar behaviour as to selecting an image, where the dropdown is
+		// closed and focus is redirected to the dropdown toggle button.
+		toggleButton?.focus();
+		toggleButton?.click();
+	};
+
+	const onRemove = () =>
+		onChange(
+			setImmutably( style, [ 'background', 'backgroundImage' ], 'none' )
+		);
+	const canRemove = ! hasValue && hasBackgroundImageValue( inheritedValue );
+
 	return (
 		<ToolsPanelItem
 			className="single-column"
@@ -311,17 +330,20 @@ function BackgroundImageToolsPanelItem( {
 					}
 					variant="secondary"
 				>
+					{ canRemove && (
+						<MenuItem
+							onClick={ () => {
+								closeAndFocus();
+								onRemove();
+							} }
+						>
+							{ __( 'Remove' ) }
+						</MenuItem>
+					) }
 					{ hasValue && (
 						<MenuItem
 							onClick={ () => {
-								const [ toggleButton ] = focus.tabbable.find(
-									replaceContainerRef.current
-								);
-								// Focus the toggle button and close the dropdown menu.
-								// This ensures similar behaviour as to selecting an image, where the dropdown is
-								// closed and focus is redirected to the dropdown toggle button.
-								toggleButton?.focus();
-								toggleButton?.click();
+								closeAndFocus();
 								resetBackgroundImage();
 							} }
 						>


### PR DESCRIPTION
## Dev Note 📓 

https://github.com/WordPress/gutenberg/pull/59354#issuecomment-2138583222

## What?

Part of:

- https://github.com/WordPress/gutenberg/issues/54336

Hello.

This PR implements @andrewserong's idea and adds functionality to remove a theme's default, site-wide background image in the editor.

See: https://github.com/WordPress/gutenberg/pull/61271#issuecomment-2095236976

## Why?

Check it out: 



https://github.com/WordPress/gutenberg/assets/6458278/6b76f775-7813-49a5-b220-1c402ad9e137





There's no way to remove a background image if it's been defined in theme.json.

## How?

By adding a "Remove" option to the image dropdown that sets the value of `background.backgroundImage` to `"none"`, when:

1. A user value has not been set, and
2. There's a theme.json value

## Testing Instructions

1. Define a background image for your site in theme.json
2. Head over to the site editor **Global Styles > Layout**
3. Under **Background**, click on the image control and then click on "Remove"
4. The background image should disappear! Save and check the frontend. The value of `background-image` should be `"none"`. 
5. In the site editor again, reset the background image value by clicking on the image control and then click on "Reset"
6. You should see the default background image again.

Here's some test theme.json!

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "https://images.pexels.com/photos/22484288/pexels-photo-22484288/free-photo-of-the-circular-stone-terraces-of-the-inca-ruins.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
			}
		}
	}
}
```

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/6458278/476e9125-c031-4183-b257-688b350ce5c4
