### PR TITLE
Remove build-types/ clean from clean:packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",
-		"distclean": "rimraf node_modules packages/*/node_modules",
+		"distclean": "git clean --force -d -X",
 		"docs:api-ref": "node ./bin/api-docs/update-api-docs.js",
 		"docs:blocks": "node ./bin/api-docs/gen-block-lib-list.js",
 		"docs:build": "npm-run-all docs:gen docs:blocks docs:api-ref docs:theme-ref",

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
 		"build:packages": "npm run --silent build:package-types && node ./bin/packages/build.js",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
 		"clean:package-types": "tsc --build --clean && rimraf \"./packages/*/build-types\"",
-		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style|build-types)\"",
+		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",
 		"distclean": "rimraf node_modules packages/*/node_modules",

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",
-		"distclean": "git clean --force -d -X",
+		"distclean": "rimraf node_modules packages/*/node_modules",
 		"docs:api-ref": "node ./bin/api-docs/update-api-docs.js",
 		"docs:blocks": "node ./bin/api-docs/gen-block-lib-list.js",
 		"docs:build": "npm-run-all docs:gen docs:blocks docs:api-ref docs:theme-ref",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

- #61939 likely introduced a regression (https://github.com/WordPress/gutenberg/pull/61939#issuecomment-2131225836). Fix it.

This branch will _fail_ the bundle-size CI job. That's because it checks out trunk and then runs scripts, where none of the changes on this PR have any impact. This will need to be landed with a failing bundle-size job.

## Why?

The build-types directories should not be removed without a full package clean. I believe this introduced the build issues.

## How?

Remove the `build-types/` directory clean from the `clean:packages` script.

## Testing Instructions

Try running `npm run dev` locally.