### PR TITLE
Remove `IS_GUTENBERG_PLUGIN` check to ensure pattern overrides ship in 6.6.

### DIFF
--- a/packages/editor/src/bindings/index.js
+++ b/packages/editor/src/bindings/index.js
@@ -12,7 +12,4 @@ import postMeta from './post-meta';
 
 const { registerBlockBindingsSource } = unlock( dispatch( blocksStore ) );
 registerBlockBindingsSource( postMeta );
-
-if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-	registerBlockBindingsSource( patternOverrides );
-}
+registerBlockBindingsSource( patternOverrides );


### PR DESCRIPTION
Reverses #59702

## What?
In the build up to WordPress 6.5, the pattern overrides feature was bumped from the release.

The `IS_GUTENBERG_PLUGIN` flag was utilized for this. In both PHP and JS the `pattern overrides` source would only be registered in the gutenberg plugin.

## Why?
The plan is to ship it in 6.6.

## How?
Removes the use of `IS_GUTENBERG_PLUGIN`. While #59702 added the flag in both `lib/load.php` and `packages/editor/src/bindings/index.js`, the `lib/load.php` flag has already been removed in another change prior to this PR.

Only the `js` flag remains, which this PR removes.

## Testing Instructions
### Prerequisites
1. In the root `package.json`, change the `IS_GUTENBERG_PLUGIN` property to `false`.
2. Build from scratch (if you have a watch task running, stop and restart it)

### Test pattern overrides
3. Insert some paragraph/image/button/heading blocks into the post editor
4. Select them and from the block options menu choose 'Create pattern
5. Name the pattern and make it synced
6. Click 'Edit original' from the block toolbar
7. Select one of the paragraph/image/button/heading blocks and in the advanced section of the inspector choose 'Enable Overrides'
8. In the resulting modal, Name the block and click the Enable button
9. Save and select the back button from the editor top bar
10. Back in the post, change the block that you enabled overrides for
11. Preview the post
12. Check that the changes are reflected