### PR TITLE
Post Sticky Toggle: Improve the design

### DIFF
--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { ToggleControl, VisuallyHidden } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -10,6 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import PostStickyCheck from './check';
 import { store as editorStore } from '../../store';
+import PostPanelRow from '../post-panel-row';
 
 export default function PostSticky() {
 	const postSticky = useSelect( ( select ) => {
@@ -21,12 +22,18 @@ export default function PostSticky() {
 
 	return (
 		<PostStickyCheck>
-			<CheckboxControl
-				__nextHasNoMarginBottom
-				label={ __( 'Stick to the top of the blog' ) }
-				checked={ postSticky }
-				onChange={ () => editPost( { sticky: ! postSticky } ) }
-			/>
+			<PostPanelRow label={ __( 'Sticky' ) }>
+				<ToggleControl
+					className="editor-post-sticky__toggle-control"
+					label={
+						<VisuallyHidden>
+							{ __( 'Stick to the top of the blog' ) }
+						</VisuallyHidden>
+					}
+					checked={ postSticky }
+					onChange={ () => editPost( { sticky: ! postSticky } ) }
+				/>
+			</PostPanelRow>
 		</PostStickyCheck>
 	);
 }

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -26,9 +26,7 @@ export default function PostSticky() {
 				<ToggleControl
 					className="editor-post-sticky__toggle-control"
 					label={
-						<VisuallyHidden>
-							{ __( 'Stick to the top of the blog' ) }
-						</VisuallyHidden>
+						<VisuallyHidden>{ __( 'Sticky' ) }</VisuallyHidden>
 					}
 					checked={ postSticky }
 					onChange={ () => editPost( { sticky: ! postSticky } ) }

--- a/packages/editor/src/components/post-sticky/style.scss
+++ b/packages/editor/src/components/post-sticky/style.scss
@@ -1,0 +1,3 @@
+.editor-post-sticky__toggle-control {
+	padding: 6px 12px;
+}

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -79,8 +79,8 @@ export default function PostSummary( { onActionPerformed } ) {
 										<BlogTitle />
 										<PostsPerPage />
 										<SiteDiscussion />
+										<PostStickyPanel />
 									</VStack>
-									<PostStickyPanel />
 									<PostFormatPanel />
 									<TemplateAreas />
 									{ fills }

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -33,6 +33,7 @@
 @import "./components/post-schedule/style.scss";
 @import "./components/post-slug/style.scss";
 @import "./components/post-status/style.scss";
+@import "./components/post-sticky/style.scss";
 @import "./components/post-sync-status/style.scss";
 @import "./components/post-taxonomies/style.scss";
 @import "./components/post-template/style.scss";

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -126,7 +126,7 @@ test.describe( 'Sidebar', () => {
 			name: 'Change discussion options',
 		} );
 		const postSummarySection = page.getByRole( 'checkbox', {
-			name: 'Stick to the top of the blog',
+			name: 'Sticky',
 		} );
 
 		await expect( postExcerptPanel ).toBeVisible();


### PR DESCRIPTION
## What?

Looking at the design of the Post Sticky control in the post editor sidebar, it looks completely broken and out of place compared to the other controls. This PR tries to bring some harmony there.

That said, there's some a11y challenges there, so in order to keep the design correctness while also keeping things accessible, I used a visually hidden label.

Before:

<img width="283" alt="Screenshot 2024-05-27 at 9 30 00 AM" src="https://github.com/WordPress/gutenberg/assets/272444/80d2de1a-77d2-47e7-a14d-9a761af2dfb8">

After:

<img width="283" alt="Screenshot 2024-05-27 at 9 29 13 AM" src="https://github.com/WordPress/gutenberg/assets/272444/d1227fac-42c5-4aa5-8e8c-d0f7d22086ae">

## Testing Instructions

 - Open the post editor sidebar.
 - Check that you can toggle the "sticky" control both visually and using a screen reader.
 - Check that it looks properly like shown in the screenshot.
