### PR TITLE
Fix detaching patterns when a pattern has overrides, but there are no override values

### DIFF
--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -102,8 +102,8 @@ export const convertSyncedPatternToStatic =
 					metadata = { ...metadata };
 					delete metadata.id;
 					delete metadata.bindings;
-					// Use overriden values of the pattern block if they exist.
-					if ( existingOverrides[ metadata.name ] ) {
+					// Use overridden values of the pattern block if they exist.
+					if ( existingOverrides?.[ metadata.name ] ) {
 						// Iterate over each overriden attribute.
 						for ( const [ attributeName, value ] of Object.entries(
 							existingOverrides[ metadata.name ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The 'detach' option for patterns was broken in `trunk` in a specific situation. If you've created a synced pattern that supports overrides but not set any values yet for an override in the instance, then the detach option fails.

## How?
The bug is caused by an `if` statement that expected the `content` attribute in a pattern block to have a defined value. When the user has not added any override values or has used the 'Reset' option, then `content` can be undefined.

## Testing Instructions
An e2e test has been added. There were already e2e tests for standard synced patterns and synced patterns with overrides, but none for this specific situation.

To manually test:
1. Insert some paragraph/image/button/heading blocks into the post editor
2. Select them and from the block options menu choose 'Create pattern
3. Name the pattern and make it synced
4. Click 'Edit original' from the block toolbar
5. Select one of the paragraph/image/button/heading blocks and in the advanced section of the inspector choose 'Enable Overrides'
6. In the resulting modal, Name the block and click the Enable button
7. Save and select the back button from the editor top bar
8. Back in the post, try using the 'Detach' option on the pattern
11. Check that the blocks are detached from the pattern with the correct values

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/677833/7cc34599-572c-473b-b5e8-8f745b7ff63e

