### PR TITLE
Improve distclean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",
-		"distclean": "rimraf node_modules packages/*/node_modules",
+		"distclean": "git clean --force -d -X",
 		"docs:api-ref": "node ./bin/api-docs/update-api-docs.js",
 		"docs:blocks": "node ./bin/api-docs/gen-block-lib-list.js",
 		"docs:build": "npm-run-all docs:gen docs:blocks docs:api-ref docs:theme-ref",


### PR DESCRIPTION

## What?

Change `distclean` script to use `git clean`.


## Why?

Ostensibly, `distclean` is a script to reset the repository to a clean state, close to what a fresh clone would look like.

It only cleans up `node_modules` directories now, which leaves a lot of built assets that can potentially cause issues. For example, the compressed-size github action uses `distclean` to reset the repo to a clean state when switching branches, which can continue to cause problems (observed in https://github.com/WordPress/gutenberg/pull/62008).

## How?

Change the script to use `git clean --force -d -X`. 

       Cleans the working tree by recursively removing files that are not under version control,
       starting from the current directory.

       -f, --force
           If the Git configuration variable clean.requireForce is not set to false, git clean will
           refuse to delete files or directories unless given -f. Git will refuse to modify untracked
           nested git repositories (directories with a .git subdirectory) unless a second -f is given.

      -d
           Normally, when no <pathspec> is specified, git clean will not recurse into untracked
           directories to avoid removing too much. Specify -d to have it recurse into such directories
           as well. If a <pathspec> is specified, -d is irrelevant; all untracked files matching the
           specified paths (with exceptions for nested git directories mentioned under --force) will
           be removed.

       -X
           Remove only files ignored by Git. This may be useful to rebuild everything from scratch,
           but keep manually created files.


This should clean up files and directories that are ignored by `git`, which should cover:
- Dependencies (npm and composer: `node_modules`, `vendor/`)
- Generated files `/build/`, `packages/*/build-*`, `.tsbuildinfo` (TypeScript cache files), etc.

This should be much closer to what the script intends. An added advantage is that it does not require `rimraf` (a dependency installed in `node_modules`) so can be run repeatedly without failing.

## Testing Instructions

- `npm run distclean` should result in a clean working directory
- running `npm run distclean` should not fail
