### PR TITLE
Pages sidebar: adds published & scheduled items

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -55,6 +55,36 @@ export const DEFAULT_VIEWS = {
 			view: DEFAULT_PAGE_BASE,
 		},
 		{
+			title: __( 'Published' ),
+			slug: 'published',
+			icon: pages,
+			view: {
+				...DEFAULT_PAGE_BASE,
+				filters: [
+					{
+						field: 'status',
+						operator: OPERATOR_IS_ANY,
+						value: 'publish',
+					},
+				],
+			},
+		},
+		{
+			title: __( 'Scheduled' ),
+			slug: 'future',
+			icon: pages,
+			view: {
+				...DEFAULT_PAGE_BASE,
+				filters: [
+					{
+						field: 'status',
+						operator: OPERATOR_IS_ANY,
+						value: 'future',
+					},
+				],
+			},
+		},
+		{
 			title: __( 'Drafts' ),
 			slug: 'drafts',
 			icon: drafts,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59659

## What?

Adds "Published" and "Scheduled" items to the Pages sidebar.

<img width="743" alt="Captura de ecrã 2024-05-27, às 12 48 48" src="https://github.com/WordPress/gutenberg/assets/583546/601f8f76-9987-40fb-ae98-fc3eb3b020d1">


## Why?

It's part of the design goal https://github.com/WordPress/gutenberg/issues/59659

## How?

Declares the new items in the sidebar item list for the Pages page.

## Testing Instructions

Visit the Pages page and verify that the new items are present and work as expected.
