### PR TITLE
Update: For synced entities the icon should be purple.

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -25,6 +25,7 @@ import { useReducedMotion } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { TEMPLATE_POST_TYPES, GLOBAL_POST_TYPES } from '../../store/constants';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
@@ -38,14 +39,6 @@ const TYPE_LABELS = {
 	// translators: 1: Template part title.
 	wp_template_part: __( 'Editing template part: %s' ),
 };
-
-const TEMPLATE_POST_TYPES = [ 'wp_template', 'wp_template_part' ];
-
-const GLOBAL_POST_TYPES = [
-	...TEMPLATE_POST_TYPES,
-	'wp_block',
-	'wp_navigation',
-];
 
 const MotionButton = motion( Button );
 

--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -26,3 +26,7 @@
 		margin-bottom: $grid-unit-10;
 	}
 }
+
+.editor-post-card-panel__icon.is-sync {
+	fill: var(--wp-block-synced-color);
+}

--- a/packages/editor/src/store/constants.js
+++ b/packages/editor/src/store/constants.js
@@ -27,3 +27,9 @@ export const TEMPLATE_ORIGINS = {
 	theme: 'theme',
 	plugin: 'plugin',
 };
+export const TEMPLATE_POST_TYPES = [ 'wp_template', 'wp_template_part' ];
+export const GLOBAL_POST_TYPES = [
+	...TEMPLATE_POST_TYPES,
+	'wp_block',
+	'wp_navigation',
+];


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59689#issuecomment-2110493251.
Makes the icon for synced entities purple.

## Screenshots or screencast <!-- if applicable -->
<img width="352" alt="Screenshot 2024-05-27 at 13 44 58" src="https://github.com/WordPress/gutenberg/assets/11271197/a7c4af34-a72b-4ed7-9906-6fe7d9f57692">

