### PR TITLE
Block Variations: Have `getActiveBlockVariation` return variation with highest specificity

### DIFF
--- a/docs/reference-guides/block-api/block-variations.md
+++ b/docs/reference-guides/block-api/block-variations.md
@@ -129,9 +129,9 @@ While the `isActive` property is optional, it's recommended. This API is used by
 
 If `isActive` is not set, the Editor cannot distinguish between an instance of the original block and your variation, so the original block information will be displayed.
 
-The property can be set to either a function or an array of strings (`string[]`).
+The property can be set to either an array of strings (`string[]`), or a function. It is recommended to use the string array version whenever possible.
 
-The function version of this property accepts a block instance's `blockAttributes` as the first argument, and the `variationAttributes` declared for a variation as the second argument. These arguments can be used to determine if a variation is active by comparing them and returning a `true` or `false` (indicating whether this variation is inactive for this block instance).
+The `string[]` version is used to declare which of the block instance's attributes should be compared to the given variation's. Each attribute will be checked and the variation will be active if all of them match.
 
 As an example, in the core Embed block, the `providerNameSlug` attribute is used to determine the embed provider (e.g. 'youtube' or 'twitter'). The variations may be declared like this:
 
@@ -162,18 +162,13 @@ const variations = [
 ]
 ```
 
- The `isActive` function can compare the block instance value for `providerNameSlug` to the value declared in the variation's declaration (the values in the code snippet above) to determine which embed variation is active:
-
-```js
-isActive: ( blockAttributes, variationAttributes ) =>
-	blockAttributes.providerNameSlug === variationAttributes.providerNameSlug,
-```
-
-The `string[]` version is used to declare which attributes should be compared as a shorthand. Each attribute will be checked and the variation will be active if all of them match. Using the same example for the embed block, the string version would look like this:
+The `isActive` property would then look like this:
 
 ```js
 isActive: [ 'providerNameSlug' ]
 ```
+
+This will cause the block instance value for `providerNameSlug` to be compared to the value declared in the variation's declaration (the values in the code snippet above) to determine which embed variation is active.
 
 Nested object paths are also supported. For example, consider a block variation that has a `query` object as an attribute. It is possible to determine if the variation is active solely based on that object's `postType` property (while ignoring all its other properties):
 
@@ -181,9 +176,18 @@ Nested object paths are also supported. For example, consider a block variation 
 isActive: [ 'query.postType' ]
 ```
 
-### Caveats to using `isActive`
+The function version of this property accepts a block instance's `blockAttributes` as the first argument, and the `variationAttributes` declared for a variation as the second argument. These arguments can be used to determine if a variation is active by comparing them and returning a `true` or `false` (indicating whether this variation is inactive for this block instance).
 
-The `isActive` property can return false positives if multiple variations exist for a specific block and the `isActive` checks are not specific enough. To demonstrate this, consider the following example:
+Using the same example for the embed block, the function version would look like this:
+
+```js
+isActive: ( blockAttributes, variationAttributes ) =>
+	blockAttributes.providerNameSlug === variationAttributes.providerNameSlug,
+```
+
+### Specificity of `isActive` matches
+
+If there are multiple variations whose `isActive` check matches a given block instance, and all of them are string arrays, then the variation with the highest _specificity_ will be chosen. Consider the following example:
 
 ```js
 wp.blocks.registerBlockVariation(
@@ -212,6 +216,6 @@ wp.blocks.registerBlockVariation(
 );
 ```
 
-The `isActive` check on both variations tests the `textColor`, but each variations uses `vivid-red`. Since the `paragraph-red` variation is registered first, once the `paragraph-red-grey` variation is inserted into the Editor, it will have the title `Red Paragraph` instead of `Red/Grey Paragraph`. As soon as the Editor finds a match, it stops checking.
+If a block instance has attributes `textColor: vivid-red` and `backgroundColor: cyan-bluish-gray`, both variations' `isActive` criterion will match that block instance. In this case, the more _specific_ match will be determined to be the active variation, where specificity is calculated as the length of each `isActive` array. This means that the `Red/Grey Paragraph` will be shown as the active variation.
 
-There have been [discussions](https://github.com/WordPress/gutenberg/issues/41303#issuecomment-1526193087) around how the API can be improved, but as of WordPress 6.3, this remains an issue to watch out for.
+Note that specificity cannot be determined for a matching variation if its `isActive` property is a function rather than a `string[]`. In this case, the first matching variation will be determined to be the active variation. For this reason, it is generally recommended to use a `string[]` rather than a `function` for the `isActive` property.

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -626,14 +626,14 @@ describe( 'selectors', () => {
 				).toEqual( variations[ 0 ] );
 				// All variations match the following attributes. However, since the third variation has a function
 				// for its isActive field, we cannot compare the specificity of each match, so instead we return the
-				// first match.
+				// best match we've found.
 				expect(
 					getActiveBlockVariation( state, blockName, {
 						firstTestAttribute: 1,
 						secondTestAttribute: 2,
 						thirdTestAttribute: 3,
 					} )
-				).toEqual( variations[ 0 ] );
+				).toEqual( variations[ 1 ] );
 				expect(
 					getActiveBlockVariation( state, blockName, {
 						firstTestAttribute: 1,

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -291,6 +291,7 @@ describe( 'selectors', () => {
 					testAttribute: {},
 					firstTestAttribute: {},
 					secondTestAttribute: {},
+					thirdTestAttribute: {},
 				},
 			};
 			const FIRST_VARIATION_TEST_ATTRIBUTE_VALUE = 1;
@@ -507,6 +508,136 @@ describe( 'selectors', () => {
 					getActiveBlockVariation( state, blockName, {
 						firstTestAttribute: 1,
 						secondTestAttribute: 20,
+					} )
+				).toEqual( variations[ 2 ] );
+			} );
+			it( 'should return the active variation using the match with the highest specificity for the given isActive array (multiple values)', () => {
+				const variations = [
+					{
+						name: 'variation-1',
+						attributes: {
+							firstTestAttribute: 1,
+							secondTestAttribute: 2,
+						},
+						isActive: [
+							'firstTestAttribute',
+							'secondTestAttribute',
+						],
+					},
+					{
+						name: 'variation-2',
+						attributes: {
+							firstTestAttribute: 1,
+							secondTestAttribute: 2,
+							thirdTestAttribute: 3,
+						},
+						isActive: [
+							'firstTestAttribute',
+							'secondTestAttribute',
+							'thirdTestAttribute',
+						],
+					},
+					{
+						name: 'variation-3',
+						attributes: {
+							firstTestAttribute: 1,
+							thirdTestAttribute: 3,
+						},
+						isActive: [
+							'firstTestAttribute',
+							'thirdTestAttribute',
+						],
+					},
+				];
+
+				const state =
+					createBlockVariationsStateWithTestBlockType( variations );
+
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						firstTestAttribute: 1,
+						secondTestAttribute: 2,
+					} )
+				).toEqual( variations[ 0 ] );
+				// All variations match the following attributes. Since all matches have an array for their isActive
+				// fields, we can compare the specificity of each match and return the most specific match.
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						firstTestAttribute: 1,
+						secondTestAttribute: 2,
+						thirdTestAttribute: 3,
+					} )
+				).toEqual( variations[ 1 ] );
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						firstTestAttribute: 1,
+						thirdTestAttribute: 3,
+					} )
+				).toEqual( variations[ 2 ] );
+			} );
+			it( 'should return the active variation using the first match given the isActive array (multiple values) and function', () => {
+				const variations = [
+					{
+						name: 'variation-1',
+						attributes: {
+							firstTestAttribute: 1,
+							secondTestAttribute: 2,
+						},
+						isActive: [
+							'firstTestAttribute',
+							'secondTestAttribute',
+						],
+					},
+					{
+						name: 'variation-2',
+						attributes: {
+							firstTestAttribute: 1,
+							secondTestAttribute: 2,
+							thirdTestAttribute: 3,
+						},
+						isActive: [
+							'firstTestAttribute',
+							'secondTestAttribute',
+							'thirdTestAttribute',
+						],
+					},
+					{
+						name: 'variation-3',
+						attributes: {
+							firstTestAttribute: 1,
+							thirdTestAttribute: 3,
+						},
+						isActive: ( blockAttributes, variationAttributes ) =>
+							blockAttributes.firstTestAttribute ===
+								variationAttributes.firstTestAttribute &&
+							blockAttributes.thirdTestAttribute ===
+								variationAttributes.thirdTestAttribute,
+					},
+				];
+
+				const state =
+					createBlockVariationsStateWithTestBlockType( variations );
+
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						firstTestAttribute: 1,
+						secondTestAttribute: 2,
+					} )
+				).toEqual( variations[ 0 ] );
+				// All variations match the following attributes. However, since the third variation has a function
+				// for its isActive field, we cannot compare the specificity of each match, so instead we return the
+				// first match.
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						firstTestAttribute: 1,
+						secondTestAttribute: 2,
+						thirdTestAttribute: 3,
+					} )
+				).toEqual( variations[ 0 ] );
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						firstTestAttribute: 1,
+						thirdTestAttribute: 3,
 					} )
 				).toEqual( variations[ 2 ] );
 			} );


### PR DESCRIPTION
## What?
Change `getActiveBlockVariation` such that if multiple variations' `isActive` arrays match the given block's attributes, the variation with the highest specificity (i.e. matching the largest number of attributes) is returned.

## Why?
See the "[Caveats to using isActive](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/#caveats-to-using-isactive)" section of the Block Variation docs.

Fixes part of https://github.com/WordPress/gutenberg/issues/41303 (see https://github.com/WordPress/gutenberg/issues/41303#issuecomment-2135217685).

## How?
By assigning a specificity score to each match, corresponding to the number of attributes specified by `isActive`, and returning the match with the highest specificity. Take the [example from the docs](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/#caveats-to-using-isactive):

```js
wp.blocks.registerBlockVariation(
	'core/paragraph',
	{
		name: 'paragraph-red',
		title: 'Red Paragraph',
		attributes: {
			textColor: 'vivid-red',
		},
		isActive: [ 'textColor' ],
	}
);

wp.blocks.registerBlockVariation(
	'core/paragraph',
	{
		name: 'paragraph-red-grey',
		title: 'Red/Grey Paragraph',
		attributes: {
			textColor: 'vivid-red',
			backgroundColor: 'cyan-bluish-gray'
		},
		isActive: [ 'textColor', 'backgroundColor' ]
	}
);
```

The specificity (i.e. `isActive.length`) of the `paragraph-red` variation is `1`, whereas for the `paragraph-red-grey` variation, it is 2. If the current block matches both variations, the one with the higher specificity (here: `paragraph-red-grey`) is returned.

Note that if any matching variation uses a _function_ rather than an array for its `isActive` field, a specificity is not assigned; as a result, the match cannot be compared to the other matches. In this case, the first matching variation will be returned instead (much like `getActiveBlockVariation` did anyway, prior to this PR). (See https://github.com/WordPress/gutenberg/issues/62068 for a related issue; fixing it should make it possible to use arrays rather than functions for in most cases.)

## Testing Instructions
Do some some testing with block variations in the editor.
Other than that, refer to automated tests.
