### PR TITLE
Add: Content panel for template parts.

### DIFF
--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -30,6 +30,7 @@ import PostTaxonomiesPanel from '../post-taxonomies/panel';
 import PostTransformPanel from '../post-transform-panel';
 import SidebarHeader from './header';
 import TemplateContentPanel from '../template-content-panel';
+import TemplatePartContentPanel from '../template-part-content-panel';
 import useAutoSwitchEditorSidebars from '../provider/use-auto-switch-editor-sidebars';
 import { sidebars } from './constants';
 import { unlock } from '../../lock-unlock';
@@ -114,6 +115,7 @@ const SidebarContent = ( {
 					{ renderingMode !== 'post-only' && (
 						<TemplateContentPanel />
 					) }
+					<TemplatePartContentPanel />
 					<PostTransformPanel />
 					<PostTaxonomiesPanel />
 					<PatternOverridesPanel />

--- a/packages/editor/src/components/template-part-content-panel/index.js
+++ b/packages/editor/src/components/template-part-content-panel/index.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as blocksStore } from '@wordpress/blocks';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { TEMPLATE_PART_POST_TYPE } from '../../store/constants';
+import { store as editorStore } from '../../store';
+
+const { BlockQuickNavigation } = unlock( blockEditorPrivateApis );
+
+function TemplatePartContentPanelInner() {
+	const blockTypes = useSelect( ( select ) => {
+		const { getBlockTypes } = select( blocksStore );
+		return getBlockTypes();
+	}, [] );
+	const themeBlockNames = useMemo( () => {
+		return blockTypes
+			.filter( ( blockType ) => {
+				return blockType.category === 'theme';
+			} )
+			.map( ( { name } ) => name );
+	}, [ blockTypes ] );
+	const themeBlocks = useSelect(
+		( select ) => {
+			const { getBlocksByName } = select( blockEditorStore );
+			return getBlocksByName( themeBlockNames );
+		},
+		[ themeBlockNames ]
+	);
+	if ( themeBlocks.length === 0 ) {
+		return null;
+	}
+	return (
+		<PanelBody title={ __( 'Content' ) }>
+			<BlockQuickNavigation clientIds={ themeBlocks } />
+		</PanelBody>
+	);
+}
+
+export default function TemplatePartContentPanel() {
+	const postType = useSelect( ( select ) => {
+		const { getCurrentPostType } = select( editorStore );
+		return getCurrentPostType();
+	}, [] );
+	if ( postType !== TEMPLATE_PART_POST_TYPE ) {
+		return null;
+	}
+
+	return <TemplatePartContentPanelInner />;
+}


### PR DESCRIPTION
This PR implements a content panel for template parts whose mockup is available here https://github.com/WordPress/gutenberg/issues/59689#issuecomment-2092659485.

Blocks that appear on the content area of template parts are the blocks whose category is 'theme'.


## Testing Instructions
I opened some template parts and verified they included a content panel.

## Screenshots or screencast <!-- if applicable -->
<img width="352" alt="Screenshot 2024-05-27 at 17 11 03" src="https://github.com/WordPress/gutenberg/assets/11271197/66ef8bc5-80cf-4e8f-826c-24035478fe61">

