### PR TITLE
Block Library: Remove CSS hack for Internet Explorer 11

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -123,10 +123,3 @@
 .color-block-support-panel__inner-wrapper > :not(.block-editor-tools-panel-color-gradient-settings__item) {
 	margin-top: $grid-unit-30;
 }
-
-
-// The frontend style.scss includes a min-height as an IE11 fix.
-// This fix causes extra spacing for the focus style in the editor, so we omit it here.
-.wp-block-cover::after {
-	min-height: auto;
-}

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -91,20 +91,6 @@
 		width: 100%;
 	}
 
-	// Using flexbox without an assigned height property breaks vertical center alignment in IE11.
-	// Appending an empty ::after element tricks IE11 into giving the cover image an implicit height, which sidesteps this issue.
-	&::after {
-		display: block;
-		content: "";
-		font-size: 0;
-		min-height: inherit;
-
-		// IE doesn't support flex so omit that.
-		@supports (position: sticky) {
-			content: none;
-		}
-	}
-
 	// Aligned cover blocks should not use our global alignment rules
 	&.aligncenter,
 	&.alignleft,


### PR DESCRIPTION
Part of #58034
Similar to #60727

## What?

This PR removes the fallback CSS for IE11 present in the `@wordpress/block-library` package. The CSS hack for IE11 in this package is only present in the Cover block.

## Why?

Support for IE11 has been [officially removed in WordPress 5.8](https://make.wordpress.org/core/2021/04/22/ie-11-support-phase-out-plan/). And since the Gutenberg plugin no longer supports WordPress 5.8, we can remove the fallback code for IE11.

Additionally, the `after` pseudo-element of the block is used for outlines, so this CSS hack for the cover block may have implications in the future.

## How?

Just removed.

## Testing Instructions

This PR does not change the behavior of the Cover block, but please be sure to check that the issue fixed in #44707 is not regressing. That is, the focus outline should exactly match the size of the cover image.

![image](https://github.com/WordPress/gutenberg/assets/54422211/3d166e5d-9a28-4c9b-b749-2193266eaa29)
