### PR TITLE
Background images: add defaults for background size

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -245,12 +245,22 @@ function BackgroundImageToolsPanelItem( {
 			return;
 		}
 
+		const sizeValue = style?.background?.backgroundSize;
+		const positionValue = style?.background?.backgroundPosition;
+
 		onChange(
-			setImmutably( style, [ 'background', 'backgroundImage' ], {
-				url: media.url,
-				id: media.id,
-				source: 'file',
-				title: media.title || undefined,
+			setImmutably( style, [ 'background' ], {
+				...style?.background,
+				backgroundImage: {
+					url: media.url,
+					id: media.id,
+					source: 'file',
+					title: media.title || undefined,
+				},
+				backgroundPosition:
+					! positionValue && ( 'auto' === sizeValue || ! sizeValue )
+						? '50% 0'
+						: positionValue,
 			} )
 		);
 	};

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -448,7 +448,7 @@ function BackgroundSizeToolsPanelItem( {
 			 * when the toggle switches to "Tile". This is to increase the chance that
 			 * the image's focus point is visible.
 			 */
-			if ( !! style?.background?.backgroundImage?.id ) {
+			if ( !! style?.background?.backgroundImage?.id && ! nextPosition ) {
 				nextPosition = '50% 0';
 			}
 		}

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -441,6 +441,7 @@ function BackgroundSizeToolsPanelItem( {
 			next === 'auto'
 		) {
 			nextRepeat = undefined;
+			next = !! style?.background?.backgroundImage?.id ? '50%' : next;
 		}
 
 		/*

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -430,10 +430,12 @@ function BackgroundSizeToolsPanelItem( {
 
 		if ( next === 'contain' ) {
 			nextRepeat = 'no-repeat';
+			nextPosition = undefined;
 		}
 
 		if ( next === 'cover' ) {
 			nextRepeat = undefined;
+			nextPosition = undefined;
 		}
 
 		if (

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -22,12 +22,11 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
-	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
-import { useCallback, Platform, useRef, useState } from '@wordpress/element';
+import { useCallback, Platform, useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
 import { isBlobURL } from '@wordpress/blob';
@@ -195,14 +194,8 @@ function BackgroundImageToolsPanelItem( {
 	onChange,
 	style,
 	inheritedValue,
-	defaultValues,
 	themeFileURIs,
 } ) {
-	const sizeValue =
-		style?.background?.backgroundSize ||
-		inheritedValue?.background?.backgroundSize ||
-		defaultValues?.backgroundSize;
-
 	const mediaUpload = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
 		[]
@@ -253,18 +246,11 @@ function BackgroundImageToolsPanelItem( {
 		}
 
 		onChange(
-			setImmutably( style, [ 'background' ], {
-				...style?.background,
-				backgroundImage: {
-					url: media.url,
-					id: media.id,
-					source: 'file',
-					title: media.title || undefined,
-				},
-				backgroundSize:
-					'auto' === sizeValue || ! sizeValue
-						? '50%'
-						: style?.background?.backgroundSize,
+			setImmutably( style, [ 'background', 'backgroundImage' ], {
+				url: media.url,
+				id: media.id,
+				source: 'file',
+				title: media.title || undefined,
 			} )
 		);
 	};
@@ -383,8 +369,6 @@ function BackgroundSizeToolsPanelItem( {
 	defaultValues,
 	themeFileURIs,
 } ) {
-	const [ lastKnownImageWidth, setLastKnownImageWidth ] =
-		useState( undefined );
 	const sizeValue =
 		style?.background?.backgroundSize ||
 		inheritedValue?.background?.backgroundSize;
@@ -457,7 +441,6 @@ function BackgroundSizeToolsPanelItem( {
 			next === 'auto'
 		) {
 			nextRepeat = undefined;
-			next = lastKnownImageWidth ?? 'auto';
 		}
 
 		/*
@@ -466,7 +449,6 @@ function BackgroundSizeToolsPanelItem( {
 		 */
 		if ( ! next && currentValueForToggle === 'auto' ) {
 			next = 'auto';
-			setLastKnownImageWidth( undefined );
 		}
 
 		onChange(
@@ -476,11 +458,6 @@ function BackgroundSizeToolsPanelItem( {
 				backgroundSize: next,
 			} )
 		);
-
-		const imageWidth = parseQuantityAndUnitFromRawValue( next );
-		if ( typeof imageWidth?.[ 0 ] !== 'undefined' && imageWidth?.[ 1 ] ) {
-			setLastKnownImageWidth( next );
-		}
 	};
 
 	const updateBackgroundPosition = ( next ) => {
@@ -645,7 +622,6 @@ export default function BackgroundPanel( {
 				isShownByDefault={ defaultControls.backgroundImage }
 				style={ value }
 				inheritedValue={ inheritedValue }
-				defaultValues={ defaultValues }
 				themeFileURIs={ themeFileURIs }
 			/>
 			{ shouldShowBackgroundSizeControls && (

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -195,11 +195,13 @@ function BackgroundImageToolsPanelItem( {
 	onChange,
 	style,
 	inheritedValue,
+	defaultValues,
 	themeFileURIs,
 } ) {
 	const sizeValue =
 		style?.background?.backgroundSize ||
-		inheritedValue?.background?.backgroundSize;
+		inheritedValue?.background?.backgroundSize ||
+		defaultValues?.backgroundSize;
 
 	const mediaUpload = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
@@ -251,19 +253,20 @@ function BackgroundImageToolsPanelItem( {
 		}
 
 		onChange(
-			setImmutably( style, [ 'background', 'backgroundImage' ], {
-				url: media.url,
-				id: media.id,
-				source: 'file',
-				title: media.title || undefined,
+			setImmutably( style, [ 'background' ], {
+				...style?.background,
+				backgroundImage: {
+					url: media.url,
+					id: media.id,
+					source: 'file',
+					title: media.title || undefined,
+				},
+				backgroundSize:
+					'auto' === sizeValue || ! sizeValue
+						? '50%'
+						: style?.background?.backgroundSize,
 			} )
 		);
-
-		if ( 'auto' === sizeValue || ! sizeValue ) {
-			onChange(
-				setImmutably( style, [ 'background', 'backgroundSize' ], '50%' )
-			);
-		}
 	};
 
 	const onFilesDrop = ( filesList ) => {
@@ -454,7 +457,7 @@ function BackgroundSizeToolsPanelItem( {
 			next === 'auto'
 		) {
 			nextRepeat = undefined;
-			next = lastKnownImageWidth ?? '50%';
+			next = lastKnownImageWidth ?? 'auto';
 		}
 
 		/*
@@ -642,6 +645,7 @@ export default function BackgroundPanel( {
 				isShownByDefault={ defaultControls.backgroundImage }
 				style={ value }
 				inheritedValue={ inheritedValue }
+				defaultValues={ defaultValues }
 				themeFileURIs={ themeFileURIs }
 			/>
 			{ shouldShowBackgroundSizeControls && (

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -450,7 +450,7 @@ function BackgroundSizeToolsPanelItem( {
 			 * when the toggle switches to "Tile". This is to increase the chance that
 			 * the image's focus point is visible.
 			 */
-			if ( !! style?.background?.backgroundImage?.id && ! nextPosition ) {
+			if ( !! style?.background?.backgroundImage?.id ) {
 				nextPosition = '50% 0';
 			}
 		}

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -426,6 +426,7 @@ function BackgroundSizeToolsPanelItem( {
 	const updateBackgroundSize = ( next ) => {
 		// When switching to 'contain' toggle the repeat off.
 		let nextRepeat = repeatValue;
+		let nextPosition = positionValue;
 
 		if ( next === 'contain' ) {
 			nextRepeat = 'no-repeat';
@@ -441,7 +442,15 @@ function BackgroundSizeToolsPanelItem( {
 			next === 'auto'
 		) {
 			nextRepeat = undefined;
-			next = !! style?.background?.backgroundImage?.id ? '50%' : next;
+			/*
+			 * A background image uploaded and set in the editor (an image with a record id),
+			 * receives a default background position of '50% 0',
+			 * when the toggle switches to "Tile". This is to increase the chance that
+			 * the image's focus point is visible.
+			 */
+			if ( !! style?.background?.backgroundImage?.id ) {
+				nextPosition = '50% 0';
+			}
 		}
 
 		/*
@@ -455,6 +464,7 @@ function BackgroundSizeToolsPanelItem( {
 		onChange(
 			setImmutably( style, [ 'background' ], {
 				...style?.background,
+				backgroundPosition: nextPosition,
 				backgroundRepeat: nextRepeat,
 				backgroundSize: next,
 			} )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

See: https://github.com/WordPress/gutenberg/issues/61928#issuecomment-2134387541

This PR:

- sets a default background position of `"50% 0"` for uploaded images when background size is toggled to "Tile"
- resets background position in between toggling
- defines a placeholder of "Auto" for the background image width image value.


https://github.com/WordPress/gutenberg/assets/6458278/46fc3deb-6988-45ed-9dda-bd4e92cd54b2


## Why?
To increase the chance that the image's focus point is visible.


## Testing Instructions

1. Insert a Group block and add a new background image.
2. Toggle the background size to "Tile"
3. Check that the position is set to "50% 0"
4. Toggle between size options, e.g., Cover, Contains, Tile. 
5. Check that the position resets between toggling (should it?)
6. With the size set to "Tile", upload an image or select a new one from the Media library. Check that the position is set to "50% 0"
7. Change the default position X Y values. Upload an image or select a new one from the Media library. Your position should be preserved.
8. For the Tile option, observe that the placeholder for image width input field underneath is "Auto"

Finally, to ensure that no default background position is set for theme.json-defined background images, set a background image in theme.json and toggle between the size settings in the site editor.


https://github.com/WordPress/gutenberg/assets/6458278/e7b6ec82-e7bd-442a-b498-b796a40cba05



