### PR TITLE
UnitControl: preserve order of incoming units

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -599,6 +599,7 @@ function BackgroundSizeControls( {
 					size="__unstable-large"
 					__unstableInputWidth="100px"
 					min={ 0 }
+					allowedUnitValues={ [ '%', 'px', 'em', 'rem', 'vw', 'vh' ] }
 					placeholder={ __( 'Auto' ) }
 					disabled={
 						currentValueForToggle !== 'auto' ||

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -107,4 +107,8 @@ export type UnitControlProps = Pick< InputControlProps, 'size' > &
 		 * Callback when either the quantity or the unit inputs gains focus.
 		 */
 		onFocus?: FocusEventHandler< HTMLInputElement | HTMLSelectElement >;
+		/**
+		 * A list of allowed unit values. If provided, only these values will be selectable.
+		 */
+		allowedUnitValues?: string[];
 	};


### PR DESCRIPTION


## What?

Testing passing an allowedUnitValues prop to UnitControl, which intends (eventually) to act in some way like `useCustomUnits` hook, but for now just filters the default units and preserves the order.

See: https://github.com/WordPress/gutenberg/issues/61928#issuecomment-2134387541

See also: https://github.com/WordPress/gutenberg/pull/31822#discussion_r633280823

## Why?

Consumers should be able to determine the order of the units in the control.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
