### PR TITLE
Classic block: Fix content syncing effect for React StrictMode

### DIFF
--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -83,12 +83,15 @@ function ClassicEdit( {
 		}
 
 		const editor = window.tinymce.get( `editor-${ clientId }` );
-		const currentContent = editor?.getContent();
+		if ( ! editor ) {
+			return;
+		}
 
+		const currentContent = editor.getContent();
 		if ( currentContent !== content ) {
 			editor.setContent( content || '' );
 		}
-	}, [ content ] );
+	}, [ clientId, content ] );
 
 	useEffect( () => {
 		const { baseURL, suffix } = window.wpEditorL10n.tinymce;
@@ -227,6 +230,7 @@ function ClassicEdit( {
 				onReadyStateChange
 			);
 			wp.oldEditor.remove( `editor-${ clientId }` );
+			didMount.current = false;
 		};
 	}, [] );
 


### PR DESCRIPTION
## What?
PR fixes a React StrictMode bug for the Classic block. The content syncing effect triggered an error in development mode.

The bug was discovered via #61943.

## Why?
The TinyMCE initialization effect was resetting the `didMount` ref during the cleanup. 

## How?
* Add an extra check if the TinyMCE editor is initialized.
* Reset `didMount` ref when TinyMCE editor is removed.

## Testing Instructions
1. Enable script development mode for `wp-env`.
2. Enable strict mode for the post editor.
3. Run classic block e2e tests - `npm run test:e2e -- editor/blocks/classic.spec.js`


<details><summary>Patch for enabling modes</summary>
<p>

```diff
diff --git .wp-env.json .wp-env.json
index 20d5597e54b..57d4e1a72d8 100644
--- .wp-env.json
+++ .wp-env.json
@@ -4,6 +4,9 @@
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {
+			"config": {
+				"SCRIPT_DEBUG": true
+			},
 			"mappings": {
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
diff --git packages/edit-post/src/index.js packages/edit-post/src/index.js
index 1e0b3fe7d4d..d80d3c161a6 100644
--- packages/edit-post/src/index.js
+++ packages/edit-post/src/index.js
@@ -7,7 +7,7 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import deprecated from '@wordpress/deprecated';
-import { createRoot } from '@wordpress/element';
+import { createRoot, StrictMode } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -131,12 +131,14 @@ export function initializeEditor(
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
 	root.render(
-		<Editor
-			settings={ settings }
-			postId={ postId }
-			postType={ postType }
-			initialEdits={ initialEdits }
-		/>
+		<StrictMode>
+			<Editor
+				settings={ settings }
+				postId={ postId }
+				postType={ postType }
+				initialEdits={ initialEdits }
+			/>
+		</StrictMode>
 	);
 
 	return root;
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.
