### PR TITLE
Compose: Fix 'useFocusOnMount' cleanup callback

### DIFF
--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -1,8 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useCallback } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import useRefEffect from '../use-ref-effect';
 
 /**
  * Hook used to focus the first tabbable element on mount.
@@ -50,15 +55,7 @@ export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
 		focusOnMountRef.current = focusOnMount;
 	}, [ focusOnMount ] );
 
-	useEffect( () => {
-		return () => {
-			if ( timerId.current ) {
-				clearTimeout( timerId.current );
-			}
-		};
-	}, [] );
-
-	return useCallback( ( node ) => {
+	return useRefEffect( ( node ) => {
 		if ( ! node || focusOnMountRef.current === false ) {
 			return;
 		}
@@ -80,5 +77,11 @@ export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
 		}
 
 		setFocus( node );
+
+		return () => {
+			if ( timerId.current ) {
+				clearTimeout( timerId.current );
+			}
+		};
 	}, [] );
 }


### PR DESCRIPTION
## What?
This PR fixes a bug in `useFocusOnMount` that prevented it from moving the focus to the first element in StrictMode environments.

The bug was discovered via #61943.

## Why?
The effects ran one extra time in StrictMode, and the extra call was removing the scheduled timer callback.

## How?
Swap `useCallback` with `useRefEffect` and move the cleanup callback.

## Testing Instructions
1. Enable strict mode for the post editor.
2. Open a post or page. 
3. Insert any block.
4. Open the block's Options dropdown.
5. Confirm that the focus is moved to the first block.
6. 
<details><summary>Patch for enabling modes</summary>
<p>

```diff
diff --git .wp-env.json .wp-env.json
index 20d5597e54b..57d4e1a72d8 100644
--- .wp-env.json
+++ .wp-env.json
@@ -4,6 +4,9 @@
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {
+			"config": {
+				"SCRIPT_DEBUG": true
+			},
 			"mappings": {
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
diff --git packages/edit-post/src/index.js packages/edit-post/src/index.js
index 1e0b3fe7d4d..d80d3c161a6 100644
--- packages/edit-post/src/index.js
+++ packages/edit-post/src/index.js
@@ -7,7 +7,7 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import deprecated from '@wordpress/deprecated';
-import { createRoot } from '@wordpress/element';
+import { createRoot, StrictMode } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -131,12 +131,14 @@ export function initializeEditor(
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
 	root.render(
-		<Editor
-			settings={ settings }
-			postId={ postId }
-			postType={ postType }
-			initialEdits={ initialEdits }
-		/>
+		<StrictMode>
+			<Editor
+				settings={ settings }
+				postId={ postId }
+				postType={ postType }
+				initialEdits={ initialEdits }
+			/>
+		</StrictMode>
 	);
 
 	return root;
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/57d94159-696c-443c-8ae6-fc5c5e2602f7

