### PR TITLE
useUploadMediaFromBlobURL: Prevent duplicate uploads in StrictMode

### DIFF
--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -33,6 +33,7 @@ export function useCanEditEntity( kind, name, recordId ) {
  */
 export function useUploadMediaFromBlobURL( args = {} ) {
 	const latestArgs = useRef( args );
+	const hasUploadStarted = useRef( false );
 	const { getSettings } = useSelect( blockEditorStore );
 
 	useLayoutEffect( () => {
@@ -40,6 +41,10 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 	} );
 
 	useEffect( () => {
+		if ( hasUploadStarted.current ) {
+			return;
+		}
+
 		if (
 			! latestArgs.current.url ||
 			! isBlobURL( latestArgs.current.url )
@@ -55,6 +60,8 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 		const { url, allowedTypes, onChange, onError } = latestArgs.current;
 		const { mediaUpload } = getSettings();
 
+		hasUploadStarted.current = true;
+
 		mediaUpload( {
 			filesList: [ file ],
 			allowedTypes,
@@ -65,10 +72,12 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 
 				revokeBlobURL( url );
 				onChange( media );
+				hasUploadStarted.current = false;
 			},
 			onError: ( message ) => {
 				revokeBlobURL( url );
 				onError( message );
+				hasUploadStarted.current = false;
 			},
 		} );
 	}, [ getSettings ] );

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -41,6 +41,8 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 	} );
 
 	useEffect( () => {
+		// Uploading is a special effect that can't be canceled via the cleanup method.
+		// The extra check avoids duplicate uploads in development mode (React.StrictMode).
 		if ( hasUploadStarted.current ) {
 			return;
 		}


### PR DESCRIPTION
## What?
PR added an extra check to the  `useUploadMediaFromBlobURL` to prevent triggering the upload process multiple times in development mode.

The bug was discovered via #61943.

## Why?
The hook didn't account for the double effect run in the `StrictMode`; the effect can't cancel the in-flight upload via the cleanup method.

~~P.S. The hooks should use the `useEffectEvent` hook when it ships in React.~~

## Testing Instructions
1. Make sure `SCRIPT_DEBUG` is set to true.
2. Enabled React `StrictMode` for the post editor.
3. Create a post.
4. Drag an image on canvas.
5. Confirm that only one `POST` request is triggered to upload the image.

<details><summary>StrictMode patch</summary>
<p>

```diff
diff --git packages/edit-post/src/index.js packages/edit-post/src/index.js
index 1e0b3fe7d4d..6e4a220f92f 100644
--- packages/edit-post/src/index.js
+++ packages/edit-post/src/index.js
@@ -7,7 +7,7 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import deprecated from '@wordpress/deprecated';
-import { createRoot } from '@wordpress/element';
+import { StrictMode, createRoot } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -131,12 +131,14 @@ export function initializeEditor(
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
 	root.render(
-		<Editor
-			settings={ settings }
-			postId={ postId }
-			postType={ postType }
-			initialEdits={ initialEdits }
-		/>
+		<StrictMode>
+			<Editor
+				settings={ settings }
+				postId={ postId }
+				postType={ postType }
+				initialEdits={ initialEdits }
+			/>
+		</StrictMode>
 	);
 
 	return root;
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/f50668fe-2a5f-48a3-aee6-ca6b34d6b31f

