### PR TITLE
Docs/interactivity api router package readme

### DIFF
--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -1,10 +1,10 @@
 # `@wordpress/interactivity-router`
 
-The package `@wordpress/interactivity-router` enables a "router engine" for the Interactivity API to load content from other pages without page reloading. Currently, the only supported mode is "region-based". Full "client-side navigation" is still in experimental phase.
+The package `@wordpress/interactivity-router` enables loading content from other pages without a full page reload. Currently, the only supported mode is "region-based". Full "client-side navigation" is still in experimental phase.
 
 The package defines an Interactivity API store with the `core/router` namespace, exposing state and actions like `navigate` and `prefetch` to handle client-side navigation.
 
-It was [introduced in WordPress Core in v6.5](https://make.wordpress.org/core/2024/02/19/merge-announcement-interactivity-api/). This means this package is already bundled in Core in any version of WordPress higher than v6.5.
+The `@wordpress/interactivity-router` package was [introduced in WordPress Core in v6.5](https://make.wordpress.org/core/2024/02/19/merge-announcement-interactivity-api/). This means this package is already bundled in Core in any version of WordPress higher than v6.5.
 
 <div class="callout callout-info">
     Check the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/">Interactivity API Reference docs in the Block Editor handbook</a> to learn more about the Interactivity API.

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -1,16 +1,23 @@
-# Interactivity Router
+# `@wordpress/interactivity-router`
 
-> **Note**
-> This package is a extension of the API shared at [Proposal: The Interactivity API – A better developer experience in building interactive blocks](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/). As part of an [Open Source project](https://developer.wordpress.org/block-editor/getting-started/faq/#the-gutenberg-project) we encourage participation in helping shape this API and the [discussions in GitHub](https://github.com/WordPress/gutenberg/discussions/categories/interactivity-api) is the best place to engage.
+The package `@wordpress/interactivity-router` defines an Interactivity API store with the `core/router` namespace, exposing state and actions like `navigate` and `prefetch` to handle client-side navigations.
 
-This package defines an Interactivity API store with the `core/router` namespace, exposing state and actions like `navigate` and `prefetch` to handle client-side navigations.
+This package was [introduced in WordPress Core in v6.5](https://make.wordpress.org/core/2024/02/19/merge-announcement-interactivity-api/). This means this package is already bundled in Core in any version of WordPress higher than v6.5.
+
+<div class="callout callout-info">
+    Check the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/">Interactivity API Reference docs in the Block Editor handbook</a> to learn more about the Interactivity API.
+</div>
+
+
 
 ## Usage
 
 The package is intended to be imported dynamically in the `view.js` files of interactive blocks.
 
 ```js
-import { store } from '@wordpress/interactivity';
+
+
+import { store } from '@wordpress/interactivity-router';
 
 store( 'myblock', {
 	actions: {
@@ -25,30 +32,6 @@ store( 'myblock', {
 } );
 ```
 
-## Frequently Asked Questions
-
-At this point, some of the questions you have about the Interactivity API may be:
-
-### What is this?
-
-This is the base of a new standard to create interactive blocks. Read [the proposal](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/) to learn more about this.
-
-### Can I use it?
-
-You can test it, but it's still very experimental.
-
-### How do I get started?
-
-The best place to start with the Interactivity API is this [**Getting started guide**](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/docs/1-getting-started.md). There you'll will find a very quick start guide and the current requirements of the Interactivity API.
-
-### Where can I ask questions?
-
-The [“Interactivity API” category](https://github.com/WordPress/gutenberg/discussions/categories/interactivity-api) in Gutenberg repo discussions is the best place to ask questions about the Interactivity API.
-
-### Where can I share my feedback about the API?
-
-The [“Interactivity API” category](https://github.com/WordPress/gutenberg/discussions/categories/interactivity-api) in Gutenberg repo discussions is also the best place to share your feedback about the Interactivity API.
-
 ## Installation
 
 Install the module:
@@ -57,7 +40,19 @@ Install the module:
 npm install @wordpress/interactivity --save
 ```
 
-_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for such language features and APIs, you should include [the polyfill shipped in `@wordpress/babel-preset-default`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/babel-preset-default#polyfill) in your code._
+This step is only required if you use the Interactivity API outside WordPress.
+
+Within WordPress, the package is already bundled in Core. To ensure it's loaded, add `@wordpress/interactivity` to the dependency array of the script module. This process is often done automatically with tools like [`wp-scripts`](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts/).
+
+Furthermore, this package assumes your code will run in an **ES2015+** environment. If you're using an environment with limited or no support for such language features and APIs, you should include the polyfill shipped in [`@wordpress/babel-preset-default`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/babel-preset-default#polyfill) in your code.
+
+
+## License
+
+Interactivity API proposal, as part of Gutenberg and the WordPress project is free software, and is released under the terms of the GNU General Public License version 2 or (at your option) any later version. See [LICENSE.md](https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md) for complete license.
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
+
 
 ## Docs & Examples
 

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -54,6 +54,10 @@ const { state, actions } = store( 'core/router', {
 
 ```
 
+<div class="callout callout-tip">
+    The core "Query Loop" block is [using this package](https://github.com/WordPress/gutenberg/blob/cd701e94ceffea7ef2f423274a2f77025bcfa1a6/packages/block-library/src/query/view.js#L35) to provide the [region based feature](https://github.com/WordPress/gutenberg/blob/cd701e94ceffea7ef2f423274a2f77025bcfa1a6/packages/block-library/src/query/index.php#L33)
+</div>
+
 ### Directives:
 
 #### `data-wp-router-region`

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -62,7 +62,7 @@ const { state, actions } = store( 'core/router', {
 ```
 
 <div class="callout callout-tip">
-    The core "Query Loop" block is [using this package](https://github.com/WordPress/gutenberg/blob/cd701e94ceffea7ef2f423274a2f77025bcfa1a6/packages/block-library/src/query/view.js#L35) to provide the [region-based navigation](https://github.com/WordPress/gutenberg/blob/cd701e94ceffea7ef2f423274a2f77025bcfa1a6/packages/block-library/src/query/index.php#L33).
+    The core "Query Loop" block is <a href="https://github.com/WordPress/gutenberg/blob/cd701e94ceffea7ef2f423274a2f77025bcfa1a6/packages/block-library/src/query/view.js#L35">using this package</a> to provide the <a href="https://github.com/WordPress/gutenberg/blob/cd701e94ceffea7ef2f423274a2f77025bcfa1a6/packages/block-library/src/query/index.php#L33">region-based navigation</a>.
 </div>
 
 ### Directives

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -2,7 +2,7 @@
 
 The package `@wordpress/interactivity-router` enables a "router engine" for the Interactivity API to load content from other pages without page reloading. Currently, the only supported mode is "region-based". Full "client-side navigation" is still in experimental phase.
 
-The package defines an Interactivity API store with the `core/router` namespace, exposing state and actions like `navigate` and `prefetch` to handle client-side navigations.
+The package defines an Interactivity API store with the `core/router` namespace, exposing state and actions like `navigate` and `prefetch` to handle client-side navigation.
 
 It was [introduced in WordPress Core in v6.5](https://make.wordpress.org/core/2024/02/19/merge-announcement-interactivity-api/). This means this package is already bundled in Core in any version of WordPress higher than v6.5.
 

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -52,20 +52,3 @@ Furthermore, this package assumes your code will run in an **ES2015+** environme
 Interactivity API proposal, as part of Gutenberg and the WordPress project is free software, and is released under the terms of the GNU General Public License version 2 or (at your option) any later version. See [LICENSE.md](https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md) for complete license.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
-
-
-## Docs & Examples
-
-**[Interactivity API Documentation](https://github.com/WordPress/gutenberg/tree/trunk/packages/interactivity/docs)** is the best place to learn about this proposal. Although it's still in progress, some key pages are already available:
-
--   **[Getting Started Guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/docs/1-getting-started.md)**: Follow this Getting Started guide to learn how to scaffold a new project and create your first interactive blocks.
--   **[API Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/docs/2-api-reference.md)**: Check this page for technical detailed explanations and examples of the directives and the store.
-
-Here you have some more resources to learn/read more about the Interactivity API:
-
--   **[Interactivity API Discussions](https://github.com/WordPress/gutenberg/discussions/52882)**
--   [Proposal: The Interactivity API – A better developer experience in building interactive blocks](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/)
--   Developer Hours sessions ([Americas](https://www.youtube.com/watch?v=RXNoyP2ZiS8&t=664s) & [APAC/EMEA](https://www.youtube.com/watch?v=6ghbrhyAcvA))
--   [wpmovies.dev](http://wpmovies.dev/) demo and its [wp-movies-demo](https://github.com/WordPress/wp-movies-demo) repo
-
-<br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
## What?
It updates the `README` of the `@wordpress/interactivity-router` package

## Why?
Because the package `@wordpress/interactivity-router` has had changes that are not properly reflected in the `README`
This PR solves https://github.com/WordPress/gutenberg/issues/62055