### PR TITLE
Block Bindings: Create utils for block bindings

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -30,7 +30,7 @@ import { useBlockRefProvider } from './use-block-refs';
 import { useIntersectionObserver } from './use-intersection-observer';
 import { useScrollIntoView } from './use-scroll-into-view';
 import { useFlashEditableBlocks } from '../../use-flash-editable-blocks';
-import { canBindBlock } from '../../../hooks/use-bindings-attributes';
+import { canBindBlock } from '../../../utils/bindings';
 
 /**
  * This hook is used to lightly mark an element as a block element. The element

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -37,7 +37,7 @@ import NavigableToolbar from '../navigable-toolbar';
 import Shuffle from './shuffle';
 import BlockBindingsIndicator from '../block-bindings-toolbar-indicator';
 import { useHasBlockToolbar } from './use-has-block-toolbar';
-import { canBindBlock } from '../../hooks/use-bindings-attributes';
+import { canBindBlock } from '../../utils/bindings';
 /**
  * Renders the block toolbar.
  *

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -38,7 +38,7 @@ import { getAllowedFormats } from './utils';
 import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import { unlock } from '../../lock-unlock';
-import { canBindBlock } from '../../hooks/use-bindings-attributes';
+import { canBindBlock } from '../../utils/bindings';
 
 export const keyboardShortcutContext = createContext();
 export const inputEventContext = createContext();

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -39,7 +39,6 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 		} = props;
 		const bindings = blockAttributes?.metadata?.bindings;
 
-		// It seems if I don't wrap this in a useSelect, the reset in pattern overrides doesn't work as expected.
 		const boundAttributes = useSelect( () => {
 			return getBoundAttributesValues( clientId, context, registry );
 		}, [ clientId, context, registry ] );

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -42,9 +42,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 		let newAttributes = blockAttributes;
 		if ( bindings ) {
 			newAttributes = transformBlockAttributesWithBindingsValues(
-				blockAttributes,
 				clientId,
-				name,
 				context,
 				registry
 			);

--- a/packages/block-editor/src/utils/bindings.js
+++ b/packages/block-editor/src/utils/bindings.js
@@ -7,6 +7,7 @@ import { store as blocksStore } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
+import { store as blockEditorStore } from '../store';
 
 /**
  * List of blocks and block attributes that can be bound.
@@ -47,26 +48,28 @@ export function canBindAttribute( blockName, attributeName ) {
 /**
  * Process the block attributes and replace them with the values obtained from the bindings.
  *
- * @param {Object} attributes   - The block attributes to process.
  * @param {string} clientId     - The block clientId.
- * @param {string} blockName    - The block name.
  * @param {Object} blockContext - The block context, which is needed for the binding sources.
  * @param {Object} registry     - The data registry.
  *
  * @return {Object} The new attributes object with the bindings values.
  */
 export function transformBlockAttributesWithBindingsValues(
-	attributes,
 	clientId,
-	blockName,
 	blockContext,
 	registry
 ) {
+	const attributes = registry
+		.select( blockEditorStore )
+		.getBlockAttributes( clientId );
 	const bindings = attributes?.metadata?.bindings;
 	if ( ! bindings ) {
 		return attributes;
 	}
 
+	const blockName = registry
+		.select( blockEditorStore )
+		.getBlockName( clientId );
 	const sources = unlock(
 		registry.select( blocksStore )
 	).getAllBlockBindingsSources();

--- a/packages/block-editor/src/utils/bindings.js
+++ b/packages/block-editor/src/utils/bindings.js
@@ -46,25 +46,23 @@ export function canBindAttribute( blockName, attributeName ) {
 }
 
 /**
- * Process the block attributes and replace them with the values obtained from the bindings.
+ * Process the bound block attributes and return the values obtained from the bindings.
  *
  * @param {string} clientId     - The block clientId.
  * @param {Object} blockContext - The block context, which is needed for the binding sources.
  * @param {Object} registry     - The data registry.
  *
- * @return {Object} The new attributes object with the bindings values.
+ * @return {Object} Object with the value obtained from the bindings of each bound attribute.
  */
-export function transformBlockAttributesWithBindingsValues(
-	clientId,
-	blockContext,
-	registry
-) {
+export function getBoundAttributesValues( clientId, blockContext, registry ) {
 	const attributes = registry
 		.select( blockEditorStore )
 		.getBlockAttributes( clientId );
 	const bindings = attributes?.metadata?.bindings;
+	const boundAttributes = {};
+
 	if ( ! bindings ) {
-		return attributes;
+		return boundAttributes;
 	}
 
 	const blockName = registry
@@ -73,8 +71,6 @@ export function transformBlockAttributesWithBindingsValues(
 	const sources = unlock(
 		registry.select( blocksStore )
 	).getAllBlockBindingsSources();
-
-	const newAttributes = { ...attributes };
 
 	for ( const [ attributeName, boundAttribute ] of Object.entries(
 		bindings
@@ -95,17 +91,17 @@ export function transformBlockAttributesWithBindingsValues(
 			args: boundAttribute.args,
 		};
 
-		newAttributes[ attributeName ] = source.getValue( args );
+		boundAttributes[ attributeName ] = source.getValue( args );
 
-		if ( newAttributes[ attributeName ] === undefined ) {
+		if ( boundAttributes[ attributeName ] === undefined ) {
 			if ( attributeName === 'url' ) {
-				newAttributes[ attributeName ] = null;
+				boundAttributes[ attributeName ] = null;
 			} else {
-				newAttributes[ attributeName ] =
+				boundAttributes[ attributeName ] =
 					source.getPlaceholder?.( args );
 			}
 		}
 	}
 
-	return newAttributes;
+	return boundAttributes;
 }

--- a/packages/block-editor/src/utils/bindings.js
+++ b/packages/block-editor/src/utils/bindings.js
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blocksStore } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+/**
+ * List of blocks and block attributes that can be bound.
+ */
+const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
+	'core/paragraph': [ 'content' ],
+	'core/heading': [ 'content' ],
+	'core/image': [ 'id', 'url', 'title', 'alt' ],
+	'core/button': [ 'url', 'text', 'linkTarget', 'rel' ],
+};
+
+/**
+ * Based on the given block name,
+ * check if it is possible to bind the block.
+ *
+ * @param {string} blockName - The block name.
+ * @return {boolean} Whether it is possible to bind the block to sources.
+ */
+export function canBindBlock( blockName ) {
+	return blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS;
+}
+
+/**
+ * Based on the given block name and attribute name,
+ * check if it is possible to bind the block attribute.
+ *
+ * @param {string} blockName     - The block name.
+ * @param {string} attributeName - The attribute name.
+ * @return {boolean} Whether it is possible to bind the block attribute.
+ */
+export function canBindAttribute( blockName, attributeName ) {
+	return (
+		canBindBlock( blockName ) &&
+		BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].includes( attributeName )
+	);
+}
+
+/**
+ * Process the block attributes and replace them with the values obtained from the bindings.
+ *
+ * @param {Object} attributes   - The block attributes to process.
+ * @param {string} clientId     - The block clientId.
+ * @param {string} blockName    - The block name.
+ * @param {Object} blockContext - The block context, which is needed for the binding sources.
+ * @param {Object} registry     - The data registry.
+ *
+ * @return {Object} The new attributes object with the bindings values.
+ */
+export function transformBlockAttributesWithBindingsValues(
+	attributes,
+	clientId,
+	blockName,
+	blockContext,
+	registry
+) {
+	const bindings = attributes?.metadata?.bindings;
+	if ( ! bindings ) {
+		return attributes;
+	}
+
+	const sources = unlock(
+		registry.select( blocksStore )
+	).getAllBlockBindingsSources();
+
+	const newAttributes = { ...attributes };
+
+	for ( const [ attributeName, boundAttribute ] of Object.entries(
+		bindings
+	) ) {
+		const source = sources[ boundAttribute.source ];
+		if (
+			! source?.getValue ||
+			! canBindAttribute( blockName, attributeName )
+		) {
+			continue;
+		}
+
+		const args = {
+			registry,
+			context: blockContext,
+			clientId,
+			attributeName,
+			args: boundAttribute.args,
+		};
+
+		newAttributes[ attributeName ] = source.getValue( args );
+
+		if ( newAttributes[ attributeName ] === undefined ) {
+			if ( attributeName === 'url' ) {
+				newAttributes[ attributeName ] = null;
+			} else {
+				newAttributes[ attributeName ] =
+					source.getPlaceholder?.( args );
+			}
+		}
+	}
+
+	return newAttributes;
+}


### PR DESCRIPTION
## What?
I'm creating a new `bindings` util file to store all the reusable functions instead of having it in the editor hook. As part of that, I'm abstracting the logic to change the block attributes with the bindings values into a function.

## Why?
It looks cleaner this way and we can reuse the same logic to replace the block attributes in the future.

## How?
Just creating a new file and creating a new `transformBlockAttributesWithBindingsValues` function to replace the block attributes with bindings.

## Testing Instructions
Tests should pass. We are not adding new functionalities.
