### PR TITLE
Editor: render publish date control when the status is `future`(scheduled)

### DIFF
--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -11,20 +11,24 @@ import { getSettings } from '@wordpress/date';
  */
 import InspectorPopoverHeader from '../inspector-popover-header';
 
-function PublishDateTimePicker(
-	{ onClose, onChange, ...additionalProps },
+export function PublishDateTimePicker(
+	{ onClose, onChange, showPopoverHeaderActions, ...additionalProps },
 	ref
 ) {
 	return (
 		<div ref={ ref } className="block-editor-publish-date-time-picker">
 			<InspectorPopoverHeader
 				title={ __( 'Publish' ) }
-				actions={ [
-					{
-						label: __( 'Now' ),
-						onClick: () => onChange?.( null ),
-					},
-				] }
+				actions={
+					showPopoverHeaderActions
+						? [
+								{
+									label: __( 'Now' ),
+									onClick: () => onChange?.( null ),
+								},
+						  ]
+						: undefined
+				}
 				onClose={ onClose }
 			/>
 			<DateTimePicker
@@ -36,4 +40,16 @@ function PublishDateTimePicker(
 	);
 }
 
-export default forwardRef( PublishDateTimePicker );
+export const PrivatePublishDateTimePicker = forwardRef( PublishDateTimePicker );
+
+function PublicPublishDateTimePicker( props, ref ) {
+	return (
+		<PrivatePublishDateTimePicker
+			{ ...props }
+			showPopoverHeaderActions
+			ref={ ref }
+		/>
+	);
+}
+
+export default forwardRef( PublicPublishDateTimePicker );

--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { DateTimePicker } from '@wordpress/components';
+import { DateTimePicker, TimePicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
 import { getSettings } from '@wordpress/date';
@@ -12,9 +12,16 @@ import { getSettings } from '@wordpress/date';
 import InspectorPopoverHeader from '../inspector-popover-header';
 
 export function PublishDateTimePicker(
-	{ onClose, onChange, showPopoverHeaderActions, ...additionalProps },
+	{
+		onClose,
+		onChange,
+		showPopoverHeaderActions,
+		isCompact,
+		...additionalProps
+	},
 	ref
 ) {
+	const DatePickerComponent = isCompact ? TimePicker : DateTimePicker;
 	return (
 		<div ref={ ref } className="block-editor-publish-date-time-picker">
 			<InspectorPopoverHeader
@@ -31,7 +38,7 @@ export function PublishDateTimePicker(
 				}
 				onClose={ onClose }
 			/>
-			<DateTimePicker
+			<DatePickerComponent
 				startOfWeek={ getSettings().l10n.startOfWeek }
 				onChange={ onChange }
 				{ ...additionalProps }
@@ -47,6 +54,7 @@ function PublicPublishDateTimePicker( props, ref ) {
 		<PrivatePublishDateTimePicker
 			{ ...props }
 			showPopoverHeaderActions
+			isCompact={ false }
 			ref={ ref }
 		/>
 	);

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -41,6 +41,7 @@ import { requiresWrapperOnCopy } from './components/writing-flow/utils';
 import { PrivateRichText } from './components/rich-text/';
 import { PrivateBlockPopover } from './components/block-popover';
 import { PrivateInserterLibrary } from './components/inserter/library';
+import { PrivatePublishDateTimePicker } from './components/publish-date-time-picker';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -82,4 +83,5 @@ lock( privateApis, {
 	PrivateInserterLibrary,
 	reusableBlocksSelectKey,
 	PrivateBlockPopover,
+	PrivatePublishDateTimePicker,
 } );

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -29,10 +29,20 @@ const { PrivatePublishDateTimePicker } = unlock( blockEditorPrivateApis );
  * @return {Component} The component to be rendered.
  */
 export default function PostSchedule( props ) {
-	return <PrivatePostSchedule { ...props } showPopoverHeaderActions />;
+	return (
+		<PrivatePostSchedule
+			{ ...props }
+			showPopoverHeaderActions
+			isCompact={ false }
+		/>
+	);
 }
 
-export function PrivatePostSchedule( { onClose, showPopoverHeaderActions } ) {
+export function PrivatePostSchedule( {
+	onClose,
+	showPopoverHeaderActions,
+	isCompact,
+} ) {
 	const { postDate, postType } = useSelect(
 		( select ) => ( {
 			postDate: select( editorStore ).getEditedPostAttribute( 'date' ),
@@ -93,6 +103,7 @@ export function PrivatePostSchedule( { onClose, showPopoverHeaderActions } ) {
 				setPreviewedMonth( parseISO( date ) )
 			}
 			onClose={ onClose }
+			isCompact={ isCompact }
 			showPopoverHeaderActions={ showPopoverHeaderActions }
 		/>
 	);

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -8,7 +8,7 @@ import { parseISO, endOfMonth, startOfMonth } from 'date-fns';
  */
 import { getSettings } from '@wordpress/date';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __experimentalPublishDateTimePicker as PublishDateTimePicker } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useState, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -16,6 +16,9 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { PrivatePublishDateTimePicker } = unlock( blockEditorPrivateApis );
 
 /**
  * Renders the PostSchedule component. It allows the user to schedule a post.
@@ -25,7 +28,11 @@ import { store as editorStore } from '../../store';
  *
  * @return {Component} The component to be rendered.
  */
-export default function PostSchedule( { onClose } ) {
+export default function PostSchedule( props ) {
+	return <PrivatePostSchedule { ...props } showPopoverHeaderActions />;
+}
+
+export function PrivatePostSchedule( { onClose, showPopoverHeaderActions } ) {
 	const { postDate, postType } = useSelect(
 		( select ) => ( {
 			postDate: select( editorStore ).getEditedPostAttribute( 'date' ),
@@ -77,7 +84,7 @@ export default function PostSchedule( { onClose } ) {
 	);
 
 	return (
-		<PublishDateTimePicker
+		<PrivatePublishDateTimePicker
 			currentDate={ postDate }
 			onChange={ onUpdateDate }
 			is12Hour={ is12HourTime }
@@ -86,6 +93,7 @@ export default function PostSchedule( { onClose } ) {
 				setPreviewedMonth( parseISO( date ) )
 			}
 			onClose={ onClose }
+			showPopoverHeaderActions={ showPopoverHeaderActions }
 		/>
 	);
 }

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -234,6 +234,7 @@ export default function PostStatus() {
 												showPopoverHeaderActions={
 													false
 												}
+												isCompact
 											/>
 										</div>
 									) }

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -27,7 +27,7 @@ import {
 	NAVIGATION_POST_TYPE,
 } from '../../store/constants';
 import PostPanelRow from '../post-panel-row';
-import PostSchedule from '../post-schedule';
+import { PrivatePostSchedule } from '../post-schedule';
 import { store as editorStore } from '../../store';
 
 const labels = {
@@ -228,7 +228,15 @@ export default function PostStatus() {
 												: status
 										}
 									/>
-									{ status === 'future' && <PostSchedule /> }
+									{ status === 'future' && (
+										<div className="editor-change-status__publish-date-wrapper">
+											<PrivatePostSchedule
+												showPopoverHeaderActions={
+													false
+												}
+											/>
+										</div>
+									) }
 									{ status !== 'private' && (
 										<VStack
 											as="fieldset"

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -27,6 +27,7 @@ import {
 	NAVIGATION_POST_TYPE,
 } from '../../store/constants';
 import PostPanelRow from '../post-panel-row';
+import PostSchedule from '../post-schedule';
 import { store as editorStore } from '../../store';
 
 const labels = {
@@ -174,11 +175,6 @@ export default function PostStatus() {
 		let newPassword = password;
 		if ( status === 'future' && new Date( date ) > new Date() ) {
 			newDate = null;
-		} else if ( value === 'future' ) {
-			if ( ! date || new Date( date ) < new Date() ) {
-				newDate = new Date();
-				newDate.setDate( newDate.getDate() + 7 );
-			}
 		}
 		if ( value === 'private' && password ) {
 			newPassword = '';
@@ -232,6 +228,7 @@ export default function PostStatus() {
 												: status
 										}
 									/>
+									{ status === 'future' && <PostSchedule /> }
 									{ status !== 'private' && (
 										<VStack
 											as="fieldset"

--- a/packages/editor/src/components/post-status/style.scss
+++ b/packages/editor/src/components/post-status/style.scss
@@ -6,7 +6,8 @@
 	}
 }
 
-.editor-change-status__password-fieldset {
+.editor-change-status__password-fieldset,
+.editor-change-status__publish-date-wrapper {
 	border-top: $border-width solid $gray-200;
 	padding-top: $grid-unit-20;
 }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/61488#issuecomment-2117560411

There are some suggestion on how to improve the scheduling flow in the editor with the new reused `PostStatus` component.

This PR for now simply does:
1. No setting automatically a future day (a week from current time) when we select the `scheduled` status from the available statuses
2. When a post is scheduled or when we select the option from the PostStatus component, the publish date component is rendered for users to select the date they want.


### Notes
1. This has some nuances similar to the problem it solves, but on the other way around. For example if a user sets the status to `scheduled` and not update the date, the final status will not be `future`. I think that's fine since the rendering of the control will be very prominent to the user to also select a date, but just mentioning.
2. The design suggested in the issue has a different date picker component and I'm reusing the one we use for the publish date. Do we need some designs updates or that's fine? 





## Testing Instructions
1. In a post try combinations with the post status to `scheduled` and the publish date and see how it feels and share feedback
