### PR TITLE
Inspector: Display home / posts page badge

### DIFF
--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -28,42 +28,52 @@ import {
 import { unlock } from '../../lock-unlock';
 
 export default function PostCardPanel( { actions } ) {
-	const { title, icon, isSync } = useSelect( ( select ) => {
-		const {
-			getEditedPostAttribute,
-			getCurrentPostType,
-			getCurrentPostId,
-			__experimentalGetTemplateInfo,
-		} = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
-		const _type = getCurrentPostType();
-		const _id = getCurrentPostId();
-		const _record = getEditedEntityRecord( 'postType', _type, _id );
-		const _templateInfo =
-			[ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes( _type ) &&
-			__experimentalGetTemplateInfo( _record );
-		let _isSync = false;
-		if ( GLOBAL_POST_TYPES.includes( _type ) ) {
-			if ( PATTERN_POST_TYPE === _type ) {
-				// When the post is first created, the top level wp_pattern_sync_status is not set so get meta value instead.
-				const currentSyncStatus =
-					getEditedPostAttribute( 'meta' )?.wp_pattern_sync_status ===
-					'unsynced'
-						? 'unsynced'
-						: getEditedPostAttribute( 'wp_pattern_sync_status' );
-				_isSync = currentSyncStatus !== 'unsynced';
-			} else {
-				_isSync = true;
+	const { isFrontPage, isPostsPage, title, icon, isSync } = useSelect(
+		( select ) => {
+			const {
+				getEditedPostAttribute,
+				getCurrentPostType,
+				getCurrentPostId,
+				__experimentalGetTemplateInfo,
+			} = select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const siteSettings = getEditedEntityRecord( 'root', 'site' );
+			const _type = getCurrentPostType();
+			const _id = getCurrentPostId();
+			const _record = getEditedEntityRecord( 'postType', _type, _id );
+			const _templateInfo =
+				[ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes(
+					_type
+				) && __experimentalGetTemplateInfo( _record );
+			let _isSync = false;
+			if ( GLOBAL_POST_TYPES.includes( _type ) ) {
+				if ( PATTERN_POST_TYPE === _type ) {
+					// When the post is first created, the top level wp_pattern_sync_status is not set so get meta value instead.
+					const currentSyncStatus =
+						getEditedPostAttribute( 'meta' )
+							?.wp_pattern_sync_status === 'unsynced'
+							? 'unsynced'
+							: getEditedPostAttribute(
+									'wp_pattern_sync_status'
+							  );
+					_isSync = currentSyncStatus !== 'unsynced';
+				} else {
+					_isSync = true;
+				}
 			}
-		}
-		return {
-			title: _templateInfo?.title || getEditedPostAttribute( 'title' ),
-			icon: unlock( select( editorStore ) ).getPostIcon( _type, {
-				area: _record?.area,
-			} ),
-			isSync: _isSync,
-		};
-	}, [] );
+			return {
+				title:
+					_templateInfo?.title || getEditedPostAttribute( 'title' ),
+				icon: unlock( select( editorStore ) ).getPostIcon( _type, {
+					area: _record?.area,
+				} ),
+				isSync: _isSync,
+				isFrontPage: siteSettings?.page_on_front === _id,
+				isPostsPage: siteSettings?.page_for_posts === _id,
+			};
+		},
+		[]
+	);
 	return (
 		<div className="editor-post-card-panel">
 			<HStack
@@ -83,8 +93,19 @@ export default function PostCardPanel( { actions } ) {
 					className="editor-post-card-panel__title"
 					weight={ 500 }
 					as="h2"
+					lineHeight={ '20px' }
 				>
 					{ title ? decodeEntities( title ) : __( 'No Title' ) }
+					{ isFrontPage && (
+						<span className="editor-post-card-panel__title-badge">
+							{ __( 'Front Page' ) }
+						</span>
+					) }
+					{ isPostsPage && (
+						<span className="editor-post-card-panel__title-badge">
+							{ __( 'Posts Page' ) }
+						</span>
+					) }
 				</Text>
 				{ actions }
 			</HStack>

--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -7,7 +7,13 @@
 		width: 100%;
 
 		&.editor-post-card-panel__title {
-			margin: 3px 0 0 0;
+			margin: 0;
+			min-height: $icon-size;
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			column-gap: $grid-unit-10;
+			row-gap: $grid-unit-05;
 		}
 	}
 
@@ -29,4 +35,16 @@
 
 .editor-post-card-panel__icon.is-sync {
 	fill: var(--wp-block-synced-color);
+}
+
+.editor-post-card-panel__title-badge {
+	background: $gray-100;
+	color: $gray-700;
+	padding: 0 $grid-unit-05;
+	border-radius: $radius-block-ui;
+	font-size: 12px;
+	font-weight: 400;
+	flex-shrink: 0;
+	line-height: $grid-unit-05 * 5;
+	display: inline-block;
 }

--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -8,7 +8,7 @@
 
 		&.editor-post-card-panel__title {
 			margin: 0;
-			min-height: $icon-size;
+			padding: 2px 0;
 			display: flex;
 			align-items: center;
 			flex-wrap: wrap;


### PR DESCRIPTION
## What?
Display a badge in the Inspector when editing the front page or the posts page.

## Why?
In data views this badge appears next to the title to help you identify these pages. However there's nothing in the Editor to communicate this detail.

## Testing Instructions
1. In reading settings configure a static homepage and a posts page
2. Open those pages in the Editor
3. Notice the 'Front page' and 'Posts page' chip in the Inspector

| Data views | Inspector | 
| --- | --- |
| <img width="378" alt="Screenshot 2024-05-28 at 13 43 43" src="https://github.com/WordPress/gutenberg/assets/846565/7e7df071-ccb1-4ed9-9a32-bc6cec22769f"> | <img width="280" alt="Screenshot 2024-05-28 at 15 25 52" src="https://github.com/WordPress/gutenberg/assets/846565/25fd542e-18c4-4b17-8bdb-acd02f33b2fb"> <img width="278" alt="Screenshot 2024-05-28 at 15 29 39" src="https://github.com/WordPress/gutenberg/assets/846565/131f08ad-62aa-40c5-9fdc-586cbc686d9e">  |

As a follow-up it might be nice to update the icon too, but as that will involve touching the command palette/document title I'd prefer to explore it separately. 
