### PR TITLE
Inspector: Add '/' prefix to Link button

### DIFF
--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -73,7 +73,7 @@ function PostURLToggle( { isOpen, onClick } ) {
 			aria-label={ sprintf( __( 'Change link: %s' ), decodedSlug ) }
 			onClick={ onClick }
 		>
-			{ decodedSlug }
+			/{ decodedSlug }
 		</Button>
 	);
 }


### PR DESCRIPTION
## What?
Adds a `/` prefix to the Link button label in the Inspector.

## Why?
The slash prefix helps make the connection with the URL. Otherwise the uncapitalised, hyphenated text string could look like a mistake. Also aligns with the input you find in the dialog which also includes the `/` prefix.

| Before | After |
| --- | --- |
| <img width="280" alt="Screenshot 2024-05-28 at 15 38 01" src="https://github.com/WordPress/gutenberg/assets/846565/8edc273a-8ddb-4b39-a06b-8e6aaf36a668"> | <img width="280" alt="Screenshot 2024-05-28 at 15 37 40" src="https://github.com/WordPress/gutenberg/assets/846565/9f98af5f-169b-4e9b-9a9f-13ad629eab08"> |
