### PR TITLE
Hide the presets panel for when there are less or exactly one presets available

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -14,7 +14,8 @@ import Variation from './variation';
 export default function ColorVariations( { title, gap = 2 } ) {
 	const colorVariations = useColorVariations();
 
-	if ( ! colorVariations?.length <= 1 ) {
+	// Return null if there is only one variation (the default).
+	if ( colorVariations?.length <= 1 ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -14,7 +14,7 @@ import Variation from './variation';
 export default function ColorVariations( { title, gap = 2 } ) {
 	const colorVariations = useColorVariations();
 
-	if ( ! colorVariations?.length ) {
+	if ( ! colorVariations?.length <= 1 ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -19,7 +19,7 @@ import Subtitle from '../subtitle';
 export default function TypographyVariations( { title, gap = 2 } ) {
 	const typographyVariations = useTypographyVariations();
 
-	if ( ! typographyVariations?.length ) {
+	if ( ! typographyVariations?.length <= 1 ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -19,7 +19,8 @@ import Subtitle from '../subtitle';
 export default function TypographyVariations( { title, gap = 2 } ) {
 	const typographyVariations = useTypographyVariations();
 
-	if ( ! typographyVariations?.length <= 1 ) {
+	// Return null if there is only one variation (the default).
+	if ( typographyVariations?.length <= 1 ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #61216

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A palette should have more than one item, particularly when that item is also used as a default.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


Update the components that show the type sets and color sets to now show if there is only one or zero presets.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Activate TwentyTwentyFour
2. Go to your TwentyTwentyFour theme's folder in `wp-content` and remove the `styles` folder
3. Go back to WP admin
4. Go to Appearance > Editor
5. Click on Styles
6. _The editor should open global styles_
7. Click on Typography 
8. _No panel titled Presets should show_
9. Go back
10. Click on Colors
11. Click on the available palette
12. _No panel titled Presets should show_


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/4f145711-c274-4682-a058-82f16159a582





