### PR TITLE
Templates: add `postTypes` and `isCustom` fields & filters

### DIFF
--- a/backport-changelog/6.6/6660.md
+++ b/backport-changelog/6.6/6660.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6660
+
+* https://github.com/WordPress/gutenberg/pull/62075

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -87,3 +87,43 @@ function gutenberg_register_global_styles_revisions_endpoints() {
 }
 
 add_action( 'rest_api_init', 'gutenberg_register_global_styles_revisions_endpoints' );
+
+/**
+ * Registers a new post_type field for the Templates REST API route.
+ */
+function gutenberg_register_template_post_type_field() {
+	register_rest_field(
+		'wp_template',
+		'post_types',
+		array(
+			'get_callback' => 'gutenberg_rest_template_post_type_callback',
+			'schema'       => array(
+				'description' => __( 'The post types the template is intended for.', 'gutenberg' ),
+				'type'        => 'array',
+				'readonly'    => true,
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_template_post_type_field' );
+
+/**
+ * Callback for the post_type field in the Templates REST API route.
+ *
+ * @param array $template The template object.
+ *
+ * @return array The post type the template is intended for.
+ */
+function gutenberg_rest_template_post_type_callback( $item ) {
+
+	$template_metadata = _get_block_template_file( 'wp_template', $item['slug'] );
+	if ( null === $template_metadata ) {
+		return array();
+	}
+
+	if ( isset( $template_metadata['postTypes'] ) ) {
+		return $template_metadata['postTypes'];
+	}
+
+	return array();
+}

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -118,12 +118,12 @@ function gutenberg_rest_template_post_type_callback( $item ) {
 
 	$template_metadata = _get_block_template_file( 'wp_template', $item['slug'] );
 	if ( null === $template_metadata ) {
-		return array();
+		return null;
 	}
 
 	if ( isset( $template_metadata['postTypes'] ) ) {
 		return $template_metadata['postTypes'];
 	}
 
-	return array();
+	return null;
 }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -380,9 +380,6 @@ export default function PageTemplates() {
 					value: key,
 					label: POST_TYPES[ key ],
 				} ) ),
-				filterBy: {
-					operators: [ OPERATOR_IS_ANY ],
-				},
 			},
 			{
 				header: __( 'Type' ),

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -63,7 +63,6 @@ const defaultConfigPerViewType = {
 		mediaField: 'preview',
 		primaryField: 'title',
 		columnFields: [ 'description' ],
-		badgeFields: [ 'isCustom' ],
 	},
 	[ LAYOUT_LIST ]: {
 		primaryField: 'title',
@@ -82,8 +81,7 @@ const DEFAULT_VIEW = {
 	},
 	// All fields are visible by default, so it's
 	// better to keep track of the hidden ones.
-	hiddenFields: [ 'preview' ],
-	// hiddenFields: [ 'preview', 'postTypes' ],
+	hiddenFields: [ 'preview', 'postTypes', 'isCustom' ],
 	layout: defaultConfigPerViewType[ LAYOUT_GRID ],
 	filters: [],
 };
@@ -205,6 +203,9 @@ const TEMPLATE_TO_POST_TYPE = {
 	// 2. Secondary templates.
 	'single-post': [ 'post' ],
 };
+
+const CUSTOM_TEMPLATE = __( 'Custom' );
+const NOT_CUSTOM_TEMPLATE = __( 'Not custom' );
 
 export default function PageTemplates() {
 	const { params } = useLocation();
@@ -388,12 +389,12 @@ export default function PageTemplates() {
 			{
 				header: __( 'Type' ),
 				id: 'isCustom',
-				getValue: ( { item } ) => item.is_custom,
+				getValue: ( { item } ) => !! item.is_custom,
 				render: ( { item } ) =>
-					item.is_custom ? 'Custom' : undefined,
+					!! item.is_custom ? CUSTOM_TEMPLATE : NOT_CUSTOM_TEMPLATE,
 				elements: [
-					{ value: true, label: 'Custom' },
-					{ value: false, label: 'Default' },
+					{ value: true, label: CUSTOM_TEMPLATE },
+					{ value: false, label: NOT_CUSTOM_TEMPLATE },
 				],
 				filterBy: {
 					operators: [ OPERATOR_IS ],

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -36,6 +36,7 @@ import { useAddedBy } from './hooks';
 import {
 	TEMPLATE_POST_TYPE,
 	OPERATOR_IS_ANY,
+	OPERATOR_IS,
 	LAYOUT_GRID,
 	LAYOUT_TABLE,
 	LAYOUT_LIST,
@@ -62,6 +63,7 @@ const defaultConfigPerViewType = {
 		mediaField: 'preview',
 		primaryField: 'title',
 		columnFields: [ 'description' ],
+		badgeFields: [ 'isCustom' ],
 	},
 	[ LAYOUT_LIST ]: {
 		primaryField: 'title',
@@ -337,6 +339,20 @@ export default function PageTemplates() {
 				],
 				filterBy: {
 					operators: [ OPERATOR_IS_ANY ],
+				},
+			},
+			{
+				header: __( 'Type' ),
+				id: 'isCustom',
+				getValue: ( { item } ) => item.is_custom,
+				render: ( { item } ) =>
+					item.is_custom ? 'Custom' : undefined,
+				elements: [
+					{ value: true, label: 'Custom' },
+					{ value: false, label: 'Default' },
+				],
+				filterBy: {
+					operators: [ OPERATOR_IS ],
 				},
 			},
 		],

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -80,7 +80,7 @@ const DEFAULT_VIEW = {
 	},
 	// All fields are visible by default, so it's
 	// better to keep track of the hidden ones.
-	hiddenFields: [ 'preview' ],
+	hiddenFields: [ 'preview', 'postTypes' ],
 	layout: defaultConfigPerViewType[ LAYOUT_GRID ],
 	filters: [],
 };
@@ -183,6 +183,12 @@ function Preview( { item, viewType } ) {
 		</ExperimentalBlockEditorProvider>
 	);
 }
+
+// TODO: templates can target Custom Post Types.
+const POST_TYPES = {
+	post: __( 'Post' ),
+	page: __( 'Page' ),
+};
 
 export default function PageTemplates() {
 	const { params } = useLocation();
@@ -314,6 +320,24 @@ export default function PageTemplates() {
 				},
 				elements: authors,
 				width: '1%',
+			},
+			{
+				header: __( 'Post types' ),
+				id: 'postTypes',
+				getValue: ( { item } ) => item.post_types,
+				render: ( { item } ) =>
+					item.post_types
+						?.map(
+							( postType ) => POST_TYPES[ postType ] || postType
+						)
+						?.join( ',' ),
+				elements: [
+					{ value: 'post', label: POST_TYPES.post },
+					{ value: 'page', label: POST_TYPES.page },
+				],
+				filterBy: {
+					operators: [ OPERATOR_IS_ANY ],
+				},
 			},
 		],
 		[ authors, view.type ]

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -187,19 +187,23 @@ function Preview( { item, viewType } ) {
 	);
 }
 
-// TODO: what are the possible post types?
-// How about CPTs added by plugins, etc.?
+// TODO: how about CPTs added by plugins, etc.?
 const POST_TYPES = {
 	post: __( 'Post' ),
 	page: __( 'Page' ),
 };
 
 // This maps the template slug to the post types it should be available for.
-// TODO: review the hierarchy and consider single-{post_type}, archives-{post_type}, etc.
+// https://developer.wordpress.org/themes/basics/template-hierarchy/#visual-overview
+// It only addresses primary and secondary templates, but not tertiary (aka variable) templates.
 const TEMPLATE_TO_POST_TYPE = {
-	single: [ 'post' ],
+	// 1. Primary templates.
+	index: [ 'post', 'page' ],
 	singular: [ 'post', 'page' ],
+	single: [ 'post' ],
 	page: [ 'page' ],
+	// 2. Secondary templates.
+	'single-post': [ 'post' ],
 };
 
 export default function PageTemplates() {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -192,6 +192,12 @@ const POST_TYPES = {
 	page: __( 'Page' ),
 };
 
+const SPECIAL_TEMPLATES = {
+	single: [ 'post' ],
+	singular: [ 'post', 'page' ],
+	page: [ 'page' ],
+};
+
 export default function PageTemplates() {
 	const { params } = useLocation();
 	const { activeView = 'all', layout } = params;
@@ -326,8 +332,20 @@ export default function PageTemplates() {
 			{
 				header: __( 'Post types' ),
 				id: 'postTypes',
-				getValue: ( { item } ) => item.post_types,
+				getValue: ( { item } ) =>
+					// This logic would be used by the filter
+					// and replicates what we have in the server at
+					// https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-template-utils.php#L1077
+					//
+					// 1. Consider the post types defined by the item, if any
+					item.post_types ||
+					// 2. Otherwise, if a template is custom add it for any CPT.
+					( item.is_custom ? [ 'post', 'page' ] : item.post_types ) || // TODO: take any CPT.
+					// 3. Finally, also consider special templates.
+					( SPECIAL_TEMPLATES[ item.slug ] ?? item.post_types ),
 				render: ( { item } ) =>
+					// TODO: note that getValue returns a different value than render.
+					// getValue is used for filtering, and render is used for display.
 					item.post_types
 						?.map(
 							( postType ) => POST_TYPES[ postType ] || postType

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -254,7 +254,7 @@ export default function PageTemplates() {
 	const registeredPostTypes = useMemo( () => {
 		const result =
 			types
-				?.filter( ( type ) => type.viewable )
+				?.filter( ( type ) => type.viewable && type.supports.editor ) // supports.editor is a proxy for supporting templates.
 				.map( ( { name, slug } ) => ( { name, slug } ) )
 				.reduce( ( acc, current ) => {
 					acc[ current.slug ] = current.name;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59659

## What?

Adds two new fields to the templates (`postTypes` & `isCustom`).

| Post types (`postTypes` field) | Type (`isCustom` field) |
| --- | --- |
| <img width="1499" alt="Captura de ecrã 2024-05-28, às 17 14 22" src="https://github.com/WordPress/gutenberg/assets/583546/293decb6-ab7a-4dcc-af84-4287e7553547"> | <img width="1499" alt="Captura de ecrã 2024-05-28, às 17 14 05" src="https://github.com/WordPress/gutenberg/assets/583546/e10bcfc2-ede5-4a19-a76e-b1d0b06f7d42"> |

## Why?

This is a preliminary step to use this to provide a new sidebar filters that include "Posts", "Pages", and "Custom", as per https://github.com/WordPress/gutenberg/issues/59659

## How?

- c821e44c89e01b1c45350f577c55fe49d554dbd5 Adds `isCustom` field & filter in the client. Displays it as a badge in the grid layout, and only renders the `Custom` value.
- 4cea71191e740259ae88c6789447d116f52320ab Adds `postType` field & filter in the client.
- f7b953e418dc127fc024b7cdda028e1669b6987f Declares `post_types` in the templates REST endpoint.
- 16518e70095d6517a42f17f1326399d8ed86ca68 Backport changelog. 

## Testing Instructions

Visit Site Editor > Templates and verify there's two new fields (hidden by default) and filters.

## TODO

- [ ] Verify `postType` logic. The current logic only accounts for templates the theme intended to register for a given post type. However, when switching templates (Post editor > swap templates), the user-created templates are also listed.
