### PR TITLE
Update: Show Pre Publish Panel when are are publishing a private post.

### DIFF
--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -71,7 +71,7 @@ export default function PublishButtonLabel() {
 		hasNonPostEntityChanges ||
 		isPublished ||
 		( postStatusHasChanged &&
-			! [ 'future', 'publish' ].includes( postStatus ) ) ||
+			! [ 'future', 'publish', 'private' ].includes( postStatus ) ) ||
 		( ! postStatusHasChanged && postStatus === 'future' )
 	) {
 		return __( 'Save' );

--- a/packages/editor/src/components/post-publish-button/post-publish-button-or-toggle.js
+++ b/packages/editor/src/components/post-publish-button/post-publish-button-or-toggle.js
@@ -55,7 +55,7 @@ export function PostPublishButtonOrToggle( {
 	if (
 		isPublished ||
 		( postStatusHasChanged &&
-			! [ 'future', 'publish' ].includes( postStatus ) ) ||
+			! [ 'future', 'publish', 'private' ].includes( postStatus ) ) ||
 		( isScheduled && isBeingScheduled ) ||
 		( isPending && ! hasPublishAction && ! isSmallerThanMediumViewport )
 	) {


### PR DESCRIPTION
## What?
Currently when you are publishing a private post it seems like we are just saving the post but the post does show up for logged in users as if it is published even though it is not visible in a lot of contexts in the front end. 

## Why?
We want to treat publishing a private post as if you are actually publishing the post.

## How?
The Pr addresses the issue by adding the prepublish flow as well updates the button to tell the use that they are publishing the post vs just saving it. 

## Testing Instructions
Create a new private post. Does it tell you to save the post or publish it? 

### Testing Instructions for Keyboard
Create a new private post. Does it tell you to save the post or publish it? 

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/115071/67fc09ec-5b99-4bff-9629-919bd7b41cf7


After:

https://github.com/WordPress/gutenberg/assets/115071/915d0040-b4ac-4c7f-8b29-228988f2de31


