### PR TITLE
Fix error when reloading while saving a pattern

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-scroll-into-view.js
@@ -10,7 +10,7 @@ export function useScrollIntoView( { isSelected } ) {
 			if ( isSelected ) {
 				const { ownerDocument } = node;
 				const { defaultView } = ownerDocument;
-				if ( ! defaultView.IntersectionObserver ) {
+				if ( ! defaultView?.IntersectionObserver ) {
 					return;
 				}
 				const observer = new defaultView.IntersectionObserver(


### PR DESCRIPTION
## What?
See #61941

An error is currently happening when running the synced patterns e2e test. It's likely to not cause any user facing issues, but can be addressed.

## How?
On this line there's a chance `defaultView` is null-ish, so we should check for that before trying to access the `IntersectionObserver` property in the early return.

## Testing Instructions
Run the synced patterns e2e tests:
```
npm run test:e2e:debug -- test/e2e/specs/editor/various/patterns.spec.js
```

and trigger the `can be inserted after refresh` test case. The error shouldn't happen