### PR TITLE
Fixed: Custom HTML Block should display content in LTR layout for all languages

### DIFF
--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -143,5 +143,6 @@
 
 .block-library-html__edit textarea.block-editor-plain-text {
 	// Custom HTML input is always LTR regardless of language.
+	/*rtl:ignore*/
 	direction: ltr;
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -141,3 +141,7 @@
 	box-sizing: inherit;
 }
 
+.block-library-html__edit textarea.block-editor-plain-text {
+	// Custom HTML input is always LTR regardless of language.
+	direction: ltr;
+}

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -141,8 +141,3 @@
 	box-sizing: inherit;
 }
 
-.block-library-html__edit textarea.block-editor-plain-text {
-	// Custom HTML input is always LTR regardless of language.
-	/*rtl:ignore*/
-	direction: ltr;
-}

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -13,12 +13,8 @@
 		box-sizing: border-box;
 		max-height: 250px;
 		@include editor-input-reset();
-	}
-
-	textarea {
-		&.block-editor-plain-text {
-			/*rtl:ignore*/
-			direction: ltr !important;
-		}
+		// HTML input is always LTR regardless of language.
+		/*rtl:ignore*/
+		direction: ltr;
 	}
 }

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -14,4 +14,11 @@
 		max-height: 250px;
 		@include editor-input-reset();
 	}
+
+	textarea {
+		.block-editor-plain-text {
+			/*rtl:ignore*/
+			direction: ltr !important;
+		}
+	}
 }

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -16,7 +16,7 @@
 	}
 
 	textarea {
-		.block-editor-plain-text {
+		&.block-editor-plain-text {
 			/*rtl:ignore*/
 			direction: ltr !important;
 		}


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/61324

## What?
Custom HTML Block will display content in LTR layout for all languages, previously it creating issue in case of RTL.

## Why?
This will makes Custom HTML BLock input LTR for all languages, which fix the issue mentioned in [PR](https://github.com/WordPress/gutenberg/issues/61324 ).

## How?
I have added the CSS to make Custom HTML Block input direction LTR.

## Screenshots or screencast 

**Before:**
![image](https://github.com/WordPress/gutenberg/assets/32844880/f171a173-5b96-4232-8a90-fe0c8fd650ec)

**After:**
![image](https://github.com/WordPress/gutenberg/assets/32844880/bb855a60-f96d-4adf-affd-563ac8aeb09c)



