### PR TITLE
Fix: add back "Block Name" in advanced inspector

### DIFF
--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -3,6 +3,13 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { InspectorControls } from '../components';
 
 /**
  * Filters registered block settings, adding an `__experimentalLabel` callback if one does not already exist.
@@ -37,6 +44,32 @@ export function addLabelCallback( settings ) {
 
 	return settings;
 }
+
+function BlockRenameControlPure( { metadata, setAttributes } ) {
+	return (
+		<InspectorControls group="advanced">
+			<TextControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ __( 'Block name' ) }
+				value={ metadata?.name || '' }
+				onChange={ ( newName ) => {
+					setAttributes( {
+						metadata: { ...metadata, name: newName },
+					} );
+				} }
+			/>
+		</InspectorControls>
+	);
+}
+
+export default {
+	edit: BlockRenameControlPure,
+	attributeKeys: [ 'metadata' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'renaming', true );
+	},
+};
 
 addFilter(
 	'blocks.registerBlockType',

--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -46,6 +46,14 @@ export function addLabelCallback( settings ) {
 }
 
 function BlockRenameControlPure( { metadata, setAttributes } ) {
+	const customName = metadata?.name;
+	const hasPatternOverrides =
+		!! customName &&
+		!! metadata?.bindings &&
+		Object.values( metadata.bindings ).some(
+			( binding ) => binding.source === 'core/pattern-overrides'
+		);
+
 	return (
 		<InspectorControls group="advanced">
 			<TextControl
@@ -58,6 +66,14 @@ function BlockRenameControlPure( { metadata, setAttributes } ) {
 						metadata: { ...metadata, name: newName },
 					} );
 				} }
+				disabled={ hasPatternOverrides }
+				help={
+					hasPatternOverrides
+						? __(
+								'This block allows overrides. Changing the name can cause problems with content entered into instances of this pattern.'
+						  )
+						: null
+				}
 			/>
 		</InspectorControls>
 	);

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -31,7 +31,7 @@ import contentLockUI from './content-lock-ui';
 import './metadata';
 import blockHooks from './block-hooks';
 import blockBindingsPanel from './block-bindings';
-import './block-renaming';
+import blockRenaming from './block-renaming';
 import './use-bindings-attributes';
 
 createBlockEditFilter(
@@ -47,6 +47,7 @@ createBlockEditFilter(
 		layout,
 		contentLockUI,
 		blockHooks,
+		blockRenaming,
 		childLayout,
 	].filter( Boolean )
 );

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -357,10 +357,8 @@ test.describe( 'Heading', () => {
 			name: 'Block navigation structure',
 		} );
 
-		const headingListViewItem = listView.getByRole( 'link' );
-
 		await expect(
-			headingListViewItem,
+			listView.getByRole( 'link' ),
 			'should show default block name if the content is empty'
 		).toHaveText( 'Heading' );
 
@@ -370,23 +368,23 @@ test.describe( 'Heading', () => {
 			} )
 			.fill( 'Heading content' );
 
-		await expect( headingListViewItem, 'should show content' ).toHaveText(
-			'Heading content'
-		);
+		await expect(
+			listView.getByRole( 'link' ),
+			'should show content'
+		).toHaveText( 'Heading content' );
 
-		await editor.clickBlockOptionsMenuItem( 'Rename' );
+		await editor.openDocumentSettingsSidebar();
+
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+
 		await page
-			.getByRole( 'dialog', { name: 'Rename' } )
-			.getByRole( 'textbox', { name: 'Block name' } )
+			.getByRole( 'textbox', {
+				name: 'Block name',
+			} )
 			.fill( 'My new name' );
 
-		await page
-			.getByRole( 'dialog', { name: 'Rename' } )
-			.getByRole( 'button', { name: 'Save' } )
-			.click();
-
 		await expect(
-			headingListViewItem,
+			listView.getByRole( 'link' ),
 			'should show custom name'
 		).toHaveText( 'My new name' );
 	} );

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -244,4 +244,104 @@ test.describe( 'Block Renaming', () => {
 			await expect( renameMenuItem ).toBeVisible();
 		} );
 	} );
+
+	test.describe( 'Block inspector renaming', () => {
+		test( 'allows renaming of blocks that support the feature via "Advanced" section of block inspector tools', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/group',
+			} );
+
+			// Select via keyboard.
+			await pageUtils.pressKeys( 'primary+a' );
+
+			// Convert to a Group block which supports renaming.
+			await editor.clickBlockOptionsMenuItem( 'Group' );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const advancedPanelToggle = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'button', {
+					name: 'Advanced',
+					expanded: false,
+				} );
+
+			await advancedPanelToggle.click();
+
+			const nameInput = page.getByRole( 'textbox', {
+				name: 'Block name',
+			} );
+
+			await expect( nameInput ).toBeEmpty();
+
+			await nameInput.fill( 'My new name' );
+
+			await expect( nameInput ).toHaveValue( 'My new name' );
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/group',
+					attributes: {
+						metadata: {
+							name: 'My new name',
+						},
+					},
+				},
+			] );
+
+			await nameInput.focus();
+			await pageUtils.pressKeys( 'primary+a' );
+			await page.keyboard.press( 'Delete' );
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/group',
+					attributes: {
+						metadata: {
+							name: '',
+						},
+					},
+				},
+			] );
+		} );
+
+		test( 'does not allow renaming of blocks that do not support the feature', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'my-plugin/block-that-does-not-support-renaming',
+			} );
+
+			// Multiselect via keyboard.
+			await pageUtils.pressKeys( 'primary+a' );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const advancedPanelToggle = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'button', {
+					name: 'Advanced',
+					expanded: false,
+				} );
+
+			await advancedPanelToggle.click();
+
+			// Expect the Rename control not to exist at all.
+			await expect(
+				page.getByRole( 'textbox', {
+					name: 'Block name',
+				} )
+			).toBeHidden();
+		} );
+	} );
 } );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -71,21 +71,24 @@ test.describe( 'Pattern Overrides', () => {
 				.getByRole( 'document', { name: 'Block: Paragraph' } )
 				.filter( { hasText: 'This paragraph can be edited' } )
 				.focus();
-
-			await editor.clickBlockOptionsMenuItem( 'Rename' );
-			await page
-				.getByRole( 'dialog', { name: 'Rename' } )
-				.getByRole( 'textbox', { name: 'Block name' } )
-				.fill( editableParagraphName );
-			await page
-				.getByRole( 'dialog', { name: 'Rename' } )
-				.getByRole( 'button', { name: 'Save' } )
-				.click();
-
 			await editor.openDocumentSettingsSidebar();
 			const editorSettings = page.getByRole( 'region', {
 				name: 'Editor settings',
 			} );
+			const advancedPanel = editorSettings.getByRole( 'button', {
+				name: 'Advanced',
+			} );
+			if (
+				( await advancedPanel.getAttribute( 'aria-expanded' ) ) ===
+				'false'
+			) {
+				await advancedPanel.click();
+			}
+			await editorSettings
+				.getByRole( 'textbox', { name: 'Block Name' } )
+				.fill( editableParagraphName );
+
+			await editor.openDocumentSettingsSidebar();
 			await editorSettings
 				.getByRole( 'button', { name: 'Advanced' } )
 				.click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR reverts #60453 and therefore closes #62079

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Having used this in a few Gutenberg Releases now, I think it's a major mistake, and we should add it back before WordPress 6.6 is released.

Renaming is a very common action on sites with more complex page structures. However, the flow for performing this action has become much slower and more complex.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By reverting #60453 and making sure that the rename text field is disabled when the block has active pattern overrides.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

 - Navigate to the Advanced Inspector of any block and see the Block Name text field appear again
 - Rename a block using the contorl
 - Create a synced pattern with pattern overrides applied. 
 - See that the text field is disabled when the block has overrides enabled. 

