### PR TITLE
Document Bar: Decode HTML entities and take into account cases where there is no title

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -21,6 +21,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as commandsStore } from '@wordpress/commands';
 import { useRef, useEffect } from '@wordpress/element';
 import { useReducedMotion } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -190,7 +191,9 @@ export default function DocumentBar() {
 									: undefined
 							}
 						>
-							{ title }
+							{ title
+								? decodeEntities( title )
+								: __( 'No Title' ) }
 						</Text>
 					</motion.div>
 					<span className="editor-document-bar__shortcut">


### PR DESCRIPTION
## What?

This PR makes two changes to the document bar title:

- Decodes HTML entities
- If there is no title yet, displays `No Title`

## Why?

This is to match the logic in the post card panel:

https://github.com/WordPress/gutenberg/blob/3ce3bbbd3dd2bcb98bbf9a530896c4bf64f7dd63/packages/editor/src/components/post-card-panel/index.js#L87

![image](https://github.com/WordPress/gutenberg/assets/54422211/f1aecf3b-fb16-4ce5-ac66-b278e3e27285)

## Testing Instructions

- Create a new post.
- The document bar will show "No Title".
- Include HTML entities in the post title, such as `&<>`.
- HTML entities should be decoded in the document bar title.
- You should be able to get the same results using "Pages" in the site editor

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/4eb8d90e-20a5-4990-ae52-e3323f9b4c92)

![image](https://github.com/WordPress/gutenberg/assets/54422211/16ad5f2d-faf7-4f59-abe5-e8071966de4b)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/f6968d34-7e16-48f8-bd67-a6759556bf41)

![image](https://github.com/WordPress/gutenberg/assets/54422211/75a5fa38-5afd-45cf-8f1b-7bb8fc9e30a8)

