### PR TITLE
block.json: Allow passing filename as `variations` field

### DIFF
--- a/backport-changelog/6.7/6668.md
+++ b/backport-changelog/6.7/6668.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6668
+
+* https://github.com/WordPress/gutenberg/pull/62092

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -427,7 +427,7 @@ See the [Example documentation](/docs/reference-guides/block-api/block-registrat
 
 ### Variations
 
--   Type: `object[]`
+-   Type: `object[]|string`
 -   Optional
 -   Localized: Yes (`title`, `description`, and `keywords` of each variation only)
 -   Property: `variations`
@@ -453,6 +453,14 @@ See the [Example documentation](/docs/reference-guides/block-api/block-registrat
 Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality. Each block variation is differentiated from the others by setting some initial attributes or inner blocks. Then at the time when a block is inserted these attributes and/or inner blocks are applied.
 
 _Note: In JavaScript you can provide a function for the `isActive` property, and a React element for the `icon`. In the `block.json` file both only support strings_
+
+_Note: Starting with version 6.7, it is possible to specify a PHP file that generates the list of block variations on the server side:_
+
+```json
+{
+	"variations": "file:./variations.php"
+}
+```
 
 See [the variations documentation](/docs/reference-guides/block-api/block-variations.md) for more details.
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -427,7 +427,7 @@ See the [Example documentation](/docs/reference-guides/block-api/block-registrat
 
 ### Variations
 
--   Type: `object[]|string`
+-   Type: `object[]|WPDefinedPath` ([learn more](#wpdefinedpath))
 -   Optional
 -   Localized: Yes (`title`, `description`, and `keywords` of each variation only)
 -   Property: `variations`
@@ -454,12 +454,39 @@ Block Variations is the API that allows a block to have similar versions of it, 
 
 _Note: In JavaScript you can provide a function for the `isActive` property, and a React element for the `icon`. In the `block.json` file both only support strings_
 
-_Note: Starting with version 6.7, it is possible to specify a PHP file that generates the list of block variations on the server side:_
+Starting with version 6.7, it is possible to specify a PHP file in `block.json` that generates the list of block variations on the server side:
 
 ```json
-{
-	"variations": "file:./variations.php"
-}
+{ "variations": "file:./variations.php" }
+```
+
+That PHP file is expected to `return` an array that contains the block variations. For example:
+
+```php
+<?php
+
+return array(
+	array(
+		'isDefault'  => true,
+		'name'       => 'wordpress',
+		'title'      => 'WordPress',
+		'icon'       => 'wordpress',
+		'attributes' => array(
+			'service' => 'wordpress',
+		),
+		'isActive'   => array( 'service' )
+	),
+	array(
+		'name'       => 'gravatar',
+		'title'      => 'Gravatar',
+		'icon'       => 'commentAuthorAvatar',
+		'attributes' => array(
+			'service' => 'gravatar',
+		),
+		'isActive'   => array( 'service' )
+	),
+);
+
 ```
 
 See [the variations documentation](/docs/reference-guides/block-api/block-variations.md) for more details.

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -466,6 +466,7 @@ For example:
 
 ```php
 <?php
+// Generate variations for a Social Icon kind of block.
 
 return array(
 	array(

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -477,13 +477,17 @@ return array(
 		'isActive'   => array( 'service' )
 	),
 	array(
-		'name'       => 'gravatar',
-		'title'      => 'Gravatar',
-		'icon'       => 'commentAuthorAvatar',
-		'attributes' => array(
-			'service' => 'gravatar',
+		'name'       => 'mail',
+		'title'      => __( 'Mail' ),
+		'keywords'   => array(
+			__( 'email' ),
+			__( 'e-mail' )
 		),
-		'isActive'   => array( 'service' )
+		'icon'       => 'mail',
+		'attributes' => array(
+			'service' => 'mail',
+		),
+		'isActive'   => array( 'mail' )
 	),
 );
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -460,7 +460,9 @@ Starting with version 6.7, it is possible to specify a PHP file in `block.json` 
 { "variations": "file:./variations.php" }
 ```
 
-That PHP file is expected to `return` an array that contains the block variations. For example:
+That PHP file is expected to `return` an array that contains the block variations. Strings found in the variations returned from the PHP file will not be localized automatically; instead, use the `__()` function as usual.
+
+For example:
 
 ```php
 <?php

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -233,10 +233,12 @@ example: {
 
 #### variations (optional)
 
--   **Type:** `Object[]`
+-   **Type:** `Object[]|string`
 -   **Since**: `WordPress 5.9.0`
 
 Similarly to how the block's styles can be declared, a block type can define block variations that the user can pick from. The difference is that, rather than changing only the visual appearance, this field provides a way to apply initial custom attributes and inner blocks at the time when a block is inserted. See the [Block Variations API](/docs/reference-guides/block-api/block-variations.md) for more details.
+
+_Note:_ Starting with WordPress 6.7, it is possible to specify a PHP file that generates the list of block variations on the server side.
 
 #### supports (optional)
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -233,12 +233,10 @@ example: {
 
 #### variations (optional)
 
--   **Type:** `Object[]|string`
+-   **Type:** `Object[]`
 -   **Since**: `WordPress 5.9.0`
 
 Similarly to how the block's styles can be declared, a block type can define block variations that the user can pick from. The difference is that, rather than changing only the visual appearance, this field provides a way to apply initial custom attributes and inner blocks at the time when a block is inserted. See the [Block Variations API](/docs/reference-guides/block-api/block-variations.md) for more details.
-
-_Note:_ Starting with WordPress 6.7, it is possible to specify a PHP file that generates the list of block variations on the server side.
 
 #### supports (optional)
 

--- a/lib/compat/wordpress-6.7/blocks.php
+++ b/lib/compat/wordpress-6.7/blocks.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Temporary compatibility shims for block APIs present in Gutenberg.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Allow passing a PHP file as `variations` field for Core versions < 6.7
+ *
+ * @param array $settings Array of determined settings for registering a block type.
+ * @param array $metadata Metadata provided for registering a block type.
+ * @return array The block type settings
+ */
+function gutenberg_filter_block_type_metadata_settings_allow_variations_php_file( $settings, $metadata ) {
+	// If `variations` is a string, it's the name of a PHP file that
+	// generates the variations.
+	if ( ! empty( $settings['variations'] ) && is_string( $settings['variations'] ) ) {
+		$variations_path = wp_normalize_path(
+			realpath(
+				dirname( $metadata['file'] ) . '/' .
+				remove_block_asset_path_prefix( $metadata['variations'] )
+			)
+		);
+		if ( $variations_path ) {
+			/**
+			 * Generates the list of block variations.
+			 *
+			 * @since 6.7.0
+			 *
+			 * @return string Returns the list of block variations.
+			 */
+			$settings['variation_callback'] = static function () use ( $variations_path ) {
+				$variations = require $variations_path;
+				return $variations;
+			};
+			// The block instance's `variations` field is only allowed to be an array
+			// (of known block variations). We unset it so that the block instance will
+			// provide a getter that returns the result of the `variation_callback` instead.
+			unset( $settings['variations'] );
+		}
+	}
+	return $settings;
+}
+add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_allow_variations_php_file', 10, 2 );

--- a/lib/compat/wordpress-6.7/blocks.php
+++ b/lib/compat/wordpress-6.7/blocks.php
@@ -19,7 +19,7 @@ function gutenberg_filter_block_type_metadata_settings_allow_variations_php_file
 		$variations_path = wp_normalize_path(
 			realpath(
 				dirname( $metadata['file'] ) . '/' .
-				remove_block_asset_path_prefix( $metadata['variations'] )
+				remove_block_asset_path_prefix( $settings['variations'] )
 			)
 		);
 		if ( $variations_path ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -141,6 +141,9 @@ require __DIR__ . '/compat/wordpress-6.6/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.6/option.php';
 require __DIR__ . '/compat/wordpress-6.6/post.php';
 
+// WordPress 6.7 compat.
+require __DIR__ . '/compat/wordpress-6.7/blocks.php';
+
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/blocks.php';

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -93,9 +93,14 @@ export const processBlockType =
 			save: () => null,
 			...bootstrappedBlockType,
 			...blockSettings,
+			// blockType.variations can be defined as a filePath.
 			variations: mergeBlockVariations(
-				bootstrappedBlockType?.variations,
-				blockSettings?.variations
+				Array.isArray( bootstrappedBlockType?.variations )
+					? bootstrappedBlockType.variations
+					: [],
+				Array.isArray( blockSettings?.variations )
+					? blockSettings.variations
+					: []
 			),
 		};
 

--- a/phpunit/blocks/block-json-variations-filename-test.php
+++ b/phpunit/blocks/block-json-variations-filename-test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Test for the block.json's variations field being a PHP file.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Test that block variations can be registered from a PHP file.
+ *
+ * @group blocks
+ */
+class Block_Json_Variations_Filename_Test extends WP_UnitTestCase {
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( 'my-plugin/notice' ) ) {
+			$registry->unregister( 'my-plugin/notice' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests registering a block with variations from a PHP file.
+	 *
+	 * @covers ::register_block_type_from_metadata
+	 */
+	public function test_register_block_type_from_metadata_with_variations_php_file() {
+		$filter_metadata_registration = static function ( $metadata ) {
+			$metadata['variations'] = 'variations.php';
+			return $metadata;
+		};
+
+		add_filter( 'block_type_metadata', $filter_metadata_registration, 10, 2 );
+		$result = register_block_type_from_metadata( GUTENBERG_DIR_TESTFIXTURES );
+		remove_filter( 'block_type_metadata', $filter_metadata_registration );
+
+		$this->assertInstanceOf( 'WP_Block_Type', $result, 'The block was not registered' );
+
+		$this->assertIsCallable( $result->variation_callback, 'The variation callback hasn\'t been set' );
+		$expected_variations = require GUTENBERG_DIR_TESTFIXTURES . '/variations.php';
+		$this->assertSame(
+			$expected_variations,
+			call_user_func( $result->variation_callback ),
+			'The variation callback hasn\'t been set correctly'
+		);
+		$this->assertSame( $expected_variations, $result->variations, 'The block variations are incorrect' );
+	}
+}

--- a/phpunit/blocks/block-json-variations-filename-test.php
+++ b/phpunit/blocks/block-json-variations-filename-test.php
@@ -42,13 +42,7 @@ class Block_Json_Variations_Filename_Test extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( 'WP_Block_Type', $result, 'The block was not registered' );
 
-		$this->assertIsCallable( $result->variation_callback, 'The variation callback hasn\'t been set' );
 		$expected_variations = require GUTENBERG_DIR_TESTFIXTURES . '/variations.php';
-		$this->assertSame(
-			$expected_variations,
-			call_user_func( $result->variation_callback ),
-			'The variation callback hasn\'t been set correctly'
-		);
-		$this->assertSame( $expected_variations, $result->variations, 'The block variations are incorrect' );
+		$this->assertSame( $expected_variations, $result->variations, "Block variations haven't been set correctly." );
 	}
 }

--- a/phpunit/blocks/block-json-variations-filename-test.php
+++ b/phpunit/blocks/block-json-variations-filename-test.php
@@ -32,7 +32,7 @@ class Block_Json_Variations_Filename_Test extends WP_UnitTestCase {
 	 */
 	public function test_register_block_type_from_metadata_with_variations_php_file() {
 		$filter_metadata_registration = static function ( $metadata ) {
-			$metadata['variations'] = 'variations.php';
+			$metadata['variations'] = 'file:./variations.php';
 			return $metadata;
 		};
 

--- a/phpunit/fixtures/variations.php
+++ b/phpunit/fixtures/variations.php
@@ -1,0 +1,10 @@
+<?php
+
+return array(
+	array(
+		'name'        => 'warning',
+		'title'       => 'warning',
+		'description' => 'Shows warning.',
+		'keywords'    => array( 'warning' )
+	)
+);

--- a/phpunit/fixtures/variations.php
+++ b/phpunit/fixtures/variations.php
@@ -5,6 +5,6 @@ return array(
 		'name'        => 'warning',
 		'title'       => 'warning',
 		'description' => 'Shows warning.',
-		'keywords'    => array( 'warning' )
-	)
+		'keywords'    => array( 'warning' ),
+	),
 );

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -897,91 +897,98 @@
 			]
 		},
 		"variations": {
-			"type": "array",
 			"description": "Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality.",
-			"items": {
-				"type": "object",
-				"required": [ "name", "title" ],
-				"additionalProperties": false,
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "The unique and machine-readable name."
-					},
-					"title": {
-						"type": "string",
-						"description": "A human-readable variation title."
-					},
-					"description": {
-						"type": "string",
-						"description": "A detailed variation description."
-					},
-					"category": {
-						"description": "A category classification, used in search interfaces to arrange block types by category.",
-						"anyOf": [
-							{
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "object",
+						"required": [ "name", "title" ],
+						"additionalProperties": false,
+						"properties": {
+							"name": {
+								"type": "string",
+								"description": "The unique and machine-readable name."
+							},
+							"title": {
+								"type": "string",
+								"description": "A human-readable variation title."
+							},
+							"description": {
+								"type": "string",
+								"description": "A detailed variation description."
+							},
+							"category": {
+								"description": "A category classification, used in search interfaces to arrange block types by category.",
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"enum": [
+											"text",
+											"media",
+											"design",
+											"widgets",
+											"theme",
+											"embed"
+										]
+									}
+								]
+							},
+							"icon": {
+								"description": "An icon helping to visualize the variation. It can have the same shape as the block type.",
 								"type": "string"
 							},
-							{
-								"enum": [
-									"text",
-									"media",
-									"design",
-									"widgets",
-									"theme",
-									"embed"
-								]
+							"isDefault": {
+								"type": "boolean",
+								"default": false,
+								"description": "Indicates whether the current variation is the default one."
+							},
+							"attributes": {
+								"type": "object",
+								"description": "Values that override block attributes."
+							},
+							"innerBlocks": {
+								"type": "array",
+								"items": {
+									"type": "array"
+								},
+								"description": "Initial configuration of nested blocks."
+							},
+							"example": {
+								"type": "object",
+								"description": "Example provides structured data for the block preview. You can set to undefined to disable the preview shown for the block type."
+							},
+							"scope": {
+								"type": "array",
+								"description": "The list of scopes where the variation is applicable.",
+								"items": {
+									"enum": [ "inserter", "block", "transform" ]
+								},
+								"default": [ "inserter", "block" ]
+							},
+							"keywords": {
+								"type": "array",
+								"description": "An array of terms (which can be translated) that help users discover the variation while searching.",
+								"items": {
+									"type": "string"
+								}
+							},
+							"isActive": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								},
+								"description": "The list of attributes that should be compared. Each attributes will be matched and the variation will be active if all of them are matching."
 							}
-						]
-					},
-					"icon": {
-						"description": "An icon helping to visualize the variation. It can have the same shape as the block type.",
-						"type": "string"
-					},
-					"isDefault": {
-						"type": "boolean",
-						"default": false,
-						"description": "Indicates whether the current variation is the default one."
-					},
-					"attributes": {
-						"type": "object",
-						"description": "Values that override block attributes."
-					},
-					"innerBlocks": {
-						"type": "array",
-						"items": {
-							"type": "array"
-						},
-						"description": "Initial configuration of nested blocks."
-					},
-					"example": {
-						"type": "object",
-						"description": "Example provides structured data for the block preview. You can set to undefined to disable the preview shown for the block type."
-					},
-					"scope": {
-						"type": "array",
-						"description": "The list of scopes where the variation is applicable.",
-						"items": {
-							"enum": [ "inserter", "block", "transform" ]
-						},
-						"default": [ "inserter", "block" ]
-					},
-					"keywords": {
-						"type": "array",
-						"description": "An array of terms (which can be translated) that help users discover the variation while searching.",
-						"items": {
-							"type": "string"
 						}
-					},
-					"isActive": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						},
-						"description": "The list of attributes that should be compared. Each attributes will be matched and the variation will be active if all of them are matching."
 					}
 				}
-			}
+			]
 		},
 		"render": {
 			"type": "string",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -900,10 +900,12 @@
 			"description": "Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality.",
 			"oneOf": [
 				{
-					"type": "string"
+					"type": "string",
+					"description": "The path to a PHP file that returns an array of block variations."
 				},
 				{
 					"type": "array",
+					"description": "An array of block variations.",
 					"items": {
 						"type": "object",
 						"required": [ "name", "title" ],


### PR DESCRIPTION
## What?
Modeled after https://core.trac.wordpress.org/changeset/54132/, which introduced the `render` field for `block.json`, as a way to point to a PHP file instead of providing a `render_callback`.

The main difference to the `variations` and `variation_callback` fields is that the `variations` field already existed prior to this PR, and it can be used to provide the static list of variations (i.e., an array). This PR makes it so that the field can be alternatively set to a string, which will be interpreted as the filename of the PHP file generating the variations.

Due to the changes to the `block.json` schema, it is recommended to view the diff [with whitespace changes hidden](https://github.com/WordPress/gutenberg/pull/62092/files?&w=1).

## Why?
See https://github.com/WordPress/wordpress-develop/pull/6668.

## How?
In the GB compat layer: By using the `block_type_metadata_settings` filter.

## Testing Instructions

Apply the following patch, and create `build/block-library/blocks/template-part/variations.php` with the content below.

<details>
<summary>
Patch
</summary>

```diff
diff --git a/packages/block-library/src/template-part/block.json b/packages/block-library/src/template-part/block.json
index 9710bdeee2e..3493946aa7a 100644
--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -29,5 +29,6 @@
 			"clientNavigation": true
 		}
 	},
+	"variations": "variations.php",
 	"editorStyle": "wp-block-template-part-editor"
 }
diff --git a/packages/block-library/src/template-part/index.php b/packages/block-library/src/template-part/index.php
index be867c4ced1..58420b999b2 100644
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -175,115 +175,6 @@ function render_block_core_template_part( $attributes ) {
 	return "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
 }
 
-/**
- * Returns an array of area variation objects for the template part block.
- *
- * @since 6.1.0
- *
- * @param array $instance_variations The variations for instances.
- *
- * @return array Array containing the block variation objects.
- */
-function build_template_part_block_area_variations( $instance_variations ) {
-	$variations    = array();
-	$defined_areas = get_allowed_block_template_part_areas();
-
-	foreach ( $defined_areas as $area ) {
-		if ( 'uncategorized' !== $area['area'] ) {
-			$has_instance_for_area = false;
-			foreach ( $instance_variations as $variation ) {
-				if ( $variation['attributes']['area'] === $area['area'] ) {
-					$has_instance_for_area = true;
-					break;
-				}
-			}
-
-			$scope = $has_instance_for_area ? array() : array( 'inserter' );
-
-			$variations[] = array(
-				'name'        => 'area_' . $area['area'],
-				'title'       => $area['label'],
-				'description' => $area['description'],
-				'attributes'  => array(
-					'area' => $area['area'],
-				),
-				'scope'       => $scope,
-				'icon'        => $area['icon'],
-			);
-		}
-	}
-	return $variations;
-}
-
-/**
- * Returns an array of instance variation objects for the template part block
- *
- * @since 6.1.0
- *
- * @return array Array containing the block variation objects.
- */
-function build_template_part_block_instance_variations() {
-	// Block themes are unavailable during installation.
-	if ( wp_installing() ) {
-		return array();
-	}
-
-	if ( ! current_theme_supports( 'block-templates' ) && ! current_theme_supports( 'block-template-parts' ) ) {
-		return array();
-	}
-
-	$variations     = array();
-	$template_parts = get_block_templates(
-		array(
-			'post_type' => 'wp_template_part',
-		),
-		'wp_template_part'
-	);
-
-	$defined_areas = get_allowed_block_template_part_areas();
-	$icon_by_area  = array_combine( array_column( $defined_areas, 'area' ), array_column( $defined_areas, 'icon' ) );
-
-	foreach ( $template_parts as $template_part ) {
-		$variations[] = array(
-			'name'        => 'instance_' . sanitize_title( $template_part->slug ),
-			'title'       => $template_part->title,
-			// If there's no description for the template part don't show the
-			// block description. This is a bit hacky, but prevent the fallback
-			// by using a non-breaking space so that the value of description
-			// isn't falsey.
-			'description' => $template_part->description || '&nbsp;',
-			'attributes'  => array(
-				'slug'  => $template_part->slug,
-				'theme' => $template_part->theme,
-				'area'  => $template_part->area,
-			),
-			'scope'       => array( 'inserter' ),
-			'icon'        => isset( $icon_by_area[ $template_part->area ] ) ? $icon_by_area[ $template_part->area ] : null,
-			'example'     => array(
-				'attributes' => array(
-					'slug'  => $template_part->slug,
-					'theme' => $template_part->theme,
-					'area'  => $template_part->area,
-				),
-			),
-		);
-	}
-	return $variations;
-}
-
-/**
- * Returns an array of all template part block variations.
- *
- * @since 5.9.0
- *
- * @return array Array containing the block variation objects.
- */
-function build_template_part_block_variations() {
-	$instance_variations = build_template_part_block_instance_variations();
-	$area_variations     = build_template_part_block_area_variations( $instance_variations );
-	return array_merge( $area_variations, $instance_variations );
-}
-
 /**
  * Registers the `core/template-part` block on the server.
  *
@@ -294,7 +185,6 @@ function register_block_core_template_part() {
 		__DIR__ . '/template-part',
 		array(
 			'render_callback'    => 'render_block_core_template_part',
-			'variation_callback' => 'build_template_part_block_variations',
 		)
 	);
 }
diff --git a/packages/block-library/src/template-part/variations.php b/packages/block-library/src/template-part/variations.php
new file mode 100644
index 00000000000..c47f0ffc127
--- /dev/null
+++ b/packages/block-library/src/template-part/variations.php
@@ -0,0 +1,112 @@
+<?php
+
+/**
+ * Returns an array of area variation objects for the template part block.
+ *
+ * @since 6.1.0
+ *
+ * @param array $instance_variations The variations for instances.
+ *
+ * @return array Array containing the block variation objects.
+ */
+function build_template_part_block_area_variations( $instance_variations ) {
+	$variations    = array();
+	$defined_areas = get_allowed_block_template_part_areas();
+
+	foreach ( $defined_areas as $area ) {
+		if ( 'uncategorized' !== $area['area'] ) {
+			$has_instance_for_area = false;
+			foreach ( $instance_variations as $variation ) {
+				if ( $variation['attributes']['area'] === $area['area'] ) {
+					$has_instance_for_area = true;
+					break;
+				}
+			}
+
+			$scope = $has_instance_for_area ? array() : array( 'inserter' );
+
+			$variations[] = array(
+				'name'        => 'area_' . $area['area'],
+				'title'       => $area['label'],
+				'description' => $area['description'],
+				'attributes'  => array(
+					'area' => $area['area'],
+				),
+				'scope'       => $scope,
+				'icon'        => $area['icon'],
+			);
+		}
+	}
+	return $variations;
+}
+
+/**
+ * Returns an array of instance variation objects for the template part block
+ *
+ * @since 6.1.0
+ *
+ * @return array Array containing the block variation objects.
+ */
+function build_template_part_block_instance_variations() {
+	// Block themes are unavailable during installation.
+	if ( wp_installing() ) {
+		return array();
+	}
+
+	if ( ! current_theme_supports( 'block-templates' ) && ! current_theme_supports( 'block-template-parts' ) ) {
+		return array();
+	}
+
+	$variations     = array();
+	$template_parts = get_block_templates(
+		array(
+			'post_type' => 'wp_template_part',
+		),
+		'wp_template_part'
+	);
+
+	$defined_areas = get_allowed_block_template_part_areas();
+	$icon_by_area  = array_combine( array_column( $defined_areas, 'area' ), array_column( $defined_areas, 'icon' ) );
+
+	foreach ( $template_parts as $template_part ) {
+		$variations[] = array(
+			'name'        => 'instance_' . sanitize_title( $template_part->slug ),
+			'title'       => $template_part->title,
+			// If there's no description for the template part don't show the
+			// block description. This is a bit hacky, but prevent the fallback
+			// by using a non-breaking space so that the value of description
+			// isn't falsey.
+			'description' => $template_part->description || '&nbsp;',
+			'attributes'  => array(
+				'slug'  => $template_part->slug,
+				'theme' => $template_part->theme,
+				'area'  => $template_part->area,
+			),
+			'scope'       => array( 'inserter' ),
+			'icon'        => isset( $icon_by_area[ $template_part->area ] ) ? $icon_by_area[ $template_part->area ] : null,
+			'example'     => array(
+				'attributes' => array(
+					'slug'  => $template_part->slug,
+					'theme' => $template_part->theme,
+					'area'  => $template_part->area,
+				),
+			),
+		);
+	}
+	return $variations;
+}
+
+/**
+ * Returns an array of all template part block variations.
+ *
+ * @since 5.9.0
+ *
+ * @return array Array containing the block variation objects.
+ */
+function build_template_part_block_variations() {
+	$instance_variations = build_template_part_block_instance_variations();
+	$area_variations     = build_template_part_block_area_variations( $instance_variations );
+	return array_merge( $area_variations, $instance_variations );
+}
+
+return build_template_part_block_variations();

```
</details>

<details>
<summary>
build/block-library/blocks/template-part/variations.php
</summary>

```php
<?php

/**
 * Returns an array of area variation objects for the template part block.
 *
 * @since 6.1.0
 *
 * @param array $instance_variations The variations for instances.
 *
 * @return array Array containing the block variation objects.
 */
function gutenberg_build_template_part_block_area_variations( $instance_variations ) {
	$variations    = array();
	$defined_areas = get_allowed_block_template_part_areas();

	foreach ( $defined_areas as $area ) {
		if ( 'uncategorized' !== $area['area'] ) {
			$has_instance_for_area = false;
			foreach ( $instance_variations as $variation ) {
				if ( $variation['attributes']['area'] === $area['area'] ) {
					$has_instance_for_area = true;
					break;
				}
			}

			$scope = $has_instance_for_area ? array() : array( 'inserter' );

			$variations[] = array(
				'name'        => 'area_' . $area['area'],
				'title'       => $area['label'],
				'description' => $area['description'],
				'attributes'  => array(
					'area' => $area['area'],
				),
				'scope'       => $scope,
				'icon'        => $area['icon'],
			);
		}
	}
	return $variations;
}

/**
 * Returns an array of instance variation objects for the template part block
 *
 * @since 6.1.0
 *
 * @return array Array containing the block variation objects.
 */
function gutenberg_build_template_part_block_instance_variations() {
	// Block themes are unavailable during installation.
	if ( wp_installing() ) {
		return array();
	}

	if ( ! current_theme_supports( 'block-templates' ) && ! current_theme_supports( 'block-template-parts' ) ) {
		return array();
	}

	$variations     = array();
	$template_parts = get_block_templates(
		array(
			'post_type' => 'wp_template_part',
		),
		'wp_template_part'
	);

	$defined_areas = get_allowed_block_template_part_areas();
	$icon_by_area  = array_combine( array_column( $defined_areas, 'area' ), array_column( $defined_areas, 'icon' ) );

	foreach ( $template_parts as $template_part ) {
		$variations[] = array(
			'name'        => 'instance_' . sanitize_title( $template_part->slug ),
			'title'       => $template_part->title,
			// If there's no description for the template part don't show the
			// block description. This is a bit hacky, but prevent the fallback
			// by using a non-breaking space so that the value of description
			// isn't falsey.
			'description' => $template_part->description || '&nbsp;',
			'attributes'  => array(
				'slug'  => $template_part->slug,
				'theme' => $template_part->theme,
				'area'  => $template_part->area,
			),
			'scope'       => array( 'inserter' ),
			'icon'        => isset( $icon_by_area[ $template_part->area ] ) ? $icon_by_area[ $template_part->area ] : null,
			'example'     => array(
				'attributes' => array(
					'slug'  => $template_part->slug,
					'theme' => $template_part->theme,
					'area'  => $template_part->area,
				),
			),
		);
	}
	return $variations;
}

/**
 * Returns an array of all template part block variations.
 *
 * @since 5.9.0
 *
 * @return array Array containing the block variation objects.
 */
function gutenberg_build_template_part_block_variations() {
	$instance_variations = gutenberg_build_template_part_block_instance_variations();
	$area_variations     = gutenberg_build_template_part_block_area_variations( $instance_variations );
	return array_merge( $area_variations, $instance_variations );
}

return gutenberg_build_template_part_block_variations();

```
</details>

(The latter is required since Gutenberg isn’t currently copying files specified in a `block.json`’s `render` or `variations` field to the `build/` directory. Refer to https://github.com/WordPress/gutenberg/issues/63077 for further information.)

Then, in the Site Editor, verify that instances of the block still work, and that their variations are detected correctly (e.g. a header template part is recognized as such in the block inspector).

**Specifically, open the inserter and enter "Header" into the search input field. _Both_ the Template Part block _and_ its Header variation should be shown.**

<img width="349" alt="image" src="https://github.com/WordPress/gutenberg/assets/96308/102df4de-df0a-45e7-a400-ce3033aba1c7">


