### PR TITLE
Tests: Change how directives processing gets disabled

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks.php
+++ b/packages/e2e-tests/plugins/interactive-blocks.php
@@ -29,11 +29,7 @@ add_action(
 			// Ensure the interactivity API is loaded.
 			wp_interactivity();
 			// But remove the server directive processing.
-			remove_filter(
-				'render_block_data',
-				'wp_interactivity_process_directives_of_interactive_blocks',
-				100
-			);
+			add_filter( 'interactivity_process_directives', '__return_false' );
 		}
 	}
 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The necessary steps for the planned changes in WordPress core are as follows: https://github.com/WordPress/wordpress-develop/pull/6331.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The existing filter gets replaced with more thigh integration with the `WP_Block` class.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

New filter `interactivity_process_directives` gets introduced to allow controlling directives processing for Interactivity API.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

E2E tests should still pass after changes land in WordPress core. It will fail currently.