### PR TITLE
Documentation: For `PostTextEditor` component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1242,7 +1242,11 @@ _Returns_
 
 ### PostTextEditor
 
-Undocumented declaration.
+Displays the Post Text Editor along with content in Visual and Text mode.
+
+_Returns_
+
+-   `JSX.Element|null`: The rendered PostTextEditor component.
 
 ### PostTitle
 

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -19,6 +19,11 @@ import { VisuallyHidden } from '@wordpress/components';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * Displays the Post Text Editor along with content in Visual and Text mode.
+ *
+ * @return {JSX.Element|null} The rendered PostTextEditor component.
+ */
 export default function PostTextEditor() {
 	const instanceId = useInstanceId( PostTextEditor );
 	const { content, blocks, type, id } = useSelect( ( select ) => {


### PR DESCRIPTION
### What?

Addresses one item in https://github.com/WordPress/gutenberg/issues/60358

### Why?

Adding documentation to existing PostTextEditor components can help with any of the following:

encourages knowledge sharing and quicker onboarding for future devs
supports maintenance and troubleshooting

### Testing Instructions

This PR justs adds a JSDoc comment to the `PostTextEditor` component and populates the README with the new documents generated by running `npm run docs:build`