### PR TITLE
Editor: Remove useless props from InserterSidebar component

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -137,7 +137,6 @@ function Layout( { initialPost } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 
-	const { closeGeneralSidebar } = useDispatch( editPostStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const {
 		mode,
@@ -244,22 +243,6 @@ function Layout( { initialPost } ) {
 		? __( 'Document Overview' )
 		: __( 'Block Library' );
 
-	const secondarySidebar = () => {
-		if ( mode === 'visual' && isInserterOpened ) {
-			return (
-				<InserterSidebar
-					closeGeneralSidebar={ closeGeneralSidebar }
-					isRightSidebarOpen={ sidebarIsOpened }
-				/>
-			);
-		}
-		if ( mode === 'visual' && isListViewOpened ) {
-			return <ListViewSidebar />;
-		}
-
-		return null;
-	};
-
 	function onPluginAreaError( name ) {
 		createErrorNotice(
 			sprintf(
@@ -351,7 +334,11 @@ function Layout( { initialPost } ) {
 					/>
 				}
 				editorNotices={ <EditorNotices /> }
-				secondarySidebar={ secondarySidebar() }
+				secondarySidebar={
+					mode === 'visual' &&
+					( ( isInserterOpened && <InserterSidebar /> ) ||
+						( isListViewOpened && <ListViewSidebar /> ) )
+				}
 				sidebar={
 					! isDistractionFree && (
 						<ComplementaryArea.Slot scope="core" />

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -60,7 +60,6 @@ const {
 	ListViewSidebar,
 	InterfaceSkeleton,
 	ComplementaryArea,
-	interfaceStore,
 	SavePublishPanels,
 	Sidebar,
 	TextEditor,
@@ -101,7 +100,6 @@ export default function Editor( { isLoading } ) {
 		editorMode,
 		canvasMode,
 		blockEditorMode,
-		isRightSidebarOpen,
 		isInserterOpen,
 		isListViewOpen,
 		isDistractionFree,
@@ -116,7 +114,6 @@ export default function Editor( { isLoading } ) {
 			select( editSiteStore )
 		);
 		const { __unstableGetEditorMode } = select( blockEditorStore );
-		const { getActiveComplementaryArea } = select( interfaceStore );
 		const { getEntityRecord, getCurrentTheme } = select( coreDataStore );
 		const {
 			isInserterOpened,
@@ -142,7 +139,6 @@ export default function Editor( { isLoading } ) {
 			blockEditorMode: __unstableGetEditorMode(),
 			isInserterOpen: isInserterOpened(),
 			isListViewOpen: isListViewOpened(),
-			isRightSidebarOpen: getActiveComplementaryArea( 'core' ),
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			showIconLabels: get( 'core', 'showIconLabels' ),
@@ -187,8 +183,6 @@ export default function Editor( { isLoading } ) {
 		CanvasLoader,
 		'edit-site-editor__loading-progress'
 	);
-
-	const { closeGeneralSidebar } = useDispatch( editSiteStore );
 
 	const settings = useSpecificEditorSettings();
 
@@ -357,12 +351,7 @@ export default function Editor( { isLoading } ) {
 						}
 						secondarySidebar={
 							isEditMode &&
-							( ( shouldShowInserter && (
-								<InserterSidebar
-									closeGeneralSidebar={ closeGeneralSidebar }
-									isRightSidebarOpen={ isRightSidebarOpen }
-								/>
-							) ) ||
+							( ( shouldShowInserter && <InserterSidebar /> ) ||
 								( shouldShowListView && <ListViewSidebar /> ) )
 						}
 						sidebar={


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/52632

Just a tiny non-impactful PR that removes some props being passed down to the InserterSidebar component. These props can now be selected directly in the component.

There is no functional change here.