### PR TITLE
Remove 'Manage...' prefix in Pages / Templates data views

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -87,7 +87,7 @@ export default function useLayoutAreas() {
 			areas: {
 				sidebar: (
 					<SidebarNavigationScreen
-						title={ __( 'Manage pages' ) }
+						title={ __( 'Pages' ) }
 						backPath={ {} }
 						content={ <DataViewsSidebarContent /> }
 					/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -20,7 +20,7 @@ export default function SidebarNavigationScreenTemplatesBrowse( { backPath } ) {
 
 	return (
 		<SidebarNavigationScreen
-			title={ __( 'Manage templates' ) }
+			title={ __( 'Templates' ) }
 			description={ __(
 				'Create new templates, or reset any customizations made to the templates supplied by your theme.'
 			) }


### PR DESCRIPTION
## What?
Remove the "Manage..." prefix in Pages / Templates data view sidebar titles. 

## Why?
See https://github.com/WordPress/gutenberg/issues/62101. Specifically: https://github.com/WordPress/gutenberg/issues/62101#issuecomment-2137597955.


## Testing Instructions
1. Open the Site Editor
2. Navigate to the "Pages" section
3. Observe the sidebar title is "Pages", not "Manage pages"
4. Navigate to the "Templates" section
5. Observe the sidebar title is "Templates", not "Manage templates"

<img width="358" alt="Screenshot 2024-05-29 at 16 15 34" src="https://github.com/WordPress/gutenberg/assets/846565/722382b2-97f5-4b83-a008-29f208d7a5c4">
<img width="357" alt="Screenshot 2024-05-29 at 16 15 42" src="https://github.com/WordPress/gutenberg/assets/846565/a883ac10-61fd-49a0-8172-fea3d3d78b14">

