### PR TITLE
MediaUpload: Keep track of the dialog state

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -396,10 +396,11 @@ class MediaUpload extends Component {
 
 	onClose() {
 		const { onClose } = this.props;
-
 		if ( onClose ) {
 			onClose();
 		}
+
+		this.isModalOpen = false;
 	}
 
 	updateCollection() {
@@ -421,6 +422,10 @@ class MediaUpload extends Component {
 	}
 
 	openModal() {
+		if ( this.isModalOpen ) {
+			return;
+		}
+
 		const {
 			allowedTypes,
 			gallery = false,
@@ -454,6 +459,7 @@ class MediaUpload extends Component {
 		}
 		this.initializeListeners();
 		this.frame.open();
+		this.isModalOpen = true;
 	}
 
 	render() {


### PR DESCRIPTION
## What?
Fixes #62105.
Related #61943.

PR updates `MediaUpload` to keep track of the Media Library dialog state. In rare cases, when the `open` method is called multiple times, it prevents several dialogs from opening.

## Why?
The "Inline Image" format opens the Media Library dialog by calling the `open` method during the render. It is a hack to emulate modal opening on a click, but React will call the class component methods like render [twice in development](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-double-rendering-in-development).

## Testing Instructions
1. Enable development mode for the post editor.
2. Create a post.
3. Add a Paragraph block.
4. Try adding the inline image.
5. Confirm that only one dialog is open.


<details><summary>Patch for enabling modes</summary>
<p>

```diff
diff --git .wp-env.json .wp-env.json
index 20d5597e54b..57d4e1a72d8 100644
--- .wp-env.json
+++ .wp-env.json
@@ -4,6 +4,9 @@
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {
+			"config": {
+				"SCRIPT_DEBUG": true
+			},
 			"mappings": {
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
diff --git packages/edit-post/src/index.js packages/edit-post/src/index.js
index 1e0b3fe7d4d..d80d3c161a6 100644
--- packages/edit-post/src/index.js
+++ packages/edit-post/src/index.js
@@ -7,7 +7,7 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import deprecated from '@wordpress/deprecated';
-import { createRoot } from '@wordpress/element';
+import { createRoot, StrictMode } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -131,12 +131,14 @@ export function initializeEditor(
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
 	root.render(
-		<Editor
-			settings={ settings }
-			postId={ postId }
-			postType={ postType }
-			initialEdits={ initialEdits }
-		/>
+		<StrictMode>
+			<Editor
+				settings={ settings }
+				postId={ postId }
+				postType={ postType }
+				initialEdits={ initialEdits }
+			/>
+		</StrictMode>
 	);
 
 	return root;
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.
