### PR TITLE
e2e: fix Site Editor Styles test

### DIFF
--- a/test/e2e/specs/site-editor/styles.spec.js
+++ b/test/e2e/specs/site-editor/styles.spec.js
@@ -45,15 +45,14 @@ test.describe( 'Styles', () => {
 			.getByRole( 'button', { name: 'Social Icons block styles' } )
 			.click();
 
-		// find the second padding control
-		const paddingControl = page
-			.locator( '[aria-label="padding"]' )
-			.nth( 1 );
-
-		// Change the padding value
-		await paddingControl.fill( '2' );
+		// Find the second padding control and change the padding value
+		await page
+			.getByRole( 'button', { name: 'Set custom size' } )
+			.nth( 1 )
+			.click();
+		await page.getByRole( 'spinbutton', { name: 'padding' } ).fill( '35' );
 
 		// Check the padding value
-		await expect( block ).toHaveCSS( 'padding-left', '35.4932px' );
+		await expect( block ).toHaveCSS( 'padding-left', '35px' );
 	} );
 } );

--- a/test/e2e/specs/site-editor/styles.spec.js
+++ b/test/e2e/specs/site-editor/styles.spec.js
@@ -54,6 +54,6 @@ test.describe( 'Styles', () => {
 		await paddingControl.fill( '2' );
 
 		// Check the padding value
-		await expect( block ).toHaveCSS( 'padding-left', '35.4644px' );
+		await expect( block ).toHaveCSS( 'padding-left', '35.4932px' );
 	} );
 } );


### PR DESCRIPTION
## What?

This PR fixes the failing E2E tests.

## Why?

This failure first occurred after #61835 was merged, which [changed the border to box-shadow in the site editor sidebar](https://github.com/WordPress/gutenberg/pull/61835/files#diff-eafe5c0c08285ac8baec6e6005cf059bd61d4b53f70cef3a407cfd32f27373b8L131-R132). This changes the width of the editor canvas by 1px.

The failing test, on the other hand, applies padding in the global styles and asserts a calculated value. But in TT3, [this spacing value uses the clamp function](https://github.com/WordPress/wordpress-develop/blob/a53b5314eabb6afbbd2b19e4c703559f229ee9da/src/wp-content/themes/twentytwentythree/theme.json#L74), so it depends on the width of the editor canvas. Since the width of the editor canvas has changed by 1px, it seems the calculated value would change too.

## Testing Instructions

The E2E tests should pass, but Linting will fail. Linting will be fixed in #62109.