### PR TITLE
Tweak pattern categories sidebar

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -147,7 +147,10 @@ function BlockPattern( {
 							/>
 
 							{ showTitle && (
-								<HStack className="block-editor-patterns__pattern-details">
+								<HStack
+									className="block-editor-patterns__pattern-details"
+									spacing={ 2 }
+								>
 									{ pattern.type ===
 										INSERTER_PATTERN_TYPES.user &&
 										! pattern.syncStatus && (

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -28,7 +28,7 @@
 
 	.block-editor-block-patterns-list__item-title {
 		flex-grow: 1;
-		font-size: 12px;
+		font-size: $helptext-font-size;
 		text-align: left;
 	}
 
@@ -60,7 +60,7 @@
 	.block-editor-patterns__pattern-details:not(:empty) {
 		align-items: center;
 		margin-top: $grid-unit-10;
-		margin-bottom: $grid-unit-10; // Add more space as there is a visual label on user-created patterns.
+		padding-bottom: $grid-unit-05; // Add more space for labels on user-created patterns.
 	}
 
 	.block-editor-patterns__pattern-icon-wrapper {

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -27,8 +27,9 @@
 	scroll-margin-bottom: ($grid-unit-40 + $grid-unit-30);
 
 	.block-editor-block-patterns-list__item-title {
-		text-align: left;
 		flex-grow: 1;
+		font-size: 12px;
+		text-align: left;
 	}
 
 	.block-editor-block-preview__container {
@@ -59,7 +60,7 @@
 	.block-editor-patterns__pattern-details:not(:empty) {
 		align-items: center;
 		margin-top: $grid-unit-10;
-		margin-bottom: $grid-unit-05; // Add more space as there is a visual label on user-created patterns.
+		margin-bottom: $grid-unit-10; // Add more space as there is a visual label on user-created patterns.
 	}
 
 	.block-editor-patterns__pattern-icon-wrapper {

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -136,7 +136,12 @@ export function PatternCategoryPreviews( {
 			>
 				<HStack>
 					<FlexBlock>
-						<Heading level={ 4 } as="div">
+						<Heading
+							className="block-editor-inserter__patterns-category-panel-title"
+							size={ 13 }
+							level={ 4 }
+							as="div"
+						>
 							{ category.label }
 						</Heading>
 					</FlexBlock>

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -113,7 +113,8 @@ export function PatternsFilter( {
 				popoverProps={ {
 					placement: 'right-end',
 				} }
-				label="Filter patterns"
+				label={ __( 'Filter patterns' ) }
+				toggleProps={ { size: 'compact' } }
 				icon={
 					<Icon
 						icon={
@@ -126,7 +127,7 @@ export function PatternsFilter( {
 							>
 								<Path
 									d="M10 17.5H14V16H10V17.5ZM6 6V7.5H18V6H6ZM8 12.5H16V11H8V12.5Z"
-									fill="#1E1E1E"
+									fill="currentColor"
 								/>
 							</SVG>
 						}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -525,8 +525,8 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__patterns-category-panel-title {
-	font-size: calc(1.25 * 13px);
+.components-heading.block-editor-inserter__patterns-category-panel-title {
+	font-weight: 500;
 }
 
 .block-editor-inserter__patterns-explore-button,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

I abstracted the visual metrics and relevant fixes applied within https://github.com/WordPress/gutenberg/pull/61518, as that effort needs more exploration. 

- Applies updated styling, improved metrics, and hierarchy to the patterns categories sidebar. 
- Fixes missing i18n and fixed hex color in the filter icon. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Open the Inserter.
3. Select the "Patterns" tab.
4. Select a category. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-30 at 16 18 46](https://github.com/WordPress/gutenberg/assets/1813435/b4ae31f4-400d-4202-a15e-73567dcfb0dc)|![CleanShot 2024-05-30 at 16 17 51](https://github.com/WordPress/gutenberg/assets/1813435/8f3a7f3d-a97f-47a5-a1ba-7b7cdcdf1d4d)|