### PR TITLE
Transform Styles: Update selector so that styles work when custom fields panel is active

### DIFF
--- a/packages/block-editor/src/utils/test/__snapshots__/transform-styles.js.snap
+++ b/packages/block-editor/src/utils/test/__snapshots__/transform-styles.js.snap
@@ -24,6 +24,12 @@ exports[`transformStyles URL rewrite should rewrite relative paths 1`] = `
 ]
 `;
 
+exports[`transformStyles error handling should handle multiple instances of \`:root :where(body)\` 1`] = `
+[
+  ".my-namespace { color: pink; } .my-namespace { color: orange; }",
+]
+`;
+
 exports[`transformStyles error handling should handle multiple instances of \`:where(body)\` 1`] = `
 [
   ".my-namespace { color: pink; } .my-namespace { color: orange; }",

--- a/packages/block-editor/src/utils/test/__snapshots__/transform-styles.js.snap
+++ b/packages/block-editor/src/utils/test/__snapshots__/transform-styles.js.snap
@@ -30,12 +30,6 @@ exports[`transformStyles error handling should handle multiple instances of \`:r
 ]
 `;
 
-exports[`transformStyles error handling should handle multiple instances of \`:where(body)\` 1`] = `
-[
-  ".my-namespace { color: pink; } .my-namespace { color: orange; }",
-]
-`;
-
 exports[`transformStyles selector wrap should ignore font-face selectors 1`] = `
 [
   "

--- a/packages/block-editor/src/utils/test/transform-styles.js
+++ b/packages/block-editor/src/utils/test/transform-styles.js
@@ -52,8 +52,8 @@ describe( 'transformStyles', () => {
 			);
 		} );
 
-		it( 'should handle multiple instances of `:where(body)`', () => {
-			const input = `:where(body) { color: pink; } :where(body) { color: orange; }`;
+		it( 'should handle multiple instances of `:root :where(body)`', () => {
+			const input = `:root :where(body) { color: pink; } :root :where(body) { color: orange; }`;
 			const output = transformStyles(
 				[
 					{

--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -18,7 +18,7 @@ function transformStyle(
 	if ( ! wrapperSelector && ! baseURL ) {
 		return css;
 	}
-	const postcssFriendlyCSS = css.replace( /:where\(body\)/g, 'body' );
+	const postcssFriendlyCSS = css.replace( /:root :where\(body\)/g, 'body' );
 	try {
 		return postcss(
 			[

--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -18,7 +18,9 @@ function transformStyle(
 	if ( ! wrapperSelector && ! baseURL ) {
 		return css;
 	}
-	const postcssFriendlyCSS = css.replace( /:root :where\(body\)/g, 'body' );
+	const postcssFriendlyCSS = css
+		.replace( /:root :where\(body\)/g, 'body' )
+		.replace( /:where\(body\)/g, 'body' );
 	try {
 		return postcss(
 			[


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #62091 

This re-implements the fix from #61602.

Update the selector in `transformStyle` to match the new selector for global styles rules introduced in https://github.com/WordPress/gutenberg/pull/61638 (the rules are now prefixed with `:root `).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the styles were prefixed with the addition of `:root `, the transform in `transformStyles` that allows the styles to work in the non-iframed editor no longer matched against the global styles rules. This PR should restore the behaviour so that the editor looks correct in both iframed and non-iframed modes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `:root ` to the selector of the `transformStyle` logic that matches against rules intended for the body element

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With TT4 theme active, open the post editor
2. In editor preferences, enable Advanced > Custom fields
3. Reload the editor
4. On `trunk` note that the global styles rules are not applied in the editor. With this PR applied the styles should be restored.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/9dd01818-b6a3-4435-8882-eea19b4da4a4) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/6bc3ddf3-f53c-408c-80c1-5b9ece1f982f) |