### PR TITLE
Editor: Unify button size in pre-publish panel

### DIFF
--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -96,6 +96,7 @@ export class PostPublishPanel extends Component {
 									disabled={ isSavingNonPostEntityChanges }
 									onClick={ onClose }
 									variant="secondary"
+									size="compact"
 								>
 									{ __( 'Cancel' ) }
 								</Button>

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -447,7 +447,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
         class="editor-post-publish-panel__header-cancel-button"
       >
         <button
-          class="components-button is-secondary"
+          class="components-button is-secondary is-compact"
           type="button"
         >
           Cancel
@@ -600,7 +600,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
         class="editor-post-publish-panel__header-cancel-button"
       >
         <button
-          class="components-button is-secondary"
+          class="components-button is-secondary is-compact"
           type="button"
         >
           Cancel
@@ -797,7 +797,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
         class="editor-post-publish-panel__header-cancel-button"
       >
         <button
-          class="components-button is-secondary"
+          class="components-button is-secondary is-compact"
           type="button"
         >
           Cancel


### PR DESCRIPTION
Follow-up: #58532

## What?

This PR unifies button sizes in the pre-publish panel.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/9c1274b8-392c-4d77-b72e-fec32b498106)| ![image](https://github.com/WordPress/gutenberg/assets/54422211/6d5afeb3-3f05-4ba1-ad63-8a82b4e34580) | 


## Why?

We unified the height of header buttons in #58532, but I forgot about the Cancel button.

## Testing Instructions

Create a new post and click the Publish button.