### PR TITLE
Global Styles: Prevent Typography panel title from wrapping

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -7,7 +7,6 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	Button,
-	Tooltip,
 } from '@wordpress/components';
 import { settings } from '@wordpress/icons';
 import { useContext } from '@wordpress/element';
@@ -40,18 +39,12 @@ function FontFamilies() {
 			<VStack spacing={ 2 }>
 				<HStack justify="space-between">
 					<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
-					<HStack justify="flex-end">
-						<Tooltip text={ __( 'Manage fonts' ) }>
-							<Button
-								onClick={ () =>
-									toggleModal( 'installed-fonts' )
-								}
-								aria-label={ __( 'Manage fonts' ) }
-								icon={ settings }
-								size="small"
-							/>
-						</Tooltip>
-					</HStack>
+					<Button
+						onClick={ () => toggleModal( 'installed-fonts' ) }
+						label={ __( 'Manage fonts' ) }
+						icon={ settings }
+						size="small"
+					/>
 				</HStack>
 				{ hasFonts ? (
 					<ItemGroup isBordered isSeparated>


### PR DESCRIPTION
## What?

This PR will prevent Typography panel title from wrapping in certain languages.

## Why?

The toggle button in the font library is wrapped in a `H-Stack` component. This component has `width: 100%`, so it may squash elements at the same level.

![h-stack](https://github.com/WordPress/gutenberg/assets/54422211/3715d44f-faa5-4b33-bbbb-60daccdf2edf)

## How?

I removed the `H-Stack` component. At the same time, I also removed the redundant `Tooltip` component.

## Testing Instructions

- Change the site language to Japanese and update the translation file.
- Open the Typography panel in the Global Styles.
- Confirm that the title does not wrap.
- When you hover over the toggle button, the tooltip appears as before.

## Screenshots or screencast <!-- if applicable -->

| Locale | Before | After |
|--------|--------|--------|
| Japanese (ja) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/6cf066f1-6005-41b9-a62c-73d9be9200b8) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/87bbb8bf-f49e-4b90-8b31-7264870e0841) |
| 繁體中文 (zh_TW)| ![image](https://github.com/WordPress/gutenberg/assets/54422211/60a87d1a-8774-499d-ac52-99abf0c4d8b7) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/1ca58456-2e7f-4ba5-97b1-a53db0aa16aa)|