### PR TITLE
Block Styles: Fix block style variation styles for blocks with complex selectors

### DIFF
--- a/backport-changelog/6.6/6662.md
+++ b/backport-changelog/6.6/6662.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/6662
 
 * https://github.com/WordPress/gutenberg/pull/57908
+* https://github.com/WordPress/gutenberg/pull/62125

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -7,17 +7,17 @@
  */
 
 /**
- * Generate class name for this application of this block's variation styles.
+ * Generate block style variation instance name.
  *
  * @since 6.6.0
  *
  * @param array  $block     Block object.
  * @param string $variation Slug for the block style variation.
  *
- * @return string The unique class name.
+ * @return string The unique variation name.
  */
-function gutenberg_create_block_style_variation_class_name( $block, $variation ) {
-	return 'is-style-' . $variation . '--' . md5( serialize( $block ) );
+function gutenberg_create_block_style_variation_instance_name( $block, $variation ) {
+	return $variation . '--' . md5( serialize( $block ) );
 }
 
 /**
@@ -79,10 +79,9 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 		return $parsed_block;
 	}
 
-	$class_name         = gutenberg_create_block_style_variation_class_name( $parsed_block, $variation );
+	$variation_instance = gutenberg_create_block_style_variation_instance_name( $parsed_block, $variation );
+	$class_name         = "is-style-$variation_instance";
 	$updated_class_name = $parsed_block['attrs']['className'] . " $class_name";
-	$variation_instance = substr( $class_name, 9 );
-	$selector           = ".$class_name";
 
 	/*
 	 * Even though block style variations are effectively theme.json partials,
@@ -135,7 +134,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 		array( 'custom' ),
 		array(
 			'skip_root_layout_styles' => true,
-			'scope'                   => $selector,
+			'scope'                   => ".$class_name",
 		)
 	);
 

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -150,7 +150,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 		return $parsed_block;
 	}
 
-	wp_register_style( 'block-style-variation-styles', false, array( 'global-styles' ) );
+	wp_register_style( 'block-style-variation-styles', false, array( 'global-styles', 'wp-block-library' ) );
 	wp_add_inline_style( 'block-style-variation-styles', $variation_styles );
 
 	/*

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -84,14 +84,16 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 	$variation_instance = substr( $class_name, 9 );
 	$class_name         = ".$class_name";
 
-	// To support blocks with more complex selectors, that can apply styles to
-	// inner markup or even different inner elements depending on the feature,
-	// the variation style data needs to be manipulated some. If the root variation
-	// styles are moved under a variations property they will generate as desired.
-	//
-	// Example blocks that require this approach include:
-	// - Button: `.wp-block-button .wp-block-button__link`
-	// - Image: `.wp-block-image` and `.wp-block-image img` for borders, shadow etc.
+	/*
+	 * To support blocks with more complex selectors, that can apply styles to
+	 * inner markup or even different inner elements depending on the feature,
+	 * the variation style data needs to be manipulated some. If the root variation
+	 * styles are moved under a variations property they will generate as desired.
+	 *
+	 * Example blocks that require this approach include:
+	 *  - Button: `.wp-block-button .wp-block-button__link`
+	 *  - Image: `.wp-block-image` and `.wp-block-image img` for borders, shadow etc.
+	 */
 	$elements_data = $variation_data['elements'] ?? array();
 	$blocks_data   = $variation_data['blocks'] ?? array();
 	unset( $variation_data['elements'] );

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -185,7 +185,7 @@ function gutenberg_render_block_style_variation_class_name( $block_content, $blo
 	 * Matches a class prefixed by `is-style`, followed by the
 	 * variation slug, then `--`, and finally a hash.
 	 *
-	 * See `gutenberg_create_block_style_variation_class_name` for class generation.
+	 * See `gutenberg_create_block_style_variation_instance_name` for class generation.
 	 */
 	preg_match( '/\bis-style-(\S+?--\w+)\b/', $block['attrs']['className'], $matches );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/62122

## What?

Fixes the style generation for instanced block style variations for blocks that use complex selectors. For example:
- Button: `.wp-block-button .wp-block-button__link`
- Image: 
   - `.wp-block-image`
   - `.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder`

## Why?

Without this fix, variation styles when applied to an instance would only be applied to the block's wrapper. This means styles like the Button block's outline block style would get double borders, padding et.c

## How?

Reworks the generation of the instanced block style variation stylesheets so that the result has selectors that apply different types of styles to the block's desired elements. For example, the Button block styles go to the inner `.wp-block-button__link` element or an Image's border goes to the inner `img`

The style load order was also tweaked to ensure the block style variations styles were loaded after the block library styles. 

## Testing Instructions

1. Register some custom block style variations following [#57908](https://github.com/WordPress/gutenberg/pull/57908)'s instructions
2. Apply these in a nested fashion and ensure they still continue to work
3. Make sure you have a button block in your post or page
4. Apply the outline block style to the button
5. Make sure all the blocks display correctly in both editors and the frontend
6. Disable separate core block assets via snippet below or activate a theme which does such as [Powder](https://github.com/bgardner/powder/tree/main)
7. Confirm block library styles do not override the outline block style variation styles for Button blocks

`add_filter( 'should_load_separate_core_block_assets', '__return_false' );`

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="1416" alt="Screenshot 2024-05-30 at 4 25 25 PM" src="https://github.com/WordPress/gutenberg/assets/60436221/1b75d076-fee0-44f9-92d2-8b736ae70069"> | <img width="1375" alt="Screenshot 2024-05-30 at 4 25 08 PM" src="https://github.com/WordPress/gutenberg/assets/60436221/f63af947-7fda-4f7c-af9a-42e52b959df3"> |
