### PR TITLE
Button: Fix ESLint warning

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -250,7 +250,7 @@ function ButtonEdit( props ) {
 						blockBindingsSource?.lockAttributesEditing() ),
 			};
 		},
-		[ isSelected ]
+		[ isSelected, metadata?.bindings?.url ]
 	);
 
 	return (

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -145,7 +145,7 @@ export function ImageEdit( {
 				scale: undefined,
 			} );
 		}
-	}, [ align ] );
+	}, [ __unstableMarkNextChangeAsNotPersistent, align, setAttributes ] );
 
 	const { getSettings } = useSelect( blockEditorStore );
 	const blockEditingMode = useBlockEditingMode();
@@ -328,7 +328,7 @@ export function ImageEdit( {
 					: __( 'Connected to dynamic data' ),
 			};
 		},
-		[ isSingleSelected ]
+		[ isSingleSelected, metadata?.bindings?.url ]
 	);
 	const placeholder = ( content ) => {
 		return (


### PR DESCRIPTION
## What?
PR updates the `useSelect` hook dependencies for the button block and fixes the ESLint warning.

Noticed while debugging #62089.

```
React Hook useSelect has a missing dependency: 'metadata?.bindings?.url'. Either include it or remove the dependency array.
```

## Testing Instructions
The functionality has e2e test coverage. CI checks should be green.

### Testing Instructions for Keyboard
Same
