### PR TITLE
Rich text: preserve comments

### DIFF
--- a/packages/block-editor/src/components/rich-text/content.scss
+++ b/packages/block-editor/src/components/rich-text/content.scss
@@ -13,10 +13,6 @@
 	&:focus {
 		// Removes outline added by the browser.
 		outline: none;
-
-		[data-rich-text-format-boundary] {
-			border-radius: $radius-small;
-		}
 	}
 }
 
@@ -32,11 +28,29 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 	opacity: 0.8;
 }
 
+[data-rich-text-comment],
+[data-rich-text-script],
+[data-rich-text-format-boundary] {
+	border-radius: 2px;
+}
+
+[data-rich-text-comment],
 [data-rich-text-script] {
 	display: inline;
+	background-color: currentColor;
 
 	&::before {
-		content: "</>";
-		background: rgb(255, 255, 0);
+		filter: invert(100%);
+		color: currentColor;
 	}
+}
+
+[data-rich-text-script]::before {
+	content: "</>";
+}
+
+// Only fill in the comment content if the comment is not replaced (in the
+// future they might be by Bits).
+[data-rich-text-comment]:empty::before {
+	content: "[" attr(data-rich-text-comment) "]";
 }

--- a/packages/block-editor/src/components/rich-text/content.scss
+++ b/packages/block-editor/src/components/rich-text/content.scss
@@ -28,29 +28,25 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 	opacity: 0.8;
 }
 
+[data-rich-text-script] {
+	display: inline;
+
+	&::before {
+		content: "</>";
+		background: rgb(255, 255, 0);
+	}
+}
+
 [data-rich-text-comment],
-[data-rich-text-script],
 [data-rich-text-format-boundary] {
 	border-radius: 2px;
 }
 
-[data-rich-text-comment],
-[data-rich-text-script] {
-	display: inline;
+[data-rich-text-comment] {
 	background-color: currentColor;
 
-	&::before {
+	span {
 		filter: invert(100%);
 		color: currentColor;
 	}
-}
-
-[data-rich-text-script]::before {
-	content: "</>";
-}
-
-// Only fill in the comment content if the comment is not replaced (in the
-// future they might be by Bits).
-[data-rich-text-comment]:empty::before {
-	content: "[" attr(data-rich-text-comment) "]";
 }

--- a/packages/block-editor/src/components/rich-text/content.scss
+++ b/packages/block-editor/src/components/rich-text/content.scss
@@ -48,5 +48,6 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 	span {
 		filter: invert(100%);
 		color: currentColor;
+		padding: 0 2px;
 	}
 }

--- a/packages/block-editor/src/components/rich-text/content.scss
+++ b/packages/block-editor/src/components/rich-text/content.scss
@@ -39,7 +39,7 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 
 [data-rich-text-comment],
 [data-rich-text-format-boundary] {
-	border-radius: 2px;
+	border-radius: $radius-small;
 }
 
 [data-rich-text-comment] {

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -469,6 +469,34 @@ function createFromElement( { element, range, isEditableTree } ) {
 			continue;
 		}
 
+		if (
+			node.nodeType === node.COMMENT_NODE ||
+			( node.nodeType === node.ELEMENT_NODE &&
+				node.tagName === 'SPAN' &&
+				node.hasAttribute( 'data-rich-text-comment' ) )
+		) {
+			const value = {
+				formats: [ , ],
+				replacements: [
+					{
+						type: '#comment',
+						attributes: {
+							'data-rich-text-comment':
+								node.nodeType === node.COMMENT_NODE
+									? node.nodeValue
+									: node.getAttribute(
+											'data-rich-text-comment'
+									  ),
+						},
+					},
+				],
+				text: OBJECT_REPLACEMENT_CHARACTER,
+			};
+			accumulateSelection( accumulator, node, range, value );
+			mergePair( accumulator, value );
+			continue;
+		}
+
 		if ( node.nodeType !== node.ELEMENT_NODE ) {
 			continue;
 		}

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -272,6 +272,21 @@ exports[`recordToDom should not error with overlapping formats (2) 1`] = `
 </body>
 `;
 
+exports[`recordToDom should preserve comments 1`] = `
+<body>
+  
+  <span
+    contenteditable="false"
+    data-rich-text-comment="comment"
+  >
+    <span>
+      [comment]
+    </span>
+  </span>
+  
+</body>
+`;
+
 exports[`recordToDom should preserve emoji 1`] = `
 <body>
   🍒
@@ -285,6 +300,21 @@ exports[`recordToDom should preserve emoji in formatting 1`] = `
   >
     🍒
   </em>
+  
+</body>
+`;
+
+exports[`recordToDom should preserve funky comments 1`] = `
+<body>
+  
+  <span
+    contenteditable="false"
+    data-rich-text-comment="/funky"
+  >
+    <span>
+      [/funky]
+    </span>
+  </span>
   
 </body>
 `;

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -280,7 +280,7 @@ exports[`recordToDom should preserve comments 1`] = `
     data-rich-text-comment="comment"
   >
     <span>
-      [comment]
+      comment
     </span>
   </span>
   
@@ -312,7 +312,7 @@ exports[`recordToDom should preserve funky comments 1`] = `
     data-rich-text-comment="/funky"
   >
     <span>
-      [/funky]
+      /funky
     </span>
   </span>
   

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -551,6 +551,58 @@ export const spec = [
 			text: '\ufffc',
 		},
 	},
+	{
+		description: 'should preserve comments',
+		html: '<!--comment-->',
+		createRange: ( element ) => ( {
+			startOffset: 0,
+			startContainer: element,
+			endOffset: 1,
+			endContainer: element,
+		} ),
+		startPath: [ 0, 0 ],
+		endPath: [ 2, 0 ],
+		record: {
+			start: 0,
+			end: 1,
+			formats: [ , ],
+			replacements: [
+				{
+					attributes: {
+						'data-rich-text-comment': 'comment',
+					},
+					type: '#comment',
+				},
+			],
+			text: '\ufffc',
+		},
+	},
+	{
+		description: 'should preserve funky comments',
+		html: '<//funky>',
+		createRange: ( element ) => ( {
+			startOffset: 0,
+			startContainer: element,
+			endOffset: 1,
+			endContainer: element,
+		} ),
+		startPath: [ 0, 0 ],
+		endPath: [ 2, 0 ],
+		record: {
+			start: 0,
+			end: 1,
+			formats: [ , ],
+			replacements: [
+				{
+					attributes: {
+						'data-rich-text-comment': '/funky',
+					},
+					type: '#comment',
+				},
+			],
+			text: '\ufffc',
+		},
+	},
 ];
 
 export const specWithRegistration = [

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -68,10 +68,16 @@ function append( element, child ) {
 	const { type, attributes } = child;
 
 	if ( type ) {
-		child = element.ownerDocument.createElement( type );
+		if ( type === '#comment' ) {
+			child = element.ownerDocument.createComment(
+				attributes[ 'data-rich-text-comment' ]
+			);
+		} else {
+			child = element.ownerDocument.createElement( type );
 
-		for ( const key in attributes ) {
-			child.setAttribute( key, attributes[ key ] );
+			for ( const key in attributes ) {
+				child.setAttribute( key, attributes[ key ] );
+			}
 		}
 	}
 

--- a/packages/rich-text/src/to-html-string.js
+++ b/packages/rich-text/src/to-html-string.js
@@ -88,6 +88,15 @@ function remove( object ) {
 }
 
 function createElementHTML( { type, attributes, object, children } ) {
+	if ( type === '#comment' ) {
+		// We can't restore the original comment delimiters, because once parsed
+		// into DOM nodes, we don't have the information. But in the future we
+		// could allow comment handlers to specify custom delimiters, for
+		// example `</{comment-content}>` for Bits, where `comment-content`
+		// would be `/{bit-name}` or `__{translatable-string}` (TBD).
+		return `<!--${ attributes[ 'data-rich-text-comment' ] }-->`;
+	}
+
 	let attributeString = '';
 
 	for ( const key in attributes ) {

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -240,7 +240,7 @@ export function toTree( {
 				} );
 				append(
 					append( pointer, { type: 'span' } ),
-					attributes[ 'data-rich-text-comment' ]
+					'[' + attributes[ 'data-rich-text-comment' ] + ']'
 				);
 			} else if ( ! isEditableTree && type === 'script' ) {
 				pointer = append(

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -229,7 +229,16 @@ export function toTree( {
 			const { type, attributes, innerHTML } = replacement;
 			const formatType = getFormatType( type );
 
-			if ( ! isEditableTree && type === 'script' ) {
+			if ( isEditableTree && type === '#comment' ) {
+				pointer = append( getParent( pointer ), {
+					type: 'span',
+					attributes: {
+						contenteditable: 'false',
+						'data-rich-text-comment':
+							attributes[ 'data-rich-text-comment' ],
+					},
+				} );
+			} else if ( ! isEditableTree && type === 'script' ) {
 				pointer = append(
 					getParent( pointer ),
 					fromFormat( {

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -240,7 +240,7 @@ export function toTree( {
 				} );
 				append(
 					append( pointer, { type: 'span' } ),
-					'[' + attributes[ 'data-rich-text-comment' ] + ']'
+					attributes[ 'data-rich-text-comment' ].trim()
 				);
 			} else if ( ! isEditableTree && type === 'script' ) {
 				pointer = append(

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -238,6 +238,10 @@ export function toTree( {
 							attributes[ 'data-rich-text-comment' ],
 					},
 				} );
+				append(
+					append( pointer, { type: 'span' } ),
+					attributes[ 'data-rich-text-comment' ]
+				);
 			} else if ( ! isEditableTree && type === 'script' ) {
 				pointer = append(
 					getParent( pointer ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #60735.
Fixes #13318.

This PR preserves HTML comments in rich text. Currently they are stripped out when HTML is parsed by rich text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should leave the content intact and interfere as little as possible. While useful on its own (and fixing a bug), this is also a preparatory PR for Bits, as it will make use of comments to anchor dynamic content inline. In the editor, the comment will then be replaced through an API by either a placeholder or the data.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Rich text uses the browser's HTML parser, so it's quite easy to store this internally.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Insert a comment in a paragraph (through the code/HTML editor) and switch back to visual. There should be a placeholder. Edit the paragraph, and the placeholder/comment should remain.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="665" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/cb3f39ea-fdcc-4701-bd0b-c6ca12489283">

