### PR TITLE
Make the fonts management modal dialog more discoverable

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -5,11 +5,13 @@ import { __ } from '@wordpress/i18n';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	Button,
 } from '@wordpress/components';
+<<<<<<< HEAD
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { settings } from '@wordpress/icons';
+=======
+>>>>>>> 72a59c77a0 (Replace Manage fonts icon button with visible text button.)
 import { useContext } from '@wordpress/element';
 
 /**
@@ -51,24 +53,31 @@ function FontFamilies() {
 			) }
 
 			<VStack spacing={ 2 }>
-				<HStack justify="space-between">
-					<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
-					<Button
-						onClick={ () => setModalTabOpen( 'installed-fonts' ) }
-						label={ __( 'Manage fonts' ) }
-						icon={ settings }
-						size="small"
-					/>
-				</HStack>
+				<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
 				{ hasFonts ? (
-					<ItemGroup isBordered isSeparated>
-						{ customFonts.map( ( font ) => (
-							<FontFamilyItem key={ font.slug } font={ font } />
-						) ) }
-						{ themeFonts.map( ( font ) => (
-							<FontFamilyItem key={ font.slug } font={ font } />
-						) ) }
-					</ItemGroup>
+					<>
+						<ItemGroup isBordered isSeparated>
+							{ customFonts.map( ( font ) => (
+								<FontFamilyItem
+									key={ font.slug }
+									font={ font }
+								/>
+							) ) }
+							{ themeFonts.map( ( font ) => (
+								<FontFamilyItem
+									key={ font.slug }
+									font={ font }
+								/>
+							) ) }
+						</ItemGroup>
+						<Button
+							className="edit-site-global-styles-font-families__manage-fonts"
+							variant="secondary"
+							onClick={ () => setModalTabOpen( 'installed-fonts' ) }
+						>
+							{ __( 'Manage fonts' ) }
+						</Button>
+					</>
 				) : (
 					<>
 						{ __( 'No fonts installed.' ) }

--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -7,11 +7,7 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-<<<<<<< HEAD
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { settings } from '@wordpress/icons';
-=======
->>>>>>> 72a59c77a0 (Replace Manage fonts icon button with visible text button.)
 import { useContext } from '@wordpress/element';
 
 /**
@@ -73,7 +69,9 @@ function FontFamilies() {
 						<Button
 							className="edit-site-global-styles-font-families__manage-fonts"
 							variant="secondary"
-							onClick={ () => setModalTabOpen( 'installed-fonts' ) }
+							onClick={ () =>
+								setModalTabOpen( 'installed-fonts' )
+							}
 						>
 							{ __( 'Manage fonts' ) }
 						</Button>

--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -69,6 +69,7 @@ function FontFamilies() {
 						<Button
 							className="edit-site-global-styles-font-families__manage-fonts"
 							variant="secondary"
+							__next40pxDefaultSize
 							onClick={ () =>
 								setModalTabOpen( 'installed-fonts' )
 							}
@@ -82,6 +83,7 @@ function FontFamilies() {
 						<Button
 							className="edit-site-global-styles-font-families__add-fonts"
 							variant="secondary"
+							__next40pxDefaultSize
 							onClick={ () => setModalTabOpen( 'upload-fonts' ) }
 						>
 							{ __( 'Add fonts' ) }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -41,7 +41,8 @@
 	color: $gray-700;
 }
 
-.edit-site-global-styles-font-families__add-fonts {
+.edit-site-global-styles-font-families__add-fonts,
+.edit-site-global-styles-font-families__manage-fonts {
 	justify-content: center;
 }
 

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -14,15 +14,15 @@ test.describe( 'Font Library', () => {
 			await editor.canvas.locator( 'body' ).click();
 		} );
 
-		test( 'should display the "Manage Fonts" icon', async ( { page } ) => {
+		test( 'should display the "Add fonts" button', async ( { page } ) => {
 			await page.getByRole( 'button', { name: 'Styles' } ).click();
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
-			const manageFontsIcon = page.getByRole( 'button', {
-				name: 'Manage Fonts',
+			const addFontsButton = page.getByRole( 'button', {
+				name: 'Add fonts',
 			} );
-			await expect( manageFontsIcon ).toBeVisible();
+			await expect( addFontsButton ).toBeVisible();
 		} );
 	} );
 
@@ -36,18 +36,20 @@ test.describe( 'Font Library', () => {
 			await editor.canvas.locator( 'body' ).click();
 		} );
 
-		test( 'should display the "Manage Fonts" icon', async ( { page } ) => {
+		test( 'should display the "Manage fonts" button', async ( {
+			page,
+		} ) => {
 			await page.getByRole( 'button', { name: 'Styles' } ).click();
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
-			const manageFontsIcon = page.getByRole( 'button', {
-				name: 'Manage Fonts',
+			const manageFontsButton = page.getByRole( 'button', {
+				name: 'Manage fonts',
 			} );
-			await expect( manageFontsIcon ).toBeVisible();
+			await expect( manageFontsButton ).toBeVisible();
 		} );
 
-		test( 'should open the "Manage Fonts" modal when clicking the "Manage Fonts" icon', async ( {
+		test( 'should open the "Manage fonts" modal when clicking the "Manage fonts" button', async ( {
 			page,
 		} ) => {
 			await page.getByRole( 'button', { name: 'Styles' } ).click();
@@ -56,7 +58,7 @@ test.describe( 'Font Library', () => {
 				.click();
 			await page
 				.getByRole( 'button', {
-					name: 'Manage Fonts',
+					name: 'Manage fonts',
 				} )
 				.click();
 			await expect( page.getByRole( 'dialog' ) ).toBeVisible();
@@ -74,7 +76,7 @@ test.describe( 'Font Library', () => {
 				.click();
 			await page
 				.getByRole( 'button', {
-					name: 'Manage Fonts',
+					name: 'Manage fonts',
 				} )
 				.click();
 			await page.getByRole( 'button', { name: 'System Font' } ).click();
@@ -120,12 +122,11 @@ test.describe( 'Font Library', () => {
 				.click();
 			await page
 				.getByRole( 'button', {
-					name: 'Manage Fonts',
+					name: 'Add fonts',
 				} )
 				.click();
 
 			// Upload local fonts.
-			await page.getByRole( 'tab', { name: 'Upload' } ).click();
 			const fileChooserPromise = page.waitForEvent( 'filechooser' );
 			await page.getByRole( 'button', { name: 'Upload Font' } ).click();
 			const fileChooser = await fileChooserPromise;
@@ -163,7 +164,7 @@ test.describe( 'Font Library', () => {
 			await page.getByRole( 'button', { name: 'Back' } ).click();
 			await page
 				.getByRole( 'button', {
-					name: 'Manage Fonts',
+					name: 'Manage fonts',
 				} )
 				.click();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/55179

## What?
<!-- In a few words, what is the PR actually doing? -->
Direct users feedback from the FSE Outreach Program and feedback from other contributors reported the font management modal dialog is little discoverable. https://github.com/WordPress/gutenberg/pull/58580 was only a partial improvement and only addressed the scenario when there's no fonts installed by making two changes:
- By adding an 'Add fonts' button. with visible text. This button opens the modal dialog to the 'Upload' tab.
- By replacing the `Aa` icon with the `settings` icon fot the button that opens the modal dialog to the 'Library' tab.

Screenshot of current situation:

![before](https://github.com/WordPress/gutenberg/assets/1682452/ced0132a-48e5-494a-9f74-f6153d6e0aca)

I can see a few issues with this.

**When there's no fonts installed:**
- The Manage Fonts 'settings' icon button opens the modal dialog showing the Library tab panel. Of course, when there's no fonts installed, this panel is empty. There's nothing users can do here.
- As far as I can tell, this is a unique case in the editor where a 'settings' icon button opens a modal dialog. This is inconsistent and potentially unexpected for users. In fact, the 'settings' icon is generally used to switch a setting control to an alternative version or for view / display settings.
- The modal dialog is a place where users can manage, upload, install, activate, deactivate fonts. It's not about 'settings'.

When there are fonts installed:
- The 'Add fonts' button disappears. This is potentially unexpected for users. As a user, I would wonder 'where's that button that I previously clicked? How can I open the font Library?' There's only two ways to do that:
  - Click an individual font. However, that brings users to the font details 'sub view'. Users would have to click go back to get the font Library.
  - Click the settings icon button. Which is reported as little discoverable and it's the main point of this issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Opening the fonts modal dialog is little discoverable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Replaces the 'settings' icon button with a 'Manage fonts' button with visible text.
- The new button is consistent with the 'Add fonts' button. It's where users would expect to see it.
- It is only shown in place of the 'Add fonts' button, when there are fonts installed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Start with no fonts installed, or uninstall / deactivate all fonts.
- Go to Site editor > Styles > Typography
- In the Typography panel, observe there's no 'settings' icon button any longer.
- Observe the 'Add fonts' button is unchanged.
- Add or activate some fonts and then close the modal dialog.
- Observe there's a new 'Manage fonts' button at the end of the fonts list.
- Click the 'Manage fonts' button. Observe it brings directly to the modal dialog > Library tab.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

After:

![after](https://github.com/WordPress/gutenberg/assets/1682452/b54e545e-6ffe-492b-a711-02d2369a2493)

