### PR TITLE
Format Library: Refactor 'Inline Image' edit component

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -104,56 +104,43 @@ function Edit( {
 	activeObjectAttributes,
 	contentRef,
 } ) {
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
-
-	function openModal() {
-		setIsModalOpen( true );
-	}
-
-	function closeModal() {
-		setIsModalOpen( false );
-	}
-
 	return (
 		<MediaUploadCheck>
-			<RichTextToolbarButton
-				icon={
-					<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-						<Path d="M4 18.5h16V17H4v1.5zM16 13v1.5h4V13h-4zM5.1 15h7.8c.6 0 1.1-.5 1.1-1.1V6.1c0-.6-.5-1.1-1.1-1.1H5.1C4.5 5 4 5.5 4 6.1v7.8c0 .6.5 1.1 1.1 1.1zm.4-8.5h7V10l-1-1c-.3-.3-.8-.3-1 0l-1.6 1.5-1.2-.7c-.3-.2-.6-.2-.9 0l-1.3 1V6.5zm0 6.1l1.8-1.3 1.3.8c.3.2.7.2.9-.1l1.5-1.4 1.5 1.4v1.5h-7v-.9z" />
-					</SVG>
-				}
-				title={ title }
-				onClick={ openModal }
-				isActive={ isObjectActive }
+			<MediaUpload
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				onSelect={ ( { id, url, alt, width: imgWidth } ) => {
+					onChange(
+						insertObject( value, {
+							type: name,
+							attributes: {
+								className: `wp-image-${ id }`,
+								style: `width: ${ Math.min(
+									imgWidth,
+									150
+								) }px;`,
+								url,
+								alt,
+							},
+						} )
+					);
+					onFocus();
+				} }
+				render={ ( { open } ) => (
+					<RichTextToolbarButton
+						icon={
+							<SVG
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 24 24"
+							>
+								<Path d="M4 18.5h16V17H4v1.5zM16 13v1.5h4V13h-4zM5.1 15h7.8c.6 0 1.1-.5 1.1-1.1V6.1c0-.6-.5-1.1-1.1-1.1H5.1C4.5 5 4 5.5 4 6.1v7.8c0 .6.5 1.1 1.1 1.1zm.4-8.5h7V10l-1-1c-.3-.3-.8-.3-1 0l-1.6 1.5-1.2-.7c-.3-.2-.6-.2-.9 0l-1.3 1V6.5zm0 6.1l1.8-1.3 1.3.8c.3.2.7.2.9-.1l1.5-1.4 1.5 1.4v1.5h-7v-.9z" />
+							</SVG>
+						}
+						title={ title }
+						onClick={ open }
+						isActive={ isObjectActive }
+					/>
+				) }
 			/>
-			{ isModalOpen && (
-				<MediaUpload
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					onSelect={ ( { id, url, alt, width: imgWidth } ) => {
-						closeModal();
-						onChange(
-							insertObject( value, {
-								type: name,
-								attributes: {
-									className: `wp-image-${ id }`,
-									style: `width: ${ Math.min(
-										imgWidth,
-										150
-									) }px;`,
-									url,
-									alt,
-								},
-							} )
-						);
-						onFocus();
-					} }
-					onClose={ closeModal }
-					render={ ( { open } ) => {
-						open();
-						return null;
-					} }
-				/>
-			) }
 			{ isObjectActive && (
 				<InlineUI
 					value={ value }


### PR DESCRIPTION
## What?
Fixes #62105.
Alternative to #62135.
Related #61943.

PR updates the 'Inline Image' edit component and how it renders the media modal trigger. The `RichTextToolbarButton` now opens the modal directly instead of managing it via a separate state.

## Why?
The "Inline Image" format opens the Media Library dialog by calling the `open` method during the render. It is a hack to emulate modal opening on a click, but React will call the class component methods like render [twice in development](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-double-rendering-in-development).

## Testing Instructions
1. Enable development mode for the post editor.
2. Create a post.
3. Add a Paragraph block.
4. Try adding the inline image.
5. Confirm that only one dialog is open.


<details><summary>Patch for enabling modes</summary>
<p>

```diff
diff --git .wp-env.json .wp-env.json
index 20d5597e54b..57d4e1a72d8 100644
--- .wp-env.json
+++ .wp-env.json
@@ -4,6 +4,9 @@
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {
+			"config": {
+				"SCRIPT_DEBUG": true
+			},
 			"mappings": {
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
diff --git packages/edit-post/src/index.js packages/edit-post/src/index.js
index 1e0b3fe7d4d..d80d3c161a6 100644
--- packages/edit-post/src/index.js
+++ packages/edit-post/src/index.js
@@ -7,7 +7,7 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import deprecated from '@wordpress/deprecated';
-import { createRoot } from '@wordpress/element';
+import { createRoot, StrictMode } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -131,12 +131,14 @@ export function initializeEditor(
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
 	root.render(
-		<Editor
-			settings={ settings }
-			postId={ postId }
-			postType={ postType }
-			initialEdits={ initialEdits }
-		/>
+		<StrictMode>
+			<Editor
+				settings={ settings }
+				postId={ postId }
+				postType={ postType }
+				initialEdits={ initialEdits }
+			/>
+		</StrictMode>
 	);
 
 	return root;
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.