### PR TITLE
Post Summary: Move PostTemplatePanel below URL and Author

### DIFF
--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -71,9 +71,9 @@ export default function PostSummary( { onActionPerformed } ) {
 									<VStack spacing={ 1 }>
 										<PostStatusPanel />
 										<PostSchedulePanel />
-										<PostTemplatePanel />
 										<PostURLPanel />
 										<PostAuthorPanel />
+										<PostTemplatePanel />
 										<PostDiscussionPanel />
 										<PostSyncStatus />
 										<BlogTitle />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Deprioritize "Template" in the post summary below "Author" and "URL/Link."

## Why?
By moving the "Template" section below "Author" and "Link," the most relevant details for content management and quick identification are prioritized, making it easier for users to find, and edit, essential information at a glance.

This adjustment aligns with the goal of enhancing the overall user experience in content editing and review processes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a page (repeat for post). 
2. Open the Inspector. 
3. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-30 at 07 50 43](https://github.com/WordPress/gutenberg/assets/1813435/b2b210cc-6d16-4b34-80ab-402c162b968f)![CleanShot 2024-05-30 at 07 50 12](https://github.com/WordPress/gutenberg/assets/1813435/a858b520-9993-4ff4-9f29-085fc8f9bc66)|![CleanShot 2024-05-30 at 07 55 21](https://github.com/WordPress/gutenberg/assets/1813435/63ec74b0-deb5-4cab-b21c-c1f85b5f94d7)![CleanShot 2024-05-30 at 07 55 41](https://github.com/WordPress/gutenberg/assets/1813435/bc6508f4-6f82-434e-b65b-7956215d9848)|