### PR TITLE
Link Control: Fix focus handlers in development mode

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -220,7 +220,6 @@ function LinkControl( {
 		// because otherwise using the keyboard to select text
 		// *within* the link format is not possible.
 		if ( isMounting.current ) {
-			isMounting.current = false;
 			return;
 		}
 
@@ -237,6 +236,16 @@ function LinkControl( {
 
 		isEndingEditWithFocus.current = false;
 	}, [ isEditingLink, isCreatingPage ] );
+
+	// The component mounting reference is maintained separately
+	// to correctly reset values in `StrictMode`.
+	useEffect( () => {
+		isMounting.current = false;
+
+		return () => {
+			isMounting.current = true;
+		};
+	}, [] );
 
 	const hasLinkValue = value?.url?.trim()?.length > 0;
 


### PR DESCRIPTION
## What?
Fixes #62089.
Related #61943.

PR fixes the `LinkControl` component's auto-focus handler and allows users to edit the linked text in development mode when the popover is rendered. 

## Why?
1. The initial value of  `isMounting` is true.
2. Effect runs and is set to false and returns early.
3. There's no cleanup, so the effect does nothing here.
4. Effect runs again; the `isMounting` is false, and focus logic is invoked.

## How?
Move the component's `isMounting` state synchronization into a separate effect and add a cleanup method.

## Testing Instructions
The following e2e test should pass in development mode, and CI checks should be green. See the original issue for enabling the dev mode.

```
npm run test:e2e -- editor/blocks/links.spec.js
npm run test:e2e -- editor/various/block-bindings.spec.js
```

### Testing Instructions for Keyboard
Same.
