### PR TITLE
Add curly brace autofix commit to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -18,3 +18,6 @@ c56e8a1910ed74f405b74bbb12fe81dea974e5c3
 
 # Autofix eslint curly rule.
 0221522f253e094b277a1485b7a2d186cb172632
+
+# ESLint: Enable react/jsx-curly-brace-presence
+5d4baa9ab5f57d207cc3a048003216a8574574d9


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Ignore automated commit 5d4baa9ab5f57d207cc3a048003216a8574574d9.

Follow up to https://github.com/WordPress/gutenberg/pull/62026

## Why?

There are not meaningful changes in the commit, it's some tooling-applied changes.