### PR TITLE
Update copy for color variations from "Presets" to "Palettes"

### DIFF
--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -86,7 +86,7 @@ export default function ColorPalettePanel( { name } ) {
 				slugPrefix="custom-"
 				popoverProps={ popoverProps }
 			/>
-			<ColorVariations title={ __( 'Presets' ) } />
+			<ColorVariations title={ __( 'Palettes' ) } />
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -96,7 +96,7 @@ function SidebarNavigationScreenGlobalStylesContent() {
 			>
 				<StyleVariationsContainer gap={ gap } />
 				{ colorVariations?.length && (
-					<ColorVariations title={ __( 'Colors' ) } gap={ gap } />
+					<ColorVariations title={ __( 'Palettes' ) } gap={ gap } />
 				) }
 				{ typographyVariations?.length && (
 					<TypographyVariations


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates text string of "Presets" to "Palettes". 

## Why?
Instead of introducing a new term, let's lean in on how these color variations are color palettes. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor. 
2. Open the global styles sidebar. 
3. Select "Colors." 
4. Select the color palette to edit it.
5. See change. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-30 at 11 10 17](https://github.com/WordPress/gutenberg/assets/1813435/db7fa642-08b6-45b9-a2dd-200b07349ff7)|![CleanShot 2024-05-30 at 11 09 59](https://github.com/WordPress/gutenberg/assets/1813435/d56910ea-21f1-404e-b1ad-ff07c1a7c74c)|



