### PR TITLE
CustomSelectControl: Fix `menuProps` mutation

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -114,7 +114,7 @@ export default function CustomSelectControl( props ) {
 		return sprintf( __( 'Currently selected: %s' ), selectedItem.name );
 	}
 
-	const menuProps = getMenuProps( {
+	let menuProps = getMenuProps( {
 		className: 'components-custom-select-control__menu',
 		'aria-hidden': ! isOpen,
 	} );
@@ -131,7 +131,11 @@ export default function CustomSelectControl( props ) {
 	if (
 		menuProps[ 'aria-activedescendant' ]?.startsWith( 'downshift-null' )
 	) {
-		delete menuProps[ 'aria-activedescendant' ];
+		const {
+			'aria-activedescendant': ariaActivedescendant,
+			...restMenuProps
+		} = menuProps;
+		menuProps = restMenuProps;
 	}
 	return (
 		<div


### PR DESCRIPTION
## What?
This PR fixes a mutation that we're performing in the `CustomSelectControl` component and updates to use a new object instead.

## Why?
In this particular case, I'm fixing it to resolve an ESLint error that was raised by the React Compiler ESLint plugin in https://github.com/WordPress/gutenberg/pull/61788

## How?
Using a new object instead of mutating the existing one.

## Testing Instructions
Verify the v1 `CustomSelectControl` component still works.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None