### PR TITLE
Script Modules: Fix private method reflection access 

### DIFF
--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -212,9 +212,9 @@ function gutenberg_dequeue_module( $module_identifier ) {
  */
 function gutenberg_print_script_module_data(): void {
 	$get_marked_for_enqueue = new ReflectionMethod( 'WP_Script_Modules', 'get_marked_for_enqueue' );
-	$get_marked_for_enqueue->setAccessible(true);
+	$get_marked_for_enqueue->setAccessible( true );
 	$get_import_map = new ReflectionMethod( 'WP_Script_Modules', 'get_import_map' );
-	$get_import_map->setAccessible(true);
+	$get_import_map->setAccessible( true );
 
 	$modules = array();
 	foreach ( array_keys( $get_marked_for_enqueue->invoke( wp_script_modules() ) ) as $id ) {

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -212,7 +212,9 @@ function gutenberg_dequeue_module( $module_identifier ) {
  */
 function gutenberg_print_script_module_data(): void {
 	$get_marked_for_enqueue = new ReflectionMethod( 'WP_Script_Modules', 'get_marked_for_enqueue' );
-	$get_import_map         = new ReflectionMethod( 'WP_Script_Modules', 'get_import_map' );
+	$get_marked_for_enqueue->setAccessible(true);
+	$get_import_map = new ReflectionMethod( 'WP_Script_Modules', 'get_import_map' );
+	$get_import_map->setAccessible(true);
 
 	$modules = array();
 	foreach ( array_keys( $get_marked_for_enqueue->invoke( wp_script_modules() ) ) as $id ) {


### PR DESCRIPTION
## What?

Set private methods accessed through reflection to accessible before invoking.

## Why?

This cases an error in some PHP versions: https://github.com/WordPress/gutenberg/pull/61658/files#r1621194664

```
PHP Fatal error: Uncaught ReflectionException: Trying to invoke private method WP_Script_Modules::get_marked_for_enqueue() from scope ReflectionMethod in /wordpress/wp-content/plugins/gutenberg/lib/experimental/script-modules.php:218
```

## How?

Setting the methods to accessible fixes the issue.

## Testing Instructions

Go to the playground:

https://playground.wordpress.net/gutenberg.html

Put this PR number in the form: `62154`

Change the playground PHP version to 7.2.
Try using the Interactivity API on the playground site. You can check the error logs on the site to ensure there are no errors related to private method access.