### PR TITLE
DataViews: Improve UX around filter customization of bundled data views

### DIFF
--- a/packages/dataviews/src/filters.tsx
+++ b/packages/dataviews/src/filters.tsx
@@ -36,6 +36,15 @@ function _Filters< Item extends AnyItem >( {
 			return;
 		}
 
+		// Check if this filter is applied by the default view.
+		const isPreAppliedFilter = view.initialFilters.some(
+			( f ) =>
+				f.field === field.id && ALL_OPERATORS.includes( f.operator )
+		);
+		if ( isPreAppliedFilter ) {
+			return;
+		}
+
 		const operators = sanitizeOperators( field );
 		if ( operators.length === 0 ) {
 			return;

--- a/packages/dataviews/src/reset-filters.tsx
+++ b/packages/dataviews/src/reset-filters.tsx
@@ -25,11 +25,13 @@ export default function ResetFilter( {
 			( _filter ) => _filter.field === field && _filter.isPrimary
 		);
 	const isDisabled =
-		! view.search &&
-		! view.filters?.some(
-			( _filter ) =>
-				_filter.value !== undefined || ! isPrimary( _filter.field )
-		);
+		( ! view.search &&
+			! view.filters?.some(
+				( _filter ) =>
+					_filter.value !== undefined || ! isPrimary( _filter.field )
+			) ) ||
+		view.filters === view.initialFilters;
+
 	return (
 		<Button
 			disabled={ isDisabled }
@@ -42,7 +44,7 @@ export default function ResetFilter( {
 					...view,
 					page: 1,
 					search: '',
-					filters: [],
+					filters: view.initialFilters,
 				} );
 			} }
 		>

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -189,6 +189,11 @@ interface ViewBase {
 	filters: Filter[];
 
 	/**
+	 * Initial filters of the view.
+	 */
+	initialFilters: Filter[];
+
+	/**
 	 * The sorting configuration.
 	 */
 	sort?: {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -61,6 +61,7 @@ function useView( postType ) {
 			DEFAULT_VIEWS[ postType ].find(
 				( { slug } ) => slug === activeView
 			)?.view;
+		defaultView.initialFilters = defaultView.filters;
 		if ( isCustom === 'false' && layout ) {
 			return {
 				...defaultView,

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -189,7 +189,7 @@ export default function PageTemplates() {
 	const { activeView = 'all', layout } = params;
 	const defaultView = useMemo( () => {
 		const usedType = layout ?? DEFAULT_VIEW.type;
-		return {
+		const view = {
 			...DEFAULT_VIEW,
 			type: usedType,
 			layout: defaultConfigPerViewType[ usedType ],
@@ -204,22 +204,28 @@ export default function PageTemplates() {
 					  ]
 					: [],
 		};
+		view.initialFilters = view.filters;
+		return view;
 	}, [ layout, activeView ] );
 	const [ view, setView ] = useState( defaultView );
 	useEffect( () => {
-		setView( ( currentView ) => ( {
-			...currentView,
-			filters:
-				activeView !== 'all'
-					? [
-							{
-								field: 'author',
-								operator: OPERATOR_IS_ANY,
-								value: [ activeView ],
-							},
-					  ]
-					: [],
-		} ) );
+		setView( ( currentView ) => {
+			const newView = {
+				...currentView,
+				filters:
+					activeView !== 'all'
+						? [
+								{
+									field: 'author',
+									operator: OPERATOR_IS_ANY,
+									value: [ activeView ],
+								},
+						  ]
+						: [],
+			};
+			newView.initialFilters = newView.filters;
+			return newView;
+		} );
 	}, [ activeView ] );
 
 	const { records, isResolving: isLoadingData } = useEntityRecords(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improve UX around filter customization of bundled data views

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Addressed first three points of - #60468 

The UX of applying filters on a bundled view can be a little confusing.
For example we are on the "Scheduled" view -
- From there I can remove the "Scheduled" status filter.
- Also add other status filters.

But doing those we will still be on the "Scheduled" bundled view page. So, seeing that screen there is no relation between the filters applied and the view.

Also when we click on the "Reset" button when on any bundled view, it resets all the filter without respecting the view.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Hide the filter option which is pre-applied by the view.
- Hide the "Reset" button when no other filter is applied other than the pre-applied filter by view.
- When "Reset" button is clicked reset the filter to the view pre-applied filter state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check the screencast below or the points written -

- Go to site-editor.
- Open "Pages".
- On the "All pages" view, we will see all the filters are present.
- Now go to some other view like "Scheduled".
- We will see that the status filter disappears - neither in the apply filter dropdown or the applied filters chips.
- The RESET button will be also not visible by default.
- Now apply any other filter, like author. You will see the "Reset" button becomes visible.
- When you click on the "Reset" button all other filters gets reverted, except filters applied by the view.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/39427067/664686b2-f70a-47cf-adb7-388e693f8e35


