### PR TITLE
Fix shadow and border for pattern categories panel

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -329,18 +329,20 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__category-panel {
 	background: $gray-100;
-	border-left: $border-width solid $gray-200;
-	border-right: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-200;
+	box-shadow: $border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 	position: absolute;
-	top: 0;
+	top: -$border-width;
 	left: 0;
-	height: 100%;
+	height: calc(100% + #{$border-width});
 	width: 100%;
 	padding: 0 $grid-unit-20;
 	display: flex;
 	flex-direction: column;
 
 	@include break-medium {
+		border-left: $border-width solid $gray-200;
 		padding: 0;
 		left: 100%;
 		width: 300px;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds the proper shadow and border combination to support https://github.com/WordPress/gutenberg/pull/61835. It's only clearly visible when the site has a dark background. Now it doesn't matter what color the site is. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Start with the Twenty Twenty Four theme, using a dark variation—or assign a dark background color to the site.
2. Open a post or page. 
3. Open the Inserter.
4. Select the "Patterns" tab.
5. Select a category. 
6. See change.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-30 at 16 07 19](https://github.com/WordPress/gutenberg/assets/1813435/a8eba683-5521-41d5-a75e-c9bb5da121f0)|![CleanShot 2024-05-30 at 16 07 47](https://github.com/WordPress/gutenberg/assets/1813435/8df818ad-a646-4593-b81b-5d92c50a7f33)|





