### PR TITLE
Align both "Design" pattern list panels

### DIFF
--- a/packages/editor/src/components/post-transform-panel/index.js
+++ b/packages/editor/src/components/post-transform-panel/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { PanelBody, PanelRow } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
@@ -62,17 +62,9 @@ function PostTransform() {
 
 	return (
 		<PanelBody
-			title={ __( 'Transform into:' ) }
+			title={ __( 'Design' ) }
 			initialOpen={ record.type === TEMPLATE_PART_POST_TYPE }
 		>
-			<PanelRow>
-				<p>
-					{ __(
-						'Choose a predefined pattern to switch up the look of your template.' // TODO - make this dynamic?
-					) }
-				</p>
-			</PanelRow>
-
 			<TemplatesList
 				availableTemplates={ availablePatterns }
 				onSelect={ onTemplateSelect }

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -333,7 +333,7 @@ test.describe( 'Site Editor Performance', () => {
 						.click();
 				} else {
 					await page
-						.getByRole( 'button', { name: 'Transform into:' } )
+						.getByRole( 'button', { name: 'Design' } )
 						.click();
 				}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make these two panels for changing the design of a template or template part the same, with "Design" as the panel title.

## Why?
They do the same thing. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Select the header template part.
3. See the "Design" panel. 
4. Click on the "Template" tab from the Inspector. 
5. See the "Design" panel. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-05-30 at 21 11 07](https://github.com/WordPress/gutenberg/assets/1813435/941c5d0c-22b0-42df-aacd-2ee5fac02bb3)|![CleanShot 2024-05-30 at 21 10 34](https://github.com/WordPress/gutenberg/assets/1813435/d8e636c7-b361-4307-b065-9be10e1f2307)|

Compared to the existing "Design" panel: 
![CleanShot 2024-05-30 at 21 11 51](https://github.com/WordPress/gutenberg/assets/1813435/5339d117-cad3-425b-8145-d79caffa460a)