### PR TITLE
Fix syncing of publish date between publish and post status panel

### DIFF
--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -17,10 +17,18 @@ export function PublishDateTimePicker(
 		onChange,
 		showPopoverHeaderActions,
 		isCompact,
+		currentDate,
 		...additionalProps
 	},
 	ref
 ) {
+	const datePickerProps = {
+		startOfWeek: getSettings().l10n.startOfWeek,
+		onChange,
+		currentDate: isCompact ? undefined : currentDate,
+		currentTime: isCompact ? currentDate : undefined,
+		...additionalProps,
+	};
 	const DatePickerComponent = isCompact ? TimePicker : DateTimePicker;
 	return (
 		<div ref={ ref } className="block-editor-publish-date-time-picker">
@@ -38,11 +46,7 @@ export function PublishDateTimePicker(
 				}
 				onClose={ onClose }
 			/>
-			<DatePickerComponent
-				startOfWeek={ getSettings().l10n.startOfWeek }
-				onChange={ onChange }
-				{ ...additionalProps }
-			/>
+			<DatePickerComponent { ...datePickerProps } />
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/62150

In this [PR](https://github.com/WordPress/gutenberg/pull/62070) I missed testing properly the syncing in both directions between the publish date and post status panel, when we update the publish date. This is the fix for that.

## Testing Instructions
1. In a post change the publish date through the publish panel
2. Open the post status panel and select `scheduled` status
3. The TimePicker component is rendered and should show the edited publish date

