### PR TITLE
MediaUpload: Remove dialog markup on close

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -400,6 +400,8 @@ class MediaUpload extends Component {
 		if ( onClose ) {
 			onClose();
 		}
+
+		this.frame.detach();
 	}
 
 	updateCollection() {


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/62108#discussion_r1619125848.

PR updates the `MediaUpload` to remove dialog markup when closed. 

## Why?
It stops leaving unused markup each time the Media Library is opened. See the related discussion on [Slack](https://wordpress.slack.com/archives/C02SX62S6/p1717055547327059) (it requires logic).

## Testing Instructions
1. Open a post or page.
2. Add an Image block.
3. Open the Media Library and close it.
4. Confirm that closing removes the Media Library markup from the DOM. Element ID starts with `__wp-uploader-`.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-29 at 19 37 13](https://github.com/WordPress/gutenberg/assets/240569/2064d010-6e82-496e-aa8c-8e95e300ea94)
