### PR TITLE
Inserter: show all blocks (alternative)

### DIFF
--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -84,16 +84,20 @@ export function BlockTypesTabPanel( {
 
 	return (
 		<>
-			{ showMostUsedBlocks && !! suggestedItems.length && (
-				<InserterPanel title={ _x( 'Most used', 'blocks' ) }>
-					<BlockTypesList
-						items={ suggestedItems }
-						onSelect={ onSelectItem }
-						onHover={ onHover }
-						label={ _x( 'Most used', 'blocks' ) }
-					/>
-				</InserterPanel>
-			) }
+			{ showMostUsedBlocks &&
+				// Only show the most used blocks if the total amount of block
+				// is larger than 1 row, otherwise it is not so useful.
+				items.length > 3 &&
+				!! suggestedItems.length && (
+					<InserterPanel title={ _x( 'Most used', 'blocks' ) }>
+						<BlockTypesList
+							items={ suggestedItems }
+							onSelect={ onSelectItem }
+							onHover={ onHover }
+							label={ _x( 'Most used', 'blocks' ) }
+						/>
+					</InserterPanel>
+				) }
 
 			{ currentlyRenderedCategories.map( ( category ) => {
 				const categoryItems = items.filter(

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -4,8 +4,6 @@
 import { __, _x } from '@wordpress/i18n';
 import { useMemo, useEffect, forwardRef } from '@wordpress/element';
 import { useAsyncList } from '@wordpress/compose';
-import { getBlockType } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,7 +14,6 @@ import useBlockTypesState from './hooks/use-block-types-state';
 import InserterListbox from '../inserter-listbox';
 import { orderBy } from '../../utils/sorting';
 import InserterNoResults from './no-results';
-import { store as blockEditorStore } from '../../store';
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
@@ -170,12 +167,6 @@ export function BlockTypesTab(
 		rootClientId,
 		onInsert
 	);
-	const rootBlockName = useSelect(
-		( select ) => {
-			return select( blockEditorStore ).getBlockName( rootClientId );
-		},
-		[ rootClientId ]
-	);
 
 	if ( ! items.length ) {
 		return <InserterNoResults />;
@@ -185,6 +176,11 @@ export function BlockTypesTab(
 	const itemsRemaining = [];
 
 	for ( const item of items ) {
+		// Skip reusable blocks, they moved to the patterns tab.
+		if ( item.category === 'reusable' ) {
+			continue;
+		}
+
 		if ( rootClientId && item.rootClientId === rootClientId ) {
 			itemsForCurrentRoot.push( item );
 		} else {
@@ -197,15 +193,6 @@ export function BlockTypesTab(
 			<div ref={ ref }>
 				{ !! itemsForCurrentRoot.length && (
 					<>
-						<div
-							className="block-editor-inserter__panel-header"
-							style={ { display: 'block' } }
-						>
-							<h2 className="block-editor-inserter__panel-title">
-								{ __( 'Can be inserted into ' ) +
-									getBlockType( rootBlockName )?.title }
-							</h2>
-						</div>
 						<BlockTypesTabPanel
 							items={ itemsForCurrentRoot }
 							categories={ categories }

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -34,6 +34,7 @@ export function BlockTypesTabPanel( {
 	onSelectItem,
 	onHover,
 	showMostUsedBlocks,
+	className,
 } ) {
 	const suggestedItems = useMemo( () => {
 		return orderBy( items, 'frecency', 'desc' ).slice(
@@ -83,7 +84,7 @@ export function BlockTypesTabPanel( {
 	);
 
 	return (
-		<>
+		<div className={ className }>
 			{ showMostUsedBlocks &&
 				// Only show the most used blocks if the total amount of block
 				// is larger than 1 row, otherwise it is not so useful.
@@ -159,7 +160,7 @@ export function BlockTypesTabPanel( {
 					);
 				}
 			) }
-		</>
+		</div>
 	);
 }
 
@@ -204,6 +205,7 @@ export function BlockTypesTab(
 							onSelectItem={ onSelectItem }
 							onHover={ onHover }
 							showMostUsedBlocks={ showMostUsedBlocks }
+							className="block-editor-inserter__insertable-blocks-at-selection"
 						/>
 						<hr />
 					</>
@@ -215,6 +217,7 @@ export function BlockTypesTab(
 					onSelectItem={ onSelectItem }
 					onHover={ onHover }
 					showMostUsedBlocks={ showMostUsedBlocks }
+					className="block-editor-inserter__all-blocks"
 				/>
 			</div>
 		</InserterListbox>

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -14,6 +14,7 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../../store';
+import { withRootClientIdOptionKey } from '../../../store/utils';
 
 /**
  * Retrieves the block types inserter state.
@@ -25,7 +26,9 @@ import { store as blockEditorStore } from '../../../store';
 const useBlockTypesState = ( rootClientId, onInsert ) => {
 	const [ items ] = useSelect(
 		( select ) => [
-			select( blockEditorStore ).getInserterItems( rootClientId ),
+			select( blockEditorStore ).getInserterItems( rootClientId, {
+				[ withRootClientIdOptionKey ]: true,
+			} ),
 		],
 		[ rootClientId ]
 	);

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -21,16 +21,17 @@ import { withRootClientIdOptionKey } from '../../../store/utils';
  *
  * @param {string=}  rootClientId Insertion's root client ID.
  * @param {Function} onInsert     function called when inserter a list of blocks.
+ * @param {boolean}  isQuick
  * @return {Array} Returns the block types state. (block types, categories, collections, onSelect handler)
  */
-const useBlockTypesState = ( rootClientId, onInsert ) => {
+const useBlockTypesState = ( rootClientId, onInsert, isQuick ) => {
 	const [ items ] = useSelect(
 		( select ) => [
 			select( blockEditorStore ).getInserterItems( rootClientId, {
-				[ withRootClientIdOptionKey ]: true,
+				[ withRootClientIdOptionKey ]: ! isQuick,
 			} ),
 		],
-		[ rootClientId ]
+		[ rootClientId, isQuick ]
 	);
 
 	const [ categories, collections ] = useSelect( ( select ) => {

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -37,7 +37,14 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 
 	const onSelectItem = useCallback(
 		(
-			{ name, initialAttributes, innerBlocks, syncStatus, content },
+			{
+				name,
+				initialAttributes,
+				innerBlocks,
+				syncStatus,
+				content,
+				rootClientId: _rootClientId,
+			},
 			shouldFocusBlock
 		) => {
 			const insertedBlock =
@@ -51,7 +58,12 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 							createBlocksFromInnerBlocksTemplate( innerBlocks )
 					  );
 
-			onInsert( insertedBlock, undefined, shouldFocusBlock );
+			onInsert(
+				insertedBlock,
+				undefined,
+				shouldFocusBlock,
+				_rootClientId
+			);
 		},
 		[ onInsert ]
 	);

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -120,9 +120,13 @@ function useInsertionPoint( {
 					meta
 				);
 			} else {
-				const parents = registry
-					.select( blockEditorStore )
-					.getBlockParents( destinationRootClientId );
+				const parents = [
+					'',
+					...registry
+						.select( blockEditorStore )
+						.getBlockParents( destinationRootClientId ),
+					destinationRootClientId,
+				];
 				const index =
 					_rootClientId === destinationRootClientId
 						? destinationIndex
@@ -169,10 +173,14 @@ function useInsertionPoint( {
 
 	const onToggleInsertionPoint = useCallback(
 		( item ) => {
-			if ( item?.rootClientId ) {
-				const parents = registry
-					.select( blockEditorStore )
-					.getBlockParents( destinationRootClientId );
+			if ( item?.hasOwnProperty( 'rootClientId' ) ) {
+				const parents = [
+					'',
+					...registry
+						.select( blockEditorStore )
+						.getBlockParents( destinationRootClientId ),
+					destinationRootClientId,
+				];
 				const index =
 					item.rootClientId === destinationRootClientId
 						? destinationIndex

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -150,13 +150,15 @@ function useInsertionPoint( {
 			} else {
 				insertBlocks(
 					blocks,
-					getIndex( {
-						destinationRootClientId,
-						destinationIndex,
-						rootClientId: _rootClientId,
-						registry,
-					} ),
-					_rootClientId,
+					isAppender
+						? getIndex( {
+								destinationRootClientId,
+								destinationIndex,
+								rootClientId: _rootClientId,
+								registry,
+						  } )
+						: destinationIndex,
+					isAppender ? rootClientId : _rootClientId,
 					selectBlockOnInsert,
 					shouldFocusBlock || shouldForceFocusBlock ? 0 : null,
 					meta

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -150,15 +150,17 @@ function useInsertionPoint( {
 			} else {
 				insertBlocks(
 					blocks,
-					isAppender
-						? getIndex( {
+					isAppender || _rootClientId === undefined
+						? destinationIndex
+						: getIndex( {
 								destinationRootClientId,
 								destinationIndex,
 								rootClientId: _rootClientId,
 								registry,
-						  } )
-						: destinationIndex,
-					isAppender ? rootClientId : _rootClientId,
+						  } ),
+					isAppender || _rootClientId === undefined
+						? destinationRootClientId
+						: _rootClientId,
 					selectBlockOnInsert,
 					shouldFocusBlock || shouldForceFocusBlock ? 0 : null,
 					meta

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -81,8 +81,13 @@ function InserterMenu(
 	const blockTypesTabRef = useRef();
 
 	const onInsert = useCallback(
-		( blocks, meta, shouldForceFocusBlock ) => {
-			onInsertBlocks( blocks, meta, shouldForceFocusBlock );
+		( blocks, meta, shouldForceFocusBlock, _rootClientId ) => {
+			onInsertBlocks(
+				blocks,
+				meta,
+				shouldForceFocusBlock,
+				_rootClientId
+			);
 			onSelect();
 
 			// Check for focus loss due to filtering blocks by selected block type
@@ -111,7 +116,7 @@ function InserterMenu(
 
 	const onHover = useCallback(
 		( item ) => {
-			onToggleInsertionPoint( !! item );
+			onToggleInsertionPoint( item );
 			setHoveredItem( item );
 		},
 		[ onToggleInsertionPoint, setHoveredItem ]

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -44,7 +44,8 @@ export default function QuickInserter( {
 	} );
 	const [ blockTypes ] = useBlockTypesState(
 		destinationRootClientId,
-		onInsertBlocks
+		onInsertBlocks,
+		true
 	);
 
 	const [ patterns ] = usePatternsState(
@@ -126,6 +127,7 @@ export default function QuickInserter( {
 					isDraggable={ false }
 					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
+					isQuick
 				/>
 			</div>
 

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -50,6 +50,7 @@ function InserterSearchResults( {
 	shouldFocusBlock = true,
 	prioritizePatterns,
 	selectBlockOnInsert,
+	isQuick,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
@@ -80,7 +81,7 @@ function InserterSearchResults( {
 		blockTypeCategories,
 		blockTypeCollections,
 		onSelectBlockType,
-	] = useBlockTypesState( destinationRootClientId, onInsertBlocks );
+	] = useBlockTypesState( destinationRootClientId, onInsertBlocks, isQuick );
 	const [ patterns, , onClickPattern ] = usePatternsState(
 		onInsertBlocks,
 		destinationRootClientId

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2053,7 +2053,21 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 						)
 					) {
 						if ( ! item.rootClientId ) {
-							delete item.rootClientId;
+							const { sectionRootClientId } = unlock(
+								getSettings( state )
+							);
+							if (
+								sectionRootClientId &&
+								canInsertBlockTypeUnmemoized(
+									state,
+									item.name,
+									sectionRootClientId
+								)
+							) {
+								item.rootClientId = sectionRootClientId;
+							} else {
+								delete item.rootClientId;
+							}
 							break;
 						} else {
 							const parentClientId = getBlockRootClientId(
@@ -2064,6 +2078,7 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 						}
 					}
 
+					// We could also add non insertable items and gray them out.
 					if ( item.hasOwnProperty( 'rootClientId' ) ) {
 						accumulator.push( item );
 					}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2057,9 +2057,12 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							)
 						) {
 							if ( ! item.rootClientId ) {
-								const { sectionRootClientId } = unlock(
-									getSettings( state )
-								);
+								let sectionRootClientId;
+								try {
+									sectionRootClientId = unlock(
+										getSettings( state )
+									).sectionRootClientId;
+								} catch ( e ) {}
 								if (
 									sectionRootClientId &&
 									canInsertBlockTypeUnmemoized(

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -22,6 +22,7 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
  * Internal dependencies
  */
 import {
+	withRootClientIdOptionKey,
 	checkAllowListRecursive,
 	checkAllowList,
 	getAllPatternsDependants,
@@ -1995,7 +1996,7 @@ const buildBlockTypeItem =
  */
 export const getInserterItems = createRegistrySelector( ( select ) =>
 	createSelector(
-		( state, rootClientId = null ) => {
+		( state, rootClientId = null, options = {} ) => {
 			const buildReusableBlockInserterItem = ( reusableBlock ) => {
 				const icon = ! reusableBlock.wp_pattern_sync_status
 					? {
@@ -2037,54 +2038,69 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 				buildScope: 'inserter',
 			} );
 
-			const blockTypeInserterItems = getBlockTypes()
+			let blockTypeInserterItems = getBlockTypes()
 				.filter( ( blockType ) =>
 					hasBlockSupport( blockType, 'inserter', true )
 				)
-				.map( buildBlockTypeInserterItem )
-				.reduce( ( accumulator, item ) => {
-					item.rootClientId = rootClientId;
+				.map( buildBlockTypeInserterItem );
 
-					while (
-						! canInsertBlockTypeUnmemoized(
-							state,
-							item.name,
-							item.rootClientId
-						)
-					) {
-						if ( ! item.rootClientId ) {
-							const { sectionRootClientId } = unlock(
-								getSettings( state )
-							);
-							if (
-								sectionRootClientId &&
-								canInsertBlockTypeUnmemoized(
-									state,
-									item.name,
-									sectionRootClientId
-								)
-							) {
-								item.rootClientId = sectionRootClientId;
-							} else {
-								delete item.rootClientId;
-							}
-							break;
-						} else {
-							const parentClientId = getBlockRootClientId(
+			if ( options[ withRootClientIdOptionKey ] ) {
+				blockTypeInserterItems = blockTypeInserterItems.reduce(
+					( accumulator, item ) => {
+						item.rootClientId = rootClientId ?? '';
+
+						while (
+							! canInsertBlockTypeUnmemoized(
 								state,
+								item.name,
 								item.rootClientId
-							);
-							item.rootClientId = parentClientId;
+							)
+						) {
+							if ( ! item.rootClientId ) {
+								const { sectionRootClientId } = unlock(
+									getSettings( state )
+								);
+								if (
+									sectionRootClientId &&
+									canInsertBlockTypeUnmemoized(
+										state,
+										item.name,
+										sectionRootClientId
+									)
+								) {
+									item.rootClientId = sectionRootClientId;
+								} else {
+									delete item.rootClientId;
+								}
+								break;
+							} else {
+								const parentClientId = getBlockRootClientId(
+									state,
+									item.rootClientId
+								);
+								item.rootClientId = parentClientId;
+							}
 						}
-					}
 
-					// We could also add non insertable items and gray them out.
-					if ( item.hasOwnProperty( 'rootClientId' ) ) {
-						accumulator.push( item );
-					}
+						// We could also add non insertable items and gray them out.
+						if ( item.hasOwnProperty( 'rootClientId' ) ) {
+							accumulator.push( item );
+						}
 
-					return accumulator;
-				}, [] );
+						return accumulator;
+					},
+					[]
+				);
+			} else {
+				blockTypeInserterItems = blockTypeInserterItems.filter(
+					( blockType ) =>
+						canIncludeBlockTypeInInserter(
+							state,
+							blockType,
+							rootClientId
+						)
+				);
+			}
 
 			const items = blockTypeInserterItems.reduce(
 				( accumulator, item ) => {

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -5,6 +5,8 @@ import { selectBlockPatternsKey } from './private-keys';
 import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
 
+export const withRootClientIdOptionKey = Symbol( 'withRootClientId' );
+
 export const checkAllowList = ( list, item, defaultResult = null ) => {
 	if ( typeof list === 'boolean' ) {
 		return list;

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -40,7 +40,7 @@ test.describe( 'Columns', () => {
 
 		// Verify Column
 		const inserterOptions = page.locator(
-			'role=region[name="Block Library"i] >> role=option'
+			'role=region[name="Block Library"i] >> .block-editor-inserter__insertable-blocks-at-selection >> role=option'
 		);
 		await expect( inserterOptions ).toHaveCount( 1 );
 		await expect( inserterOptions ).toHaveText( 'Column' );

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -48,9 +48,13 @@ test.describe( 'Child Blocks', () => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Toggle block inserter' } );
-		const blockLibrary = page.getByRole( 'region', {
-			name: 'Block Library',
-		} );
+		const blockLibrary = page
+			.getByRole( 'region', {
+				name: 'Block Library',
+			} )
+			.locator(
+				'.block-editor-inserter__insertable-blocks-at-selection'
+			);
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();
@@ -82,9 +86,13 @@ test.describe( 'Child Blocks', () => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Toggle block inserter' } );
-		const blockLibrary = page.getByRole( 'region', {
-			name: 'Block Library',
-		} );
+		const blockLibrary = page
+			.getByRole( 'region', {
+				name: 'Block Library',
+			} )
+			.locator(
+				'.block-editor-inserter__insertable-blocks-at-selection'
+			);
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -46,9 +46,13 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Toggle block inserter' } );
-		const blockLibrary = page.getByRole( 'region', {
-			name: 'Block Library',
-		} );
+		const blockLibrary = page
+			.getByRole( 'region', {
+				name: 'Block Library',
+			} )
+			.locator(
+				'.block-editor-inserter__insertable-blocks-at-selection'
+			);
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();
@@ -89,9 +93,13 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Toggle block inserter' } );
-		const blockLibrary = page.getByRole( 'region', {
-			name: 'Block Library',
-		} );
+		const blockLibrary = page
+			.getByRole( 'region', {
+				name: 'Block Library',
+			} )
+			.locator(
+				'.block-editor-inserter__insertable-blocks-at-selection'
+			);
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #60991
This is an alternative to #61873.

This PR changes `getInserterItems` to always return all items, but each item defines at which root client ID it can be inserted. 

Inside the inserter, when a block is selected, there's a list for blocks that can be inserted at the selection, and a list with remaining blocks. Since each of these blocks have a root client ID, we know where to show the insertion point. The index at which to insert is derived from the selection.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #60991.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
