### PR TITLE
Do not auto save post status changes

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -598,10 +598,14 @@ export const saveEntityRecord =
 							return acc;
 						},
 						{
+							// Do not update the `status` if we have edited it when auto saving.
+							// It's very important to let the user explicitly save this change,
+							// because it can lead to unexpected results. An example would be to
+							// have a draft post and change the status to publish.
 							status:
 								data.status === 'auto-draft'
 									? 'draft'
-									: data.status,
+									: undefined,
 						}
 					);
 					updatedRecord = await __unstableFetch( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Found by @Mamaduka [here](https://github.com/WordPress/gutenberg/pull/62070#pullrequestreview-2087319702):

> Unrelated note: I've noticed that a post might get accidentally Published/Scheduled if you're playing with the settings and the autosave functionality kicks in. I'm not sure if this is a new or old issue, but I would expect not to publish my posts accidentally.

With autosaves we only update very specific attributes (handled above my changes here). The exception was only for when creating a new post (initial status `auto-draft`) to make the status `draft`. Previously there was no specific `post status` panel to edit the attribute directly, so it was safe to just use the saved post status, but it seems we don't need to make that update in any other case.

## Steps to reproduce
1. Open a draft post.
2. Change status to Published or Scheduled.
3. Trigger an autosave - `window.wp.data.dispatch( 'core/editor' ).autosave()`.
4. Reload the page, and notice you'll get unsaved changes warning.
5. Notice that the post isn't a draft anymore.




## Testing Instructions
1. Everything should work as before with autosaves with the exception of being to change status 


