### PR TITLE
Synced Pattern: Wait for pattern creation in e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -388,6 +388,13 @@ test.describe( 'Synced pattern', () => {
 			.getByRole( 'button', { name: 'Add' } )
 			.click();
 
+		// Wait until the pattern is created.
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Pattern',
+			} )
+		).toBeVisible();
+
 		await admin.createNewPost();
 		await editor.canvas
 			.getByRole( 'button', { name: 'Add default block' } )
@@ -432,11 +439,11 @@ test.describe( 'Synced pattern', () => {
 			.click();
 
 		// Wait until the pattern is created.
-		await editor.canvas
-			.getByRole( 'document', {
+		await expect(
+			editor.canvas.getByRole( 'document', {
 				name: 'Block: Pattern',
 			} )
-			.waitFor();
+		).toBeVisible();
 
 		// Check that only the pattern block is present.
 		const existingBlocks = await editor.getBlocks();


### PR DESCRIPTION
## What?
Closes #61941.

PR updates `can be inserted after refresh` patterns e2e test to prevent them from triggering an error during the test runs.

## How?
Use the fix suggested by @t-hamano - https://github.com/WordPress/gutenberg/issues/61941#issuecomment-2131243572.

## Testing Instructions
1. Open pattern e2e test in UI - `npm run test:e2e -- test/e2e/specs/editor/various/patterns.spec.js --ui`
2. Run the `can be inserted after refresh` test.
3. The error shouldn't be logged in the Console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-05-24 at 14 38 15](https://github.com/WordPress/gutenberg/assets/240569/63391b6f-1f2b-4560-9352-0d30a1720770)
