### PR TITLE
Align the template title to the center in the 'Add template' screen

### DIFF
--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -128,6 +128,7 @@ function TemplateListItem( {
 					spacing={ 0 }
 				>
 					<Text
+						align="center"
 						weight={ 500 }
 						lineHeight={ 1.53846153846 } // 20px
 					>


### PR DESCRIPTION
## What?

Since https://github.com/WordPress/gutenberg/pull/60367, it's possible that templates shown in the 'Add template' screen might have a long title. This PR makes sure multi-line titles appear center-aligned, keeping the same alignmend as single-line tites.

## Why?

In order to keep consistency between templates, making sure all of them look center-aligned.

## Testing Instructions

1. Make it so a long template title is rendered in the _Add template_ screen. I achieved so with this snippet:

```PHP
add_action( 'init', function () {
	register_post_type(
		'recipe',
		array(
			'public'       => true,
			'show_in_rest' => true,
			'labels'       => array(
				'name'          => 'Recipes',
				'singular_name' => 'Recipe',
				'template_name' => 'Very long recipe template name',
			),
		)
	);
} );
```
2. Go to Appearance > Editor > Templates > Add New Template.
3. Verify the _Very long recipe template name_ title is aligned to the center.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast

Before | After
--- | ---
![Screenshot showing the long title aligned to the left](https://github.com/WordPress/gutenberg/assets/3616980/d9b09d6a-61fa-4067-aaae-23af225650cf) | ![Screenshot showing the long title centered](https://github.com/WordPress/gutenberg/assets/3616980/7f4916f7-ea10-4935-aa00-7da21f656f48)
