### PR TITLE
Parser: Update validateBlock to use fixedBlock

### DIFF
--- a/packages/blocks/src/api/parser/fix-custom-classname.js
+++ b/packages/blocks/src/api/parser/fix-custom-classname.js
@@ -42,27 +42,30 @@ export function getHTMLRootElementClasses( innerHTML ) {
  * @return {Object} Filtered block attributes.
  */
 export function fixCustomClassname( blockAttributes, blockType, innerHTML ) {
-	if ( hasBlockSupport( blockType, 'customClassName', true ) ) {
-		// To determine difference, serialize block given the known set of
-		// attributes, with the exception of `className`. This will determine
-		// the default set of classes. From there, any difference in innerHTML
-		// can be considered as custom classes.
-		const { className: omittedClassName, ...attributesSansClassName } =
-			blockAttributes;
-		const serialized = getSaveContent( blockType, attributesSansClassName );
-		const defaultClasses = getHTMLRootElementClasses( serialized );
-		const actualClasses = getHTMLRootElementClasses( innerHTML );
-
-		const customClasses = actualClasses.filter(
-			( className ) => ! defaultClasses.includes( className )
-		);
-
-		if ( customClasses.length ) {
-			blockAttributes.className = customClasses.join( ' ' );
-		} else if ( serialized ) {
-			delete blockAttributes.className;
-		}
+	if ( ! hasBlockSupport( blockType, 'customClassName', true ) ) {
+		return blockAttributes;
 	}
 
-	return blockAttributes;
+	const modifiedBlockAttributes = { ...blockAttributes };
+	// To determine difference, serialize block given the known set of
+	// attributes, with the exception of `className`. This will determine
+	// the default set of classes. From there, any difference in innerHTML
+	// can be considered as custom classes.
+	const { className: omittedClassName, ...attributesSansClassName } =
+		modifiedBlockAttributes;
+	const serialized = getSaveContent( blockType, attributesSansClassName );
+	const defaultClasses = getHTMLRootElementClasses( serialized );
+	const actualClasses = getHTMLRootElementClasses( innerHTML );
+
+	const customClasses = actualClasses.filter(
+		( className ) => ! defaultClasses.includes( className )
+	);
+
+	if ( customClasses.length ) {
+		modifiedBlockAttributes.className = customClasses.join( ' ' );
+	} else if ( serialized ) {
+		delete modifiedBlockAttributes.className;
+	}
+
+	return modifiedBlockAttributes;
 }

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -178,7 +178,7 @@ function applyBlockValidation( unvalidatedBlock, blockType ) {
 	);
 	// Attempt to validate the block once again after the built-in fixes.
 	const [ isFixedValid, validationIssues ] = validateBlock(
-		unvalidatedBlock,
+		fixedBlock,
 		blockType
 	);
 

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -50,6 +50,37 @@ describe( 'block parser', () => {
 	} );
 
 	describe( 'parseRawBlock', () => {
+		it( 'should apply className block validation fixes', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					fruit: {
+						type: 'string',
+						source: 'text',
+						selector: 'div',
+					},
+				},
+				save: ( { attributes } ) => (
+					// eslint-disable-next-line react/no-unknown-property
+					<div class={ attributes.className }>
+						{ attributes.fruit }
+					</div>
+				),
+			} );
+
+			const block = parseRawBlock( {
+				blockName: 'core/test-block',
+				innerHTML: '<div class="custom-class">Bananas</div>',
+				attrs: { fruit: 'Bananas' },
+			} );
+
+			expect( block.name ).toEqual( 'core/test-block' );
+			expect( block.attributes ).toEqual( {
+				fruit: 'Bananas',
+				className: 'custom-class',
+			} );
+		} );
+
 		it( 'should create the requested block if it exists', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -70,14 +70,15 @@ describe( 'block parser', () => {
 
 			const block = parseRawBlock( {
 				blockName: 'core/test-block',
-				innerHTML: '<div class="custom-class">Bananas</div>',
+				innerHTML:
+					'<div class="custom-class another-custom-class">Bananas</div>',
 				attrs: { fruit: 'Bananas' },
 			} );
 
 			expect( block.name ).toEqual( 'core/test-block' );
 			expect( block.attributes ).toEqual( {
 				fruit: 'Bananas',
-				className: 'custom-class',
+				className: 'custom-class another-custom-class',
 			} );
 		} );
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/62176

## What?
Updated the second `validateBlock` execution to run against `fixedBlock` after we have attempted to apply fixes if it fails validation for the first time.

## Why?
It appears as though we are revalidating the original `unvalidatedBlock` instead of `fixedBlock` during the second execution of `validateBlock()`.

## How?
Updated the variable being passed to `validateBlock`

## Testing Instructions
1. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
