### PR TITLE
Fixed Media Text Block Issue : When crop image to fill is enabled, the image in nested media & text blocks does not show

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -75,13 +75,13 @@
 	vertical-align: middle;
 }
 
-.wp-block-media-text.is-image-fill .wp-block-media-text__media {
+.wp-block-media-text.is-image-fill > .wp-block-media-text__media {
 	height: 100%;
 	min-height: 250px;
 	background-size: cover;
 }
 
-.wp-block-media-text.is-image-fill .wp-block-media-text__media > a {
+.wp-block-media-text.is-image-fill > .wp-block-media-text__media > a {
 	display: block;
 	height: 100%;
 }

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -86,7 +86,7 @@
 	height: 100%;
 }
 
-.wp-block-media-text.is-image-fill .wp-block-media-text__media img {
+.wp-block-media-text.is-image-fill > .wp-block-media-text__media img {
 	// The image is visually hidden but accessible to assistive technologies.
 	position: absolute;
 	width: 1px;


### PR DESCRIPTION
## What?
Fix: https://github.com/WordPress/gutenberg/issues/62166
When the media & text block has an image (or featured image), and the setting "Crop image to fill" is enabled,
and another media & text block is added in the content area, the image of that second media & text block is hidden. It is hidden by the CSS from the first (outer) media & text block.


## Why?
This will fixed the issue which occur when crop image to fill is enabled, the image in nested media & text blocks.

## How?
I have  resolved this by adding `>` to the relevant CSS selectors.

## Testing Instructions
1. Add a media and text block and select an image as the media.
2. In the block settings panel, enable "crop image to fill".
3. Add another media & text block inside. Try to select an image.
4. Confirm that the image is hidden in the editor and the front.
