### PR TITLE
Don't show non-existing and not supported attributes in block bindings panel

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -14,10 +14,11 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { canBindAttribute } from '../hooks/use-bindings-attributes';
 import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
 
-export const BlockBindingsPanel = ( { metadata } ) => {
+export const BlockBindingsPanel = ( { name, metadata } ) => {
 	const { bindings } = metadata || {};
 	const { sources } = useSelect( ( select ) => {
 		const _sources = unlock(
@@ -33,11 +34,15 @@ export const BlockBindingsPanel = ( { metadata } ) => {
 		return null;
 	}
 
+	// Don't show not allowed attributes.
 	// Don't show the bindings connected to pattern overrides in the inspectors panel.
 	// TODO: Explore if this should be abstracted to let other sources decide.
 	const filteredBindings = { ...bindings };
 	Object.keys( filteredBindings ).forEach( ( key ) => {
-		if ( filteredBindings[ key ].source === 'core/pattern-overrides' ) {
+		if (
+			! canBindAttribute( name, key ) ||
+			filteredBindings[ key ].source === 'core/pattern-overrides'
+		) {
 			delete filteredBindings[ key ];
 		}
 	} );


### PR DESCRIPTION
## What?
Remove the non existing and not supported attributes from the block bindings panel.

## Why?
It is a bit confusing because they won't work or do anything.

## How?
Just using the `canBindAttribute` util to decide if it should be deleted or not.

## Testing Instructions
* Add a paragraph connected to a non-existing attribute.
```
<!-- wp:paragraph {"metadata":{"bindings":{"fake":{"source":"core/post-meta","args":{"key":"text_field"}}}}} -->
<p>Default</p>
<!-- /wp:paragraph -->
```
* Check that in the block inspector there is no bindings panel.
* Add an image with some supported attributes and some non-supported attributes.
```
<!-- wp:image {"metadata":{"bindings":{"alt":{"source":"core/post-meta","args":{"key":"text_field"}},"caption":{"source":"core/post-meta","args":{"key":"text_field"}}}}} -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->
```
* Check that the bindings panel only shows the alt attribute.