### PR TITLE
[Mobile] - Image corrector - Check the path extension is a valid one

### DIFF
--- a/packages/blocks/src/api/raw-handling/image-corrector.native.js
+++ b/packages/blocks/src/api/raw-handling/image-corrector.native.js
@@ -10,7 +10,9 @@ export default function imageCorrector( node ) {
 		return;
 	}
 
-	// For local files makes sure the extension is a valid one, if not it removes the path.
+	// For local files makes sure the path doesn't end with an invalid extension.
+	// This scenario often happens with content from MS Word and similar text apps.
+	// We still need to support local files pasted from the users Media library.
 	if ( node.src.startsWith( 'file:' ) && node.src.slice( -1 ) === '/' ) {
 		node.setAttribute( 'src', '' );
 	}

--- a/packages/blocks/src/api/raw-handling/image-corrector.native.js
+++ b/packages/blocks/src/api/raw-handling/image-corrector.native.js
@@ -10,7 +10,8 @@ export default function imageCorrector( node ) {
 		return;
 	}
 
-	if ( node.src.indexOf( 'file:' ) === 0 ) {
+	// For local files makes sure the extension is a valid one, if not it removes the path.
+	if ( node.src.startsWith( 'file:' ) && node.src.slice( -1 ) === '/' ) {
 		node.setAttribute( 'src', '' );
 	}
 

--- a/packages/edit-post/src/test/__snapshots__/editor.native.js.snap
+++ b/packages/edit-post/src/test/__snapshots__/editor.native.js.snap
@@ -8,7 +8,7 @@ exports[`Editor adds empty image block when pasting unsupported HTML local image
 
 exports[`Editor adds image block when pasting HTML local image path 1`] = `
 "<!-- wp:image -->
-<figure class="wp-block-image"><img src="file://path/to/file.png" alt=""/></figure>
+<figure class="wp-block-image"><img src="file:///path/to/file.png" alt=""/></figure>
 <!-- /wp:image -->"
 `;
 

--- a/packages/edit-post/src/test/__snapshots__/editor.native.js.snap
+++ b/packages/edit-post/src/test/__snapshots__/editor.native.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Editor adds empty image block when pasting unsupported HTML local image path 1`] = `
+"<!-- wp:image -->
+<figure class="wp-block-image"><img src="" alt=""/></figure>
+<!-- /wp:image -->"
+`;
+
+exports[`Editor adds image block when pasting HTML local image path 1`] = `
+"<!-- wp:image -->
+<figure class="wp-block-image"><img src="file://path/to/file.png" alt=""/></figure>
+<!-- /wp:image -->"
+`;
+
 exports[`Editor appends media correctly for allowed types 1`] = `
 "<!-- wp:image -->
 <figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt=""/></figure>

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -9,8 +9,10 @@ import {
 	getEditorHtml,
 	getEditorTitle,
 	initializeEditor,
+	pasteIntoRichText,
 	screen,
 	setupCoreBlocks,
+	within,
 } from 'test/helpers';
 import { BackHandler } from 'react-native';
 
@@ -96,6 +98,38 @@ describe( 'Editor', () => {
 		act( () => {
 			toggleModeCallback();
 		} );
+	} );
+
+	it( 'adds empty image block when pasting unsupported HTML local image path', async () => {
+		await initializeEditor();
+		await addBlock( screen, 'Paragraph' );
+
+		const paragraphBlock = getBlock( screen, 'Paragraph' );
+		fireEvent.press( paragraphBlock );
+		const paragraphTextInput =
+			within( paragraphBlock ).getByPlaceholderText( 'Start writing…' );
+
+		pasteIntoRichText( paragraphTextInput, {
+			text: '<div><img src="file:LOW-RES.png"></div>',
+		} );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'adds image block when pasting HTML local image path', async () => {
+		await initializeEditor();
+		await addBlock( screen, 'Paragraph' );
+
+		const paragraphBlock = getBlock( screen, 'Paragraph' );
+		fireEvent.press( paragraphBlock );
+		const paragraphTextInput =
+			within( paragraphBlock ).getByPlaceholderText( 'Start writing…' );
+
+		pasteIntoRichText( paragraphTextInput, {
+			files: [ 'file:///path/to/file.png' ],
+		} );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
 	it( 'appends media correctly for allowed types', async () => {

--- a/test/native/integration-test-helpers/rich-text-paste.js
+++ b/test/native/integration-test-helpers/rich-text-paste.js
@@ -6,19 +6,20 @@ import { fireEvent } from '@testing-library/react-native';
 /**
  * Paste content into a RichText component.
  *
- * @param {import('react-test-renderer').ReactTestInstance} richText       RichText test instance.
- * @param {Object}                                          content        Content to paste.
- * @param {string}                                          content.text   Text format of the content.
- * @param {string}                                          [content.html] HTML format of the content. If not provided, text format will be used.
+ * @param {import('react-test-renderer').ReactTestInstance} richText        RichText test instance.
+ * @param {Object}                                          content         Content to paste.
+ * @param {string}                                          content.text    Text format of the content.
+ * @param {string}                                          [content.html]  HTML format of the content. If not provided, text format will be used.
+ * @param {string}                                          [content.files] Files array to add to the editor.
  */
-export const pasteIntoRichText = ( richText, { text, html } ) => {
+export const pasteIntoRichText = ( richText, { text, html, files = [] } ) => {
 	fireEvent( richText, 'focus' );
 	fireEvent( richText, 'paste', {
 		preventDefault: jest.fn(),
 		nativeEvent: {
 			eventCount: 1,
 			target: undefined,
-			files: [],
+			files,
 			pastedHtml: html || text,
 			pastedText: text,
 		},


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6903
- https://github.com/wordpress-mobile/WordPress-Android/pull/20929
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23297

## What?
This is a follow-up of https://github.com/WordPress/gutenberg/pull/60676 that introduced a regression for the iOS app.

## Why?
Recent changes in https://github.com/WordPress/gutenberg/pull/60676 introduced a regression where iOS users cannot copy an image from their OS media library and paste it into the editor.

## How?
By updating how we filter `file` paths when pasting HTML content.

## Testing Instructions

> [!NOTE]  
> Please use the following builds to test:
> - [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/23297#issuecomment-2144890500)
> - [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/20929#issuecomment-2144896643)

## Pasting HTML content

- Open the editor
- Copy the following HTML content:

<details>
<summary>HTML</summary>

```html
<div><img src="file:LOW-RES.png"></div>
```
</details>

- Paste the HTML
- **Expect** the app to not crash

## Copy image from the iOS Media library

- Open the editor
- Go to the iOS Photos app
- Copy an image
- Go back to the editor
- Tap on a Paragraph block
- Paste the content from the clipboard
- **Expect** the image to be added as an Image block and uploaded to the server

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

## Copy image from the iOS Media library

Before|After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/b0b5e4ef-232f-4cbf-a2c8-85487a48213a" width=200 />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/7a78f4de-920f-41c5-8393-896cc0668112" width=200 />


