### PR TITLE
Fix UI order for theme.json spacing sizes

### DIFF
--- a/backport-changelog/6.6/6616.md
+++ b/backport-changelog/6.6/6616.md
@@ -3,3 +3,4 @@ https://github.com/WordPress/wordpress-develop/pull/6616
 * https://github.com/WordPress/gutenberg/pull/58409
 * https://github.com/WordPress/gutenberg/pull/61328
 * https://github.com/WordPress/gutenberg/pull/61842
+* https://github.com/WordPress/gutenberg/pull/62199

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3852,6 +3852,10 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array The merged set of spacing sizes.
 	 */
 	private static function merge_spacing_sizes( $base, $incoming ) {
+		// Preserve the order if there are no base (spacingScale) values.
+		if ( empty( $base ) ) {
+			return $incoming;
+		}
 		$merged = array();
 		foreach ( $base as $item ) {
 			$merged[ $item['slug'] ] = $item;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3859,6 +3859,7 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $incoming as $item ) {
 			$merged[ $item['slug'] ] = $item;
 		}
+		ksort( $merged, SORT_NUMERIC );
 		return array_values( $merged );
 	}
 

--- a/packages/block-editor/src/components/spacing-sizes-control/hooks/use-spacing-sizes.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/hooks/use-spacing-sizes.js
@@ -42,7 +42,19 @@ export default function useSpacingSizes() {
 			...customSizes,
 			...themeSizes,
 			...defaultSizes,
-		].sort( ( a, b ) => compare( a.slug, b.slug ) );
+		];
+
+		// Only sort if more than one origin has presets defined in order to
+		// preserve order for themes that don't include default presets and
+		// want a custom order.
+		if (
+			( customSizes.length && 1 ) +
+				( themeSizes.length && 1 ) +
+				( defaultSizes.length && 1 ) >
+			1
+		) {
+			sizes.sort( ( a, b ) => compare( a.slug, b.slug ) );
+		}
 
 		return sizes.length > RANGE_CONTROL_MAX_SIZE
 			? [

--- a/packages/block-editor/src/components/spacing-sizes-control/hooks/use-spacing-sizes.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/hooks/use-spacing-sizes.js
@@ -65,8 +65,6 @@ export default function useSpacingSizes() {
 					},
 					...sizes,
 			  ]
-			: // See https://github.com/WordPress/gutenberg/pull/44247 for reasoning
-			  // to use the index as the name in the range control.
-			  sizes.map( ( { slug, size }, i ) => ( { name: i, slug, size } ) );
+			: sizes;
 	}, [ customSizes, themeSizes, defaultSizes ] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Solves the ordering issue for spacing sizing presets in v2 theme.json files that don't follow the `'10'`, `'20'`, etc. convention for slugs.

~The labels in the range slider remain numbers as, I believe, that was the intention of the feedback that #44247 fixed on the server instead of in the UI. It was a bug if the slider didn't show numbers.~

The labels are kept as t-shirt sizes when using the slider now.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #62194

> With Gutenberg 18.5 RC1 active, numbers are now being used in areas such as padding, and the mapping is out of order:
> 
> 1 = var(--wp--preset--spacing--large)
> 2 = var(--wp--preset--spacing--medium)
> 3 = var(--wp--preset--spacing--small)
> 4 = var(--wp--preset--spacing--x-large)
> 5 = var(--wp--preset--spacing--x-small)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It works by only sorting presets when they need to be merged.

See https://github.com/WordPress/gutenberg/issues/62194#issuecomment-2142933855 for details, but to summarize the constraints of the problem:

- Any solution must to work for both v2 and v3 as there is no distinction in the code (v2 shaped theme.json data automatically get converted to the v3 shape before anything can be done with the data).
- Sorting of multi-origin presets must be done in the UI as they are separated out on the server and cannot be merged until they're loaded in the JS.
- Renaming of multi-origin presets must be done in the UI for similar reasons.
- v2 themes with `spacingSizes` slugs that do not conform to the number convention must use the ordering defined in the theme.json file.

V2 theme.json files will _always_ only have one `spacingSizes` array, either the one defined in theme.json the one generated (in order) from `spacingSizes` values.

V2 theme.json files will _always_ only have one origin of `spacingSizes` defined.

V3 theme.json files allow both `spacingScale` and `spacingSizes` to be defined at the same time and the results merged into one array. When this is done on the server, we can sort the merged values. These merged values become `spacingSizes` for their origin in the frontend.

V3 theme.json files allow `default`, `theme`, and `custom` origins for `spacingSizes` that are separated until they reach the frontend. Only sort them in the frontend if more than one origin is defined.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add this in a `"version": 2` theme.json file.

```json
"spacing": {
	"spacingSizes": [
		{
			"name": "xSmall",
			"size": "clamp(10px, 2vw, 20px)",
			"slug": "x-small"
		},
		{
			"name": "Small",
			"size": "clamp(30px, 4vw, 40px)",
			"slug": "small"
		},
		{
			"name": "Medium",
			"size": "clamp(40px, 6vw, 60px)",
			"slug": "medium"
		},
		{
			"name": "Large",
			"size": "clamp(50px, 8vw, 80px)",
			"slug": "large"
		},
		{
			"name": "xLarge",
			"size": "clamp(60px, 10vw, 100px)",
			"slug": "x-large"
		}
	],
	"units": [ "%", "px", "em", "rem", "vh", "vw" ]
}
```

~The slider should still use numbers, but the presets should remain in their original order.~

The slider uses the preset names and remain in their original order.

xSmall = var(--wp--preset--spacing--x-small)
Small = var(--wp--preset--spacing--small)
Medium = var(--wp--preset--spacing--medium)
Large = var(--wp--preset--spacing--large)
xLarge = var(--wp--preset--spacing--x-large)

Additionally, v3 files should behave the same when `defaultSpacingSizes` is also set to `false`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
