### PR TITLE
Post Featured Image: Shadows not applied to block instances

### DIFF
--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -50,12 +50,9 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! empty( $attributes['scale'] ) ) {
 		$extra_styles .= "object-fit:{$attributes['scale']};";
 	}
-	if ( ! empty( $attributes['style']['shadow'] ) ) {
-		$shadow_styles = wp_style_engine_get_styles( array( 'shadow' => $attributes['style']['shadow'] ) );
 
-		if ( ! empty( $shadow_styles['css'] ) ) {
-			$extra_styles .= $shadow_styles['css'];
-		}
+	if ( ! empty( $attributes['style']['shadow'] ) ) {
+		$extra_styles .= "box-shadow:{$attributes['style']['shadow']};";
 	}
 
 	if ( ! empty( $extra_styles ) ) {


### PR DESCRIPTION
Follow up #59616

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR fixes an issue where the shadow is not applied to the Post Featured block under the following conditions:

- Apply shadow to block instance
- On the front end

## Why?

In the current implementation, CSS is generated via the style engine in the render callback function.

However, the value returned from the style engine is as follows and does not contain `css` key:

```
array(1) {
  ["declarations"]=>
  array(1) {
    ["box-shadow"]=>
    string(65) "6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1)"
  }
}
```

## How?

Shadow is just a CSS value, and there is no class like `has-shadow`. In this case, I don't think there is any need to use the style engine.

## Testing Instructions

- Insert a Post Featured Image block and apply a shadow.
- The shadow will be applied on the front end.
- Bonus: In the global style, apply a shadow to the Post Featured Image block. That shadow should be overwritten by the block instance shadow.
