### PR TITLE
block.json schema: Add supports.splitting field

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -643,7 +643,7 @@
 				},
 				"splitting": {
 					"type": "boolean",
-					"description": "This property indicates whether the block should merge its content with the content of the pasted block when it is pasted, and whether it should split the block when the Enter key is pressed.",
+					"description": "This property indicates whether the block can split when the Enter key is pressed or when blocks are pasted.",
 					"default": false
 				}
 			},

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -640,6 +640,11 @@
 							}
 						}
 					]
+				},
+				"splitting": {
+					"type": "boolean",
+					"description": "This property indicates whether the block should merge its content with the content of the pasted block when it is pasted, and whether it should split the block when the Enter key is pressed.",
+					"default": false
 				}
 			},
 			"additionalProperties": true


### PR DESCRIPTION
Related to #54543

## What?

This PR adds `supports.splitting` field to the block.json schema.

## Why?

This new field is a public API and therefore needs to be defined in the schema.

## How?

I created a description field based on the content of #54543, but it was difficult to explain well. If you have any suggestions for a more understandable explanation, I would be grateful.

## Testing Instructions

Create a JSON file like the one below locally and check that the code editor suggests "splitting".

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/block-json-schema-splitting/schemas/json/block.json",
	"apiVersion": 3,
	"title": "Test",
	"name": "test/test",
	"supports": {
	}
}
```

![image](https://github.com/WordPress/gutenberg/assets/54422211/c72ef739-5fb0-4693-8fb5-bc818e77a07c)