### PR TITLE
Style Book: allow activation when the canvas mode is "view"

### DIFF
--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -160,7 +160,7 @@ export default function EditorInterface( {
 
 					<EditorContentSlotFill.Slot>
 						{ ( [ editorCanvasView ] ) =>
-							! isPreviewMode && editorCanvasView ? (
+							editorCanvasView ? (
 								editorCanvasView
 							) : (
 								<>


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/62204

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove the `!  isPreviewMode` check before rendering contents of the `editorCanvasView` slot.

The effect is that the style book can be opened from the global styles side bar in preview mode when switching style variations. 

## Why?

Before https://github.com/WordPress/gutenberg/pull/62146, there was no check for preview mode when rendering the editor canvas container slot. 

What is preview mode?

It's another way of saying `canvasMode === 'view'`, which is a another way of saying that the editor view is not currently editable.

Thanks to @t-hamano for catching it.

## Testing Instructions

1. Open the site editor and go to the Styles page in the left hand side menu.
2. Click on the "Style Book" button.
3. It should open the style book


https://github.com/WordPress/gutenberg/assets/6458278/b13b56df-7fca-4d3e-9705-4e8ff9993dd2

