### PR TITLE
Editor: Avoid remounts of `DocumentBar`

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -29,7 +29,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { TEMPLATE_POST_TYPES, GLOBAL_POST_TYPES } from '../../store/constants';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import PostTypeSupportCheck from '../post-type-support-check';
 
 const TYPE_LABELS = {
 	// translators: 1: Pattern title.
@@ -182,25 +181,20 @@ export default function DocumentBar() {
 						}
 					>
 						<BlockIcon icon={ templateIcon } />
-						<PostTypeSupportCheck supportKeys="title">
-							<Text
-								size="body"
-								as="h1"
-								aria-label={
-									TYPE_LABELS[ postType ]
-										? // eslint-disable-next-line @wordpress/valid-sprintf
-										  sprintf(
-												TYPE_LABELS[ postType ],
-												title
-										  )
-										: undefined
-								}
-							>
-								{ title
-									? decodeEntities( title )
-									: __( 'No Title' ) }
-							</Text>
-						</PostTypeSupportCheck>
+						<Text
+							size="body"
+							as="h1"
+							aria-label={
+								TYPE_LABELS[ postType ]
+									? // eslint-disable-next-line @wordpress/valid-sprintf
+									  sprintf( TYPE_LABELS[ postType ], title )
+									: undefined
+							}
+						>
+							{ title
+								? decodeEntities( title )
+								: __( 'No Title' ) }
+						</Text>
 					</motion.div>
 					<span className="editor-document-bar__shortcut">
 						{ displayShortcut.primary( 'k' ) }

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -29,6 +29,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { TEMPLATE_POST_TYPES, GLOBAL_POST_TYPES } from '../../store/constants';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import PostTypeSupportCheck from '../post-type-support-check';
 
 const TYPE_LABELS = {
 	// translators: 1: Pattern title.
@@ -181,20 +182,25 @@ export default function DocumentBar() {
 						}
 					>
 						<BlockIcon icon={ templateIcon } />
-						<Text
-							size="body"
-							as="h1"
-							aria-label={
-								TYPE_LABELS[ postType ]
-									? // eslint-disable-next-line @wordpress/valid-sprintf
-									  sprintf( TYPE_LABELS[ postType ], title )
-									: undefined
-							}
-						>
-							{ title
-								? decodeEntities( title )
-								: __( 'No Title' ) }
-						</Text>
+						<PostTypeSupportCheck supportKeys="title">
+							<Text
+								size="body"
+								as="h1"
+								aria-label={
+									TYPE_LABELS[ postType ]
+										? // eslint-disable-next-line @wordpress/valid-sprintf
+										  sprintf(
+												TYPE_LABELS[ postType ],
+												title
+										  )
+										: undefined
+								}
+							>
+								{ title
+									? decodeEntities( title )
+									: __( 'No Title' ) }
+							</Text>
+						</PostTypeSupportCheck>
 					</motion.div>
 					<span className="editor-document-bar__shortcut">
 						{ displayShortcut.primary( 'k' ) }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -25,7 +25,6 @@ import MoreMenu from '../more-menu';
 import PostPreviewButton from '../post-preview-button';
 import PostPublishButtonOrToggle from '../post-publish-button/post-publish-button-or-toggle';
 import PostSavedState from '../post-saved-state';
-import PostTypeSupportCheck from '../post-type-support-check';
 import PostViewLink from '../post-view-link';
 import PreviewDropdown from '../preview-dropdown';
 import { store as editorStore } from '../../store';
@@ -117,13 +116,7 @@ function Header( {
 							! isBlockToolsCollapsed && hasTopToolbar,
 					} ) }
 				>
-					{ ! title ? (
-						<PostTypeSupportCheck supportKeys="title">
-							<DocumentBar />
-						</PostTypeSupportCheck>
-					) : (
-						title
-					) }
+					{ ! title ? <DocumentBar /> : title }
 				</div>
 			</motion.div>
 			<motion.div


### PR DESCRIPTION
## What?
Removes the `PostTypeSupportCheck` that is around `DocumentBar`.

## Why?
Fixes #61875

## More
`PostTypeSupportCheck` causes its children to remount as it relies on `getPostType` which is asynchronous. The change in this PR avoids the remount that interferes with animation.

## Testing Instructions
1. Open a page in the Site or Post editor
2. Select “Edit template” in the sidebar
3. Note the animation in the Document Bar

### Testing Instructions for Keyboard
Same as above, but I can add more detail if needed.

## Screenshots or screencast <!-- if applicable -->
### Currently

https://github.com/WordPress/gutenberg/assets/9000376/1717312c-4c59-4f66-997a-d69c0164e4ff

### On this branch

https://github.com/WordPress/gutenberg/assets/9000376/cc2561b6-769e-48e4-a1bf-9d623ccb63ed

