### PR TITLE
Add documentation for WordCount component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1592,7 +1592,11 @@ Undocumented declaration.
 
 ### WordCount
 
-Undocumented declaration.
+Renders the word count of the post content.
+
+_Returns_
+
+-   `JSX.Element|null`: The rendered WordCount component.
 
 ### WritingFlow
 

--- a/packages/editor/src/components/word-count/index.js
+++ b/packages/editor/src/components/word-count/index.js
@@ -10,6 +10,11 @@ import { count as wordCount } from '@wordpress/wordcount';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * Renders the word count of the post content.
+ *
+ * @return {JSX.Element|null} The rendered WordCount component.
+ */
 export default function WordCount() {
 	const content = useSelect(
 		( select ) => select( editorStore ).getEditedPostAttribute( 'content' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added documentation in the readme for WordCount component and also on component itself. Related to #60358 