### PR TITLE
Fix applying bindings or pattern overrides to button blocks with empty text

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -48,6 +48,7 @@ function gutenberg_reregister_core_block_types() {
 				'archives.php'                     => 'core/archives',
 				'avatar.php'                       => 'core/avatar',
 				'block.php'                        => 'core/block',
+				'button.php'                       => 'core/button',
 				'calendar.php'                     => 'core/calendar',
 				'categories.php'                   => 'core/categories',
 				'cover.php'                        => 'core/cover',

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -22,7 +22,6 @@ function render_block_core_button( $attributes, $content ) {
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a
 	 * `<div>` wrapper. Find the a or button tag.
-	 *
 	 */
 	$tag = null;
 	while ( $p->next_tag() ) {
@@ -32,29 +31,32 @@ function render_block_core_button( $attributes, $content ) {
 		}
 	}
 
-	// If this happens, the likelihood is there's no block content.
+	/*
+	 * If this happens, the likelihood is there's no block content,
+	 * or the block has been modified by a plugin.
+	 */
 	if ( null === $tag ) {
-		return '';
+		return $content;
 	}
 
 	// Build a string of the inner text.
 	$text = '';
 	while ( $p->next_token() ) {
-		switch ( $p->get_token_name() ) {
-			case '#text':
-				$text .= $p->get_modifiable_text();
-				break;
+		$token_name = $p->get_token_name();
+		// Stop when encountering the closing tag.
+		if ( $tag === $token_name ) {
+			break;
+		}
 
-			case 'BR':
-				$text .= '';
-				break;
+		if ( '#text' === $token_name ) {
+			$text .= $p->get_modifiable_text();
+			continue;
 		}
 	}
 
 	/*
 	 * When there's no text, render nothing for the block.
-	 * It's this way because an anchor or button element without text results
-	 * in poor accessibility.
+	 * See https://github.com/WordPress/gutenberg/issues/17221.
 	 */
 	if ( '' === trim( $text ) ) {
 		return '';

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -5,7 +5,7 @@
  * @package WordPress
  */
 
- /**
+/**
  * Renders the `core/button` block on the server,
  *
  * @since 6.6.0
@@ -16,7 +16,7 @@
  *
  * @return string The block content.
  */
-function render_block_core_button( $attributes, $content, $block ) {
+function render_block_core_button( $attributes, $content ) {
 	$p = new WP_HTML_Tag_Processor( $content );
 
 	/*

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Server-side rendering of the `core/button` block.
+ *
+ * @package WordPress
+ */
+
+ /**
+ * Renders the `core/button` block on the server,
+ *
+ * @since 6.6.0
+ *
+ * @param array    $attributes The block attributes.
+ * @param string   $content    The block content.
+ * @param WP_Block $block      The block object.
+ *
+ * @return string The block content.
+ */
+function render_block_core_button( $attributes, $content, $block ) {
+	$p = new WP_HTML_Tag_Processor( $content );
+
+	if ( ! $p->next_tag( 'a' ) ) {
+		return '';
+	}
+
+	$text = '';
+	while ( $p->next_token() ) {
+		switch ( $p->get_token_name() ) {
+			case '#text':
+				$text .= $p->get_modifiable_text();
+				break;
+
+			case 'BR':
+				$text .= '';
+				break;
+		}
+	}
+
+	// When there's no `text` set, avoid rendering an inaccessible button.
+	if ( trim( $text ) === '' ) {
+		return '';
+	}
+
+	return $content;
+}
+
+/**
+ * Registers the `core/button` block on server.
+ *
+ * @since 6.6.0
+ */
+function register_block_core_button() {
+	register_block_type_from_metadata(
+		__DIR__ . '/button',
+		array(
+			'render_callback' => 'render_block_core_button',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_button' );

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -39,26 +39,15 @@ function render_block_core_button( $attributes, $content ) {
 		return $content;
 	}
 
-	// Build a string of the inner text.
-	$text = '';
-	while ( $p->next_token() ) {
-		$token_name = $p->get_token_name();
-		// Stop when encountering the closing tag.
-		if ( $tag === $token_name ) {
-			break;
-		}
-
-		if ( '#text' === $token_name ) {
-			$text .= $p->get_modifiable_text();
-			continue;
-		}
-	}
+	// If the next token is the closing tag, the button is empty.
+	$p->next_token();
+	$is_empty = $p->get_token_name() === $tag;
 
 	/*
 	 * When there's no text, render nothing for the block.
 	 * See https://github.com/WordPress/gutenberg/issues/17221.
 	 */
-	if ( '' === trim( $text ) ) {
+	if ( $is_empty ) {
 		return '';
 	}
 

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -19,10 +19,25 @@
 function render_block_core_button( $attributes, $content, $block ) {
 	$p = new WP_HTML_Tag_Processor( $content );
 
-	if ( ! $p->next_tag( 'a' ) ) {
+	/*
+	 * The button block can render an `<a>` or `<button>` and also has a
+	 * `<div>` wrapper. Find the a or button tag.
+	 *
+	 */
+	$tag = null;
+	while ( $p->next_tag() ) {
+		$tag = $p->get_tag();
+		if ( 'A' === $tag || 'BUTTON' === $tag ) {
+			break;
+		}
+	}
+
+	// If this happens, the likelihood is there's no block content.
+	if ( null === $tag ) {
 		return '';
 	}
 
+	// Build a string of the inner text.
 	$text = '';
 	while ( $p->next_token() ) {
 		switch ( $p->get_token_name() ) {
@@ -36,8 +51,12 @@ function render_block_core_button( $attributes, $content, $block ) {
 		}
 	}
 
-	// When there's no `text` set, avoid rendering an inaccessible button.
-	if ( trim( $text ) === '' ) {
+	/*
+	 * When there's no text, render nothing for the block.
+	 * It's this way because an anchor or button element without text results
+	 * in poor accessibility.
+	 */
+	if ( '' === trim( $text ) ) {
 		return '';
 	}
 

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -40,12 +40,22 @@ function render_block_core_button( $attributes, $content ) {
 	}
 
 	// If the next token is the closing tag, the button is empty.
-	$p->next_token();
-	$is_empty = $p->get_token_name() === $tag;
+	$is_empty = true;
+	while ( $p->next_token() && $tag !== $p->get_token_name() && $is_empty ) {
+		if ( '#comment' !== $p->get_token_type() ) {
+			/**
+			 * Anything else implies this is not empty.
+			 * This might include any text content (including a space),
+			 * inline images or other HTML.
+			 */
+			$is_empty = false;
+		}
+	}
 
 	/*
 	 * When there's no text, render nothing for the block.
-	 * See https://github.com/WordPress/gutenberg/issues/17221.
+	 * See https://github.com/WordPress/gutenberg/issues/17221 for the
+	 * reasoning behind this.
 	 */
 	if ( $is_empty ) {
 		return '';

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -31,10 +31,6 @@ export default function save( { attributes, className } ) {
 		width,
 	} = attributes;
 
-	if ( RichText.isEmpty( text ) ) {
-		return null;
-	}
-
 	const TagName = tagName || 'a';
 	const isButtonTag = 'button' === TagName;
 	const buttonType = type || 'button';

--- a/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap
@@ -2,51 +2,69 @@
 
 exports[`Buttons block color customization sets a background color 1`] = `
 "<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"luminous-vivid-amber"} /--></div>
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"luminous-vivid-amber"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-luminous-vivid-amber-background-color has-background wp-element-button" href=""></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block color customization sets a custom gradient background color 1`] = `
 "<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"style":{"color":{"gradient":"linear-gradient(200deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)"}}} /--></div>
+<div class="wp-block-buttons"><!-- wp:button {"style":{"color":{"gradient":"linear-gradient(200deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button" href="" style="background:linear-gradient(200deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)"></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block color customization sets a gradient background color 1`] = `
 "<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"gradient":"light-green-cyan-to-vivid-green-cyan"} /--></div>
+<div class="wp-block-buttons"><!-- wp:button {"gradient":"light-green-cyan-to-vivid-green-cyan"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-light-green-cyan-to-vivid-green-cyan-gradient-background has-background wp-element-button" href=""></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block color customization sets a text color 1`] = `
 "<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"textColor":"pale-pink"} /--></div>
+<div class="wp-block-buttons"><!-- wp:button {"textColor":"pale-pink"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-pale-pink-color has-text-color wp-element-button" href=""></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block justify content sets Justify items center option 1`] = `
 "<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons"><!-- wp:button /--></div>
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block justify content sets Justify items left option 1`] = `
 "<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"}} -->
-<div class="wp-block-buttons"><!-- wp:button /--></div>
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block justify content sets Justify items right option 1`] = `
 "<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"}} -->
-<div class="wp-block-buttons"><!-- wp:button /--></div>
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;
 
 exports[`Buttons block when a button is shown adds another button using the inline appender 1`] = `
 "<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button /-->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href=""></a></div>
+<!-- /wp:button -->
 
-<!-- wp:button /--></div>
+<!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href=""></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->
 
 <!-- wp:paragraph -->
@@ -56,7 +74,9 @@ exports[`Buttons block when a button is shown adds another button using the inli
 
 exports[`Buttons block when a button is shown adds another button using the inserter 1`] = `
 "<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button /-->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href=""></a></div>
+<!-- /wp:button -->
 
 <!-- wp:button -->
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Hello!</a></div>

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -21,7 +21,9 @@ import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 
 const BUTTONS_HTML = `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button /--></div>
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"></a></div>
+<!-- /wp:button --></div>
 <!-- /wp:buttons -->`;
 
 beforeAll( () => {
@@ -248,10 +250,9 @@ describe( 'Buttons block', () => {
 			'Justify items right',
 		].forEach( ( justificationOption ) =>
 			it( `sets ${ justificationOption } option`, async () => {
-				const initialHtml = `<!-- wp:buttons -->
-				<div class="wp-block-buttons"><!-- wp:button /--></div>
-				<!-- /wp:buttons -->`;
-				const screen = await initializeEditor( { initialHtml } );
+				const screen = await initializeEditor( {
+					initialHtml: BUTTONS_HTML,
+				} );
 
 				const [ block ] = await screen.findAllByLabelText(
 					/Buttons Block\. Row 1/


### PR DESCRIPTION
## What?
Fixes #61303

An issue for block bindings and pattern overrides is when a button block's text is left empty, the editor saves no html due to a conditional return in the block's save function.

When a binding tries dynamically to update a button block in this state, it won't be able to due to the missing content.

This PR changes the button block so that the conditional rendering is implemented dynamically on the server. This allows block bindings to dynamically change the content of the block, even when there's empty text.

## How?
Uses the tag processor to check for inner content.

The `text` of a button block is a sourced attribute, so the sever is unable to parse the attribute value, so it needs to be read from the content.

## Testing Instructions
1. Create a synced pattern with an empty button block (no text defined)
2. Allow overrides for the button block
3. Save the pattern
4. Create a new post and insert the pattern you just created
5. Enter some text into the button
6. Preview the post

Expected: The button should appear with the override text.

As a general smoke test, it's also worth checking that buttons outside of patterns continue to work as expected when they have and do not have text.

You should also be able to add a button that has text to a pattern, and then override it with no text, and it won't render in the frontend

## Screenshots or screencast <!-- if applicable -->
### Editor
![Screenshot 2024-06-03 at 4 26 47 pm](https://github.com/WordPress/gutenberg/assets/677833/43589335-b825-4ea6-898a-6470d3cd79b6)

### Frontend
![Screenshot 2024-06-03 at 4 27 58 pm](https://github.com/WordPress/gutenberg/assets/677833/bb87fc66-9c1a-4df5-b256-e11af096b608)


