### PR TITLE
Try: Contextual frame bg color to avoid artifacting.

### DIFF
--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -1,7 +1,13 @@
 iframe[name="editor-canvas"] {
+	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
 	display: block;
-	background-color: $gray-300;
-	box-sizing: border-box;
+
+	// Show a dark background in "frame" mode to avoid edge artifacts.
+	// Show a gray background in all other contexts, such as zoom.
+	background-color: $gray-900;
+	.is-full-canvas & {
+		background-color: $gray-300;
+	}
 }

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -3,11 +3,5 @@ iframe[name="editor-canvas"] {
 	width: 100%;
 	height: 100%;
 	display: block;
-
-	// Show a dark background in "frame" mode to avoid edge artifacts.
-	// Show a gray background in all other contexts, such as zoom.
-	background-color: $gray-900;
-	.is-full-canvas & {
-		background-color: $gray-300;
-	}
+	background-color: transparent;
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -4,6 +4,11 @@
 	color: $gray-400;
 	display: flex;
 	flex-direction: column;
+
+	// Show a dark background in "frame" mode to avoid edge artifacts.
+	&:not(.is-full-canvas) .editor-visual-editor {
+		background: $gray-900;
+	}
 }
 
 .edit-site-layout__hub {

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -2,7 +2,13 @@
 	position: relative;
 	height: 100%;
 	display: block;
-	background-color: $gray-300;
+
+	// Show a dark background in "frame" mode to avoid edge artifacts.
+	// Show a gray background in all other contexts, such as zoom.
+	background-color: $gray-900;
+	.is-full-canvas & {
+		background-color: $gray-300;
+	}
 
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -2,13 +2,7 @@
 	position: relative;
 	height: 100%;
 	display: block;
-
-	// Show a dark background in "frame" mode to avoid edge artifacts.
-	// Show a gray background in all other contexts, such as zoom.
-	background-color: $gray-900;
-	.is-full-canvas & {
-		background-color: $gray-300;
-	}
+	background-color: $gray-300;
 
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;


### PR DESCRIPTION
## What?

When you have a theme with a dark background, the scale-up animation of the frame in the site editor has a white halo artifacting itself due to rounding math in the scale-up process:


https://github.com/WordPress/gutenberg/assets/1204802/a47b117f-e761-4317-97af-a85f12ebf735

This is due to the light gray background that is applied to the frame background peeking out.

This PR solves that by contextually applying a dark background to the framed contexts:


https://github.com/WordPress/gutenberg/assets/1204802/384cd5da-2704-4316-b8fc-53441e09ff8a

What about when you're using a light theme, you might ask? The artifacting is still addressed in that case because the outer background is dark. So it's only an issue when it's a dark background, a light frame background, and then a dark content background inside.

## Testing Instructions

Use a dark background, test the site editor, mouse over the frame to scale it up.

Note that previously the light gray background was applied specifically to address an issue with zoom out mode. Please do test that this still works.