### PR TITLE
Try: Fix mover positioning.

### DIFF
--- a/packages/editor/src/components/collapsible-block-toolbar/style.scss
+++ b/packages/editor/src/components/collapsible-block-toolbar/style.scss
@@ -64,8 +64,9 @@
 		// Move up a little to prevent the toolbar shift when focus is on the vertical movers.
 		@include break-small() {
 			&:not(.is-horizontal) .block-editor-block-mover__move-button-container {
+				height: 40px;
 				position: relative;
-				top: -10px;
+				top: -5px; // Should be -4px, but that causes scrolling when focus lands on the movers, in a 60px header.
 			}
 		}
 	}

--- a/packages/editor/src/components/collapsible-block-toolbar/style.scss
+++ b/packages/editor/src/components/collapsible-block-toolbar/style.scss
@@ -64,7 +64,7 @@
 		// Move up a little to prevent the toolbar shift when focus is on the vertical movers.
 		@include break-small() {
 			&:not(.is-horizontal) .block-editor-block-mover__move-button-container {
-				height: 40px;
+				height: $grid-unit-50;
 				position: relative;
 				top: -5px; // Should be -4px, but that causes scrolling when focus lands on the movers, in a 60px header.
 			}


### PR DESCRIPTION
## What?

The mover position when Top Toolbar is enabled is current pushed upwards:

![movers pushed upwards](https://github.com/WordPress/gutenberg/assets/1204802/80fcf692-58a2-4279-99f4-2a9e2c5662e5)

This PR improves but doesn't entirely fix this issue, by addressing some metrics.

![movers better positioned](https://github.com/WordPress/gutenberg/assets/1204802/e05536bc-c951-41aa-b5cd-510b7539e7c7)

This is a draft because https://github.com/WordPress/gutenberg/pull/60729 appears to fix this too. Let me know your thoughts.