### PR TITLE
Remove unused `syncDerivedUpdates` action

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -9,7 +9,6 @@ import { cloneBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { undoIgnoreBlocks } from '../../store/undo-ignore';
 
 const noop = () => {};
 
@@ -274,10 +273,6 @@ export default function useBlockSync( {
 				const updateParent = isPersistent
 					? onChangeRef.current
 					: onInputRef.current;
-				const undoIgnore = undoIgnoreBlocks.has( blocks );
-				if ( undoIgnore ) {
-					undoIgnoreBlocks.delete( blocks );
-				}
 				updateParent( blocks, {
 					selection: {
 						selectionStart: getSelectionStart(),
@@ -285,7 +280,6 @@ export default function useBlockSync( {
 						initialPosition:
 							getSelectedBlocksInitialCaretPosition(),
 					},
-					undoIgnore,
 				} );
 			}
 			previousAreBlocksDifferent = areBlocksDifferent;

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -6,7 +6,6 @@ import { Platform } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { undoIgnoreBlocks } from './undo-ignore';
 import { store as blockEditorStore } from './index';
 import { unlock } from '../lock-unlock';
 
@@ -289,34 +288,6 @@ export function deleteStyleOverride( id ) {
 	return {
 		type: 'DELETE_STYLE_OVERRIDE',
 		id,
-	};
-}
-
-/**
- * A higher-order action that mark every change inside a callback as "non-persistent"
- * and ignore pushing to the undo history stack. It's primarily used for synchronized
- * derived updates from the block editor without affecting the undo history.
- *
- * @param {() => void} callback The synchronous callback to derive updates.
- */
-export function syncDerivedUpdates( callback ) {
-	return ( { dispatch, select, registry } ) => {
-		registry.batch( () => {
-			// Mark every change in the `callback` as non-persistent.
-			dispatch( {
-				type: 'SET_EXPLICIT_PERSISTENT',
-				isPersistentChange: false,
-			} );
-			callback();
-			dispatch( {
-				type: 'SET_EXPLICIT_PERSISTENT',
-				isPersistentChange: undefined,
-			} );
-
-			// Ignore pushing undo stack for the updated blocks.
-			const updatedBlocks = select.getBlocks();
-			undoIgnoreBlocks.add( updatedBlocks );
-		} );
 	};
 }
 

--- a/packages/block-editor/src/store/undo-ignore.js
+++ b/packages/block-editor/src/store/undo-ignore.js
@@ -1,4 +1,4 @@
 // Keep track of the blocks that should not be pushing an additional
 // undo stack when editing the entity.
-// See the implementation of `syncDerivedUpdates` and `useBlockSync`.
+// See the implementation of `useBlockSync`.
 export const undoIgnoreBlocks = new WeakSet();

--- a/packages/block-editor/src/store/undo-ignore.js
+++ b/packages/block-editor/src/store/undo-ignore.js
@@ -1,4 +1,0 @@
-// Keep track of the blocks that should not be pushing an additional
-// undo stack when editing the entity.
-// See the implementation of `useBlockSync`.
-export const undoIgnoreBlocks = new WeakSet();


### PR DESCRIPTION
## What?
Remove `syncDerivedUpdates` private action.

## Why?

In [this pull request](https://github.com/WordPress/gutenberg/pull/60721), how pattern overrides are handled was changed and `syncDerivedUpdates` action doesn't seem to be used anymore. I assume it it better to remove it and add it back if needed.

## How?
Just removing the code.

## Testing Instructions
Tests should pass.
