### PR TITLE
Update URL to uppercase.

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -125,7 +125,7 @@ const LinkControlSearchInput = forwardRef(
 					className={ className }
 					value={ value }
 					onChange={ onInputChange }
-					placeholder={ placeholder ?? __( 'Search or type url' ) }
+					placeholder={ placeholder ?? __( 'Search or type URL' ) }
 					__experimentalRenderSuggestions={
 						showSuggestions ? handleRenderSuggestions : null
 					}

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -235,7 +235,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await page.getByPlaceholder( 'Search or type url' ).fill( '' );
+		await page.getByPlaceholder( 'Search or type URL' ).fill( '' );
 		await page.keyboard.type( '/handbook' );
 
 		// Submit the link.
@@ -349,7 +349,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await page.getByPlaceholder( 'Search or type url' ).fill( '' );
+		await page.getByPlaceholder( 'Search or type URL' ).fill( '' );
 		await page.keyboard.type( '/handbook' );
 
 		// Submit the link.
@@ -679,7 +679,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// Note: getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await linkPopover.getByPlaceholder( 'Search or type url' ).fill( '' );
+		await linkPopover.getByPlaceholder( 'Search or type URL' ).fill( '' );
 		await page.keyboard.type( 'wordpress.org' );
 
 		// Save the link.

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -2044,7 +2044,7 @@ test.describe( 'Block bindings', () => {
 					.getByRole( 'button', { name: 'Edit link', exact: true } )
 					.click();
 				await page
-					.getByPlaceholder( 'Search or type url' )
+					.getByPlaceholder( 'Search or type URL' )
 					.fill( '#url-custom-field-modified' );
 				await pageUtils.pressKeys( 'Enter' );
 
@@ -2103,7 +2103,7 @@ test.describe( 'Block bindings', () => {
 					.getByRole( 'button', { name: 'Edit link', exact: true } )
 					.click();
 				await page
-					.getByPlaceholder( 'Search or type url' )
+					.getByPlaceholder( 'Search or type URL' )
 					.fill( imageCustomFieldSrc );
 				await pageUtils.pressKeys( 'Enter' );
 


### PR DESCRIPTION
## What?

Noticed that we are using URL in lowercase in this placeholder:

![lowercase url](https://github.com/WordPress/gutenberg/assets/1204802/e993f883-0224-473a-853c-5a07aad95d0d)

Shouldn't that be uppercase, since it's an acronym? This PR makes it so:

![uppercase URL](https://github.com/WordPress/gutenberg/assets/1204802/04c79afb-9799-48d3-a53b-c36dd2578359)

## Testing Instructions

Insert a link, notice the placeholder text having uppercase URL.
