### PR TITLE
Scripts: Pin the @wordpress/scripts version to a version supported by 6.5

### DIFF
--- a/packages/create-block/lib/init-wp-scripts.js
+++ b/packages/create-block/lib/init-wp-scripts.js
@@ -16,7 +16,7 @@ module.exports = async ( { slug } ) => {
 	info(
 		'Installing `@wordpress/scripts` package. It might take a couple of minutes...'
 	);
-	await command( 'npm install @wordpress/scripts --save-dev', {
+	await command( 'npm install @wordpress/scripts@27 --save-dev', {
 		cwd,
 	} );
 


### PR DESCRIPTION
Related #62202

## What?

WordPress 6.6 was updated to use the new JSX transform but it's not released yet. That said, the latest version of the wp-scripts package targets 6.6 (and the Gutenberg plugin) by default and it's used to build Gutenberg itself so it was updated to use the new JSX.

For this reason, we need to pin the `@wordpress/create-block` tool to a version of wp-scripts that is supported by WordPress 6.5.

## Testing Instructions

1 : Create a new wordpress plugin "npx ../path-to-gutenberg-clone/packages/create-block"
2: cd test-plugin
3 : npm start
3 : activate plugin test-plugin
4 : edit a new page in wp-admin
5 : try to add the new block "/test-plugin"
6: The block should appear.
