### PR TITLE
[Mobile] - Unsupported block - UI improvements

### DIFF
--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -44,17 +44,12 @@ export class UnsupportedBlockEdit extends Component {
 	}
 
 	toggleSheet() {
-		const {
-			attributes,
-			block,
-			clientId,
-			isUnsupportedBlockEditorSupported,
-		} = this.props;
+		const { attributes, block, clientId } = this.props;
 		const { originalName } = attributes;
 		const title = this.getTitle();
 		const blockContent = serialize( block ? [ block ] : [] );
 
-		if ( isUnsupportedBlockEditorSupported ) {
+		if ( this.canEditUnsupportedBlock() ) {
 			requestUnsupportedBlockFallback(
 				blockContent,
 				clientId,
@@ -67,6 +62,18 @@ export class UnsupportedBlockEdit extends Component {
 		this.setState( {
 			showHelp: ! this.state.showHelp,
 		} );
+	}
+
+	canEditUnsupportedBlock() {
+		const {
+			canEnableUnsupportedBlockEditor,
+			isUnsupportedBlockEditorSupported,
+		} = this.props;
+
+		return (
+			! canEnableUnsupportedBlockEditor &&
+			isUnsupportedBlockEditorSupported
+		);
 	}
 
 	closeSheet() {
@@ -207,7 +214,7 @@ export class UnsupportedBlockEdit extends Component {
 
 		const subtitle = (
 			<Text style={ subTitleStyle }>
-				{ isUnsupportedBlockEditorSupported
+				{ this.canEditUnsupportedBlock()
 					? __( 'Tap to edit' )
 					: __( 'Unsupported' ) }
 			</Text>

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -194,11 +194,7 @@ export class UnsupportedBlockEdit extends Component {
 
 	render() {
 		const { originalName } = this.props.attributes;
-		const {
-			isUnsupportedBlockEditorSupported,
-			getStylesFromColorScheme,
-			preferredColorScheme,
-		} = this.props;
+		const { getStylesFromColorScheme, preferredColorScheme } = this.props;
 		const blockType = coreBlocks[ originalName ];
 
 		const title = this.getTitle();
@@ -242,7 +238,7 @@ export class UnsupportedBlockEdit extends Component {
 						styles.unsupportedBlockDark
 					) }
 				>
-					{ ! isUnsupportedBlockEditorSupported &&
+					{ ! this.canEditUnsupportedBlock() &&
 						this.renderHelpIcon() }
 					<View style={ styles.unsupportedBlockHeader }>
 						<Icon

--- a/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
@@ -9,12 +9,21 @@ exports[`Missing block renders without crashing 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": true,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }
   }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
   accessible={true}
+  collapsable={false}
   focusable={true}
   onClick={[Function]}
   onResponderGrant={[Function]}
@@ -23,72 +32,79 @@ exports[`Missing block renders without crashing 1`] = `
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "opacity": 1,
+    }
+  }
 >
-  <View
-    accessibilityHint="Tap here to show help"
-    accessibilityLabel="Help button"
-    accessibilityRole="button"
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": undefined,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
-    accessible={true}
-    collapsable={false}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      {
-        "opacity": 1,
-      }
-    }
-  >
-    <Svg
-      height={24}
-      label="Help icon"
-      style={{}}
-      viewBox="0 0 24 24"
-      width={24}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      Path
-    </Svg>
-  </View>
   <View>
-    <Svg
-      fill="white"
-      height={24}
-      style={{}}
-      viewBox="0 0 24 24"
-      width={24}
-      xmlns="http://www.w3.org/2000/svg"
+    <View
+      accessibilityHint="Tap here to show help"
+      accessibilityLabel="Help button"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "opacity": 1,
+        }
+      }
     >
-      Path
-    </Svg>
+      <Svg
+        height={24}
+        label="Help icon"
+        style={{}}
+        viewBox="0 0 24 24"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        Path
+      </Svg>
+    </View>
+    <View>
+      <Svg
+        fill="white"
+        height={24}
+        style={{}}
+        viewBox="0 0 24 24"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        Path
+      </Svg>
+      <Text>
+        missing/block/title
+      </Text>
+    </View>
     <Text>
-      missing/block/title
+      Unsupported
     </Text>
   </View>
-  <Text>
-    Unsupported
-  </Text>
 </View>
 `;

--- a/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
@@ -3,8 +3,28 @@
     display: none;
 }
 
+/* Remove header toolbar */
+.editor-header__toolbar {
+    display: none;
+}
+
+/* Hide all children of editor-header__settings */
+.editor-header__settings > * {
+    display: none;
+}
+
+/* Show only the interface-pinned-items container */
+.editor-header__settings > .interface-pinned-items {
+    display: block;
+}
+
+.components-button.editor-post-publish-panel__toggle.is-primary{
+    display: none;
+}
+
 /* Remove default block appender at the end of the post */
-.block-list-appender {
+.block-list-appender, .block-list-appender__toggle,
+.block-editor-inserter, .components-autocomplete__popover {
     display: none;
 }
 
@@ -15,6 +35,11 @@
 
 /* Remove default block appender at the end of the post (WP v5.0~v5.1) */
 .editor-default-block-appender {
+    display: none;
+}
+
+/* Remove block inserter popover */
+.block-editor-block-popover {
     display: none;
 }
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/62050

**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6904
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23299
- https://github.com/wordpress-mobile/WordPress-Android/pull/20930

## What?
This PR fixes some UI issues in the Unsupported block editor WebView as well as improvements in the Unsupported block editing flow within the mobile editor.

## Why?
To improve the Unsupported block editing experience for users.

## How?
First, it adds new style overrides to hide some of the UI of the web editor, like the Publish button or inserter actions. Users should only see the block options.

It changes the unsupported block editing flow by removing a step and just allowing users to tap the block to edit it using the WebView.

For sites that don't have support, they will see the current flow of a modal with the different options.

## Testing Instructions

> [!NOTE]  
> Please use the following builds to test:
> - [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/23299#issuecomment-2145634434)
> - [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/20930#issuecomment-2145646114)

Follow the Unsupported block test cases but take into account that these steps will need to be updated as in some cases, tapping on the Unsupported block would open the editor directly (Simple sites).

- [ ] [Unsupported Block Editing - Test Cases](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/unsupported-block-editing.md)

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

## Hiding UI elements

Before|After
-|-
<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/2f56fcbe-7f88-47a1-a91c-5b6296e66660" width=250 />|<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/1fe13fb2-7bd4-4862-bf9a-072b0b75001e" width=250 />

## New flow for sites that support Unsupported block editing

https://github.com/WordPress/gutenberg/assets/4885740/4c42a464-4119-4096-9f9b-9467c00393ac


