### PR TITLE
Editor: Refine availability of rename post action

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1049,6 +1049,7 @@ export function usePostActions( postType, onActionPerformed ) {
 	const isPattern = postType === PATTERN_POST_TYPE;
 	const isLoaded = !! postTypeObject;
 	const supportsRevisions = !! postTypeObject?.supports?.revisions;
+	const supportsTitle = !! postTypeObject?.supports?.title;
 	return useMemo( () => {
 		if ( ! isLoaded ) {
 			return [];
@@ -1064,7 +1065,7 @@ export function usePostActions( postType, onActionPerformed ) {
 				: false,
 			isTemplateOrTemplatePart && duplicateTemplatePartAction,
 			isPattern && duplicatePatternAction,
-			renamePostAction,
+			supportsTitle && renamePostAction,
 			isPattern && exportPatternAsJSONAction,
 			isTemplateOrTemplatePart ? resetTemplateAction : restorePostAction,
 			isTemplateOrTemplatePart || isPattern
@@ -1124,5 +1125,6 @@ export function usePostActions( postType, onActionPerformed ) {
 		onActionPerformed,
 		isLoaded,
 		supportsRevisions,
+		supportsTitle,
 	] );
 }

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -618,7 +618,11 @@ const renamePostAction = {
 	id: 'rename-post',
 	label: __( 'Rename' ),
 	isEligible( post ) {
-		if ( post.status === 'trash' ) {
+		if (
+			post.status === 'trash' ||
+			post.status === 'auto-draft' ||
+			! ( 'title' in post )
+		) {
 			return false;
 		}
 		// Templates, template parts and patterns have special checks for renaming.

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -618,11 +618,7 @@ const renamePostAction = {
 	id: 'rename-post',
 	label: __( 'Rename' ),
 	isEligible( post ) {
-		if (
-			post.status === 'trash' ||
-			post.status === 'auto-draft' ||
-			! ( 'title' in post )
-		) {
+		if ( post.status === 'trash' ) {
 			return false;
 		}
 		// Templates, template parts and patterns have special checks for renaming.

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -59,6 +59,42 @@ test.describe( 'Test Custom Post Types', () => {
 		await expect( parentPageLocator ).toHaveValue( parentPage );
 	} );
 
+	test( 'should not be able to rename a post that is either auto-drafted or lacks title support', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost( { postType: 'hierar-no-title' } );
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'hi' );
+		await editor.openDocumentSettingsSidebar();
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', {
+				name: 'Hierarchical No Title',
+			} )
+			.click();
+		await page.getByRole( 'button', { name: 'Actions' } ).click();
+		await page.getByRole( 'menu', { name: 'Actions' } ).isVisible();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Rename' } )
+		).toHaveCount( 0 );
+		await page.keyboard.press( 'Escape' );
+
+		await editor.publishPost();
+		await page.reload();
+
+		// Make sure rename is omitted not just because the post status had been auto-draft.
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'button', { name: 'Actions' } ).click();
+		await page.getByRole( 'menu', { name: 'Actions' } ).isVisible();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Rename' } )
+		).toHaveCount( 0 );
+	} );
+
 	test( 'should create a cpt with a legacy block in its template without WSOD', async ( {
 		admin,
 		editor,

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -59,37 +59,14 @@ test.describe( 'Test Custom Post Types', () => {
 		await expect( parentPageLocator ).toHaveValue( parentPage );
 	} );
 
-	test( 'should not be able to rename a post that is either auto-drafted or lacks title support', async ( {
+	test( 'should not be able to rename a post that lacks title support', async ( {
 		admin,
 		editor,
 		page,
 	} ) => {
 		await admin.createNewPost( { postType: 'hierar-no-title' } );
-		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
-			.click();
-		await page.keyboard.type( 'hi' );
-		await editor.openDocumentSettingsSidebar();
-		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'tab', {
-				name: 'Hierarchical No Title',
-			} )
-			.click();
-		await page.getByRole( 'button', { name: 'Actions' } ).click();
-		await page.getByRole( 'menu', { name: 'Actions' } ).isVisible();
-		await expect(
-			page.getByRole( 'menuitem', { name: 'Rename' } )
-		).toHaveCount( 0 );
-		await page.keyboard.press( 'Escape' );
-
-		await editor.publishPost();
-		await page.reload();
-
-		// Make sure rename is omitted not just because the post status had been auto-draft.
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'button', { name: 'Actions' } ).click();
-		await page.getByRole( 'menu', { name: 'Actions' } ).isVisible();
 		await expect(
 			page.getByRole( 'menuitem', { name: 'Rename' } )
 		).toHaveCount( 0 );


### PR DESCRIPTION
## What?
Omits the "rename" action on posts without "title" support.

## Why?
At present a post without "title" support has the action available but using it causes the editor to crash.

## How?
Adds a condition to omit the action when the post type lacks title support.

## Testing Instructions
If you don’t have a custom post type without title support handy there’s an e2e test added in the first commit that fails without the second commit. So from this branch with dev script running:

1. `checkout HEAD~`
2. `npm run test:e2e -- custom-post-types`
3. Observe failure because "rename" action was present
4. `git switch -`
5. Repeat step 2
6. Observe success

Or manually:
1. Open a post of a type without "title" support
2. Open the post’s "Actions" menu
3. Observe "rename" is not present.

## Screenshots or screencast
Before this PR, the crash:

https://github.com/WordPress/gutenberg/assets/9000376/337ecab0-00b0-47d0-98c0-ab9ca8336ca0

