### PR TITLE
Inserter: Return the same items when the state and parameters don't change

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -8,7 +8,7 @@ import {
 	parse,
 } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,13 +25,18 @@ import { withRootClientIdOptionKey } from '../../../store/utils';
  * @return {Array} Returns the block types state. (block types, categories, collections, onSelect handler)
  */
 const useBlockTypesState = ( rootClientId, onInsert, isQuick ) => {
+	const options = useMemo(
+		() => ( { [ withRootClientIdOptionKey ]: ! isQuick } ),
+		[ isQuick ]
+	);
 	const [ items ] = useSelect(
 		( select ) => [
-			select( blockEditorStore ).getInserterItems( rootClientId, {
-				[ withRootClientIdOptionKey ]: ! isQuick,
-			} ),
+			select( blockEditorStore ).getInserterItems(
+				rootClientId,
+				options
+			),
 		],
-		[ rootClientId, isQuick ]
+		[ rootClientId, options ]
 	);
 
 	const [ categories, collections ] = useSelect( ( select ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -76,6 +76,8 @@ const EMPTY_ARRAY = [];
  */
 const EMPTY_SET = new Set();
 
+const EMPTY_OBJECT = {};
+
 /**
  * Returns a block's name given its client ID, or null if no block exists with
  * the client ID.
@@ -1996,7 +1998,7 @@ const buildBlockTypeItem =
  */
 export const getInserterItems = createRegistrySelector( ( select ) =>
 	createSelector(
-		( state, rootClientId = null, options = {} ) => {
+		( state, rootClientId = null, options = EMPTY_OBJECT ) => {
 			const buildReusableBlockInserterItem = ( reusableBlock ) => {
 				const icon = ! reusableBlock.wp_pattern_sync_status
 					? {


### PR DESCRIPTION
## What?
PR updates the selector in the `useBlockTypesState` hook to return the same `items` when the state and parameters haven't changed.

This is a follow-up to https://github.com/WordPress/gutenberg/pull/62169#issuecomment-2145155218.

## Why?
The `getInserterItems` is a memoized selector, and when an argument is different on each call, it will return different (fresh) values. This behavior makes it complicated to add `array` or `object` type parameters to similar selectors. Example: #40718.

## How?
Memoize the `options` passed to the selector on the component level.

I don't like shifting this responsibility to the consumer, but I see no other way besides changing the `getInserterItems` signature.

## Testing Instructions
1. Open a post or page.
2. Open the global inserter.
3. Confirm the `useBlockTypesState` hook generates no warning.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-06-03 at 16 58 49](https://github.com/WordPress/gutenberg/assets/240569/b4124d17-b34c-4771-8817-74ff2618e1f5)

