### PR TITLE
Documentation: Better changelogs for the JSX transform upgrade

### DIFF
--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or anterior, you should not upgrade to this version and continue using @wordpress/babel-preset-default@7.
+
 -   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)).
 -   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or anterior, you should not upgrade to this version and continue using @wordpress/babel-preset-default@7.
+**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or earlier, you should not upgrade to this version and continue using @wordpress/babel-preset-default@7.
 
 -   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)).
 -   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or anterior, you should not upgrade to this version and continue using @wordpress/dependency-extraction-webpack-plugin@5.
+**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or earlier, you should not upgrade to this version and continue using @wordpress/dependency-extraction-webpack-plugin@5.
 
 -   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)).
 -   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Breaking Changes
 
+**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or anterior, you should not upgrade to this version and continue using @wordpress/dependency-extraction-webpack-plugin@5.
+
+-   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)).
 -   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 
 ## 5.9.0 (2024-05-16)

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Breaking Changes
 
--   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)).
+**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or anterior, you should not upgrade to this version and continue using @wordpress/scripts@27.
+
+-   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)). 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).
 -   Increase the minimum required Node.js version to v18.12.0 matching long-term support releases ([#31270](https://github.com/WordPress/gutenberg/pull/61930)). Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or anterior, you should not upgrade to this version and continue using @wordpress/scripts@27.
+**Note** If you're using @wordpress/scripts for building JS scripts to target WordPress 6.5 or earlier, you should not upgrade to this version and continue using @wordpress/scripts@27.
 
 -   Use React's automatic runtime to transform JSX ([#61692](https://github.com/WordPress/gutenberg/pull/61692)). 
 -   Variables like `process.env.IS_GUTENBERG_PLUGIN` have been replaced by `globalThis.IS_GUTENBERG_PLUGIN`. Build systems using `process.env` should be updated ([#61486](https://github.com/WordPress/gutenberg/pull/61486)).


### PR DESCRIPTION
Related #62202

## What?

The new JSX transform upgrade has a side consequence that we overlooked a bit. It meant that the new build packages don't support WP 6.5 and prior anymore since they require the new JSX runtime to be present.

The current PR updates the related package changelogs to clarify that. People building for 6.5 and before should stick with their current dependencies.
