### PR TITLE
Make edit site pagination buttons accessibly disabled

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -180,7 +180,8 @@
 		margin-bottom: $grid-unit-05;
 		line-height: 1.2;
 	}
-	.components-button.is-tertiary:disabled {
+	.components-button.is-tertiary:disabled,
+	.components-button.is-tertiary[aria-disabled="true"] {
 		color: $gray-600;
 	}
 	.components-button.is-tertiary:hover {

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -46,8 +46,7 @@ export default function Pagination( {
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => changePage( 1 ) }
-					// Disable reason: Would not cause confusion, and allows quicker access to a relevant nav button.
-					// eslint-disable-next-line no-restricted-syntax
+					__experimentalIsFocusable
 					disabled={ disabled || currentPage === 1 }
 					aria-label={ __( 'First page' ) }
 				>
@@ -56,8 +55,7 @@ export default function Pagination( {
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => changePage( currentPage - 1 ) }
-					// Disable reason: Would not cause confusion, and allows quicker access to a relevant nav button.
-					// eslint-disable-next-line no-restricted-syntax
+					__experimentalIsFocusable
 					disabled={ disabled || currentPage === 1 }
 					aria-label={ __( 'Previous page' ) }
 				>
@@ -76,8 +74,7 @@ export default function Pagination( {
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => changePage( currentPage + 1 ) }
-					// Disable reason: Would not cause confusion, and allows quicker access to a relevant nav button.
-					// eslint-disable-next-line no-restricted-syntax
+					__experimentalIsFocusable
 					disabled={ disabled || currentPage === numPages }
 					aria-label={ __( 'Next page' ) }
 				>
@@ -86,8 +83,7 @@ export default function Pagination( {
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => changePage( numPages ) }
-					// Disable reason: Would not cause confusion, and allows quicker access to a relevant nav button.
-					// eslint-disable-next-line no-restricted-syntax
+					__experimentalIsFocusable
 					disabled={ disabled || currentPage === numPages }
 					aria-label={ __( 'Last page' ) }
 				>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow-up to https://github.com/WordPress/gutenberg/pull/62080
Cc @mirka 

## What?
<!-- In a few words, what is the PR actually doing? -->
Pagination buttons are a typical case where buttons must be still focusable also when 'disabled'. 
Looking at the code statically as per the investigation made on  https://github.com/WordPress/gutenberg/pull/62080, it may appear that they can be 'truly' disabled. However, when using and interacting with these buttons via a keyboard here's the typical scenario where a focus loss must be prevented:
- Focus is on the Next or Last button.
- Press the Entrer key as many times as necessary to reach the last page.
- When on the last page, the button gets disabled dynamically _while_ it has focus.
- As such, focus is lost.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To prevent focus losses.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the `__experimentalIsFocusable`
Removes the eslint disable comment.
Adjusts the style.

Note: the styling of a disabled-focusable button should work consistently with all button variants. For example, the Undo and Redo buttons use `opacity` while these buttons only use a color change. This should be addressed in the Button component though and there should not be 'local' styling overrides. I'll create a separate issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to Site Editor > Styles > Revisions.
- Meks sure to have many styles revisions so that the panel will show pagination buttons.
- Use the keyboard.
- Navigate to the pagination buttons and reach the last page (pr going backwards, reach the first page).
- Observe the buttons are still focusable and get an `aria-disabled="true"` attribute instead of a `disabled` one.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
