### PR TITLE
Fix site editor breaking when user selects bound and non-bound blocks at the same time

### DIFF
--- a/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
+++ b/packages/block-editor/src/components/block-bindings-toolbar-indicator/index.js
@@ -57,7 +57,9 @@ export default function BlockBindingsToolbarIndicator( { clientIds } ) {
 				isConnectedToPatternOverrides: getBlocksByClientId(
 					clientIds
 				).some( ( block ) =>
-					Object.values( block?.attributes.metadata?.bindings ).some(
+					Object.values(
+						block?.attributes?.metadata?.bindings || {}
+					).some(
 						( binding ) =>
 							binding.source === 'core/pattern-overrides'
 					)


### PR DESCRIPTION
## What?
Fix a bug that breaks the site editor when user select blocks that use bindings and blocks that don't.

If I am not mistaken, it was introduced in [this pull request](https://github.com/WordPress/gutenberg/pull/61560), so I might be missing context.

## Why?
It breaks the editor.

## How?
At [this point](https://github.com/WordPress/gutenberg/compare/fix/site-editor-breaking-with-bindings?expand=1#diff-53c7becd18a8bab09d6e368f39a58eacb5ac5dcb25a80b2826308dedeaafc570R60-R62), ensure that if there are no bindings it iterates through an empty object.

## Testing Instructions
* Go to the site editor home.
* Add a block connected to any custom field.
```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"my_custom_field"}}}}} -->
<p>Default</p>
<!-- /wp:paragraph -->
```
* Add any other block.
* Select the bound block.
* Multi select the other block using "Shift", for example.
* Check that the site editor keeps working.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/34552881/2fcb09d8-8d56-41c4-9f18-f181bf3f61fe


**After**

https://github.com/WordPress/gutenberg/assets/34552881/58890202-d9f3-47ff-91db-99e7d31d8e9a