### PR TITLE
Replace exec with spawn in performance runner script

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -159,7 +159,8 @@ function printStats( m, s ) {
  */
 async function runTestSuite( testSuite, testRunnerDir, runKey ) {
 	await runShellScript(
-		`npm run test:performance -- ${ testSuite }`,
+		'npm',
+		[ 'run', 'test:performance', '--', testSuite ],
 		testRunnerDir,
 		{
 			...process.env,
@@ -329,7 +330,7 @@ async function runPerformanceTests( branches, options ) {
 	const testRunnerDir = path.join( baseDir + '/tests' );
 
 	logAtIndent( 2, 'Copying source to:', formats.success( testRunnerDir ) );
-	await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
+	await runShellScript( 'cp', [ '-R', sourceDir, testRunnerDir ] );
 
 	logAtIndent(
 		2,
@@ -341,7 +342,11 @@ async function runPerformanceTests( branches, options ) {
 
 	logAtIndent( 2, 'Installing dependencies and building' );
 	await runShellScript(
-		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npx playwright install chromium --with-deps && npm run build:packages"`,
+		'bash',
+		[
+			'-c',
+			'"source $HOME/.nvm/nvm.sh && nvm install && npm ci && npx playwright install chromium --with-deps && npm run build:packages"',
+		],
 		testRunnerDir
 	);
 
@@ -376,7 +381,7 @@ async function runPerformanceTests( branches, options ) {
 		const buildDir = path.join( envDir, 'plugin' );
 
 		logAtIndent( 3, 'Copying source to:', formats.success( buildDir ) );
-		await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
+		await runShellScript( 'cp', [ '-R', sourceDir, buildDir ] );
 
 		logAtIndent( 3, 'Checking out:', formats.success( branch ) );
 		// @ts-ignore
@@ -384,7 +389,11 @@ async function runPerformanceTests( branches, options ) {
 
 		logAtIndent( 3, 'Installing dependencies and building' );
 		await runShellScript(
-			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm ci && npm run build"`,
+			'bash',
+			[
+				'-c',
+				'"source $HOME/.nvm/nvm.sh && nvm install && npm ci && npm run build"',
+			],
 			buildDir
 		);
 
@@ -479,13 +488,13 @@ async function runPerformanceTests( branches, options ) {
 				const envDir = branchDirs[ branch ];
 
 				logAtIndent( 3, 'Starting environment' );
-				await runShellScript( `${ wpEnvPath } start`, envDir );
+				await runShellScript( wpEnvPath, [ 'start' ], envDir );
 
 				logAtIndent( 3, 'Running tests' );
 				await runTestSuite( testSuite, testRunnerDir, runKey );
 
 				logAtIndent( 3, 'Stopping environment' );
-				await runShellScript( `${ wpEnvPath } stop`, envDir );
+				await runShellScript( wpEnvPath, [ 'stop' ], envDir );
 			}
 		}
 	}

--- a/bin/plugin/lib/utils.js
+++ b/bin/plugin/lib/utils.js
@@ -4,7 +4,7 @@
 // @ts-ignore
 const inquirer = require( 'inquirer' );
 const fs = require( 'fs' );
-const { spawn } = require( 'child_process' );
+const childProcess = require( 'child_process' );
 const { v4: uuid } = require( 'uuid' );
 const path = require( 'path' );
 const os = require( 'os' );
@@ -19,29 +19,23 @@ const { log, formats } = require( './logger' );
  *
  * @typedef {NodeJS.ProcessEnv} Env
  *
- * @param {string}   command
- * @param {string[]} args
- * @param {string=}  cwd     Current working directory.
- * @param {Env=}     env     Environment variables.
- * @param {boolean=} shell   Use shell.
+ * @param {string}                               command
+ * @param {string[]}                             args
+ * @param {import('child_process').SpawnOptions} options
  */
-async function runShellScript( command, args, cwd, env = {}, shell = false ) {
-	if ( ! command ) {
-		throw new Error( 'No command provided' );
-	}
-
+async function spawn( command, args, options ) {
 	return new Promise( ( resolve, reject ) => {
-		const child = spawn( command, args, {
-			cwd,
+		const child = childProcess.spawn( command, args, {
 			env: {
 				NO_CHECKS: 'true',
 				PATH: process.env.PATH,
 				HOME: process.env.HOME,
 				USER: process.env.USER,
-				...env,
+				...options.env,
 			},
-			shell: /cp|bash/.test( command ) ? true : shell,
+			shell: false,
 			stdio: 'inherit',
+			...options,
 		} );
 
 		let stdout = '';
@@ -175,7 +169,7 @@ module.exports = {
 	askForConfirmation,
 	runStep,
 	readJSONFile,
-	runShellScript,
+	spawn,
 	getRandomTemporaryPath,
 	getFilesFromDir,
 };

--- a/bin/plugin/lib/utils.js
+++ b/bin/plugin/lib/utils.js
@@ -4,6 +4,7 @@
 // @ts-ignore
 const inquirer = require( 'inquirer' );
 const fs = require( 'fs' );
+const { promisify } = require( 'util' );
 const childProcess = require( 'child_process' );
 const { v4: uuid } = require( 'uuid' );
 const path = require( 'path' );
@@ -23,30 +24,18 @@ const { log, formats } = require( './logger' );
  * @param {string=} cwd    Working directory.
  * @param {Env=}    env    Additional environment variables to pass to the script.
  */
-function runShellScript( script, cwd, env = {} ) {
-	return new Promise( ( resolve, reject ) => {
-		childProcess.exec(
-			script,
-			{
-				cwd,
-				env: {
-					NO_CHECKS: 'true',
-					PATH: process.env.PATH,
-					HOME: process.env.HOME,
-					USER: process.env.USER,
-					...env,
-				},
-			},
-			function ( error, stdout, stderr ) {
-				if ( error ) {
-					console.log( stdout ); // Sometimes the error message is thrown via stdout.
-					console.log( stderr );
-					reject( error );
-				} else {
-					resolve( true );
-				}
-			}
-		);
+async function runShellScript( script, cwd, env = {} ) {
+	const execPromisified = promisify( childProcess.exec );
+
+	return await execPromisified( script, {
+		cwd,
+		env: {
+			NO_CHECKS: 'true',
+			PATH: process.env.PATH,
+			HOME: process.env.HOME,
+			USER: process.env.USER,
+			...env,
+		},
 	} );
 }
 

--- a/bin/plugin/lib/utils.js
+++ b/bin/plugin/lib/utils.js
@@ -17,8 +17,6 @@ const { log, formats } = require( './logger' );
 /**
  * Utility to run a child script
  *
- * @typedef {NodeJS.ProcessEnv} Env
- *
  * @param {string}                               command
  * @param {string[]}                             args
  * @param {import('child_process').SpawnOptions} options

--- a/bin/plugin/lib/utils.js
+++ b/bin/plugin/lib/utils.js
@@ -63,14 +63,14 @@ async function spawn( command, args, options ) {
 			} else {
 				reject(
 					new Error(
-						`Process exited with code ${ code }: ${ stderr }`
+						`Process ${ command } exited with code ${ code }: ${ stderr }`
 					)
 				);
 			}
 		} );
 
 		child.on( 'error', ( error ) => {
-			reject( error );
+			reject( `Process ${ command } ended with error: ${ error }` );
 		} );
 	} );
 }

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -28,6 +28,22 @@ async function getAPIRootURL( request: APIRequestContext ) {
 	const links = response.headers().link;
 	const restLink = links?.match( /<([^>]+)>; rel="https:\/\/api\.w\.org\/"/ );
 
+	console.log( response.headers() ); // eslint-disable-line no-console
+
+	try {
+		const html = await response.text();
+		console.log( html ); // eslint-disable-line no-console
+	} catch ( error ) {
+		// noop
+	}
+
+	try {
+		const json = await response.json();
+		console.log( json ); // eslint-disable-line no-console
+	} catch ( error ) {
+		// noop
+	}
+
 	if ( ! restLink ) {
 		throw new Error( `Failed to discover REST API endpoint.
  Link header: ${ links }` );

--- a/test/performance/playwright.config.ts
+++ b/test/performance/playwright.config.ts
@@ -14,9 +14,7 @@ process.env.ASSETS_PATH = path.join( __dirname, 'assets' );
 
 const config = defineConfig( {
 	...baseConfig,
-	reporter: process.env.CI
-		? './config/performance-reporter.ts'
-		: [ [ 'list' ], [ './config/performance-reporter.ts' ] ],
+	reporter: [ [ 'list' ], [ './config/performance-reporter.ts' ] ],
 	forbidOnly: !! process.env.CI,
 	fullyParallel: false,
 	retries: 0,

--- a/test/performance/specs/front-end-block-theme.spec.js
+++ b/test/performance/specs/front-end-block-theme.spec.js
@@ -42,6 +42,7 @@ test.describe( 'Front End Performance', () => {
 			// Go to the base URL.
 			// eslint-disable-next-line playwright/no-networkidle
 			await page.goto( '/', { waitUntil: 'networkidle' } );
+			await page.locator( '.oopsie' ).waitFor( { timeout: 1000 } );
 
 			// Take the measurements.
 			const ttfb = await metrics.getTimeToFirstByte();

--- a/test/performance/specs/front-end-block-theme.spec.js
+++ b/test/performance/specs/front-end-block-theme.spec.js
@@ -42,7 +42,6 @@ test.describe( 'Front End Performance', () => {
 			// Go to the base URL.
 			// eslint-disable-next-line playwright/no-networkidle
 			await page.goto( '/', { waitUntil: 'networkidle' } );
-			await page.locator( '.oopsie' ).waitFor( { timeout: 1000 } );
 
 			// Take the measurements.
 			const ttfb = await metrics.getTimeToFirstByte();


### PR DESCRIPTION
Related slack convo: [link](https://wordpress.slack.com/archives/C02QB2JS7/p1717483146113199?thread_ts=1717143284.055259&cid=C02QB2JS7)

## What?
Performance tests runner seems to be [swallowing the tests errors](https://github.com/WordPress/gutenberg/actions/runs/9361910664/job/25769690941), printing a cryptic exception:

```sh
Error: Command failed: npm run test:performance -- site-editor

    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1105:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'npm run test:performance -- site-editor'
}
```

Let's see if passing the outputs the recommended way makes the errors appear as expected.