### PR TITLE
Block Variations: Compare objects based on given properties

### DIFF
--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -12,7 +12,7 @@ import { RichTextData } from '@wordpress/rich-text';
 /**
  * Internal dependencies
  */
-import { getValueFromObjectPath } from './utils';
+import { getValueFromObjectPath, matchesAttributes } from './utils';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
 /** @typedef {import('../api/registration').WPBlockVariationScope} WPBlockVariationScope */
@@ -276,6 +276,17 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 				);
 				if ( blockAttributeValue instanceof RichTextData ) {
 					blockAttributeValue = blockAttributeValue.toHTMLString();
+				}
+				// If the attribute value is an object, we need to compare its properties.
+				if (
+					variationAttributeValue !== null &&
+					typeof variationAttributeValue === 'object' &&
+					variationAttributeValue.constructor === Object
+				) {
+					return matchesAttributes(
+						blockAttributeValue,
+						variationAttributeValue
+					);
 				}
 				return variationAttributeValue === blockAttributeValue;
 			} );

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -277,18 +277,10 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 				if ( blockAttributeValue instanceof RichTextData ) {
 					blockAttributeValue = blockAttributeValue.toHTMLString();
 				}
-				// If the attribute value is an object, we need to compare its properties.
-				if (
-					variationAttributeValue !== null &&
-					typeof variationAttributeValue === 'object' &&
-					variationAttributeValue.constructor === Object
-				) {
-					return matchesAttributes(
-						blockAttributeValue,
-						variationAttributeValue
-					);
-				}
-				return variationAttributeValue === blockAttributeValue;
+				return matchesAttributes(
+					blockAttributeValue,
+					variationAttributeValue
+				);
 			} );
 			if ( isMatch && definedAttributesLength > maxMatchedAttributes ) {
 				match = variation;

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -494,6 +494,51 @@ describe( 'selectors', () => {
 					} )
 				).toEqual( variations[ 1 ] );
 			} );
+			it( 'should compare object attributes in the isActive array based on given properties', () => {
+				const variations = [
+					{
+						name: 'variation-1',
+						attributes: {
+							testAttribute: {
+								nestedProperty: 1,
+								secondNestedProperty: 10,
+							},
+						},
+						isActive: [ 'testAttribute' ],
+					},
+					{
+						name: 'variation-2',
+						attributes: {
+							testAttribute: {
+								nestedProperty: 2,
+								secondNestedProperty: 20,
+							},
+						},
+						isActive: [ 'testAttribute' ],
+					},
+				];
+				const state =
+					createBlockVariationsStateWithTestBlockType( variations );
+
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						testAttribute: {
+							nestedProperty: 1,
+							secondNestedProperty: 10,
+							otherNestedProperty: 5555,
+						},
+					} )
+				).toEqual( variations[ 0 ] );
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						testAttribute: {
+							nestedProperty: 2,
+							secondNestedProperty: 20,
+							otherNestedProperty: 5555,
+						},
+					} )
+				).toEqual( variations[ 1 ] );
+			} );
 			it( 'should return the active variation based on the given isActive array (multiple values)', () => {
 				const variations = [
 					{

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -499,22 +499,40 @@ describe( 'selectors', () => {
 					{
 						name: 'variation-1',
 						attributes: {
-							testAttribute: {
+							firstTestAttribute: {
 								nestedProperty: 1,
 								secondNestedProperty: 10,
 							},
+							secondTestAttribute: {
+								nestedProperty: {
+									firstDeeplyNestedProperty: 'a1',
+									secondDeeplyNestedProperty: 'a2',
+								},
+							},
 						},
-						isActive: [ 'testAttribute' ],
+						isActive: [
+							'firstTestAttribute',
+							'secondTestAttribute.nestedProperty',
+						],
 					},
 					{
 						name: 'variation-2',
 						attributes: {
-							testAttribute: {
+							firstTestAttribute: {
 								nestedProperty: 2,
 								secondNestedProperty: 20,
 							},
+							secondTestAttribute: {
+								nestedProperty: {
+									firstDeeplyNestedProperty: 'b1',
+									secondDeeplyNestedProperty: 'b2',
+								},
+							},
 						},
-						isActive: [ 'testAttribute' ],
+						isActive: [
+							'firstTestAttribute',
+							'secondTestAttribute.nestedProperty',
+						],
 					},
 				];
 				const state =
@@ -522,19 +540,33 @@ describe( 'selectors', () => {
 
 				expect(
 					getActiveBlockVariation( state, blockName, {
-						testAttribute: {
+						firstTestAttribute: {
 							nestedProperty: 1,
 							secondNestedProperty: 10,
 							otherNestedProperty: 5555,
+						},
+						secondTestAttribute: {
+							nestedProperty: {
+								firstDeeplyNestedProperty: 'a1',
+								secondDeeplyNestedProperty: 'a2',
+								otherDeeplyNestedProperty: 'ffff',
+							},
 						},
 					} )
 				).toEqual( variations[ 0 ] );
 				expect(
 					getActiveBlockVariation( state, blockName, {
-						testAttribute: {
+						firstTestAttribute: {
 							nestedProperty: 2,
 							secondNestedProperty: 20,
 							otherNestedProperty: 5555,
+						},
+						secondTestAttribute: {
+							nestedProperty: {
+								firstDeeplyNestedProperty: 'b1',
+								secondDeeplyNestedProperty: 'b2',
+								otherDeeplyNestedProperty: 'ffff',
+							},
 						},
 					} )
 				).toEqual( variations[ 1 ] );

--- a/packages/blocks/src/store/utils.js
+++ b/packages/blocks/src/store/utils.js
@@ -18,3 +18,27 @@ export const getValueFromObjectPath = ( object, path, defaultValue ) => {
 	} );
 	return value ?? defaultValue;
 };
+
+/**
+ * Determine whether a set of object properties matches a given object.
+ *
+ * Given an object of block attributes and an object of variation attributes,
+ * this function checks recursively whether all the variation attributes are
+ * present in the block attributes object.
+ *
+ * @param {Object} blockAttributes     The object to inspect.
+ * @param {Object} variationAttributes The object of property values to match.
+ * @return {boolean} Whether the block attributes match the variation attributes.
+ */
+export function matchesAttributes( blockAttributes, variationAttributes ) {
+	return Object.entries( variationAttributes ).every( ( [ key, value ] ) => {
+		if (
+			typeof value === 'object' &&
+			value !== null &&
+			typeof blockAttributes[ key ] === 'object'
+		) {
+			return matchesAttributes( blockAttributes[ key ], value );
+		}
+		return blockAttributes[ key ] === value;
+	} );
+}

--- a/packages/blocks/src/store/utils.js
+++ b/packages/blocks/src/store/utils.js
@@ -19,6 +19,14 @@ export const getValueFromObjectPath = ( object, path, defaultValue ) => {
 	return value ?? defaultValue;
 };
 
+function isObject( candidate ) {
+	return (
+		typeof candidate === 'object' &&
+		candidate.constructor === Object &&
+		candidate !== null
+	);
+}
+
 /**
  * Determine whether a set of object properties matches a given object.
  *
@@ -31,17 +39,12 @@ export const getValueFromObjectPath = ( object, path, defaultValue ) => {
  * @return {boolean} Whether the block attributes match the variation attributes.
  */
 export function matchesAttributes( blockAttributes, variationAttributes ) {
-	if ( ! blockAttributes ) {
-		return false;
+	if ( isObject( blockAttributes ) && isObject( variationAttributes ) ) {
+		return Object.entries( variationAttributes ).every(
+			( [ key, value ] ) =>
+				matchesAttributes( blockAttributes?.[ key ], value )
+		);
 	}
-	return Object.entries( variationAttributes ).every( ( [ key, value ] ) => {
-		if (
-			typeof value === 'object' &&
-			value !== null &&
-			typeof blockAttributes[ key ] === 'object'
-		) {
-			return matchesAttributes( blockAttributes[ key ], value );
-		}
-		return blockAttributes[ key ] === value;
-	} );
+
+	return blockAttributes === variationAttributes;
 }

--- a/packages/blocks/src/store/utils.js
+++ b/packages/blocks/src/store/utils.js
@@ -31,6 +31,9 @@ export const getValueFromObjectPath = ( object, path, defaultValue ) => {
  * @return {boolean} Whether the block attributes match the variation attributes.
  */
 export function matchesAttributes( blockAttributes, variationAttributes ) {
+	if ( ! blockAttributes ) {
+		return false;
+	}
 	return Object.entries( variationAttributes ).every( ( [ key, value ] ) => {
 		if (
 			typeof value === 'object' &&


### PR DESCRIPTION
## What?

If a block variation has an `isActive` property that is an array of strings (attribute names), and one of the attributes referenced therein is an object, compare that attribute based on the object properties specified by the variation, rather than by reference.

## Why?
Object attributes of a variation are currently compared by reference to the given block's attributes, meaning that the comparison will never return `true`.

For example, take the following variation of the Paragraph block:

```diff
diff --git a/packages/block-library/src/paragraph/block.json b/packages/block-library/src/paragraph/block.json
index 6f11baf838..8bd350fb1e 100644
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -70,5 +70,25 @@
 		}
 	},
 	"editorStyle": "wp-block-paragraph-editor",
-	"style": "wp-block-paragraph"
+	"style": "wp-block-paragraph",
+	"variations": [
+		{
+			"name": "warning",
+			"title": "Warning",
+			"icon": "warning",
+			"attributes": {
+				"metadata": {
+					"bindings": {
+						"content": {
+							"source": "core/post-meta",
+							"args": {
+								"key": "text_field"
+							}
+						}
+					}
+				}
+			},
+			"isActive": [ "metadata.bindings.content" ]
+		}
+	]
 }
```

Prior to this PR, `isActive` would return `false` for the given variation, because it would compare the given block's `metadata.bindings.content` (nested) attribute by object reference to the variation's. 

## How?
By (recursively) iterating over the object properties specified by the variation and comparing those to the given block's. (In the example above, those properties are `source` and `args`; since `args` is an object itself, the comparison steps into it recursively and compares its `key` property to the given block's as well).

Note that this PR re-introduces the `matchesAttributes` util function (albeit in a different place) that was previously removed by #58194.

## Testing Instructions
Smoke-test block variations and verify that they still work as before.
Optionally, try adding the above variation to the Paragraph block, and verify that the variation is correctly detected (thus fixing the issue reported [in this comment](https://github.com/WordPress/gutenberg/pull/62031#issuecomment-2142102041)).
