### PR TITLE
Fix: Remove unused code from dataviews styles.

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -603,11 +603,6 @@
 	}
 }
 
-.dataviews-filters__custom-menu-radio-item-prefix {
-	display: block;
-	width: 24px;
-}
-
 .dataviews-bulk-edit-button.components-button {
 	flex-shrink: 0;
 }


### PR DESCRIPTION
The selector and its styles "dataviews-filters__custom-menu-radio-item-prefix" were added in https://github.com/WordPress/gutenberg/pull/57651/ and were used at the time in https://github.com/WordPress/gutenberg/blob/8ddabf7fab5fbbc13afafbb23ddf8d15630930f7/packages/dataviews/src/dropdown-menu-helper.js.
Right now the className is not used anywhere but we missed the removal of the CSS code.

## Testing Instructions
Verified the filters in dataviews look as before.
