### PR TITLE
Chore: Simplify a padding style on dataviews.

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -370,8 +370,7 @@
 		line-height: 16px;
 
 		&:not(:empty) {
-			padding: $grid-unit-15 0;
-			padding-top: 0;
+			padding: 0 0 $grid-unit-15;
 		}
 
 		.dataviews-view-grid__field {


### PR DESCRIPTION
The styles `padding: $grid-unit-15 0; padding-top: 0;` could be expressed in a simpler way as `padding: 0 0 $grid-unit-15;`. This PR applies that enhancement.

