### PR TITLE
Fix: Show homepage link on frontpage instead of the slug.

### DIFF
--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { safeDecodeURIComponent } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -58,10 +59,17 @@ export default function PostURLPanel() {
 }
 
 function PostURLToggle( { isOpen, onClick } ) {
-	const slug = useSelect(
-		( select ) => select( editorStore ).getEditedPostSlug(),
-		[]
-	);
+	const { slug, isFrontPage, postLink } = useSelect( ( select ) => {
+		const { getCurrentPostId, getCurrentPost } = select( editorStore );
+		const { getEditedEntityRecord } = select( coreStore );
+		const siteSettings = getEditedEntityRecord( 'root', 'site' );
+		const _id = getCurrentPostId();
+		return {
+			slug: select( editorStore ).getEditedPostSlug(),
+			isFrontPage: siteSettings?.page_on_front === _id,
+			postLink: getCurrentPost()?.link,
+		};
+	}, [] );
 	const decodedSlug = safeDecodeURIComponent( slug );
 	return (
 		<Button
@@ -73,7 +81,7 @@ function PostURLToggle( { isOpen, onClick } ) {
 			aria-label={ sprintf( __( 'Change link: %s' ), decodedSlug ) }
 			onClick={ onClick }
 		>
-			/{ decodedSlug }
+			{ isFrontPage ? postLink : <>/{ decodedSlug }</> }
 		</Button>
 	);
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/62065
On the trunk for the homepage/frontpage of a site, we are still showing the slug as the link which is wrong. This PR fixes the issue and shows the true homepage URL for the frontpage.

cc: @jameskoster 

## Testing Instructions
I verified the true homepage URL is shown for pages marked as the frontpage.

Before:

<img width="351" alt="Screenshot 2024-06-04 at 13 34 59" src="https://github.com/WordPress/gutenberg/assets/11271197/2a5419ac-f6f2-4dd3-b3a1-90e5c3701a5f">

After:
<img width="349" alt="Screenshot 2024-06-04 at 13 32 15" src="https://github.com/WordPress/gutenberg/assets/11271197/92a0693c-bac6-4b81-b84a-a897ad2f7232">

