### PR TITLE
Button Block: Allow custom width

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -17,12 +17,11 @@ import { unlock } from '../lock-unlock';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, useRef, useMemo } from '@wordpress/element';
 import {
-	Button,
-	ButtonGroup,
 	PanelBody,
 	TextControl,
 	ToolbarButton,
 	Popover,
+	FontSizePicker,
 } from '@wordpress/components';
 import {
 	AlignmentControl,
@@ -125,24 +124,34 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 
 	return (
 		<PanelBody title={ __( 'Settings' ) }>
-			<ButtonGroup aria-label={ __( 'Button width' ) }>
-				{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
-					return (
-						<Button
-							key={ widthValue }
-							size="small"
-							variant={
-								widthValue === selectedWidth
-									? 'primary'
-									: undefined
-							}
-							onClick={ () => handleChange( widthValue ) }
-						>
-							{ widthValue }%
-						</Button>
-					);
-				} ) }
-			</ButtonGroup>
+			<FontSizePicker
+				fontSizes={ [
+					{
+						name: '25%',
+						size: '25%',
+						slug: '25',
+					},
+					{
+						name: '50%',
+						size: '50%',
+						slug: '50',
+					},
+					{
+						name: '75%',
+						size: '75%',
+						slug: '75',
+					},
+					{
+						name: '100%',
+						size: '100%',
+						slug: '100',
+					},
+				] }
+				withSlider
+				units={ [ '%', 'px', 'rem' ] }
+				onChange={ ( widthValue ) => handleChange( widthValue ) }
+				value={ selectedWidth }
+			/>
 		</PanelBody>
 	);
 }
@@ -262,10 +271,10 @@ function ButtonEdit( props ) {
 			<div
 				{ ...blockProps }
 				className={ clsx( blockProps.className, {
-					[ `has-custom-width wp-block-button__width-${ width }` ]:
-						width,
+					[ `has-custom-width` ]: width,
 					[ `has-custom-font-size` ]: blockProps.style.fontSize,
 				} ) }
+				style={ { width } }
 			>
 				<RichText
 					ref={ mergedRef }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -66,12 +66,17 @@ export default function save( { attributes, className } ) {
 	// A title will no longer be assigned for new or updated button block links.
 
 	const wrapperClasses = clsx( className, {
-		[ `has-custom-width wp-block-button__width-${ width }` ]: width,
+		[ `has-custom-width` ]: width,
 		[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
 	} );
 
 	return (
-		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+		<div
+			{ ...useBlockProps.save( {
+				className: wrapperClasses,
+				style: { width },
+			} ) }
+		>
 			<RichText.Content
 				tagName={ TagName }
 				type={ isButtonTag ? buttonType : null }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -52,23 +52,6 @@ $blocks-block__margin: 0.5em;
 			font-size: inherit;
 		}
 	}
-
-	&.wp-block-button__width-25 {
-		width: calc(25% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.75));
-	}
-
-	&.wp-block-button__width-50 {
-		width: calc(50% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.5));
-	}
-
-	&.wp-block-button__width-75 {
-		width: calc(75% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.25));
-	}
-
-	&.wp-block-button__width-100 {
-		width: 100%;
-		flex-basis: 100%;
-	}
 }
 
 // For vertical buttons, gap is not factored into width calculations.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes: #62247
## What?
<!-- In a few words, what is the PR actually doing? -->
Add FontSizePicker for button block for custom width size
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To allow custom width for button block
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We are using the FontSizePicker for width of the button so that we can choose the custom size as well. And instead of giving width using class we are using the style attribute.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1280" alt="Screenshot 2024-06-04 at 5 20 33 PM" src="https://github.com/WordPress/gutenberg/assets/40138190/7f903dc6-21fc-4447-8a4e-bce42427f49c">
<img width="1280" alt="Screenshot 2024-06-04 at 5 25 30 PM" src="https://github.com/WordPress/gutenberg/assets/40138190/bbd5963d-8b7d-4700-80bd-4b1dce5070f6">
