### PR TITLE
Skip 'Site Updated' message if only post meta was saved

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -798,7 +798,6 @@ export const saveEditedEntityRecord =
 			name,
 			recordId
 		);
-
 		const record = { [ entityIdKey ]: recordId, ...edits };
 		return await {
 			values: dispatch.saveEntityRecord( kind, name, record, options ),

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -798,8 +798,12 @@ export const saveEditedEntityRecord =
 			name,
 			recordId
 		);
+
 		const record = { [ entityIdKey ]: recordId, ...edits };
-		return await dispatch.saveEntityRecord( kind, name, record, options );
+		return await {
+			values: dispatch.saveEntityRecord( kind, name, record, options ),
+			metaChange: !! edits?.meta,
+		};
 	};
 
 /**

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -203,7 +203,7 @@ export const saveDirtyEntities =
 					registry
 						.dispatch( noticesStore )
 						.createErrorNotice( __( 'Saving failed.' ) );
-				} else {
+				} else if ( ! values.every( ( value ) => value.metaChange ) ) {
 					registry
 						.dispatch( noticesStore )
 						.createSuccessNotice( __( 'Site updated.' ), {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR aims to avoid rendering the "Site Updated" message if only post metadata in an entity has changed, namely in relation to [editing meta via block bindings](https://github.com/WordPress/gutenberg/pull/61753).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/62236
We don't want to erroneously show the "Site Updated" message.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Right now, it adds a flag to `saveEditedEntityRecord()` if edits include post meta, and prevents the "Site Updated" message from showing if this is the only kind of edit that occurred.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

<details>
<summary>1. Register post meta by adding this snippet to your theme's functions.php</summary>

```php
add_action( 'init', 'test_block_bindings' );

function test_block_bindings() {
	register_meta(
		'post',
		'text_field',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'default'           => 'default text value',
		)
	);
}
```

</details>


<details>

<summary>2. In the post editor, add a paragraph block bound to the custom field using the Code Editor</summary>

```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field"}}}}} -->
<p>Paragraph content</p>
<!-- /wp:paragraph -->
```

</details>
 
3. Press the Save button.
4. Notice that the "Site Updated" message does not appear, as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
