### PR TITLE
Fix template footer click to focus canvas

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -597,3 +597,17 @@
 		}
 	}
 }
+
+@mixin selected-block-outline() {
+	content: "";
+	position: absolute;
+	pointer-events: none;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	outline-color: var(--wp-admin-theme-color);
+	outline-style: solid;
+	outline-width: calc(var(--wp-admin-border-width-focus) / var(--wp-block-editor-iframe-zoom-out-scale, 1));
+	outline-offset: calc((-1 * var(--wp-admin-border-width-focus)) / var(--wp-block-editor-iframe-zoom-out-scale, 1));
+}

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -108,6 +108,7 @@ _Parameters_
 
 -   _props_ `Object`: Component props.
 -   _props.rootLabelText_ `string`: Translated label for the root element of the breadcrumb trail.
+-   _props.focusableWrapperRef_ `Object`: Ref of the element to focus when the breadcrumb is clicked.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -12,6 +12,7 @@ import { chevronRightSmall, Icon } from '@wordpress/icons';
 import BlockTitle from '../block-title';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { __unstableUseBlockRef as useBlockRef } from '../block-list/use-block-props/use-block-refs';
 
 /**
  * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
@@ -37,6 +38,10 @@ function BlockBreadcrumb( { rootLabelText } ) {
 	}, [] );
 	const rootLabel = rootLabelText || __( 'Document' );
 
+	// We don't care about this specific ref, but this is a way
+	// to get a ref within the editor canvas so we can focus it later.
+	const blockRef = useBlockRef( clientId );
+
 	/*
 	 * Disable reason: The `list` ARIA role is redundant but
 	 * Safari+VoiceOver won't announce the list otherwise.
@@ -60,7 +65,11 @@ function BlockBreadcrumb( { rootLabelText } ) {
 					<Button
 						className="block-editor-block-breadcrumb__button"
 						variant="tertiary"
-						onClick={ clearSelectedBlock }
+						onClick={ () => {
+							clearSelectedBlock();
+							// Focus the editor iframe.
+							blockRef.current?.closest( 'body' )?.focus();
+						} }
 					>
 						{ rootLabel }
 					</Button>

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -68,7 +68,9 @@ function BlockBreadcrumb( { rootLabelText } ) {
 						onClick={ () => {
 							clearSelectedBlock();
 							// Focus the editor iframe.
-							blockRef.current?.closest( 'body' )?.focus();
+							blockRef.current
+								?.closest( '[aria-label="Block canvas"]' )
+								?.focus();
 						} }
 					>
 						{ rootLabel }

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -12,16 +12,16 @@ import { chevronRightSmall, Icon } from '@wordpress/icons';
 import BlockTitle from '../block-title';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { __unstableUseBlockRef as useBlockRef } from '../block-list/use-block-props/use-block-refs';
 
 /**
  * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
  *
- * @param {Object} props               Component props.
- * @param {string} props.rootLabelText Translated label for the root element of the breadcrumb trail.
- * @return {Element}                   Block Breadcrumb.
+ * @param {Object} props                     Component props.
+ * @param {string} props.rootLabelText       Translated label for the root element of the breadcrumb trail.
+ * @param {Object} props.focusableWrapperRef Ref of the element to focus when the breadcrumb is clicked.
+ * @return {Element}                         Block Breadcrumb.
  */
-function BlockBreadcrumb( { rootLabelText } ) {
+function BlockBreadcrumb( { rootLabelText, focusableWrapperRef } ) {
 	const { selectBlock, clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { clientId, parents, hasSelection } = useSelect( ( select ) => {
 		const {
@@ -37,10 +37,6 @@ function BlockBreadcrumb( { rootLabelText } ) {
 		};
 	}, [] );
 	const rootLabel = rootLabelText || __( 'Document' );
-
-	// We don't care about this specific ref, but this is a way
-	// to get a ref within the editor canvas so we can focus it later.
-	const blockRef = useBlockRef( clientId );
 
 	/*
 	 * Disable reason: The `list` ARIA role is redundant but
@@ -67,10 +63,9 @@ function BlockBreadcrumb( { rootLabelText } ) {
 						variant="tertiary"
 						onClick={ () => {
 							clearSelectedBlock();
+
 							// Focus the editor iframe.
-							blockRef.current
-								?.closest( '[aria-label="Block canvas"]' )
-								?.focus();
+							focusableWrapperRef.current?.focus();
 						} }
 					>
 						{ rootLabel }

--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -16,6 +16,18 @@ import { useMouseMoveTypingReset } from '../observe-typing';
 import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useBlockCommands } from '../use-block-commands';
 
+function FocusableWrapper( { children } ) {
+	return (
+		<div
+			className="block-editor-accessible-wrapper"
+			tabIndex="-1"
+			aria-label="Block canvas"
+		>
+			{ children }
+		</div>
+	);
+}
+
 export function ExperimentalBlockCanvas( {
 	shouldIframe = true,
 	height = '300px',
@@ -49,7 +61,7 @@ export function ExperimentalBlockCanvas( {
 						width: '100%',
 					} }
 				>
-					{ children }
+					<FocusableWrapper>{ children }</FocusableWrapper>
 				</WritingFlow>
 			</BlockTools>
 		);
@@ -70,7 +82,7 @@ export function ExperimentalBlockCanvas( {
 				name="editor-canvas"
 			>
 				<EditorStyles styles={ styles } />
-				{ children }
+				<FocusableWrapper>{ children }</FocusableWrapper>
 			</Iframe>
 		</BlockTools>
 	);

--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useMergeRefs } from '@wordpress/compose';
-import { useRef } from '@wordpress/element';
+import { useRef, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,17 +16,18 @@ import { useMouseMoveTypingReset } from '../observe-typing';
 import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useBlockCommands } from '../use-block-commands';
 
-function FocusableWrapper( { children } ) {
+const FocusableWrapper = forwardRef( ( { children }, ref ) => {
 	return (
 		<div
 			className="block-editor-accessible-wrapper"
 			tabIndex="-1"
 			aria-label="Block canvas"
+			ref={ ref }
 		>
 			{ children }
 		</div>
 	);
-}
+} );
 
 export function ExperimentalBlockCanvas( {
 	shouldIframe = true,
@@ -35,6 +36,7 @@ export function ExperimentalBlockCanvas( {
 	styles,
 	contentRef: contentRefProp,
 	iframeProps,
+	focusableWrapperRef,
 } ) {
 	useBlockCommands();
 	const resetTypingRef = useMouseMoveTypingReset();
@@ -61,7 +63,9 @@ export function ExperimentalBlockCanvas( {
 						width: '100%',
 					} }
 				>
-					<FocusableWrapper>{ children }</FocusableWrapper>
+					<FocusableWrapper ref={ focusableWrapperRef }>
+						{ children }
+					</FocusableWrapper>
 				</WritingFlow>
 			</BlockTools>
 		);
@@ -82,7 +86,9 @@ export function ExperimentalBlockCanvas( {
 				name="editor-canvas"
 			>
 				<EditorStyles styles={ styles } />
-				<FocusableWrapper>{ children }</FocusableWrapper>
+				<FocusableWrapper ref={ focusableWrapperRef }>
+					{ children }
+				</FocusableWrapper>
 			</Iframe>
 		</BlockTools>
 	);

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -17,20 +17,6 @@
 	}
 }
 
-@mixin selectedOutline() {
-	content: "";
-	position: absolute;
-	pointer-events: none;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	outline-color: var(--wp-admin-theme-color);
-	outline-style: solid;
-	outline-width: calc(var(--wp-admin-border-width-focus) / var(--wp-block-editor-iframe-zoom-out-scale, 1));
-	outline-offset: calc((-1 * var(--wp-admin-border-width-focus)) / var(--wp-block-editor-iframe-zoom-out-scale, 1));
-}
-
 // Hide selections on this element, otherwise Safari will include it stacked
 // under your actual selection.
 // This uses a CSS hack to show the rules to Safari only. Failing here is okay,
@@ -101,7 +87,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		// We're using a pseudo element to overflow placeholder borders
 		// and any border inside the block itself.
 		&::after {
-			@include selectedOutline();
+			@include selected-block-outline();
 			z-index: 1;
 
 			// Show a light color for dark themes.
@@ -281,7 +267,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	&:not(.rich-text):not([contenteditable="true"]).is-selected {
 
 		&::after {
-			@include selectedOutline();
+			@include selected-block-outline();
 		}
 	}
 }

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -65,3 +65,13 @@
 		}
 	}
 }
+
+.block-editor-accessible-wrapper:focus-visible {
+	outline: none;
+
+	&::after {
+		content: "";
+		@include selected-block-outline();
+		position: fixed;
+	}
+}

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/block-editor';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useViewportMatch } from '@wordpress/compose';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -116,6 +116,7 @@ export default function EditorInterface( {
 		},
 		[ entitiesSavedStatesCallback ]
 	);
+	const focusableWrapperRef = useRef();
 
 	return (
 		<InterfaceSkeleton
@@ -191,6 +192,9 @@ export default function EditorInterface( {
 											// eslint-disable-next-line jsx-a11y/no-autofocus
 											autoFocus={ autoFocus }
 											iframeProps={ iframeProps }
+											focusableWrapperRef={
+												focusableWrapperRef
+											}
 										/>
 									) }
 									{ children }
@@ -208,7 +212,10 @@ export default function EditorInterface( {
 				isRichEditingEnabled &&
 				blockEditorMode !== 'zoom-out' &&
 				mode === 'visual' && (
-					<BlockBreadcrumb rootLabelText={ documentLabel } />
+					<BlockBreadcrumb
+						rootLabelText={ documentLabel }
+						focusableWrapperRef={ focusableWrapperRef }
+					/>
 				)
 			}
 			actions={

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -104,6 +104,7 @@ function VisualEditor( {
 	iframeProps,
 	contentRef,
 	className,
+	focusableWrapperRef,
 } ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const isMobileViewport = useViewportMatch( 'small', '<' );
@@ -407,6 +408,7 @@ function VisualEditor( {
 							...deviceStyles,
 						},
 					} }
+					focusableWrapperRef={ focusableWrapperRef }
 				>
 					{ themeSupportsLayout &&
 						! themeHasDisabledLayoutStyles &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Clicking the Template button in the footer breadcrumbs causes a focus loss to the body of the page. This PR sets focus to the editor canvas instead, making it similar to how the other buttons in footer breadcrumbs work.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
a11y. Focus management.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When clicking. "Template" in the footer breadcrumbs, set focus on the editor canvas.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Select a block
- Click the root "Template" button in the footer
- Focus should be visible on the editor canvas

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/967608/dcb0e4cb-2352-4ee0-aa40-99d04ce5af08

