### PR TITLE
Chore: Simplify a padding style on global styles.

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -84,8 +84,7 @@
 	color: $gray-800;
 	font-weight: 600;
 	line-height: 1.2;
-	padding: $grid-unit-20;
-	padding-bottom: 0;
+	padding: $grid-unit-20 $grid-unit-20 0;
 	margin: 0;
 }
 


### PR DESCRIPTION
Having the two rules "padding: $grid-unit-20; padding-bottom: 0;" is equivalent to the single rule "padding: $grid-unit-20 $grid-unit-20 0;". This PR applies the simplification.
