### PR TITLE
Interactivity API: Increase directive `wp-each-child` priority.

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
@@ -235,13 +235,28 @@
 	<p data-testid="item" data-wp-each-child>delta</p>
 </div>
 
+<hr>
+
 <div
 	data-wp-interactive="directive-each"
-	data-wp-context='{ "list": [ "beta"] }'
+	data-wp-context='{ "list": [ "beta" ], "callbackRunCount": 0 }'
 	data-testid="elements with directives"
 >
 	<template data-wp-each="context.list">
-		<div data-wp-text="context.item" data-testid="item" data-wp-run="callbacks.shouldRun"></div>
+		<div
+			data-testid="item"
+			data-wp-text="context.item"
+			data-wp-priority-2-init="callbacks.updateCallbackRunCount"
+		></div>
 	</template>
-	<div data-testid="item" data-wp-each-child data-wp-run="callbacks.shouldNotRun"></div>
+	<div
+		data-wp-each-child
+		data-testid="item"
+		data-wp-text="context.item"
+		data-wp-priority-2-init="callbacks.updateCallbackRunCount"
+	></div>
+	<data
+		data-testid="callbackRunCount"
+		data-wp-text="context.callbackRunCount"
+	></data>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
@@ -234,3 +234,14 @@
 	<p data-testid="item" data-wp-each-child>gamma</p>
 	<p data-testid="item" data-wp-each-child>delta</p>
 </div>
+
+<div
+	data-wp-interactive="directive-each"
+	data-wp-context='{ "list": [ "beta"] }'
+	data-testid="elements with directives"
+>
+	<template data-wp-each="context.list">
+		<div data-wp-text="context.item" data-testid="item" data-wp-run="callbacks.shouldRun"></div>
+	</template>
+	<div data-testid="item" data-wp-each-child data-wp-run="callbacks.shouldNotRun"></div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext } from '@wordpress/interactivity';
+import { store, getContext, useInit, privateApis } from '@wordpress/interactivity';
 
 const { state } = store( 'directive-each' );
 
@@ -190,14 +190,30 @@ store( 'directive-each', {
 	}
 } );
 
+const { directive } = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
+
+/*
+ * This is a high-priority version of the wp-init directive, to test directives
+ * with such priority or lower don't run in elements with wp-each-child.
+ */
+directive(
+	'priority-2-init',
+	( { directives: { 'priority-2-init': init }, evaluate } ) => {
+		init.forEach( ( entry ) => {
+			useInit( () => evaluate( entry ) );
+		} );
+	},
+	{ priority: 2 }
+);
+
 store('directive-each', {
     callbacks: {
-		shouldRun() {
-			window.didThisRun = true;
-		},
-        shouldNotRun() {
-            window.didThisRun = false;
-        },
+		updateCallbackRunCount() {
+			const ctx = getContext();
+			ctx.callbackRunCount += 1;
+		}
     },
 });
 

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
@@ -190,3 +190,14 @@ store( 'directive-each', {
 	}
 } );
 
+store('directive-each', {
+    callbacks: {
+		shouldRun() {
+			window.didThisRun = true;
+		},
+        shouldNotRun() {
+            window.didThisRun = false;
+        },
+    },
+});
+

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -632,5 +632,5 @@ export default () => {
 		{ priority: 20 }
 	);
 
-	directive( 'each-child', () => null );
+	directive( 'each-child', () => null, { priority: 4 } );
 };

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -632,5 +632,5 @@ export default () => {
 		{ priority: 20 }
 	);
 
-	directive( 'each-child', () => null, { priority: 4 } );
+	directive( 'each-child', () => null, { priority: 1 } );
 };

--- a/test/e2e/specs/interactivity/directive-each.spec.ts
+++ b/test/e2e/specs/interactivity/directive-each.spec.ts
@@ -493,15 +493,16 @@ test.describe( 'data-wp-each', () => {
 		await expect( banana ).toHaveAttribute( 'data-tag', '1' );
 	} );
 
-	test( 'directives inside each element should work', async ( { page } ) => {
+	test( 'directives inside elements with `wp-each-child` should not run', async ( {
+		page,
+	} ) => {
 		const element = page
 			.getByTestId( 'elements with directives' )
 			.getByTestId( 'item' );
+		const callbackRunCount = page
+			.getByTestId( 'elements with directives' )
+			.getByTestId( 'callbackRunCount' );
 		await expect( element ).toHaveText( 'beta' );
-		const didRun = await page.evaluate( () => {
-			/* @ts-ignore */
-			return window.didThisRun;
-		} );
-		expect( didRun ).toBe( true );
+		await expect( callbackRunCount ).toHaveText( '1' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/directive-each.spec.ts
+++ b/test/e2e/specs/interactivity/directive-each.spec.ts
@@ -492,4 +492,16 @@ test.describe( 'data-wp-each', () => {
 		await expect( avocado ).toHaveAttribute( 'data-tag', '0' );
 		await expect( banana ).toHaveAttribute( 'data-tag', '1' );
 	} );
+
+	test( 'directives inside each element should work', async ( { page } ) => {
+		const element = page
+			.getByTestId( 'elements with directives' )
+			.getByTestId( 'item' );
+		await expect( element ).toHaveText( 'beta' );
+		const didRun = await page.evaluate( () => {
+			/* @ts-ignore */
+			return window.didThisRun;
+		} );
+		expect( didRun ).toBe( true );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Co-authored with @DAreRodz, bug found by @zaguiini
Increase `data-wp-each` priority to fix trying to process non existent elements in the dom.

## Why?

To add some context, the `data-wp-each-child` directive is intended to remove the node in which it appears. Why? Because `data-wp-each` is the one that actually renders it.

The issue is that it has the same priority level as most directives, and they are grouped into the same `Directives` component and evaluated together. Thus, even though the component returns `null`, all its hooks are evaluated, i.e., the ones that `data-wp-bind`, `data-wp-on` etc., register. Also, the `data-wp-each` server-side processing maintains the directives that appear in child nodes. 😬

That's why the element is `null` inside the `useInit` hook called in `data-wp-bind`; because it _is_. The thing is that `data-wp-bind` should not be evaluated (nor other directives).

## How?

One quick fix for this issue is to increase the `data-wp-each-child` priority, being the first one in being evaluated.

Other fix could be not to server side render the directives in the content created by the template tag, in the `data-wp-each` SSR processing. I did not measure it, but being that content already evaluated, adding the directives in the SSR should be triggering a not needed re-evaluation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1) Create an interactive block with `wp-each` SSR, like this one:
 ```php
<?php
$context = array('list' => ['one', 'two', 'three']);
?>
<div
	data-wp-interactive="counter-block"
    <?php echo wp_interactivity_data_wp_context($context) ; ?> 
>
    <template data-wp-each="context.list" data-wp-each-key="context.item">
        <div data-wp-bind--id="context.item">
            <span data-wp-text="context.item"></span>
        </div>
    </template>
</div>
```

2) Check that in `trunk`, an error appears on the console.
3) Apply this PR, reload, check that there are no errors.

## Screenshots or screencast <!-- if applicable -->
PR not applied
![Screenshot 2024-06-04 at 18 48 02](https://github.com/WordPress/gutenberg/assets/37012961/88f9a573-3ecc-4b19-b0f6-301b3c86897e)

PR applied
![Screenshot 2024-06-04 at 18 48 42](https://github.com/WordPress/gutenberg/assets/37012961/c740da8c-b606-4fc5-90a8-50782f7793ad)

Leaving the PR on draft until we decide which approach is better.

