### PR TITLE
Fix: Remove unused typography panel styles.

### DIFF
--- a/packages/edit-site/src/components/global-styles-sidebar/style.scss
+++ b/packages/edit-site/src/components/global-styles-sidebar/style.scss
@@ -47,7 +47,6 @@
 	font-weight: 500;
 }
 
-.edit-site-typography-panel,
 .edit-site-global-styles-sidebar .block-editor-panel-color-gradient-settings {
 	border: 0;
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -23,11 +23,6 @@
 	overflow: hidden;
 }
 
-.edit-site-typography-panel__full-width-control {
-	grid-column: 1 / -1;
-	max-width: 100%;
-}
-
 .edit-site-global-styles-screen {
 	margin: $grid-unit-15 $grid-unit-20 $grid-unit-20;
 }


### PR DESCRIPTION
There is no element with class edit-site-typography-panel and edit-site-typography-panel__full-width-control but some CSS referencing the classes was kept. This PR fixes the issue by removing the unused CSS code.

## Testing Instructions
Verified the typography panel looks the same as before.
