### PR TITLE
Update versions in WP for minor 6.5 releases & 6.6

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,11 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 17.8-18.5          | 6.6               |
+| 16.8-17.7          | 6.5.4             |
+| 16.8-17.7          | 6.5.3             |
+| 16.8-17.7          | 6.5.2             |
+| 16.8-17.7          | 6.5.1             |
 | 16.8-17.7          | 6.5               |
 | 16.2-16.7          | 6.4.3             |
 | 16.2-16.7          | 6.4.2             |

--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -7,6 +7,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
 | 17.8-18.5          | 6.6               |
+| 16.8-17.7          | 6.5.5             |
 | 16.8-17.7          | 6.5.4             |
 | 16.8-17.7          | 6.5.3             |
 | 16.8-17.7          | 6.5.2             |


### PR DESCRIPTION
## What?

Simple doc update to align with the latest WP releases. Of note, 6.5.4 isn't out yet but RC1 is out. Adding it in here so when it's released we have all of the recent releases covered. 

## Why?

To help ensure folks know what's landed in each major WP release.

