### PR TITLE
Block Inserter Category and Output Heuristics

### DIFF
--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -21,6 +21,9 @@ const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
 const MAX_SUGGESTED_ITEMS = 6;
 
+const INSERTABLE_BLOCKS_AT_SELECTION_CATEGORY =
+	'insertable-blocks-at-selection';
+
 /**
  * Shared reference to an empty array for cases where it is important to avoid
  * returning a new array reference on every invocation and rerendering the component.
@@ -121,6 +124,10 @@ export function BlockTypesTabPanel( {
 							onHover={ onHover }
 							label={ category.title }
 						/>
+						{ category.slug ===
+							INSERTABLE_BLOCKS_AT_SELECTION_CATEGORY && (
+							<div className="block-editor-inserter__category-panel-divider" />
+						) }
 					</InserterPanel>
 				);
 			} ) }
@@ -181,16 +188,16 @@ export function BlockTypesTab(
 		return <InserterNoResults />;
 	}
 
-	const currentlySelectedBlockType = getBlockType(
-		getBlockName( rootClientId )
-	);
-
 	let allCategories = [];
 
 	if ( rootClientId && categories.length ) {
+		const currentlySelectedBlockType = getBlockType(
+			getBlockName( rootClientId )
+		);
+
 		allCategories = [
 			{
-				slug: currentlySelectedBlockType.name,
+				slug: INSERTABLE_BLOCKS_AT_SELECTION_CATEGORY,
 				title: currentlySelectedBlockType.title,
 				icon: null,
 			},
@@ -211,7 +218,7 @@ export function BlockTypesTab(
 		if ( rootClientId && item.rootClientId === rootClientId ) {
 			allItems.push( {
 				...item,
-				category: currentlySelectedBlockType.name,
+				category: INSERTABLE_BLOCKS_AT_SELECTION_CATEGORY,
 			} );
 		} else {
 			allItems.push( { ...item } );

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -256,7 +256,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__category-panel-divider {
 	width: calc(100% + #{ $grid-unit-20 * 2});
 	margin-left: -$grid-unit-20;
-	padding-top: $grid-unit-20;
+	margin-bottom: $grid-unit-20;
 	border-bottom: $border-width solid $gray-200;
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -253,7 +253,10 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__insertable-blocks-at-selection {
+.block-editor-inserter__category-panel-divider {
+	width: calc(100% + #{ $grid-unit-20 * 2});
+	margin-left: -$grid-unit-20;
+	padding-top: $grid-unit-20;
 	border-bottom: $border-width solid $gray-200;
 }
 

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -40,7 +40,7 @@ test.describe( 'Columns', () => {
 
 		// Verify Column
 		const inserterOptions = page.locator(
-			'role=region[name="Block Library"i] >> .block-editor-inserter__insertable-blocks-at-selection >> role=option'
+			'role=region[name="Block Library"i] >> role=option'
 		);
 		await expect( inserterOptions ).toHaveCount( 1 );
 		await expect( inserterOptions ).toHaveText( 'Column' );

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -48,13 +48,9 @@ test.describe( 'Child Blocks', () => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Toggle block inserter' } );
-		const blockLibrary = page
-			.getByRole( 'region', {
-				name: 'Block Library',
-			} )
-			.locator(
-				'.block-editor-inserter__insertable-blocks-at-selection'
-			);
+		const blockLibrary = page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();
@@ -86,13 +82,9 @@ test.describe( 'Child Blocks', () => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Toggle block inserter' } );
-		const blockLibrary = page
-			.getByRole( 'region', {
-				name: 'Block Library',
-			} )
-			.locator(
-				'.block-editor-inserter__insertable-blocks-at-selection'
-			);
+		const blockLibrary = page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -46,13 +46,9 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Toggle block inserter' } );
-		const blockLibrary = page
-			.getByRole( 'region', {
-				name: 'Block Library',
-			} )
-			.locator(
-				'.block-editor-inserter__insertable-blocks-at-selection'
-			);
+		const blockLibrary = page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();
@@ -93,13 +89,9 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
 			.getByRole( 'button', { name: 'Toggle block inserter' } );
-		const blockLibrary = page
-			.getByRole( 'region', {
-				name: 'Block Library',
-			} )
-			.locator(
-				'.block-editor-inserter__insertable-blocks-at-selection'
-			);
+		const blockLibrary = page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
 
 		await blockInserter.click();
 		await expect( blockLibrary ).toBeVisible();


### PR DESCRIPTION
Some polish for the new inserter category output:

- Only output one "most used" categories list. If there is a selected block, this goes beneath the allowed selected blocks.
- Adds current block name as the category title for its allowed blocks

- **If no block is selected**/default empty block, output all categories and blocks as it was in past versions of WordPress.
- **If a block is selected**, filter the available blocks.
  - **If more than 80% of the blocks are allowed for this block**, don't bother filtering. Output all items. This is to allow the "Most Used" blocks to be at the top without repeating it further down, and not bother filtering when most every block is allowed.
  - **If there are less than 80% of the block items available** for the selected block, output the filtered items first.
    - **If there is only one block category (ie "Text"), replace the category title with the block title.** The List Block is an example of this. This avoids situations where "Text" is followed by another "Text" category.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improves the UX for the block inserter category output.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Polish the UX, as there are some areas that feel off, such as:
- showing two Most Used categories. Most used seems useful when it's relative to all blocks, not a filtered list of a small number of blocks.
- Don't output multiple levels of the same heading next to each other. For example, Text followed by another Text category. 
- When there are many blocks available (like the Group block), it outputs nearly all blocks with one available beyond it. This filtering seems irrelevant at that point and feels off that there's one standalone category at the end.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds `selectedBlockItems` and `selectedBlockCategories` props added to the `<BlockTypesTabPanel />` component and only outputs this component once.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

#### Default State

<!-- <img width="1259" alt="" src="https://github.com/WordPress/gutenberg/assets/967608/a483be6a-d1ff-4808-8f17-0aaf72ecc423"> -->

- Select the empty default block
- Open inserter
- Categories should show as normal.

#### Selected block with One Category Item

<!-- <img width="1259" alt="" src="https://github.com/WordPress/gutenberg/assets/967608/43dded05-9ff7-4845-86e4-29cad0bf4970"> -->

- Select a list block
- Open inserter
- First category should be "List"
- List Item should be the first block item
- All other items should show after this, including Most Used if the option is on.

#### Selected block with Multiple Categories

<!-- <img width="1259" alt="" src="https://github.com/WordPress/gutenberg/assets/967608/d6619d95-8ef3-4213-b4e8-c41f3139685a"> -->

- Select a navigation link block
- Open inserter
- Navigation Block allowed blocks should show first, within default category titles
- All other items should show after this, including Most Used if the option is on.

#### Selected Block with almost all available blocks

<!-- <img width="1259" alt="" src="https://github.com/WordPress/gutenberg/assets/967608/cdcbf2ba-4595-4284-a537-a5c63652e837"> -->

- Select the group block
- Open inserter
- Categories should show as normal (no filtering of allowed blocks)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/967608/57bcc2ae-952d-41b9-a50f-b64e0568b438


