### PR TITLE
Add ability to set default rendering mode per post type

### DIFF
--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php
@@ -31,11 +31,11 @@ class Gutenberg_REST_Post_Types_Controller_6_6 extends WP_REST_Post_Types_Contro
 			 * The dynamic portion of the hook name, `$item->name`, refers to the post type slug.
 			 *
 			 * @since 6.6.0
-			 * @param string $default_rendering_mode Default rendering mode for the post type.
-			 * @param string $post_type              Post type name.
+			 * @param string       $default_rendering_mode Default rendering mode for the post type.
+			 * @param WP_Post_Type $post_type              Post type object.
 			 * @return string Default rendering mode for the post type.
 			 */
-			$response->data['rendering_mode'] = apply_filters( "{$item->name}_default_rendering_mode", $item->rendering_mode, $item->name );
+			$rendering_mode = apply_filters( "{$item->name}_default_rendering_mode", $item->rendering_mode, $item );
 
 			/**
 			 * Filters the block editor rendering mode for a post type.
@@ -45,7 +45,7 @@ class Gutenberg_REST_Post_Types_Controller_6_6 extends WP_REST_Post_Types_Contro
 			 * @param string $post_type              Post type name.
 			 * @return string Default rendering mode for the post type.
 			 */
-			$response->data['rendering_mode'] = apply_filters( 'post_type_default_rendering_mode', $item->rendering_mode, $item->name );
+			$response->data['rendering_mode'] = apply_filters( 'post_type_default_rendering_mode', $rendering_mode, $item->name );
 		}
 
 		return rest_ensure_response( $response );

--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php
@@ -23,7 +23,19 @@ class Gutenberg_REST_Post_Types_Controller_6_6 extends WP_REST_Post_Types_Contro
 		$response = parent::prepare_item_for_response( $item, $request );
 		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
 
-		if ( 'edit' === $context ) {
+		if ( 'edit' === $context && post_type_supports( $item->name, 'editor' ) ) {
+			/**
+			 * Filters the block editor rendering mode for a specific post type.
+			 *
+			 * The dynamic portion of the hook name, `$item->name`, refers to the post type slug.
+			 *
+			 * @since 6.6.0
+			 * @param string $default_rendering_mode Default rendering mode for the post type.
+			 * @param string $post_type              Post type name.
+			 * @return string Default rendering mode for the post type.
+			 */
+			$response->data['rendering_mode'] = apply_filters( "{$item->name}_default_rendering_mode", $item->rendering_mode, $item->name );
+
 			/**
 			 * Filters the block editor rendering mode for a post type.
 			 *
@@ -32,9 +44,9 @@ class Gutenberg_REST_Post_Types_Controller_6_6 extends WP_REST_Post_Types_Contro
 			 * @param string $post_type              Post type name.
 			 * @return string Default rendering mode for the post type.
 			 */
-			$response->data['rendering_mode'] = apply_filters( 'post_type_default_rendering_mode', 'post-only', $item->name );
+			$response->data['rendering_mode'] = apply_filters( 'post_type_default_rendering_mode', $item->rendering_mode, $item->name );
 		}
 
-		return $response;
+		return rest_ensure_response( $response );
 	}
 }

--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php
@@ -23,7 +23,8 @@ class Gutenberg_REST_Post_Types_Controller_6_6 extends WP_REST_Post_Types_Contro
 		$response = parent::prepare_item_for_response( $item, $request );
 		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
 
-		if ( 'edit' === $context && post_type_supports( $item->name, 'editor' ) ) {
+		// Property will only exist if the post type supports the block editor.
+		if ( 'edit' === $context && property_exists( $item, 'rendering_mode' ) ) {
 			/**
 			 * Filters the block editor rendering mode for a specific post type.
 			 *

--- a/lib/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php
+++ b/lib/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Post_Types_Controller_6_6 class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Gutenberg_REST_Post_Types_Controller_6_6 class
+ *
+ * Add Block Editor default rendering mode to the post type response
+ * to allow enabling/disabling at the post type level.
+ */
+class Gutenberg_REST_Post_Types_Controller_6_6 extends WP_REST_Post_Types_Controller {
+	/**
+	 * Add Block Editor default rendering mode setting to the response.
+	 *
+	 * @param WP_Post_Type      $item    Post type object.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$response = parent::prepare_item_for_response( $item, $request );
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+
+		if ( 'edit' === $context ) {
+			/**
+			 * Filters the block editor rendering mode for a post type.
+			 *
+			 * @since 6.6.0
+			 * @param string $default_rendering_mode Default rendering mode for the post type.
+			 * @param string $post_type              Post type name.
+			 * @return string Default rendering mode for the post type.
+			 */
+			$response->data['rendering_mode'] = apply_filters( 'post_type_default_rendering_mode', 'post-only', $item->name );
+		}
+
+		return $response;
+	}
+}

--- a/lib/compat/wordpress-6.6/post.php
+++ b/lib/compat/wordpress-6.6/post.php
@@ -11,8 +11,26 @@
 function gutenberg_add_excerpt_support_to_wp_block() {
 	add_post_type_support( 'wp_block', 'excerpt' );
 }
-
 add_action( 'init', 'gutenberg_add_excerpt_support_to_wp_block' );
+
+/**
+ * Add the rendering_mode property to the WP_Post_Type object.
+ * This property can be overwritten by using the post_type_default_rendering_mode filter.
+ *
+ * @param array $args Array of post type arguments.
+ * @return array Updated array of post type arguments.
+ */
+function gutenberg_post_type_default_rendering_mode( $args ) {
+	if (
+		( isset( $args['show_in_rest'] ) && $args['show_in_rest'] ) &&
+		( isset( $args['supports'] ) && in_array( 'editor', $args['supports'], true ) )
+	) {
+		$args['rendering_mode'] = 'post-only';
+	}
+
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_post_type_default_rendering_mode', 10, 2 );
 
 /**
  * Updates the labels for the template post type.

--- a/lib/compat/wordpress-6.6/post.php
+++ b/lib/compat/wordpress-6.6/post.php
@@ -23,7 +23,8 @@ add_action( 'init', 'gutenberg_add_excerpt_support_to_wp_block' );
 function gutenberg_post_type_default_rendering_mode( $args ) {
 	if (
 		( isset( $args['show_in_rest'] ) && $args['show_in_rest'] ) &&
-		( isset( $args['supports'] ) && in_array( 'editor', $args['supports'], true ) )
+		( isset( $args['supports'] ) && in_array( 'editor', $args['supports'], true ) ) &&
+		( ! isset( $args['rendering_mode'] ) )
 	) {
 		$args['rendering_mode'] = 'post-only';
 	}

--- a/lib/compat/wordpress-6.6/post.php
+++ b/lib/compat/wordpress-6.6/post.php
@@ -17,7 +17,7 @@ add_action( 'init', 'gutenberg_add_excerpt_support_to_wp_block' );
  * Add the rendering_mode property to the WP_Post_Type object.
  * This property can be overwritten by using the post_type_default_rendering_mode filter.
  *
- * @param array $args Array of post type arguments.
+ * @param array  $args      Array of post type arguments.
  * @return array Updated array of post type arguments.
  */
 function gutenberg_post_type_default_rendering_mode( $args ) {
@@ -30,7 +30,7 @@ function gutenberg_post_type_default_rendering_mode( $args ) {
 
 	return $args;
 }
-add_filter( 'register_post_type_args', 'gutenberg_post_type_default_rendering_mode', 10, 2 );
+add_filter( 'register_post_type_args', 'gutenberg_post_type_default_rendering_mode', 10, 1 );
 
 /**
  * Updates the labels for the template post type.

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -77,6 +77,16 @@ function gutenberg_add_class_list_to_public_post_types() {
 }
 add_action( 'rest_api_init', 'gutenberg_add_class_list_to_public_post_types' );
 
+if ( ! function_exists( 'gutenberg_add_post_type_rendering_mode' ) ) {
+	/**
+	 * Add Block Editor default rendering mode to the post type response.
+	 */
+	function gutenberg_add_post_type_rendering_mode() {
+		$controller = new Gutenberg_REST_Post_Types_Controller_6_6();
+		$controller->register_routes();
+	}
+}
+add_action( 'rest_api_init', 'gutenberg_add_post_type_rendering_mode' );
 
 /**
  * Registers the Global Styles Revisions REST API routes.

--- a/lib/load.php
+++ b/lib/load.php
@@ -49,6 +49,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 6.6 compat.
 	require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-global-styles-revisions-controller-6-6.php';
 	require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';
+	require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-post-types-controller-6-6.php';
 	require __DIR__ . '/compat/wordpress-6.6/rest-api.php';
 
 	// Plugin specific code.

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -31,6 +31,20 @@ function Editor( {
 	initialEdits,
 	...props
 } ) {
+	// Get the rendering mode for the post type.
+	const postTypeRenderingMode = useSelect(
+		( select ) => {
+			const postTypeObject =
+				select( coreStore ).getPostType( initialPostType );
+			if ( postTypeObject && postTypeObject?.rendering_mode ) {
+				return postTypeObject?.rendering_mode;
+			}
+
+			return 'post-only';
+		},
+		[ initialPostType ]
+	);
+
 	const {
 		currentPost,
 		onNavigateToEntityRecord,
@@ -38,7 +52,7 @@ function Editor( {
 	} = useNavigateToEntityRecord(
 		initialPostId,
 		initialPostType,
-		'post-only'
+		postTypeRenderingMode
 	);
 
 	const { post, template } = useSelect(
@@ -78,7 +92,7 @@ function Editor( {
 			...settings,
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
-			defaultRenderingMode: 'post-only',
+			defaultRenderingMode: postTypeRenderingMode,
 		} ),
 		[ settings, onNavigateToEntityRecord, onNavigateToPreviousEntityRecord ]
 	);

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -37,7 +37,7 @@ function Editor( {
 			const postTypeObject =
 				select( coreStore ).getPostType( initialPostType );
 			if ( postTypeObject && postTypeObject?.rendering_mode ) {
-				return postTypeObject?.rendering_mode;
+				return postTypeObject.rendering_mode;
 			}
 
 			return 'post-only';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
**Related Issue & PR:** 
- https://github.com/WordPress/gutenberg/issues/58038
- https://github.com/WordPress/gutenberg/pull/61844

This PR adds a filterable `rendering_mode` property to the `WP_Post_Type` object allowing users to define the default rendering mode for the editor for that post type.

The `rendering_mode` property can be added to the arguments when registering the post type via `register_post_type()` and can be overwritten using the available filters:
- `{$post_type}_default_rendering_mode`: To target an individual specific post type.
```php
/**
 * Filters the block editor rendering for a specific post type.
 *
 * The dynamic portion of the hook name, `$post_type->name`, refers to the post type slug.
 *
 * @param string       $rendering_mode The current rendering mode set with the post type registration.
 * @param WP_Post_Type $post_type      The current post type object.
 */
$rendering_mode = apply_filters( "{$post_type->name}_default_rendering_mode", $post_type->rendering_mode, $post_type );
```

- `post_type_default_rendering_mode`: To target all (or multiple) post types.
```php
/**
 * Filters the block editor rendering for a post type.
 *
 * @param string $rendering_mode  The current rendering mode set with the post type registration.
 * @param string $post_type_name  The current post type name
 */
$rendering_mode = apply_filters( 'post_type_default_rendering_mode', $post_type->rendering_mode, $post_type->name );
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently there is no way to set the default rendering mode of the block editor. You can select the mode while _in_ the block editor, but upon refreshing that mode is reset back to the default `post-only`. With this update developers have more control over the editing experience and provides a means of setting the default view for the block editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The [linked PR](https://github.com/WordPress/gutenberg/pull/61844) has a discussion that mentions this setting should be applied at the **post type** level, allowing for a difference editing mode per post type. This PR applies the `rendering_mode` property to the `WP_Post_Type` object itself and provides multiple ways of overriding or setting the default for a custom (or core) post type.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a new `post` post type and observe the default editor UI.
2. In your `functions.php` file (or similar) use one of the available filters to set the `rendering_mode` property to `template-lock`:
```php
add_filter(
    'post_type_default_rendering_mode',
    function () {
        return 'template-lock';
    }
);
```
3. Refresh the `post` editor and confirm you are now seeing the Template UI instead of the default Post UI.
4. Create a new `page` post and confirm the `page` editor also loads with the Template UI.
5. Update the filter in `functions.php` to target only the `page` post type:
```php
add_filter(
    'page_default_rendering_mode',
    function () {
        return 'template-lock';
    }
);

```
6. Reload the `page` editor and confirm it still renders the Template UI.
7. Refresh the `post` editor and confirm it now renders the default Post UI.
8. Update the filter in `functions.php` to set the rendering mode for the `post` **and** `page` post types, but no others:
```php
add_filter(
    'post_type_default_rendering_mode',
    function ( $mode, $post_type ) {
        if ( 'page' === $post_type || 'post' === $post_type ) {
            return 'template-lock';
        }

        return $mode;
    },
    10,
    2
)
```
9. Register a custom post type using `register_post_type` and set the `rendering_mode` parameter to `template-lock`:
```php
register_post_type(
    'my_custom_type',
    [
        'show_in_rest'   => true,
        'supports'       => [ 'title', 'editor' ],
        'rendering_mode' => 'template-lock',
    ]
);
```
10. Visit the editor for your custom post type and confirm it loads with the Template UI.
11. Remove the `rendering_mode` argument from your post type registration & confirm the editor now loads with the default Post UI.
