### PR TITLE
Migrate theme.json based on origin

### DIFF
--- a/backport-changelog/6.6/6737.md
+++ b/backport-changelog/6.6/6737.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6737
+
+* https://github.com/WordPress/gutenberg/pull/62305

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -741,7 +741,7 @@ class WP_Theme_JSON_Gutenberg {
 			$origin = 'theme';
 		}
 
-		$this->theme_json    = WP_Theme_JSON_Schema_Gutenberg::migrate( $theme_json );
+		$this->theme_json    = WP_Theme_JSON_Schema_Gutenberg::migrate( $theme_json, $origin );
 		$registry            = WP_Block_Type_Registry::get_instance();
 		$valid_block_names   = array_keys( $registry->get_all_registered() );
 		$valid_element_names = array_keys( static::ELEMENTS );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3278,7 +3278,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * Removes insecure data from theme.json.
 	 *
 	 * @since 5.9.0
-	 * @since 6.6.0 Added support for block style variation element styles.
+	 * @since 6.6.0 Added support for block style variation element styles and $origin parameter.
 	 *
 	 * @param array $theme_json Structure to sanitize.
 	 * @param string $origin    Optional. What source of data this object represents.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -734,7 +734,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param array  $theme_json A structure that follows the theme.json schema.
 	 * @param string $origin     Optional. What source of data this object represents.
-	 *                           One of 'default', 'theme', or 'custom'. Default 'theme'.
+	 *                           One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
 	 */
 	public function __construct( $theme_json = array( 'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA ), $origin = 'theme' ) {
 		if ( ! in_array( $origin, static::VALID_ORIGINS, true ) ) {
@@ -3281,12 +3281,18 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.6.0 Added support for block style variation element styles.
 	 *
 	 * @param array $theme_json Structure to sanitize.
+	 * @param string $origin    Optional. What source of data this object represents.
+	 *                          One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
 	 * @return array Sanitized structure.
 	 */
-	public static function remove_insecure_properties( $theme_json ) {
+	public static function remove_insecure_properties( $theme_json, $origin = 'theme' ) {
+		if ( ! in_array( $origin, static::VALID_ORIGINS, true ) ) {
+			$origin = 'theme';
+		}
+
 		$sanitized = array();
 
-		$theme_json = WP_Theme_JSON_Schema_Gutenberg::migrate( $theme_json );
+		$theme_json = WP_Theme_JSON_Schema_Gutenberg::migrate( $theme_json, $origin );
 
 		$valid_block_names   = array_keys( static::get_blocks_metadata() );
 		$valid_element_names = array_keys( static::ELEMENTS );

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -540,10 +540,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		/** This filter is documented in wp-includes/class-wp-theme-json-resolver.php */
-		$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
-		$config     = $theme_json->get_data();
-
-		static::$user = new WP_Theme_JSON_Gutenberg( $config, 'custom' );
+		$theme_json   = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+		static::$user = $theme_json->get_theme_json();
 
 		return static::$user;
 	}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -534,6 +534,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				isset( $decoded_data['isGlobalStylesUserThemeJSON'] ) &&
 				$decoded_data['isGlobalStylesUserThemeJSON']
 			) {
+				unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
 				$config = $decoded_data;
 			}
 		}
@@ -541,9 +542,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		/** This filter is documented in wp-includes/class-wp-theme-json-resolver.php */
 		$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
 		$config     = $theme_json->get_data();
-
-		// Needs to be set for schema migrations of user data.
-		$config['isGlobalStylesUserThemeJSON'] = true;
 
 		static::$user = new WP_Theme_JSON_Gutenberg( $config, 'custom' );
 

--- a/lib/class-wp-theme-json-schema-gutenberg.php
+++ b/lib/class-wp-theme-json-schema-gutenberg.php
@@ -42,7 +42,7 @@ class WP_Theme_JSON_Schema_Gutenberg {
 	 *
 	 * @param array  $theme_json The structure to migrate.
 	 * @param string $origin     Optional. What source of data this object represents.
-	 *                           One of 'default', 'theme', or 'custom'. Default 'theme'.
+	 *                           One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
 	 *
 	 * @return array The structure in the last version.
 	 */

--- a/lib/class-wp-theme-json-schema-gutenberg.php
+++ b/lib/class-wp-theme-json-schema-gutenberg.php
@@ -105,10 +105,9 @@ class WP_Theme_JSON_Schema_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $old Data to migrate.
-	 * @param string $origin     What source of data this object represents.
-	 *                           One of 'default', 'theme', or 'custom'.
-	 *
+	 * @param array $old     Data to migrate.
+	 * @param string $origin What source of data this object represents.
+	 *                       One of 'blocks', 'default', 'theme', or 'custom'.
 	 * @return array Data with defaultFontSizes set to false.
 	 */
 	private static function migrate_v2_to_v3( $old, $origin ) {

--- a/lib/class-wp-theme-json-schema-gutenberg.php
+++ b/lib/class-wp-theme-json-schema-gutenberg.php
@@ -40,11 +40,13 @@ class WP_Theme_JSON_Schema_Gutenberg {
 	 * @since 5.9.0
 	 * @since 6.6.0 Migrate up to v3.
 	 *
-	 * @param array $theme_json The structure to migrate.
+	 * @param array  $theme_json The structure to migrate.
+	 * @param string $origin     Optional. What source of data this object represents.
+	 *                           One of 'default', 'theme', or 'custom'. Default 'theme'.
 	 *
 	 * @return array The structure in the last version.
 	 */
-	public static function migrate( $theme_json ) {
+	public static function migrate( $theme_json, $origin = 'theme' ) {
 		if ( ! isset( $theme_json['version'] ) ) {
 			$theme_json = array(
 				'version' => WP_Theme_JSON::LATEST_SCHEMA,
@@ -57,7 +59,7 @@ class WP_Theme_JSON_Schema_Gutenberg {
 				$theme_json = self::migrate_v1_to_v2( $theme_json );
 				// Deliberate fall through. Once migrated to v2, also migrate to v3.
 			case 2:
-				$theme_json = self::migrate_v2_to_v3( $theme_json );
+				$theme_json = self::migrate_v2_to_v3( $theme_json, $origin );
 		}
 
 		return $theme_json;
@@ -104,10 +106,12 @@ class WP_Theme_JSON_Schema_Gutenberg {
 	 * @since 6.6.0
 	 *
 	 * @param array $old Data to migrate.
+	 * @param string $origin     What source of data this object represents.
+	 *                           One of 'default', 'theme', or 'custom'.
 	 *
 	 * @return array Data with defaultFontSizes set to false.
 	 */
-	private static function migrate_v2_to_v3( $old ) {
+	private static function migrate_v2_to_v3( $old, $origin ) {
 		// Copy everything.
 		$new = $old;
 
@@ -118,10 +122,7 @@ class WP_Theme_JSON_Schema_Gutenberg {
 		 * Remaining changes do not need to be applied to the custom origin,
 		 * as they should take on the value of the theme origin.
 		 */
-		if (
-			isset( $new['isGlobalStylesUserThemeJSON'] ) &&
-			true === $new['isGlobalStylesUserThemeJSON']
-		) {
+		if ( 'custom' === $origin ) {
 			return $new;
 		}
 

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -31,7 +31,7 @@ function gutenberg_filter_global_styles_post( $data ) {
 	) {
 		unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
 
-		$data_to_encode = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $decoded_data );
+		$data_to_encode = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $decoded_data, 'custom' );
 
 		$data_to_encode['isGlobalStylesUserThemeJSON'] = true;
 		return wp_slash( wp_json_encode( $data_to_encode ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

- Updates the API for `WP_Theme_JSON_Schema_Gutenberg::migrate` to accept an origin.
- Use the new origin argument to conditionally migrate changes in theme.json v3

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See the discussion in https://github.com/WordPress/gutenberg/pull/61262/files#r1589940214

@oandregal
> Perhaps we can absorb `$config['isGlobalStylesUserThemeJSON'] = true;` as part of `WP_Theme_JSON_Data_Gutenberg`. We may want to still check that's true before returning to be extra-safe (line 553) but we wouldn't need a second transformation.

@joemcgill 
> Looks like the `$config['isGlobalStylesUserThemeJSON']` modification was made as part of [2012a36](https://github.com/WordPress/gutenberg/commit/2012a36da2a7752dceeda3dcf0af8e58985e8072) (#58409).
> 
> @ajlende is there a reason why this would still be necessary if we use the `WP_Theme_JSON_Gutenberg` object already present in the `WP_Theme_JSON_Data_Gutenberg` object?

@ajlende
> The `$config['isGlobalStylesUserThemeJSON']` is required for migrations that don't need to run for the custom origin in `WP_Theme_JSON_Schema::migrate` (called on `new WP_Theme_JSON()`). If the origin could be passed to `migrate` in some other way, then it would be fine.
> 
> https://github.com/WordPress/gutenberg/blob/cc2fcbe5e7d4384c27aa6615d2a9660f873fe572/lib/class-wp-theme-json-schema-gutenberg.php#L115-L124

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
