### PR TITLE
`CustomSelectControlV2`: Fix initial value not being set in the select for the V1 legacy adapter

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -151,6 +151,10 @@ export default function FontAppearanceControl( props ) {
 				key: value,
 				name,
 				style: { fontStyle: undefined, fontWeight: value },
+				className: 'yay-custom-class-name-yolo',
+				arbitrary: 'property',
+				foo: 'bar',
+				bar: 'foooo',
 			} );
 		} );
 		return combinedOptions;
@@ -212,9 +216,9 @@ export default function FontAppearanceControl( props ) {
 				describedBy={ getDescribedBy() }
 				options={ selectOptions }
 				value={ currentSelection }
-				onChange={ ( { selectedItem } ) =>
-					onChange( selectedItem.style )
-				}
+				onChange={ ( { selectedItem } ) => {
+					onChange( selectedItem.style );
+				} }
 			/>
 		)
 	);

--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -151,10 +151,6 @@ export default function FontAppearanceControl( props ) {
 				key: value,
 				name,
 				style: { fontStyle: undefined, fontWeight: value },
-				className: 'yay-custom-class-name-yolo',
-				arbitrary: 'property',
-				foo: 'bar',
-				bar: 'foooo',
 			} );
 		} );
 		return combinedOptions;
@@ -216,9 +212,9 @@ export default function FontAppearanceControl( props ) {
 				describedBy={ getDescribedBy() }
 				options={ selectOptions }
 				value={ currentSelection }
-				onChange={ ( { selectedItem } ) => {
-					onChange( selectedItem.style );
-				} }
+				onChange={ ( { selectedItem } ) =>
+					onChange( selectedItem.style )
+				}
 			/>
 		)
 	);

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -36,16 +36,15 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 			await Promise.resolve();
 			const state = store.getState();
 
+			const option = options.find( ( item ) => item.name === nextValue );
+
 			const changeObject = {
 				highlightedIndex: state.renderedItems.findIndex(
 					( item ) => item.value === nextValue
 				),
 				inputValue: '',
 				isOpen: state.open,
-				selectedItem: {
-					name: nextValue as string,
-					key: nextValue as string,
-				},
+				selectedItem: option!,
 				type: '',
 			};
 			onChange( changeObject );
@@ -121,4 +120,15 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	);
 }
 
-export default CustomSelectControl;
+export function ClassicCustomSelectControlV2Adapter(
+	props: LegacyCustomSelectProps
+) {
+	return (
+		<CustomSelectControl
+			__experimentalShowSelectedHint={ false }
+			{ ...props }
+		/>
+	);
+}
+
+export default ClassicCustomSelectControlV2Adapter;

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -57,7 +57,6 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	} );
 
 	useEffect( () => {
-		// This is a workaround for selecting the right item upon mount
 		if ( value ) {
 			store.setValue( value.name );
 		}

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -52,7 +52,7 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	} );
 
 	const children = options.map(
-		( { name, key, __experimentalHint, ...rest } ) => {
+		( { name, key, __experimentalHint, style, className } ) => {
 			const withHint = (
 				<Styled.WithHintWrapper>
 					<span>{ name }</span>
@@ -67,7 +67,8 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 					key={ key }
 					value={ name }
 					children={ __experimentalHint ? withHint : name }
-					{ ...rest }
+					style={ style }
+					className={ className }
 				/>
 			);
 		}

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -5,6 +5,11 @@
 import * as Ariakit from '@ariakit/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import _CustomSelect from '../custom-select';
@@ -50,6 +55,14 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 			onChange( changeObject );
 		},
 	} );
+
+	useEffect( () => {
+		// This is a workaround for selecting the right item upon mount
+		if ( value ) {
+			store.setValue( value.name );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const children = options.map(
 		( { name, key, __experimentalHint, style, className } ) => {

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -14,7 +14,11 @@ import { useState } from '@wordpress/element';
  */
 import UncontrolledCustomSelectControl from '..';
 
-const customClass = 'amber-skies';
+const className = 'amber-skies';
+const style = {
+	backgroundColor: 'rgb(127, 255, 212)',
+	rotate: '13deg',
+};
 
 const legacyProps = {
 	label: 'label!',
@@ -26,7 +30,7 @@ const legacyProps = {
 		{
 			key: 'flower2',
 			name: 'crimson clover',
-			className: customClass,
+			className,
 		},
 		{
 			key: 'flower3',
@@ -35,15 +39,18 @@ const legacyProps = {
 		{
 			key: 'color1',
 			name: 'amber',
-			className: customClass,
+			className,
 		},
 		{
 			key: 'color2',
 			name: 'aquamarine',
-			style: {
-				backgroundColor: 'rgb(127, 255, 212)',
-				rotate: '13deg',
-			},
+			style,
+		},
+		{
+			key: 'aquarela-key',
+			name: 'aquarela',
+			className,
+			style,
 		},
 	],
 };
@@ -53,7 +60,9 @@ const ControlledCustomSelectControl = ( {
 	onChange,
 	...restProps
 }: React.ComponentProps< typeof UncontrolledCustomSelectControl > ) => {
+	const { value: overrideValue } = restProps;
 	const [ value, setValue ] = useState( options[ 0 ] );
+	const initialValue = overrideValue ?? value;
 	return (
 		<UncontrolledCustomSelectControl
 			{ ...restProps }
@@ -63,7 +72,7 @@ const ControlledCustomSelectControl = ( {
 				setValue( args.selectedItem );
 			} }
 			value={ options.find(
-				( option: any ) => option.key === value.key
+				( option: any ) => option.key === initialValue.key
 			) }
 		/>
 	);
@@ -148,7 +157,7 @@ describe.each( [
 		// assert against filtered array
 		itemsWithClass.map( ( { name } ) =>
 			expect( screen.getByRole( 'option', { name } ) ).toHaveClass(
-				customClass
+				className
 			)
 		);
 
@@ -160,7 +169,7 @@ describe.each( [
 		// assert against filtered array
 		itemsWithoutClass.map( ( { name } ) =>
 			expect( screen.getByRole( 'option', { name } ) ).not.toHaveClass(
-				customClass
+				className
 			)
 		);
 	} );
@@ -286,7 +295,7 @@ describe.each( [
 			expect.objectContaining( {
 				inputValue: '',
 				isOpen: false,
-				selectedItem: { key: 'violets', name: 'violets' },
+				selectedItem: { key: 'flower1', name: 'violets' },
 				type: '',
 			} )
 		);
@@ -302,6 +311,7 @@ describe.each( [
 			expect.objectContaining( {
 				inputValue: '',
 				isOpen: false,
+
 				selectedItem: expect.objectContaining( {
 					name: 'aquamarine',
 				} ),
@@ -328,7 +338,7 @@ describe.each( [
 		await type( 'p' );
 		await press.Enter();
 
-		expect( mockOnChange ).toHaveReturnedWith( 'poppy' );
+		expect( mockOnChange ).toHaveReturnedWith( 'flower1' );
 	} );
 
 	describe( 'Keyboard behavior and accessibility', () => {
@@ -456,5 +466,58 @@ describe.each( [
 				} )
 			).toBeVisible();
 		} );
+	} );
+
+	// V1 styles items via a `style` or `className` metadata property in the option item object. Some consumers still expect it, e.g:
+	//
+	// - https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/font-appearance-control/index.js#L216
+	//
+	// Returning these properties as part of the item object was not tested as part of the V1 test. Possibly this was an accidental API?
+	// or was it intentional? If intentional, we might need to implement something similar in V2, too? The alternative is to rely on the
+	// `key` attriute for the item and get the actual data from some dictionary in a store somewhere, which would require refactoring
+	// consumers that rely on the self-contained `style` and `className` attributes.
+	it( 'Should return style metadata as part of the selected option from onChange', async () => {
+		const mockOnChange = jest.fn();
+
+		render( <Component { ...legacyProps } onChange={ mockOnChange } /> );
+
+		await click(
+			screen.getByRole( 'combobox', {
+				expanded: false,
+			} )
+		);
+
+		await click(
+			screen.getByRole( 'option', {
+				name: 'aquarela',
+			} )
+		);
+
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				selectedItem: expect.objectContaining( {
+					className,
+					style,
+				} ),
+			} )
+		);
+	} );
+
+	it( 'Should display the initial value passed as the selected value', async () => {
+		const initialSelectedItem = legacyProps.options[ 5 ];
+
+		const testProps = {
+			...legacyProps,
+			value: initialSelectedItem,
+		};
+
+		render( <Component { ...testProps } /> );
+
+		const currentSelectedItem = await screen.findByRole( 'combobox', {
+			expanded: false,
+		} );
+
+		// Verify the initial selected value
+		expect( currentSelectedItem ).toHaveTextContent( 'aquarela' );
 	} );
 } );

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -507,4 +507,22 @@ describe.each( [
 			} )
 		);
 	} );
+
+	it( 'Should display the initial value passed as the selected value', async () => {
+		const initialSelectedItem = legacyProps.options[ 5 ];
+
+		const testProps = {
+			...legacyProps,
+			value: initialSelectedItem,
+		};
+
+		render( <Component { ...testProps } /> );
+
+		const currentSelectedItem = await screen.findByRole( 'combobox', {
+			expanded: false,
+		} );
+
+		// Verify the initial selected value
+		expect( currentSelectedItem ).toHaveTextContent( 'aquarela' );
+	} );
 } );

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -502,22 +502,4 @@ describe.each( [
 			} )
 		);
 	} );
-
-	it( 'Should display the initial value passed as the selected value', async () => {
-		const initialSelectedItem = legacyProps.options[ 5 ];
-
-		const testProps = {
-			...legacyProps,
-			value: initialSelectedItem,
-		};
-
-		render( <Component { ...testProps } /> );
-
-		const currentSelectedItem = await screen.findByRole( 'combobox', {
-			expanded: false,
-		} );
-
-		// Verify the initial selected value
-		expect( currentSelectedItem ).toHaveTextContent( 'aquarela' );
-	} );
 } );

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -51,6 +51,8 @@ const legacyProps = {
 			name: 'aquarela',
 			className,
 			style,
+			customPropFoo: 'foo',
+			customPropBar: 30,
 		},
 	],
 };
@@ -469,14 +471,11 @@ describe.each( [
 	} );
 
 	// V1 styles items via a `style` or `className` metadata property in the option item object. Some consumers still expect it, e.g:
-	//
 	// - https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/font-appearance-control/index.js#L216
-	//
-	// Returning these properties as part of the item object was not tested as part of the V1 test. Possibly this was an accidental API?
-	// or was it intentional? If intentional, we might need to implement something similar in V2, too? The alternative is to rely on the
-	// `key` attriute for the item and get the actual data from some dictionary in a store somewhere, which would require refactoring
-	// consumers that rely on the self-contained `style` and `className` attributes.
-	it( 'Should return style metadata as part of the selected option from onChange', async () => {
+	// Besides that, the `option` prop is documented as havin the type:
+	// - `Array<{ key: String, name: String, style: ?{}, className: ?String, ...rest }>`
+	// Notice the `...test` there. We should keep supporting the arbitrary props like this.
+	it( 'Should return style and custom metadata as part of the selected option from onChange', async () => {
 		const mockOnChange = jest.fn();
 
 		render( <Component { ...legacyProps } onChange={ mockOnChange } /> );
@@ -487,17 +486,23 @@ describe.each( [
 			} )
 		);
 
-		await click(
-			screen.getByRole( 'option', {
-				name: 'aquarela',
-			} )
-		);
+		const optionElement = screen.getByRole( 'option', {
+			name: 'aquarela',
+		} );
+
+		// Assert that the option element does not have the custom attributes
+		expect( optionElement ).not.toHaveAttribute( 'customPropFoo' );
+		expect( optionElement ).not.toHaveAttribute( 'customPropBar' );
+
+		await click( optionElement );
 
 		expect( mockOnChange ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				selectedItem: expect.objectContaining( {
 					className,
 					style,
+					customPropFoo: 'foo',
+					customPropBar: 30,
 				} ),
 			} )
 		);

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -79,6 +79,7 @@ type LegacyOption = {
 	style?: React.CSSProperties;
 	className?: string;
 	__experimentalHint?: string;
+	[ key: string ]: any;
 };
 
 /**

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -63,7 +63,8 @@ export {
 	useCompositeState as __unstableUseCompositeState,
 } from './composite';
 export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
-export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
+//export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
+export { ClassicCustomSelectControlV2Adapter as CustomSelectControl } from './custom-select-control-v2/legacy-component';
 export { default as CustomSelectControlV2 } from './custom-select-control-v2';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -63,7 +63,9 @@ export {
 	useCompositeState as __unstableUseCompositeState,
 } from './composite';
 export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
-export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
+//export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
+export { ClassicCustomSelectControlV2Adapter as CustomSelectControl } from './custom-select-control-v2/legacy-component';
+export { default as CustomSelectControlV2 } from './custom-select-control-v2';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -63,8 +63,7 @@ export {
 	useCompositeState as __unstableUseCompositeState,
 } from './composite';
 export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
-//export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
-export { ClassicCustomSelectControlV2Adapter as CustomSelectControl } from './custom-select-control-v2/legacy-component';
+export { StableCustomSelectControl as CustomSelectControl } from './custom-select-control';
 export { default as CustomSelectControlV2 } from './custom-select-control-v2';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';


### PR DESCRIPTION
Split from: https://github.com/WordPress/gutenberg/pull/61272.

Depends on: https://github.com/WordPress/gutenberg/pull/62255.

## What?

Fixes an issue in the legacy adapter where the initial `value` passed to the select wasn't being auto-selected, effectively causing a mismatch between the store and the rendered value.

## Why?

Consumers expect the select to have the option defined by the `value` prop selected when it mounts, but the legacy adapter was not doing that, e.g: if you selected an option, and the component was unmounted/mounted from scratch again, it would select the first option instead of the option defined by `value`. 

IMPORTANT: V2 is still not replacing the classic V1 in the GB app yet. We'll eventually replace the classic export with the V1 adapter, and the commit [here](https://github.com/WordPress/gutenberg/pull/62308/commits/77212176165031cbe946d4c6c330b6d2bc493903) will be reverted before merging (it's here just to make it easier to test the adapter in the app while reviewing this PR).


## How?

Ths PR fixes by making sure the value in the Ariakit store is selected upon mount from the `value` passed.



## Testing Instructions

* Tests should pass;
* See the screenshot below to see how to test manually.


## Screenshots or screencast









| Before the fix | After the fix |
|---------|---------|
| <video src="https://github.com/WordPress/gutenberg/assets/81248/c3447a53-720a-4763-bad1-93dff3eb63df" controls="controls" style="max-width: 730px;"></video> | <video src="https://github.com/WordPress/gutenberg/assets/81248/4baf5bb0-c4aa-4c5a-9ae6-a606ea1518c3" controls="controls" style="max-width: 730px;"></video>  |

_**NOTE**: You may notice some styling issues in the select. These were already fixed in https://github.com/WordPress/gutenberg/pull/61272 and will be split in a follow-up PR to this one._ 