### PR TITLE
Revert CSS removal for interface footer breadcrumbs

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -28,6 +28,7 @@ $z-layers: (
 	".block-editor-warning": 5,
 	".block-library-gallery-item__inline-menu": 20,
 	".block-editor-url-input__suggestions": 30,
+	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
 	".interface-interface-skeleton__content": 20,
 	".edit-widgets-header": 30,

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -163,6 +163,16 @@ html.interface-interface-skeleton__html-container {
 	@include break-medium() {
 		display: flex;
 	}
+
+	.block-editor-block-breadcrumb {
+		z-index: z-index(".edit-post-layout__footer");
+		display: flex;
+		background: $white;
+		height: $button-size-small;
+		align-items: center;
+		font-size: $default-font-size;
+		padding: 0 ($grid-unit-15 + 6px);
+	}
 }
 
 .interface-interface-skeleton__actions {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Reverts part of the CSS removal for the interface footer's breadcrumbs rules, removed in #62237

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This CSS added left padding and ensured the height of the footer breadcrumbs was correct when no blocks were selected in the site and post editors. Re-instating the CSS appears to get the styling working again.

There's a comment in https://github.com/WordPress/gutenberg/pull/62237/files#r1624428431 that this CSS was in the wrong place. However, for now, let's re-instate the CSS and it can be moved elsewhere in a follow-up if need be. (I.e. the padding rule is appropriate as a child of the interface footer, but perhaps the height, etc, should be in the breadcrumbs component instead?)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Re-instate some of the removed lines from #62237

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In `trunk`, open the post editor and don't select any blocks. Note that the height of the footer breadcrumbs is too small.
2. With this PR applied, the height should be correct. It should also look correct if you select nested blocks.
3. Repeat in the site editor and check that the interface footer's breadcrumbs look correct

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1183" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/1e5e75ab-10fe-46a3-9d92-15f7054ca685">

<img width="1179" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/f59fb4bb-c16a-4616-9182-3a176e4660e5">

### After

<img width="1179" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/85d232b6-0420-4437-97c3-8192c6c773a5">

<img width="1181" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/5ef0b966-b203-49cc-aa1f-fcaa08a0e3c8">
