### PR TITLE
List View: Fix home and end key behaviour in very long lists

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -194,10 +194,14 @@ function ListViewBranch( props ) {
 				// This prevents the entire tree from being rendered when a branch is
 				// selected, or a user selects all blocks, while still enabling scroll
 				// into view behavior when selecting a block or opening the list view.
+				// The first and last blocks of the list are always rendered, to ensure
+				// that Home and End keys work as expected.
 				const showBlock =
 					isDragged ||
 					blockInView ||
-					( isSelected && clientId === selectedClientIds[ 0 ] );
+					( isSelected && clientId === selectedClientIds[ 0 ] ) ||
+					index === 0 ||
+					index === blockCount - 1;
 				return (
 					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						{ showBlock && (

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -1120,7 +1120,7 @@ test.describe( 'List View', () => {
 				'Pressing keyboard shortcut should also work when the menu is opened and focused'
 			)
 			.toMatchObject( [
-				{ name: 'core/paragraph', selected: true, focused: false },
+				{ name: 'core/paragraph', selected: true, focused: true },
 				{ name: 'core/file', selected: false, focused: false },
 			] );
 		await expect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #49563 

Ensure that in very long lists, where the list view items are windowed (only rendered if they're visible) that the Home and End keys take the user to the very beginning or end of the list.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In very long documents or templates, the windowing logic in the list view takes effect which means that only visible items in the list view are rendered. This means that when you press Home or End to go up or down the list, the logic that determines which item to focus finds the end of the _visible_ list instead of the end of the block tree. As a result, on `trunk` when you press End, you don't go to the end of the list, but instead only to the end of the current visible window.

The proposed fix is to always render the first and last items of the list, so that there are focusable items for the Home and End keys to go to. This way it's possible to immediately go to the very beginning or end of the list.

Note: Page Up and Page Down keys are not yet supported in the list view. I'm exploring that separately over in https://github.com/WordPress/gutenberg/pull/61474, though I'm unsure how much time I'll have to advance that one in the short-term.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the list view's logic where it determines whether to render the current list view item as a "real" item, always render if it's the first or last item in the list.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In a document with a very large number of blocks (e.g. > 100 blocks), open the list view, and then click a block in the list view twice to make sure that focus is within the list view.

Press Home and End keys on your keyboard. Notice that on `trunk` the Home and End keys don't always take you to the beginning or end of the document. With this PR applied, it should always take you to the beginning or end.

For a quick way to add a large number of blocks, I like to copy + paste text from a book in the public domain. E.g. [here's a copy of Dracula](https://www.gutenberg.org/files/345/345-h/345-h.htm).

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/c6d96760-0a0c-4391-a18b-15c386b06697

### After

https://github.com/WordPress/gutenberg/assets/14988353/c06afa26-267b-47e8-905d-bcd3b0083dbf
