### PR TITLE
Performance reporter: print the stdout/stderr from the worker

### DIFF
--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -212,6 +212,18 @@ class PerformanceReporter implements Reporter {
 			console.table( printableResults );
 		}
 	}
+
+	printsToStdio() {
+		return true;
+	}
+
+	onStdOut( chunk: string | Buffer ) {
+		process.stdout.write( chunk );
+	}
+
+	onStdErr( chunk: string | Buffer ) {
+		process.stderr.write( chunk );
+	}
 }
 
 export default PerformanceReporter;


### PR DESCRIPTION
Enhances the `PerformanceReporter` with `onStdOut` and `onStdErr` methods so that errors during the test run are reported even in CI where no other reporter is used.

Inspired by the `dot` reporter in Playwright: https://github.com/microsoft/playwright/blob/main/packages/playwright/src/reporters/dot.ts#L32-L42