### PR TITLE
Editor: Only render the site logo once if there's a fill

### DIFF
--- a/packages/edit-post/src/components/back-button/index.js
+++ b/packages/edit-post/src/components/back-button/index.js
@@ -21,12 +21,19 @@ const slideX = {
 function BackButton( { initialPost } ) {
 	return (
 		<BackButtonFill>
-			<motion.div
-				variants={ slideX }
-				transition={ { type: 'tween', delay: 0.8 } }
-			>
-				<FullscreenModeClose showTooltip initialPost={ initialPost } />
-			</motion.div>
+			{ ( { length } ) =>
+				length <= 1 && (
+					<motion.div
+						variants={ slideX }
+						transition={ { type: 'tween', delay: 0.8 } }
+					>
+						<FullscreenModeClose
+							showTooltip
+							initialPost={ initialPost }
+						/>
+					</motion.div>
+				)
+			}
 		</BackButtonFill>
 	);
 }

--- a/packages/editor/src/components/header/back-button.js
+++ b/packages/editor/src/components/header/back-button.js
@@ -20,7 +20,12 @@ const BackButtonSlot = ( { children } ) => {
 		return children;
 	}
 
-	return <Slot bubblesVirtually />;
+	return (
+		<Slot
+			bubblesVirtually
+			fillProps={ { length: ! fills ? 0 : fills.length } }
+		/>
+	);
 };
 BackButton.Slot = BackButtonSlot;
 


### PR DESCRIPTION
Fixes #62318 

## What?

Recently, we've updated the edit-post code base to use the Slot/Fill to customize the default "back button" of the `EditorInterface` component. The problem is that this meant that if there was already a plugin using that slot, we'll end up with two logos or two back buttons. 

This PR adds the registered fills count as a fill prop, and only renders the default core provided fill if there's no extra fill registered by a plugin.

## Testing Instructions

- Duplicate this line https://github.com/WordPress/gutenberg/blob/a58e49bcdabe1def93c9f6bd9553b9766bcf25a2/packages/edit-post/src/components/layout/index.js#L288
- You should not see any site logo (or w logo) in the post editor header.