### PR TITLE
Global Styles: Prevent loss of custom variation data in API response

### DIFF
--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -514,6 +514,39 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 	}
 
 	/**
+	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::update_item
+	 */
+	public function test_update_item_with_custom_block_style_variations() {
+		wp_set_current_user( self::$admin_id );
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
+		$variations = array(
+			'dark' => array(
+				'color' => array(
+					'background' => '#000000',
+					'text'       => '#ffffff',
+				),
+			),
+		);
+		$request    = new WP_REST_Request( 'PUT', '/wp/v2/global-styles/' . self::$global_styles_id );
+		$request->set_body_params(
+			array(
+				'styles' => array(
+					'blocks' => array(
+						'core/group' => array(
+							'variations' => $variations,
+						),
+					),
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSame( $variations, $data['styles']['blocks']['core/group']['variations'] );
+	}
+
+	/**
 	 * @doesNotPerformAssertions
 	 */
 	public function test_delete_item() {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/62303

## What?

Ensures custom block style variation data isn't omitted from the global styles API response when saving styles in the site editor.

## Why?

When saving global styles data without this fix, any tweaks to custom block style variations are omitted from the global styles endpoint response. This missing data makes it appear as though the tweaks have been lost until the editor is reloaded.

## How?

Within the `prepare_item_for_response` method of the global styles controller, a fresh theme json instance is created. For such a request this never triggers the theme json data filters that custom block style variations rely on to register custom block styles. Unregistered block style variations get stripped out during theme json sanitization.

Rather than do all the heavy lifting of parsing theme.json partial files for the theme, applying data filters etc. this PR registers the custom block style variations found in the global styles post, directly. 

## Testing Instructions

There are some [duotone support actions](https://github.com/WordPress/gutenberg/blob/trunk/lib/block-supports/duotone.php#L21-L22) in Gutenberg that trigger all the theme json filters. So to test this fix fully, those actions need to be temporarily disabled.

1. Comment out the [duotone support actions](https://github.com/WordPress/gutenberg/blob/trunk/lib/block-supports/duotone.php#L21-L22) that masked this issue
2. Add a custom block style variation to your theme.json (see #62303 for snippet)
3. Navigate to Appearance > Editor 
4. Select a group block and apply the custom variation
5. Navigate to Styles > Blocks > Group > dark (variation name)
6. Change the background color for the variation and confirm it is reflected in the editor
7. Save the changes and confirm the background color is still correct in the editor
8. For good measure check the frontend
9. Uncomment the duotone support actions from step 1 and repeat the process. It should still work.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/a7d59fad-29a1-40d1-84c7-9606f170aef5" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/3ad6e58b-d05b-4048-8e35-79987ed1808c" /> |



