### PR TITLE
Data: Add error handle to the 'registry.batch' method

### DIFF
--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -322,9 +322,21 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 
 		emitter.pause();
 		Object.values( stores ).forEach( ( store ) => store.emitter.pause() );
-		callback();
-		emitter.resume();
-		Object.values( stores ).forEach( ( store ) => store.emitter.resume() );
+		try {
+			callback();
+			emitter.resume();
+			Object.values( stores ).forEach( ( store ) =>
+				store.emitter.resume()
+			);
+		} catch ( error ) {
+			emitter.resume();
+			Object.values( stores ).forEach( ( store ) =>
+				store.emitter.resume()
+			);
+
+			// Re-throw the error after resuming the work for debugging.
+			throw error;
+		}
 	}
 
 	let registry = {

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -324,18 +324,11 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		Object.values( stores ).forEach( ( store ) => store.emitter.pause() );
 		try {
 			callback();
+		} finally {
 			emitter.resume();
 			Object.values( stores ).forEach( ( store ) =>
 				store.emitter.resume()
 			);
-		} catch ( error ) {
-			emitter.resume();
-			Object.values( stores ).forEach( ( store ) =>
-				store.emitter.resume()
-			);
-
-			// Re-throw the error after resuming the work for debugging.
-			throw error;
 		}
 	}
 

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -755,6 +755,28 @@ describe( 'createRegistry', () => {
 			} );
 			expect( listener ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		it( 'should handle errors', () => {
+			const store = registry.registerStore( 'myAwesomeReducer', {
+				reducer: ( state = 0 ) => state + 1,
+			} );
+			const listener = jest.fn();
+			const error = new Error( 'Whoops' );
+			subscribeWithUnsubscribe( listener );
+
+			expect( () => {
+				registry.batch( () => {
+					throw error;
+				} );
+			} ).toThrow( error );
+			expect( listener ).not.toHaveBeenCalled();
+
+			registry.batch( () => {
+				store.dispatch( { type: 'dummy' } );
+				store.dispatch( { type: 'dummy' } );
+			} );
+			expect( listener ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
 	describe( 'use', () => {


### PR DESCRIPTION
## What?
Resolves: #62311.

PR adds an error handler to the `registry.batch` method and avoids pausing all store emitters during the error.

## Testing Instructions
1. Open a post or page.
2. Run selector via Console - `wp.data.select( 'core' ).getEntityRecords( 'root', 'site' );`.
3. Confirm that the editor is still responsive.

### Testing Instructions for Keyboard
Same.
