### PR TITLE
Editor: Make revisions more prominent

### DIFF
--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -11,19 +11,11 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import PostLastRevisionCheck from './check';
+import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
 
-/**
- * Renders the component for displaying the last revision of a post.
- *
- * @return {Component} The component to be rendered.
- */
-function PostLastRevision() {
-	return <PrivatePostLastRevision isLink={ false } />;
-}
-
-export function PrivatePostLastRevision( { isLink } ) {
-	const { lastRevisionId, revisionsCount } = useSelect( ( select ) => {
+function usePostLastRevisionInfo() {
+	return useSelect( ( select ) => {
 		const { getCurrentPostLastRevisionId, getCurrentPostRevisionsCount } =
 			select( editorStore );
 		return {
@@ -31,6 +23,15 @@ export function PrivatePostLastRevision( { isLink } ) {
 			revisionsCount: getCurrentPostRevisionsCount(),
 		};
 	}, [] );
+}
+
+/**
+ * Renders the component for displaying the last revision of a post.
+ *
+ * @return {Component} The component to be rendered.
+ */
+function PostLastRevision() {
+	const { lastRevisionId, revisionsCount } = usePostLastRevisionInfo();
 
 	return (
 		<PostLastRevisionCheck>
@@ -39,15 +40,32 @@ export function PrivatePostLastRevision( { isLink } ) {
 					revision: lastRevisionId,
 				} ) }
 				className="editor-post-last-revision__title"
-				icon={ isLink ? undefined : backup }
+				icon={ backup }
 				iconPosition="right"
 				text={ sprintf(
 					/* translators: %s: number of revisions */
 					__( 'Revisions (%s)' ),
 					revisionsCount
 				) }
-				variant={ isLink ? 'link' : undefined }
 			/>
+		</PostLastRevisionCheck>
+	);
+}
+
+export function PrivatePostLastRevision() {
+	const { lastRevisionId, revisionsCount } = usePostLastRevisionInfo();
+	return (
+		<PostLastRevisionCheck>
+			<PostPanelRow label={ __( 'Revisions' ) }>
+				<Button
+					href={ addQueryArgs( 'revision.php', {
+						revision: lastRevisionId,
+					} ) }
+					className="editor-private-post-last-revision__button"
+					text={ revisionsCount }
+					variant="tertiary"
+				/>
+			</PostPanelRow>
 		</PostLastRevisionCheck>
 	);
 }

--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -19,6 +19,10 @@ import { store as editorStore } from '../../store';
  * @return {Component} The component to be rendered.
  */
 function PostLastRevision() {
+	return <PrivatePostLastRevision isLink={ false } />;
+}
+
+export function PrivatePostLastRevision( { isLink } ) {
 	const { lastRevisionId, revisionsCount } = useSelect( ( select ) => {
 		const { getCurrentPostLastRevisionId, getCurrentPostRevisionsCount } =
 			select( editorStore );
@@ -35,13 +39,14 @@ function PostLastRevision() {
 					revision: lastRevisionId,
 				} ) }
 				className="editor-post-last-revision__title"
-				icon={ backup }
+				icon={ isLink ? undefined : backup }
 				iconPosition="right"
 				text={ sprintf(
 					/* translators: %s: number of revisions */
 					__( 'Revisions (%s)' ),
 					revisionsCount
 				) }
+				variant={ isLink ? 'link' : undefined }
 			/>
 		</PostLastRevisionCheck>
 	);

--- a/packages/editor/src/components/post-last-revision/style.scss
+++ b/packages/editor/src/components/post-last-revision/style.scss
@@ -1,6 +1,11 @@
 .editor-post-last-revision__title {
 	width: 100%;
 	font-weight: 500;
+
+	&.is-link {
+		width: fit-content;
+		font-weight: unset;
+	}
 }
 
 .editor-post-last-revision__title.components-button.has-icon {

--- a/packages/editor/src/components/post-last-revision/style.scss
+++ b/packages/editor/src/components/post-last-revision/style.scss
@@ -1,11 +1,6 @@
 .editor-post-last-revision__title {
 	width: 100%;
 	font-weight: 500;
-
-	&.is-link {
-		width: fit-content;
-		font-weight: unset;
-	}
 }
 
 .editor-post-last-revision__title.components-button.has-icon {
@@ -32,4 +27,8 @@
 	.editor-post-last-revision__title.components-button.components-button {
 		padding: $grid-unit-20;
 	}
+}
+
+.editor-private-post-last-revision__button {
+	display: inline-block;
 }

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -30,6 +30,7 @@ import PostsPerPage from '../posts-per-page';
 import SiteDiscussion from '../site-discussion';
 import { store as editorStore } from '../../store';
 import TemplateAreas from '../template-areas';
+import { PrivatePostLastRevision } from '../post-last-revision';
 
 /**
  * Module Constants
@@ -66,6 +67,7 @@ export default function PostSummary( { onActionPerformed } ) {
 							<VStack spacing={ 1 }>
 								<PostContentInformation />
 								<PostLastEditedPanel />
+								<PrivatePostLastRevision isLink />
 							</VStack>
 							{ ! isRemovedPostStatusPanel && (
 								<VStack spacing={ 2 }>

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -67,7 +67,6 @@ export default function PostSummary( { onActionPerformed } ) {
 							<VStack spacing={ 1 }>
 								<PostContentInformation />
 								<PostLastEditedPanel />
-								<PrivatePostLastRevision isLink />
 							</VStack>
 							{ ! isRemovedPostStatusPanel && (
 								<VStack spacing={ 2 }>
@@ -78,6 +77,7 @@ export default function PostSummary( { onActionPerformed } ) {
 										<PostAuthorPanel />
 										<PostTemplatePanel />
 										<PostDiscussionPanel />
+										<PrivatePostLastRevision />
 										<PageAttributesPanel />
 										<PostSyncStatus />
 										<BlogTitle />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/62041

There is some feedback in the issue that the revisions link and revisions number should be a bit more prominent, besides the post action in the ellipsis menu. This PR adds this info in post summary like suggested in the below [comment](https://github.com/WordPress/gutenberg/pull/62323#issuecomment-2149329070).


## Testing Instructions
1. Observe the revisions info in the post summary panel.

## Screenshots or screencast <!-- if applicable -->

<img width="281" alt="Screenshot 2024-06-06 at 9 49 28 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/35bdce99-e573-493b-a517-ea671bc6f73c">
