### PR TITLE
Interactivity API template create block: Removed warning for generated README from template

### DIFF
--- a/packages/create-block-interactive-template/block-templates/README.md.mustache
+++ b/packages/create-block-interactive-template/block-templates/README.md.mustache
@@ -1,16 +1,8 @@
 # Interactive Block
 
-> **Warning**
-> **This block requires Gutenberg 16.2 or superior to work**. The Interactivity API is, at the moment, not part of WordPress Core as it is still very experimental, and very likely to change. 
-
 > **Note**
-> This block uses the API shared at [Proposal: The Interactivity API – A better developer experience in building interactive blocks](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/). 
+> Check the [Interactivity API Reference docs in the Block Editor handbook](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/) to learn more about the Interactivity API.
 
 {{#isBasicVariant}}
 This block has been created with the `create-block-interactive-template` and shows a basic structure of an interactive block that uses the Interactivity API.
 {{/isBasicVariant}}
-
-Check the following resources for more info about the Interactivity API:
-- [`@wordpress/interactivity` package](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/README.md)
-- [Proposal: The Interactivity API – A better developer experience in building interactive blocks](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/)
-- [“Interactivity API” category](https://github.com/WordPress/gutenberg/discussions/categories/interactivity-api) in Gutenberg repo discussions


### PR DESCRIPTION
## What?
Removes the following **Warning** from the generated README when using `create-block-interactive-template` template for `create-block` tool

> This block requires Gutenberg 16.2 or superior to work. The Interactivity API is, at the moment, not part of WordPress Core as it is still very experimental, and very likely to change.

## Why?
Because the API has evolved since that message was set and that warning is not needed anymore