### PR TITLE
Block Variations: Detect active variation correctly based on RichText attribute

### DIFF
--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -262,16 +262,16 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 				continue;
 			}
 			const isMatch = definedAttributes.every( ( attribute ) => {
-				const attributeValue = getValueFromObjectPath(
-					attributes,
+				const variationAttributeValue = getValueFromObjectPath(
+					variation.attributes,
 					attribute
 				);
-				if ( attributeValue === undefined ) {
+				if ( variationAttributeValue === undefined ) {
 					return false;
 				}
 				return (
-					attributeValue ===
-					getValueFromObjectPath( variation.attributes, attribute )
+					variationAttributeValue ===
+					getValueFromObjectPath( attributes, attribute )
 				);
 			} );
 			if ( isMatch && definedAttributesLength > maxMatchedAttributes ) {

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -269,10 +269,11 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 				if ( variationAttributeValue === undefined ) {
 					return false;
 				}
-				return (
-					variationAttributeValue ===
-					getValueFromObjectPath( attributes, attribute )
+				const blockAttributeValue = getValueFromObjectPath(
+					attributes,
+					attribute
 				);
+				return variationAttributeValue === blockAttributeValue;
 			} );
 			if ( isMatch && definedAttributesLength > maxMatchedAttributes ) {
 				match = variation;

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -7,6 +7,7 @@ import removeAccents from 'remove-accents';
  * WordPress dependencies
  */
 import { createSelector } from '@wordpress/data';
+import { RichTextData } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -269,10 +270,13 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 				if ( variationAttributeValue === undefined ) {
 					return false;
 				}
-				const blockAttributeValue = getValueFromObjectPath(
+				let blockAttributeValue = getValueFromObjectPath(
 					attributes,
 					attribute
 				);
+				if ( blockAttributeValue instanceof RichTextData ) {
+					blockAttributeValue = blockAttributeValue.toHTMLString();
+				}
 				return variationAttributeValue === blockAttributeValue;
 			} );
 			if ( isMatch && definedAttributesLength > maxMatchedAttributes ) {

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -17,6 +17,11 @@ import {
 	getActiveBlockVariation,
 } from '../selectors';
 
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+
 const keyBlocksByName = ( blocks ) =>
 	blocks.reduce(
 		( result, block ) => ( { ...result, [ block.name ]: block } ),
@@ -449,6 +454,43 @@ describe( 'selectors', () => {
 						firstTestAttribute: {
 							nestedProperty: 2,
 						},
+					} )
+				).toEqual( variations[ 1 ] );
+			} );
+			it( 'should support RichText attributes in the isActive array', () => {
+				const variations = [
+					{
+						name: 'variation-1',
+						attributes: {
+							firstTestAttribute:
+								'This is a <strong>RichText</strong> attribute.',
+						},
+						isActive: [ 'firstTestAttribute' ],
+					},
+					{
+						name: 'variation-2',
+						attributes: {
+							firstTestAttribute:
+								'This is a <em>RichText</em> attribute.',
+						},
+						isActive: [ 'firstTestAttribute' ],
+					},
+				];
+				const state =
+					createBlockVariationsStateWithTestBlockType( variations );
+
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						firstTestAttribute: RichTextData.fromHTMLString(
+							'This is a <strong>RichText</strong> attribute.'
+						),
+					} )
+				).toEqual( variations[ 0 ] );
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						firstTestAttribute: RichTextData.fromHTMLString(
+							'This is a <em>RichText</em> attribute.'
+						),
 					} )
 				).toEqual( variations[ 1 ] );
 			} );


### PR DESCRIPTION
## What?
If a block variation has an `isActive` property that is an array of strings (attribute names), and one of the attributes referenced therein is a `RichText` value, compare the given `RichText` string correctly to the given block's.

## Why?
Block variations aren't currently recognized as active if one of the distinguishing attributes is a RichText value, see https://github.com/WordPress/gutenberg/pull/62031#issuecomment-2142197224.

## How?
By translating the `RichTextData` object received from the given block's attributes to an HTML string, via [`RichTextData.toHTMLString()`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-rich-text/#tohtmlstring).

## Testing Instructions

Apply the following patch to create a variation of the Paragraph block:

```diff
diff --git a/packages/block-library/src/paragraph/block.json b/packages/block-library/src/paragraph/block.json
index 6f11baf838a..f2f75912954 100644
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -69,6 +69,18 @@
                        "clientNavigation": true
                }
        },
+       "variations": [
+               {
+                       "name": "warning-with-color",
+                       "title": "Warning with color",
+                       "icon": "warning",
+                       "attributes": {
+                               "content": "This is a <strong>warning</strong> message.",
+                               "backgroundColor": "luminous-vivid-amber"
+                       },
+                       "isActive": [ "content", "backgroundColor" ]
+               }
+       ],
        "editorStyle": "wp-block-paragraph-editor",
        "style": "wp-block-paragraph"
 }
```

Then, create a new post and insert a Paragraph block in the editor that matches the variation -- e.g. by switching to the Code Editor and pasting the following markup:

```html
<!-- wp:paragraph {"backgroundColor":"luminous-vivid-amber"} -->
<p class="has-luminous-vivid-amber-background-color has-background">This is a <strong>warning</strong> message.</p>
<!-- /wp:paragraph -->
```

In the Block Inspector, verify that the variation is correctly recognized as "Warning with color" (rather than "Paragraph").

Note that if you make any modification to that block (e.g. change the text or formatting), it will no longer be recognized, and will show up as "Paragraph" block in the Block Inspector insted.

## Screenshots or screencast

| Before | After |
|-------|-------|
| <img width="872" alt="image" src="https://github.com/WordPress/gutenberg/assets/96308/22f59be4-15e7-4d9e-8aaa-2c71229a7487"> | <img width="871" alt="image" src="https://github.com/WordPress/gutenberg/assets/96308/b3d7106e-6f0e-42d7-a2d6-221a0443c75e"> |
