### PR TITLE
E2E Utils: Add retry mechanism to the REST API discovery

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -45,7 +45,7 @@ async function getAPIRootURL( request: APIRequestContext ) {
 				timeout: 60_000, // 1 minute.
 			}
 		)
-		.not.toBeNull();
+		.not.toBeFalsy();
 
 	const [ , rootURL ] = restLink as RegExpMatchArray;
 

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -3,6 +3,7 @@
  */
 import * as fs from 'fs/promises';
 import { dirname } from 'path';
+import { expect } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 
 /**
@@ -39,10 +40,30 @@ async function getAPIRootURL( request: APIRequestContext ) {
 }
 
 async function setupRest( this: RequestUtils ): Promise< StorageState > {
-	const [ nonce, rootURL ] = await Promise.all( [
-		this.login(),
-		getAPIRootURL( this.request ),
-	] );
+	let nonce = '';
+	let rootURL = '';
+
+	await expect
+		.poll(
+			async () => {
+				try {
+					[ nonce, rootURL ] = await Promise.all( [
+						this.login(),
+						getAPIRootURL( this.request ),
+					] );
+				} catch ( error ) {
+					// Prints the error if the timeout is reached.
+					return error;
+				}
+
+				return nonce && rootURL ? true : false;
+			},
+			{
+				message: 'Failed to setup REST API.',
+				timeout: 60_000, // 1 minute.
+			}
+		)
+		.toBe( true );
 
 	const { cookies } = await this.request.storageState();
 

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -3,7 +3,6 @@
  */
 import * as fs from 'fs/promises';
 import { dirname } from 'path';
-import { expect } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 
 /**
@@ -23,31 +22,18 @@ function splitRequestsToChunks( requests: BatchRequest[], chunkSize: number ) {
 }
 
 async function getAPIRootURL( request: APIRequestContext ) {
-	let restLink: unknown = null;
+	// Discover the API root url using link header.
+	// See https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/#link-header
+	const response = await request.head( WP_BASE_URL );
+	const links = response.headers().link;
+	const restLink = links?.match( /<([^>]+)>; rel="https:\/\/api\.w\.org\/"/ );
 
-	// Retry until the REST API root URL is discovered.
-	// See https://github.com/WordPress/gutenberg/issues/61627
-	await expect
-		.poll(
-			async () => {
-				// Discover the API root url using link header.
-				// See https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/#link-header
-				const response = await request.head( WP_BASE_URL );
-				const links = response.headers().link;
-				restLink = links?.match(
-					/<([^>]+)>; rel="https:\/\/api\.w\.org\/"/
-				);
+	if ( ! restLink ) {
+		throw new Error( `Failed to discover REST API endpoint.
+ Link header: ${ links }` );
+	}
 
-				return restLink;
-			},
-			{
-				message: 'Failed to discover REST API endpoint.',
-				timeout: 60_000, // 1 minute.
-			}
-		)
-		.not.toBeFalsy();
-
-	const [ , rootURL ] = restLink as RegExpMatchArray;
+	const [ , rootURL ] = restLink;
 
 	return rootURL;
 }

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -42,7 +42,7 @@ async function getAPIRootURL( request: APIRequestContext ) {
 			},
 			{
 				message: 'Failed to discover REST API endpoint.',
-				timeout: 60_000, // 1 minute.
+				timeout: 120_000, // 2 minutes.
 			}
 		)
 		.not.toBeNull();

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -42,7 +42,7 @@ async function getAPIRootURL( request: APIRequestContext ) {
 			},
 			{
 				message: 'Failed to discover REST API endpoint.',
-				timeout: 120_000, // 2 minutes.
+				timeout: 60_000, // 1 minute.
 			}
 		)
 		.not.toBeNull();

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -43,6 +43,8 @@ async function setupRest( this: RequestUtils ): Promise< StorageState > {
 	let nonce = '';
 	let rootURL = '';
 
+	// Poll until the REST API is discovered.
+	// See https://github.com/WordPress/gutenberg/issues/61627
 	await expect
 		.poll(
 			async () => {

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -45,7 +45,7 @@ async function getAPIRootURL( request: APIRequestContext ) {
 				timeout: 60_000, // 1 minute.
 			}
 		)
-		.not.toBeFalsy();
+		.not.toBeNull();
 
 	const [ , rootURL ] = restLink as RegExpMatchArray;
 

--- a/test/performance/playwright.config.ts
+++ b/test/performance/playwright.config.ts
@@ -14,9 +14,7 @@ process.env.ASSETS_PATH = path.join( __dirname, 'assets' );
 
 const config = defineConfig( {
 	...baseConfig,
-	reporter: process.env.CI
-		? './config/performance-reporter.ts'
-		: [ [ 'list' ], [ './config/performance-reporter.ts' ] ],
+	reporter: [ [ 'list' ], [ './config/performance-reporter.ts' ] ],
 	forbidOnly: !! process.env.CI,
 	fullyParallel: false,
 	retries: 0,

--- a/test/performance/playwright.config.ts
+++ b/test/performance/playwright.config.ts
@@ -30,6 +30,7 @@ const config = defineConfig( {
 		actionTimeout: 120_000, // 2 minutes.
 		video: 'off',
 	},
+	webServer: null, // We're starting the server from the runner script.
 } );
 
 export default config;

--- a/test/performance/playwright.config.ts
+++ b/test/performance/playwright.config.ts
@@ -28,7 +28,6 @@ const config = defineConfig( {
 		actionTimeout: 120_000, // 2 minutes.
 		video: 'off',
 	},
-	webServer: null, // We're starting the server from the runner script.
 } );
 
 export default config;


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/61627
Fixes https://github.com/WordPress/gutenberg/issues/60366

Related thread: https://wordpress.slack.com/archives/C02QB2JS7/p1717143284055259

## What?
Add a retry mechanism to the REST API discovery so that it doesn't fail when the env is not ready yet.

## Testing Instructions
- All tests should pass.
- Perf tests on `trunk` have been failing, so I've triggered a workflow using params from the failing job with this branch as a test runner. [It should pass](https://github.com/WordPress/gutenberg/actions/runs/9383258293/job/25836466597).