### PR TITLE
Fix ExcerptPanel decode issue

### DIFF
--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { ExternalLink, TextareaControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -52,7 +53,9 @@ export default function PostExcerpt( {
 		[]
 	);
 	const { editPost } = useDispatch( editorStore );
-	const [ localExcerpt, setLocalExcerpt ] = useState( excerpt );
+	const [ localExcerpt, setLocalExcerpt ] = useState(
+		decodeEntities( excerpt )
+	);
 	const updatePost = ( value ) => {
 		editPost( { [ usedAttribute ]: value } );
 	};

--- a/packages/editor/src/components/post-excerpt/panel.js
+++ b/packages/editor/src/components/post-excerpt/panel.js
@@ -13,6 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useState } from '@wordpress/element';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -173,7 +174,7 @@ function PrivateExcerpt() {
 	}
 	const excerptText = !! excerpt && (
 		<Text align="left" numberOfLines={ 4 } truncate>
-			{ excerpt }
+			{ decodeEntities( excerpt ) }
 		</Text>
 	);
 	if ( ! allowEditing ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/WordPress/gutenberg/issues/62335

## What?
In the Site Editor, it displays the page title as part of the template description in the Template panel in the Site Editor Sidebar. This PR will fix the HTML entities decode, for example, a template for a page called
"Hello World & Hello WP" Would show the description: "Template for Hello World &amp; Hello WP". After applying this patch this issue will resolved.

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="284" alt="template-description" src="https://github.com/WordPress/gutenberg/assets/13062380/b0a10df7-27a8-436a-8cbe-a61dab6f8c46">

### After
<img width="632" alt="Screenshot 2024-06-05 at 6 42 25 PM" src="https://github.com/WordPress/gutenberg/assets/13062380/3aa7fd2e-85d0-48ac-96ba-84bab9e49a5c">
