### PR TITLE
Test using Node.js 22.x.

### DIFF
--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -20,7 +20,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '21']
+                node: ['20', '22']
                 os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
 
         steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '21']
+                node: ['20', '22']
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
@@ -66,7 +66,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '21']
+                node: ['20', '22']
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This updates the version of Node.js used in test matrices from `20.x` & `21.x` to `20.x` & `22.x`.

## Why?
[Version 20.0.0 was released on April 4, 2024](https://nodejs.org/en/blog/release/v20.0.0) and is the new "current" release for Node.js. The latest version for this major release is is 22.2.0.

[21.x has now reached end-of-life](https://github.com/nodejs/Release?tab=readme-ov-file#end-of-life-releases). In Node.js, odd numbered versions are not promoted to (Active|Maintenance) LTS. Instead they [serve only as the current release for ~6 months](https://github.com/nodejs/Release?tab=readme-ov-file#release-plan).

Some of our test workflows are currently set up to run on 20.x (the current minimum required version of Node.js to contribute) and the latest current version (now 22.x) as a way to proactively test against new versions that become available with the aim to make increasing the minimum version required more easily in the future.

## Testing Instructions
These workflows should not be considered all inclusive testing. Contributors can run `22.x` locally and report any additional problems that are discovered.

A full list of the [changes in 22.0.0 can be found in the project's changelog](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#2024-04-24-version-2200-current-rafaelgss-and-marco-ippolito).