### PR TITLE
Scroll to top by default in full-page client-side navigation experiment

### DIFF
--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -369,7 +369,7 @@ if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 		// Navigate on click.
 		document.addEventListener(
 			'click',
-			function ( event ) {
+			async function ( event ) {
 				const target = event.target as Element;
 				const ref = target.closest( 'a' );
 				if (
@@ -378,7 +378,7 @@ if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 					! target.hasAttribute( 'data-wp-on--click' ) // Don't override other click directives.
 				) {
 					event.preventDefault();
-					actions.navigate( ref.href );
+					await actions.navigate( ref.href );
 					// Scroll to the top of the page by default.
 					window.scrollTo( 0, 0 );
 				}

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -370,10 +370,17 @@ if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 		document.addEventListener(
 			'click',
 			function ( event ) {
-				const ref = ( event.target as Element ).closest( 'a' );
-				if ( isValidLink( ref ) && isValidEvent( event ) ) {
+				const target = event.target as Element;
+				const ref = target.closest( 'a' );
+				if (
+					isValidLink( ref ) &&
+					isValidEvent( event ) &&
+					! target.hasAttribute( 'data-wp-on--click' ) // Don't override other click directives.
+				) {
 					event.preventDefault();
 					actions.navigate( ref.href );
+					// Scroll to the top of the page by default.
+					window.scrollTo( 0, 0 );
 				}
 			},
 			true

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -370,17 +370,18 @@ if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 		document.addEventListener(
 			'click',
 			async function ( event ) {
-				const target = event.target as Element;
-				const ref = target.closest( 'a' );
-				if (
-					isValidLink( ref ) &&
-					isValidEvent( event ) &&
-					! target.hasAttribute( 'data-wp-on--click' ) // Don't override other click directives.
-				) {
-					event.preventDefault();
-					await actions.navigate( ref.href );
-					// Scroll to the top of the page by default.
-					window.scrollTo( 0, 0 );
+				if ( event.target && event.target instanceof HTMLElement ) {
+					const ref = event.target.closest( 'a' );
+					if (
+						isValidLink( ref ) &&
+						isValidEvent( event ) &&
+						! event.target.hasAttribute( 'data-wp-on--click' ) // Don't override other click directives.
+					) {
+						event.preventDefault();
+						await actions.navigate( ref.href );
+						// Scroll to the top of the page by default.
+						window.scrollTo( 0, 0 );
+					}
 				}
 			},
 			true

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -324,12 +324,6 @@ export const { state, actions } = store( 'core/router', {
 							? '\u00A0'
 							: '' );
 				}
-
-				// Scroll to the anchor if exits in the link.
-				const { hash } = new URL( href, window.location.href );
-				if ( hash ) {
-					document.querySelector( hash )?.scrollIntoView();
-				}
 			} else {
 				yield forcePageReload( href );
 			}
@@ -379,8 +373,18 @@ if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 					) {
 						event.preventDefault();
 						await actions.navigate( ref.href );
-						// Scroll to the top of the page by default.
-						window.scrollTo( 0, 0 );
+
+						// Scroll to the anchor if it exists in the link.
+						const { hash } = new URL(
+							ref.href,
+							window.location.href
+						);
+						if ( !! hash ) {
+							document.querySelector( hash )?.scrollIntoView();
+						} else {
+							// Scroll to the top of the page by default.
+							window.scrollTo( 0, 0 );
+						}
 					}
 				}
 			},


### PR DESCRIPTION
## What?
Automatically scroll to the top of the page when in full-page client-side navigation experiment.

Apart from that, it adds a check to ensure it doesn't overlap with other `data-wp-on--click` directives. This way, they can decide their own behavior as the query loop is doing, for example.

## Why?
I believe it is the expected behavior.

## How?
* Using `window.scrollTo( 0, 0 )` after calling `actions.navigate`.
* Check that `target` doesn't have the `data-wp-on--click` directive.

## Testing Instructions
1. Go to Gutenberg->Experiments and enable the full-page client-side aviation experiment.
2. Go to the frontend and scroll.
3. Click on any link and check it scroll to the top of the page.
4. Go to a query loop, click on "Next page", and check it doesn't scroll to the top of the page.
