### PR TITLE
Core Data: Fix errors when the entities list doesn't contain config key

### DIFF
--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -110,7 +110,11 @@ export function items( state = {}, action ) {
 				[ context ]: {
 					...state[ context ],
 					...action.items.reduce( ( accumulator, value ) => {
-						const itemId = value[ key ];
+						const itemId = value?.[ key ];
+						if ( ! itemId ) {
+							return accumulator;
+						}
+
 						accumulator[ itemId ] = conservativeMapItem(
 							state?.[ context ]?.[ itemId ],
 							value
@@ -164,7 +168,10 @@ export function itemIsComplete( state = {}, action ) {
 				[ context ]: {
 					...state[ context ],
 					...action.items.reduce( ( result, item ) => {
-						const itemId = item[ key ];
+						const itemId = item?.[ key ];
+						if ( ! itemId ) {
+							return result;
+						}
 
 						// Defer to completeness if already assigned. Technically the
 						// data may be outdated if receiving items for a field subset.
@@ -232,7 +239,7 @@ const receiveQueries = compose( [
 	return {
 		itemIds: getMergedItemIds(
 			state?.itemIds || [],
-			action.items.map( ( item ) => item[ key ] ),
+			action.items.flatMap( ( item ) => item?.[ key ] ?? [] ),
 			page,
 			perPage
 		),

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -111,9 +111,6 @@ export function items( state = {}, action ) {
 					...state[ context ],
 					...action.items.reduce( ( accumulator, value ) => {
 						const itemId = value?.[ key ];
-						if ( ! itemId ) {
-							return accumulator;
-						}
 
 						accumulator[ itemId ] = conservativeMapItem(
 							state?.[ context ]?.[ itemId ],
@@ -169,9 +166,6 @@ export function itemIsComplete( state = {}, action ) {
 					...state[ context ],
 					...action.items.reduce( ( result, item ) => {
 						const itemId = item?.[ key ];
-						if ( ! itemId ) {
-							return result;
-						}
 
 						// Defer to completeness if already assigned. Technically the
 						// data may be outdated if receiving items for a field subset.

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -233,7 +233,7 @@ const receiveQueries = compose( [
 	return {
 		itemIds: getMergedItemIds(
 			state?.itemIds || [],
-			action.items.flatMap( ( item ) => item?.[ key ] ?? [] ),
+			action.items.map( ( item ) => item?.[ key ] ).filter( Boolean ),
 			page,
 			perPage
 		),

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -256,7 +256,7 @@ function entity( entityConfig ) {
 						const nextState = { ...state };
 
 						for ( const record of action.items ) {
-							const recordId = record[ action.key ];
+							const recordId = record?.[ action.key ];
 							const edits = nextState[ recordId ];
 							if ( ! edits ) {
 								continue;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -278,7 +278,7 @@ export const getEntityRecords =
 				if ( ! query?._fields && ! query.context ) {
 					const key = entityConfig.key || DEFAULT_ENTITY_KEY;
 					const resolutionsArgs = records
-						.filter( ( record ) => record[ key ] )
+						.filter( ( record ) => record?.[ key ] )
 						.map( ( record ) => [ kind, name, record[ key ] ] );
 
 					dispatch( {


### PR DESCRIPTION
## What?
Closes #62311.

PR fixes errors when data returned by the endpoint for `getEntityRecords` doesn't contain config or default `key` property.

## Testing Instructions
1. Open a post or page.
2. Run selector via Console - `wp.data.select( 'core' ).getEntityRecords( 'root', 'site' );.`
3. Check the errors via - `wp.data.select( 'core' ).getResolutionError( 'getEntityRecords', [ 'root', 'site' ] );`.
4. You can also set a logpoint [here](https://github.com/WordPress/gutenberg/blob/0011ca615e4d5424e7220fc363a443bf62fe0852/packages/core-data/src/resolvers.js#L299). 

### Testing Instructions for Keyboard
Same.