### PR TITLE
List view: show context menu for content-only blocks in posts

### DIFF
--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -11,7 +11,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __experimentalText as Text, MenuItem } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { lockSmall as lock } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -80,32 +79,20 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 		);
 	}
 
-	// The post has a parent template part, but the user does not have the capability to edit template parts.
+	const isPattern = entity.type === 'wp_block';
+	let helpText = isPattern
+		? __(
+				'Edit the pattern to move, delete, or make further changes to this block.'
+		  )
+		: __(
+				'Edit the template to move, delete, or make further changes to this block.'
+		  );
+
 	if ( ! canEditTemplates ) {
-		return (
-			<>
-				<BlockSettingsMenuFirstItem>
-					<MenuItem
-						icon={ lock }
-						iconPosition="left"
-						role="none"
-						disabled
-					>
-						{ __( 'Locked' ) }
-					</MenuItem>
-				</BlockSettingsMenuFirstItem>
-				<Text
-					variant="muted"
-					as="p"
-					className="editor-content-only-settings-menu__description"
-				>
-					{ __( 'Sorry, you cannot edit this block.' ) }
-				</Text>
-			</>
+		helpText = __(
+			'Only users with permissions to edit the template can move or delete this block'
 		);
 	}
-
-	const isPattern = entity.type === 'wp_block';
 
 	return (
 		<>
@@ -117,6 +104,7 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 							postType: entity.type,
 						} );
 					} }
+					disabled={ ! canEditTemplates }
 				>
 					{ isPattern ? __( 'Edit pattern' ) : __( 'Edit template' ) }
 				</MenuItem>
@@ -126,13 +114,7 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 				as="p"
 				className="editor-content-only-settings-menu__description"
 			>
-				{ isPattern
-					? __(
-							'Edit the pattern to move, delete, or make further changes to this block.'
-					  )
-					: __(
-							'Edit the template to move, delete, or make further changes to this block.'
-					  ) }
+				{ helpText }
 			</Text>
 		</>
 	);

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -31,8 +31,14 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 				} = select( blockEditorStore );
 				const contentOnly =
 					getBlockEditingMode( clientId ) === 'contentOnly';
+				const _canEditTemplateParts = select( coreStore ).canUser(
+					'create',
+					'templates'
+				);
 				if ( ! contentOnly ) {
-					return {};
+					return {
+						canEditTemplateParts: _canEditTemplateParts,
+					};
 				}
 				const patternParent = getBlockParentsByBlockName(
 					clientId,
@@ -41,10 +47,6 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 				)[ 0 ];
 
 				let record;
-				const _canEditTemplateParts = select( coreStore ).canUser(
-					'create',
-					'templates'
-				);
 				if ( patternParent ) {
 					record = select( coreStore ).getEntityRecord(
 						'postType',
@@ -54,7 +56,7 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 				} else {
 					const { getCurrentTemplateId } = select( editorStore );
 					const templateId = getCurrentTemplateId();
-					if ( templateId && _canEditTemplateParts ) {
+					if ( templateId ) {
 						record = select( coreStore ).getEntityRecord(
 							'postType',
 							'wp_template',
@@ -72,7 +74,8 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 			[ clientId ]
 		);
 
-	if ( ! canEditTemplateParts ) {
+	// The post has a parent template part, but the user does not have the capability to edit template parts.
+	if ( ! canEditTemplateParts && entity ) {
 		return (
 			<>
 				<BlockSettingsMenuFirstItem>

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { CONTENT_ONLY_BLOCKS } from '../provider/disable-non-page-content-blocks';
 
 function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 	const { entity, onNavigateToEntityRecord, canEditTemplates } = useSelect(
@@ -26,6 +27,7 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 				getBlockParentsByBlockName,
 				getSettings,
 				getBlockAttributes,
+				getBlockName,
 			} = select( blockEditorStore );
 			const contentOnly =
 				getBlockEditingMode( clientId ) === 'contentOnly';
@@ -48,7 +50,10 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 			} else {
 				const { getCurrentTemplateId } = select( editorStore );
 				const templateId = getCurrentTemplateId();
-				if ( templateId ) {
+				if (
+					CONTENT_ONLY_BLOCKS.includes( getBlockName( clientId ) ) &&
+					templateId
+				) {
 					record = select( coreStore ).getEntityRecord(
 						'postType',
 						'wp_template',

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -17,7 +17,6 @@ import { __ } from '@wordpress/i18n';
  */
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { CONTENT_ONLY_BLOCKS } from '../provider/disable-non-page-content-blocks';
 
 function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 	const { entity, onNavigateToEntityRecord, canEditTemplates } = useSelect(
@@ -27,7 +26,6 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 				getBlockParentsByBlockName,
 				getSettings,
 				getBlockAttributes,
-				getBlockName,
 			} = select( blockEditorStore );
 			const contentOnly =
 				getBlockEditingMode( clientId ) === 'contentOnly';
@@ -50,10 +48,10 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 			} else {
 				const { getCurrentTemplateId } = select( editorStore );
 				const templateId = getCurrentTemplateId();
-				if (
-					CONTENT_ONLY_BLOCKS.includes( getBlockName( clientId ) ) &&
-					templateId
-				) {
+				const { getContentLockingParent } = unlock(
+					select( blockEditorStore )
+				);
+				if ( ! getContentLockingParent( clientId ) && templateId ) {
 					record = select( coreStore ).getEntityRecord(
 						'postType',
 						'wp_template',

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -6,7 +6,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
-export const DEFAULT_CONTENT_ONLY_BLOCKS = [
+const DEFAULT_CONTENT_ONLY_BLOCKS = [
 	'core/post-title',
 	'core/post-featured-image',
 	'core/post-content',

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -6,7 +6,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
-const DEFAULT_CONTENT_ONLY_BLOCKS = [
+export const DEFAULT_CONTENT_ONLY_BLOCKS = [
 	'core/post-title',
 	'core/post-featured-image',
 	'core/post-content',


### PR DESCRIPTION

## What?
Maybe resolves https://github.com/WordPress/gutenberg/issues/62352

Ensures the Edit template context menu is shown for all post types in the post editor/site editor pages.

Display a not-very-pretty dialogue box where a user cannot edit a template.

## Why?

Since https://github.com/WordPress/gutenberg/pull/61127, a context menu is displayed for list view items that a locked, e.g., template parts and blocks

Previously the context menu was only shown for pages, and there was no check if the user can edit template. 

## How?

Rather than check for a post type, just look for a `templateId`.

A `templateId` will exists for post types that have a template and not for templates, patterns, template parts themselves.

## Testing Instructions

As admin, open up a post in the post editor. In the post settings, click on "Show template"

<img width="325" alt="Screenshot 2024-06-06 at 3 53 47 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/873f06b4-6589-4c86-a0cf-fb65d4e9674d">

Open the list view and click on the ellipsis menu for template-related items, e.g., Title, Content and any template parts like a Header.


https://github.com/WordPress/gutenberg/assets/6458278/c204597d-a4fa-453a-9399-74386179fcef



Ensure that you can see the edit context menu above. 

Template parts and other page/post template blocks such as post title, content and featured images should have the "Edit template" context menu.

Locked items in the page/post content will get the "Unlock" context menu.

Check that all the above applies for pages in the post editor and the site editor.

Now log in as an Author, create a new post. In the post settings, click on "Show template".

Open the list view and click on the ellipsis menu for template-related items.

You should see a message that explains that you can't edit the block.



<img width="620" alt="Screenshot 2024-06-07 at 4 17 51 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/99b8bd24-307e-4325-9a5a-3ecc9c644f36">





