### PR TITLE
Update custom CSS handling to be consistent with block global styles.

### DIFF
--- a/backport-changelog/6.7/6750.md
+++ b/backport-changelog/6.7/6750.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6750
+
+* https://github.com/WordPress/gutenberg/pull/62357

--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -58,7 +58,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 		 * entered by users does not break other global styles.
 		 */
 		$global_styles[] = array(
-			'css'            => gutenberg_get_global_styles_custom_css(),
+			'css'            => gutenberg_get_global_stylesheet( array( 'custom-css' ) ),
 			'__unstableType' => 'user',
 			'isGlobalStyles' => true,
 		);

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1409,6 +1409,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string The global styles custom CSS.
 	 */
 	public function get_custom_css() {
+		_deprecated_function( __METHOD__, '6.7.0', 'get_stylesheet' );
 		$block_custom_css = '';
 		$block_nodes      = $this->get_block_custom_css_nodes();
 		foreach ( $block_nodes as $node ) {
@@ -1427,6 +1428,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string The global styles base custom CSS.
 	 */
 	public function get_base_custom_css() {
+		_deprecated_function( __METHOD__, 'Gutenberg 18.6.0', 'get_stylesheet' );
 		return isset( $this->theme_json['styles']['css'] ) ? $this->theme_json['styles']['css'] : '';
 	}
 
@@ -1438,6 +1440,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array The block nodes.
 	 */
 	public function get_block_custom_css_nodes() {
+		_deprecated_function( __METHOD__, 'Gutenberg 18.6.0', 'get_block_nodes' );
 		$block_nodes = array();
 
 		// Add the global styles block CSS.
@@ -1470,6 +1473,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string The global styles custom CSS for the block.
 	 */
 	public function get_block_custom_css( $css, $selector ) {
+		_deprecated_function( __METHOD__, 'Gutenberg 18.6.0', 'get_styles_for_block' );
 		return $this->process_blocks_custom_css( $css, $selector );
 	}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1355,6 +1355,12 @@ class WP_Theme_JSON_Gutenberg {
 			$stylesheet .= $this->get_preset_classes( $setting_nodes, $origins );
 		}
 
+		// Load the custom CSS last so it has the highest specificity.
+		if ( in_array( 'custom-css', $types, true ) ) {
+			// Add the global styles root CSS.
+			$stylesheet .= _wp_array_get( $this->theme_json, array( 'styles', 'css' ) );
+		}
+
 		return $stylesheet;
 	}
 
@@ -2646,6 +2652,7 @@ class WP_Theme_JSON_Gutenberg {
 				'selectors'  => $feature_selectors,
 				'duotone'    => $duotone_selector,
 				'variations' => $variation_selectors,
+				'css'        => $selector,
 			);
 
 			if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'] ) ) {
@@ -2853,6 +2860,11 @@ class WP_Theme_JSON_Gutenberg {
 		// 6. Generate and append the style variation rulesets.
 		foreach ( $style_variation_declarations as $style_variation_selector => $individual_style_variation_declarations ) {
 			$block_rules .= static::to_ruleset( ":root :where($style_variation_selector)", $individual_style_variation_declarations );
+		}
+
+		// 7. Generate and append any custom CSS rules.
+		if ( isset( $node['css'] ) ) {
+			$block_rules .= $this->process_blocks_custom_css( $node['css'], $selector );
 		}
 
 		return $block_rules;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2867,7 +2867,7 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		// 7. Generate and append any custom CSS rules.
-		if ( isset( $node['css'] ) ) {
+		if ( isset( $node['css'] ) && ! $is_root_selector ) {
 			$block_rules .= $this->process_blocks_custom_css( $node['css'], $selector );
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1405,6 +1405,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * Returns the global styles custom css.
 	 *
 	 * @since 6.2.0
+	 * @deprecated 6.7.0 Use {@see 'get_stylesheet'} instead.
 	 *
 	 * @return string The global styles custom CSS.
 	 */
@@ -1422,8 +1423,7 @@ class WP_Theme_JSON_Gutenberg {
 
 	/**
 	 * Returns the global styles base custom CSS.
-	 *
-	 * @since 6.6.0
+	 * This function is deprecated; please do not sync to core.
 	 *
 	 * @return string The global styles base custom CSS.
 	 */
@@ -1434,8 +1434,7 @@ class WP_Theme_JSON_Gutenberg {
 
 	/**
 	 * Returns the block nodes with custom CSS.
-	 *
-	 * @since 6.6.0
+	 * This function is deprecated; please do not sync to core.
 	 *
 	 * @return array The block nodes.
 	 */
@@ -1464,8 +1463,7 @@ class WP_Theme_JSON_Gutenberg {
 
 	/**
 	 * Returns the global styles custom CSS for a single block.
-	 *
-	 * @since 6.6.0
+	 * This function is deprecated; please do not sync to core.
 	 *
 	 * @param array  $css The block css node.
 	 * @param string $selector The block selector.

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -144,6 +144,7 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
  * @return string
  */
 function gutenberg_get_global_styles_custom_css() {
+	_deprecated_function( __FUNCTION__, 'Gutenberg 18.6.0', 'gutenberg_get_global_stylesheet' );
 	// Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme developers workflow.
 	$can_use_cached = ! WP_DEBUG;
 	$cache_key      = 'gutenberg_get_global_custom_css';
@@ -177,6 +178,7 @@ function gutenberg_get_global_styles_custom_css() {
  * @return string The global base custom CSS.
  */
 function gutenberg_get_global_styles_base_custom_css() {
+	_deprecated_function( __FUNCTION__, 'Gutenberg 18.6.0', 'gutenberg_get_global_stylesheet' );
 	if ( ! wp_theme_has_theme_json() ) {
 		return '';
 	}
@@ -211,6 +213,7 @@ function gutenberg_get_global_styles_base_custom_css() {
  * @global WP_Styles $wp_styles
  */
 function gutenberg_add_global_styles_block_custom_css() {
+	_deprecated_function( __FUNCTION__, 'Gutenberg 18.6.0', 'gutenberg_add_global_styles_for_blocks' );
 	global $wp_styles;
 
 	if ( ! wp_theme_has_theme_json() || ! wp_should_load_separate_core_block_assets() ) {

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -43,6 +43,19 @@ function gutenberg_enqueue_global_styles() {
 	add_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
 
 	$stylesheet = gutenberg_get_global_stylesheet();
+
+	/*
+	 * Dequeue the Customizer's custom CSS
+	 * and add it before the global styles custom CSS.
+	 */
+	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
+	// Get the custom CSS from the Customizer and add it to the global stylesheet.
+	$custom_css  = wp_get_custom_css();
+	$stylesheet .= $custom_css;
+
+	// Add the global styles custom CSS at the end.
+	$stylesheet .= gutenberg_get_global_stylesheet( array( 'custom-css' ) );
+
 	if ( empty( $stylesheet ) ) {
 		return;
 	}
@@ -53,35 +66,6 @@ function gutenberg_enqueue_global_styles() {
 
 	// Add each block as an inline css.
 	gutenberg_add_global_styles_for_blocks();
-
-	/*
-	 * Add the custom CSS for the global styles.
-	 * Before that, dequeue the Customizer's custom CSS
-	 * and add it before the global styles custom CSS.
-	 * Don't enqueue Customizer's custom CSS separately.
-	 */
-	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
-
-	$custom_css = wp_get_custom_css();
-
-	if ( ! wp_should_load_separate_core_block_assets() ) {
-		/*
-		 * If loading all block assets together, add both
-		 * the base and block custom CSS at once. Else load
-		 * the base custom CSS only, and the block custom CSS
-		 * will be added to the inline CSS for each block in
-		 * gutenberg_add_global_styles_block_custom_css().
-		 */
-		$custom_css .= gutenberg_get_global_styles_custom_css();
-	} else {
-		$custom_css .= gutenberg_get_global_styles_base_custom_css();
-	}
-
-	if ( ! empty( $custom_css ) ) {
-		wp_add_inline_style( 'global-styles', $custom_css );
-	}
-
-	gutenberg_add_global_styles_block_custom_css();
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4850,12 +4850,31 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected_styles, $theme_json->get_stylesheet(), 'Styles returned from "::get_stylesheet()" with top-level background image as string type does not match expectations' );
 	}
 
-	public function test_get_custom_css_handles_global_custom_css() {
+	/**
+	 * Tests that base custom CSS is generated correctly.
+	 */
+	public function test_get_stylesheet_handles_base_custom_css() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'styles'  => array(
-					'css'    => 'body {color:purple;}',
+					'css' => 'body {color:purple;}',
+				),
+			)
+		);
+
+		$custom_css = 'body {color:purple;}';
+		$this->assertSame( $custom_css, $theme_json->get_stylesheet( array( 'custom-css' ) ) );
+	}
+
+	/**
+	 * Tests that block custom CSS is generated correctly.
+	 */
+	public function test_get_styles_for_block_handles_block_custom_css() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
 					'blocks' => array(
 						'core/paragraph' => array(
 							'css' => 'color:red;',
@@ -4865,8 +4884,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$custom_css = 'body {color:purple;}:root :where(p){color:red;}';
-		$this->assertSame( $custom_css, $theme_json->get_custom_css() );
+		$paragraph_node = array(
+			'name'      => 'core/paragraph',
+			'path'      => array( 'styles', 'blocks', 'core/paragraph' ),
+			'selector'  => 'p',
+			'selectors' => array(
+				'root' => 'p',
+			),
+		);
+
+		$custom_css = ':root :where(p){color:red;}';
+		$this->assertSame( $custom_css, $theme_json->get_styles_for_block( $paragraph_node ) );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Addresses [several](https://github.com/WordPress/gutenberg/pull/58991#discussion_r1507923422) [concerns](https://github.com/WordPress/gutenberg/pull/58991#discussion_r1507927224) on the PR that added conditional loading of block custom CSS. 

* Custom CSS for blocks should be loaded only when the block is present on the page when `wp_should_load_separate_core_block_assets` is true;
* Global styles custom CSS should be handled by the same logic as other global styles;
* Any custom CSS coming from the Customizer should be loaded before the global styles custom CSS, as has been the case since #47396.
* Functions previously used for custom CSS handling and no longer needed have been deprecated.
   * Deprecation notice for functions in core is tagged with WP 6.7
   * For Gutenberg-only functions it's tagged with next plugin version.
* Because base and block-specific custom CSS are now generated in different places, I replaced the test for the now-deprecated `get_custom_css` function with two different tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Test with custom CSS added at base level and at block level, in theme.json or through the global styles UI
2. Check that custom CSS for blocks is loaded only when the block is present on the page when `wp_should_load_separate_core_block_assets` is true (which it is by default in most block themes);
3. Add `add_filter( 'should_load_separate_core_block_assets', '__return_false', 11 );` to the theme's functions.php and check that custom CSS for all blocks always loads in the front end.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
