### PR TITLE
FlatTermSelector: Update the term suggestion limit

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -26,9 +26,12 @@ import MostUsedTerms from './most-used-terms';
 const EMPTY_ARRAY = [];
 
 /**
- * Module constants
+ * How the max suggestions limit was chosen:
+ *  - Matches the `per_page` range set by the REST API.
+ *  - Can't use "unbound" query. The `FormTokenField` needs a fixed number.
+ *  - Matches default for `FormTokenField`.
  */
-const MAX_TERMS_SUGGESTIONS = 20;
+const MAX_TERMS_SUGGESTIONS = 100;
 const DEFAULT_QUERY = {
 	per_page: MAX_TERMS_SUGGESTIONS,
 	_fields: 'id,name',


### PR DESCRIPTION
## What?
Closes #60791.

PR updates the number of suggestions rendered for the `FlatTermSelector` component when searching terms.

## Why?
How the max suggestions limit was chosen:
- Matches the `per_page` range set by the REST API.
- Can't use "unbound" query. The `FormTokenField` needs a fixed limit for display.
- Matches default for `FormTokenField`.

## Testing Instructions
1. Generate post tags via WP-CLI or any other tool - `wp term generate post_tag --count=1000`
2. Open a post.
3. Start typing in the tag selector.
4. Confirm it renders more than 20 suggestions - type "Tag"

### Testing Instructions for Keyboard
Same.
