### PR TITLE
Fix increasingly big canvas in the post editor when editing patterns

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -137,6 +137,7 @@ function useEditorStyles() {
 		editorSettings.disableLayoutStyles,
 		editorSettings.styles,
 		hasThemeStyleSupport,
+		postType,
 	] );
 }
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -59,6 +59,10 @@ const DESIGN_POST_TYPES = [
 	'wp_navigation',
 ];
 
+const TYPEWRITER_STYLE = {
+	css: 'body{padding-bottom: 40vh}',
+};
+
 function useEditorStyles() {
 	const {
 		hasThemeStyleSupport,
@@ -114,11 +118,11 @@ function useEditorStyles() {
 			} );
 		}
 
-		const baseStyles = hasThemeStyles
+		let baseStyles = hasThemeStyles
 			? editorSettings.styles ?? []
 			: defaultEditorStyles;
 
-		// Add a constant padding for the typewritter effect. When typing at the
+		// Add a constant padding for the typewriter effect. When typing at the
 		// bottom, there needs to be room to scroll up.
 		if (
 			! isZoomedOutView &&
@@ -126,9 +130,11 @@ function useEditorStyles() {
 			renderingMode === 'post-only' &&
 			! DESIGN_POST_TYPES.includes( postType )
 		) {
-			baseStyles.push( {
-				css: 'body{padding-bottom: 40vh}',
-			} );
+			baseStyles.push( TYPEWRITER_STYLE );
+		} else if ( baseStyles.includes( TYPEWRITER_STYLE ) ) {
+			baseStyles = baseStyles.filter(
+				( style ) => style !== TYPEWRITER_STYLE
+			);
 		}
 
 		return baseStyles;
@@ -137,6 +143,7 @@ function useEditorStyles() {
 		editorSettings.disableLayoutStyles,
 		editorSettings.styles,
 		hasThemeStyleSupport,
+		postType,
 	] );
 }
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -118,7 +118,7 @@ function useEditorStyles() {
 			? editorSettings.styles ?? []
 			: defaultEditorStyles;
 
-		// Add a constant padding for the typewritter effect. When typing at the
+		// Add a constant padding for the typewriter effect. When typing at the
 		// bottom, there needs to be room to scroll up.
 		if (
 			! isZoomedOutView &&
@@ -126,9 +126,12 @@ function useEditorStyles() {
 			renderingMode === 'post-only' &&
 			! DESIGN_POST_TYPES.includes( postType )
 		) {
-			baseStyles.push( {
-				css: 'body{padding-bottom: 40vh}',
-			} );
+			return [
+				...baseStyles,
+				{
+					css: 'body{padding-bottom: 40vh}',
+				},
+			];
 		}
 
 		return baseStyles;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -59,10 +59,6 @@ const DESIGN_POST_TYPES = [
 	'wp_navigation',
 ];
 
-const TYPEWRITER_STYLE = {
-	css: 'body{padding-bottom: 40vh}',
-};
-
 function useEditorStyles() {
 	const {
 		hasThemeStyleSupport,
@@ -118,11 +114,11 @@ function useEditorStyles() {
 			} );
 		}
 
-		let baseStyles = hasThemeStyles
+		const baseStyles = hasThemeStyles
 			? editorSettings.styles ?? []
 			: defaultEditorStyles;
 
-		// Add a constant padding for the typewriter effect. When typing at the
+		// Add a constant padding for the typewritter effect. When typing at the
 		// bottom, there needs to be room to scroll up.
 		if (
 			! isZoomedOutView &&
@@ -130,11 +126,9 @@ function useEditorStyles() {
 			renderingMode === 'post-only' &&
 			! DESIGN_POST_TYPES.includes( postType )
 		) {
-			baseStyles.push( TYPEWRITER_STYLE );
-		} else if ( baseStyles.includes( TYPEWRITER_STYLE ) ) {
-			baseStyles = baseStyles.filter(
-				( style ) => style !== TYPEWRITER_STYLE
-			);
+			baseStyles.push( {
+				css: 'body{padding-bottom: 40vh}',
+			} );
 		}
 
 		return baseStyles;
@@ -143,7 +137,6 @@ function useEditorStyles() {
 		editorSettings.disableLayoutStyles,
 		editorSettings.styles,
 		hasThemeStyleSupport,
-		postType,
 	] );
 }
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -128,8 +128,7 @@ function useEditorStyles() {
 			! isZoomedOutView &&
 			! hasMetaBoxes &&
 			renderingMode === 'post-only' &&
-			! DESIGN_POST_TYPES.includes( postType ) &&
-			! baseStyles.includes( TYPEWRITER_STYLE )
+			! DESIGN_POST_TYPES.includes( postType )
 		) {
 			baseStyles.push( TYPEWRITER_STYLE );
 		} else if ( baseStyles.includes( TYPEWRITER_STYLE ) ) {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -128,7 +128,8 @@ function useEditorStyles() {
 			! isZoomedOutView &&
 			! hasMetaBoxes &&
 			renderingMode === 'post-only' &&
-			! DESIGN_POST_TYPES.includes( postType )
+			! DESIGN_POST_TYPES.includes( postType ) &&
+			! baseStyles.includes( TYPEWRITER_STYLE )
 		) {
 			baseStyles.push( TYPEWRITER_STYLE );
 		} else if ( baseStyles.includes( TYPEWRITER_STYLE ) ) {


### PR DESCRIPTION
## What?
There seems to have been a bug introduced lately to editing patterns in the post editor. The editor canvas has lots of empty space at the bottom that grows increasingly bigger as more content is added.

This PR fixes it.

## How?
I tracked it down to a `padding-bottom: 40vh` that's added in the `useEditorStyles` hook. It shouldn't be added for patterns, but it looks like the React hook is missing the `postType` dependency.

Then a second issue is that some code needs to be added to remove the styles when already added.

Thirdly, I added an extra check to make sure multiple padding rules aren't being added.

## Testing Instructions
1. Insert a synced pattern in the post editor
2. Click 'Edit original' on the toolbar
3. Confirm the canvas should be sized to the content
4. Try adding more blocks to the pattern and confirm the size stays consistent

## Screenshots or screencast <!-- if applicable -->
### Before
![Screenshot 2024-06-06 at 5 16 56 pm](https://github.com/WordPress/gutenberg/assets/677833/f81b43f4-0abe-43f6-b67a-547ae8759951)

### After
![Screenshot 2024-06-06 at 5 16 27 pm](https://github.com/WordPress/gutenberg/assets/677833/8e58f8dd-3002-4f0c-b03b-50f7f2429837)