### PR TITLE
Only run block bindings Gutenberg logic for sites using WordPress versions below 6.5 

### DIFF
--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -46,7 +46,9 @@ function gutenberg_register_metadata_attribute( $args ) {
 }
 add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' );
 
-/**
+// Only process block bindings if they are not processed in core.
+if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
+	/**
  * Depending on the block attribute name, replace its value in the HTML based on the value provided.
  *
  * @param string $block_content  Block Content.
@@ -55,100 +57,99 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * @param mixed  $source_value   The value used to replace in the HTML.
  * @return string The modified block content.
  */
-function gutenberg_block_bindings_replace_html( $block_content, $block_name, string $attribute_name, $source_value ) {
-	var_dump( 'replace gutenberg' );
-	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-	if ( ! isset( $block_type->attributes[ $attribute_name ]['source'] ) ) {
-		return $block_content;
-	}
+	function gutenberg_block_bindings_replace_html( $block_content, $block_name, string $attribute_name, $source_value ) {
+		var_dump( 'replace gutenberg' );
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+		if ( ! isset( $block_type->attributes[ $attribute_name ]['source'] ) ) {
+			return $block_content;
+		}
 
-	// Depending on the attribute source, the processing will be different.
-	switch ( $block_type->attributes[ $attribute_name ]['source'] ) {
-		case 'html':
-		case 'rich-text':
-			$block_reader = new WP_HTML_Tag_Processor( $block_content );
+		// Depending on the attribute source, the processing will be different.
+		switch ( $block_type->attributes[ $attribute_name ]['source'] ) {
+			case 'html':
+			case 'rich-text':
+				$block_reader = new WP_HTML_Tag_Processor( $block_content );
 
-			// TODO: Support for CSS selectors whenever they are ready in the HTML API.
-			// In the meantime, support comma-separated selectors by exploding them into an array.
-			$selectors = explode( ',', $block_type->attributes[ $attribute_name ]['selector'] );
-			// Add a bookmark to the first tag to be able to iterate over the selectors.
-			$block_reader->next_tag();
-			$block_reader->set_bookmark( 'iterate-selectors' );
+				// TODO: Support for CSS selectors whenever they are ready in the HTML API.
+				// In the meantime, support comma-separated selectors by exploding them into an array.
+				$selectors = explode( ',', $block_type->attributes[ $attribute_name ]['selector'] );
+				// Add a bookmark to the first tag to be able to iterate over the selectors.
+				$block_reader->next_tag();
+				$block_reader->set_bookmark( 'iterate-selectors' );
 
-			// TODO: This shouldn't be needed when the `set_inner_html` function is ready.
-			// Store the parent tag and its attributes to be able to restore them later in the button.
-			// The button block has a wrapper while the paragraph and heading blocks don't.
-			if ( 'core/button' === $block_name ) {
-				$button_wrapper                 = $block_reader->get_tag();
-				$button_wrapper_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
-				$button_wrapper_attrs           = array();
-				foreach ( $button_wrapper_attribute_names as $name ) {
-					$button_wrapper_attrs[ $name ] = $block_reader->get_attribute( $name );
+				// TODO: This shouldn't be needed when the `set_inner_html` function is ready.
+				// Store the parent tag and its attributes to be able to restore them later in the button.
+				// The button block has a wrapper while the paragraph and heading blocks don't.
+				if ( 'core/button' === $block_name ) {
+					$button_wrapper                 = $block_reader->get_tag();
+					$button_wrapper_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
+					$button_wrapper_attrs           = array();
+					foreach ( $button_wrapper_attribute_names as $name ) {
+						$button_wrapper_attrs[ $name ] = $block_reader->get_attribute( $name );
+					}
 				}
-			}
 
-			foreach ( $selectors as $selector ) {
-				// If the parent tag, or any of its children, matches the selector, replace the HTML.
-				if ( strcasecmp( $block_reader->get_tag( $selector ), $selector ) === 0 || $block_reader->next_tag(
+				foreach ( $selectors as $selector ) {
+					// If the parent tag, or any of its children, matches the selector, replace the HTML.
+					if ( strcasecmp( $block_reader->get_tag( $selector ), $selector ) === 0 || $block_reader->next_tag(
+						array(
+							'tag_name' => $selector,
+						)
+					) ) {
+						$block_reader->release_bookmark( 'iterate-selectors' );
+
+						// TODO: Use `set_inner_html` method whenever it's ready in the HTML API.
+						// Until then, it is hardcoded for the paragraph, heading, and button blocks.
+						// Store the tag and its attributes to be able to restore them later.
+						$selector_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
+						$selector_attrs           = array();
+						foreach ( $selector_attribute_names as $name ) {
+							$selector_attrs[ $name ] = $block_reader->get_attribute( $name );
+						}
+						$selector_markup = "<$selector>" . wp_kses_post( $source_value ) . "</$selector>";
+						$amended_content = new WP_HTML_Tag_Processor( $selector_markup );
+						$amended_content->next_tag();
+						foreach ( $selector_attrs as $attribute_key => $attribute_value ) {
+							$amended_content->set_attribute( $attribute_key, $attribute_value );
+						}
+						if ( 'core/paragraph' === $block_name || 'core/heading' === $block_name ) {
+							return $amended_content->get_updated_html();
+						}
+						if ( 'core/button' === $block_name ) {
+							$button_markup  = "<$button_wrapper>{$amended_content->get_updated_html()}</$button_wrapper>";
+							$amended_button = new WP_HTML_Tag_Processor( $button_markup );
+							$amended_button->next_tag();
+							foreach ( $button_wrapper_attrs as $attribute_key => $attribute_value ) {
+								$amended_button->set_attribute( $attribute_key, $attribute_value );
+							}
+							return $amended_button->get_updated_html();
+						}
+					} else {
+						$block_reader->seek( 'iterate-selectors' );
+					}
+				}
+				$block_reader->release_bookmark( 'iterate-selectors' );
+				return $block_content;
+
+			case 'attribute':
+				$amended_content = new WP_HTML_Tag_Processor( $block_content );
+				if ( ! $amended_content->next_tag(
 					array(
-						'tag_name' => $selector,
+						// TODO: build the query from CSS selector.
+						'tag_name' => $block_type->attributes[ $attribute_name ]['selector'],
 					)
 				) ) {
-					$block_reader->release_bookmark( 'iterate-selectors' );
-
-					// TODO: Use `set_inner_html` method whenever it's ready in the HTML API.
-					// Until then, it is hardcoded for the paragraph, heading, and button blocks.
-					// Store the tag and its attributes to be able to restore them later.
-					$selector_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
-					$selector_attrs           = array();
-					foreach ( $selector_attribute_names as $name ) {
-						$selector_attrs[ $name ] = $block_reader->get_attribute( $name );
-					}
-					$selector_markup = "<$selector>" . wp_kses_post( $source_value ) . "</$selector>";
-					$amended_content = new WP_HTML_Tag_Processor( $selector_markup );
-					$amended_content->next_tag();
-					foreach ( $selector_attrs as $attribute_key => $attribute_value ) {
-						$amended_content->set_attribute( $attribute_key, $attribute_value );
-					}
-					if ( 'core/paragraph' === $block_name || 'core/heading' === $block_name ) {
-						return $amended_content->get_updated_html();
-					}
-					if ( 'core/button' === $block_name ) {
-						$button_markup  = "<$button_wrapper>{$amended_content->get_updated_html()}</$button_wrapper>";
-						$amended_button = new WP_HTML_Tag_Processor( $button_markup );
-						$amended_button->next_tag();
-						foreach ( $button_wrapper_attrs as $attribute_key => $attribute_value ) {
-							$amended_button->set_attribute( $attribute_key, $attribute_value );
-						}
-						return $amended_button->get_updated_html();
-					}
-				} else {
-					$block_reader->seek( 'iterate-selectors' );
+					return $block_content;
 				}
-			}
-			$block_reader->release_bookmark( 'iterate-selectors' );
-			return $block_content;
+				$amended_content->set_attribute( $block_type->attributes[ $attribute_name ]['attribute'], $source_value );
+				return $amended_content->get_updated_html();
 
-		case 'attribute':
-			$amended_content = new WP_HTML_Tag_Processor( $block_content );
-			if ( ! $amended_content->next_tag(
-				array(
-					// TODO: build the query from CSS selector.
-					'tag_name' => $block_type->attributes[ $attribute_name ]['selector'],
-				)
-			) ) {
+			default:
 				return $block_content;
-			}
-			$amended_content->set_attribute( $block_type->attributes[ $attribute_name ]['attribute'], $source_value );
-			return $amended_content->get_updated_html();
-
-		default:
-			return $block_content;
+		}
 	}
-}
 
-// Only process block bindings if they are not processed in core.
-if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
+
 	/**
 	 * Process the block bindings attribute.
 	 *

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -56,6 +56,7 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
  * @return string The modified block content.
  */
 function gutenberg_block_bindings_replace_html( $block_content, $block_name, string $attribute_name, $source_value ) {
+	var_dump( 'replace gutenberg' );
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 	if ( ! isset( $block_type->attributes[ $attribute_name ]['source'] ) ) {
 		return $block_content;
@@ -147,7 +148,7 @@ function gutenberg_block_bindings_replace_html( $block_content, $block_name, str
 }
 
 // Only process block bindings if they are not processed in core.
-if ( class_exists( 'WP_Block_Bindings_Registry' ) ) {
+if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 	/**
 	 * Process the block bindings attribute.
 	 *

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -148,7 +148,6 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 		}
 	}
 
-
 	/**
 	 * Process the block bindings attribute.
 	 *

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -49,16 +49,15 @@ add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' 
 // Only process block bindings if they are not processed in core.
 if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 	/**
- * Depending on the block attribute name, replace its value in the HTML based on the value provided.
- *
- * @param string $block_content  Block Content.
- * @param string $block_name     The name of the block to process.
- * @param string $attribute_name The attribute name to replace.
- * @param mixed  $source_value   The value used to replace in the HTML.
- * @return string The modified block content.
- */
+	 * Depending on the block attribute name, replace its value in the HTML based on the value provided.
+	 *
+	 * @param string $block_content  Block Content.
+	 * @param string $block_name     The name of the block to process.
+	 * @param string $attribute_name The attribute name to replace.
+	 * @param mixed  $source_value   The value used to replace in the HTML.
+	 * @return string The modified block content.
+	 */
 	function gutenberg_block_bindings_replace_html( $block_content, $block_name, string $attribute_name, $source_value ) {
-		var_dump( 'replace gutenberg' );
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 		if ( ! isset( $block_type->attributes[ $attribute_name ]['source'] ) ) {
 			return $block_content;


### PR DESCRIPTION
## What?
Ensure the Gutenberg block bindings logic only runs on sites using a WordPress version below 6.5.

## Why?
At this moment, if users have WordPress 6.5 or above, and the Gutenberg plugin installed, block bindings are processed twice. Once by core and once by Gutenberg. This seems unnecessary because the Gutenberg logic was only added for compatibility with older WordPress versions.

## How?
Checking that the class `WP_Block_Bindings_Registry` doesn't exist before running the block bindings compact logic in Gutenberg.

## Aspects to consider

Some aspects to consider with this approach:
- This would limit ourselves to make changes to this logic in Gutenberg first. On the other hand, I believe it should be fine to work directly in core for this. Additionally, we can always use the `render_block` filter again in the future if we want.
- Is there a better way to check if the bindings are being processed? I tried checking the methods, but they are private so I believe it is not possible.
- Is it okay to hide the existing Gutenberg functions? With this change, WordPress sites above 6.5 can't use `gutenberg_block_bindings_replace_html` and `gutenberg_process_block_bindings`. However, they were meant to be internal, so I assume that shouldn't be a problem, right?

Opinions?

## Testing instructions

**Before**
After creating a binding, check that both `WP_Block->replace_html` (link) and `gutenberg_block_bindings_replace_html` run.

**After**
After creating a binding, check that only `WP_Block->replace_html` (link) runs.