### PR TITLE
Query: Adjust the position of sticky search field in Patterns modal

### DIFF
--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -39,7 +39,8 @@
 		position: sticky;
 		top: 0;
 		padding: $grid-unit-20 0;
-		margin-bottom: 2px;
+		transform: translateY(- $grid-unit-05); // Offsets the top padding on the modal content container
+		margin-bottom: - $grid-unit-05;
 		z-index: z-index(".block-library-query-pattern__selection-search");
 	}
 }


### PR DESCRIPTION
## What?

This PR fixes a small gap at the top of the search bar in pattern modals in a query loop block.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/3b04ece5-5dd1-4793-97ee-9a88a03f7a92)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/e0314731-e0d8-4f81-83bc-9577f7636895)

## Why?

This gap is [padding added to prevent focus outline cutoff in the Modal component](https://github.com/WordPress/gutenberg/blob/3a1cbcf6c1a82cca1b4948c461a355a8e453f444/packages/components/src/modal/style.scss#L155). So even if we apply `top:0` to a sticky search bar, this gap remains.

## How?

At first, I thought it would be a simple solution to change the top position by 4px like this:

```diff
diff --git a/packages/block-library/src/query/editor.scss b/packages/block-library/src/query/editor.scss
index 61b553b6ed..1efc29944a 100644
--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -37,7 +37,7 @@
        .block-library-query-pattern__selection-search {
                background: $white;
                position: sticky;
-               top: 0;
+               top: - $grid-unit-05;
                padding: $grid-unit-20 0;
                margin-bottom: 2px;
                z-index: z-index(".block-library-query-pattern__selection-search");
```

But this approach would cause the search bar to shift when scrolling:

https://github.com/WordPress/gutenberg/assets/54422211/fc4b84c7-01f8-4685-940f-94c440bb1a80

Therefore, I tried the following approach:

- Keep `top:0` and shift it up by 4px via `transform`
- Since it's shifted up by 4px, apply `-4px` to the bottom margin

This will make the padding above and below the search bar uniform at 16px, and there should be no gaps.

## Testing Instructions

- Insert a Query Loop block.
- Click "Choose" button.
- Scroll the modal content.