### PR TITLE
Fix: Omit default parameters from pages, template parts, and patterns

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -35,11 +35,15 @@ export default function DataViewItem( {
 	const iconToUse =
 		icon || VIEW_LAYOUTS.find( ( v ) => v.type === type ).icon;
 
+	let activeView = isCustom ? customViewId : slug;
+	if ( activeView === 'all' ) {
+		activeView = undefined;
+	}
 	const linkInfo = useLink( {
 		postType,
 		layout,
-		activeView: isCustom ? customViewId : slug,
-		isCustom: isCustom ? 'true' : 'false',
+		activeView,
+		isCustom: isCustom ? 'true' : undefined,
 	} );
 	return (
 		<HStack

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/category-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/category-item.js
@@ -3,7 +3,12 @@
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useLink } from '../routes/link';
-import { TEMPLATE_PART_POST_TYPE, PATTERN_TYPES } from '../../utils/constants';
+import {
+	TEMPLATE_PART_POST_TYPE,
+	TEMPLATE_PART_ALL_AREAS_CATEGORY,
+	PATTERN_DEFAULT_CATEGORY,
+	PATTERN_TYPES,
+} from '../../utils/constants';
 
 export default function CategoryItem( {
 	count,
@@ -14,7 +19,11 @@ export default function CategoryItem( {
 	type,
 } ) {
 	const linkInfo = useLink( {
-		categoryId: id,
+		categoryId:
+			id !== TEMPLATE_PART_ALL_AREAS_CATEGORY &&
+			id !== PATTERN_DEFAULT_CATEGORY
+				? id
+				: undefined,
 		postType:
 			type === TEMPLATE_PART_POST_TYPE
 				? TEMPLATE_PART_POST_TYPE

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -106,8 +106,12 @@ export default function SidebarNavigationScreenPatterns( { backPath } ) {
 	const {
 		params: { postType, categoryId },
 	} = useLocation();
-	const currentCategory = categoryId || PATTERN_DEFAULT_CATEGORY;
 	const currentType = postType || PATTERN_TYPES.user;
+	const currentCategory =
+		categoryId ||
+		( currentType === PATTERN_TYPES.user
+			? PATTERN_DEFAULT_CATEGORY
+			: TEMPLATE_PART_ALL_AREAS_CATEGORY );
 
 	const { templatePartAreas, hasTemplateParts, isLoading } =
 		useTemplatePartAreas();


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/60709

Fixes the first bug @youknowriad identified.


## Testing Instructions
1- Go to pages: The url should be `wp-admin/site-editor.php?postType=page`
2- Click "drafts": The url becomes something like `/wp-admin/site-editor.php?postType=page&activeView=drafts`.
3- Go back to "all pages" Verify the url is still `wp-admin/site-editor.php?postType=page`.

Repeat these steps for template parts and patterns verify that when switching views and going back to all view the URL is still the same
