### PR TITLE
Patterns: Fix the 'canRemove' condition for the 'Detach' action

### DIFF
--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -18,13 +18,14 @@ import { unlock } from '../lock-unlock';
 function PatternsManageButton( { clientId } ) {
 	const { canRemove, isVisible, managePatternsUrl } = useSelect(
 		( select ) => {
-			const { getBlock, canRemoveBlock, getBlockCount } =
+			const { getBlock, canRemoveBlock, getBlockRootClientId } =
 				select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const reusableBlock = getBlock( clientId );
+			const rootClientId = getBlockRootClientId( clientId );
 
 			return {
-				canRemove: canRemoveBlock( clientId ),
+				canRemove: canRemoveBlock( clientId, rootClientId ),
 				isVisible:
 					!! reusableBlock &&
 					isReusableBlock( reusableBlock ) &&
@@ -33,7 +34,6 @@ function PatternsManageButton( { clientId } ) {
 						'blocks',
 						reusableBlock.attributes.ref
 					),
-				innerBlockCount: getBlockCount( clientId ),
 				// The site editor and templates both check whether the user
 				// has edit_theme_options capabilities. We can leverage that here
 				// and omit the manage patterns link if the user can't access it.


### PR DESCRIPTION
## What?
Fixes #62368.

PR fixes the `canRemoveBlock` selector call in the `PatternsManageButton` component so that it correctly displays the "Detach" menu item.

## Why?
The components should check if removal action is available relative to the root block. The global root (`''`) is locked for pages, but the content is editable.

## Testing Instructions
1. Open the Site Editor.
2. Select "Pages".
3. Select "Add new page".
4. Open the Inserter.
5. Insert a synced pattern (denoted by a purple icon).
6. Open the block toolbar options menu.
7. See the "Detach" menu item.

### Testing Instructions for Keyboard
Same.
