### PR TITLE
i18n: Patterns: Disambiguate singular & plural uses of 'Synced' & 'Unsynced'

### DIFF
--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -84,10 +84,7 @@ export default function InitPatternModal() {
 							/>
 							<ReusableBlocksRenameHint />
 							<ToggleControl
-								label={ _x(
-									'Synced',
-									'Option that makes an individual pattern synchronized'
-								) }
+								label={ _x( 'Synced', 'pattern (singular)' ) }
 								help={ __(
 									'Sync this pattern across multiple locations.'
 								) }

--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -85,9 +85,8 @@ export default function InitPatternModal() {
 							<ReusableBlocksRenameHint />
 							<ToggleControl
 								label={ _x( 'Synced', 'pattern (singular)' ) }
-								help={ _x(
-									'Sync this pattern across multiple locations.',
-									'user action'
+								help={ __(
+									'Sync this pattern across multiple locations.'
 								) }
 								checked={ ! syncType }
 								onChange={ () => {

--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -85,8 +85,9 @@ export default function InitPatternModal() {
 							<ReusableBlocksRenameHint />
 							<ToggleControl
 								label={ _x( 'Synced', 'pattern (singular)' ) }
-								help={ __(
-									'Sync this pattern across multiple locations.'
+								help={ _x(
+									'Sync this pattern across multiple locations.',
+									'user action'
 								) }
 								checked={ ! syncType }
 								onChange={ () => {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -298,13 +298,19 @@ export default function DataviewsPatterns() {
 						<span
 							className={ `edit-site-patterns__field-sync-status-${ item.syncStatus }` }
 						>
-							{ SYNC_FILTERS.find(
-								( { value } ) => value === item.syncStatus
-							)?.label ||
-								SYNC_FILTERS.find(
-									( { value } ) =>
-										value === PATTERN_SYNC_TYPES.unsynced
-								).label }
+							{
+								(
+									SYNC_FILTERS.find(
+										( { value } ) =>
+											value === item.syncStatus
+									) ||
+									SYNC_FILTERS.find(
+										( { value } ) =>
+											value ===
+											PATTERN_SYNC_TYPES.unsynced
+									)
+								).label
+							}
 						</span>
 					);
 				},

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -86,15 +86,12 @@ const DEFAULT_VIEW = {
 const SYNC_FILTERS = [
 	{
 		value: PATTERN_SYNC_TYPES.full,
-		label: _x( 'Synced', 'Option that shows all synchronized patterns' ),
+		label: _x( 'Synced', 'pattern (singular)' ),
 		description: __( 'Patterns that are kept in sync across the site.' ),
 	},
 	{
 		value: PATTERN_SYNC_TYPES.unsynced,
-		label: _x(
-			'Not synced',
-			'Option that shows all patterns that are not synchronized'
-		),
+		label: _x( 'Not synced', 'pattern (singular)' ),
 		description: __(
 			'Patterns that can be changed freely without affecting the site.'
 		),

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -35,14 +35,8 @@ export default function PostSyncStatus() {
 		<PostPanelRow label={ __( 'Sync status' ) }>
 			<div className="editor-post-sync-status__value">
 				{ syncStatus === 'unsynced'
-					? _x(
-							'Not synced',
-							'Text that indicates that the pattern is not synchronized'
-					  )
-					: _x(
-							'Synced',
-							'Text that indicates that the pattern is synchronized'
-					  ) }
+					? _x( 'Not synced', 'pattern (singular)' )
+					: _x( 'Synced', 'pattern (singular)' ) }
 			</div>
 		</PostPanelRow>
 	);

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -129,10 +129,7 @@ export function CreatePatternModalContents( {
 					categoryMap={ categoryMap }
 				/>
 				<ToggleControl
-					label={ _x(
-						'Synced',
-						'Option that makes an individual pattern synchronized'
-					) }
+					label={ _x( 'Synced', 'pattern (singular)' ) }
 					help={ __(
 						'Sync this pattern across multiple locations.'
 					) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -9,6 +9,10 @@ import { BlockSettingsMenuControls } from '@wordpress/block-editor';
 import ReusableBlockConvertButton from './reusable-block-convert-button';
 import ReusableBlocksManageButton from './reusable-blocks-manage-button';
 
+/*
+ * FIXME: CAN WE GET RID OF THIS COMPONENT? AS FAR AS I CAN SEE, IT'S EXPORTED
+ * BUT NEVER USED, ONLY MENTIONED IN DOCUMENTATION.
+ */
 export default function ReusableBlocksMenuItems( { rootClientId } ) {
 	return (
 		<BlockSettingsMenuControls>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -9,10 +9,6 @@ import { BlockSettingsMenuControls } from '@wordpress/block-editor';
 import ReusableBlockConvertButton from './reusable-block-convert-button';
 import ReusableBlocksManageButton from './reusable-blocks-manage-button';
 
-/*
- * FIXME: CAN WE GET RID OF THIS COMPONENT? AS FAR AS I CAN SEE, IT'S EXPORTED
- * BUT NEVER USED, ONLY MENTIONED IN DOCUMENTATION.
- */
 export default function ReusableBlocksMenuItems( { rootClientId } ) {
 	return (
 		<BlockSettingsMenuControls>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -184,10 +184,7 @@ export default function ReusableBlockConvertButton( {
 								placeholder={ __( 'My pattern' ) }
 							/>
 							<ToggleControl
-								label={ _x(
-									'Synced',
-									'Option that makes an individual pattern synchronized'
-								) }
+								label={ _x( 'Synced', 'pattern (singular)' ) }
 								help={ __(
 									'Sync this pattern across multiple locations.'
 								) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -185,6 +185,12 @@ export default function ReusableBlockConvertButton( {
 							/>
 							<ToggleControl
 								label={ _x( 'Synced', 'pattern (singular)' ) }
+								/*
+								 * FIXME: See my other FIXME for
+								 * ReusableBlocksMenuItems. If we can get
+								 * rid of that one, can we get rid of this
+								 * one?
+								 */
 								help={ __(
 									'Sync this pattern across multiple locations.'
 								) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -185,12 +185,6 @@ export default function ReusableBlockConvertButton( {
 							/>
 							<ToggleControl
 								label={ _x( 'Synced', 'pattern (singular)' ) }
-								/*
-								 * FIXME: See my other FIXME for
-								 * ReusableBlocksMenuItems. If we can get
-								 * rid of that one, can we get rid of this
-								 * one?
-								 */
 								help={ __(
 									'Sync this pattern across multiple locations.'
 								) }


### PR DESCRIPTION
## What?
Add or amend i18n context to labels "Synced" and "Unsynced" to disambiguate strings where the adjective qualifies a singular noun ("a [synced] pattern") from those qualifying a plural noun ("the [synced] patterns").

## Why?
English spoils developers by being so lightly inflected. :)

In many languages, adjectives have case inflections for number. In my usual locale (pt-PT):
* o padrão **sincronizado** (_the synced pattern_)
* os padrões **sincronizados** (_the synced patterns_)

Without clear context attached to short strings like `'Synced'`, translators have no way to know which case to use, nor to encode different translations (one for singular and one for plural). For instance, in my locale, I spotted the sync status badge for patterns "mis-numbered":

<img width="937" alt="sync-state-number-mismatch" src="https://github.com/WordPress/gutenberg/assets/150562/305eb69b-3ff0-40fa-855f-49cbcde80c31">

## How?
Consistently provide i18n context to the strings "Synced" and "Unsynced" whenever they appear in UI to refer to patterns' sync status. This context (via `_x()`) should read:
* `pattern (singular)` when the string is used in the context of a single pattern (e.g. a a status badge in a Data Views grid listing; a sync option when creating a new pattern)
* `patterns` (preexisting context) when the string is used in the context of a group of patterns (e.g. a select control to filter between "All" / "Synced" / "Unsynced")

Previously, strings either had no context or had one that would lead translators to assume the wrong number.

## Context

- #55935: Fix addressing a similar report during the 6.4 cycle, which saw the first addition of i18n context
- #60284: Introduction of badge fields in Data Views

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
