### PR TITLE
Global Styles: Fix UI appearing on blocks that don't support text alignment

### DIFF
--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -299,6 +299,7 @@ export function useSettingsForBlockElement(
 			'fontStyle',
 			'fontWeight',
 			'letterSpacing',
+			'textAlign',
 			'textTransform',
 			'textDecoration',
 			'writingMode',


### PR DESCRIPTION
Fixes #62369

## What?

This PR fixes an issue where the Text Alinment UI would unintentionally appear even though the block did not support `typography.textAlign`.

## Why?

#61182 changed `textAlign` to `true` in the default `theme.json`, so this support is enabled at a global level, but we still needed to check if a block actually supported it.

## How?

Added `textAlign` to the `useSettingsForBlockElement` hook.

## Testing Instructions

Visit the following screens in the default state. The Text Alignment UI should not be visible on any of the screens.

- Global Styles > Typograhy > Text, Links, Headings, Captions, Buttons
- Global Styles > Blocks > Any block

After that, add `textAlign` support to Media & Text.

```diff
diff --git a/packages/block-library/src/media-text/block.json b/packages/block-library/src/media-text/block.json
index 0f3519acb5..782da2e1eb 100644
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -117,6 +117,7 @@
                        "padding": true
                },
                "typography": {
+                       "textAlign": true,
                        "fontSize": true,
                        "lineHeight": true,
                        "__experimentalFontFamily": true,
```

The Text Alignment UI should _only_ be visible in the following places:

- Block Instance > Block Toolbar
- Global Styles > Blocks > Media & Text