### PR TITLE
Documentation: EntitiesSavedStates editor component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -390,7 +390,17 @@ _Returns_
 
 ### EntitiesSavedStates
 
-Undocumented declaration.
+Renders the component for managing saved states of entities.
+
+_Parameters_
+
+-   _props_ `Object`: The component props.
+-   _props.close_ `Function`: The function to close the dialog.
+-   _props.renderDialog_ `Function`: The function to render the dialog.
+
+_Returns_
+
+-   `JSX.Element`: The rendered component.
 
 ### ErrorBoundary
 

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -40,6 +40,23 @@ export default function EntitiesSavedStates( {
 	);
 }
 
+/**
+ * Renders a panel for saving entities with dirty records.
+ *
+ * @param {Object}   props                       The component props.
+ * @param {string}   props.additionalPrompt      Additional prompt to display.
+ * @param {Function} props.close                 Function to close the panel.
+ * @param {Function} props.onSave                Function to call when saving entities.
+ * @param {boolean}  props.saveEnabled           Flag indicating if save is enabled.
+ * @param {string}   props.saveLabel             Label for the save button.
+ * @param {Function} props.renderDialog          Function to render a custom dialog.
+ * @param {Array}    props.dirtyEntityRecords    Array of dirty entity records.
+ * @param {boolean}  props.isDirty               Flag indicating if there are dirty entities.
+ * @param {Function} props.setUnselectedEntities Function to set unselected entities.
+ * @param {Array}    props.unselectedEntities    Array of unselected entities.
+ *
+ * @return {JSX.Element} The rendered component.
+ */
 export function EntitiesSavedStatesExtensible( {
 	additionalPrompt = undefined,
 	close,

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -26,6 +26,15 @@ function identity( values ) {
 	return values;
 }
 
+/**
+ * Renders the component for managing saved states of entities.
+ *
+ * @param {Object}   props              The component props.
+ * @param {Function} props.close        The function to close the dialog.
+ * @param {Function} props.renderDialog The function to render the dialog.
+ *
+ * @return {JSX.Element} The rendered component.
+ */
 export default function EntitiesSavedStates( {
 	close,
 	renderDialog = undefined,


### PR DESCRIPTION
## What? & Why?
Addresses one item in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `EntitiesSavedStates` component and run `npm run docs:build` to populate the `README` with the newly added documents.
