### PR TITLE
Fix: DataViews: Active page is not highlighted properly in list view.

### DIFF
--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -38,10 +38,12 @@ interface DataViewsProps< Item extends AnyItem > {
 		totalPages: number;
 	};
 	supportedLayouts: string[];
+	selection?: string[];
+	setSelection?: ( selection: string[] ) => void;
 	onSelectionChange?: ( items: Item[] ) => void;
 }
 
-const defaultGetItemId = ( item: AnyItem ) => item.id;
+const defaultGetItemId = ( item: AnyItem ) => item.id + '';
 const defaultOnSelectionChange = () => {};
 
 function useSomeItemHasAPossibleBulkAction< Item extends AnyItem >(
@@ -72,9 +74,22 @@ export default function DataViews< Item extends AnyItem >( {
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
+	selection: selectionProperty,
+	setSelection: setSelectionProperty,
 	onSelectionChange = defaultOnSelectionChange,
 }: DataViewsProps< Item > ) {
-	const [ selection, setSelection ] = useState< string[] >( [] );
+	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
+	let selection, setSelection;
+	if (
+		selectionProperty !== undefined &&
+		setSelectionProperty !== undefined
+	) {
+		selection = selectionProperty;
+		setSelection = setSelectionProperty;
+	} else {
+		selection = selectionState;
+		setSelection = setSelectionState;
+	}
 	const [ openedFilter, setOpenedFilter ] = useState< string | null >( null );
 
 	useEffect( () => {

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -43,7 +43,7 @@ interface DataViewsProps< Item extends AnyItem > {
 	onSelectionChange?: ( items: Item[] ) => void;
 }
 
-const defaultGetItemId = ( item: AnyItem ) => item.id + '';
+const defaultGetItemId = ( item: AnyItem ) => item.id;
 const defaultOnSelectionChange = () => {};
 
 function useSomeItemHasAPossibleBulkAction< Item extends AnyItem >(

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -315,7 +315,7 @@ export default function ViewList< Item extends AnyItem >(
 	} = props;
 	const baseId = useInstanceId( ViewList, 'view-list' );
 	const selectedItem = data?.findLast( ( item ) =>
-		selection.includes( item.id )
+		selection.includes( getItemId( item ) )
 	);
 
 	const mediaField = fields.find(

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -206,6 +206,18 @@ export default function PagePages() {
 	const [ view, setView ] = useView( postType );
 	const history = useHistory();
 
+	const [ selection, setSelection ] = useState( [] );
+
+	const {
+		params: { postId },
+	} = useLocation();
+	const [ postIdToSelect, setPostIdToSelect ] = useState();
+	useEffect( () => {
+		if ( postId ) {
+			setPostIdToSelect( postId );
+		}
+	}, [ postId ] );
+
 	const onSelectionChange = useCallback(
 		( items ) => {
 			const { params } = history.getLocationWithParams();
@@ -265,6 +277,20 @@ export default function PagePages() {
 		totalItems,
 		totalPages,
 	} = useEntityRecords( 'postType', postType, queryArgs );
+
+	useEffect( () => {
+		if ( ! postIdToSelect ) {
+			return;
+		}
+		// Only try to select an item if the loading is complete and we have items.
+		if ( ! isLoadingPages && pages && pages.length ) {
+			// If the item is not in the current selection, select it.
+			if ( selection.length !== 1 || selection[ 0 ] !== postIdToSelect ) {
+				setSelection( [ postIdToSelect ] );
+			}
+			setPostIdToSelect( undefined );
+		}
+	}, [ postIdToSelect, selection, isLoadingPages, pages ] );
 
 	const { records: authors, isResolving: isLoadingAuthors } =
 		useEntityRecords( 'root', 'user', { per_page: -1 } );
@@ -523,6 +549,8 @@ export default function PagePages() {
 				isLoading={ isLoadingPages || isLoadingAuthors }
 				view={ view }
 				onChangeView={ onChangeView }
+				selection={ selection }
+				setSelection={ setSelection }
 				onSelectionChange={ onSelectionChange }
 			/>
 		</Page>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -211,7 +211,7 @@ export default function PagePages() {
 	const {
 		params: { postId },
 	} = useLocation();
-	const [ postIdToSelect, setPostIdToSelect ] = useState();
+	const [ postIdToSelect, setPostIdToSelect ] = useState( postId );
 	useEffect( () => {
 		if ( postId ) {
 			setPostIdToSelect( postId );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/60708.

This PR adds a "controlled" mode for the selection in the DataViews component (passing the selection as a prop) as suggested by @youknowriad.
Adds logic to make the current link in the URL the selection. For this to work we needed some logic to avoid race conditions e.g.: we should only include the selection if the items are loaded otherwise dataviews code automatically removes the selection.
We also had some cases where the selection id were integers instead of strings and we missed a usage getItemId.


## Testing Instructions
Go to http://localhost:7888/site-wp-dev/wp-admin/site-editor.php?postType=page&postId=1246 (1246 needs to be a valid page id)
Verify the active page is highlighted properly.
