### PR TITLE
Documentation: PostPublishButton, PostPublishButtonLabel editor components

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1187,7 +1187,11 @@ Renders the publish button.
 
 ### PostPublishButtonLabel
 
-Undocumented declaration.
+Renders the label for the publish button.
+
+_Returns_
+
+-   `string`: The label for the publish button.
 
 ### PostPublishPanel
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1183,7 +1183,7 @@ _Returns_
 
 ### PostPublishButton
 
-Undocumented declaration.
+Renders the publish button.
 
 ### PostPublishButtonLabel
 

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -205,6 +205,9 @@ export class PostPublishButton extends Component {
 	}
 }
 
+/**
+ * Renders the publish button.
+ */
 export default compose( [
 	withSelect( ( select ) => {
 		const {

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -10,6 +10,11 @@ import { useViewportMatch } from '@wordpress/compose';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * Renders the label for the publish button.
+ *
+ * @return {string} The label for the publish button.
+ */
 export default function PublishButtonLabel() {
 	const isSmallerThanMediumViewport = useViewportMatch( 'medium', '<' );
 	const {


### PR DESCRIPTION
## What? & Why?
Addresses two items in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `PostPublishButton` and `PostPublishButtonLabel` components and run `npm run docs:build` to populate the `README` with the newly added documents.
