### PR TITLE
Documentation: PostPublishPanel editor component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1191,7 +1191,7 @@ Undocumented declaration.
 
 ### PostPublishPanel
 
-Undocumented declaration.
+Renders a panel for publishing a post.
 
 ### PostSavedState
 

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -131,6 +131,9 @@ export class PostPublishPanel extends Component {
 	}
 }
 
+/**
+ * Renders a panel for publishing a post.
+ */
 export default compose( [
 	withSelect( ( select ) => {
 		const { getPostType } = select( coreStore );


### PR DESCRIPTION
## What? & Why?
Addresses one item in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `PostPublishPanel` component and run `npm run docs:build` to populate the `README` with the newly added documents.
