### PR TITLE
Edit site: Restore animations on site hub and canvas

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -1,15 +1,4 @@
-/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
-::view-transition-old(frame),
-::view-transition-new(frame) {
-  animation-duration: 0;
-}
-/* stylelint-enable */
-
 .edit-site-visual-editor__editor-canvas {
-	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
-	view-transition-name: frame;
-	/* stylelint-enable */
-
 	&.is-focused {
 		outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
 		outline-offset: calc(-2 * var(--wp-admin-border-width-focus));

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -7,7 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
 	EditorKeyboardShortcutsRegister,
@@ -41,11 +40,10 @@ import {
 } from '../editor-canvas-container';
 import SaveButton from '../save-button';
 import SiteEditorMoreMenu from '../more-menu';
-import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
 import useEditorTitle from './use-editor-title';
 
-const { Editor, BackButton } = unlock( editorPrivateApis );
+const { Editor } = unlock( editorPrivateApis );
 const { useHistory } = unlock( routerPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
 
@@ -122,7 +120,6 @@ export default function EditSiteEditor( { isLoading } ) {
 		],
 		[ settings.styles, canvasMode, currentPostIsTrashed ]
 	);
-	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const history = useHistory();
 	const onActionPerformed = useCallback(
@@ -210,23 +207,6 @@ export default function EditSiteEditor( { isLoading } ) {
 						! isEditingPage && <PluginTemplateSettingPanel.Slot />
 					}
 				>
-					{ isEditMode && (
-						<BackButton>
-							{ ( { length } ) =>
-								length <= 1 && (
-									<Button
-										label={ __( 'Open Navigation' ) }
-										className="edit-site-layout__view-mode-toggle"
-										onClick={ () =>
-											setCanvasMode( 'view' )
-										}
-									>
-										<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-									</Button>
-								)
-							}
-						</BackButton>
-					) }
 					<SiteEditorMoreMenu />
 					{ supportsGlobalStyles && <GlobalStylesSidebar /> }
 				</Editor>

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -160,24 +160,23 @@
 	}
 
 	&::before {
-		transition: box-shadow 0.1s ease;
+		opacity: 0;
+		transition: opacity 0.1s linear;
 		@include reduce-motion("transition");
 		content: "";
 		display: block;
 		position: absolute;
-		top: 9px;
-		right: 9px;
-		bottom: 9px;
-		left: 9px;
+		z-index: 1;
+		inset: 7px;
 		border-radius: $radius-block-ui + $border-width + $border-width;
-		box-shadow: none;
 	}
 
-	// Lightened spot color focus.
-	&:focus::before {
+	&:focus-visible::before {
+		opacity: 1;
 		box-shadow:
-			inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1),
-			inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color),
+			inset 0 0 0 calc(var(--wp-admin-border-width-focus) + 0.5px) rgba($white, 0.5),
+			0 0 0 calc(var(--wp-admin-border-width-focus) - 1px) rgba($white, 0.5);
 	}
 
 	.edit-site-layout__view-mode-toggle-icon {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -18,26 +18,31 @@
 }
 
 .edit-site-layout__sidebar-region {
-	z-index: z-index(".edit-site-layout__sidebar");
+	/* z-index: z-index(".edit-site-layout__sidebar"); */
 	width: 100vw;
 	flex-shrink: 0;
+	display: flex;
+	flex-direction: column;
 
-	@include break-medium {
-		width: $nav-sidebar-width;
+	&,
+	// Direct children’s width is also specified so they maintain it when the
+	// sidebar region collapses for full screen canvas.
+	& > * {
+		@include break-medium {
+			width: $nav-sidebar-width;
+		}
 	}
 
-	// This is only necessary for the exit animation
 	.edit-site-layout.is-full-canvas & {
-		position: fixed !important;
-		height: 100vh;
-		left: 0;
-		top: 0;
+		// Frees the space for the canvas.
+		width: 0;
 	}
 
 	.edit-site-layout__sidebar {
 		display: flex;
 		flex-direction: column;
-		height: 100%;
+		flex: 1;
+		overflow: hidden;
 	}
 
 	.resizable-editor__drag-handle {
@@ -81,7 +86,7 @@
 .edit-site-layout__canvas {
 	position: absolute;
 	top: 0;
-	left: 0;
+	left: auto;
 	bottom: 0;
 	width: 100%;
 	display: flex;
@@ -132,20 +137,7 @@
 	height: 100%;
 }
 
-/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
-html.canvas-mode-edit-transition::view-transition-group(toggle) {
-	animation-delay: 255ms;
-}
-/* stylelint-enable  */
-
-.edit-site-layout.is-full-canvas .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
-	display: none;
-}
-
 .edit-site-layout__view-mode-toggle.components-button {
-	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
-	view-transition-name: toggle;
-	/* stylelint-enable  */
 	position: relative;
 	color: $white;
 	height: $header-height;
@@ -195,6 +187,10 @@ html.canvas-mode-edit-transition::view-transition-group(toggle) {
 		justify-content: center;
 		align-items: center;
 	}
+}
+
+.edit-site-editor__editor-interface .editor-header {
+	padding-inline: $header-height 0;
 }
 
 .edit-site-layout__actions {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -108,7 +108,8 @@
 
 		.edit-site-resizable-frame__inner-content {
 			box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
-			transition: border-radius 0.4s;
+			transition: border-radius 0.6s linear;
+			@include reduce-motion("transition");
 			// This ensure the radius work properly.
 			overflow: hidden;
 

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -7,13 +7,19 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { memo, forwardRef } from '@wordpress/element';
+import { memo } from '@wordpress/element';
 import { search } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
+import { useReducedMotion } from '@wordpress/compose';
 import { displayShortcut } from '@wordpress/keycodes';
 import { filterURLForDisplay } from '@wordpress/url';
 
@@ -24,82 +30,113 @@ import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
 
-const SiteHub = memo(
-	forwardRef( ( { isTransparent }, ref ) => {
-		const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
-			const { getSettings } = unlock( select( editSiteStore ) );
+const SiteHub = memo( ( { isTransparent, canvasMode } ) => {
+	const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
 
-			const {
-				getSite,
-				getUnstableBase, // Site index.
-			} = select( coreStore );
-			const _site = getSite();
-			return {
-				dashboardLink:
-					getSettings().__experimentalDashboardLink || 'index.php',
-				homeUrl: getUnstableBase()?.home,
-				siteTitle:
-					! _site?.title && !! _site?.url
-						? filterURLForDisplay( _site?.url )
-						: _site?.title,
-			};
-		}, [] );
-		const { open: openCommandCenter } = useDispatch( commandsStore );
+		const {
+			getSite,
+			getUnstableBase, // Site index.
+		} = select( coreStore );
+		const _site = getSite();
+		return {
+			dashboardLink:
+				getSettings().__experimentalDashboardLink || 'index.php',
+			homeUrl: getUnstableBase()?.home,
+			siteTitle:
+				! _site?.title && !! _site?.url
+					? filterURLForDisplay( _site?.url )
+					: _site?.title,
+		};
+	}, [] );
+	const { open: openCommandCenter } = useDispatch( commandsStore );
+	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+	const reduceMotion = useReducedMotion();
 
-		return (
-			<div className="edit-site-site-hub">
-				<HStack justify="flex-start" spacing="0">
-					<div
+	const siteIconButtonProps =
+		canvasMode === 'edit'
+			? {
+					onClick: ( event ) => {
+						event.preventDefault();
+						setCanvasMode( 'view' );
+					},
+					label: __( 'Open Navigation' ),
+			  }
+			: {
+					label: __( 'Go to the Dashboard' ),
+			  };
+
+	return (
+		<div className="edit-site-site-hub">
+			<HStack spacing="0">
+				<div
+					className={ clsx(
+						'edit-site-site-hub__view-mode-toggle-container',
+						{
+							'has-transparent-background': isTransparent,
+						}
+					) }
+				>
+					<Button
+						{ ...siteIconButtonProps }
+						// Even though `href` is not used in edit mode it’s kept so the
+						// component doesn't remount as a `<button>` and break the animation.
+						// Seems like ideally a href could be used for the 'Open navigation'
+						// action as well as it does generate history.
+						href={ dashboardLink }
 						className={ clsx(
-							'edit-site-site-hub__view-mode-toggle-container',
-							{
-								'has-transparent-background': isTransparent,
-							}
+							'edit-site-layout__view-mode-toggle',
+							{ 'is-exit': canvasMode === 'view' }
 						) }
 					>
-						<Button
-							ref={ ref }
-							href={ dashboardLink }
-							label={ __( 'Go to the Dashboard' ) }
-							className="edit-site-layout__view-mode-toggle"
-							style={ {
-								transform: 'scale(0.5)',
-								borderRadius: 4,
+						<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+					</Button>
+				</div>
+
+				<AnimatePresence>
+					{ canvasMode === 'view' && (
+						<HStack
+							as={ motion.div }
+							initial={ { opacity: 0 } }
+							animate={ { opacity: 1 } }
+							exit={ { opacity: 0 } }
+							transition={ {
+								type: 'tween',
+								duration: reduceMotion ? 0 : 0.3,
+								ease: 'linear',
+								delay: canvasMode === 'view' ? 0.2 : 0,
 							} }
 						>
-							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-						</Button>
-					</div>
-
-					<HStack>
-						<div className="edit-site-site-hub__title">
-							<Button
-								variant="link"
-								href={ homeUrl }
-								target="_blank"
-								label={ __( 'View site (opens in a new tab)' ) }
+							<div className="edit-site-site-hub__title">
+								<Button
+									variant="link"
+									href={ homeUrl }
+									target="_blank"
+									label={ __(
+										'View site (opens in a new tab)'
+									) }
+								>
+									{ decodeEntities( siteTitle ) }
+								</Button>
+							</div>
+							<HStack
+								spacing={ 0 }
+								className="edit-site-site-hub__actions"
 							>
-								{ decodeEntities( siteTitle ) }
-							</Button>
-						</div>
-						<HStack
-							spacing={ 0 }
-							expanded={ false }
-							className="edit-site-site-hub__actions"
-						>
-							<Button
-								className="edit-site-site-hub_toggle-command-center"
-								icon={ search }
-								onClick={ () => openCommandCenter() }
-								label={ __( 'Open command palette' ) }
-								shortcut={ displayShortcut.primary( 'k' ) }
-							/>
+								<Button
+									className="edit-site-site-hub_toggle-command-center"
+									icon={ search }
+									onClick={ () => openCommandCenter() }
+									label={ __( 'Open command palette' ) }
+									shortcut={ displayShortcut.primary( 'k' ) }
+								/>
+							</HStack>
 						</HStack>
-					</HStack>
-				</HStack>
-			</div>
-		);
-	} )
-);
+					) }
+				</AnimatePresence>
+			</HStack>
+		</div>
+	);
+} );
 
 export default SiteHub;

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -3,20 +3,39 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: $grid-unit-10;
-	margin-right: $grid-unit-15;
+	padding-right: $grid-unit-15;
 }
 
 .edit-site-site-hub__actions {
-	flex-shrink: 0;
+	flex: 0 0 min-content;
+	margin-inline: auto 0;
 }
 
 .edit-site-site-hub__view-mode-toggle-container {
+	z-index: 3; // TODO: add and use: z-index(".edit-site-site-hub__view-mode-toggle-container");
+	background: $gray-900;
 	height: $header-height;
 	width: $header-height;
 	flex-shrink: 0;
 
 	&.has-transparent-background .edit-site-layout__view-mode-toggle-icon {
 		background: transparent;
+	}
+}
+
+.edit-site-layout__view-mode-toggle-icon {
+	transition: transform 0.3s ease-out;
+	@include reduce-motion("transition");
+
+	transform: scale(1);
+
+	.is-exit > & {
+		// Scales so the svg path inside the default WP icon is 20px.
+		transform: scale(0.6667);
+	}
+
+	:not(.is-exit):hover > & {
+		transform: scale(0.96);
 	}
 }
 

--- a/packages/edit-site/src/components/site-icon/index.js
+++ b/packages/edit-site/src/components/site-icon/index.js
@@ -23,10 +23,6 @@ function SiteIcon( { className } ) {
 		};
 	}, [] );
 
-	if ( isRequestingSite && ! siteIconUrl ) {
-		return <div className="edit-site-site-icon__image" />;
-	}
-
 	const icon = siteIconUrl ? (
 		<img
 			className="edit-site-site-icon__image"
@@ -43,7 +39,7 @@ function SiteIcon( { className } ) {
 
 	return (
 		<div className={ clsx( className, 'edit-site-site-icon' ) }>
-			{ icon }
+			{ isRequestingSite ? null : icon }
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -1,10 +1,6 @@
 .edit-site-site-icon__icon {
 	fill: currentColor;
-
-	.edit-site-layout.is-full-canvas & {
-		// Make the WordPress icon not so big in full canvas.
-		padding: $grid-unit-15 * 0.5; // 6px.
-	}
+	padding: $grid-unit-15 * 0.5; // 6px.
 }
 
 .edit-site-site-icon__image {

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -6,6 +6,7 @@
 .edit-site-site-icon__image {
 	width: 100%;
 	height: 100%;
+	border-radius: $radius-block-ui * 2;
 	object-fit: cover;
 	background: #333;
 

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -13,67 +13,45 @@ import { store as editorStore } from '@wordpress/editor';
 export const setCanvasMode =
 	( mode ) =>
 	( { registry, dispatch } ) => {
-		const switchCanvasMode = () => {
-			registry.batch( () => {
-				const isMediumOrBigger =
-					window.matchMedia( '(min-width: 782px)' ).matches;
-				registry.dispatch( blockEditorStore ).clearSelectedBlock();
-				registry.dispatch( editorStore ).setDeviceType( 'Desktop' );
+		registry.batch( () => {
+			const isMediumOrBigger =
+				window.matchMedia( '(min-width: 782px)' ).matches;
+			registry.dispatch( blockEditorStore ).clearSelectedBlock();
+			registry.dispatch( editorStore ).setDeviceType( 'Desktop' );
+			registry
+				.dispatch( blockEditorStore )
+				.__unstableSetEditorMode( 'edit' );
+			const isPublishSidebarOpened = registry
+				.select( editorStore )
+				.isPublishSidebarOpened();
+			dispatch( {
+				type: 'SET_CANVAS_MODE',
+				mode,
+			} );
+			const isEditMode = mode === 'edit';
+			if ( isPublishSidebarOpened && ! isEditMode ) {
+				registry.dispatch( editorStore ).closePublishSidebar();
+			}
+
+			// Check if the block list view should be open by default.
+			// If `distractionFree` mode is enabled, the block list view should not be open.
+			// This behavior is disabled for small viewports.
+			if (
+				isMediumOrBigger &&
+				isEditMode &&
 				registry
-					.dispatch( blockEditorStore )
-					.__unstableSetEditorMode( 'edit' );
-				const isPublishSidebarOpened = registry
-					.select( editorStore )
-					.isPublishSidebarOpened();
-				dispatch( {
-					type: 'SET_CANVAS_MODE',
-					mode,
-				} );
-				const isEditMode = mode === 'edit';
-				if ( isPublishSidebarOpened && ! isEditMode ) {
-					registry.dispatch( editorStore ).closePublishSidebar();
-				}
-
-				// Check if the block list view should be open by default.
-				// If `distractionFree` mode is enabled, the block list view should not be open.
-				// This behavior is disabled for small viewports.
-				if (
-					isMediumOrBigger &&
-					isEditMode &&
-					registry
-						.select( preferencesStore )
-						.get( 'core', 'showListViewByDefault' ) &&
-					! registry
-						.select( preferencesStore )
-						.get( 'core', 'distractionFree' )
-				) {
-					registry
-						.dispatch( editorStore )
-						.setIsListViewOpened( true );
-				} else {
-					registry
-						.dispatch( editorStore )
-						.setIsListViewOpened( false );
-				}
-				registry.dispatch( editorStore ).setIsInserterOpened( false );
-			} );
-		};
-
-		if ( ! document.startViewTransition ) {
-			switchCanvasMode();
-		} else {
-			document.documentElement.classList.add(
-				`canvas-mode-${ mode }-transition`
-			);
-			const transition = document.startViewTransition( () =>
-				switchCanvasMode()
-			);
-			transition.finished.finally( () => {
-				document.documentElement.classList.remove(
-					`canvas-mode-${ mode }-transition`
-				);
-			} );
-		}
+					.select( preferencesStore )
+					.get( 'core', 'showListViewByDefault' ) &&
+				! registry
+					.select( preferencesStore )
+					.get( 'core', 'distractionFree' )
+			) {
+				registry.dispatch( editorStore ).setIsListViewOpened( true );
+			} else {
+				registry.dispatch( editorStore ).setIsListViewOpened( false );
+			}
+			registry.dispatch( editorStore ).setIsInserterOpened( false );
+		} );
 	};
 
 /**

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -196,8 +196,7 @@
 	}
 
 	.editor-header {
-		background-color: $white;
-		border-bottom: 1px solid #e0e0e0;
+		box-shadow: inherit;
 		position: absolute;
 		width: 100%;
 


### PR DESCRIPTION
## What
Restores animations and another detail or two that were lost in #61579.

## Why
The previous transition was a good bit nicer. The current will lend to an impression that the app is shoddy.

## More 
The idea with #61579 was to simplify. It certainly had a nice ratio of deletions to additions but while some concerns may have been simplified others were complicated. Moreover, its deletions must not have been enabled just because the hub is no longer persistent and fixed above everything. I say that because this PR has net zero additions while restoring the previous transition.

The main caveat with this is that Distraction Free mode has a visual difference. The hub persists there too. However, the mode works. To me, this makes a better trade-off and it can be completely fixed too. I don’t want this PR getting any more unwieldy for review so I’ll put such changes in another.

## How?

- Puts Site icon button in front of the editor header
- Removes back button in the header
- Restores hover and transition on Site icon button (with CSS instead of framer-motion)
- Removes view transitions

The rest of these are more independent and could probably each be extracted as their own PRs in case any of them prove debatable.
- 338a600bb8e05e550d14781276474dfb1303372c
  - Restores border-radius on site icon (when it’s an image)
  - Tries improving the focus ring of the site icon
- 21910a4b41953f12d715f47dcf59a813772e7053 Respects reduced motion of canvas border-radius transition and tweaks the duration otherwise.
- b9654ef3861cd88eb8ab365997d36100254e887b Fixes a disparate bit of header styling in Distraction Free mode.
- e1d6734bbd006ac3234719460e3e161ddacd86fa Fixes a flash of background color and unintended initial transition of the site icon.

## Testing Instructions
1. Open the site editor and observe animations while switching between view/edit.

## Screenshots or screencast <!-- if applicable -->
### On this branch (0.2x speed)

https://github.com/WordPress/gutenberg/assets/9000376/f522971e-d95d-4855-82fa-a12582e67512

### On trunk (0.2x speed)

https://github.com/WordPress/gutenberg/assets/9000376/198ba7eb-e19d-40d5-bee5-ef594ed0a00a
