### PR TITLE
Documentation: ThemeSupportCheck editor component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1499,7 +1499,17 @@ Undocumented declaration.
 
 ### ThemeSupportCheck
 
-Undocumented declaration.
+Checks if the current theme supports specific features and renders the children if supported.
+
+_Parameters_
+
+-   _props_ `Object`: The component props.
+-   _props.children_ `Element`: The children to render if the theme supports the specified features.
+-   _props.supportKeys_ `string|string[]`: The key(s) of the theme support(s) to check.
+
+_Returns_
+
+-   `JSX.Element|null`: The rendered children if the theme supports the specified features, otherwise null.
 
 ### TimeToRead
 

--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -9,6 +9,15 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editorStore } from '../../store';
 
+/**
+ * Checks if the current theme supports specific features and renders the children if supported.
+ *
+ * @param {Object}          props             The component props.
+ * @param {Element}         props.children    The children to render if the theme supports the specified features.
+ * @param {string|string[]} props.supportKeys The key(s) of the theme support(s) to check.
+ *
+ * @return {JSX.Element|null} The rendered children if the theme supports the specified features, otherwise null.
+ */
 export default function ThemeSupportCheck( { children, supportKeys } ) {
 	const { postType, themeSupports } = useSelect( ( select ) => {
 		return {


### PR DESCRIPTION
## What? & Why?
Addresses _one_ item in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `ThemeSupportCheck` component and run `npm run docs:build` to populate the `README` with the newly added documents.
