### PR TITLE
Documentation: useEntitiesSavedStatesIsDirty editor component

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1531,7 +1531,11 @@ _Returns_
 
 ### useEntitiesSavedStatesIsDirty
 
-Undocumented declaration.
+Custom hook that determines if any entities are dirty (edited) and provides a way to manage selected/unselected entities.
+
+_Returns_
+
+-   `Object`: An object containing the following properties: - dirtyEntityRecords: An array of dirty entity records. - isDirty: A boolean indicating if there are any dirty entity records. - setUnselectedEntities: A function to set the unselected entities. - unselectedEntities: An array of unselected entities.
 
 ### usePostScheduleLabel
 

--- a/packages/editor/src/components/entities-saved-states/hooks/use-is-dirty.js
+++ b/packages/editor/src/components/entities-saved-states/hooks/use-is-dirty.js
@@ -5,6 +5,15 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
 
+/**
+ * Custom hook that determines if any entities are dirty (edited) and provides a way to manage selected/unselected entities.
+ *
+ * @return {Object} An object containing the following properties:
+ *   - dirtyEntityRecords: An array of dirty entity records.
+ *   - isDirty: A boolean indicating if there are any dirty entity records.
+ *   - setUnselectedEntities: A function to set the unselected entities.
+ *   - unselectedEntities: An array of unselected entities.
+ */
 export const useIsDirty = () => {
 	const { editedEntities, siteEdits, siteEntityConfig } = useSelect(
 		( select ) => {


### PR DESCRIPTION
## What? & Why?
Addresses _one_ item in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `useEntitiesSavedStatesIsDirty` component and run `npm run docs:build` to populate the `README` with the newly added documents.
