### PR TITLE
Fix: Pattern navigation toggles zoom out view while navigating the categories

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-preview-panel.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-preview-panel.js
@@ -2,9 +2,8 @@
  * Internal dependencies
  */
 import { PatternCategoryPreviews } from './pattern-category-previews';
-import { useZoomOut } from '../../../hooks/use-zoom-out';
 
-function PatternCategoryPreviewPanelInner( {
+export function PatternCategoryPreviewPanel( {
 	rootClientId,
 	onInsert,
 	onHover,
@@ -23,18 +22,4 @@ function PatternCategoryPreviewPanelInner( {
 			patternFilter={ patternFilter }
 		/>
 	);
-}
-
-function PatternCategoryPreviewPanelWithZoomOut( props ) {
-	useZoomOut();
-	return <PatternCategoryPreviewPanelInner { ...props } />;
-}
-
-export function PatternCategoryPreviewPanel( props ) {
-	// When the pattern panel is showing, we want to use zoom out mode
-	if ( window.__experimentalEnableZoomedOutPatternsTab ) {
-		return <PatternCategoryPreviewPanelWithZoomOut { ...props } />;
-	}
-
-	return <PatternCategoryPreviewPanelInner { ...props } />;
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -32,6 +32,14 @@ import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
 import { store as blockEditorStore } from '../../store';
+import { useZoomOut } from '../../hooks/use-zoom-out';
+
+const ZoomOutHandler = ( { children, showPatternPanel } ) => {
+	// When the pattern panel is showing, we want to use zoom out mode
+	useZoomOut( showPatternPanel );
+
+	return <>{ children }</>;
+};
 
 const NOOP = () => {};
 function InserterMenu(
@@ -306,7 +314,7 @@ function InserterMenu(
 		}
 	}, [] );
 
-	return (
+	const menuContent = (
 		<div
 			className={ clsx( 'block-editor-inserter__menu', {
 				'show-panel': showPatternPanel || showMediaPanel,
@@ -343,6 +351,18 @@ function InserterMenu(
 				</Popover>
 			) }
 		</div>
+	);
+
+	return (
+		<>
+			{ window.__experimentalEnableZoomedOutPatternsTab ? (
+				<ZoomOutHandler showPatternPanel={ showPatternPanel }>
+					{ menuContent }
+				</ZoomOutHandler>
+			) : (
+				menuContent
+			) }
+		</>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
FIxes: #62364 

## Why?
While navigating the Patterns categories in the Inserter, the zoom-out view changes from zoom-out to zoom-in

## How?
Conditionally uses the useZoomOut() hook within a component.

## Testing Instructions
1. Gutenberg > Experiment > click on Enable zoomed out view when selecting a pattern category in the main inserter.
2. Open a page in the editor
3. Open the Inserter with the Pattern tab and navigate all the patterns

https://github.com/WordPress/gutenberg/assets/77401999/d4801025-d7c1-4c3f-9d1f-24fea1449a92

