### PR TITLE
Update get-started-with-create-block.md

### DIFF
--- a/docs/getting-started/devenv/get-started-with-create-block.md
+++ b/docs/getting-started/devenv/get-started-with-create-block.md
@@ -25,6 +25,10 @@ The `slug` provided (`todo-list`) defines the folder name for the scaffolded plu
 
 Navigate to the Plugins page of our local WordPress installation and activate the "Todo List" plugin. The example block will then be available in the Editor. 
 
+<div class="callout callout-info">
+    If you can't find your block inside the Editor please read more <a hre="https://github.com/WordPress/gutenberg/issues/62202">here</a>. Currently there is a known issue with @wordpress/scripts@28 and you will need to use @wordpress/scripts@27.9.0 in your package.json file
+</div>
+
 ### Basic usage
 
 The `create-block` assumes you will use modern JavaScript (ESNext and JSX) to build your block. This requires a build step to compile the code into a format that browsers can understand. Luckily, the `wp-scripts` package handles this process for you. Refer to the [Get started with wp-scripts](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts) for an introduction to this package. 


### PR DESCRIPTION
Added a little note for those who can't figure out why the block isn't showing inside the Editor with a link to the issue and temporary fix.

I myself got stuck here for a while and found some comments around the web asking for a solution.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Showing a note with a solution

## Why?
Some users get stuck and can't find the block they just created using @wordpress/scripts@28

## How?
The temporary solution is showing a note that explains the problem

## Testing Instructions
1. Use npx @wordpress/create-block@latest todo-list inside plugins folder
2. A folder for a block called "todo-list" is created
3. Activate the block from the Plugins section inside WP dashboard
4. Go inside the Editor
5. Search the block
6. Block isn't showing

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
