### PR TITLE
Remove Slideshare embed block variation.

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -260,14 +260,6 @@ const variations = [
 		attributes: { providerNameSlug: 'scribd', responsive: true },
 	},
 	{
-		name: 'slideshare',
-		title: 'Slideshare',
-		icon: embedContentIcon,
-		description: __( 'Embed Slideshare content.' ),
-		patterns: [ /^https?:\/\/(.+?\.)?slideshare\.net\/.+/i ],
-		attributes: { providerNameSlug: 'slideshare', responsive: true },
-	},
-	{
 		name: 'smugmug',
 		title: 'SmugMug',
 		icon: embedPhotoIcon,


### PR DESCRIPTION
## What?

Remove the Slideshare oEmbed block variation.

Fixes #62203
See [WP#61349](https://core.trac.wordpress.org/ticket/61349)

## Why?

The open oembed endpoint has [effectively been deprecated](https://core.trac.wordpress.org/ticket/61349#comment:4).

## How?

Delete the code from variations.js 

## Testing Instructions
1. Open the post editor
2. Type `/slide` in the post content and confirm slideshare is not shown as an option
3. Open the block inserted and confirm slideshare is not listed

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->
