### PR TITLE
Global styles: display tooltips for pagination buttons on styles revision

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -173,19 +173,14 @@
 		// Safari from rendering the page / total text.
 		will-change: opacity;
 	}
+
 	.components-button.is-tertiary {
-		font-size: 28px;
-		font-weight: 200;
 		color: $gray-900;
-		margin-bottom: $grid-unit-05;
-		line-height: 1.2;
 	}
+
 	.components-button.is-tertiary:disabled,
 	.components-button.is-tertiary[aria-disabled="true"] {
 		color: $gray-600;
-	}
-	.components-button.is-tertiary:hover {
-		background: transparent;
 	}
 }
 

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -12,6 +12,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
+import { previous, chevronLeft, chevronRight, next } from '@wordpress/icons';
 
 export default function Pagination( {
 	currentPage,
@@ -49,20 +50,16 @@ export default function Pagination( {
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === 1 }
 					label={ __( 'First page' ) }
-					showTooltip
-				>
-					«
-				</Button>
+					icon={ previous }
+				/>
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => changePage( currentPage - 1 ) }
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === 1 }
 					label={ __( 'Previous page' ) }
-					showTooltip
-				>
-					‹
-				</Button>
+					icon={ chevronLeft }
+				/>
 			</HStack>
 			<Text variant="muted">
 				{ sprintf(
@@ -79,20 +76,16 @@ export default function Pagination( {
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === numPages }
 					label={ __( 'Next page' ) }
-					showTooltip
-				>
-					›
-				</Button>
+					icon={ chevronRight }
+				/>
 				<Button
 					variant={ buttonVariant }
 					onClick={ () => changePage( numPages ) }
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === numPages }
 					label={ __( 'Last page' ) }
-					showTooltip
-				>
-					»
-				</Button>
+					icon={ next }
+				/>
 			</HStack>
 		</HStack>
 	);

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -49,6 +49,8 @@ export default function Pagination( {
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === 1 }
 					aria-label={ __( 'First page' ) }
+					label={ __( 'First page' ) }
+					showTooltip
 				>
 					«
 				</Button>
@@ -58,6 +60,8 @@ export default function Pagination( {
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === 1 }
 					aria-label={ __( 'Previous page' ) }
+					label={ __( 'Previous page' ) }
+					showTooltip
 				>
 					‹
 				</Button>
@@ -77,6 +81,8 @@ export default function Pagination( {
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === numPages }
 					aria-label={ __( 'Next page' ) }
+					label={ __( 'Next page' ) }
+					showTooltip
 				>
 					›
 				</Button>
@@ -86,6 +92,8 @@ export default function Pagination( {
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === numPages }
 					aria-label={ __( 'Last page' ) }
+					label={ __( 'Last page' ) }
+					showTooltip
 				>
 					»
 				</Button>

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -48,7 +48,6 @@ export default function Pagination( {
 					onClick={ () => changePage( 1 ) }
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === 1 }
-					aria-label={ __( 'First page' ) }
 					label={ __( 'First page' ) }
 					showTooltip
 				>
@@ -59,7 +58,6 @@ export default function Pagination( {
 					onClick={ () => changePage( currentPage - 1 ) }
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === 1 }
-					aria-label={ __( 'Previous page' ) }
 					label={ __( 'Previous page' ) }
 					showTooltip
 				>
@@ -80,7 +78,6 @@ export default function Pagination( {
 					onClick={ () => changePage( currentPage + 1 ) }
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === numPages }
-					aria-label={ __( 'Next page' ) }
 					label={ __( 'Next page' ) }
 					showTooltip
 				>
@@ -91,7 +88,6 @@ export default function Pagination( {
 					onClick={ () => changePage( numPages ) }
 					__experimentalIsFocusable
 					disabled={ disabled || currentPage === numPages }
-					aria-label={ __( 'Last page' ) }
 					label={ __( 'Last page' ) }
 					showTooltip
 				>

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -51,6 +51,7 @@ export default function Pagination( {
 					disabled={ disabled || currentPage === 1 }
 					label={ __( 'First page' ) }
 					icon={ previous }
+					size="compact"
 				/>
 				<Button
 					variant={ buttonVariant }
@@ -59,6 +60,7 @@ export default function Pagination( {
 					disabled={ disabled || currentPage === 1 }
 					label={ __( 'Previous page' ) }
 					icon={ chevronLeft }
+					size="compact"
 				/>
 			</HStack>
 			<Text variant="muted">
@@ -77,6 +79,7 @@ export default function Pagination( {
 					disabled={ disabled || currentPage === numPages }
 					label={ __( 'Next page' ) }
 					icon={ chevronRight }
+					size="compact"
 				/>
 				<Button
 					variant={ buttonVariant }
@@ -85,6 +88,7 @@ export default function Pagination( {
 					disabled={ disabled || currentPage === numPages }
 					label={ __( 'Last page' ) }
 					icon={ next }
+					size="compact"
 				/>
 			</HStack>
 		</HStack>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Maybe resolves https://github.com/WordPress/gutenberg/issues/62283

Adds tooltips to pagination buttons for Global Styles revisions.

## Why?

To expose the button name via tooltip.

## How?

Using the `showTooltip` prop on the Button component.

## Testing Instructions

- Go to Site editor > Styles
- Create at least 11 styles revisions by changes the styles and saving. This ensure the styles revisions will paginate.
- Open styles revisions.
- Hover or focus the pagination buttons.
- Observe that  tooltips appear.


## Screenshots or screencast <!-- if applicable -->



https://github.com/WordPress/gutenberg/assets/6458278/8925ec82-b3b7-42ba-a7e2-69f95f7b9367

