### PR TITLE
Update Node version for flaky test reporter

### DIFF
--- a/packages/report-flaky-tests/action.yml
+++ b/packages/report-flaky-tests/action.yml
@@ -13,5 +13,5 @@ inputs:
         required: true
         default: 'flaky-tests'
 runs:
-    using: 'node16'
+    using: 'node20'
     main: 'build/index.js'


### PR DESCRIPTION
## What?
PR updates the Node version for the flaky test reporter action.

## Why?
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

## Testing Instructions
It shouldn't generate a notice in the e2e tests summary.
