### PR TITLE
Bootstrap the dashboard layout

### DIFF
--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -14,7 +14,7 @@ function gutenberg_posts_dashboard() {
 	wp_register_style(
 		'wp-gutenberg-posts-dashboard',
 		gutenberg_url( 'build/edit-site/posts.css', __FILE__ ),
-		array()
+		array( 'wp-components', 'wp-commands' ),
 	);
 	wp_enqueue_style( 'wp-gutenberg-posts-dashboard' );
 	wp_add_inline_script( 'wp-edit-site', 'window.wp.editSite.initializePostsDashboard( "gutenberg-posts-dashboard" );', 'after' );

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -14,7 +14,7 @@ function gutenberg_posts_dashboard() {
 	wp_register_style(
 		'wp-gutenberg-posts-dashboard',
 		gutenberg_url( 'build/edit-site/posts.css', __FILE__ ),
-		array( 'wp-components', 'wp-commands' ),
+		array( 'wp-components', 'wp-commands' )
 	);
 	wp_enqueue_style( 'wp-gutenberg-posts-dashboard' );
 	wp_add_inline_script( 'wp-edit-site', 'window.wp.editSite.initializePostsDashboard( "gutenberg-posts-dashboard" );', 'after' );

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -17,9 +17,25 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import Layout from '../layout';
 import { unlock } from '../../lock-unlock';
+import { useCommonCommands } from '../../hooks/commands/use-common-commands';
+import { useEditModeCommands } from '../../hooks/commands/use-edit-mode-commands';
+import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
+import useLayoutAreas from '../layout/router';
+import useSetCommandContext from '../../hooks/commands/use-set-command-context';
 
 const { RouterProvider } = unlock( routerPrivateApis );
 const { GlobalStylesProvider } = unlock( editorPrivateApis );
+
+function AppLayout() {
+	// This ensures the edited entity id and type are initialized properly.
+	useInitEditedEntityFromURL();
+	useEditModeCommands();
+	useCommonCommands();
+	useSetCommandContext();
+	const route = useLayoutAreas();
+
+	return <Layout route={ route } />;
+}
 
 export default function App() {
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -41,7 +57,7 @@ export default function App() {
 			<GlobalStylesProvider>
 				<UnsavedChangesWarning />
 				<RouterProvider>
-					<Layout />
+					<AppLayout />
 					<PluginArea onError={ onPluginAreaError } />
 				</RouterProvider>
 			</GlobalStylesProvider>

--- a/packages/edit-site/src/components/posts-app/index.js
+++ b/packages/edit-site/src/components/posts-app/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	UnsavedChangesWarning,
+	privateApis as editorPrivateApis,
+} from '@wordpress/editor';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import Layout from '../layout';
+import Page from '../page';
+import { unlock } from '../../lock-unlock';
+
+const { RouterProvider } = unlock( routerPrivateApis );
+const { GlobalStylesProvider } = unlock( editorPrivateApis );
+
+const defaultRoute = {
+	key: 'index',
+	areas: {
+		sidebar: 'Empty Sidebar',
+		content: <Page>Welcome to Posts</Page>,
+		preview: undefined,
+		mobile: <Page>Welcome to Posts</Page>,
+	},
+};
+
+export default function PostsApp() {
+	return (
+		<GlobalStylesProvider>
+			<UnsavedChangesWarning />
+			<RouterProvider>
+				<Layout route={ defaultRoute } />
+			</RouterProvider>
+		</GlobalStylesProvider>
+	);
+}

--- a/packages/edit-site/src/hooks/commands/use-set-command-context.js
+++ b/packages/edit-site/src/hooks/commands/use-set-command-context.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { privateApis as commandsPrivateApis } from '@wordpress/commands';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { useCommandContext } = unlock( commandsPrivateApis );
+
+/**
+ * React hook used to set the correct command context based on the current state.
+ */
+export default function useSetCommandContext() {
+	const { hasBlockSelected, canvasMode } = useSelect( ( select ) => {
+		const { getCanvasMode } = unlock( select( editSiteStore ) );
+		const { getBlockSelectionStart } = select( blockEditorStore );
+		return {
+			canvasMode: getCanvasMode(),
+			hasBlockSelected: getBlockSelectionStart(),
+		};
+	}, [] );
+	// Sets the right context for the command palette
+	let commandContext = 'site-editor';
+	if ( canvasMode === 'edit' ) {
+		commandContext = 'entity-edit';
+	}
+	if ( hasBlockSelected ) {
+		commandContext = 'block-selection-edit';
+	}
+	useCommandContext( commandContext );
+}

--- a/packages/edit-site/src/posts.js
+++ b/packages/edit-site/src/posts.js
@@ -4,6 +4,11 @@
 import { createRoot, StrictMode } from '@wordpress/element';
 
 /**
+ * Internal dependencies
+ */
+import PostsApp from './components/posts-app';
+
+/**
  * Initializes the "Posts Dashboard"
  * @param {string} id DOM element id.
  */
@@ -14,7 +19,11 @@ export function initializePostsDashboard( id ) {
 	const target = document.getElementById( id );
 	const root = createRoot( target );
 
-	root.render( <StrictMode>Welcome To Posts</StrictMode> );
+	root.render(
+		<StrictMode>
+			<PostsApp />
+		</StrictMode>
+	);
 
 	return root;
 }

--- a/packages/edit-site/src/posts.scss
+++ b/packages/edit-site/src/posts.scss
@@ -1,3 +1,14 @@
+@import "../../dataviews/src/style.scss";
+@import "./components/layout/style.scss";
+@import "./components/page/style.scss";
+@import "./components/save-hub/style.scss";
+@import "./components/save-panel/style.scss";
+@import "./components/sidebar/style.scss";
+@import "./components/site-hub/style.scss";
+@import "./components/site-icon/style.scss";
+@import "./components/editor-canvas-container/style.scss";
+@import "./components/resizable-frame/style.scss";
+
 @include wordpress-admin-schemes();
 
 #wpadminbar,
@@ -7,13 +18,29 @@
 #wpcontent {
 	margin-left: 0;
 }
+body.js #wpbody {
+	padding-top: 0;
+}
 body {
 	@include wp-admin-reset("#gutenberg-posts-dashboard");
+}
+#gutenberg-posts-dashboard {
 	@include reset;
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	min-height: 100vh;
+	height: 100vh;
+
+	// On mobile the main content area has to scroll, otherwise you can invoke
+	// the over-scroll bounce on the non-scrolling container, for a bad experience.
+	@include break-small {
+		bottom: 0;
+		left: 0;
+		min-height: 100vh;
+		position: fixed;
+		right: 0;
+		top: 0;
+	}
+
+	.no-js & {
+		min-height: 0;
+		position: static;
+	}
 }


### PR DESCRIPTION
Related #62371 

## What?

This PR just reuses the "Layout" component from the site editor in the new posts dashboard. It doesn't do a lot aside setting things in order to be able to add "routes" and "pages" for the posts dataviews...

The results for the moment is as shown in the screenshot.

<img width="1470" alt="Screenshot 2024-06-07 at 11 32 15 AM" src="https://github.com/WordPress/gutenberg/assets/272444/5e0af784-6d5b-49f1-9880-640eb6d102bd">

## Testing Instructions

1- Check that the site editor continues to work as expected.
2- Check that the experimental "posts" page looks like the screenshot above (you can use the command palette if you want :P) 