### PR TITLE
Add e2e test to ensure block bindings work well with symbols and numbers

### DIFF
--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1975,6 +1975,41 @@ test.describe( 'Block bindings', () => {
 				).toHaveText( 'new value' );
 			} );
 
+			// Related issue: https://github.com/WordPress/gutenberg/issues/62347
+			test( 'should be possible to use symbols and numbers as the custom field value', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						anchor: 'paragraph-binding',
+						content: 'paragraph default content',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: { key: 'text_custom_field' },
+								},
+							},
+						},
+					},
+				} );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+
+				await expect( paragraphBlock ).toHaveAttribute(
+					'contenteditable',
+					'true'
+				);
+				await paragraphBlock.fill( '$10.00' );
+				// Check the value of the custom field is being updated by visiting the frontend.
+				const previewPage = await editor.openPreviewPage();
+				await expect(
+					previewPage.locator( '#paragraph-binding' )
+				).toHaveText( '$10.00' );
+			} );
+
 			test( 'should be possible to edit the value of the url custom field from the button', async ( {
 				editor,
 				page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add an e2e case to cover use cases like [this one](https://github.com/WordPress/gutenberg/issues/62396#top), where symbols and numbers couldn't be used at the start of a binding value.

## Why?
To ensure we don't break things again in the future.

## How?
I just added a e2e test for a paragraph connected to a custom field. I thought about replicating the same for pattern overrides, but I felt I was just replicating the test. Happy to add it if considered necessary.

## Testing Instructions
Tests should pass once [this code](https://github.com/WordPress/wordpress-develop/pull/6744) in WordPress is updated.