### PR TITLE
Update disabled checkbox cursor style

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -301,7 +301,7 @@
 	&:disabled {
 		background: $gray-100;
 		border-color: $gray-300;
-		cursor: default;
+		cursor: not-allowed;
 
 		// Override style inherited from wp-admin. Required to avoid degraded appearance on different backgrounds.
 		opacity: 1;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: #62349

## Why?
In the Site Editor's data views, checkboxes remain visible even when items are unselectable, causing confusion and suggesting interaction.

## How?
Changing the cursor to `not allowed` for unselectable items in the Site Editor improves clarity and usability.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open site editor.
2. Select Templates.
3. Try to select the unselectable templates.

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/77401999/206806b7-0242-4c43-b1df-270970e14b94

