### PR TITLE
Add Button support for iconPosition top and showDescription

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Enhancements
 
+-   `Button`: Add Button support for iconPosition top and showDescription. ([#62412](https://github.com/WordPress/gutenberg/pull/62412))
 -   `PaletteEdit`: use `Item` internally instead of custom styles ([#66164](https://github.com/WordPress/gutenberg/pull/66164)).
 
 ## 28.10.0 (2024-10-16)

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -164,7 +164,7 @@ If provided, renders an [Icon](/packages/components/src/icon/README.md) componen
 
 -   Required: No
 
-#### `iconPosition`: `'left' | 'right'`
+#### `iconPosition`: `'left' | 'right' | 'top'`
 
 If provided with `icon`, sets the position of icon relative to the `text`. Available options are `left|right`.
 

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -140,9 +140,16 @@ An optional additional class name to apply to the rendered button.
 
 #### `description`: `string`
 
-An accessible description for the button.
+A visually hidden accessible description for the button.
 
 -   Required: No
+
+#### `showDescription`: `boolean`
+
+Whether to show the accessible description.
+
+-   Required: No
+-   Default: `false`
 
 #### `disabled`: `boolean`
 

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -161,6 +161,7 @@ export function UnforwardedButton(
 		'is-destructive': isDestructive,
 		'has-text': !! icon && ( hasChildren || text ),
 		'has-icon': !! icon,
+		'has-icon-position-top': iconPosition === 'top',
 	} );
 
 	const trulyDisabled = disabled && ! accessibleWhenDisabled;
@@ -224,7 +225,7 @@ export function UnforwardedButton(
 
 	const elementChildren = (
 		<>
-			{ icon && iconPosition === 'left' && (
+			{ icon && ( iconPosition === 'left' || iconPosition === 'top' ) && (
 				<Icon icon={ icon } size={ iconSize } />
 			) }
 			{ text && <>{ text }</> }

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -112,6 +112,7 @@ export function UnforwardedButton(
 		text,
 		variant,
 		description,
+		showDescription,
 		...buttonOrAnchorProps
 	} = useDeprecatedProps( props );
 
@@ -276,13 +277,15 @@ export function UnforwardedButton(
 		  }
 		: {};
 
+	const DescriptionComponent = showDescription ? 'span' : VisuallyHidden;
+
 	return (
 		<>
 			<Tooltip { ...tooltipProps }>{ element }</Tooltip>
 			{ description && (
-				<VisuallyHidden>
+				<DescriptionComponent className="components-button__description">
 					<span id={ descriptionId }>{ description }</span>
-				</VisuallyHidden>
+				</DescriptionComponent>
 			) }
 		</>
 	);

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -234,7 +234,6 @@
 	/**
 	 * Link buttons.
 	 */
-
 	&.is-link {
 		margin: 0;
 		padding: 0;
@@ -402,6 +401,16 @@
 	.components-visually-hidden {
 		height: auto;
 	}
+}
+
+.components-button__description {
+	display: block;
+	margin-top: $grid-unit-10;
+	margin-bottom: 0;
+	font-family: inherit;
+	font-weight: normal;
+	font-size: $default-font-size;
+	color: $gray-700;
 }
 
 @keyframes components-button__busy-animation {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -343,6 +343,18 @@
 			padding-left: $grid-unit-10;
 			gap: $grid-unit-05;
 		}
+
+		&.has-icon-position-top {
+			flex-direction: column;
+			height: auto;
+			padding-left: $grid-unit-10;
+			padding-right: $grid-unit-10;
+			white-space: normal;
+
+			&.is-small {
+				line-height: normal;
+			}
+		}
 	}
 
 	// Toggled style.
@@ -376,6 +388,7 @@
 	svg {
 		fill: currentColor;
 		outline: none;
+		flex-shrink: 0;
 
 		// Optimizate for high contrast modes.
 		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -55,7 +55,7 @@ type BaseButtonProps = {
 	 *
 	 * @default 'left'
 	 */
-	iconPosition?: 'left' | 'right';
+	iconPosition?: 'left' | 'right' | 'top';
 	/**
 	 * If provided with `icon`, sets the icon size.
 	 * Please refer to the Icon component for more details regarding

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -47,6 +47,12 @@ type BaseButtonProps = {
 	 */
 	description?: string;
 	/**
+	 * Whether to show the accessible description.
+	 *
+	 * @default false
+	 */
+	showDescription?: boolean;
+	/**
 	 * If provided, renders an Icon component inside the button.
 	 */
 	icon?: IconProps[ 'icon' ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/62373

## What?
<!-- In a few words, what is the PR actually doing? -->
- Extends the `iconPosition` prop to support a new `top` value.
- Adds a `showDescription` prop to make the Button accessible description visible.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As detailed in https://github.com/WordPress/gutenberg/issues/62373 there are scenarios where a Button would benefit from a couple new features:
- Show the icon on toop and the label below the icon, stacked vertically.
- Show the visually hidden accessible description. The current implementation incorrectly assumes the description has to always be visually hidden. Instead, there are cass where the description has to be visible.

Both features would allow to avoid 'ad-hoc' implementations and overrides in the editor components, which also add maintenance cost, inconsistencies, and are prone to bugs and reduced accessibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
See above

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Build and run the Storybook `npm run storybook:dev`.
- In the Storybook, select the Button component.
- Set an icon, and set the `iconPosition` prop to 'top.
- Observe the button renders with the icon at the top and the label text below the icon. Example screenshot:

![Screenshot 2024-06-07 at 15 08 29](https://github.com/WordPress/gutenberg/assets/1682452/cd73443d-9357-4115-afca-1e36b58e6596)


- Set a description text for the `describedBy` prop.
- Set the new `showDescription` prop to `true`.
- Observe the accessible description is visible below the button.
- Note: I opted to style the description with the same default styling of the Inputbase description. Example screenshots:

![Screenshot 2024-06-07 at 14 17 44](https://github.com/WordPress/gutenberg/assets/1682452/648ef994-72b2-42d5-97a5-b016a933536b)

![Screenshot 2024-06-07 at 14 40 05](https://github.com/WordPress/gutenberg/assets/1682452/17dae513-e2df-4e20-a204-479b8e5ae19e)

- Play with all the other props and button variants to check bad paths and potential breakages.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
