### PR TITLE
Try: Fix flaky DataViews e2e test

### DIFF
--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -54,7 +54,9 @@ test.describe( 'Dataviews List Layout', () => {
 		// Make sure the items have loaded before reaching for the 1st item in the list.
 		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
-		await expect( page.getByLabel( 'Privacy Policy' ) ).toBeFocused();
+		await expect(
+			page.getByRole( 'grid' ).getByRole( 'button' ).first()
+		).toBeFocused();
 	} );
 
 	test( 'Navigates from items list to preview via TAB, and vice versa', async ( {


### PR DESCRIPTION
## What?
Fixes #61701.

PR tries to fix the flaky `Items list is reachable via TAB` e2e test, which occasionally fails because the "Privacy Policy" isn't always the first item.

## How?
The test doesn't need to know which item is first. It only needs to check that it receives the focus.

## Testing Instructions
CI checks should be green.
