### PR TITLE
Placeholders: Fix contrast.

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/content.scss
+++ b/packages/block-editor/src/components/block-variation-picker/content.scss
@@ -13,7 +13,7 @@
 	font-size: $helptext-font-size;
 
 	svg {
-		fill: $gray-400 !important;
+		fill: $gray-600 !important;
 	}
 
 	.components-button {


### PR DESCRIPTION
## What?

The icons in the placeholder don't meet 3:1 UI contrast:

![before](https://github.com/WordPress/gutenberg/assets/1204802/aabcf368-58a7-45c5-9e62-13a4b016939b)

With this PR, they do:

![after](https://github.com/WordPress/gutenberg/assets/1204802/2d317bb7-0e3f-4764-85b3-44688e28f8ea)

## Testing Instructions

Insert group, columns, or other placeholders. The variation icons should have sufficient contrast.