### PR TITLE
Raw handling: allow pasting SVGs

### DIFF
--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -3,7 +3,6 @@
  */
 import { pasteHandler } from '@wordpress/blocks';
 import { isEmpty, insert, create } from '@wordpress/rich-text';
-import { isURL } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -22,7 +21,6 @@ export default ( props ) => ( element ) => {
 			formatTypes,
 			tagName,
 			onReplace,
-			__unstableEmbedURLOnPaste,
 			preserveWhiteSpace,
 			pastePlainText,
 		} = props.current;
@@ -92,15 +90,7 @@ export default ( props ) => ( element ) => {
 
 		let mode = 'INLINE';
 
-		const trimmedPlainText = plainText.trim();
-
-		if (
-			__unstableEmbedURLOnPaste &&
-			isEmpty( value ) &&
-			isURL( trimmedPlainText ) &&
-			// For the link pasting feature, allow only http(s) protocols.
-			/^https?:/.test( trimmedPlainText )
-		) {
+		if ( isEmpty( value ) ) {
 			mode = 'BLOCKS';
 		}
 

--- a/packages/blocks/src/api/raw-handling/image-corrector.js
+++ b/packages/blocks/src/api/raw-handling/image-corrector.js
@@ -14,6 +14,10 @@ export default function imageCorrector( node ) {
 
 	// This piece cannot be tested outside a browser env.
 	if ( node.src.indexOf( 'data:' ) === 0 ) {
+		if ( node.src.indexOf( 'data:image/svg+xml' ) === 0 ) {
+			return;
+		}
+
 		const [ properties, data ] = node.src.split( ',' );
 		const [ type ] = properties.slice( 5 ).split( ';' );
 

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -32,6 +32,7 @@ import brRemover from './br-remover';
 import { deepFilterHTML, isPlain, getBlockContentSchema } from './utils';
 import emptyParagraphRemover from './empty-paragraph-remover';
 import slackParagraphCorrector from './slack-paragraph-corrector';
+import svgToImage from './svg-to-image';
 
 const log = ( ...args ) => window?.console?.log?.( ...args );
 
@@ -179,6 +180,8 @@ export function pasteHandler( {
 			if ( typeof piece !== 'string' ) {
 				return piece;
 			}
+
+			piece = deepFilterHTML( piece, [ svgToImage ] );
 
 			const filters = [
 				googleDocsUIDRemover,

--- a/packages/blocks/src/api/raw-handling/svg-to-image.js
+++ b/packages/blocks/src/api/raw-handling/svg-to-image.js
@@ -1,0 +1,11 @@
+export default function svgToImage( node, doc ) {
+	if ( node.nodeName !== 'svg' ) {
+		return;
+	}
+
+	// Replace with image with data URL.
+	const svgString = node.outerHTML;
+	const img = doc.createElement( 'img' );
+	img.src = 'data:image/svg+xml,' + encodeURIComponent( svgString );
+	node.parentNode.replaceChild( img, node );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently if you paste SVGs, they won't be pasted.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's strange that nothing happens.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We can encode the SVG as a data URI and load it in an image block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

```
<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14.9967 1.18476C16.187 0.587163 17.5 1.52528 17.5 2.76613V4.19565C18.1951 4.10424 18.9166 4.04749 19.6806 4.0216C20.662 3.98877 21.5 4.76781 21.5 5.77016V17.6072C21.5 18.5501 20.7469 19.3407 19.7874 19.3551C16.8086 19.4004 14.6111 19.9426 12.1323 21.3994C12.0131 21.4701 11.8736 21.5083 11.7275 21.5038C11.6913 21.5027 11.6552 21.499 11.6195 21.4927C11.5256 21.4762 11.4381 21.4425 11.3602 21.395C8.88431 19.9415 6.68869 19.4004 3.71291 19.3561C2.75232 19.3419 2 18.5492 2 17.6072V5.77016C2 4.8024 2.79493 3.98842 3.79117 4.02055C6.57817 4.1104 8.79699 4.58666 11.1309 5.72827C11.6742 3.81587 13.2168 2.07681 14.9967 1.18476ZM16 5.08418C15.9998 5.0749 15.9998 5.06565 16 5.05642V2.76613C16 2.67464 15.9535 2.59328 15.8767 2.54332C15.803 2.49543 15.7321 2.49394 15.6696 2.52533C14.1133 3.3053 12.8208 4.88125 12.5 6.43922V17.5801C13.3937 16.4999 14.583 15.6419 15.8423 15.2191C15.9324 15.1889 16 15.1008 16 14.9921V5.08418ZM3.74284 5.51976C6.55499 5.61041 8.67662 6.11116 11 7.3452V19.4931C8.69756 18.3454 6.49244 17.8972 3.73509 17.8562C3.61368 17.8544 3.5 17.7491 3.5 17.6071V5.77014C3.5 5.61991 3.62307 5.51589 3.74284 5.51976ZM13.1976 19.1655C15.1501 18.3049 17.0798 17.9316 19.3895 17.8636C19.5134 17.8599 19.6384 17.8572 19.7646 17.8552C19.887 17.8534 20 17.7481 20 17.6071V5.77014C20 5.63649 19.8856 5.51556 19.7311 5.52073C18.9363 5.54768 18.2004 5.60961 17.5 5.70965V10.7818V14.9921C17.5 15.7315 17.0336 16.4014 16.3198 16.6411C15.0821 17.0567 13.9243 18.0236 13.1976 19.1655Z" fill="currentColor"></path></svg>
```

> [!IMPORTANT]  
> Use the Github copy button for the snippet above, otherwise you'll copy the code element too.

Or take any other SVG from https://convertkit.com and paste it into GB.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
