### PR TITLE
Fix: Don't allow synced patterns to be inserted on shuffling.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -60,7 +60,9 @@ export default function Shuffle( { clientId, as = Container } ) {
 				pattern.blocks.length === 1 &&
 				pattern.categories?.some( ( category ) => {
 					return categories.includes( category );
-				} )
+				} ) &&
+				// Check if the pattern is not a synced pattern.
+				( pattern.syncStatus === 'unsynced' || ! pattern.id )
 			);
 		} );
 	}, [ categories, patterns ] );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/62294

Currently, the pattern shuffle inserts synced patterns as unsynced. This PR fixes the issue by applying the suggestion by @talldan, of not allowing to shuffle to a synced pattern.


## Testing Instructions
With the 2024 theme I verified there are originally 2 patterns on the testimonials category.
I created two duplicates of the "Annie Steiner CEO, Greenprint" patterns one that is synced and made the text of the pattern say sync and one that is unsync and made the text of the pattern say unsync.
I added a testimonial pattern and verified the pattern shuffle switches between the two patterns that come with the team and the unsync pattern I created, but never shuffles to the sync patterns.
