### PR TITLE
`CustomSelectControlV2`: Fix styling issues

### DIFF
--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -92,7 +92,7 @@ function _CustomSelect(
 	} = props;
 
 	return (
-		<>
+		<Styled.SelectWrapper>
 			{ hideLabelFromVision ? ( // TODO: Replace with BaseControl
 				<VisuallyHidden as="label">{ label }</VisuallyHidden>
 			) : (
@@ -116,7 +116,7 @@ function _CustomSelect(
 					</CustomSelectContext.Provider>
 				</Styled.SelectPopover>
 			</InputBase>
-		</>
+		</Styled.SelectWrapper>
 	);
 }
 

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -14,6 +14,10 @@ import type { CustomSelectButtonSize } from './types';
 
 const ITEM_PADDING = space( 2 );
 
+export const SelectWrapper = styled.div`
+	display: block;
+`;
+
 export const WithHintWrapper = styled.div`
 	display: flex;
 	justify-content: space-between;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -96,6 +96,7 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	border-radius: 2px;
 	background: ${ COLORS.theme.background };
 	border: 1px solid ${ COLORS.theme.foreground };
+	z-index: 9999; // Ensure the popover is on top
 
 	&[data-focus-visible] {
 		outline: none; // outline will be on the trigger, rather than the popover

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -104,6 +104,7 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	position: absolute !important;
 	max-height: 400px;
 	overflow: auto;
+	min-width: 100%;
 
 	&[data-focus-visible] {
 		outline: none; // outline will be on the trigger, rather than the popover

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -117,6 +117,8 @@ export const SelectItem = styled( Ariakit.SelectItem )`
 	padding: ${ ITEM_PADDING };
 	font-size: ${ CONFIG.fontSize };
 	line-height: 2.15rem; // TODO: Remove this in default but keep for back-compat in legacy
+	user-select: none;
+
 	&[data-active-item] {
 		background-color: ${ COLORS.theme.gray[ 300 ] };
 	}

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -97,6 +97,7 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	background: ${ COLORS.theme.background };
 	border: 1px solid ${ COLORS.theme.foreground };
 	z-index: 9999; // Ensure the popover is on top
+	position: absolute !important;
 
 	&[data-focus-visible] {
 		outline: none; // outline will be on the trigger, rather than the popover

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -98,6 +98,7 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	border: 1px solid ${ COLORS.theme.foreground };
 	z-index: 9999; // Ensure the popover is on top
 	position: absolute !important;
+	max-height: 400px;
 
 	&[data-focus-visible] {
 		outline: none; // outline will be on the trigger, rather than the popover

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -99,6 +99,7 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	z-index: 9999; // Ensure the popover is on top
 	position: absolute !important;
 	max-height: 400px;
+	overflow: auto;
 
 	&[data-focus-visible] {
 		outline: none; // outline will be on the trigger, rather than the popover

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -22,6 +22,7 @@ export const WithHintWrapper = styled.div`
 	display: flex;
 	justify-content: space-between;
 	flex: 1;
+	flex-wrap: wrap;
 `;
 
 export const SelectedExperimentalHintItem = styled.span`


### PR DESCRIPTION
Split from: https://github.com/WordPress/gutenberg/pull/61272.
Depends on: https://github.com/WordPress/gutenberg/pull/62308.

## What?

Fix styling issues found while testing it via the legacy adapter. See each commit for a description of each fix.

## Why?

We're preparing V2 for shipping, and these visual issues need to be fixed before we replace the V1 implementation with the adapter. This is part of a series of PRs with other fixes/tweaks to the new control (see the top of the description).

## How?

By tweaking the CSS rules for the various elements that make up the component.

## Testing Instructions

* Check all the stories in storybook - for V2 and the adapter. Make sure they look alright;

* Then tests with consumers. Here are a few consumers that can be used to test it in practice:

1. `wp-admin/site-editor.php?canvas=edit`: Add a `date` block and uncheck the "Default format' checkbox in the settings in order for the select to show;
2. In any editor, select a paragraph, and under "Typography" add the "Appearance" select;
3. Add a `spacer` block, and in the "Height" settings, there's a custom select for it as well.
4. Then there's the storybook stories, too.

There's another one under https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/hooks/position.js#L290, but I couldn't find exactly where this feature is yet.

Other slight visual changes might also be made, and the review's goal is to discuss whether it's okay to keep them or if we should fix them (as in making it exactly/closer to V1).


## TODO

- [ ] Rebase from https://github.com/WordPress/gutenberg/pull/62198, fix any conflicts and review issues;
- [ ] Address other styling issues listed [here](https://github.com/WordPress/gutenberg/pull/61272#issuecomment-2136367426) that are still an issue after the rebase.

## Screenshots or screencast <!-- if applicable -->
