### PR TITLE
Fix `@since` tag in docblock in `WP_Theme_JSON_Data_Gutenberg`.

### DIFF
--- a/lib/class-wp-theme-json-data-gutenberg.php
+++ b/lib/class-wp-theme-json-data-gutenberg.php
@@ -72,7 +72,7 @@ class WP_Theme_JSON_Data_Gutenberg {
 	/**
 	 * Return theme JSON object.
 	 *
-	 * @since 18.3.0
+	 * @since 18.5.0
 	 *
 	 * @return WP_Theme_JSON
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The `get_theme_json` method was actually added in v18.5.0, not  18.3.0. This corrects the docblock reference.

See: 
* [18.3](https://github.com/WordPress/gutenberg/blob/v18.3.0/lib/class-wp-theme-json-data-gutenberg.php)
* [18.4](https://github.com/WordPress/gutenberg/blob/v18.4.0/lib/class-wp-theme-json-data-gutenberg.php)
* [18.5](https://github.com/WordPress/gutenberg/blob/v18.5.0/lib/class-wp-theme-json-data-gutenberg.php)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Corrected by @ryelle in this trac comment: https://core.trac.wordpress.org/ticket/61112#comment:25