### PR TITLE
Classic Block: Display "Convert to blocks" button even if it is inside a Content block

### DIFF
--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -40,7 +40,12 @@ function isTmceEmpty( editor ) {
 export default function FreeformEdit( props ) {
 	const { clientId } = props;
 	const canRemove = useSelect(
-		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
+		( select ) => {
+			const { canRemoveBlock, getBlockRootClientId } =
+				select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
+			return canRemoveBlock( clientId, rootClientId );
+		},
 		[ clientId ]
 	);
 	const [ isIframed, setIsIframed ] = useState( false );


### PR DESCRIPTION
I discovered this while reviewing #62374

## What?
This PR fixes the issue where the "Convert to blocks" button is not displayed when a Classic block is inside a Content block.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/75027d15-c4d2-4c17-a9e8-dca07fbfe136)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/9d080ed2-fe1a-48e5-b40a-8876c2fbe3ee)

## Why?

I think the cause is the same as described in #62374. We need to check the root block to see if the button can be converted, i.e. if the block can be deleted.

## Testing Instructions

- Open the page editor.
- Switch to the code editor and enter just text.
- Switch to visual mode. The text should be automatically converted to a Classic block.
- Enable "Show template" in the sidebar.
- The "Convert to blocks" button should appear in the block toolbar.
