### PR TITLE
Several typo correction in documentations

### DIFF
--- a/docs/contributors/folder-structure.md
+++ b/docs/contributors/folder-structure.md
@@ -76,7 +76,7 @@ The following snippet explains how the Gutenberg repository is structured omitti
     │   Set of documentation pages composing the [Block editor handbook](https://developer.wordpress.org/block-editor/).
     │
     ├── platform-docs
-    │   Documentation website targetted to non WordPress developpers 
+    │   Documentation website targeted to non WordPress developers 
     │   using Gutenberg in their own applications. 
     │   Deployed on [https://wordpress.org/gutenberg-framework/](https://wordpress.org/gutenberg-framework/).
     │

--- a/docs/reference-guides/slotfills/README.md
+++ b/docs/reference-guides/slotfills/README.md
@@ -68,7 +68,7 @@ See [core code](https://github.com/WordPress/gutenberg/tree/HEAD/packages/editor
 ```js
 export default function PostSummary( { onActionPerformed } ) {
 	const { isRemovedPostStatusPanel } = useSelect( ( select ) => {
-		// We use isEditorPanelRemoved to hide the panel if it was programatically removed. We do
+		// We use isEditorPanelRemoved to hide the panel if it was programmatically removed. We do
 		// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
 		const { isEditorPanelRemoved, getCurrentPostType } =
 			select( editorStore );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/62432