### PR TITLE
Fixed : Disambiguate "Cover" translatable string in the context of background-panel.js

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -23,7 +23,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
 import { useCallback, Platform, useRef } from '@wordpress/element';
@@ -544,7 +544,7 @@ function BackgroundSizeToolsPanelItem( {
 				<ToggleGroupControlOption
 					key="cover"
 					value="cover"
-					label={ __( 'Cover' ) }
+					label={ _x( 'Cover', 'Scale option for dimensions control' ) }
 				/>
 				<ToggleGroupControlOption
 					key="contain"

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -549,12 +549,12 @@ function BackgroundSizeToolsPanelItem( {
 				<ToggleGroupControlOption
 					key="contain"
 					value="contain"
-					label={ __( 'Contain' ) }
+					label={ _x( 'Contain', 'Scale option for dimensions control' ) }
 				/>
 				<ToggleGroupControlOption
 					key="tile"
 					value="auto"
-					label={ __( 'Tile' ) }
+					label={ _x( 'Tile', 'Scale option for dimensions control' ) }
 				/>
 			</ToggleGroupControl>
 			<HStack justify="flex-start" spacing={ 2 } as="span">

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -544,17 +544,26 @@ function BackgroundSizeToolsPanelItem( {
 				<ToggleGroupControlOption
 					key="cover"
 					value="cover"
-					label={ _x( 'Cover', 'Scale option for dimensions control' ) }
+					label={ _x(
+						'Cover',
+						'Size option for background image control'
+					) }
 				/>
 				<ToggleGroupControlOption
 					key="contain"
 					value="contain"
-					label={ _x( 'Contain', 'Scale option for dimensions control' ) }
+					label={ _x(
+						'Contain',
+						'Size option for background image control'
+					) }
 				/>
 				<ToggleGroupControlOption
 					key="tile"
 					value="auto"
-					label={ _x( 'Tile', 'Scale option for dimensions control' ) }
+					label={ _x(
+						'Tile',
+						'Size option for background image control'
+					) }
 				/>
 			</ToggleGroupControl>
 			<HStack justify="flex-start" spacing={ 2 } as="span">


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/62426

## What?
[In image block's background-panel.js context](https://github.com/WordPress/gutenberg/blob/bbdf1a7f39dd75f672fe863c9d8ac7bf8faa874b/packages/block-editor/src/components/global-styles/background-panel.js#L547), there is a "Cover" string sharing its translation with other occurrences of "Cover", like the Cover block. It results in wrong translation of the setting in some locales, like in French where the Cover Block is translated into "Bloc Bannière" while "Cover Size" cannot be translated into "Taille Bannière".

This PR will fix the issue raised in https://github.com/WordPress/gutenberg/issues/62426

## Why?
It fixed the disambiguate we have in "Cover" translatable string in the context of `background-panel.js`

## How?
This PR will add some context using _x(), just like we did in [this other occurrence of "Cover", in a very similar context](https://github.com/WordPress/gutenberg/blob/bbdf1a7f39dd75f672fe863c9d8ac7bf8faa874b/packages/block-library/src/image/image.js#L61) to fix this issue.

## Testing Instructions

1. Install `fr_FR` language pack
2. Open `Background panel component`
3. See that the "Cover" string is translated into "Bannière". "Couvrir" should be used instead.

## Screenshots or screencast <!-- if applicable -->

**Before:**

![image](https://github.com/WordPress/gutenberg/assets/32844880/1d9087f5-6266-4ece-b178-f1d651e30710)

**After:**

![image](https://github.com/WordPress/gutenberg/assets/32844880/a312883b-7a93-4486-b798-bfa3710b5080)
