### PR TITLE
Freeform: autoconvert on mount (opt-in)

### DIFF
--- a/packages/block-editor/src/components/block-list/auto-convert-freeform.js
+++ b/packages/block-editor/src/components/block-list/auto-convert-freeform.js
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+import { useRegistry } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { rawHandler, serialize } from '@wordpress/blocks';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export default function useAutoConvert() {
+	const registry = useRegistry();
+	useEffect( () => {
+		const { getSettings, getBlockOrder, getBlockName, getBlock } =
+			registry.select( blockEditorStore );
+		const { autoConvertFreeform } = getSettings();
+
+		if ( ! autoConvertFreeform ) {
+			return;
+		}
+
+		const order = getBlockOrder( '' );
+
+		if ( order.length !== 1 ) {
+			return;
+		}
+
+		const [ clientId ] = order;
+		const blockName = getBlockName( clientId );
+
+		if ( blockName !== 'core/freeform' ) {
+			return;
+		}
+
+		const block = getBlock( clientId );
+		const newBlocks = rawHandler( { HTML: serialize( block ) } );
+		const { replaceBlocks } = registry.dispatch( blockEditorStore );
+		const { createSuccessNotice } = registry.dispatch( noticesStore );
+
+		replaceBlocks( block.clientId, newBlocks );
+		createSuccessNotice( __( 'Freeform content converted to blocks.' ), {
+			type: 'snackbar',
+			isDismissible: true,
+			actions: [
+				{
+					label: __( 'Undo' ),
+					onClick: () => {
+						replaceBlocks(
+							newBlocks.map( ( b ) => b.clientId ),
+							[ block ]
+						);
+					},
+				},
+			],
+		} );
+	}, [ registry ] );
+}

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -40,6 +40,7 @@ import {
 } from '../block-edit/context';
 import { useTypingObserver } from '../observe-typing';
 import { unlock } from '../../lock-unlock';
+import useAutoConvert from './auto-convert-freeform';
 
 export const IntersectionObserver = createContext();
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
@@ -119,6 +120,7 @@ function Root( { className, ...settings } ) {
 		},
 		settings
 	);
+	useAutoConvert();
 	return (
 		<IntersectionObserver.Provider value={ intersectionObserver }>
 			<div { ...innerBlocksProps } />

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -171,6 +171,8 @@ export const SETTINGS_DEFAULTS = {
 	__unstableGalleryWithImageBlocks: false,
 	__unstableIsPreviewMode: false,
 
+	autoConvertFreeform: true,
+
 	// These settings will be completely revamped in the future.
 	// The goal is to evolve this into an API which will instruct
 	// the block inspector to animate transitions between what it

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -44,6 +44,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalGlobalStylesBaseStyles',
 	'__unstableGalleryWithImageBlocks',
 	'alignWide',
+	'autoConvertFreeform',
 	'blockInspectorTabs',
 	'allowedMimeTypes',
 	'bodyPlaceholder',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

If there's only a single freeform block, auto convert it to blocks if the `autoConvertFreeform` setting is enabled.

To do: only set `autoConvertFreeform` to true based on some back-end checks such as whether revisions are enabled and an explicit opt-in flag.

To do: add an e2e test.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
