### PR TITLE
Add `context` in post actions API

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -456,7 +456,10 @@ export default function PagePages() {
 		[ authors, view.type, frontPageId, postsPageId ]
 	);
 
-	const postTypeActions = usePostActions( 'page' );
+	const postTypeActions = usePostActions( {
+		postType: 'page',
+		context: 'list',
+	} );
 	const editAction = useEditPostAction();
 	const actions = useMemo(
 		() => [ editAction, ...postTypeActions ],

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -354,8 +354,14 @@ export default function DataviewsPatterns() {
 		return filterSortAndPaginate( patterns, viewWithoutFilters, fields );
 	}, [ patterns, view, fields, type ] );
 
-	const templatePartActions = usePostActions( TEMPLATE_PART_POST_TYPE );
-	const patternActions = usePostActions( PATTERN_TYPES.user );
+	const templatePartActions = usePostActions( {
+		postType: TEMPLATE_PART_POST_TYPE,
+		context: 'list',
+	} );
+	const patternActions = usePostActions( {
+		postType: PATTERN_TYPES.user,
+		context: 'list',
+	} );
 	const editAction = useEditPostAction();
 
 	const actions = useMemo( () => {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -323,7 +323,10 @@ export default function PageTemplates() {
 		return filterSortAndPaginate( records, view, fields );
 	}, [ records, view, fields ] );
 
-	const postTypeActions = usePostActions( TEMPLATE_POST_TYPE );
+	const postTypeActions = usePostActions( {
+		postType: TEMPLATE_POST_TYPE,
+		context: 'list',
+	} );
 	const editAction = useEditPostAction();
 	const actions = useMemo(
 		() => [ editAction, ...postTypeActions ],

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -42,7 +42,7 @@ export default function PostActions( { onActionPerformed, buttonProps } ) {
 			postType: _postType,
 		};
 	}, [] );
-	const allActions = usePostActions( postType, onActionPerformed );
+	const allActions = usePostActions( { postType, onActionPerformed } );
 
 	const actions = useMemo( () => {
 		return allActions.filter( ( action ) => {

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -363,14 +363,12 @@ test.describe( 'Footnotes', () => {
 
 		// Open revisions.
 		await editor.openDocumentSettingsSidebar();
-		const editorSettings = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-		await editorSettings.getByRole( 'tab', { name: 'Post' } ).click();
-		await editorSettings.getByRole( 'button', { name: 'Actions' } ).click();
 		await page
-			.getByRole( 'menu' )
-			.getByRole( 'menuitem', { name: 'View revisions' } )
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Post' } )
+			.click();
+		await page
+			.locator( '.editor-private-post-last-revision__button' )
 			.click();
 		await page.locator( '.revisions-controls .ui-slider-handle' ).focus();
 		await page.keyboard.press( 'ArrowLeft' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Related: https://github.com/WordPress/gutenberg/pull/62323 - in the aspect of not showing the `revisions` action in `edit` mode.


This PR proposes the addition of a new `context` prop in post actions API. Post actions in their majority are meant to be used in any context like in data views (lists) or in editors as part of the ellipsis menu in inspector controls. There are some exceptions though and a couple examples are:
1. In editors we want to give more prominence to the revisions actions and is currently also shown as part of the post summary. For this reason we want to avoid the extraneous action in the ellipsis menu (related linked PR above)
2. In lists of entities (currently only in site editor) we have the `editPost` action which doesn't make sense in the editors, as we already editing. For that reason this actions lived in edit-site package and was separated from all the other actions that live in `editor` package (for now).

My suggestion for the new `context` property values is  a separation between `list` and whatever view/layout might use them in the future...  Due to the unification of editors I don't think it makes sense to consider `edit-post|edit-site` etc.. and also experimented with `edit/view` context but the lines might blur when we have `list` views with editing allowed. It's a private API, so we can always revisit.

A consumer of actions in order to get them from where ever (right now with `usePostActions` hook) can provide a specific context if needs to, but the absence of it means fetch all (default). Additionally actions can provide a context where they are allowed and is separate from `isEligible`, as it's meant for checks regarding a specific item. 



I'd welcome any feedback and suggestions about the API.




## Testing Instructions
1. Everything should work as before, including the `edit post` action
2. View revisions action is only available in site editor lists
