### PR TITLE
Inserter: Don't focus the inserter when opening

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -12,7 +12,6 @@ import {
 	useCallback,
 	useMemo,
 	useRef,
-	useLayoutEffect,
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -294,18 +293,6 @@ function InserterMenu(
 		setSelectedTab( value );
 	};
 
-	// Focus first active tab, if any
-	const tabsRef = useRef();
-	useLayoutEffect( () => {
-		if ( tabsRef.current ) {
-			window.requestAnimationFrame( () => {
-				tabsRef.current
-					.querySelector( '[role="tab"][aria-selected="true"]' )
-					?.focus();
-			} );
-		}
-	}, [] );
-
 	return (
 		<div
 			className={ clsx( 'block-editor-inserter__menu', {
@@ -316,7 +303,6 @@ function InserterMenu(
 		>
 			<div className="block-editor-inserter__main-area">
 				<InserterTabs
-					ref={ tabsRef }
 					onSelect={ handleSetSelectedTab }
 					onClose={ onClose }
 					selectedTab={ selectedTab }

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -28,10 +28,6 @@ import { store as editorStore } from '../../store';
 import EditorHistoryRedo from '../editor-history/redo';
 import EditorHistoryUndo from '../editor-history/undo';
 
-const preventDefault = ( event ) => {
-	event.preventDefault();
-};
-
 function DocumentTools( { className, disableBlockTools = false } ) {
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editorStore );
@@ -117,7 +113,6 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 						className="editor-document-tools__inserter-toggle"
 						variant="primary"
 						isPressed={ isInserterOpened }
-						onMouseDown={ preventDefault }
 						onClick={ toggleInserter }
 						disabled={ disableBlockTools }
 						icon={ plus }

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -65,7 +65,7 @@ export default function InserterSidebar() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
-		focusOnMount: true,
+		focusOnMount: false,
 	} );
 	const libraryRef = useRef();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is to address: https://github.com/WordPress/gutenberg/issues/62441

## Why?
In other sidebar panels we don't automatically focus the panel, we only do it when a user interacts with the panel.

## How?
Removes the code that autofocusses the inserter.

## Testing Instructions
1. Reload the site editor
2. Open the inserter
3. Confirm that focus remains on the toggle inserter button
