### PR TITLE
Color Variations: Use Grid rather than VStack

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	__experimentalGrid as Grid,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -22,13 +25,13 @@ export default function ColorVariations( { title, gap = 2 } ) {
 	return (
 		<VStack spacing={ 3 }>
 			{ title && <Subtitle level={ 3 }>{ title }</Subtitle> }
-			<VStack spacing={ gap }>
+			<Grid spacing={ gap }>
 				{ colorVariations.map( ( variation, index ) => (
 					<Variation key={ index } variation={ variation } isPill>
 						{ () => <StylesPreviewColors /> }
 					</Variation>
 				) ) }
-			</VStack>
+			</Grid>
 		</VStack>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A small fix to make the color-only variations (alternate color palettes) more palatable. :) 

Currently, if a theme includes more than a few, it becomes quite a heavy/tedious view. This PR switches the VStack to use Grid, which more closely resembles both the layout of theme style variations and block style variations, making the UI a bit more familiar. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor.
2. Open the "Colors" panel. 
3. Select the palette to edit it.
4. See changes. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-06-07 at 08 35 20](https://github.com/WordPress/gutenberg/assets/1813435/94c384f7-c77d-471d-accc-0b48408ae0e3)|![CleanShot 2024-06-07 at 08 40 40](https://github.com/WordPress/gutenberg/assets/1813435/852c11bd-309e-4d84-8329-1ce7edf8f139)|

