### PR TITLE
DataViews: Fix unnecessary horizontal scrollbar in list layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -436,6 +436,7 @@
 			.components-button {
 				opacity: 0;
 				position: fixed;
+				right: 0;
 			}
 		}
 


### PR DESCRIPTION
## What?

This PR fixes the horizontal scrollbar that occurs when the DataViews is in the list layout.

Note: The screenshot below is from Windows OS. On MacOS, you can reproduce this issue by changing the scrollbar setting to always visible.

![dataviews](https://github.com/WordPress/gutenberg/assets/54422211/20ad13a2-f5ee-4b62-909c-54fbe3674719)

## Why?

I think the problem is probably due to the fact that the visually invisible button sticks out from the content when the item is not focused or selected.

![image](https://github.com/WordPress/gutenberg/assets/54422211/10252a67-f107-49f7-8563-c8d48e54b332)

## How?

There are probably a few different approaches we could consider, but defining `right:0` prevents the button from overflowing the parent element and solves the problem.

## Testing Instructions

- If you are testing on MacOS, change the scrollbar settings to always show.
- In the Templates or the Pages screen, change the data view layout to List.
