### PR TITLE
Fix: Add `network-active` to valid options in `PluginStatus` Type definition

### DIFF
--- a/packages/core-data/src/entity-types/plugin.ts
+++ b/packages/core-data/src/entity-types/plugin.ts
@@ -73,7 +73,7 @@ declare module './base-entity-records' {
 	}
 }
 
-export type PluginStatus = 'active' | 'inactive';
+export type PluginStatus = 'active' | 'inactive' | 'network-active';
 export type Plugin< C extends Context = 'edit' > = OmitNevers<
 	_BaseEntityRecords.Plugin< C >
 >;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds `network-active` to valid options in `PluginStatus` type definition

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It is a valid option that the Rest API returns: https://github.com/WordPress/wordpress-develop/blob/bca94a5fe45f9414f0d11a16372895a4817b1716/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php#L61

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding the string to the type

