### PR TITLE
Fix flaky Site Editor command center e2e test

### DIFF
--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -43,9 +43,11 @@ test.describe( 'Site editor command palette', () => {
 			.click();
 		await page.keyboard.type( 'index' );
 		await page.getByRole( 'option', { name: 'index' } ).click();
-		await expect( page.getByRole( 'heading', { level: 1 } ) ).toHaveText(
-			'Index'
-		);
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'heading', { level: 1 } )
+		).toHaveText( 'Index' );
 	} );
 
 	test( 'Open the command palette and navigate to Customize CSS', async ( {


### PR DESCRIPTION
## What?
Fixes #62403.

Fixes flaky test in `site-editor/command-center.spec.js` suite.

## Why?
It looks like in testing environment left sidebar's and top toolbar's heading can are available on page for a second and PW pick ups both locators.

I narrowed down the locators to avoid the failures.

## Testing Instructions
* CI checks should be green.
* `npm run test:e2e -- test/e2e/specs/site-editor/command-center.spec.js`.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/5461d424-5c7c-4490-81a0-190b771c6939

