### PR TITLE
Search Block: Adds settings to limit search results

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -811,7 +811,7 @@ Help visitors find your content. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/search
 -	**Category:** widgets
 -	**Supports:** align (center, left, right), color (background, gradients, text), interactivity, typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** buttonPosition, buttonText, buttonUseIcon, isSearchFieldHidden, label, placeholder, query, showLabel, width, widthUnit
+-	**Attributes:** buttonPosition, buttonText, buttonUseIcon, categories, isSearchFieldHidden, label, limitResults, placeholder, postType, query, showLabel, width, widthUnit
 
 ## Separator
 

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -46,6 +46,18 @@
 		"isSearchFieldHidden": {
 			"type": "boolean",
 			"default": false
+		},
+		"limitResults": {
+			"type": "boolean",
+			"default": false
+		},
+		"postType": {
+			"type": "string",
+			"default": "post"
+		},
+		"categories": {
+			"type": "object",
+			"default": {}
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -196,12 +196,41 @@ function render_block_core_search( $attributes ) {
 		';
 	}
 
+	$post_type_input = '';
+	$taxonomy_inputs = '';
+
+	if ( $attributes['limitResults'] ) {
+		$post_type  = ! empty( $attributes['postType'] ) ? $attributes['postType'] : '';
+		$taxonomies = ! empty( $attributes['categories'] ) ? $attributes['categories'] : array();
+
+		foreach ( $taxonomies as $taxonomy => $terms ) {
+			if ( ! empty( $terms ) ) {
+				$taxonomy_terms = array_map(
+					function ( $term_id ) use ( $taxonomy ) {
+						$term = get_term_by( 'id', $term_id, $taxonomy );
+						return $term ? $term->slug : '';
+					},
+					$terms
+				);
+
+				$input_name       = ( 'category' === $taxonomy ) ? 'category_name' : ( ( 'post_tag' === $taxonomy ) ? 'tag' : $taxonomy );
+				$taxonomy_input   = sprintf( '<input type="hidden" name="%s" value="%s" />', esc_attr( $input_name ), esc_attr( implode( ',', $taxonomy_terms ) ) );
+				$taxonomy_inputs .= $taxonomy_input;
+			}
+		}
+
+		if ( ! empty( $post_type ) ) {
+			$post_type_input = sprintf( '<input type="hidden" name="post_type" value="%s" />', esc_attr( $post_type ) );
+		}
+	}
+
 	return sprintf(
-		'<form role="search" method="get" action="%1s" %2s %3s>%4s</form>',
+		'<form role="search" method="get" action="%1s" %2s %3s>%4s %5$s</form>',
 		esc_url( home_url( '/' ) ),
 		$wrapper_attributes,
 		$form_directives,
-		$label . $field_markup
+		$label . $field_markup,
+		$post_type_input . $taxonomy_inputs
 	);
 }
 

--- a/packages/block-library/src/search/taxonomy-controls.js
+++ b/packages/block-library/src/search/taxonomy-controls.js
@@ -1,0 +1,191 @@
+/**
+ * WordPress dependencies
+ */
+import { FormTokenField } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useState, useEffect } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import { useTaxonomies } from './utils';
+
+const BASE_QUERY = {
+	order: 'asc',
+	_fields: 'id,name',
+	context: 'view',
+};
+const EMPTY_ARRAY = [];
+
+// Helper function to get the term id based on user input in terms `FormTokenField`.
+const getTermIdByTermValue = ( terms, termValue ) => {
+	// First we check for exact match by `term.id` or case sensitive `term.name` match.
+	const termId =
+		termValue?.id || terms?.find( ( term ) => term.name === termValue )?.id;
+	if ( termId ) {
+		return termId;
+	}
+
+	/**
+	 * Here we make an extra check for entered terms in a non case sensitive way,
+	 * to match user expectations, due to `FormTokenField` behaviour that shows
+	 * suggestions which are case insensitive.
+	 *
+	 * Although WP tries to discourage users to add terms with the same name (case insensitive),
+	 * it's still possible if you manually change the name, as long as the terms have different slugs.
+	 * In this edge case we always apply the first match from the terms list.
+	 */
+	const termValueLower = termValue.toLocaleLowerCase();
+	return terms?.find(
+		( term ) => term.name.toLocaleLowerCase() === termValueLower
+	)?.id;
+};
+
+export function TaxonomyControls( { categories, onChange, postType } ) {
+	const taxonomies = useTaxonomies( postType );
+
+	if ( ! taxonomies || taxonomies.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ taxonomies.map( ( taxonomy ) => {
+				const termIds = categories[ taxonomy.slug ] || [];
+				const handleChange = ( newTermIds ) =>
+					onChange( {
+						...categories,
+						[ taxonomy.slug ]: newTermIds,
+					} );
+
+				return (
+					<TaxonomyItem
+						key={ taxonomy.slug }
+						taxonomy={ taxonomy }
+						termIds={ termIds }
+						onChange={ handleChange }
+					/>
+				);
+			} ) }
+		</>
+	);
+}
+
+/**
+ * Renders a `FormTokenField` for a given taxonomy.
+ *
+ * @param {Object}   props          The props for the component.
+ * @param {Object}   props.taxonomy The taxonomy object.
+ * @param {number[]} props.termIds  An array with the block's term ids for the given taxonomy.
+ * @param {Function} props.onChange Callback `onChange` function.
+ * @return {JSX.Element} The rendered component.
+ */
+function TaxonomyItem( { taxonomy, termIds, onChange } ) {
+	const [ search, setSearch ] = useState( '' );
+	const [ value, setValue ] = useState( EMPTY_ARRAY );
+	const [ suggestions, setSuggestions ] = useState( EMPTY_ARRAY );
+	const debouncedSearch = useDebounce( setSearch, 250 );
+	const { searchResults, searchHasResolved } = useSelect(
+		( select ) => {
+			if ( ! search ) {
+				return {
+					searchResults: EMPTY_ARRAY,
+					searchHasResolved: true,
+				};
+			}
+			const { getEntityRecords, hasFinishedResolution } =
+				select( coreStore );
+			const selectorArgs = [
+				'taxonomy',
+				taxonomy.slug,
+				{
+					...BASE_QUERY,
+					search,
+					orderby: 'name',
+					exclude: termIds,
+					per_page: 20,
+				},
+			];
+			return {
+				searchResults: getEntityRecords( ...selectorArgs ),
+				searchHasResolved: hasFinishedResolution(
+					'getEntityRecords',
+					selectorArgs
+				),
+			};
+		},
+		[ search, termIds ]
+	);
+	// `existingTerms` are the ones fetched from the API and their type is `{ id: number; name: string }`.
+	// They are used to extract the terms' names to populate the `FormTokenField` properly
+	// and to sanitize the provided `termIds`, by setting only the ones that exist.
+	const existingTerms = useSelect(
+		( select ) => {
+			if ( ! termIds?.length ) {
+				return EMPTY_ARRAY;
+			}
+			const { getEntityRecords } = select( coreStore );
+			return getEntityRecords( 'taxonomy', taxonomy.slug, {
+				...BASE_QUERY,
+				include: termIds,
+				per_page: termIds.length,
+			} );
+		},
+		[ termIds ]
+	);
+	// Update the `value` state only after the selectors are resolved
+	// to avoid emptying the input when we're changing terms.
+	useEffect( () => {
+		if ( ! termIds?.length ) {
+			setValue( EMPTY_ARRAY );
+		}
+		if ( ! existingTerms?.length ) {
+			return;
+		}
+		// Returns only the existing entity ids. This prevents the component
+		// from crashing in the editor, when non existing ids are provided.
+		const sanitizedValue = termIds.reduce( ( accumulator, id ) => {
+			const entity = existingTerms.find( ( term ) => term.id === id );
+			if ( entity ) {
+				accumulator.push( {
+					id,
+					value: entity.name,
+				} );
+			}
+			return accumulator;
+		}, [] );
+		setValue( sanitizedValue );
+	}, [ termIds, existingTerms ] );
+	// Update suggestions only when the query has resolved.
+	useEffect( () => {
+		if ( ! searchHasResolved ) {
+			return;
+		}
+		setSuggestions( searchResults.map( ( result ) => result.name ) );
+	}, [ searchResults, searchHasResolved ] );
+	const onTermsChange = ( newTermValues ) => {
+		const newTermIds = new Set();
+		for ( const termValue of newTermValues ) {
+			const termId = getTermIdByTermValue( searchResults, termValue );
+			if ( termId ) {
+				newTermIds.add( termId );
+			}
+		}
+		setSuggestions( EMPTY_ARRAY );
+		onChange( Array.from( newTermIds ) );
+	};
+	return (
+		<FormTokenField
+			label={ taxonomy.name }
+			value={ value }
+			onInputChange={ debouncedSearch }
+			suggestions={ suggestions }
+			displayTransform={ decodeEntities }
+			onChange={ onTermsChange }
+			__experimentalShowHowTo={ false }
+		/>
+	);
+}

--- a/packages/block-library/src/search/utils.js
+++ b/packages/block-library/src/search/utils.js
@@ -1,4 +1,11 @@
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
  * Constants
  */
 export const PC_WIDTH_DEFAULT = 50;
@@ -15,3 +22,64 @@ export const MIN_WIDTH = 220;
 export function isPercentageUnit( unit ) {
 	return unit === '%';
 }
+
+/**
+ * Returns a helper object that contains:
+ * 1. An `options` object from the available post types, to be passed to a `SelectControl`.
+ * 2. A helper map with available taxonomies per post type.
+ *
+ * @return {Object} The helper object related to post types.
+ */
+export const usePostTypes = () => {
+	const postTypes = useSelect( ( select ) => {
+		const { getPostTypes } = select( coreStore );
+		const excludedPostTypes = [ 'attachment' ];
+		const filteredPostTypes = getPostTypes( { per_page: -1 } )?.filter(
+			( { viewable, slug } ) =>
+				viewable && ! excludedPostTypes.includes( slug )
+		);
+		return filteredPostTypes;
+	}, [] );
+	const postTypesTaxonomiesMap = useMemo( () => {
+		if ( ! postTypes?.length ) {
+			return;
+		}
+		return postTypes.reduce( ( accumulator, type ) => {
+			accumulator[ type.slug ] = type.taxonomies;
+			return accumulator;
+		}, {} );
+	}, [ postTypes ] );
+	const postTypesSelectOptions = useMemo(
+		() =>
+			( postTypes || [] ).map( ( { labels, slug } ) => ( {
+				label: labels.singular_name,
+				value: slug,
+			} ) ),
+		[ postTypes ]
+	);
+	return { postTypesTaxonomiesMap, postTypesSelectOptions };
+};
+
+/**
+ * Hook that returns the taxonomies associated with a specific post type.
+ *
+ * @param {string} postType The post type from which to retrieve the associated taxonomies.
+ * @return {Object[]} An array of the associated taxonomies.
+ */
+export const useTaxonomies = ( postType ) => {
+	const taxonomies = useSelect(
+		( select ) => {
+			const { getTaxonomies } = select( coreStore );
+			return getTaxonomies( {
+				type: postType,
+				per_page: -1,
+			} );
+		},
+		[ postType ]
+	);
+	return useMemo( () => {
+		return taxonomies?.filter(
+			( { visibility } ) => !! visibility?.publicly_queryable
+		);
+	}, [ taxonomies ] );
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes: #62420 

## Why?
The search block currently does not provide options to limit search results to specific post types or categories. This PR adds the settings to limit the search results based on specific post types or categories. These settings are designed to be similar to those in the `Query Loop` block, utilizing query variables to filter the results displayed on the results page.

## Showcase?
https://github.com/WordPress/gutenberg/assets/77401999/abacda33-29db-47ed-893e-9bc636588370

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Test by turning on and off the toggle of `Limit Search Results`
2. Test by setting the post type to any posts (I have created a CPT `Book`)
3. Test by setting any category or tags (I have created a custom taxonomy `Book Type` for the default posts and the CPT `book`)
