### PR TITLE
Block Bindings / Pattern Overrides: Prevent normal attribute updates when a __default binding exists

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -97,8 +97,9 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			unlock( select( blocksStore ) ).getAllBlockBindingsSources()
 		);
 		const { name, clientId, context } = props;
-		const hasDefaultBinding =
-			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ];
+		const hasPatternOverridesDefaultBinding =
+			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ]
+				?.source === 'core/pattern-overrides';
 		const bindings = useMemo(
 			() =>
 				replacePatternOverrideDefaultBindings(
@@ -215,8 +216,11 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						}
 					}
 
+					// Only apply normal attribute updates to blocks
+					// that have partial bindings. Currently this is
+					// only skipped for pattern overrides sources.
 					if (
-						! hasDefaultBinding &&
+						! hasPatternOverridesDefaultBinding &&
 						Object.keys( keptAttributes ).length
 					) {
 						setAttributes( keptAttributes );
@@ -231,7 +235,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 				context,
 				setAttributes,
 				sources,
-				hasDefaultBinding,
+				hasPatternOverridesDefaultBinding,
 			]
 		);
 

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -97,6 +97,8 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			unlock( select( blocksStore ) ).getAllBlockBindingsSources()
 		);
 		const { name, clientId, context } = props;
+		const hasDefaultBinding =
+			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ];
 		const bindings = useMemo(
 			() =>
 				replacePatternOverrideDefaultBindings(
@@ -213,7 +215,10 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						}
 					}
 
-					if ( Object.keys( keptAttributes ).length ) {
+					if (
+						! hasDefaultBinding &&
+						Object.keys( keptAttributes ).length
+					) {
 						setAttributes( keptAttributes );
 					}
 				} );
@@ -226,6 +231,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 				context,
 				setAttributes,
 				sources,
+				hasDefaultBinding,
 			]
 		);
 


### PR DESCRIPTION
## What?
See #62287, and specifically the comment here - https://github.com/WordPress/gutenberg/issues/62287#issuecomment-2159921605.

When overriding an image block, the image caption set in the media library can show and then unexpectedly disappear after a save and a refresh.

At the moment, the caption field is unsupported as a block binding (or pattern overrides) attribute, so it shouldn't be changeable from a pattern instance. This may change in the future, but that's a separate investigation.

## Why?
The issue happens due to the way block bindings continues to update the unbound attributes for a block. When adding an image to an image block, there are a range of attributes that are set by the block (`url`, `id`, `alt`, `caption` etc), and only some of these are supported by block bindings.

The ones that are supported get set as pattern overrides correctly. The ones that aren't still cause the normal attributes of the block to be updated. This is why the caption can appear. After a refresh, the caption disappears because the blocks in a pattern instance aren't saved anywhere.

The block bindings behavior makes sense for most binding sources. For example, if you only bind an image src to post meta, it's still possible to edit the other attributes. But for patterns, that's not true, users can't edit the unbound attributes.

It's worth noting that it's not just caption, the image block also sets some other attributes that might cause unexpected bugs, so even if caption is supported by block bindings in the future, a change like this is still required.

## How?
The PR addresses it by leveraging the `__default` binding added in https://github.com/WordPress/gutenberg/pull/60694. Essentially it considers the `__default` binding as covering all block attributes, but only the supported ones have active bindings.

## Testing Instructions
1. Add an empty image to a post
2. Select it and create a pattern using the block options menu on the toolbar
3. In the resulting dialog, name the pattern, keep it as a synced pattern, and submit
4. The pattern should be created in the post and selected. Select the 'Edit original' button from the block toolbar to edit the pattern.
5. Select the image
6. From the block inspector's advanced panel, select the Enable Overrides option
7. In the dialog, give the block a name (i.e. 'Image') and submit
8. Save the pattern
9. Go back to the post using the back button in the top bar
10. Select the image block, and select the 'Media Library' upload option
11. Select an image from the media library that has a caption set, or upload one and set a caption and choose it for the block

In this branch: the caption doesn't appear on the image
In trunk: the caption appears on the image but disappears after a refresh

## Screenshots or screencast <!-- if applicable -->
### Before
https://github.com/WordPress/gutenberg/assets/677833/8de70340-aa66-4312-82fe-4e3800d91f12

### After
https://github.com/WordPress/gutenberg/assets/677833/650a0997-957e-43f0-8b67-229ed1619982


