### PR TITLE
Cherry pick script: make authenticated requests

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -170,12 +170,24 @@ async function fetchPRs() {
  * @return {Promise<Object>} Parsed response JSON.
  */
 async function GitHubFetch( path ) {
+	const token = getGitHubAuthToken();
 	const response = await fetch( 'https://api.github.com' + path, {
 		headers: {
 			Accept: 'application/vnd.github.v3+json',
+			Authorization: `Bearer ${ token }`,
 		},
 	} );
 	return await response.json();
+}
+
+/**
+ * Retrieves the GitHub authentication token using `gh auth token`.
+ *
+ * @return {string} The GitHub authentication token.
+ */
+function getGitHubAuthToken() {
+	const result = cli( 'gh', [ 'auth', 'token' ] );
+	return result.trim();
 }
 
 /**

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -186,8 +186,7 @@ async function GitHubFetch( path ) {
  * @return {string} The GitHub authentication token.
  */
 function getGitHubAuthToken() {
-	const result = cli( 'gh', [ 'auth', 'token' ] );
-	return result.trim();
+	return cli( 'gh', [ 'auth', 'token' ] );
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make authenticated requests to the GitHub API.

## Why?
During the 6.6 Beta 2 release, we ran into rate limiting issues due to conflicts that had to be resolved, which meant that we had to run the script multiple times.

Non-authenticated requests have a 60 per hour limit, even on public endpoints.


## How?
In order to avoid it in the future, we can grab the token generated by `gh` and use it to make authenticated requests instead, which have a 5000-per hour limit.

```sh
➜  gutenberg git:(trunk) curl -v --request GET \
--url "https://api.github.com/octocat" \
--header "Authorization: Bearer <TOKEN_GENERATED_BY_GH_CLI>" \
--header "X-GitHub-Api-Version: 2022-11-28"
...
< HTTP/2 200
< server: GitHub.com
< date: Tue, 11 Jun 2024 10:36:15 GMT
< content-type: application/octocat-stream
< content-length: 917
< x-github-api-version-selected: 2022-11-28
< x-ratelimit-limit: 5000
< x-ratelimit-remaining: 4992
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
