### PR TITLE
Add support for local keyframes through a PostCSS plugin.

### DIFF
--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -122,9 +122,10 @@ async function buildCSS( file ) {
 		data: ''.concat( '@use "sass:math";', importLists, contents ),
 	} );
 
-	const result = await postcss(
-		require( '@wordpress/postcss-plugins-preset' )
-	).process( builtSass.css, {
+	const result = await postcss( [
+		require( 'postcss-local-keyframes' ),
+		...require( '@wordpress/postcss-plugins-preset' ),
+	] ).process( builtSass.css, {
 		from: 'src/app.css',
 		to: 'dest/app.css',
 	} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,8 @@
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/widgets": "file:packages/widgets",
 				"@wordpress/wordcount": "file:packages/wordcount",
-				"es-module-shims": "^1.8.2"
+				"es-module-shims": "^1.8.2",
+				"postcss-local-keyframes": "^0.0.2"
 			},
 			"devDependencies": {
 				"@actions/core": "1.9.1",
@@ -42420,6 +42421,17 @@
 			"peerDependencies": {
 				"postcss": "^7.0.0 || ^8.0.1",
 				"webpack": "^5.0.0"
+			}
+		},
+		"node_modules/postcss-local-keyframes": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-local-keyframes/-/postcss-local-keyframes-0.0.2.tgz",
+			"integrity": "sha512-nRN01llvxnqLw1TZu4kBknHwpxPPK3DLLJClQ3eTGhS+jBNyoIAMx0hw+fdiDOy7TXjfnojamPwUm/UxBEZDTw==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.8"
 			}
 		},
 		"node_modules/postcss-media-query-parser": {
@@ -88796,6 +88808,11 @@
 				"klona": "^2.0.5",
 				"semver": "^7.3.5"
 			}
+		},
+		"postcss-local-keyframes": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-local-keyframes/-/postcss-local-keyframes-0.0.2.tgz",
+			"integrity": "sha512-nRN01llvxnqLw1TZu4kBknHwpxPPK3DLLJClQ3eTGhS+jBNyoIAMx0hw+fdiDOy7TXjfnojamPwUm/UxBEZDTw=="
 		},
 		"postcss-media-query-parser": {
 			"version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
 		"@wordpress/warning": "file:packages/warning",
 		"@wordpress/widgets": "file:packages/widgets",
 		"@wordpress/wordcount": "file:packages/wordcount",
-		"es-module-shims": "^1.8.2"
+		"es-module-shims": "^1.8.2",
+		"postcss-local-keyframes": "^0.0.2"
 	},
 	"devDependencies": {
 		"@actions/core": "1.9.1",

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -3,7 +3,7 @@
 	overflow-y: auto;
 }
 
-@keyframes slide-from-right {
+@keyframes local--slide-from-right {
 	from {
 		transform: translateX(50px);
 		opacity: 0;
@@ -14,7 +14,7 @@
 	}
 }
 
-@keyframes slide-from-left {
+@keyframes local--slide-from-left {
 	from {
 		transform: translateX(-50px);
 		opacity: 0;
@@ -47,11 +47,11 @@
 	}
 
 	&.slide-from-left {
-		animation-name: slide-from-left;
+		animation-name: local--slide-from-left;
 	}
 
 	&.slide-from-right {
-		animation-name: slide-from-right;
+		animation-name: local--slide-from-right;
 	}
 
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add the `postcss-local-keyframes` PostCSS plugin ([created and maintained by me](https://github.com/DaniGuardiola/postcss-local-keyframes)) to the build pipeline in order to allow keyframe animation names to be local to their stylesheets.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To prevent them from conflicting with other global CSS definitions. See prior attempt here: https://github.com/WordPress/gutenberg/pull/61940

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Animation names prefixed with `local--` will be prepended with a hash on output. Read the linked plugin README above for full examples and docs. The plugin has been added with default options (global scope by default, notably).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run the build script (`npm run build`) and then look for output CSS files. You can search for `.edit-site-sidebar__screen-wrapper.slide-from-left` to quickly find the output of the file modified in this PR for testing purposes. The output file in this case is `packages/edit-site/build-style/posts.css`.

You should see something like `animation-name: _tpypm_slide-from-left;` (note the hash prefix).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

n/a

## Screenshots or screencast <!-- if applicable -->

n/a
