### PR TITLE
Image lightbox: fix jitter scrolling by adopting css based overflow fix

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -258,12 +258,8 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-class--show-closing-animation="state.showClosingAnimation"
 			data-wp-watch="callbacks.setOverlayFocus"
 			data-wp-on--keydown="actions.handleKeydown"
-			data-wp-on-async--touchstart="actions.handleTouchStart"
-			data-wp-on--touchmove="actions.handleTouchMove"
-			data-wp-on-async--touchend="actions.handleTouchEnd"
 			data-wp-on-async--click="actions.hideLightbox"
 			data-wp-on-async-window--resize="callbacks.setOverlayStyles"
-			data-wp-on-async-window--scroll="actions.handleScroll"
 			tabindex="-1"
 			>
 				<button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button">

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -207,7 +207,7 @@
 
 	.lightbox-image-container {
 		position: absolute;
-		overflow: hidden;
+		// overflow: hidden;
 		top: 50%;
 		left: 50%;
 		transform-origin: top left;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Image lightbox currently uses javascript based scroll position reset on scroll event. This causes slight jitter effect in the UI.

![lightbox-scroll](https://github.com/WordPress/gutenberg/assets/1935113/01ca9032-5894-44e1-8d1c-3b917d9ec36c)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This fix removes the javascript based handlers. Instead it sets `overflow: hidden` to the `body` element when lightbox is invoked and restores its `original overflow state` when lightbox is closed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable "Expand on click" option for the image block in global styles.
2. Add an image to a page or post.
3. Click on the image to expand.
4. Try scrolling with and without this fix. Observe that scroll jitter is gone.
5. Also, test in a touch device.

