### PR TITLE
List View: Respect default shortcuts in modals

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -181,6 +181,12 @@ function ListViewBlock( {
 			return;
 		}
 
+		// Do not handle events if it comes from modals;
+		// retain the default behavior for these keys.
+		if ( event.target.closest( '[role=dialog]' ) ) {
+			return;
+		}
+
 		const isDeleteKey = [ BACKSPACE, DELETE ].includes( event.keyCode );
 
 		// If multiple blocks are selected, deselect all blocks when the user
@@ -196,12 +202,6 @@ function ListViewBlock( {
 			isDeleteKey ||
 			isMatch( 'core/block-editor/remove', event )
 		) {
-			// Do not handle single-key block deletion shortcuts when events come from modals;
-			// retain the default behavior for these keys.
-			if ( isDeleteKey && event.target.closest( '[role=dialog]' ) ) {
-				return;
-			}
-
 			const {
 				blocksToUpdate: blocksToDelete,
 				firstBlockClientId,


### PR DESCRIPTION
Similar to #61606
Fixes #62478

## What?

This PR will respect the default behavior when keyboard events occur in a modal.

This fixes the issue where we couldn't select all the text in modals with `Ctrl + a`, (`command + a`).

## Why?

This is because the event matches the shortcut for selecting all blocks at this point:

https://github.com/WordPress/gutenberg/blob/2d34e2aaa56e52c379b01bed2df2344ba01c9bb4/packages/block-editor/src/components/list-view/block.js#L290

## How?

I initially considered adding special handling for this shortcut. But it seemed more logical to me to just respect the default shortcuts for all events that occur inside a modal.

## Testing Instructions

- Insert some blocks.
- Open the List View and select one block.
- Open the "Rename" or "Create pattern" menu.
- Execute `Ctrl + a`, (`command + a`) in the text field.
- All of the text should be selected.
- Close the modal and select a block from the list view.
- Execute `Ctrl + a`, (`command + a`) in the text field.
- All of the blocks should be selected.
- Bonus: Follow the steps in #61606 to make sure the Delete and BackSpace keys still work.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/b1095b42-7510-41c8-ac66-33a7d729a826


