### PR TITLE
Fix: Unquoted file argument in declaration check script

### DIFF
--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -70,7 +70,7 @@ async function getDecFile( packagePath ) {
 async function typecheckDeclarations( file ) {
 	return new Promise( ( resolve, reject ) => {
 		exec(
-			`npx tsc --target esnext --moduleResolution node --noEmit ${ file }`,
+			`npx tsc --target esnext --moduleResolution node --noEmit "${ file }"`,
 			( error, stdout, stderr ) => {
 				if ( error ) {
 					reject( { file, error, stderr, stdout } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Quote the file argument used in the script that checks compiled types.

## Why?

If a path includes spaces, it's interpreted as multiple arguments causing the script to fail.

[This was mentioned in Core slack](https://wordpress.slack.com/archives/C02QB2JS7/p1718086430650019). @WunderBart noticed the problematic paths seemed to include spaces.

## How?

Quote the file argument.

## Testing Instructions

`npm run build:package-types` should continue to work as expected.
