### PR TITLE
Caption utility component: Allow the main CSS Class Name to be excluded from the markup.

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -121,6 +121,7 @@ export default function QuoteEdit( {
 					}
 					addLabel={ __( 'Add citation' ) }
 					removeLabel={ __( 'Remove citation' ) }
+					excludeMainElementClassName
 					className="wp-block-quote__citation"
 					insertBlocksAfter={ insertBlocksAfter }
 					{ ...( ! isWebPlatform ? { textAlign } : {} ) }

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -121,7 +121,7 @@ export default function QuoteEdit( {
 					}
 					addLabel={ __( 'Add citation' ) }
 					removeLabel={ __( 'Remove citation' ) }
-					excludeMainElementClassName
+					excludeElementClassName
 					className="wp-block-quote__citation"
 					insertBlocksAfter={ insertBlocksAfter }
 					{ ...( ! isWebPlatform ? { textAlign } : {} ) }

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -32,6 +32,7 @@ export function Caption( {
 	placeholder = __( 'Add caption' ),
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
+	excludeMainElementClassName,
 	className,
 	readOnly,
 	tagName = 'figcaption',
@@ -70,6 +71,7 @@ export function Caption( {
 		},
 		[ isCaptionEmpty ]
 	);
+
 	return (
 		<>
 			{ showToolbarButton && (
@@ -96,7 +98,9 @@ export function Caption( {
 						tagName={ tagName }
 						className={ clsx(
 							className,
-							__experimentalGetElementClassName( 'caption' )
+							excludeMainElementClassName
+								? ''
+								: __experimentalGetElementClassName( 'caption' )
 						) }
 						ref={ ref }
 						aria-label={ label }

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -32,7 +32,7 @@ export function Caption( {
 	placeholder = __( 'Add caption' ),
 	label = __( 'Caption text' ),
 	showToolbarButton = true,
-	excludeMainElementClassName,
+	excludeElementClassName,
 	className,
 	readOnly,
 	tagName = 'figcaption',
@@ -98,7 +98,7 @@ export function Caption( {
 						tagName={ tagName }
 						className={ clsx(
 							className,
-							excludeMainElementClassName
+							excludeElementClassName
 								? ''
 								: __experimentalGetElementClassName( 'caption' )
 						) }


### PR DESCRIPTION
## What?

Extending the Caption utility component by allowing the main CSS Class Name to be excluded from the HTML Markup using a prop called `excludeElementClassName`. Also, the Quote block was modified to use the prop.

## Why?

This update is related to this issue: [62208](https://github.com/WordPress/gutenberg/issues/62208)

The new prop allows us to reuse the existing Caption component in places where its main CSS Class Name (`.wp-element-caption`) isn't needed.

## How?

It addresses the issue by adding a prop to the Caption component, which excludes the main CSS Class Name when needed.

## Testing Instructions

1. Insert a Quote block with a citation.
2. Inspect the HTML markup of the block.
3. The `wp-element-caption` CSS Class Name shouldn't exist in the `<cite>` element.
4. Insert a Gallery block with some images and add captions to them.
5. Inspect the HTML markup of an image caption.
6. The `wp-element-caption` CSS Class Name should exist in the `<figcaption>` element.

