### PR TITLE
Fix: Invalid link on explanations documentation.

### DIFF
--- a/docs/explanations/README.md
+++ b/docs/explanations/README.md
@@ -8,5 +8,5 @@
 -   [Block Editor Performance](/docs/explanations/architecture/performance.md).
 -   What are the decision decisions behind the Data Module?
 -   [Why is Puppeteer the tool of choice for end-to-end tests?](/docs/explanations/architecture/automated-testing.md)
--   [What’s the difference between the different editor packages? What’s the purpose of each package?](/docs/explanations/architecture/modularity.md/#whats-the-difference-between-the-different-editor-packages-whats-the-purpose-of-each-package)
+-   [What’s the difference between the different editor packages? What’s the purpose of each package?](/docs/explanations/architecture/modularity.md#whats-the-difference-between-the-different-editor-packages-whats-the-purpose-of-each-package)
 -   [Template and template parts flows](/docs/explanations/architecture/full-site-editing-templates.md)


### PR DESCRIPTION
The section "What’s the difference between the different editor packages? What’s the purpose of each package?" does not exist anymore but the link to it was kept.
This PR removes the invalid link.
