### PR TITLE
Fix: Post_type template is not used when creating a page in site editor.

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -30,3 +30,51 @@ if ( ! function_exists( 'gutenberg_register_edit_site_export_controller_endpoint
 }
 
 add_action( 'rest_api_init', 'gutenberg_register_edit_site_export_controller_endpoints' );
+
+if ( ! function_exists( 'gutenberg_register_wp_rest_post_types_controller_fields' ) ) {
+	/**
+	 * Adds `template` and `template_lock` fields to WP_REST_Post_Types_Controller class.
+	 */
+	function gutenberg_register_wp_rest_post_types_controller_fields() {
+		register_rest_field(
+			'type',
+			'template',
+			array(
+				'get_callback' => function ( $item ) {
+					$post_type = get_post_type_object( $item['slug'] );
+					if ( ! empty( $post_type ) && ! empty( $post_type->template ) ) {
+						return $post_type->template;
+					}
+					return null;
+				},
+				'schema'       => array(
+					'type'        => 'array',
+					'description' => __( 'The template associated with the post type.', 'gutenberg' ),
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+			)
+		);
+		register_rest_field(
+			'type',
+			'template_lock',
+			array(
+				'get_callback' => function ( $item ) {
+					$post_type = get_post_type_object( $item['slug'] );
+					if ( ! empty( $post_type ) && ! empty( $post_type->template_lock ) ) {
+						return $post_type->template_lock;
+					}
+					return null;
+				},
+				'schema'       => array(
+					'type'        => 'string',
+					'emum'        => array( 'all', 'insert', 'contentOnly' ),
+					'description' => __( 'The template_lock specified for the post type.', 'gutenberg' ),
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+			)
+		);
+	}
+}
+add_action( 'rest_api_init', 'gutenberg_register_wp_rest_post_types_controller_fields' );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -68,7 +68,7 @@ if ( ! function_exists( 'gutenberg_register_wp_rest_post_types_controller_fields
 				},
 				'schema'       => array(
 					'type'        => 'string',
-					'emum'        => array( 'all', 'insert', 'contentOnly' ),
+					'enum'        => array( 'all', 'insert', 'contentOnly' ),
 					'description' => __( 'The template_lock specified for the post type.', 'gutenberg' ),
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -45,7 +45,6 @@ if ( ! function_exists( 'gutenberg_register_wp_rest_post_types_controller_fields
 					if ( ! empty( $post_type ) && ! empty( $post_type->template ) ) {
 						return $post_type->template;
 					}
-					return null;
 				},
 				'schema'       => array(
 					'type'        => 'array',
@@ -61,10 +60,9 @@ if ( ! function_exists( 'gutenberg_register_wp_rest_post_types_controller_fields
 			array(
 				'get_callback' => function ( $item ) {
 					$post_type = get_post_type_object( $item['slug'] );
-					if ( ! empty( $post_type ) && ! empty( $post_type->template_lock ) ) {
+					if ( ! empty( $post_type ) && ! empty( $post_type->template_lock ) && false !== $post_type->template_lock ) {
 						return $post_type->template_lock;
 					}
-					return null;
 				},
 				'schema'       => array(
 					'type'        => 'string',

--- a/packages/edit-site/src/components/add-new-page/index.js
+++ b/packages/edit-site/src/components/add-new-page/index.js
@@ -9,11 +9,12 @@ import {
 	TextControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useRegistry } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 import { decodeEntities } from '@wordpress/html-entities';
+import { serialize, synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 
 export default function AddNewPageModal( { onSave, onClose } ) {
 	const [ isCreatingPage, setIsCreatingPage ] = useState( false );
@@ -22,6 +23,7 @@ export default function AddNewPageModal( { onSave, onClose } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
+	const { resolveSelect } = useRegistry();
 
 	async function createPage( event ) {
 		event.preventDefault();
@@ -31,6 +33,8 @@ export default function AddNewPageModal( { onSave, onClose } ) {
 		}
 		setIsCreatingPage( true );
 		try {
+			const pagePostType =
+				await resolveSelect( coreStore ).getPostType( 'page' );
 			const newPage = await saveEntityRecord(
 				'postType',
 				'page',
@@ -38,6 +42,14 @@ export default function AddNewPageModal( { onSave, onClose } ) {
 					status: 'draft',
 					title,
 					slug: title || __( 'No title' ),
+					content: !! pagePostType.template
+						? serialize(
+								synchronizeBlocksWithTemplate(
+									[],
+									pagePostType.template
+								)
+						  )
+						: undefined,
 				},
 				{ throwOnError: true }
 			);


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/60710

The site editor now allows to create a new page but if the page post type has a template assigned to it the template is ignored.
This PR fixes the issue.

To fix the issue, the Rest API has been extended for the types endpoint. Two new fields were added template and template_lock.


## Testing Instructions
I added the following test code to scrip-loader.php.
```
function myplugin_register_template() {
    $post_type_object = get_post_type_object( 'page' );
    $post_type_object->template = array(
        array( 'core/image' ),
    );
}
add_action( 'init', 'myplugin_register_template' );
```
I created a new page on the site editor and verified the template was used as expected.

