### PR TITLE
remove: unnessary theme installation at docker setup

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,10 +8,7 @@
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
-				"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",
-				"wp-content/themes/gutenberg-test-themes/twentytwentyone": "https://downloads.wordpress.org/theme/twentytwentyone.2.1.zip",
-				"wp-content/themes/gutenberg-test-themes/twentytwentythree": "https://downloads.wordpress.org/theme/twentytwentythree.1.3.zip",
-				"wp-content/themes/gutenberg-test-themes/twentytwentyfour": "https://downloads.wordpress.org/theme/twentytwentyfour.1.0.zip"
+				"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes"
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR removes TT4, TT3 and TT1 theme installation when running `npm run wp-env start` as we are already getting all default themes from WordPress.

## Why?
https://github.com/WordPress/gutenberg/issues/62491

## How?
remove unnecessary theme installations from `.wp-env.json` file.

## Screenshot after modifying `.wp-env.json`

<img width="1341" alt="Screenshot 2024-06-11 at 23 36 24" src="https://github.com/WordPress/gutenberg/assets/75293077/fbb7d043-4a6a-450c-b464-128e14de94c1">
