### PR TITLE
Global Styles: Fix registration of theme style variation defined block styles

### DIFF
--- a/backport-changelog/6.6/6756.md
+++ b/backport-changelog/6.6/6756.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/6756
 
 * https://github.com/WordPress/gutenberg/pull/62461
+* https://github.com/WordPress/gutenberg/pull/62495

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -330,6 +330,25 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Controller {
 			} elseif ( isset( $existing_config['styles'] ) ) {
 				$config['styles'] = $existing_config['styles'];
 			}
+
+			/*
+			 * If the incoming request is going to create a new variation
+			 * that is not yet registered, we register it here.
+			 * This is because the variations are registered on init,
+			 * but we want this endpoint to return the new variation immediately:
+			 * if we don't register it, it'll be stripped out of the response
+			 * just in this request (subsequent ones will be ok).
+			 * Take the variations defined in styles.blocks.variations from the incoming request
+			 * that are not part of the $existing_config.
+			 */
+			if ( isset( $request['styles']['blocks']['variations'] ) ) {
+				$existing_variations = isset( $existing_config['styles']['blocks']['variations'] ) ? $existing_config['styles']['blocks']['variations'] : array();
+				$new_variations      = array_diff_key( $request['styles']['blocks']['variations'], $existing_variations );
+				if ( ! empty( $new_variations ) ) {
+					gutenberg_register_block_style_variations_from_theme_json_data( $new_variations );
+				}
+			}
+
 			if ( isset( $request['settings'] ) ) {
 				$config['settings'] = $request['settings'];
 			} elseif ( isset( $existing_config['settings'] ) ) {

--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -514,6 +514,56 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 	}
 
 	/**
+	 * Tests the submission of a custom block style variation that was defined
+	 * within a theme style variation and wouldn't be registered at the time
+	 * of saving via the API.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::update_item
+	 */
+	public function test_update_item_with_custom_block_style_variations() {
+		wp_set_current_user( self::$admin_id );
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
+
+		$group_variations = array(
+			'fromThemeStyleVariation' => array(
+				'color' => array(
+					'background' => '#ffffff',
+					'text'       => '#000000',
+				),
+			),
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/global-styles/' . self::$global_styles_id );
+		$request->set_body_params(
+			array(
+				'styles' => array(
+					'blocks' => array(
+						'variations' => array(
+							'fromThemeStyleVariation' => array(
+								'blockTypes' => array( 'core/group', 'core/columns' ),
+								'color'      => array(
+									'background' => '#000000',
+									'text'       => '#ffffff',
+								),
+							),
+						),
+						'core/group' => array(
+							'variations' => $group_variations,
+						),
+					),
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSame( $group_variations, $data['styles']['blocks']['core/group']['variations'] );
+	}
+
+	/**
 	 * @doesNotPerformAssertions
 	 */
 	public function test_delete_item() {


### PR DESCRIPTION
Addresses https://github.com/WordPress/wordpress-develop/pull/6756#issuecomment-2160027377

## What?

Ensures theme style variation defined block style variations are supported when saving global styles via the the REST API.

## Why?

If block style variations aren't registered they are stripping out during the sanitization of theme json data. This makes it appear as though global style customizations have been lost until the editor is reloaded.

## How?

When a theme style variation is selected, its values are copied into the user origin data to be saved. This includes the shared block style variation definitions that need registering.

The REST API has been updated to register shared block style variations prior to saving the global styles. This maintains the data for variations they weren't able to be registered via the normal `init` filter.

## Testing Instructions

1. Register style variations the `styles/ember.json` (theme style variation) file, paste the following under styles.blocks.variations:

```json
"VariationDark": {
    "blockTypes": [
        "core/group",
        "core/columns"
    ],
    "color": {
            "background": "yellow"
    }
}
```

2. Open the site editor, go to Styles, apply the "Ember" theme style variation **AND DO NOT SAVE IT YET**. 
3. Go to the site editor, select a group block, and verify the VariationDark is available:
4. Update the `VariationDark` variation by going to "Global Styles > Blocks > Group > VariationDark". Modify the background color to something else.
5. Save the post. The expected result is that the new background stays as it is and it's not reset. 
6. Confirm the global styles API unit tests pass:
`npm run test:unit:php:base -- --filter WP_REST_Global_Styles_Controller_Gutenberg_Test::test_update_item_with_custom_block_style_variations`

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/d73323b3-d6b8-429e-8374-3113c3d66b49" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/bf99346d-1432-4ce0-b29c-4886431f1ad4" /> |

