### PR TITLE
Verse block: add background image and minimum height support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -948,7 +948,7 @@ Insert poetry. Use special spacing formats. Or quote song lyrics. ([Source](http
 
 -	**Name:** core/verse
 -	**Category:** text
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** content, textAlign
 
 ## Video

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -21,12 +21,25 @@
 	},
 	"supports": {
 		"anchor": true,
+		"background": {
+			"backgroundImage": true,
+			"backgroundSize": true,
+			"__experimentalDefaultControls": {
+				"backgroundImage": true
+			}
+		},
 		"color": {
 			"gradients": true,
 			"link": true,
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true
+			}
+		},
+		"dimensions": {
+			"minHeight": true,
+			"__experimentalDefaultControls": {
+				"minHeight": false
 			}
 		},
 		"typography": {


### PR DESCRIPTION
## What?

This PR adds support for background images for the Verse block. 

For flexibility to display varying image heights, it also opts in to minimum height, but not as a default control.

## Why?

The Verse block contains a pre element that formats text as it would be presented in the browser. Top notch for poetry!

The ability to add background images extends visual differentiation, and allows users to set unique design patterns. 

Example:


<img width="488" alt="Screenshot 2024-06-12 at 3 02 22 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/4cdde2b8-54fe-43f6-aba9-251be5628a9b">



As for adding minimum height support, it ensures that users can adequately space Verse blocks to accommodate taller images.

## How?

Turning on the block supports in block.json

## Testing Instructions

Add a Verse block to a post.

Select a background image, and play around with minimum height and other styles according to your fancy.

Here's some HTML to get you started:

```html
<!-- wp:verse -->
<pre class="wp-block-verse">When the letter arrived,<br>     and a day so contrived.<br><br>the first word of it, scrawled and thin<br>     breath drawing in<br><br>I read it, and read it<br>      I read it again.<br><br>With the sun in the west,<br>I stubbed out the candle<br>    And with the beef casserole,<br>    threw it all out with the rest.     <br></pre>
<!-- /wp:verse -->
```