### PR TITLE
Post content block: add background image and padding support 

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -616,7 +616,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 -	**Name:** core/post-content
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~
 
 ## Date
 

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -11,11 +11,23 @@
 		"align": [ "wide", "full" ],
 		"html": false,
 		"layout": true,
+		"background": {
+			"backgroundImage": true,
+			"backgroundSize": true,
+			"__experimentalDefaultControls": {
+				"backgroundImage": true
+			}
+		},
 		"dimensions": {
 			"minHeight": true
 		},
 		"spacing": {
-			"blockGap": true
+			"blockGap": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
 		},
 		"color": {
 			"gradients": true,


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add support for background images for post content block. For flexibility to allow background images to wrap the text, also opt in to padding, but not as default controls

## Why?

The Post Content block usually appears as a single block in templates to wrap post and page content.

Background images widen the array of tools at the user's disposal to create unique designs.
As for adding padding support, it ensures that users can adequately space text away from the top of the block.


| Without padding  | With padding |
| ------------- | ------------- |
| <img width="400" alt="Screenshot 2024-06-12 at 3 19 32 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/de45bfb6-fac6-4ba8-acdd-2d3f7687b9e0"> | <img width="400" alt="Screenshot 2024-06-12 at 3 19 17 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/fda43c85-98fc-4f4d-8a2b-8006aebe045d"> |




## How?

Turning on the block supports in block.json

## Testing Instructions

Head over to the Site Editor and select a template that has a Post Content block in it, e.g., single posts or pages template in 2024.

Select a background image, and play around with other styles according to your whim.

