### PR TITLE
 Restore "Edit site" in Gutenberg plugin

### DIFF
--- a/lib/compat/wordpress-6.6/admin-bar.php
+++ b/lib/compat/wordpress-6.6/admin-bar.php
@@ -32,7 +32,7 @@ function gutenberg_admin_bar_edit_site_menu( $wp_admin_bar ) {
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'site-editor',
-			'title' => __( 'Site Editor' ),
+			'title' => __( 'Edit site' ),
 			'href'  => add_query_arg(
 				array(
 					'postType' => 'wp_template',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/62493

This PR Update admin menu text to `Edit site` from `Site Editor`