### PR TITLE
Change `Site Editor` to `Edit site`

### DIFF
--- a/lib/compat/wordpress-6.6/admin-bar.php
+++ b/lib/compat/wordpress-6.6/admin-bar.php
@@ -32,7 +32,7 @@ function gutenberg_admin_bar_edit_site_menu( $wp_admin_bar ) {
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'site-editor',
-			'title' => __( 'Site Editor' ),
+			'title' => __( 'Edit site' ),
 			'href'  => add_query_arg(
 				array(
 					'postType' => 'wp_template',

--- a/lib/compat/wordpress-6.6/admin-bar.php
+++ b/lib/compat/wordpress-6.6/admin-bar.php
@@ -43,6 +43,18 @@ function gutenberg_admin_bar_edit_site_menu( $wp_admin_bar ) {
 			),
 		)
 	);
+
+	if ( is_blog_admin() && is_multisite() && current_user_can( 'manage_sites' ) ) {
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'site-name',
+				'id'     => 'edit-site',
+				'title'  => __( 'Manage Site' ),
+				'href'   => network_admin_url( 'site-info.php?id=' . get_current_blog_id() ),
+			)
+		);
+	}
+
 }
 remove_action( 'admin_bar_menu', 'wp_admin_bar_edit_site_menu', 40 );
 add_action( 'admin_bar_menu', 'gutenberg_admin_bar_edit_site_menu', 41 );

--- a/lib/compat/wordpress-6.6/admin-bar.php
+++ b/lib/compat/wordpress-6.6/admin-bar.php
@@ -25,7 +25,7 @@ function gutenberg_admin_bar_edit_site_menu( $wp_admin_bar ) {
 	}
 
 	// Don't show for users who can't edit theme options or when in the admin.
-	if ( ! current_user_can( 'edit_theme_options' ) || is_admin() ) {
+	if ( ! current_user_can( 'edit_theme_options' ) || is_admin() || ( is_blog_admin() && is_multisite() && current_user_can( 'manage_sites' ) ) ) {
 		return;
 	}
 
@@ -43,18 +43,6 @@ function gutenberg_admin_bar_edit_site_menu( $wp_admin_bar ) {
 			),
 		)
 	);
-
-	if ( is_blog_admin() && is_multisite() && current_user_can( 'manage_sites' ) ) {
-		$wp_admin_bar->add_node(
-			array(
-				'parent' => 'site-name',
-				'id'     => 'edit-site',
-				'title'  => __( 'Manage Site' ),
-				'href'   => network_admin_url( 'site-info.php?id=' . get_current_blog_id() ),
-			)
-		);
-	}
-
 }
 remove_action( 'admin_bar_menu', 'wp_admin_bar_edit_site_menu', 40 );
 add_action( 'admin_bar_menu', 'gutenberg_admin_bar_edit_site_menu', 41 );


### PR DESCRIPTION
## What?
Change site editor to edit site

## Why?
Fixes: #62493 

## Screenshots or screencast <!-- if applicable -->
<img width="689" alt="Screenshot 2024-06-12 at 11 02 15" src="https://github.com/WordPress/gutenberg/assets/75293077/373ae883-aa16-47da-bc82-8629e5957757">
