### PR TITLE
Adds address tag to template part and group & cover block.

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -159,7 +159,7 @@ export default function CoverInspectorControls( {
 			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
 		),
 		address: __(
-			'The <address> element should contain contact information for its nearest <article> or <body> ancestor.).'
+			'The <address> element should contain contact information for its nearest <article> or <body> ancestor.'
 		),
 		footer: __(
 			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -158,6 +158,9 @@ export default function CoverInspectorControls( {
 		aside: __(
 			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
 		),
+		address: __(
+			'The <address> element should contain contact information for its nearest <article> or <body> ancestor.).'
+		),
 		footer: __(
 			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
 		),
@@ -353,6 +356,7 @@ export default function CoverInspectorControls( {
 						{ label: '<section>', value: 'section' },
 						{ label: '<article>', value: 'article' },
 						{ label: '<aside>', value: 'aside' },
+						{ label: '<address>', value: 'address' },
 						{ label: '<footer>', value: 'footer' },
 					] }
 					value={ tagName }

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -46,7 +46,7 @@ function GroupEditControls( { tagName, onSelectTagName } ) {
 			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
 		),
 		address: __(
-			'The <address> element should contain contact information for its nearest <article> or <body> ancestor.).'
+			'The <address> element should contain contact information for its nearest <article> or <body> ancestor.'
 		),
 		footer: __(
 			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -45,6 +45,9 @@ function GroupEditControls( { tagName, onSelectTagName } ) {
 		aside: __(
 			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
 		),
+		address: __(
+			'The <address> element should contain contact information for its nearest <article> or <body> ancestor.).'
+		),
 		footer: __(
 			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
 		),
@@ -62,6 +65,7 @@ function GroupEditControls( { tagName, onSelectTagName } ) {
 					{ label: '<section>', value: 'section' },
 					{ label: '<article>', value: 'article' },
 					{ label: '<aside>', value: 'aside' },
+					{ label: '<address>', value: 'address' },
 					{ label: '<footer>', value: 'footer' },
 				] }
 				value={ tagName }

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -28,7 +28,7 @@ const htmlElementMessages = {
 		"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
 	),
 	address: __(
-		'The <address> element should contain contact information for its nearest <article> or <body> ancestor.).'
+		'The <address> element should contain contact information for its nearest <article> or <body> ancestor.'
 	),
 	footer: __(
 		'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -27,6 +27,9 @@ const htmlElementMessages = {
 	aside: __(
 		"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
 	),
+	address: __(
+		'The <address> element should contain contact information for its nearest <article> or <body> ancestor.).'
+	),
 	footer: __(
 		'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
 	),
@@ -111,6 +114,7 @@ export function TemplatePartAdvancedControls( {
 					{ label: '<article>', value: 'article' },
 					{ label: '<aside>', value: 'aside' },
 					{ label: '<footer>', value: 'footer' },
+					{ label: '<address>', value: 'address' },
 					{ label: '<div>', value: 'div' },
 				] }
 				value={ tagName || '' }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes: #62494 

## Why?
See [this](https://github.com/WordPress/gutenberg/issues/62494#issue-2347262293)

## How?
Adds `address` tag option to the HTML elements in template part, cover & group blocks.

## Screencast
https://github.com/WordPress/gutenberg/assets/77401999/2c4b8d0f-2dbc-4ddf-9e2c-5fdbccbf6621
