### PR TITLE
Add entity type for individual Term objects

### DIFF
--- a/packages/core-data/src/entity-types/index.ts
+++ b/packages/core-data/src/entity-types/index.ts
@@ -15,6 +15,7 @@ import type { PostRevision } from './post-revision';
 import type { Settings } from './settings';
 import type { Sidebar } from './sidebar';
 import type { Taxonomy } from './taxonomy';
+import type { Term } from './term';
 import type { Theme } from './theme';
 import type { User } from './user';
 import type { Type } from './type';
@@ -40,6 +41,7 @@ export type {
 	Settings,
 	Sidebar,
 	Taxonomy,
+	Term,
 	Theme,
 	Updatable,
 	User,

--- a/packages/core-data/src/entity-types/term.ts
+++ b/packages/core-data/src/entity-types/term.ts
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies
+ */
+import type { Context, ContextualField, OmitNevers } from './helpers';
+
+import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+
+declare module './base-entity-records' {
+	export namespace BaseEntityRecords {
+		export interface Term< C extends Context > {
+			/**
+			 * A human-readable description of the term.
+			 */
+			description: ContextualField< string, 'view' | 'edit', C >;
+			/**
+			 * The title for the term.
+			 */
+			name: string;
+			/**
+			 * An alphanumeric identifier for the term.
+			 */
+			slug: string;
+			/**
+			 * The number of objects with the term.
+			 */
+			count: number;
+			/**
+			 * The ID for the term.
+			 */
+			id: number;
+			/**
+			 * The link for the term.
+			 */
+			link: string;
+			/**
+			 * Meta fields for the term.
+			 */
+			meta: { [ key: string ]: unknown };
+			/**
+			 * The parent term ID.
+			 */
+			parent: number;
+			/**
+			 * The term taxonomy slug.
+			 */
+			taxonomy: string;
+		}
+	}
+}
+
+export type Term< C extends Context = 'edit' > = OmitNevers<
+	_BaseEntityRecords.Term< C >
+>;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a new `Term` type to the available entity types exported from the `core-data` package.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

' getEntityRecord' is commonly used to deal with individual terms outside of any taxonomy. Currently, we don't expose any types for it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding the type to the correct folder and exporting it.