### PR TITLE
Ensure that openref is defined before accessing to .current

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -40,6 +40,8 @@ export function useInBetweenInserter() {
 			}
 
 			function onMouseMove( event ) {
+				// openRef is the reference to the insertion point between blocks.
+				// If the reference is not set or the insertion point is already open, return.
 				if ( openRef === undefined || openRef.current ) {
 					return;
 				}

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -40,7 +40,7 @@ export function useInBetweenInserter() {
 			}
 
 			function onMouseMove( event ) {
-				if ( openRef.current ) {
+				if ( openRef === undefined || openRef.current ) {
 					return;
 				}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR improves a check to ensure that JS errors aren't triggered. You can see more details at: https://github.com/woocommerce/woocommerce/issues/48308



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

By default, InsertionPointOpenRef is defined as an empty context in Gutenberg. You can find the context definition [here](https://github.com/WordPress/gutenberg/blob/c06914890b23b26542a616487fde6a6b6a09df8b/packages/block-editor/src/components/block-tools/index.js).

When Gutenberg is used as a framework, the BlockTools component ([that defined the context](https://github.com/WordPress/gutenberg/blob/c06914890b23b26542a616487fde6a6b6a09df8b/packages/block-editor/src/components/block-tools/index.js/#L192-L193)) may not be utilized in some projects (e.g., Customize Your Store project). In such cases, JavaScript will throw an error at the following line: [use-in-between-inserter.js#L43](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-list/use-in-between-inserter.js#L43).

To prevent this error, we need to update the check for InsertionPointOpenRef to handle scenarios where the context isn't defined. This PR will ensure that the context is defined, avoiding runtime errors.




