### PR TITLE
mess with focus

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -150,7 +150,10 @@ class PrivateInserter extends Component {
 			prioritizePatterns,
 			onSelectOrClose,
 			selectBlockOnInsert,
+			isInserterOpened,
 		} = this.props;
+
+		console.log( 'index', 'isInsertOpened', isInserterOpened );
 
 		if ( isQuick ) {
 			return (
@@ -186,6 +189,7 @@ class PrivateInserter extends Component {
 				clientId={ clientId }
 				isAppender={ isAppender }
 				showInserterHelpPanel={ showInserterHelpPanel }
+				isInserterOpened={ isInserterOpened }
 			/>
 		);
 	}
@@ -421,6 +425,7 @@ export const ComposedPrivateInserter = compose( [
 ] )( PrivateInserter );
 
 const Inserter = forwardRef( ( props, ref ) => {
+	console.log( 'InserterProps', props );
 	return <ComposedPrivateInserter ref={ ref } { ...props } />;
 } );
 

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -27,6 +27,7 @@ function InserterLibrary(
 		onSelect = noop,
 		shouldFocusBlock = false,
 		onClose,
+		isInserterOpened,
 	},
 	ref
 ) {
@@ -58,6 +59,7 @@ function InserterLibrary(
 			shouldFocusBlock={ shouldFocusBlock }
 			ref={ ref }
 			onClose={ onClose }
+			isInserterOpened={ isInserterOpened }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -12,7 +12,6 @@ import {
 	useCallback,
 	useMemo,
 	useRef,
-	useLayoutEffect,
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -49,6 +48,7 @@ function InserterMenu(
 		onClose,
 		__experimentalInitialTab,
 		__experimentalInitialCategory,
+		isInserterOpened,
 	},
 	ref
 ) {
@@ -294,18 +294,6 @@ function InserterMenu(
 		setSelectedTab( value );
 	};
 
-	// Focus first active tab, if any
-	const tabsRef = useRef();
-	useLayoutEffect( () => {
-		if ( tabsRef.current ) {
-			window.requestAnimationFrame( () => {
-				tabsRef.current
-					.querySelector( '[role="tab"][aria-selected="true"]' )
-					?.focus();
-			} );
-		}
-	}, [] );
-
 	return (
 		<div
 			className={ clsx( 'block-editor-inserter__menu', {
@@ -316,10 +304,10 @@ function InserterMenu(
 		>
 			<div className="block-editor-inserter__main-area">
 				<InserterTabs
-					ref={ tabsRef }
 					onSelect={ handleSetSelectedTab }
 					onClose={ onClose }
 					selectedTab={ selectedTab }
+					isInserterOpened={ isInserterOpened }
 				>
 					{ inserterSearch }
 					{ selectedTab === 'blocks' &&

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -6,7 +6,12 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { forwardRef } from '@wordpress/element';
+import {
+	forwardRef,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+} from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 
 /**
@@ -33,13 +38,36 @@ const mediaTab = {
 	title: __( 'Media' ),
 };
 
-function InserterTabs( { onSelect, children, onClose, selectedTab }, ref ) {
+function InserterTabs(
+	{ onSelect, children, onClose, selectedTab, isInserterOpened },
+	ref
+) {
 	const tabs = [ blocksTab, patternsTab, mediaTab ];
+	console.log( 'isInserterOpened', isInserterOpened );
+	// Focus first active tab, if any
+	const tabsRef = useRef();
+	useEffect( () => {
+		console.log( tabsRef );
+		if ( tabsRef?.current ) {
+			//window.requestAnimationFrame( () => {
+			console.log( 'focus' );
+			console.log( document.activeElement );
+			console.log( tabsRef?.current.innerHTML );
+			console.log( selectedTab );
+			console.log( tabsRef?.current?.querySelector( '[role="tab"]' ) );
+
+			tabsRef?.current?.querySelector( '[role="tab"]' )?.focus();
+			//} );
+		}
+	}, [ isInserterOpened ] );
 
 	return (
 		<div className="block-editor-inserter__tabs" ref={ ref }>
 			<Tabs onSelect={ onSelect } selectedTabId={ selectedTab }>
-				<div className="block-editor-inserter__tablist-and-close-button">
+				<div
+					className="block-editor-inserter__tablist-and-close-button"
+					ref={ tabsRef }
+				>
 					<Button
 						className="block-editor-inserter__close-button"
 						icon={ closeSmall }

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -146,9 +146,11 @@ export default function EditorInterface( {
 			editorNotices={ <EditorNotices /> }
 			secondarySidebar={
 				! isPreviewMode &&
-				mode === 'visual' &&
-				( ( isInserterOpened && <InserterSidebar /> ) ||
-					( isListViewOpened && <ListViewSidebar /> ) )
+				mode === 'visual' && (
+					<>
+						<InserterSidebar /> <ListViewSidebar />{ ' ' }
+					</>
+				)
 			}
 			sidebar={
 				! isPreviewMode &&

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -30,6 +30,7 @@ export default function InserterSidebar() {
 		insertionPoint,
 		showMostUsedBlocks,
 		sidebarIsOpened,
+		isInserterOpened,
 	} = useSelect( ( select ) => {
 		const {
 			getInserterSidebarToggleRef,
@@ -57,6 +58,7 @@ export default function InserterSidebar() {
 			sidebarIsOpened: !! (
 				getActiveComplementaryArea( 'core' ) || isPublishSidebarOpened()
 			),
+			isInserterOpened: select( editorStore ).isInserterOpened(),
 		};
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( editorStore );
@@ -105,6 +107,7 @@ export default function InserterSidebar() {
 				}
 				ref={ libraryRef }
 				onClose={ closeInserterSidebar }
+				isInserterOpened={ isInserterOpened }
 			/>
 		</div>
 	);
@@ -120,11 +123,13 @@ export default function InserterSidebar() {
 			</div>
 		);
 	}
+
 	return (
 		<div
 			ref={ inserterDialogRef }
 			{ ...inserterDialogProps }
 			className="editor-inserter-sidebar"
+			style={ { display: isInserterOpened ? 'block' : 'none' } }
 		>
 			{ inserterContents }
 		</div>


### PR DESCRIPTION
This is an attempt to address https://github.com/WordPress/gutenberg/issues/62441

My observation is that sometings focussing a tab with a script triggers focus visible and other times it doesn't. I thought there could be several reasons for this:

1. The tab component gets remounted every time the inserter opens
2. The focus happens on a request animation frame

This PR tries to change those things to see if it makes a difference but it doesn't.