### PR TITLE
Inserter: Allow focus to move to the toggle when opening the inserter

### DIFF
--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -28,10 +28,6 @@ import { store as editorStore } from '../../store';
 import EditorHistoryRedo from '../editor-history/redo';
 import EditorHistoryUndo from '../editor-history/undo';
 
-const preventDefault = ( event ) => {
-	event.preventDefault();
-};
-
 function DocumentTools( { className, disableBlockTools = false } ) {
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editorStore );
@@ -71,6 +67,19 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			isZoomedOutView: __unstableGetEditorMode() === 'zoom-out',
 		};
 	}, [] );
+
+	const preventDefault = ( event ) => {
+		// Because the inserter behaves like a dialog,
+		// if the inserter is opened already then when we click on the toggle button
+		// then the initial click event will close the inserter and then be propagated
+		// to the inserter toggle and it will open it again.
+		// To prevent this we need to stop the propagation of the event.
+		// This won't be necessary when the inserter no longer behaves like a dialog.
+
+		if ( isInserterOpened ) {
+			event.preventDefault();
+		}
+	};
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideViewport = useViewportMatch( 'wide' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix for https://github.com/WordPress/gutenberg/issues/62441

We noticed that the focus-visible state of the tabs is sometimes set and other times not. This seems to be connected to where focus is when it is moved to the tabs. This change ensures that when opening the inserter, focus is always moved to the toggle button before the tabs are focussed. This ensures that when the browser focuses the tabs it can correctly handle apply focus-visible or not, depending on how the user interacted with the toggle.

## Why?
The tabs should only show focus when they are navigated to via keyboard interactions, not mouse.

## How?
Only prevent the default events happening on the toggle when the inserter is already open. We need to prevent the default events when the inserter is open because the inserter behaves like a dialog.

If the inserter is opened already then when we click on the toggle button then the initial click event will close the inserter and then be propagated to the inserter toggle and it will open it again. To prevent this we need to stop the propagation of the event.

This won't be necessary when the inserter no longer behaves like a dialog.

## Testing Instructions
1. Open the Site Editor.
2. Open the inserter using the mouse.
3. Check that there is no focus ring on the tabs.
4. Close the inserter using the mouse - this can be by clicking on the close buttons, or by clicking anywhere else in the canvas.
5. Check that focus is returned to the toggle button.

### Testing Instructions for Keyboard
1. Open the Site Editor.
2. Open the inserter using the keyboard.
3. Check that there is no focus ring on the tabs.
4. Close the inserter using the keyboard - this could be using the close button or using Escape.
5. Check that focus is returned to the toggle button.

## Notes
See https://cssence.com/2022/focus-visible-and-javascript/ for more details on how focus-visible should work.

Props @jeryj  for working with me on this.
