### PR TITLE
Alternative: Escape in select mode moves focus to canvas wrapper

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -164,11 +164,6 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 		const isEnter = keyCode === ENTER;
 		const isSpace = keyCode === SPACE;
 		const isShift = event.shiftKey;
-		if ( isEscape && editorMode === 'navigation' ) {
-			setNavigationMode( false );
-			event.preventDefault();
-			return;
-		}
 
 		if ( keyCode === BACKSPACE || keyCode === DELETE ) {
 			removeBlock( clientId );

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -81,6 +81,7 @@ export default function BlockTools( {
 	} = useShowBlockTools();
 
 	const {
+		clearSelectedBlock,
 		duplicateBlocks,
 		removeBlocks,
 		replaceBlocks,
@@ -152,6 +153,12 @@ export default function BlockTools( {
 				// block so that focus is directed back to the beginning of the selection.
 				// In effect, to the user this feels like deselecting the multi-selection.
 				selectBlock( clientIds[ 0 ] );
+			} else if ( clientIds.length === 1 ) {
+				event.preventDefault();
+				clearSelectedBlock();
+				__unstableContentRef?.current
+					?.querySelector( '[aria-label="Block canvas"]' )
+					?.focus();
 			}
 		} else if ( isMatch( 'core/block-editor/collapse-list-view', event ) ) {
 			// If focus is currently within a text field, such as a rich text block or other editable field,


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/62196. Builds off of work in https://github.com/WordPress/gutenberg/pull/62290.

An escape keypress previously [toggled the state between editing and select mode](https://github.com/WordPress/gutenberg/pull/58637/). This returns the behavior to the previous implementation of Escape clearing block focus. Now escape when in select mode focuses a Block canvas labelled wrapper element within the body element of the canvas.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- In select mode, Escape selects the wrapping "Block canvas"
- Shows a blue border when the canvas is focused

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Allow block deselection using Escape
- Show focus on canvas element

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Click a nested block
- Escape to enter select mode
- Escape to clear selected block and focus canvas

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
