### PR TITLE
Try revamped Document Bar

### DIFF
--- a/packages/editor/src/components/collapsible-block-toolbar/style.scss
+++ b/packages/editor/src/components/collapsible-block-toolbar/style.scss
@@ -78,5 +78,5 @@
 }
 
 .editor-collapsible-block-toolbar__toggle {
-	margin-left: 2px; // Allow focus ring to be fully visible
+	align-self: center;
 }

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -198,6 +198,8 @@ export default function DocumentBar() {
 						onClick={ () => openCommandCenter() }
 						size="compact"
 						variant="tertiary"
+						label={ __( 'Open the command palette' ) }
+						aria-haspopup="true"
 					>
 						<span className="editor-document-bar__shortcut">
 							{ displayShortcut.primary( 'k' ) }

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -118,6 +118,8 @@ export default function DocumentBar() {
 		mounted.current = true;
 	}, [] );
 
+	const transition = { duration: isReducedMotion ? 0 : 5.233 };
+
 	return (
 		<div
 			className={ clsx( 'editor-document-bar', {
@@ -128,6 +130,7 @@ export default function DocumentBar() {
 			<AnimatePresence>
 				{ hasBackButton && (
 					<MotionButton
+						key="back-button"
 						className="editor-document-bar__back"
 						icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
 						onClick={ ( event ) => {
@@ -135,16 +138,11 @@ export default function DocumentBar() {
 							onNavigateToPreviousEntityRecord();
 						} }
 						size="compact"
-						initial={
-							mounted.current
-								? { opacity: 0, transform: 'translateX(15%)' }
-								: false // Don't show entry animation when DocumentBar mounts.
-						}
-						animate={ { opacity: 1, transform: 'translateX(0%)' } }
-						exit={ { opacity: 0, transform: 'translateX(15%)' } }
-						transition={
-							isReducedMotion ? { duration: 0 } : undefined
-						}
+						variant="tertiary"
+						initial={ { opacity: 0, x: 12 } }
+						animate={ { opacity: 1, x: 0 } }
+						exit={ { opacity: 0, x: 12 } }
+						transition={ transition }
 					>
 						{ __( 'Back' ) }
 					</MotionButton>
@@ -153,32 +151,27 @@ export default function DocumentBar() {
 			{ isNotFound ? (
 				<Text>{ __( 'Document not found' ) }</Text>
 			) : (
-				<Button
-					className="editor-document-bar__command"
-					onClick={ () => openCommandCenter() }
-					size="compact"
-				>
+				<div className="editor-document-bar__core">
+					<Button
+						onClick={ () => openCommandCenter() }
+						size="compact"
+						variant="tertiary"
+					>
+						<span className="editor-document-bar__shortcut">
+							{ displayShortcut.primary( 'k' ) }
+						</span>
+					</Button>
 					<motion.div
 						className="editor-document-bar__title"
 						// Force entry animation when the back button is added or removed.
 						key={ hasBackButton }
 						initial={
-							mounted.current
-								? {
-										opacity: 0,
-										transform: hasBackButton
-											? 'translateX(15%)'
-											: 'translateX(-15%)',
-								  }
+							mounted.current || hasBackButton
+								? { opacity: 0, x: hasBackButton ? 12 : -12 }
 								: false // Don't show entry animation when DocumentBar mounts.
 						}
-						animate={ {
-							opacity: 1,
-							transform: 'translateX(0%)',
-						} }
-						transition={
-							isReducedMotion ? { duration: 0 } : undefined
-						}
+						animate={ { opacity: 1, x: 0 } }
+						transition={ transition }
 					>
 						<BlockIcon icon={ templateIcon } />
 						<Text
@@ -196,10 +189,7 @@ export default function DocumentBar() {
 								: __( 'No Title' ) }
 						</Text>
 					</motion.div>
-					<span className="editor-document-bar__shortcut">
-						{ displayShortcut.primary( 'k' ) }
-					</span>
-				</Button>
+				</div>
 			) }
 		</div>
 	);

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -1,6 +1,5 @@
 .editor-document-bar {
 	display: flex;
-	align-items: center;
 	height: $button-size-compact;
 	justify-content: space-between;
 	// Flex items will, by default, refuse to shrink below a minimum
@@ -8,21 +7,24 @@
 	// subsequently truncate child text, we set an explicit min-width.
 	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 	min-width: 0;
-	background: $gray-100;
 	border-radius: $grid-unit-05;
 	width: min(100%, 416px);
 
-	&:hover {
-		background-color: $gray-200;
-	}
-
 	.components-button {
-		border-radius: $grid-unit-05;
+		background: $gray-100;
+
 		transition: all 0.1s ease-out;
 		@include reduce-motion("transition");
-
-		&:hover {
-			background: $gray-200;
+	}
+	&:not(.has-back-button) .components-button {
+		border-radius: $grid-unit-05;
+	}
+	&.has-back-button {
+		> .components-button {
+			border-radius: $grid-unit-05 0 0 $grid-unit-05;
+		}
+		.editor-document-bar__core .components-button {
+			border-radius: 0 $grid-unit-05 $grid-unit-05 0;
 		}
 	}
 
@@ -31,24 +33,37 @@
 	}
 }
 
-.editor-document-bar__command {
+.editor-document-bar__core {
+	position: relative;
+	display: flex;
 	flex-grow: 1;
-	color: var(--wp-block-synced-color);
-	overflow: hidden;
+
+	button {
+		max-width: 100%;
+		position: absolute;
+		inset: 0;
+		justify-content: flex-end;
+	}
 }
 
 .editor-document-bar__title {
 	flex-grow: 1;
-	overflow: hidden;
 	color: $gray-900;
 	gap: $grid-unit-05;
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	max-width: 100%;
+	pointer-events: none;
 
-	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
+	// Ensures centered alignment and prevents overlapping of the contents.
 	@include break-medium() {
-		padding-left: $grid-unit-30;
+		// Offsets by the width of the command shortcut label plus its spacing from the side and the gap.
+		padding-inline: $grid-unit-30 + $grid-unit-15 + $grid-unit-05;
+		.has-back-button & {
+			// Offsets by the width of the back button.
+			padding-inline: 0 74px;
+		}
 	}
 
 	.editor-document-bar.is-global & {
@@ -56,6 +71,7 @@
 	}
 
 	.block-editor-block-icon {
+		fill: currentColor;
 		min-width: $grid-unit-30;
 		flex-shrink: 0;
 	}
@@ -84,11 +100,12 @@
 	flex-shrink: 0;
 	color: $gray-700;
 	gap: 0;
-	z-index: 1;
-	position: absolute;
 
+	&:focus {
+		// Ensure the focus ring is in front of the adjacent button.
+		z-index: 1;
+	}
 	&:hover {
 		color: $gray-900;
-		background-color: transparent;
 	}
 }

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -1,6 +1,7 @@
 // The height (4px greater than compact buttons) is to create room for focus rings of contained buttons.
 $bar-height: $button-size-compact + $grid-unit-05;
 $bar-content-inset: ( $bar-height - $button-size-compact ) * 0.5;
+$back-button-width-fallback: 74px;
 
 .editor-document-bar {
 	display: flex;
@@ -31,6 +32,12 @@ $bar-content-inset: ( $bar-height - $button-size-compact ) * 0.5;
 	flex-grow: 1;
 	max-width: 100%;
 
+	.has-back-button.editor-document-bar & {
+		// Prevents transitory overflow during animation by limiting the width
+		// to 100% minus the back button width plus the gap.
+		max-width: calc(100% - (#{$bar-content-inset} + var(--back-button-width, #{$back-button-width-fallback})));
+	}
+
 	button {
 		max-width: 100%;
 		position: absolute;
@@ -54,14 +61,14 @@ $bar-content-inset: ( $bar-height - $button-size-compact ) * 0.5;
 	@include break-medium() {
 		// Offsets by the width of the command shortcut label plus its spacing from the side plus the gap.
 		padding-inline: $grid-unit-30 + $grid-unit-15 + $grid-unit-05;
-
-		// Offsets by the width of the back button.
-		:nth-child(2).editor-document-bar__core & {
-			padding-inline: 0 74px;
-		}
 	}
 
-	.editor-document-bar.is-global & {
+	// Offsets by the width of the back button when present.
+	.has-back-button .editor-document-bar__core & {
+		padding-inline: 0 var(--back-button-width, $back-button-width-fallback);
+	}
+
+	&.is-global {
 		color: var(--wp-block-synced-color);
 	}
 

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -1,52 +1,46 @@
+// The height (4px greater than compact buttons) is to create room for focus rings of contained buttons.
+$bar-height: $button-size-compact + $grid-unit-05;
+$bar-content-inset: ( $bar-height - $button-size-compact ) * 0.5;
+
 .editor-document-bar {
 	display: flex;
-	height: $button-size-compact;
 	justify-content: space-between;
 	// Flex items will, by default, refuse to shrink below a minimum
 	// intrinsic width. In order to shrink this flexbox item, and
 	// subsequently truncate child text, we set an explicit min-width.
 	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 	min-width: 0;
+	height: $bar-height;
 	border-radius: $grid-unit-05;
+	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus, $border-width-focus-fallback) $gray-100;
+	gap: $bar-content-inset;
+	padding: $bar-content-inset;
 	width: min(100%, 416px);
-
-	.components-button {
-		background: $gray-100;
-
-		transition: all 0.1s ease-out;
-		@include reduce-motion("transition");
-	}
-	&:not(.has-back-button) .components-button {
-		border-radius: $grid-unit-05;
-	}
-	&.has-back-button {
-		> .components-button {
-			border-radius: $grid-unit-05 0 0 $grid-unit-05;
-		}
-		.editor-document-bar__core .components-button {
-			border-radius: 0 $grid-unit-05 $grid-unit-05 0;
-		}
-	}
+	overflow: hidden;
 
 	@include break-large() {
 		width: min(100%, 450px);
 	}
+
 }
 
 .editor-document-bar__core {
 	position: relative;
 	display: flex;
+	align-items: center;
 	flex-grow: 1;
+	max-width: 100%;
 
 	button {
 		max-width: 100%;
 		position: absolute;
-		inset: 0;
+		inset-inline: 0;
 		justify-content: flex-end;
 	}
 }
 
 .editor-document-bar__title {
+	position: relative;
 	flex-grow: 1;
 	color: $gray-900;
 	gap: $grid-unit-05;
@@ -58,10 +52,11 @@
 
 	// Ensures centered alignment and prevents overlapping of the contents.
 	@include break-medium() {
-		// Offsets by the width of the command shortcut label plus its spacing from the side and the gap.
+		// Offsets by the width of the command shortcut label plus its spacing from the side plus the gap.
 		padding-inline: $grid-unit-30 + $grid-unit-15 + $grid-unit-05;
-		.has-back-button & {
-			// Offsets by the width of the back button.
+
+		// Offsets by the width of the back button.
+		:nth-child(2).editor-document-bar__core & {
 			padding-inline: 0 74px;
 		}
 	}
@@ -80,7 +75,6 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: 70%;
 		color: currentColor;
 	}
 }
@@ -96,15 +90,12 @@
 }
 
 .editor-document-bar__back.components-button.has-icon.has-text {
+	align-self: center;
 	min-width: $button-size;
 	flex-shrink: 0;
 	color: $gray-700;
 	gap: 0;
 
-	&:focus {
-		// Ensure the focus ring is in front of the adjacent button.
-		z-index: 1;
-	}
 	&:hover {
 		color: $gray-900;
 	}

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -110,14 +110,15 @@ function Header( {
 						onToggle={ setIsBlockToolsCollapsed }
 					/>
 				) }
-				<div
+				<motion.div
+					layout
 					className={ clsx( 'editor-header__center', {
 						'is-collapsed':
 							! isBlockToolsCollapsed && hasTopToolbar,
 					} ) }
 				>
 					{ ! title ? <DocumentBar /> : title }
-				</div>
+				</motion.div>
 			</motion.div>
 			<motion.div
 				variants={ toolbarVariations }

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -32,7 +32,6 @@
 }
 
 .editor-header__center {
-	overflow: hidden;
 	flex-grow: 1;
 	display: flex;
 	align-items: center;

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -3,7 +3,6 @@
 	background: $white;
 	display: flex;
 	flex-wrap: wrap;
-	align-items: center;
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
 	justify-content: space-between;
@@ -22,13 +21,6 @@
 	flex-grow: 3;
 	// Hide the overflow so flex will limit its width. Block toolbar will allow scrolling on fixed toolbar.
 	overflow: hidden;
-	// Leave enough room for the focus ring to show.
-	padding: 2px 0;
-	align-items: center;
-	// Allow focus ring to be fully visible on furthest right button.
-	@include break-medium() {
-		padding-right: var(--wp-admin-border-width-focus);
-	}
 
 	.table-of-contents {
 		display: none;
@@ -40,14 +32,18 @@
 }
 
 .editor-header__center {
+	overflow: hidden;
 	flex-grow: 1;
 	display: flex;
+	align-items: center;
 	justify-content: center;
 	// Flex items will, by default, refuse to shrink below a minimum
 	// intrinsic width. In order to shrink this flexbox item, and
 	// subsequently truncate child text, we set an explicit min-width.
 	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 	min-width: 0;
+	// Allow focus ring to be fully visible on inline edges of contained buttons.
+	padding-inline: var(--wp-admin-border-width-focus);
 
 	&.is-collapsed {
 		display: none;


### PR DESCRIPTION
## What?
An attempt to fix/improve the Document Bar.

## Why?
- Its markup should be valid HTML
- The command palette button’s focus and hover states shouldn’t appear to include the back button.
- The command palette button should have an appropriate accessible label and indicate that it has a popup.
- Its responsive display and truncation of text should work better.

These points are all part of #51460, though I'm not sure this completely resolves that issue.

## How?
- Restructures
   - for valid markup (moves `<h1>` and `<div>` out of the `<button>`)
   - to keep the document title from being in the accessible text of a button that launches the command palette
- Restyles
  - to respond better at narrower sizes
  - so the command palette button doesn’t overlap the back button
This change lead to the substantial design difference in this PR. Currently the background and its hover state are on the root element and each button needs its own. Putting the same background on the buttons to preserve the design isn’t enough. Their border-radius would have to be removed on the sides the buttons meet. Then during transitions the buttons fading and overlapping ruin the effect*
- Puts an accessible label related to the button action on the command palette button and gives it an `aria-haspopup` attribute
- Tries an exit animation for the changes between template/document
- Tries a layout animation on the container (this isn’t ideal or even on focus—just an attempt to soften the layout jump that was somewhat recently introduced)

*Perhaps this can be retried as it was before revising the animation and now it possibly could work.

## Testing Instructions
1. Open a post/page in the editor 
2. Interact with the document bar
3. Edit the template
4. Repeat step 2

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/9000376/d51a0771-1986-4d9a-8b91-41630df95b05

