### PR TITLE
Site Editor: Fix modal incorrect size for edit template modal

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -158,6 +158,7 @@
 	&.hide-header {
 		margin-top: 0;
 		padding-top: $grid-unit-40;
+		max-width: $modal-width-medium;
 	}
 
 	&.is-scrollable:focus-visible {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/62524
Changed modal width to medium size. 

## Screenshots or screencast <!-- if applicable -->
<img width="1299" alt="image" src="https://github.com/WordPress/gutenberg/assets/61308756/dca5b2ed-3ff9-4175-8ab3-70b72c5fa97a">
