### PR TITLE
Global Styles: Skip registration of variation styles when unsupported

### DIFF
--- a/backport-changelog/6.6/6837.md
+++ b/backport-changelog/6.6/6837.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/6837
+
+* https://github.com/WordPress/gutenberg/pull/62529
+* https://github.com/WordPress/gutenberg/pull/62610

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -486,6 +486,13 @@ function gutenberg_register_block_style_variations_from_theme_json_data( $variat
  * @access private
  */
 function gutenberg_register_block_style_variations_from_theme() {
+	$has_partials_directory = is_dir( get_stylesheet_directory() . '/styles' ) || is_dir( get_template_directory() . '/styles' );
+
+	// Skip any registration of styles if no theme.json or variation partials.
+	if ( ! wp_theme_has_theme_json() && ! $has_partials_directory ) {
+		return;
+	}
+
 	// Partials from `/styles`.
 	$variations_partials = WP_Theme_JSON_Resolver_Gutenberg::get_style_variations( 'block' );
 	gutenberg_register_block_style_variations_from_theme_json_data( $variations_partials );

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -486,9 +486,19 @@ function gutenberg_register_block_style_variations_from_theme_json_data( $variat
  * @access private
  */
 function gutenberg_register_block_style_variations_from_theme() {
+	/*
+	 * Skip any registration of styles if no theme.json or variation partials are present.
+	 *
+	 * Given the possibility of hybrid themes, this check can't rely on if the theme
+	 * is a block theme or not. Instead:
+	 *   - If there is a primary theme.json, continue.
+	 *   - If there is a partials directory, continue.
+	 *   - The only variations to be registered from the global styles user origin,
+	 *     are those that have been copied in from the selected theme style variation.
+	 *     For a theme style variation to be selected it would have to have a partial
+	 *     theme.json file covered by the previous check.
+	 */
 	$has_partials_directory = is_dir( get_stylesheet_directory() . '/styles' ) || is_dir( get_template_directory() . '/styles' );
-
-	// Skip any registration of styles if no theme.json or variation partials.
 	if ( ! wp_theme_has_theme_json() && ! $has_partials_directory ) {
 		return;
 	}


### PR DESCRIPTION
## What?

Prevents going through all the work of searching for theme.json partials, parsing them and the core theme.json etc when the theme doesn't have its own theme.json.

## Why?

Performance and simplicity.

## How?

Make a check to `wp_theme_has_theme_json()` and return early if applicable.

## Testing Instructions

1. Add a block style variation to a theme via any source e.g. through its theme.json and the snippet below:

```json
                       "variations": {
                               "FromTheme": {
                                       "blockTypes": [
                                               "core/group",
                                               "core/columns"
                                       ],
                                       "color": {
                                               "background": "blue"
                                       }
                               }
                       },
```

2. Confirm this variation still shows and works appropriately
3. Switch theme to a classic theme and confirm no variations are shown
4. Update a hybrid theme to have a block style variation within its theme.json via snippet below. 

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"styles": {
		"blocks": {
			"variations": {
				"FromTheme": {
					"blockTypes": [ "core/group", "core/columns" ],
					"color": {
						"background": "blue"
					}
				}
			}
		}
	}
}

```

5. Confirm the variation shows
