### PR TITLE
Fix "insert before/after" not showing for blocks in site editor

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -31,12 +31,10 @@ export default function BlockActions( {
 				getDirectInsertBlock,
 				canMoveBlocks,
 				canRemoveBlocks,
-				getBlockEditingMode,
 			} = select( blockEditorStore );
 
 			const blocks = getBlocksByClientId( clientIds );
 			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
-			const rootBlockEditingMode = getBlockEditingMode( rootClientId );
 			const canInsertDefaultBlock = canInsertBlockType(
 				getDefaultBlockName(),
 				rootClientId
@@ -48,9 +46,7 @@ export default function BlockActions( {
 			return {
 				canMove: canMoveBlocks( clientIds, rootClientId ),
 				canRemove: canRemoveBlocks( clientIds, rootClientId ),
-				canInsertBlock:
-					( canInsertDefaultBlock || !! directInsertBlock ) &&
-					rootBlockEditingMode === 'default',
+				canInsertBlock: canInsertDefaultBlock || !! directInsertBlock,
 				canCopyStyles: blocks.every( ( block ) => {
 					return (
 						!! block &&

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -64,6 +64,7 @@ export function BlockSettingsDropdown( {
 		selectedBlockClientIds,
 		openedBlockSettingsMenu,
 		isContentOnly,
+		hasPatternParent,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -75,6 +76,7 @@ export function BlockSettingsDropdown( {
 				getBlockAttributes,
 				getOpenedBlockSettingsMenu,
 				getBlockEditingMode,
+				getBlockParentsByBlockName,
 			} = unlock( select( blockEditorStore ) );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -100,6 +102,11 @@ export function BlockSettingsDropdown( {
 				openedBlockSettingsMenu: getOpenedBlockSettingsMenu(),
 				isContentOnly:
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
+				hasPatternParent: !! getBlockParentsByBlockName(
+					firstBlockClientId,
+					'core/block',
+					true
+				),
 			};
 		},
 		[ firstBlockClientId ]
@@ -256,28 +263,34 @@ export function BlockSettingsDropdown( {
 										{ __( 'Duplicate' ) }
 									</MenuItem>
 								) }
-								{ canInsertBlock && (
-									<>
-										<MenuItem
-											onClick={ pipe(
-												onClose,
-												onInsertBefore
-											) }
-											shortcut={ shortcuts.insertBefore }
-										>
-											{ __( 'Add before' ) }
-										</MenuItem>
-										<MenuItem
-											onClick={ pipe(
-												onClose,
-												onInsertAfter
-											) }
-											shortcut={ shortcuts.insertAfter }
-										>
-											{ __( 'Add after' ) }
-										</MenuItem>
-									</>
-								) }
+								{ canInsertBlock &&
+									// Don't show "insert before/after" for pattern overrides blocks.
+									! ( isContentOnly && hasPatternParent ) && (
+										<>
+											<MenuItem
+												onClick={ pipe(
+													onClose,
+													onInsertBefore
+												) }
+												shortcut={
+													shortcuts.insertBefore
+												}
+											>
+												{ __( 'Add before' ) }
+											</MenuItem>
+											<MenuItem
+												onClick={ pipe(
+													onClose,
+													onInsertAfter
+												) }
+												shortcut={
+													shortcuts.insertAfter
+												}
+											>
+												{ __( 'Add after' ) }
+											</MenuItem>
+										</>
+									) }
 							</MenuGroup>
 							{ canCopyStyles && ! isContentOnly && (
 								<MenuGroup>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -64,7 +64,6 @@ export function BlockSettingsDropdown( {
 		selectedBlockClientIds,
 		openedBlockSettingsMenu,
 		isContentOnly,
-		hasPatternParent,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -76,7 +75,6 @@ export function BlockSettingsDropdown( {
 				getBlockAttributes,
 				getOpenedBlockSettingsMenu,
 				getBlockEditingMode,
-				getBlockParentsByBlockName,
 			} = unlock( select( blockEditorStore ) );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -102,11 +100,6 @@ export function BlockSettingsDropdown( {
 				openedBlockSettingsMenu: getOpenedBlockSettingsMenu(),
 				isContentOnly:
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
-				hasPatternParent: !! getBlockParentsByBlockName(
-					firstBlockClientId,
-					'core/block',
-					true
-				),
 			};
 		},
 		[ firstBlockClientId ]
@@ -263,34 +256,28 @@ export function BlockSettingsDropdown( {
 										{ __( 'Duplicate' ) }
 									</MenuItem>
 								) }
-								{ canInsertBlock &&
-									// Don't show "insert before/after" for pattern overrides blocks.
-									! ( isContentOnly && hasPatternParent ) && (
-										<>
-											<MenuItem
-												onClick={ pipe(
-													onClose,
-													onInsertBefore
-												) }
-												shortcut={
-													shortcuts.insertBefore
-												}
-											>
-												{ __( 'Add before' ) }
-											</MenuItem>
-											<MenuItem
-												onClick={ pipe(
-													onClose,
-													onInsertAfter
-												) }
-												shortcut={
-													shortcuts.insertAfter
-												}
-											>
-												{ __( 'Add after' ) }
-											</MenuItem>
-										</>
-									) }
+								{ canInsertBlock && ! isContentOnly && (
+									<>
+										<MenuItem
+											onClick={ pipe(
+												onClose,
+												onInsertBefore
+											) }
+											shortcut={ shortcuts.insertBefore }
+										>
+											{ __( 'Add before' ) }
+										</MenuItem>
+										<MenuItem
+											onClick={ pipe(
+												onClose,
+												onInsertAfter
+											) }
+											shortcut={ shortcuts.insertAfter }
+										>
+											{ __( 'Add after' ) }
+										</MenuItem>
+									</>
+								) }
 							</MenuGroup>
 							{ canCopyStyles && ! isContentOnly && (
 								<MenuGroup>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/62367.

Fix "Insert before" & "Insert after" not showing in the site editor when editing pages.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The bug was introduced in https://github.com/WordPress/gutenberg/pull/61127#discussion_r1629851012. The condition was not enough because it's checking the root client id (parent block).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Move the check to the block settings menu and check the block itself.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Follow the instructions in https://github.com/WordPress/gutenberg/issues/62367 and expect to see "Insert before/after".
2. Expect "Insert before/after" not to show when selecting binding blocks inside pattern overrides.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/c2afe9e9-fdff-45ae-91ae-a054472f6f41)
