### PR TITLE
Editor: Render editPost slots only in the post editor (same for site editor)

### DIFF
--- a/packages/edit-post/src/deprecated.js
+++ b/packages/edit-post/src/deprecated.js
@@ -12,6 +12,7 @@ import {
 	PluginSidebar as EditorPluginSidebar,
 	PluginSidebarMoreMenuItem as EditorPluginSidebarMoreMenuItem,
 } from '@wordpress/editor';
+import { getPath } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -19,6 +20,10 @@ import deprecated from '@wordpress/deprecated';
  */
 import { unlock } from './lock-unlock';
 const { PluginPostExcerpt } = unlock( editorPrivateApis );
+
+const isSiteEditor = getPath( window.location.href )?.includes(
+	'site-editor.php'
+);
 
 const deprecateSlot = ( name ) => {
 	deprecated( `wp.editPost.${ name }`, {
@@ -32,6 +37,9 @@ const deprecateSlot = ( name ) => {
  * @see PluginBlockSettingsMenuItem in @wordpress/editor package.
  */
 export function PluginBlockSettingsMenuItem( props ) {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginBlockSettingsMenuItem' );
 	return <EditorPluginBlockSettingsMenuItem { ...props } />;
 }
@@ -40,6 +48,9 @@ export function PluginBlockSettingsMenuItem( props ) {
  * @see PluginDocumentSettingPanel in @wordpress/editor package.
  */
 export function PluginDocumentSettingPanel( props ) {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginDocumentSettingPanel' );
 	return <EditorPluginDocumentSettingPanel { ...props } />;
 }
@@ -48,6 +59,9 @@ export function PluginDocumentSettingPanel( props ) {
  * @see PluginMoreMenuItem in @wordpress/editor package.
  */
 export function PluginMoreMenuItem( props ) {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginMoreMenuItem' );
 	return <EditorPluginMoreMenuItem { ...props } />;
 }
@@ -56,6 +70,9 @@ export function PluginMoreMenuItem( props ) {
  * @see PluginPrePublishPanel in @wordpress/editor package.
  */
 export function PluginPrePublishPanel( props ) {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginPrePublishPanel' );
 	return <EditorPluginPrePublishPanel { ...props } />;
 }
@@ -64,6 +81,9 @@ export function PluginPrePublishPanel( props ) {
  * @see PluginPostPublishPanel in @wordpress/editor package.
  */
 export function PluginPostPublishPanel( props ) {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginPostPublishPanel' );
 	return <EditorPluginPostPublishPanel { ...props } />;
 }
@@ -72,6 +92,9 @@ export function PluginPostPublishPanel( props ) {
  * @see PluginPostStatusInfo in @wordpress/editor package.
  */
 export function PluginPostStatusInfo( props ) {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginPostStatusInfo' );
 	return <EditorPluginPostStatusInfo { ...props } />;
 }
@@ -80,6 +103,9 @@ export function PluginPostStatusInfo( props ) {
  * @see PluginSidebar in @wordpress/editor package.
  */
 export function PluginSidebar( props ) {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginSidebar' );
 	return <EditorPluginSidebar { ...props } />;
 }
@@ -88,6 +114,9 @@ export function PluginSidebar( props ) {
  * @see PluginSidebarMoreMenuItem in @wordpress/editor package.
  */
 export function PluginSidebarMoreMenuItem( props ) {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginSidebarMoreMenuItem' );
 	return <EditorPluginSidebarMoreMenuItem { ...props } />;
 }
@@ -96,6 +125,9 @@ export function PluginSidebarMoreMenuItem( props ) {
  * @see PluginPostExcerpt in @wordpress/editor package.
  */
 export function __experimentalPluginPostExcerpt() {
+	if ( isSiteEditor ) {
+		return null;
+	}
 	deprecated( 'wp.editPost.__experimentalPluginPostExcerpt', {
 		since: '6.6',
 		hint: 'Core and custom panels can be access programmatically using their panel name.',

--- a/packages/edit-site/src/deprecated.js
+++ b/packages/edit-site/src/deprecated.js
@@ -6,7 +6,12 @@ import {
 	PluginSidebar as EditorPluginSidebar,
 	PluginSidebarMoreMenuItem as EditorPluginSidebarMoreMenuItem,
 } from '@wordpress/editor';
+import { getPath } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
+
+const isSiteEditor = getPath( window.location.href )?.includes(
+	'site-editor.php'
+);
 
 const deprecateSlot = ( name ) => {
 	deprecated( `wp.editPost.${ name }`, {
@@ -20,6 +25,9 @@ const deprecateSlot = ( name ) => {
  * @see PluginMoreMenuItem in @wordpress/editor package.
  */
 export function PluginMoreMenuItem( props ) {
+	if ( ! isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginMoreMenuItem' );
 	return <EditorPluginMoreMenuItem { ...props } />;
 }
@@ -28,6 +36,9 @@ export function PluginMoreMenuItem( props ) {
  * @see PluginSidebar in @wordpress/editor package.
  */
 export function PluginSidebar( props ) {
+	if ( ! isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginSidebar' );
 	return <EditorPluginSidebar { ...props } />;
 }
@@ -36,6 +47,9 @@ export function PluginSidebar( props ) {
  * @see PluginSidebarMoreMenuItem in @wordpress/editor package.
  */
 export function PluginSidebarMoreMenuItem( props ) {
+	if ( ! isSiteEditor ) {
+		return null;
+	}
 	deprecateSlot( 'PluginSidebarMoreMenuItem' );
 	return <EditorPluginSidebarMoreMenuItem { ...props } />;
 }


### PR DESCRIPTION
Related #52632 

## What?

It seems that some plugins are using the old editPost and editSite slots in the same script files and might also be using these script files in site editor even if they're meant only for post editor (or vice versa). While obviously there are better solutions for these plugin authors to avoid loading the slots and scripts were not needed, this PR tries to mitigate the slots unification effects on this kind of scripts.

 - EditPost slots only work on edit-post.
 - EditSite slots only work on edit-site.
