### PR TITLE
Update all `ConfirmDialog`s in the codebase to be size=medium

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -382,6 +382,7 @@ function ConfirmDeleteDialog( {
 			confirmButtonText={ __( 'Delete' ) }
 			onCancel={ handleCancelUninstall }
 			onConfirm={ handleConfirmUninstall }
+			size="medium"
 		>
 			{ font &&
 				sprintf(

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -198,6 +198,7 @@ function ScreenRevisions() {
 					onCancel={ () =>
 						setIsLoadingRevisionWithUnsavedChanges( false )
 					}
+					size="medium"
 				>
 					{ __(
 						'Are you sure you want to apply this revision? Any unsaved changes will be lost.'

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -201,6 +201,7 @@ export default function ShadowsEditPanel() {
 						setIsConfirmDialogVisible( false );
 					} }
 					confirmButtonText={ __( 'Delete' ) }
+					size="medium"
 				>
 					{ sprintf(
 						// translators: %s: name of the shadow

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-confirm-dialog.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/delete-confirm-dialog.js
@@ -16,6 +16,7 @@ export default function DeleteConfirmDialog( { onClose, onConfirm } ) {
 			} }
 			onCancel={ onClose }
 			confirmButtonText={ __( 'Delete' ) }
+			size="medium"
 		>
 			{ __( 'Are you sure you want to delete this Navigation Menu?' ) }
 		</ConfirmDialog>

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -77,6 +77,7 @@ export default function PostSwitchToDraftButton() {
 				onConfirm={ handleConfirm }
 				onCancel={ () => setShowConfirmDialog( false ) }
 				confirmButtonText={ confirmButtonText }
+				size="medium"
 			>
 				{ alertMessage }
 			</ConfirmDialog>

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -77,7 +77,6 @@ export default function PostSwitchToDraftButton() {
 				onConfirm={ handleConfirm }
 				onCancel={ () => setShowConfirmDialog( false ) }
 				confirmButtonText={ confirmButtonText }
-				size="medium"
 			>
 				{ alertMessage }
 			</ConfirmDialog>

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -55,6 +55,7 @@ export default function PostTrash() {
 				onConfirm={ handleConfirm }
 				onCancel={ () => setShowConfirmDialog( false ) }
 				confirmButtonText={ __( 'Move to trash' ) }
+				size="medium"
 			>
 				{ __(
 					'Are you sure you want to move this post to the trash?'

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -133,6 +133,7 @@ export default function PostVisibility( { onClose } ) {
 				onConfirm={ confirmPrivate }
 				onCancel={ handleDialogCancel }
 				confirmButtonText={ __( 'Publish' ) }
+				size="medium"
 			>
 				{ __( 'Would you like to privately publish this post now?' ) }
 			</ConfirmDialog>

--- a/packages/editor/src/components/template-validation-notice/index.js
+++ b/packages/editor/src/components/template-validation-notice/index.js
@@ -51,6 +51,7 @@ export default function TemplateValidationNotice() {
 					synchronizeTemplate();
 				} }
 				onCancel={ () => setShowConfirmDialog( false ) }
+				size="medium"
 			>
 				{ __(
 					'Resetting the template may result in loss of content, do you want to continue?'

--- a/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
@@ -80,6 +80,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 				} );
 			} }
 			onCancel={ () => setIsDialogOpen( false ) }
+			size="medium"
 		>
 			{ __(
 				'You’ve tried to select a block that is part of a template, which may be used on other posts and pages. Would you like to edit the template?'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #62524

Adds `size="medium"` to the `ConfirmDialog`s shown across gutenberg.

## Why?
Lots of the `ConfirmDialog` usage across the codebase is very inconsistent. The dialog expands to the width of the text content, so some are very big, some are very small.

## How?
Add `size="medium"` to anywhere we use `ConfirmDialog`.

It could also be added to the base component as an opinionated size, though it would be a breaking change.

There are unfortunately a lot of modals that look like a `ConfirmDialog` in the codebase, but are actually reimplementing it. I haven't hunted every one down. I don't plan to completely address this issue, just make a reasonable attempt at bringing some consistency.

Also, some of the `ConfirmDialog`s that I changed I couldn't find a way to trigger. I don't think it's a big issue, this just changes the `min-width`.

## Testing Instructions
- Try selecting a block that's part of a template when editing a page in the site editor
- Try changing a post status to private during the second step of the publishing flow
- Try deleting a navigation menu
- Try applying a global styles revision
- Try deleting an installed font

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-06-13 at 4 20 57 pm](https://github.com/WordPress/gutenberg/assets/677833/61078c8a-2e84-4a89-b725-53037b8a53a9)
![Screenshot 2024-06-13 at 4 15 17 pm](https://github.com/WordPress/gutenberg/assets/677833/c2c59165-ab0b-425f-a850-377ea449f74e)
![Screenshot 2024-06-13 at 4 11 09 pm](https://github.com/WordPress/gutenberg/assets/677833/dd5a2174-04f2-458a-af19-9a824e937487)
![Screenshot 2024-06-13 at 4 10 38 pm](https://github.com/WordPress/gutenberg/assets/677833/bb4caa35-2188-4308-a2bd-26c54c1c8513)
![Screenshot 2024-06-13 at 4 09 03 pm](https://github.com/WordPress/gutenberg/assets/677833/1a786037-5f7c-48a9-86a2-5e98216762e9)

