### PR TITLE
Use stable reference for `getEntityActions` action

### DIFF
--- a/packages/editor/src/dataviews/store/private-selectors.ts
+++ b/packages/editor/src/dataviews/store/private-selectors.ts
@@ -1,8 +1,15 @@
 /**
+ * WordPress dependencies
+ */
+import type { Action } from '@wordpress/dataviews';
+
+/**
  * Internal dependencies
  */
 import type { State } from './reducer';
 
+const EMPTY_ARRAY: Action< any >[] = [];
+
 export function getEntityActions( state: State, kind: string, name: string ) {
-	return state.actions[ kind ]?.[ name ] ?? [];
+	return state.actions[ kind ]?.[ name ] ?? EMPTY_ARRAY;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small follow up of: https://github.com/WordPress/gutenberg/pull/62052#discussion_r1637800466

>Fixes the "The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders. " warning.



### Testing instructions
Everything should work as before regarding the post actions