### PR TITLE
Template inspector: Small visual adjustments.

### DIFF
--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -35,6 +35,10 @@
 
 .editor-post-card-panel__icon.is-sync {
 	fill: var(--wp-block-synced-color);
+
+	& + h2 {
+		color: var(--wp-block-synced-color);
+	}
 }
 
 .editor-post-card-panel__title-badge {

--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -36,7 +36,7 @@
 .editor-post-card-panel__icon.is-sync {
 	fill: var(--wp-block-synced-color);
 
-	& + h2 {
+	& + .editor-post-card-panel__title {
 		color: var(--wp-block-synced-color);
 	}
 }

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -6,7 +6,7 @@
 }
 
 .editor-post-panel__row-label {
-	width: 30%;
+	width: 38%;
 	flex-shrink: 0;
 	min-height: $grid-unit-40;
 	display: flex;

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -69,7 +69,7 @@ export default function PostSummary( { onActionPerformed } ) {
 								<PostLastEditedPanel />
 							</VStack>
 							{ ! isRemovedPostStatusPanel && (
-								<VStack spacing={ 2 }>
+								<VStack spacing={ 4 }>
 									<VStack spacing={ 1 }>
 										<PostStatusPanel />
 										<PostSchedulePanel />


### PR DESCRIPTION
## What?

A small amount of spacing changes to the post/page/template inspector summary panel.

## Why?

The added spacing avoids some wrapping and improves legibility.

## How?

* The left column in the summary panel is 8% wider avoiding wrapping of, among other things, "Posts per page"
* Spacing above and below summary items is now identical, so "Areas" doesn't look so tightly coupled.
* If a template has a purple icon denoting synced/used in multiple places, now the text is also purple.

Page inspector before and after:

| Before | After |
|--------|--------|
| <img src="https://github.com/WordPress/gutenberg/assets/1204802/878b0708-58f0-4c9b-b498-d9bc0f4e0635" alt=""> | <img src="https://github.com/WordPress/gutenberg/assets/1204802/ea052ace-779c-48ba-96b7-15c8459257ab" alt=""> | 

Template inspector ebefore and after:

| Before | After |
|--------|--------|
| ![template before](https://github.com/WordPress/gutenberg/assets/1204802/5c320f16-7409-4df9-8cee-3b398c74129f) | ![template after](https://github.com/WordPress/gutenberg/assets/1204802/b77ef7c7-29d3-4990-b654-1e989d428370) | 

## Testing Instructions

Test the main document inspector in post, page, site editors, across pages and templates, and posts for good measure. 
