### PR TITLE
Speed up check-build-type-declaration-files

### DIFF
--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -70,7 +70,7 @@ async function getDecFile( packagePath ) {
 async function typecheckDeclarations( file ) {
 	return new Promise( ( resolve, reject ) => {
 		exec(
-			`npx tsc --target esnext --moduleResolution node --noEmit "${ file }"`,
+			`npx tsc --target esnext --moduleResolution node --noEmit --skipLibCheck "${ file }"`,
 			( error, stdout, stderr ) => {
 				if ( error ) {
 					reject( { file, error, stderr, stdout } );

--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -70,7 +70,7 @@ async function getDecFile( packagePath ) {
 async function typecheckDeclarations( file ) {
 	return new Promise( ( resolve, reject ) => {
 		exec(
-			`./node_modules/.bin/tsc --target esnext --moduleResolution node --noEmit "${ file }"`,
+			`npx tsc --target esnext --moduleResolution node --noEmit "${ file }"`,
 			( error, stdout, stderr ) => {
 				if ( error ) {
 					reject( { file, error, stderr, stdout } );

--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -70,7 +70,7 @@ async function getDecFile( packagePath ) {
 async function typecheckDeclarations( file ) {
 	return new Promise( ( resolve, reject ) => {
 		exec(
-			`npx tsc --target esnext --moduleResolution node --noEmit "${ file }"`,
+			`./node_modules/.bin/tsc --target esnext --moduleResolution node --noEmit "${ file }"`,
 			( error, stdout, stderr ) => {
 				if ( error ) {
 					reject( { file, error, stderr, stdout } );


### PR DESCRIPTION
## What?

[The `./bin/packages/check-build-type-declaration-files.js` script](https://github.com/WordPress/gutenberg/blob/trunk/bin/packages/check-build-type-declaration-files.js) runs on [`build:package-types`](https://github.com/WordPress/gutenberg/blob/fe8fe408fcfa066a9efd51ceafc51410c8f6d393/package.json#L271) (and therefore on `build`). It's run _very frequently_ and is pretty slow.

This tries two simple strategies to speed it up.

### No npx

(Reverted due to unsufficient impact)

`npx` adds some overhead. Calling the `tsc` binary directly is faster, but this only saves a couple of ms per run.

**1.06 ± 0.04 times faster than trunk**

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `trunk` | 4.780 ± 0.152 | 4.608 | 5.063 | 1.06 ± 0.04 |
| `branch` | 4.529 ± 0.122 | 4.344 | 4.688 | 1.00 |

### skipLibCheck

Our types are compiled without `skipLibCheck` enabled, so the libraries we use should be checked. When we run _this script_, there's so much interdependence between our packages that we're checking out own package types _over and over_ and we checking all of our libraries again. We should be able to enable `skipLibCheck` and save some time, the lib check is the point of this script itself.

If there were problems in our packages, without `skipLibCheck` enabled we'd see the same problems over and over for the packages themselves and for every dependent package.

**3.15 ± 0.12 times faster than trunk**

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `trunk` | 4.940 ± 0.139 | 4.755 | 5.177 | 3.15 ± 0.12 |
| `branch` | 1.567 ± 0.039 | 1.524 | 1.657 | 1.00 |


## Testing Instructions

`node ./bin/packages/check-build-type-declaration-files.js` should be faster on this branch than on trunk.

## Future

~This should be a good candidate for parallelization with something like `worker-farm` for bigger gains.~