### PR TITLE
Global Styles: Add a typesets section to Typography

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-typeset.js
+++ b/packages/edit-site/src/components/global-styles/screen-typeset.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import TypographyVariations from './variations/variations-typography';
+import ScreenHeader from './header';
+import Typeset from './typeset';
+
+function ScreenTypeset() {
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Typesets' ) }
+				description={ __(
+					'Font pairings and typographic styling applied across the site.'
+				) }
+			/>
+			<div className="edit-site-global-styles-screen">
+				<VStack spacing={ 7 }>
+					<Typeset />
+					<TypographyVariations title={ __( 'Presets' ) } />
+				</VStack>
+			</div>
+		</>
+	);
+}
+
+export default ScreenTypeset;

--- a/packages/edit-site/src/components/global-styles/screen-typeset.js
+++ b/packages/edit-site/src/components/global-styles/screen-typeset.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 
 /**
@@ -9,21 +11,29 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
  */
 import TypographyVariations from './variations/variations-typography';
 import ScreenHeader from './header';
-import Typeset from './typeset';
+import FontFamilies from './font-families';
 
 function ScreenTypeset() {
+	const fontLibraryEnabled = useSelect(
+		( select ) =>
+			select( editorStore ).getEditorSettings().fontLibraryEnabled,
+		[]
+	);
+
 	return (
 		<>
 			<ScreenHeader
 				title={ __( 'Typesets' ) }
 				description={ __(
-					'Font pairings and typographic styling applied across the site.'
+					'Fonts and typographic styling applied across the site.'
 				) }
 			/>
 			<div className="edit-site-global-styles-screen">
 				<VStack spacing={ 7 }>
-					<Typeset />
-					<TypographyVariations title={ __( 'Presets' ) } />
+					<TypographyVariations />
+
+					{ ! window.__experimentalDisableFontLibrary &&
+						fontLibraryEnabled && <FontFamilies /> }
 				</VStack>
 			</div>
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-typeset.js
+++ b/packages/edit-site/src/components/global-styles/screen-typeset.js
@@ -32,8 +32,7 @@ function ScreenTypeset() {
 				<VStack spacing={ 7 }>
 					<TypographyVariations />
 
-					{ ! window.__experimentalDisableFontLibrary &&
-						fontLibraryEnabled && <FontFamilies /> }
+					{ fontLibraryEnabled && <FontFamilies /> }
 				</VStack>
 			</div>
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -10,10 +10,10 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import TypographyElements from './typography-elements';
-import TypographyVariations from './variations/variations-typography';
 import FontFamilies from './font-families';
 import ScreenHeader from './header';
 import FontSizesCount from './font-sizes/font-sizes-count';
+import TypesetButton from './typeset-button';
 
 function ScreenTypography() {
 	const fontLibraryEnabled = useSelect(
@@ -32,9 +32,9 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen">
 				<VStack spacing={ 7 }>
+					<TypesetButton />
 					{ fontLibraryEnabled && <FontFamilies /> }
 					<TypographyElements />
-					<TypographyVariations title={ __( 'Presets' ) } />
 					<FontSizesCount />
 				</VStack>
 			</div>

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -3,25 +3,16 @@
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { store as editorStore } from '@wordpress/editor';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import TypographyElements from './typography-elements';
-import FontFamilies from './font-families';
 import ScreenHeader from './header';
 import FontSizesCount from './font-sizes/font-sizes-count';
 import TypesetButton from './typeset-button';
 
 function ScreenTypography() {
-	const fontLibraryEnabled = useSelect(
-		( select ) =>
-			select( editorStore ).getEditorSettings().fontLibraryEnabled,
-		[]
-	);
-
 	return (
 		<>
 			<ScreenHeader

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -11,8 +13,15 @@ import TypographyElements from './typography-elements';
 import ScreenHeader from './header';
 import FontSizesCount from './font-sizes/font-sizes-count';
 import TypesetButton from './typeset-button';
+import FontFamilies from './font-families';
 
 function ScreenTypography() {
+	const fontLibraryEnabled = useSelect(
+		( select ) =>
+			select( editorStore ).getEditorSettings().fontLibraryEnabled,
+		[]
+	);
+
 	return (
 		<>
 			<ScreenHeader

--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -47,7 +47,7 @@ function TypesetButton() {
 			variations.find( ( variation ) =>
 				areGlobalStyleConfigsEqual( userConfig, variation )
 			),
-		[ ( userConfig, variations ) ]
+		[ userConfig, variations ]
 	);
 
 	let title;

--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -23,10 +23,9 @@ import { getFontFamilies } from './utils';
 import { NavigationButtonAsItem } from './navigation-button';
 import Subtitle from './subtitle';
 import { unlock } from '../../lock-unlock';
+import { filterObjectByProperty } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
-const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
-	blockEditorPrivateApis
-);
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 
 function TypesetButton() {
@@ -41,21 +40,27 @@ function TypesetButton() {
 			coreStore
 		).__experimentalGetCurrentThemeGlobalStylesVariations();
 	}, [] );
-
-	const activeVariation = useMemo(
-		() =>
-			variations.find( ( variation ) =>
-				areGlobalStyleConfigsEqual( userConfig, variation )
-			),
-		[ userConfig, variations ]
+	const userTypographyConfig = filterObjectByProperty(
+		userConfig,
+		'typography'
 	);
 
-	let title;
-	if ( activeVariation ) {
-		title = activeVariation.title;
-	} else {
-		title = allFontFamilies.map( ( font ) => font?.name ).join( ', ' );
-	}
+	const title = useMemo( () => {
+		if ( Object.keys( userTypographyConfig ).length === 0 ) {
+			return __( 'Default' );
+		}
+		const activeVariation = variations.find( ( variation ) => {
+			return (
+				JSON.stringify(
+					filterObjectByProperty( variation, 'typography' )
+				) === JSON.stringify( userTypographyConfig )
+			);
+		} );
+		if ( activeVariation ) {
+			return activeVariation.title;
+		}
+		return allFontFamilies.map( ( font ) => font?.name ).join( ', ' );
+	}, [ userTypographyConfig, variations ] );
 
 	return (
 		hasFonts && (

--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { isRTL, __ } from '@wordpress/i18n';
+import {
+	__experimentalItemGroup as ItemGroup,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	FlexItem,
+} from '@wordpress/components';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { useContext } from '@wordpress/element';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import FontLibraryProvider from './font-library-modal/context';
+import { getFontFamilies } from './utils';
+import { NavigationButtonAsItem } from './navigation-button';
+import Subtitle from './subtitle';
+import { unlock } from '../../lock-unlock';
+
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
+const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
+
+function TypesetButton() {
+	const { base } = useContext( GlobalStylesContext );
+	const { user: userConfig } = useContext( GlobalStylesContext );
+	const config = mergeBaseAndUserConfigs( base, userConfig );
+	const allFontFamilies = getFontFamilies( config );
+	const hasFonts =
+		allFontFamilies.filter( ( font ) => font !== null ).length > 0;
+
+	return (
+		hasFonts && (
+			<VStack spacing={ 2 }>
+				<HStack justify="space-between">
+					<Subtitle level={ 3 }>{ __( 'Typeset' ) }</Subtitle>
+				</HStack>
+				<ItemGroup isBordered isSeparated>
+					<NavigationButtonAsItem
+						path="/typography/typeset"
+						aria-label={ __( 'Typeset' ) }
+					>
+						<HStack direction="row">
+							<FlexItem>
+								{ allFontFamilies
+									.map( ( font ) => font.name )
+									.join( ', ' ) }
+							</FlexItem>
+							<Icon
+								icon={ isRTL() ? chevronLeft : chevronRight }
+							/>
+						</HStack>
+					</NavigationButtonAsItem>
+				</ItemGroup>
+			</VStack>
+		)
+	);
+}
+
+export default ( { ...props } ) => (
+	<FontLibraryProvider>
+		<TypesetButton { ...props } />
+	</FontLibraryProvider>
+);

--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -47,7 +47,7 @@ function TypesetButton() {
 						<HStack direction="row">
 							<FlexItem>
 								{ allFontFamilies
-									.map( ( font ) => font.name )
+									.map( ( font ) => font?.name )
 									.join( ', ' ) }
 							</FlexItem>
 							<Icon

--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -52,7 +52,7 @@ function TypesetButton() {
 		const activeVariation = variations.find( ( variation ) => {
 			return (
 				JSON.stringify(
-					filterObjectByProperty( variation, 'typography' )
+					filterObjectByProperties( variation, 'typography' )
 				) === JSON.stringify( userTypographyConfig )
 			);
 		} );

--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -40,7 +40,7 @@ function TypesetButton() {
 			coreStore
 		).__experimentalGetCurrentThemeGlobalStylesVariations();
 	}, [] );
-	const userTypographyConfig = filterObjectByProperty(
+	const userTypographyConfig = filterObjectByProperties(
 		userConfig,
 		'typography'
 	);

--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -23,7 +23,7 @@ import { getFontFamilies } from './utils';
 import { NavigationButtonAsItem } from './navigation-button';
 import Subtitle from './subtitle';
 import { unlock } from '../../lock-unlock';
-import { filterObjectByProperty } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { filterObjectByProperties } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );

--- a/packages/edit-site/src/components/global-styles/typeset.js
+++ b/packages/edit-site/src/components/global-styles/typeset.js
@@ -47,12 +47,18 @@ function Typesets() {
 
 				<VStack spacing={ 2 }>
 					<HStack justify="space-between">
-						<Subtitle level={ 3 }>{ __( 'Typeset' ) }</Subtitle>
+						<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
 					</HStack>
 					<ItemGroup isBordered isSeparated>
-						{ allFontFamilies.map( ( font ) => (
-							<FontFamilyItem key={ font.slug } font={ font } />
-						) ) }
+						{ allFontFamilies.map(
+							( font ) =>
+								font && (
+									<FontFamilyItem
+										key={ font.slug }
+										font={ font }
+									/>
+								)
+						) }
 					</ItemGroup>
 				</VStack>
 			</>

--- a/packages/edit-site/src/components/global-styles/typeset.js
+++ b/packages/edit-site/src/components/global-styles/typeset.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalItemGroup as ItemGroup,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import FontLibraryProvider, {
+	FontLibraryContext,
+} from './font-library-modal/context';
+import FontLibraryModal from './font-library-modal';
+import FontFamilyItem from './font-family-item';
+import Subtitle from './subtitle';
+import { getFontFamilies } from './utils';
+import { unlock } from '../../lock-unlock';
+
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
+const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
+
+function Typesets() {
+	const { modalTabOpen, setModalTabOpen } = useContext( FontLibraryContext );
+	const { base } = useContext( GlobalStylesContext );
+	const { user: userConfig } = useContext( GlobalStylesContext );
+	const config = mergeBaseAndUserConfigs( base, userConfig );
+	const allFontFamilies = getFontFamilies( config );
+	const hasFonts =
+		allFontFamilies.filter( ( font ) => font !== null ).length > 0;
+
+	return (
+		hasFonts && (
+			<>
+				{ !! modalTabOpen && (
+					<FontLibraryModal
+						onRequestClose={ () => setModalTabOpen( null ) }
+						defaultTabId={ modalTabOpen }
+					/>
+				) }
+
+				<VStack spacing={ 2 }>
+					<HStack justify="space-between">
+						<Subtitle level={ 3 }>{ __( 'Typeset' ) }</Subtitle>
+					</HStack>
+					<ItemGroup isBordered isSeparated>
+						{ allFontFamilies.map( ( font ) => (
+							<FontFamilyItem key={ font.slug } font={ font } />
+						) ) }
+					</ItemGroup>
+				</VStack>
+			</>
+		)
+	);
+}
+
+export default ( { ...props } ) => (
+	<FontLibraryProvider>
+		<Typesets { ...props } />
+	</FontLibraryProvider>
+);

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -32,6 +32,7 @@ import {
 } from './screen-block-list';
 import ScreenBlock from './screen-block';
 import ScreenTypography from './screen-typography';
+import ScreenTypeset from './screen-typeset';
 import ScreenTypographyElement from './screen-typography-element';
 import FontSize from './font-sizes/font-size';
 import FontSizes from './font-sizes/font-sizes';
@@ -321,6 +322,10 @@ function GlobalStylesUI() {
 
 			<GlobalStylesNavigationScreen path="/typography/font-sizes/:origin/:slug">
 				<FontSize />
+			</GlobalStylesNavigationScreen>
+
+			<GlobalStylesNavigationScreen path="/typography/typeset">
+				<ScreenTypeset />
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path="/typography/text">

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -52,7 +52,15 @@ function getFontFamilyFromSetting( fontFamilies, setting ) {
 }
 
 export function getFontFamilies( themeJson ) {
-	const fontFamilies = themeJson?.settings?.typography?.fontFamilies?.theme; // TODO this could not be under theme.
+	const themeFontFamilies =
+		themeJson?.settings?.typography?.fontFamilies?.theme;
+	const customFontFamilies =
+		themeJson?.settings?.typography?.fontFamilies?.custom;
+
+	let fontFamilies = themeFontFamilies;
+	if ( customFontFamilies ) {
+		fontFamilies = [ ...themeFontFamilies, ...customFontFamilies ];
+	}
 	const bodyFontFamilySetting = themeJson?.styles?.typography?.fontFamily;
 	const bodyFontFamily = getFontFamilyFromSetting(
 		fontFamilies,

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -57,9 +57,13 @@ export function getFontFamilies( themeJson ) {
 	const customFontFamilies =
 		themeJson?.settings?.typography?.fontFamilies?.custom;
 
-	let fontFamilies = themeFontFamilies;
-	if ( customFontFamilies ) {
+	let fontFamilies = [];
+	if ( themeFontFamilies && customFontFamilies ) {
 		fontFamilies = [ ...themeFontFamilies, ...customFontFamilies ];
+	} else if ( themeFontFamilies ) {
+		fontFamilies = themeFontFamilies;
+	} else if ( customFontFamilies ) {
+		fontFamilies = customFontFamilies;
 	}
 	const bodyFontFamilySetting = themeJson?.styles?.typography?.fontFamily;
 	const bodyFontFamily = getFontFamilyFromSetting(


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/62156.

Adds a new "Typesets" screen in which to show typography presets.

## Why?
If there are a lot of typography presets the list will get very long, so it's better to show them on a separate screen.

## How?
1. Create a new typeset screen
2. Add a link to this screen from the typography screen
3. Move presets to the new screen

## Testing Instructions
0. Modify TT4 by cloning the Malestrom variation and removing all properties except typograpghy
1. Open the Site Editor
2. Open Global Styles
3. Open Typography
4. Check that you see the Typeset button
5. Click on the Typeset button
6. You should see the typeset for the current Global Styles
7. You should also see some additional presets
8. Click on the presets 
9. You should see the typeset change

## Screenshots or screencast <!-- if applicable -->
<img width="293" alt="Screenshot 2024-06-19 at 16 38 05" src="https://github.com/WordPress/gutenberg/assets/275961/f480253a-d4a7-4721-a392-0cc19c3d4c9d">
<img width="295" alt="Screenshot 2024-06-19 at 16 37 51" src="https://github.com/WordPress/gutenberg/assets/275961/05d5ee4e-f980-4348-a8ad-e87240c52351">
