### PR TITLE
Update link editor previews and edit

### DIFF
--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -10,7 +10,6 @@ import {
 	ExternalLink,
 	Button,
 	__experimentalInputControl as InputControl,
-	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
@@ -83,7 +82,9 @@ export default function PostURL( { onClose } ) {
 			<VStack spacing={ 3 }>
 				{ isEditable && (
 					<div>
-						{ __( 'Customize the last part of the URL. ' ) }
+						{ __(
+							'Customize the post name in the URL (in bold below). '
+						) }
 						<ExternalLink
 							href={ __(
 								'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
@@ -97,16 +98,11 @@ export default function PostURL( { onClose } ) {
 					{ isEditable && (
 						<InputControl
 							__next40pxDefaultSize
-							prefix={
-								<InputControlPrefixWrapper>
-									/
-								</InputControlPrefixWrapper>
-							}
 							suffix={
 								<Button
 									icon={ copySmall }
 									ref={ copyButtonRef }
-									label={ __( 'Copy' ) }
+									label={ __( 'Copy Link' ) }
 								/>
 							}
 							label={ __( 'Link' ) }

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -5,7 +5,7 @@ import { useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { safeDecodeURIComponent } from '@wordpress/url';
+import { safeDecodeURI } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -59,18 +59,21 @@ export default function PostURLPanel() {
 }
 
 function PostURLToggle( { isOpen, onClick } ) {
-	const { slug, isFrontPage, postLink } = useSelect( ( select ) => {
-		const { getCurrentPostId, getCurrentPost } = select( editorStore );
+	const { isFrontPage, postLink, permalink } = useSelect( ( select ) => {
+		const { getCurrentPostId, getCurrentPost, getPermalink } =
+			select( editorStore );
 		const { getEditedEntityRecord } = select( coreStore );
 		const siteSettings = getEditedEntityRecord( 'root', 'site' );
 		const _id = getCurrentPostId();
+
 		return {
-			slug: select( editorStore ).getEditedPostSlug(),
 			isFrontPage: siteSettings?.page_on_front === _id,
 			postLink: getCurrentPost()?.link,
+			permalink: getPermalink(),
 		};
 	}, [] );
-	const decodedSlug = safeDecodeURIComponent( slug );
+
+	const decodedLink = safeDecodeURI( permalink );
 	return (
 		<Button
 			size="compact"
@@ -78,10 +81,10 @@ function PostURLToggle( { isOpen, onClick } ) {
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			// translators: %s: Current post link.
-			aria-label={ sprintf( __( 'Change link: %s' ), decodedSlug ) }
+			aria-label={ sprintf( __( 'Change link: %s' ), decodedLink ) }
 			onClick={ onClick }
 		>
-			{ isFrontPage ? postLink : <>/{ decodedSlug }</> }
+			{ isFrontPage ? postLink : <>{ decodedLink }</> }
 		</Button>
 	);
 }

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -2,6 +2,11 @@
 	width: 100%;
 }
 
+.editor-post-url__panel-toggle {
+	display: block;
+	overflow-wrap: break-word;
+}
+
 .editor-post-url__panel-dialog .editor-post-url {
 	// sidebar width - popover padding - form margin
 	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -25,9 +25,3 @@
 .editor-post-url__link-slug {
 	font-weight: 600;
 }
-
-// TODO: This might indicate a need to update the InputControl itself, as
-// there is no way currently to control the padding when adding prefix/suffix.
-.editor-post-url__input input.components-input-control__input {
-	padding-inline-start: 0 !important;
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #62414 : Editor: Link preview overflows with long strings and only shows postname 

From @hrkhal 

> The Link Preview in the unified publishing details overflows when long strings are present in the post name and it does not show the full url path.

**Step-by-step reproduction instructions**

- Go to permalink settings and set a custom structure of /%year%/%monthnum%/%day%/prefix-%postname%-%post_id%-suffix/
- Create a new post, give it a post name of "helloworldhelloworldhelloworld"
- Observe that a) the link preview does not wrap and b) that the preview is only the post name

**Current behaviour**

<img width="375" alt="Screenshot 2024-06-13 at 13 26 40" src="https://github.com/WordPress/gutenberg/assets/1530368/8f309b79-58c0-4266-805c-d18f1d274b23">

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

From @hrkhal 

> Enterprise users would expect to see the full url path in the preview at a glance. Displaying the full path would better align with what was in 6.4 and what our users expect.

As only the post name can be edited in this setting, it would be useful if that were clearer.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- This give the full url in the "Link" field and wraps the URL
- In the edit dialog, it updates the instructions to make it clear that only part of the slug is editable
- In the edit dialog, it removes the prefixed "/" in the input as the postname is not necessarily the string which starts the slug

<img width="524" alt="Screenshot 2024-06-13 at 13 27 56" src="https://github.com/WordPress/gutenberg/assets/1530368/e8770b4b-65a2-4f3c-a17c-64cbda862792">

<img width="368" alt="Screenshot 2024-06-13 at 13 27 10" src="https://github.com/WordPress/gutenberg/assets/1530368/f57d1f47-1000-467d-ba48-2e24e29f7260">


## Testing Instructions
- Go to permalink settings and set the structure to `/%year%/%monthnum%/%day%/prefix-%postname%-%post_id%-suffix/`
- Create a post with the name "helloworldhelloworldhelloworld"
- Look at the Link field in the sidebar, it should show the full url with the slug `prefix-helloworldhelloworldhelloworld-suffix`
- Click on the link and look at the dialog which allows you to edit the postname
- The description should say "Customize the post name in the URL (in bold below)."
- The Input should not start with a "/"
- The tooltip on the copy button in the dialog says "Copy Link" 
- The postname should show in the Input (it does not wrap here)

