### PR TITLE
Save Panel: Remove connections icon and fix padding

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { CheckboxControl, Flex, PanelRow } from '@wordpress/components';
+import { CheckboxControl, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -59,13 +59,9 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 				/>
 			</PanelRow>
 			{ hasPostMetaChanges && (
-				<PanelRow>
-					<Flex className="entities-saved-states__post-meta">
-						<span className="entities-saved-states__bindings-text">
-							{ __( 'Post Meta.' ) }
-						</span>
-					</Flex>
-				</PanelRow>
+				<ul className="entities-saved-states__changes">
+					<li>{ __( 'Post Meta.' ) }</li>
+				</ul>
 			) }
 		</>
 	);

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -1,12 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { Icon, CheckboxControl, Flex, PanelRow } from '@wordpress/components';
+import { CheckboxControl, Flex, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { connection } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -62,11 +61,6 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 			{ hasPostMetaChanges && (
 				<PanelRow>
 					<Flex className="entities-saved-states__post-meta">
-						<Icon
-							className="entities-saved-states__connections-icon"
-							icon={ connection }
-							size={ 24 }
-						/>
 						<span className="entities-saved-states__bindings-text">
 							{ __( 'Post Meta.' ) }
 						</span>

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -32,7 +32,7 @@
 }
 
 .entities-saved-states__post-meta {
-	margin-left: $grid-unit-30;
+	margin-left: 28px;
 	align-items: center;
 }
 

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -30,16 +30,3 @@
 		margin-bottom: $grid-unit-05;
 	}
 }
-
-.entities-saved-states__post-meta {
-	margin-left: 28px;
-	align-items: center;
-}
-
-.entities-saved-states__connections-icon {
-	flex-grow: 0;
-}
-
-.entities-saved-states__bindings-text {
-	flex-grow: 1;
-}

--- a/test/e2e/specs/editor/various/publish-panel.spec.js
+++ b/test/e2e/specs/editor/various/publish-panel.spec.js
@@ -164,7 +164,7 @@ test.describe( 'Post publish panel', () => {
 		await expect( publishPanel ).toBeVisible();
 
 		const postMetaPanel = publishPanel.locator(
-			'.entities-saved-states__post-meta'
+			'.entities-saved-states__changes'
 		);
 
 		await expect( postMetaPanel ).toBeVisible();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR revises the styles of the indicator regarding post meta in the save panel, namely removing the connections icon and fixing the padding.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
While the connections icon is explanatory when post meta has been modified via Block Bindings, it is possible to modify post meta by other means and it is not accurate to show the icon in all circumstances.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR removes the connections icon and modifies the styles to fix the padding.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
<details>
<summary>1. Register post meta by adding this snippet to your theme's functions.php</summary>

```php
add_action( 'init', 'test_block_bindings' );

function test_block_bindings() {
	register_meta(
		'post',
		'text_field',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'default'           => 'default text value',
		)
	);
}
```

</details>


<details>

<summary>2. Add a paragraph block bound to the custom field using the Code Editor</summary>

```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field"}}}}} -->
<p>Paragraph content</p>
<!-- /wp:paragraph -->
```

</details>
 
3. Press the Save button.
4. Verify that the Save Panel appears with the updated styles.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before
<img width="1206" alt="save-panel_before" src="https://github.com/WordPress/gutenberg/assets/5360536/39340d83-827e-40f9-8c54-e427e04bf903">

### After
<img width="1204" alt="save-panel_after" src="https://github.com/WordPress/gutenberg/assets/5360536/2fefdfcd-1a97-45c5-8d99-759b96a70912">
