### PR TITLE
Reorders colors in color palette with body and text colors first

### DIFF
--- a/packages/edit-site/src/components/global-styles/preset-colors.js
+++ b/packages/edit-site/src/components/global-styles/preset-colors.js
@@ -1,11 +1,42 @@
 /**
+ * WordPress dependencies
+ */
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
  * Internal dependencies
  */
 import { useStylesPreviewColors } from './hooks';
+import { unlock } from '../../lock-unlock';
 
 export default function PresetColors() {
+	const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 	const { paletteColors } = useStylesPreviewColors();
-	return paletteColors.slice( 0, 5 ).map( ( { slug, color }, index ) => (
+	const [ backgroundColorValue ] = useGlobalStyle( 'color.background' );
+	const [ textColorValue ] = useGlobalStyle( 'color.text' );
+
+	const backgroundColorIndex = paletteColors.findIndex(
+		( { color } ) => color === backgroundColorValue
+	);
+	const textColorIndex = paletteColors.findIndex(
+		( { color } ) => color === textColorValue
+	);
+
+	if ( backgroundColorIndex !== -1 ) {
+		const backgroundColor = paletteColors.splice(
+			backgroundColorIndex,
+			1
+		)[ 0 ];
+		paletteColors.unshift( backgroundColor );
+	}
+	if ( textColorIndex !== -1 ) {
+		const textColor = paletteColors.splice( textColorIndex, 1 )[ 0 ];
+		paletteColors.splice( 1, 0, textColor );
+	}
+
+	const firstFiveColors = paletteColors.slice( 0, 5 );
+
+	return firstFiveColors.map( ( { slug, color }, index ) => (
 		<div
 			key={ `${ slug }-${ index }` }
 			style={ {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes: #62117 

## Why?
Currently color palette colors are ordered exactly as depicted in a theme variation's JSON file. So it doesn't shows which palette would be considered a `dark` palette.

## How?
Fetches the background and text colors and replaces them from the palette, positioning them at the first and second indexes, respectively.
