### PR TITLE
Remove html encoded entities from post slug when cleaning

### DIFF
--- a/packages/url/src/clean-for-slug.js
+++ b/packages/url/src/clean-for-slug.js
@@ -24,7 +24,7 @@ export function cleanForSlug( string ) {
 		return '';
 	}
 	return (
-		removeAccents( string )
+		removeAccents( string.replace( /&amp;/g, '' ).replace( /&lt;/g, '' ) )
 			// Convert each group of whitespace, periods, and forward slashes to a hyphen.
 			.replace( /[\s\./]+/g, '-' )
 			// Remove anything that's not a letter, number, underscore or hyphen.

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -1117,6 +1117,24 @@ describe( 'cleanForSlug', () => {
 		expect( cleanForSlug( 'the long - cat' ) ).toBe( 'the-long-cat' );
 		expect( cleanForSlug( 'the----long---cat' ) ).toBe( 'the-long-cat' );
 	} );
+
+	it( 'Should remove html entities for ampersands', () => {
+		expect(
+			cleanForSlug( 'the long cat &amp; a dog &amp;&amp; fish' )
+		).toBe( 'the-long-cat-a-dog-fish' );
+		expect( cleanForSlug( 'the long cat &amp;amp; dog' ) ).toBe(
+			'the-long-cat-amp-dog'
+		);
+	} );
+
+	it( 'Should remove html entities for less thans', () => {
+		expect( cleanForSlug( '&lt;red is not blue>' ) ).toBe(
+			'red-is-not-blue'
+		);
+		expect( cleanForSlug( '&amp;lt; red and blue are purple' ) ).toBe(
+			'lt-red-and-blue-are-purple'
+		);
+	} );
 } );
 
 describe( 'normalizePath', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines: -->
Fixes #62543

## What?
<!-- In a few words, what is the PR actually doing? -->

This removes the html encoded entity strings for & and < from the slug in `cleanForSlug()`. These are only two entities which seem to cause an issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

>When you type Ampersand & And as the title of an Post and save the Post as a draft, you will see that the URL becomes /ampersand-amp-and/. If you publish the Post, the URL becomes /ampersand-and/.

**Step-by-step reproduction instructions**

- Go to Settings > Permalinks and set Post name as a permalink structure.
- Create a Post and type Ampersand & And as the Post title.
- Save the Post as a Draft.
- In the editor sidebar click on the URL to view the generated URL. It is this: /ampersand-amp-and/
- Publish the Post.
- Chceck URL of the Post. It is this: /ampersand-and/

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replaces `&amp;` and `&lt;` with an empty string in `cleanForSlug()`. Also adds tests.

## Testing Instructions

- create a post with the title `And & &&& &amp; &&& &lt;1 039898':!#*() &&& <>.“‘”’" hey` (note the string `&amp;` and string `&lt;`)
- check the post slug shown in the Link field in the sidebar, it should be  `and-amp-lt1-039898-hey`
- publish the post and look at the post name bit in the slug on the front end, it should be the same `and-amp-lt1-039898-hey` 

