### PR TITLE
Section styles: consolidate variation name

### DIFF
--- a/backport-changelog/6.6/6824.md
+++ b/backport-changelog/6.6/6824.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6824
+
+* https://github.com/WordPress/gutenberg/pull/62550

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -455,7 +455,7 @@ function gutenberg_register_block_style_variations_from_theme_json_data( $variat
 		 * Block style variations read in via standalone theme.json partials
 		 * need to have their name set to the kebab case version of their title.
 		 */
-		$variation_name  = $have_named_variations ? $key : _wp_to_kebab_case( $variation['title'] );
+		$variation_name  = $have_named_variations ? $key : ( $variation['slug'] ?? _wp_to_kebab_case( $variation['title'] ) );
 		$variation_label = $variation['title'] ?? $variation_name;
 
 		foreach ( $supported_blocks as $block_type ) {

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -244,7 +244,7 @@ function gutenberg_resolve_block_style_variations( $variations ) {
 		 * Block style variations read in via standalone theme.json partials
 		 * need to have their name set to the kebab case version of their title.
 		 */
-		$variation_name = $have_named_variations ? $key : _wp_to_kebab_case( $variation['title'] );
+		$variation_name = $have_named_variations ? $key : ( $variation['slug'] ?? _wp_to_kebab_case( $variation['title'] ) );
 
 		foreach ( $supported_blocks as $block_type ) {
 			// Add block style variation data under current block type.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -357,6 +357,7 @@ class WP_Theme_JSON_Gutenberg {
 		'styles',
 		'templateParts',
 		'title',
+		'slug',
 		'version',
 	);
 

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -94,6 +94,22 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 			),
 		);
 
+		/*
+		 * This style is to be deliberately overwritten by the theme.json partial
+		 * See `phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json`.
+		 */
+		register_block_style(
+			'core/group',
+			array(
+				'name'       => 'WithSlug',
+				'style_data' => array(
+					'color' => array(
+						'background' => 'whitesmoke',
+						'text'       => 'black',
+					),
+				),
+			)
+		);
 		register_block_style(
 			'core/group',
 			array(
@@ -106,6 +122,12 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		$group_styles = $theme_json['styles']['blocks']['core/group'] ?? array();
 		$expected     = array(
 			'variations' => array(
+				'WithSlug'                => array(
+					'color' => array(
+						'background' => 'aliceblue',
+						'text'       => 'midnightblue',
+					),
+				),
 				'my-variation'            => $variation_styles_data,
 
 				/*

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -151,6 +151,7 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		);
 
 		unregister_block_style( 'core/group', 'my-variation' );
+		unregister_block_style( 'core/group', 'WithSlug' );
 
 		$this->assertSameSetsWithIndex( $group_styles, $expected );
 	}

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1118,6 +1118,18 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					array(
+						'blockTypes' => array( 'core/group', 'core/columns' ),
+						'version'    => 3,
+						'slug'       => 'WithSlug',
+						'title'      => 'With Slug',
+						'styles'     => array(
+							'color' => array(
+								'background' => 'aliceblue',
+								'text'       => 'midnightblue',
+							),
+						),
+					),
 				),
 			),
 		);

--- a/phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json
+++ b/phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json
@@ -1,0 +1,12 @@
+{
+	"version": 3,
+	"blockTypes": [ "core/group", "core/columns" ],
+	"slug": "WithSlug",
+	"title": "With Slug",
+	"styles": {
+		"color": {
+			"background": "aliceblue",
+			"text": "midnightblue"
+		}
+	}
+}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2696,6 +2696,10 @@
 			"type": "string",
 			"description": "Title of the global styles variation. If not defined, the file name will be used."
 		},
+		"slug": {
+			"type": "string",
+			"description": "Slug of the global styles variation. If not defined, the kebab-case title will be used."
+		},
 		"description": {
 			"type": "string",
 			"description": "Description of the global styles variation."


### PR DESCRIPTION
## What?

This PR enables theme.json partials to provide a different slug than the generated kebab-case to follow what any other registration mechanism (`block.json`, `register_style_variation`) does.

## Why?

For theme.json partials to work like any other registration mechanism, and to enable them to override variations with names that don't follow the kebab-case convention.

The existing mechanisms to register block style variations require a `name` and a `label`, see [docs](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/). The `name` is used to generate the associated class (e.g.: `is-style-NAME`) and we don't do any processing of it — all the following are correct:

| Variation Name | Generated class |
| --- | --- |
| `dark` | `is-style-dark` |
| `Dark` | `is-style-Dark` |
| `PitchDark` | `is-style-PitchDark` |
| `pitch-dark` | `is-style-pitch-dark` |

**Before** this PR, the `title` from the theme.json partials was preprocessed to generate a kebab-cased variation name & class:

| Partial's Title | Variation Name | Generated class |
| --- | --- | --- |
| `dark` | `dark` | `is-style-dark` |
| `Dark` | `dark` | `is-style-dark` |
| `PitchDark` | `pitch-dark` | `is-style-pitch-dark` |
| `pitch-dark` | `pitch-dark` | `is-style-pitch-dark` |

**After** this PR, the theme.json partials can contain an optional `slug` (alternative: `name`?) key to be used in registering the variation and generating its class. This enables the theme.json partials to work with any variation name or class that wasn't kebab-case:

| Partial's Title | Partial's slug | Variation Name | Generated class |
| --- | --- | --- | --- |
| `dark` | - | `dark` | `is-style-dark` |
| `Dark` | `Dark` | `Dark` | `is-style-Dark` |
| `PitchDark` | `PitchDark` | `PitchDark` | `is-style-PitchDark` |
| `pitch-dark` | - | `pitch-dark` | `is-style-pitch-dark` |

Note the `slug` is optional and most of the cases will just let `title` be kebab-cased.

## How?

Allow `slug` to be provided in theme.json partials:

- Use `slug` if present, otherwise kebab-case the `title` a602aae7a669a2be1dae4ad4ad65fb115146224c
- Update schemas c0cca639858f0db2ea7d1784beca62c693ad6d4d

## Testing Instructions

Register a variation with a non-kebab-cased name. For example, paste the following in the `functions.php` of TT4:

```php
		register_block_style(
			'core/group',
			array(
				'name'         => 'MyVariation',
				'label'        => __( 'My variation', 'twentytwentyfour' ),
				'inline_style' => '
				.is-style-MyVariation {
					background-color: red;
				}',
			)
		);
```

- Go to the editor and verify there is a variation for the group block called "My variation" and that applying it would set the background to red.
- Create the file `styles/partial.json` with the following contents:

```json
{
    "$schema": "https://schemas.wp.org/trunk/theme.json",
    "version": 2,
    "title": "My variation",
    "blockTypes": [ "core/group" ],
    "styles": {
            "color": {
                    "background": "blue",
                    "text": "white"
            }
    }
}
```

- Go to the editor. You'll see two variations registered. 

<img width="273" alt="Captura de ecrã 2024-06-13, às 23 15 33" src="https://github.com/WordPress/gutenberg/assets/583546/b44bd4ac-866a-4ad4-8ed8-37d182c1b245">

- Now, update the `partial.json` to include a `slug` that matches the variation name provided by `register_block_style` call:

```json
{
    "$schema": "https://schemas.wp.org/trunk/theme.json",
    "version": 2,
    "title": "My variation",
    "slug": "MyVariation",
    "blockTypes": [ "core/group" ],
    "styles": {
            "color": {
                    "background": "blue",
                    "text": "white"
            }
    }
}
```

- Go to the editor and verify that there is only one variation again:

<img width="273" alt="Captura de ecrã 2024-06-13, às 23 12 48" src="https://github.com/WordPress/gutenberg/assets/583546/3a972a5a-9e58-4cf3-a0e5-a392edf0e115">

- Confirm that the partial's style gets applied correctly as it takes precedence over the PHP block style registration.