### PR TITLE
Section styles: support i18n for variations declared in `theme.json` or theme style variations

### DIFF
--- a/backport-changelog/6.6/6825.md
+++ b/backport-changelog/6.6/6825.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6825
+
+* https://github.com/WordPress/gutenberg/pull/62552

--- a/lib/theme-i18n.json
+++ b/lib/theme-i18n.json
@@ -81,6 +81,15 @@
 			}
 		}
 	},
+	"styles": {
+		"blocks": {
+			"variations": {
+				"*": {
+					"title": "Style variation name"
+				}
+			}
+		}
+	},
 	"customTemplates": [
 		{
 			"title": "Custom template name"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2288,6 +2288,10 @@
 				},
 				{
 					"properties": {
+						"title": {
+							"type": "string",
+							"description": "Title of the global styles variation."
+						},
 						"blockTypes": {
 							"type": "array",
 							"items": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2290,7 +2290,7 @@
 					"properties": {
 						"title": {
 							"type": "string",
-							"description": "Title of the global styles variation."
+							"description": "Style variation name."
 						},
 						"blockTypes": {
 							"type": "array",


### PR DESCRIPTION
## What?

This PR adds support for internationalizing the block style variations labels defined from a `theme.json` or a theme style variation (e.g.: `styles/ember.json`).

## Why?

We want to enable internationalization of the block style variations defined from a `theme.json` or a theme style variation.

## How?

Allow `title` to be provided when registering block style variations from `theme.json` or theme style variations (e.g.: `styles/ember.json`):

- Update theme.json schema to allow `title` as a valid property
- Update theme-i18n.json schema to signal `title` as a translatable property 

## Testing Instructions

In the `theme.json` of the theme, paste the following contents under `styles.blocks.variations`:

```json
"myvariation": {
    "title": "My Variation",
    "blockTypes": ["core/group"],
    "color": {
        "background": "var(--wp--preset--color--base-2)"
    }
}
```

| Without the `title` | With the `title` |
| --- | --- |
| <img width="278" alt="Captura de ecrã 2024-06-13, às 21 51 45" src="https://github.com/WordPress/gutenberg/assets/583546/88aa296e-8dba-4b36-bfd2-f56ef9006576"> | <img width="278" alt="Captura de ecrã 2024-06-13, às 21 52 04" src="https://github.com/WordPress/gutenberg/assets/583546/9c78d6a9-01c0-4870-82a5-322c12282b85"> |

Note that the `title` was already permitted, so it didn't require any style registration/generation changes. This PR adds it as part of the schema used by editors for linting and makes it translatable.

## Related work

Enabling the `styles.blocks.variations.*.title` property to be translatable requires:

- updating the wp-cli/i18n-command that processes WordPress & the ecosystem (plugins, themes) to extract the strings https://github.com/wp-cli/i18n-command/pull/405
- update the `theme-i18n.json` in WordPress core as well (to be done as part of backporting this PR)
