### PR TITLE
Fix: Unable to remove custom colors on safari.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -92,6 +92,8 @@ $z-layers: (
 	// For larger views, the wp-admin navbar dropdown should be at top of
 	// the Publish Post sidebar.
 	".editor-post-publish-panel {greater than small}": 99998,
+	// above the sidebar
+	".components-palette-edit__remove-button": 100010,
 
 	// For larger views, the wp-admin navbar dropdown should be on top of
 	// the multi-entity saving sidebar.

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -201,7 +201,6 @@ function Option< T extends Color | Gradient >( {
 		<PaletteItem
 			className={ isEditing ? 'is-selected' : undefined }
 			as={ isEditing ? 'div' : 'button' }
-			onClick={ isEditing ? undefined : onStartEditing }
 			aria-label={
 				isEditing
 					? undefined
@@ -212,7 +211,9 @@ function Option< T extends Color | Gradient >( {
 					  )
 			}
 			ref={ setPopoverAnchor }
-			{ ...( isEditing ? { ...focusOutsideProps } : {} ) }
+			{ ...( isEditing
+				? { ...focusOutsideProps }
+				: { onClick: onStartEditing } ) }
 		>
 			<HStack justify="flex-start">
 				<IndicatorStyled colorValue={ value } />
@@ -245,14 +246,13 @@ function Option< T extends Color | Gradient >( {
 					) }
 				</FlexItem>
 				{ isEditing && ! canOnlyChangeValues && (
-					<FlexItem>
-						<RemoveButton
-							size="small"
-							icon={ lineSolid }
-							label={ __( 'Remove color' ) }
-							onClick={ onRemove }
-						/>
-					</FlexItem>
+					<RemoveButton
+						className="components-palette-edit__remove-button"
+						size="small"
+						icon={ lineSolid }
+						label={ __( 'Remove color' ) }
+						onClick={ onRemove }
+					/>
 				) }
 			</HStack>
 			{ isEditing && (
@@ -311,7 +311,10 @@ function PaletteEditListView< T extends Color | Gradient >( {
 								)
 							);
 						} }
-						onRemove={ () => {
+						onRemove={ ( event ) => {
+							event.preventDefault();
+							event.stopPropagation();
+							setEditingElement( null );
 							const newElements = elements.filter(
 								( _currentElement, currentIndex ) => {
 									if ( currentIndex === index ) {
@@ -323,7 +326,6 @@ function PaletteEditListView< T extends Color | Gradient >( {
 							onChange(
 								newElements.length ? newElements : undefined
 							);
-							setEditingElement( null );
 						} }
 						isEditing={ index === editingElement }
 						onStopEditing={ () => {

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -201,7 +201,7 @@ function Option< T extends Color | Gradient >( {
 		<PaletteItem
 			className={ isEditing ? 'is-selected' : undefined }
 			as={ isEditing ? 'div' : 'button' }
-			onClick={ onStartEditing }
+			onClick={ isEditing ? undefined : onStartEditing }
 			aria-label={
 				isEditing
 					? undefined
@@ -312,7 +312,6 @@ function PaletteEditListView< T extends Color | Gradient >( {
 							);
 						} }
 						onRemove={ () => {
-							setEditingElement( null );
 							const newElements = elements.filter(
 								( _currentElement, currentIndex ) => {
 									if ( currentIndex === index ) {
@@ -324,6 +323,7 @@ function PaletteEditListView< T extends Color | Gradient >( {
 							onChange(
 								newElements.length ? newElements : undefined
 							);
+							setEditingElement( null );
 						} }
 						isEditing={ index === editingElement }
 						onStopEditing={ () => {

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -7,3 +7,7 @@
 		width: 100%;
 	}
 }
+
+.components-palette-edit__remove-button {
+	z-index: z-index(".components-palette-edit__remove-button");
+}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/62261

To be honest I don't know the root cause of the issue. It seems to happen only on Safari. I tried many many fixes and this combination of changes seem to work:
- Increases the z-index of the remove button to be higher than sidebar.
- Don't pass an onClick event to the parent if we are already editing that color.
- Stop the event propagation on the remove button.

cc: @noisysocks and @richtabor in case you can confirm if the issue is also fixed for you.

## Testing Instructions
Use Safari.
Go to Appearance → Editor → Colors → Palette.
Add a custom color and press Done.
Click the button to remove that custom color and see if it works as expected.
