### PR TITLE
Interactivity: Fix `withScope` to restore scope on thrown exception inside async functions

### DIFF
--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -145,18 +145,26 @@ export function withScope( func: ( ...args: unknown[] ) => unknown ) {
 				try {
 					it = gen.next( value );
 				} finally {
-					resetNamespace();
 					resetScope();
+					resetNamespace();
 				}
+
 				try {
 					value = await it.value;
 				} catch ( e ) {
+					setNamespace( ns );
+					setScope( scope );
 					gen.throw( e );
+				} finally {
+					resetScope();
+					resetNamespace();
 				}
+
 				if ( it.done ) {
 					break;
 				}
 			}
+
 			return value;
 		};
 	}


### PR DESCRIPTION
## What?

Fixes `withScope()` to maintain the Interactivity scope on captured exceptions inside async functions.

Related to https://github.com/WordPress/gutenberg/pull/59708

## Why?

This was previously fixed inside the store proxy handlers but not inside `withScope()`, which contains the same logic.

## How?

Done so by 1) fixing the code inside `withScope()`, then 2) removing the duplicated code, and 3) using `withScope()` inside the store proxy handlers.

## Testing Instructions

Tested by e2e tests (inside `test/e2e/specs/interactivity/async-actions.spec.ts`).
