### PR TITLE
Shortcut Help modal: Remove CSS hack for Internet Explorer 11

### DIFF
--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/style.scss
@@ -33,9 +33,6 @@
 	&__shortcut-description {
 		flex: 1;
 		margin: 0;
-
-		// IE 11 flex item fix - ensure the item does not collapse.
-		flex-basis: auto;
 	}
 
 	&__shortcut-key-combination {

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/style.scss
@@ -33,9 +33,6 @@
 	&__shortcut-description {
 		flex: 1;
 		margin: 0;
-
-		// IE 11 flex item fix - ensure the item does not collapse.
-		flex-basis: auto;
 	}
 
 	&__shortcut-key-combination {

--- a/packages/editor/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/editor/src/components/keyboard-shortcut-help-modal/style.scss
@@ -33,9 +33,6 @@
 	&__shortcut-description {
 		flex: 1;
 		margin: 0;
-
-		// IE 11 flex item fix - ensure the item does not collapse.
-		flex-basis: auto;
 	}
 
 	&__shortcut-key-combination {


### PR DESCRIPTION
Part of #58034

## What?

Remove the CSS code for IE11 that exists in the keyboard shortcuts modal.

![ie-hack](https://github.com/WordPress/gutenberg/assets/54422211/1a235047-a6d9-4d28-9ecc-ee9406c8ea9b)

## Why?

Support for IE11 has been [officially removed in WordPress 5.8](https://make.wordpress.org/core/2021/04/22/ie-11-support-phase-out-plan/). And since the Gutenberg plugin no longer supports WordPress 5.8, we can remove the fallback code for IE11.

## Testing Instructions

The layout of the shortcuts modal should remain the same.