### PR TITLE
Sort spacing sizes when all slugs begin numerically

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/hooks/use-spacing-sizes.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/hooks/use-spacing-sizes.js
@@ -44,15 +44,8 @@ export default function useSpacingSizes() {
 			...defaultSizes,
 		];
 
-		// Only sort if more than one origin has presets defined in order to
-		// preserve order for themes that don't include default presets and
-		// want a custom order.
-		if (
-			( customSizes.length && 1 ) +
-				( themeSizes.length && 1 ) +
-				( defaultSizes.length && 1 ) >
-			1
-		) {
+		// Using numeric slugs opts-in to sorting by slug.
+		if ( sizes.every( ( { slug } ) => /^[0-9]/.test( slug ) ) ) {
 			sizes.sort( ( a, b ) => compare( a.slug, b.slug ) );
 		}
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -444,9 +444,8 @@
 										"type": "string"
 									},
 									"slug": {
-										"description": "Unique identifier for the space size preset. Will be sorted numerically. For best cross theme compatibility these should be in the form '10','20','30','40','50','60', etc. with '50' representing the 'Medium' size step.",
-										"type": "string",
-										"pattern": "^[0-9].*$"
+										"description": "Unique identifier for the space size preset. For best cross theme compatibility these should be in the form '10','20','30','40','50','60', etc. with '50' representing the 'Medium' size step. If all slugs begin with a number they will be merged with default and user slugs and sorted numerically.",
+										"type": "string"
 									},
 									"size": {
 										"description": "CSS space-size value, including units.",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Changes the sorting heuristic for `spacingSizes` from having more than one origin to all slugs from all origins beginning numerically.

Removes the numeric requirement for slugs in the schema.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #62520

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

> The heuristics for sorting that I added in https://github.com/WordPress/gutenberg/pull/62199 were focused on figuring out v2 vs v3 schemas. If we do away with heuristics and simply sort when all slugs start with a number, the sorting becomes an opt-in feature by the theme using numeric slugs. The numeric slugs become a bonus feature rather than a requirement for correct operation.
>
> We'll still want to update the UI to have sections, but I don't think that's critical to fix until we have UI for adding user origin spacing presets. At that point, if a user adds a new preset that isn't numeric, then that will effectively opt-out of the merging and sorting of presets even if the theme is using numeric slugs.

https://github.com/WordPress/gutenberg/issues/62520#issuecomment-2167205559

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Try numeric and non-numeric slugs with and without defaults enabled to see if sorting happens when you would expect.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
