### PR TITLE
Fix PHP Warning thrown when get_block_file_template() returns null

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -114,7 +114,11 @@ function render_block_core_template_part( $attributes ) {
 	$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
 
 	if ( is_null( $content ) ) {
-		if ( $is_debug && isset( $attributes['slug'] ) ) {
+		if ( $is_debug ) {
+			if ( ! isset( $attributes['slug'] ) ) {
+				// If there is no slug this is a placeholder and we dont want to return any message.
+				return '';
+			}
 			return sprintf(
 				/* translators: %s: Template part slug. */
 				__( 'Template part has been deleted or is unavailable: %s' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a refresh PR for the core trac ticket: [#59318](https://core.trac.wordpress.org/ticket/59318), and for the GH issue #62559 

## Why?
To fix the deprecation notice passing null to non-nullable when referring to missing template parts.

## How?
N/A

## Testing Instructions
1. Open wp-content/themes/twentytwentyfour/templates/home.html file in your favorite code editor.
2. In the footer template-part, change the slug to something that does not exist:
<!-- wp:template-part {"slug":"doesnotexistfooter","area":"footer","tagName":"footer"} /-->	
3. $is_debug needs to be false. Two ways to accomplish this:
    a. Set WP_DEBUG to false in wp-config.php.
    b . Set WP_DEBUG_DISPLAY to false in wp-config.php`.
    c. Temporarily modify the [following line of code](https://core.trac.wordpress.org/browser/tags/6.3.4/src/wp-includes/blocks/template-part.php#L110) in wp-includes/blocks/template-part.php to hardcode it to false. This approach lets you keep WP_DEBUG and WP_DEBUG_DISPLAY set to true to further see the deprecation notice in the front-end.
$is_debug = false; //WP_DEBUG && WP_DEBUG_DISPLAY;	
4. Open the home page in the front. 🐞 A Deprecation notice is thrown (viewable in the server logs, debug.log, and/or on the screen in your browser).

Props @hellofromtonya 

## Screenshots or screencast <!-- if applicable -->
N/A
