### PR TITLE
fetchLinkSuggestions: Allow for partial matching

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
@@ -264,14 +264,16 @@ export default async function fetchLinkSuggestions(
  * @param search
  */
 export function sortResults( results: SearchResult[], search: string ) {
-	const searchTokens = new Set( tokenize( search ) );
+	const searchTokens = tokenize( search );
 
 	const scores = {};
 	for ( const result of results ) {
 		if ( result.title ) {
 			const titleTokens = tokenize( result.title );
-			const matchingTokens = titleTokens.filter( ( token ) =>
-				searchTokens.has( token )
+			const matchingTokens = titleTokens.filter( ( titleToken ) =>
+				searchTokens.some( ( searchToken ) =>
+					titleToken.includes( searchToken )
+				)
 			);
 			scores[ result.id ] = matchingTokens.length / titleTokens.length;
 		} else {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follows https://github.com/WordPress/gutenberg/pull/62397.

Really quick attempt at addressing @andrewserong's comment https://github.com/WordPress/gutenberg/pull/62397#pullrequestreview-2117554375.

## Why?
See https://github.com/WordPress/gutenberg/pull/62397#pullrequestreview-2117554375.

## How?
Update the scoring function added in https://github.com/WordPress/gutenberg/pull/62397 to consider a title token as matching if it _contains_ (`str1.includes(str2)`, not `str1 === str2`) any of the search tokens.

## Testing Instructions
Same as https://github.com/WordPress/gutenberg/pull/62397, but search for something like "trave" instead of "travel".