### PR TITLE
Fix: Flakey deferred store test

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -3,7 +3,7 @@
  */
 import { store, getContext } from '@wordpress/interactivity';
 
-globalThis.addEventListener(
+window.addEventListener(
 	'_test_proceed_',
 	() => {
 		store( 'test/deferred-store', {

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -3,16 +3,20 @@
  */
 import { store, getContext } from '@wordpress/interactivity';
 
-globalThis.addEventListener( '_test_proceed_', () => {
-	store( 'test/deferred-store', {
-		state: {
-			reversedText() {
-				return [ ...getContext().text ].reverse().join( '' );
-			},
+globalThis.addEventListener(
+	'_test_proceed_',
+	() => {
+		store( 'test/deferred-store', {
+			state: {
+				reversedText() {
+					return [ ...getContext().text ].reverse().join( '' );
+				},
 
-			get reversedTextGetter() {
-				return [ ...getContext().text ].reverse().join( '' );
+				get reversedTextGetter() {
+					return [ ...getContext().text ].reverse().join( '' );
+				},
 			},
-		},
-	} );
-} );
+		} );
+	},
+	{ once: true }
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -3,18 +3,16 @@
  */
 import { store, getContext } from '@wordpress/interactivity';
 
-document.addEventListener( 'DOMContentLoaded', () => {
-	setTimeout( () => {
-		store( 'test/deferred-store', {
-			state: {
-				reversedText() {
-					return [ ...getContext().text ].reverse().join( '' );
-				},
-
-				get reversedTextGetter() {
-					return [ ...getContext().text ].reverse().join( '' );
-				},
+globalThis.addEventListener( '_test_proceed_', () => {
+	store( 'test/deferred-store', {
+		state: {
+			reversedText() {
+				return [ ...getContext().text ].reverse().join( '' );
 			},
-		} );
-	}, 100 );
+
+			get reversedTextGetter() {
+				return [ ...getContext().text ].reverse().join( '' );
+			},
+		},
+	} );
 } );

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -21,7 +21,7 @@ test.describe( 'deferred store', () => {
 	} ) => {
 		const resultInput = page.getByTestId( 'result' );
 		await expect( resultInput ).toHaveText( '' );
-		globalThis.dispatchEvent( new Event( '_test_proceed_' ) );
+		window.dispatchEvent( new Event( '_test_proceed_' ) );
 		await expect( resultInput ).toHaveText( 'Hello, world!' );
 	} );
 
@@ -32,7 +32,7 @@ test.describe( 'deferred store', () => {
 	} ) => {
 		const resultInput = page.getByTestId( 'result-getter' );
 		await expect( resultInput ).toHaveText( '' );
-		globalThis.dispatchEvent( new Event( '_test_proceed_' ) );
+		window.dispatchEvent( new Event( '_test_proceed_' ) );
 		await expect( resultInput ).toHaveText( 'Hello, world!' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -21,6 +21,7 @@ test.describe( 'deferred store', () => {
 	} ) => {
 		const resultInput = page.getByTestId( 'result' );
 		await expect( resultInput ).toHaveText( '' );
+		globalThis.dispatchEvent( new Event( '_test_proceed_' ) );
 		await expect( resultInput ).toHaveText( 'Hello, world!' );
 	} );
 
@@ -31,6 +32,7 @@ test.describe( 'deferred store', () => {
 	} ) => {
 		const resultInput = page.getByTestId( 'result-getter' );
 		await expect( resultInput ).toHaveText( '' );
+		globalThis.dispatchEvent( new Event( '_test_proceed_' ) );
 		await expect( resultInput ).toHaveText( 'Hello, world!' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -21,7 +21,9 @@ test.describe( 'deferred store', () => {
 	} ) => {
 		const resultInput = page.getByTestId( 'result' );
 		await expect( resultInput ).toHaveText( '' );
-		window.dispatchEvent( new Event( '_test_proceed_' ) );
+		await page.evaluate( () => {
+			window.dispatchEvent( new Event( '_test_proceed_' ) );
+		} );
 		await expect( resultInput ).toHaveText( 'Hello, world!' );
 	} );
 
@@ -32,7 +34,9 @@ test.describe( 'deferred store', () => {
 	} ) => {
 		const resultInput = page.getByTestId( 'result-getter' );
 		await expect( resultInput ).toHaveText( '' );
-		window.dispatchEvent( new Event( '_test_proceed_' ) );
+		await page.evaluate( () => {
+			window.dispatchEvent( new Event( '_test_proceed_' ) );
+		} );
 		await expect( resultInput ).toHaveText( 'Hello, world!' );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix flakey test #59899.

This is an improvement on https://github.com/WordPress/gutenberg/pull/61359.

Closes #59899.

## How?

Instead of setting an arbitrary timeout that's long enough, we'll initialize the store when a custom event fires. We can dispatch that even when we're ready for tests to proceed.

## Testing Instructions
CI passes.
