### PR TITLE
Fix author visibility issue in the editor.

### DIFF
--- a/packages/editor/src/components/post-author/hook.js
+++ b/packages/editor/src/components/post-author/hook.js
@@ -59,5 +59,7 @@ export function useAuthorsQuery( search ) {
 		return fetchedAuthors;
 	}, [ authors, postAuthor ] );
 
-	return { authorId, authorOptions, postAuthor };
+	const firstAuthor = authors && authors.length > 0 ? authors[ 0 ] : '';
+
+	return { firstAuthor, authorId, authorOptions, postAuthor };
 }

--- a/packages/editor/src/components/post-author/panel.js
+++ b/packages/editor/src/components/post-author/panel.js
@@ -15,8 +15,8 @@ import PostPanelRow from '../post-panel-row';
 import { useAuthorsQuery } from './hook';
 
 function PostAuthorToggle( { isOpen, onClick } ) {
-	const { postAuthor } = useAuthorsQuery();
-	const authorName = postAuthor?.name || '';
+	const { firstAuthor, postAuthor } = useAuthorsQuery();
+	const authorName = postAuthor?.name || firstAuthor.name;
 	return (
 		<Button
 			size="compact"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixed the Author Visibility issue by displaying the alphabetically first author's name when the post/page is created by a super admin that does not have their user registered in the sub-site.
Fixes the issue: https://github.com/WordPress/gutenberg/issues/62574

## Why?
There is a UI issue if we are not able to see any author's name. It fixes that.

## How?
When a super admin adds a new post/page and its user is not registered on the sub-site, then instead of showing nothing for the author I have added the name of the alphabetically first author's name. 

## Testing Instructions
- Login to your WordPress site using a Super admin user.
- Go on a sub-site where the Super admin user you are using does not have its user registered.
- Open a new post or page.
- Check the author in the right panel of the editor.

## Screenshots or screencast <!-- if applicable -->
<img width="294" alt="author-fix" src="https://github.com/WordPress/gutenberg/assets/62138457/2665f7ab-a440-453d-bb36-16b7d21700cb">
<img width="1470" alt="Screenshot 2024-06-14 at 4 16 26 PM" src="https://github.com/WordPress/gutenberg/assets/62138457/d9692a95-0bee-4695-b700-00783078844c">

