### PR TITLE
Global Styles: Don't apply the background and text colors to typography previews

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -15,6 +15,7 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
+import { filterObjectByProperty } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../../lock-unlock';
 
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
@@ -22,18 +23,22 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
 
-export default function Variation( { variation, children, isPill } ) {
+export default function Variation( { variation, children, isPill, property } ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
-	const context = useMemo(
-		() => ( {
+
+	const context = useMemo( () => {
+		let merged = mergeBaseAndUserConfigs( base, variation );
+		if ( property ) {
+			merged = filterObjectByProperty( merged, property );
+		}
+		return {
 			user: variation,
 			base,
-			merged: mergeBaseAndUserConfigs( base, variation ),
+			merged,
 			setUserConfig: () => {},
-		} ),
-		[ variation, base ]
-	);
+		};
+	}, [ variation, base, property ] );
 
 	const selectVariation = () => setUserConfig( variation );
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -27,7 +27,12 @@ export default function ColorVariations( { title, gap = 2 } ) {
 			{ title && <Subtitle level={ 3 }>{ title }</Subtitle> }
 			<Grid spacing={ gap }>
 				{ colorVariations.map( ( variation, index ) => (
-					<Variation key={ index } variation={ variation } isPill>
+					<Variation
+						key={ index }
+						variation={ variation }
+						isPill
+						property="color"
+					>
 						{ () => <StylesPreviewColors /> }
 					</Variation>
 				) ) }

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -35,7 +35,11 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 				{ typographyVariations &&
 					typographyVariations.length &&
 					typographyVariations.map( ( variation, index ) => (
-						<Variation key={ index } variation={ variation }>
+						<Variation
+							key={ index }
+							variation={ variation }
+							property="typography"
+						>
 							{ ( isFocused ) => (
 								<PreviewIframe
 									label={ variation?.title }


### PR DESCRIPTION
## What?
Fix #61217. Alternative to #61898. 

Removes all style rules from color and typography variation previews, except the for the property that is in the preset.

## Why?
The typography presets only change typography styles so it makes sense to keep these preview clear of any other settings.

## How?
Pass the property that we are previewing to the variation component as a prop. If present we use this prop to filter out only this style so it can be used in the preview.

## Testing Instructions
1. Open the site editor
2. Open the Styles section in preview mode
3. Check that the typography previews don't have background colors
4. Open Global Styles > Typography
5. Check that the typography previews don't have background colors

### Testing Instructions for Keyboard
This is a visual change.

## Screenshots or screencast <!-- if applicable -->
<img width="281" alt="Screenshot 2024-06-14 at 12 42 51" src="https://github.com/WordPress/gutenberg/assets/275961/5c161f1c-2f0c-4fef-af21-ee336a2d3e77">
<img width="352" alt="Screenshot 2024-06-14 at 12 42 40" src="https://github.com/WordPress/gutenberg/assets/275961/be14b28e-2d71-4f27-a7dc-ebfb087e5db7">

