### PR TITLE
Documentation: VisualEditorGlobalKeyboardShortcuts, TextEditorGlobalKeyboardShortcuts editor components

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1603,9 +1603,11 @@ _Returns_
 
 ### TextEditorGlobalKeyboardShortcuts
 
-Component handles the global keyboard shortcuts for the Text editor.
+Represents the TextEditorGlobalKeyboardShortcuts component. This component is responsible for handling global keyboard shortcuts in the editor.
 
-It provides functionality for various keyboard shortcuts such as toggling editor mode, toggling distraction-free mode, undo/redo.
+_Type_
+
+-   `EditorKeyboardShortcuts`
 
 ### ThemeSupportCheck
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1712,7 +1712,11 @@ _Type_
 
 ### VisualEditorGlobalKeyboardShortcuts
 
-Undocumented declaration.
+Represents the VisualEditorGlobalKeyboardShortcuts component. This component is responsible for handling global keyboard shortcuts in the editor.
+
+_Type_
+
+-   `EditorKeyboardShortcuts`
 
 ### Warning
 

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -115,9 +115,9 @@ export * from './deprecated';
 export const VisualEditorGlobalKeyboardShortcuts = EditorKeyboardShortcuts;
 
 /**
- * Component handles the global keyboard shortcuts for the Text editor.
+ * Represents the TextEditorGlobalKeyboardShortcuts component.
+ * This component is responsible for handling global keyboard shortcuts in the editor.
  *
- * It provides functionality for various keyboard shortcuts such as toggling editor mode,
- * toggling distraction-free mode, undo/redo.
+ * @type {EditorKeyboardShortcuts}
  */
 export const TextEditorGlobalKeyboardShortcuts = EditorKeyboardShortcuts;

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -105,6 +105,13 @@ export { default as CharacterCount } from './character-count';
 export { default as EditorProvider } from './provider';
 
 export * from './deprecated';
+
+/**
+ * Represents the VisualEditorGlobalKeyboardShortcuts component.
+ * This component is responsible for handling global keyboard shortcuts in the editor.
+ *
+ * @type {EditorKeyboardShortcuts}
+ */
 export const VisualEditorGlobalKeyboardShortcuts = EditorKeyboardShortcuts;
 
 /**


### PR DESCRIPTION
## What? & Why?
Addresses two items in #60358

Adding documentation to existing editor components can help with any of the following:
- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add a JSDoc comment to the `VisualEditorGlobalKeyboardShortcuts` and updated `TextEditorGlobalKeyboardShortcut` for consistency components and run `npm run docs:build` to populate the `README` with the newly added documents.
