### PR TITLE
convert escape-html package to TS

### DIFF
--- a/packages/escape-html/CHANGELOG.md
+++ b/packages/escape-html/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Refactor to TypeScript ([#62586](https://github.com/WordPress/gutenberg/pull/62586)).
+
 ## 3.0.0 (2024-05-31)
 
 ### Breaking Changes

--- a/packages/escape-html/src/escape-greater.ts
+++ b/packages/escape-html/src/escape-greater.ts
@@ -6,10 +6,10 @@
  *
  * See: https://core.trac.wordpress.org/ticket/45387
  *
- * @param {string} value Original string.
+ * @param value Original string.
  *
- * @return {string} Escaped string.
+ * @return Escaped string.
  */
-export default function __unstableEscapeGreaterThan( value ) {
+export default function __unstableEscapeGreaterThan( value: string ): string {
 	return value.replace( />/g, '&gt;' );
 }

--- a/packages/escape-html/src/index.ts
+++ b/packages/escape-html/src/index.ts
@@ -11,10 +11,9 @@ import __unstableEscapeGreaterThan from './escape-greater';
  * and noncharacters."
  *
  * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
- *
- * @type {RegExp}
  */
-const REGEXP_INVALID_ATTRIBUTE_NAME = /[\u007F-\u009F "'>/="\uFDD0-\uFDEF]/;
+const REGEXP_INVALID_ATTRIBUTE_NAME: RegExp =
+	/[\u007F-\u009F "'>/="\uFDD0-\uFDEF]/;
 
 /**
  * Returns a string with ampersands escaped. Note that this is an imperfect
@@ -26,33 +25,33 @@ const REGEXP_INVALID_ATTRIBUTE_NAME = /[\u007F-\u009F "'>/="\uFDD0-\uFDEF]/;
  * @see https://w3c.github.io/html/syntax.html#ambiguous-ampersand
  * @see https://w3c.github.io/html/syntax.html#named-character-references
  *
- * @param {string} value Original string.
+ * @param value Original string.
  *
- * @return {string} Escaped string.
+ * @return Escaped string.
  */
-export function escapeAmpersand( value ) {
+export function escapeAmpersand( value: string ): string {
 	return value.replace( /&(?!([a-z0-9]+|#[0-9]+|#x[a-f0-9]+);)/gi, '&amp;' );
 }
 
 /**
  * Returns a string with quotation marks replaced.
  *
- * @param {string} value Original string.
+ * @param value Original string.
  *
- * @return {string} Escaped string.
+ * @return Escaped string.
  */
-export function escapeQuotationMark( value ) {
+export function escapeQuotationMark( value: string ): string {
 	return value.replace( /"/g, '&quot;' );
 }
 
 /**
  * Returns a string with less-than sign replaced.
  *
- * @param {string} value Original string.
+ * @param value Original string.
  *
- * @return {string} Escaped string.
+ * @return Escaped string.
  */
-export function escapeLessThan( value ) {
+export function escapeLessThan( value: string ): string {
 	return value.replace( /</g, '&lt;' );
 }
 
@@ -72,11 +71,11 @@ export function escapeLessThan( value ) {
  *
  * See: https://core.trac.wordpress.org/ticket/45387
  *
- * @param {string} value Attribute value.
+ * @param value Attribute value.
  *
- * @return {string} Escaped attribute value.
+ * @return Escaped attribute value.
  */
-export function escapeAttribute( value ) {
+export function escapeAttribute( value: string ): string {
 	return __unstableEscapeGreaterThan(
 		escapeQuotationMark( escapeAmpersand( value ) )
 	);
@@ -90,11 +89,11 @@ export function escapeAttribute( value ) {
  * "the text must not contain the character U+003C LESS-THAN SIGN (<) or an
  * ambiguous ampersand."
  *
- * @param {string} value Element value.
+ * @param value Element value.
  *
- * @return {string} Escaped HTML element value.
+ * @return Escaped HTML element value.
  */
-export function escapeHTML( value ) {
+export function escapeHTML( value: string ): string {
 	return escapeLessThan( escapeAmpersand( value ) );
 }
 
@@ -103,21 +102,21 @@ export function escapeHTML( value ) {
  * `escapeHTML`, because for editable HTML, ALL ampersands must be escaped in
  * order to render the content correctly on the page.
  *
- * @param {string} value Element value.
+ * @param value Element value.
  *
- * @return {string} Escaped HTML element value.
+ * @return Escaped HTML element value.
  */
-export function escapeEditableHTML( value ) {
+export function escapeEditableHTML( value: string ): string {
 	return escapeLessThan( value.replace( /&/g, '&amp;' ) );
 }
 
 /**
  * Returns true if the given attribute name is valid, or false otherwise.
  *
- * @param {string} name Attribute name to test.
+ * @param name Attribute name to test.
  *
- * @return {boolean} Whether attribute is valid.
+ * @return Whether attribute is valid.
  */
-export function isValidAttributeName( name ) {
+export function isValidAttributeName( name: string ): boolean {
 	return ! REGEXP_INVALID_ATTRIBUTE_NAME.test( name );
 }

--- a/packages/escape-html/src/test/index.ts
+++ b/packages/escape-html/src/test/index.ts
@@ -9,17 +9,19 @@ import {
 	escapeHTML,
 	isValidAttributeName,
 	escapeEditableHTML,
-} from '../';
+} from '..';
 import __unstableEscapeGreaterThan from '../escape-greater';
 
-function testUnstableEscapeGreaterThan( implementation ) {
+type Implementation = ( str: string ) => string;
+
+function testUnstableEscapeGreaterThan( implementation: Implementation ) {
 	it( 'should escape greater than', () => {
 		const result = implementation( 'Chicken > Ribs' );
 		expect( result ).toBe( 'Chicken &gt; Ribs' );
 	} );
 }
 
-function testEscapeAmpersand( implementation ) {
+function testEscapeAmpersand( implementation: Implementation ) {
 	it( 'should escape ampersand', () => {
 		const result = implementation(
 			'foo & bar &amp; &AMP; baz &#931; &#bad; &#x3A3; &#X3a3; &#xevil;'
@@ -31,7 +33,7 @@ function testEscapeAmpersand( implementation ) {
 	} );
 }
 
-function testEscapeQuotationMark( implementation ) {
+function testEscapeQuotationMark( implementation: Implementation ) {
 	it( 'should escape quotation mark', () => {
 		const result = implementation( '"Be gone!"' );
 
@@ -39,7 +41,7 @@ function testEscapeQuotationMark( implementation ) {
 	} );
 }
 
-function testEscapeLessThan( implementation ) {
+function testEscapeLessThan( implementation: Implementation ) {
 	it( 'should escape less than', () => {
 		const result = implementation( 'Chicken < Ribs' );
 


### PR DESCRIPTION
## What?
This PR converts the escape-html package to TypeScript.

## Why?
Ensures package is fully type checked.

## How?
converted files to .ts
explicitly type functions and incorrectly-implied variables, based on @type, @param and @return comments

## Testing Instructions
- `npm run test:unit -- packages/escape-html` tests pass
- `npm run build:package-types` returns a zero exit code

### reference PR
Closes https://github.com/WordPress/gutenberg/pull/61607
