### PR TITLE
Revert "Revert test data for `WithSlug` variation (#62579)"

### DIFF
--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -94,6 +94,22 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 			),
 		);
 
+		/*
+		 * This style is to be deliberately overwritten by the theme.json partial
+		 * See `phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json`.
+		 */
+		register_block_style(
+			'core/group',
+			array(
+				'name'       => 'WithSlug',
+				'style_data' => array(
+					'color' => array(
+						'background' => 'whitesmoke',
+						'text'       => 'black',
+					),
+				),
+			)
+		);
 		register_block_style(
 			'core/group',
 			array(
@@ -106,6 +122,12 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		$group_styles = $theme_json['styles']['blocks']['core/group'] ?? array();
 		$expected     = array(
 			'variations' => array(
+				'WithSlug'                => array(
+					'color' => array(
+						'background' => 'aliceblue',
+						'text'       => 'midnightblue',
+					),
+				),
 				'my-variation'            => $variation_styles_data,
 
 				/*
@@ -129,6 +151,7 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		);
 
 		unregister_block_style( 'core/group', 'my-variation' );
+		unregister_block_style( 'core/group', 'WithSlug' );
 
 		$this->assertSameSetsWithIndex( $group_styles, $expected );
 	}

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -10,6 +10,41 @@
 
 class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	/**
+	 * Administrator ID.
+	 *
+	 * @var int
+	 */
+	protected static $administrator_id;
+
+	/**
+	 * WP_Theme_JSON_Resolver_Gutenberg::$blocks_cache property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $property_blocks_cache;
+
+	/**
+	 * Original value of the WP_Theme_JSON_Resolver_Gutenberg::$blocks_cache property.
+	 *
+	 * @var array
+	 */
+	private static $property_blocks_cache_orig_value;
+
+	/**
+	 * WP_Theme_JSON_Resolver_Gutenberg::$core property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $property_core;
+
+	/**
+	 * Original value of the WP_Theme_JSON_Resolver_Gutenberg::$core property.
+	 *
+	 * @var WP_Theme_JSON_Gutenberg
+	 */
+	private static $property_core_orig_value;
+
+	/**
 	 * Theme root directory.
 	 *
 	 * @var string|null
@@ -22,6 +57,31 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	 * @var array|null
 	 */
 	private $orig_theme_dir;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$administrator_id = self::factory()->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_email' => 'administrator@example.com',
+			)
+		);
+
+		static::$property_blocks_cache = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'blocks_cache' );
+		static::$property_blocks_cache->setAccessible( true );
+		static::$property_blocks_cache_orig_value = static::$property_blocks_cache->getValue();
+
+		static::$property_core = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'core' );
+		static::$property_core->setAccessible( true );
+		static::$property_core_orig_value = static::$property_core->getValue();
+	}
+
+	public static function tear_down_after_class() {
+		static::$property_blocks_cache->setValue( null, static::$property_blocks_cache_orig_value );
+		static::$property_core->setValue( null, static::$property_core_orig_value );
+		parent::tear_down_after_class();
+	}
 
 	public function set_up() {
 		parent::set_up();

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1118,6 +1118,18 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					array(
+						'blockTypes' => array( 'core/group', 'core/columns' ),
+						'version'    => 3,
+						'slug'       => 'WithSlug',
+						'title'      => 'With Slug',
+						'styles'     => array(
+							'color' => array(
+								'background' => 'aliceblue',
+								'text'       => 'midnightblue',
+							),
+						),
+					),
 				),
 			),
 		);

--- a/phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json
+++ b/phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json
@@ -1,0 +1,12 @@
+{
+	"version": 3,
+	"blockTypes": [ "core/group", "core/columns" ],
+	"slug": "WithSlug",
+	"title": "With Slug",
+	"styles": {
+		"color": {
+			"background": "aliceblue",
+			"text": "midnightblue"
+		}
+	}
+}


### PR DESCRIPTION
Reverts https://github.com/WordPress/gutenberg/pull/62579
Follow-up to https://github.com/WordPress/gutenberg/pull/62550

This PR brings back one test we had to put in quarantine to unblock other PRs from lading.