### PR TITLE
[Mobile] - Fix issues when pasting HTML content

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -245,12 +245,8 @@ class RCTAztecView: Aztec.TextView {
     }
 
     private func readHTML(from pasteboard: UIPasteboard) -> String? {
-
         if let data = pasteboard.data(forPasteboardType: kUTTypeHTML as String), let html = String(data: data, encoding: .utf8) {
-            // Make sure we are not getting a full HTML DOC. We only want inner content
-            if !html.hasPrefix("<!DOCTYPE html") {
-                return html
-            }
+            return html
         }
 
         if let flatRTFDString = read(from: pasteboard, uti: kUTTypeFlatRTFD, documentType: DocumentType.rtfd) {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,6 +13,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [internal] Fix Inserter items list filtering [#62334]
 -   [*] Prevent hiding the keyboard when creating new list items [#62446]
 -   [*] RichText - Fix undefined onDelete callback [#62486]
+-   [*] Fix issue when pasting HTML content [#62588]
 
 ## 1.120.0
 -   [*] Prevent deleting content when backspacing in the first Paragraph block [#62069]


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6933

## What?
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1157 where copying HTML from other external apps would fail to retain the formatting.

## Why?
To prevent removing list formatting from external apps like the iOS Notes app when pasting content into the editor.

## How?
By removing the prefix check and allow the `pasteHandler` functionality to handle the full HTML content.

The original issue also mentions Android but the issues it mentions was when we didn't have the List block with inner blocks and we were using Aztec's List formatter.

## Testing Instructions

> [!NOTE]  
> Please use the following builds to test:
> - [iOS Only](https://github.com/wordpress-mobile/WordPress-iOS/pull/23361#issuecomment-2168333040)

## Case 1 - Pasting content from the iOS Notes app
- Open the editor
- Paste list items from the Notes app
- **Expect** to see the lists as List blocks, not Paragraph blocks.

## Case 2 - Pasting content from a Website
- Open the editor
- Go to a Website and copy some of the content
- Paste it into the editor
- **Expect** the content to be inserted with its format

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/4885740/8e082f16-b76f-477c-b182-a6fec4242706

