### PR TITLE
Fix: the trash post action doesn't take into account user capabilities.

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -309,12 +309,12 @@ const trashPostAction = {
 
 function useTrashPostAction( postType ) {
 	const registry = useRegistry();
-	const { resource, canUserResolvers } = useSelect(
+	const { resource, cachedCanUserResolvers } = useSelect(
 		( select ) => {
 			const { getPostType, getCachedResolvers } = select( coreStore );
 			return {
 				resource: getPostType( postType )?.rest_base || '',
-				canUserResolvers: getCachedResolvers().canUser,
+				cachedCanUserResolvers: getCachedResolvers().canUser,
 			};
 		},
 		[ postType ]
@@ -331,8 +331,10 @@ function useTrashPostAction( postType ) {
 				);
 			},
 		} ),
+		// We are making this use memo depend on cachedCanUserResolvers as a way to make the component using this hook re-render
+		// when user capabilities are resolved. This makes sure the isEligible function is re-evaluated.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ registry, resource, canUserResolvers ]
+		[ registry, resource, cachedCanUserResolvers ]
 	);
 }
 
@@ -1143,9 +1145,7 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		isPattern,
 		postTypeObject?.viewable,
 		duplicatePostAction,
-		permanentlyDeletePostAction,
 		trashPostActionForPostType,
-		restorePostAction,
 		onActionPerformed,
 		isLoaded,
 		supportsRevisions,

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -3,7 +3,7 @@
  */
 import { external, trash, backup } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, _n, sprintf, _x } from '@wordpress/i18n';
@@ -147,165 +147,207 @@ const deletePostAction = {
 	},
 };
 
-const trashPostAction = {
-	id: 'move-to-trash',
-	label: __( 'Move to Trash' ),
-	isPrimary: true,
-	icon: trash,
-	isEligible( item ) {
-		return ! [ 'auto-draft', 'trash' ].includes( item.status );
-	},
-	supportsBulk: true,
-	hideModalHeader: true,
-	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
-		const [ isBusy, setIsBusy ] = useState( false );
-		const { createSuccessNotice, createErrorNotice } =
-			useDispatch( noticesStore );
-		const { deleteEntityRecord } = useDispatch( coreStore );
-		return (
-			<VStack spacing="5">
-				<Text>
-					{ items.length === 1
-						? sprintf(
-								// translators: %s: The item's title.
-								__(
-									'Are you sure you want to move to trash "%s"?'
-								),
-								getItemTitle( items[ 0 ] )
-						  )
-						: sprintf(
-								// translators: %d: The number of items (2 or more).
-								_n(
-									'Are you sure you want to move to trash %d item?',
-									'Are you sure you want to move to trash %d items?',
-									items.length
-								),
-								items.length
-						  ) }
-				</Text>
-				<HStack justify="right">
-					<Button
-						variant="tertiary"
-						onClick={ closeModal }
-						disabled={ isBusy }
-						__experimentalIsFocusable
-					>
-						{ __( 'Cancel' ) }
-					</Button>
-					<Button
-						variant="primary"
-						onClick={ async () => {
-							setIsBusy( true );
-							const promiseResult = await Promise.allSettled(
-								items.map( ( item ) =>
-									deleteEntityRecord(
-										'postType',
-										item.type,
-										item.id,
-										{},
-										{ throwOnError: true }
-									)
-								)
-							);
-							// If all the promises were fulfilled with success.
-							if (
-								promiseResult.every(
-									( { status } ) => status === 'fulfilled'
-								)
-							) {
-								let successMessage;
-								if ( promiseResult.length === 1 ) {
-									successMessage = sprintf(
-										/* translators: The item's title. */
-										__( '"%s" moved to trash.' ),
+function useTrashPostAction( postType ) {
+	const registry = useRegistry();
+	const { resource, canUserResolvers } = useSelect(
+		( select ) => {
+			const { getPostType, getCachedResolvers } = select( coreStore );
+			return {
+				resource: getPostType( postType )?.rest_base || '',
+				canUserResolvers: getCachedResolvers().canUser,
+			};
+		},
+		[ postType ]
+	);
+	return useMemo(
+		() => ( {
+			id: 'move-to-trash',
+			label: __( 'Move to Trash' ),
+			isPrimary: true,
+			icon: trash,
+			isEligible( item ) {
+				return (
+					registry
+						.select( coreStore )
+						.canUser( 'delete', resource, item.id ) &&
+					! [ 'auto-draft', 'trash' ].includes( item.status )
+				);
+			},
+			supportsBulk: true,
+			hideModalHeader: true,
+			RenderModal: ( { items, closeModal, onActionPerformed } ) => {
+				const [ isBusy, setIsBusy ] = useState( false );
+				const { createSuccessNotice, createErrorNotice } =
+					useDispatch( noticesStore );
+				const { deleteEntityRecord } = useDispatch( coreStore );
+				return (
+					<VStack spacing="5">
+						<Text>
+							{ items.length === 1
+								? sprintf(
+										// translators: %s: The item's title.
+										__(
+											'Are you sure you want to move to trash "%s"?'
+										),
 										getItemTitle( items[ 0 ] )
-									);
-								} else if ( items[ 0 ].type === 'page' ) {
-									successMessage = sprintf(
-										/* translators: The number of items. */
-										__( '%s items moved to trash.' ),
+								  )
+								: sprintf(
+										// translators: %d: The number of items (2 or more).
+										_n(
+											'Are you sure you want to move to trash %d item?',
+											'Are you sure you want to move to trash %d items?',
+											items.length
+										),
 										items.length
-									);
-								} else {
-									successMessage = sprintf(
-										/* translators: The number of posts. */
-										__( '%s items move to trash.' ),
-										items.length
-									);
-								}
-								createSuccessNotice( successMessage, {
-									type: 'snackbar',
-									id: 'move-to-trash-action',
-								} );
-							} else {
-								// If there was at least one failure.
-								let errorMessage;
-								// If we were trying to delete a single item.
-								if ( promiseResult.length === 1 ) {
-									if ( promiseResult[ 0 ].reason?.message ) {
-										errorMessage =
-											promiseResult[ 0 ].reason.message;
-									} else {
-										errorMessage = __(
-											'An error occurred while moving to trash the item.'
+								  ) }
+						</Text>
+						<HStack justify="right">
+							<Button
+								variant="tertiary"
+								onClick={ closeModal }
+								disabled={ isBusy }
+								__experimentalIsFocusable
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button
+								variant="primary"
+								onClick={ async () => {
+									setIsBusy( true );
+									const promiseResult =
+										await Promise.allSettled(
+											items.map( ( item ) =>
+												deleteEntityRecord(
+													'postType',
+													item.type,
+													item.id,
+													{},
+													{ throwOnError: true }
+												)
+											)
 										);
-									}
-									// If we were trying to delete multiple items.
-								} else {
-									const errorMessages = new Set();
-									const failedPromises = promiseResult.filter(
-										( { status } ) => status === 'rejected'
-									);
-									for ( const failedPromise of failedPromises ) {
-										if ( failedPromise.reason?.message ) {
-											errorMessages.add(
-												failedPromise.reason.message
+									// If all the promises were fulfilled with success.
+									if (
+										promiseResult.every(
+											( { status } ) =>
+												status === 'fulfilled'
+										)
+									) {
+										let successMessage;
+										if ( promiseResult.length === 1 ) {
+											successMessage = sprintf(
+												/* translators: The item's title. */
+												__( '"%s" moved to trash.' ),
+												getItemTitle( items[ 0 ] )
+											);
+										} else if (
+											items[ 0 ].type === 'page'
+										) {
+											successMessage = sprintf(
+												/* translators: The number of items. */
+												__(
+													'%s items moved to trash.'
+												),
+												items.length
+											);
+										} else {
+											successMessage = sprintf(
+												/* translators: The number of posts. */
+												__( '%s items move to trash.' ),
+												items.length
 											);
 										}
-									}
-									if ( errorMessages.size === 0 ) {
-										errorMessage = __(
-											'An error occurred while moving to trash the items.'
-										);
-									} else if ( errorMessages.size === 1 ) {
-										errorMessage = sprintf(
-											/* translators: %s: an error message */
-											__(
-												'An error occurred while moving to trash the item: %s'
-											),
-											[ ...errorMessages ][ 0 ]
-										);
+										createSuccessNotice( successMessage, {
+											type: 'snackbar',
+											id: 'move-to-trash-action',
+										} );
 									} else {
-										errorMessage = sprintf(
-											/* translators: %s: a list of comma separated error messages */
-											__(
-												'Some errors occurred while moving to trash the items: %s'
-											),
-											[ ...errorMessages ].join( ',' )
-										);
+										// If there was at least one failure.
+										let errorMessage;
+										// If we were trying to delete a single item.
+										if ( promiseResult.length === 1 ) {
+											if (
+												promiseResult[ 0 ].reason
+													?.message
+											) {
+												errorMessage =
+													promiseResult[ 0 ].reason
+														.message;
+											} else {
+												errorMessage = __(
+													'An error occurred while moving to trash the item.'
+												);
+											}
+											// If we were trying to delete multiple items.
+										} else {
+											const errorMessages = new Set();
+											const failedPromises =
+												promiseResult.filter(
+													( { status } ) =>
+														status === 'rejected'
+												);
+											for ( const failedPromise of failedPromises ) {
+												if (
+													failedPromise.reason
+														?.message
+												) {
+													errorMessages.add(
+														failedPromise.reason
+															.message
+													);
+												}
+											}
+											if ( errorMessages.size === 0 ) {
+												errorMessage = __(
+													'An error occurred while moving to trash the items.'
+												);
+											} else if (
+												errorMessages.size === 1
+											) {
+												errorMessage = sprintf(
+													/* translators: %s: an error message */
+													__(
+														'An error occurred while moving to trash the item: %s'
+													),
+													[ ...errorMessages ][ 0 ]
+												);
+											} else {
+												errorMessage = sprintf(
+													/* translators: %s: a list of comma separated error messages */
+													__(
+														'Some errors occurred while moving to trash the items: %s'
+													),
+													[ ...errorMessages ].join(
+														','
+													)
+												);
+											}
+										}
+										createErrorNotice( errorMessage, {
+											type: 'snackbar',
+										} );
 									}
-								}
-								createErrorNotice( errorMessage, {
-									type: 'snackbar',
-								} );
-							}
-							if ( onActionPerformed ) {
-								onActionPerformed( items );
-							}
-							setIsBusy( false );
-							closeModal();
-						} }
-						isBusy={ isBusy }
-						disabled={ isBusy }
-						__experimentalIsFocusable
-					>
-						{ __( 'Trash' ) }
-					</Button>
-				</HStack>
-			</VStack>
-		);
-	},
-};
+									if ( onActionPerformed ) {
+										onActionPerformed( items );
+									}
+									setIsBusy( false );
+									closeModal();
+								} }
+								isBusy={ isBusy }
+								disabled={ isBusy }
+								__experimentalIsFocusable
+							>
+								{ __( 'Trash' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				);
+			},
+		} ),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[ registry, resource, canUserResolvers ]
+	);
+}
 
 const permanentlyDeletePostAction = {
 	id: 'permanently-delete',
@@ -1020,6 +1062,7 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 	);
 
 	const duplicatePostAction = useDuplicatePostAction( postType );
+	const trashPostAction = useTrashPostAction( postType );
 	const isTemplateOrTemplatePart = [
 		TEMPLATE_POST_TYPE,
 		TEMPLATE_PART_POST_TYPE,
@@ -1113,6 +1156,9 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		isPattern,
 		postTypeObject?.viewable,
 		duplicatePostAction,
+		permanentlyDeletePostAction,
+		trashPostAction,
+		restorePostAction,
 		onActionPerformed,
 		isLoaded,
 		supportsRevisions,


### PR DESCRIPTION
Right now we show the trash post action all the time even if the user does not have the correct capabilities.
We essentially regressed on https://github.com/WordPress/gutenberg/issues/23144.
This PR adds equivalent checks to the ones added at https://github.com/WordPress/gutenberg/pull/23174.

It is a bit hacky because we are calling a selector inside isEligible and to make sure things rerender we make the memorization depend on the result of getCachedResolvers.

It is also not ideal in the sense we make a REST API request per post to make sure the user has the permissions. In a list with 50 posts, it is not a very good solution.

I considered not using canUser, and instead retrieving the capabilities of the post and the user: delete_others_posts, delete_post, delete_posts, delete_private_posts, delete_published_posts,delete_published_posts. Implement the verification on the client e.g.: check if the post is published or private, and verify if the user capabilities are there. These would only depend on postType and user so we would not require a request per post. However, it is incompatible with some ways developers change capabilities (e.g.: the sample below would not work with this approach).

So I opted for the more reliable approach that we were already using.

This should be part of 6.6 as showing the UI to trash posts when the user has no capability for that is a regression.

cc: @youknowriad, @ntsekouras as people inside the actions work.

<b>Reviewers note:</b>
Hide whitespace: https://github.com/WordPress/gutenberg/pull/62589/files?w=1

The only changes are the inclusion of useRegistry and useSelect and their use inside isEligible, excluding these changes the action was kept exactly as before.

## Testing Instructions
I pasted the following code snipped on load.php:
```
function remove_delete_post_capability( $caps, $cap, $user_id, $args ) {
    if ( 'delete_post' == $cap ) {
        // Get the current user object
        $current_user = wp_get_current_user();
        // Check if the current user is the user we want to remove the capability from
        if ( $current_user->ID == $user_id ) {
            // Remove the 'delete_post' capability
            // It's done by returning a capability that the user does not have, for example 'do_not_allow'
            $caps[] = 'do_not_allow';
        }
    }

    return $caps;
}

add_filter( 'map_meta_cap', 'remove_delete_post_capability', 10, 4 );
```

I verified the option to trash pages was not available on Dataviews pages list and site editor.
I opened a post on the post editor and verified that the action to trash the post was unavailable.