### PR TITLE
Fix: Check Capability to create pages on DataViews add new page button

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -277,15 +277,19 @@ export default function PagePages() {
 		[ totalItems, totalPages ]
 	);
 
-	const { frontPageId, postsPageId, addNewLabel } = useSelect( ( select ) => {
-		const { getEntityRecord, getPostType } = select( coreStore );
-		const siteSettings = getEntityRecord( 'root', 'site' );
-		return {
-			frontPageId: siteSettings?.page_on_front,
-			postsPageId: siteSettings?.page_for_posts,
-			addNewLabel: getPostType( 'page' )?.labels?.add_new_item,
-		};
-	} );
+	const { frontPageId, postsPageId, addNewLabel, canCreatePage } = useSelect(
+		( select ) => {
+			const { getEntityRecord, getPostType, canUser } =
+				select( coreStore );
+			const siteSettings = getEntityRecord( 'root', 'site' );
+			return {
+				frontPageId: siteSettings?.page_on_front,
+				postsPageId: siteSettings?.page_for_posts,
+				addNewLabel: getPostType( 'page' )?.labels?.add_new_item,
+				canCreatePage: canUser( 'create', 'pages' ),
+			};
+		}
+	);
 
 	const fields = useMemo(
 		() => [
@@ -496,7 +500,8 @@ export default function PagePages() {
 		<Page
 			title={ __( 'Pages' ) }
 			actions={
-				addNewLabel && (
+				addNewLabel &&
+				canCreatePage && (
 					<>
 						<Button
 							variant="primary"


### PR DESCRIPTION
We display the "Add New Page" option for all users, causing errors for those without page creation capabilities.
This PR fixes the issue we now check if the user is able to create pages when rendering the button.

## Testing Instructions
I pasted this test code on load.php to remove the capability to create pages:
```
// Allow only administrators to create pages by default.
add_filter(
	'register_page_post_type_args',
	function ( $args ) {
		$args['capabilities']['create_posts'] = 'nonexistent_capability';

		return $args;
	},
);
```
I went to `/wp-admin/site-editor.php?postType=page` and verified that "Add New Page" button was not available.