### PR TITLE
Focus Editor Region from Template Footer Click

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -12,6 +12,7 @@ import { chevronRightSmall, Icon } from '@wordpress/icons';
 import BlockTitle from '../block-title';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { __unstableUseBlockRef as useBlockRef } from '../block-list/use-block-props/use-block-refs';
 
 /**
  * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
@@ -37,6 +38,10 @@ function BlockBreadcrumb( { rootLabelText } ) {
 	}, [] );
 	const rootLabel = rootLabelText || __( 'Document' );
 
+	// We don't care about this specific ref, but this is a way
+	// to get a ref within the editor canvas so we can focus it later.
+	const blockRef = useBlockRef( clientId );
+
 	/*
 	 * Disable reason: The `list` ARIA role is redundant but
 	 * Safari+VoiceOver won't announce the list otherwise.
@@ -60,7 +65,42 @@ function BlockBreadcrumb( { rootLabelText } ) {
 					<Button
 						className="block-editor-block-breadcrumb__button"
 						variant="tertiary"
-						onClick={ clearSelectedBlock }
+						onClick={ () => {
+							// Find the block editor wrapper for the selected block
+							const blockEditor = blockRef.current?.closest(
+								'.editor-styles-wrapper'
+							);
+
+							const editorCanvas =
+								document
+									.querySelectorAll(
+										'iframe[name="editor-canvas"]'
+									)
+									.values()
+									.find( ( iframe ) => {
+										// Find the iframe that contains our contentRef
+										const iframeDocument =
+											iframe.contentDocument ||
+											iframe.contentWindow.document;
+
+										return (
+											iframeDocument ===
+											blockEditor.ownerDocument
+										);
+									} ) ?? blockEditor;
+
+							// The region is provivided by the editor, not the block-editor.
+							// We should send focus to the region if one is available to reuse the
+							// same interface for navigating landmarks. If no region is available,
+							// use the canvas instead.
+							const focusableWrapper =
+								editorCanvas?.closest( '[role="region"]' ) ??
+								editorCanvas;
+
+							clearSelectedBlock();
+
+							focusableWrapper.focus();
+						} }
 					>
 						{ rootLabel }
 					</Button>

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -13,6 +13,7 @@ import BlockTitle from '../block-title';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { __unstableUseBlockRef as useBlockRef } from '../block-list/use-block-props/use-block-refs';
+import getEditorRegion from '../../utils/get-editor-region';
 
 /**
  * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
@@ -71,35 +72,9 @@ function BlockBreadcrumb( { rootLabelText } ) {
 								'.editor-styles-wrapper'
 							);
 
-							const editorCanvas =
-								document
-									.querySelectorAll(
-										'iframe[name="editor-canvas"]'
-									)
-									.values()
-									.find( ( iframe ) => {
-										// Find the iframe that contains our contentRef
-										const iframeDocument =
-											iframe.contentDocument ||
-											iframe.contentWindow.document;
-
-										return (
-											iframeDocument ===
-											blockEditor.ownerDocument
-										);
-									} ) ?? blockEditor;
-
-							// The region is provivided by the editor, not the block-editor.
-							// We should send focus to the region if one is available to reuse the
-							// same interface for navigating landmarks. If no region is available,
-							// use the canvas instead.
-							const focusableWrapper =
-								editorCanvas?.closest( '[role="region"]' ) ??
-								editorCanvas;
-
 							clearSelectedBlock();
 
-							focusableWrapper.focus();
+							getEditorRegion( blockEditor ).focus();
 						} }
 					>
 						{ rootLabel }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -25,6 +25,7 @@ import usePopoverScroll from '../block-popover/use-popover-scroll';
 import ZoomOutModeInserters from './zoom-out-mode-inserters';
 import { useShowBlockTools } from './use-show-block-tools';
 import { unlock } from '../../lock-unlock';
+import getEditorRegion from '../../utils/get-editor-region';
 
 function selector( select ) {
 	const {
@@ -161,33 +162,7 @@ export default function BlockTools( {
 			) {
 				event.preventDefault();
 				clearSelectedBlock();
-				// If there are multiple editors, we need to find the iframe that contains our contentRef to make sure
-				// we're focusing the region that contains this editor.
-				const editorCanvas =
-					Array.from(
-						document
-							.querySelectorAll( 'iframe[name="editor-canvas"]' )
-							.values()
-					).find( ( iframe ) => {
-						// Find the iframe that contains our contentRef
-						const iframeDocument =
-							iframe.contentDocument ||
-							iframe.contentWindow.document;
-
-						return (
-							iframeDocument ===
-							__unstableContentRef.current.ownerDocument
-						);
-					} ) ?? __unstableContentRef.current;
-
-				// The region is provivided by the editor, not the block-editor.
-				// We should send focus to the region if one is available to reuse the
-				// same interface for navigating landmarks. If no region is available,
-				// use the canvas instead.
-				const focusableWrapper =
-					editorCanvas?.closest( '[role="region"]' ) ?? editorCanvas;
-
-				focusableWrapper.focus();
+				getEditorRegion( __unstableContentRef.current ).focus();
 			}
 		} else if ( isMatch( 'core/block-editor/collapse-list-view', event ) ) {
 			// If focus is currently within a text field, such as a rich text block or other editable field,

--- a/packages/block-editor/src/utils/get-editor-region.js
+++ b/packages/block-editor/src/utils/get-editor-region.js
@@ -1,0 +1,32 @@
+/**
+ * Gets the editor region for a given editor canvas element or
+ * returns the passed element if no region is found
+ *
+ * @param { Object } editor
+ * @return { Object } The editor region or given editor element
+ */
+export default function getEditorRegion( editor ) {
+	if ( ! editor ) {
+		return null;
+	}
+
+	// If there are multiple editors, we need to find the iframe that contains our contentRef to make sure
+	// we're focusing the region that contains this editor.
+	const editorCanvas =
+		document
+			.querySelectorAll( 'iframe[name="editor-canvas"]' )
+			.values()
+			.find( ( iframe ) => {
+				// Find the iframe that contains our contentRef
+				const iframeDocument =
+					iframe.contentDocument || iframe.contentWindow.document;
+
+				return iframeDocument === editor.ownerDocument;
+			} ) ?? editor;
+
+	// The region is provivided by the editor, not the block-editor.
+	// We should send focus to the region if one is available to reuse the
+	// same interface for navigating landmarks. If no region is available,
+	// use the canvas instead.
+	return editorCanvas?.closest( '[role="region"]' ) ?? editorCanvas;
+}

--- a/packages/block-editor/src/utils/get-editor-region.js
+++ b/packages/block-editor/src/utils/get-editor-region.js
@@ -2,7 +2,7 @@
  * Gets the editor region for a given editor canvas element or
  * returns the passed element if no region is found
  *
- * @param { Object } editor
+ * @param { Object } editor The editor canvas element.
  * @return { Object } The editor region or given editor element
  */
 export default function getEditorRegion( editor ) {
@@ -13,16 +13,15 @@ export default function getEditorRegion( editor ) {
 	// If there are multiple editors, we need to find the iframe that contains our contentRef to make sure
 	// we're focusing the region that contains this editor.
 	const editorCanvas =
-		document
-			.querySelectorAll( 'iframe[name="editor-canvas"]' )
-			.values()
-			.find( ( iframe ) => {
-				// Find the iframe that contains our contentRef
-				const iframeDocument =
-					iframe.contentDocument || iframe.contentWindow.document;
+		Array.from(
+			document.querySelectorAll( 'iframe[name="editor-canvas"]' ).values()
+		).find( ( iframe ) => {
+			// Find the iframe that contains our contentRef
+			const iframeDocument =
+				iframe.contentDocument || iframe.contentWindow.document;
 
-				return iframeDocument === editor.ownerDocument;
-			} ) ?? editor;
+			return iframeDocument === editor.ownerDocument;
+		} ) ?? editor;
 
 	// The region is provivided by the editor, not the block-editor.
 	// We should send focus to the region if one is available to reuse the


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Clicking the Template button in the footer breadcrumbs causes a focus loss to the body of the page. This PR sets focus to the editor region instead, making it similar to how the other buttons in footer breadcrumbs work.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
a11y. Focus management.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When clicking "Template" in the footer breadcrumbs, set focus on the editor canvas region through a new utility, getEditorRegion. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Select a block
- Click the root "Template" button in the footer
- Focus should _not_ be visible on the canvas as it uses focus-visible (only shows focus if activated via moving to it via keyboard), but focus should be there. 
- Tab to check focus is at the top of the editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Select a block
- Tab many times to the root "Template" button in the footer
- Focus should be visible on the canvas

## Screenshots or screencast <!-- if applicable -->



