### PR TITLE
Fix: empty style attribute issue in navigation block

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -519,6 +519,8 @@ class WP_Navigation_Block_Renderer {
 			';
 		}
 
+		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );	
+
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
 				<div class="%5$s" %7$s id="%1$s" %11$s>
@@ -537,7 +539,7 @@ class WP_Navigation_Block_Renderer {
 			$toggle_aria_label_close,
 			esc_attr( implode( ' ', $responsive_container_classes ) ),
 			esc_attr( implode( ' ', $open_button_classes ) ),
-			( ! empty( esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ) ) ) ? ( 'style="' . esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ) . '"' ) : '',
+			( ! empty( $overlay_inline_styles ) ) ? "style=$overlay_inline_styles" : '',
 			$toggle_button_content,
 			$toggle_close_button_content,
 			$open_button_directives,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -521,7 +521,7 @@ class WP_Navigation_Block_Renderer {
 
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
-				<div class="%5$s" style="%7$s" id="%1$s" %11$s>
+				<div class="%5$s" %7$s id="%1$s" %11$s>
 					<div class="wp-block-navigation__responsive-close" tabindex="-1">
 						<div class="wp-block-navigation__responsive-dialog" %12$s>
 							<button %4$s class="wp-block-navigation__responsive-container-close" %13$s>%9$s</button>
@@ -537,7 +537,7 @@ class WP_Navigation_Block_Renderer {
 			$toggle_aria_label_close,
 			esc_attr( implode( ' ', $responsive_container_classes ) ),
 			esc_attr( implode( ' ', $open_button_classes ) ),
-			esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ),
+			( ! empty( esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ) ) ) ? ( 'style="' . esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ) . '"' ) : '',
 			$toggle_button_content,
 			$toggle_close_button_content,
 			$open_button_directives,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -539,7 +539,7 @@ class WP_Navigation_Block_Renderer {
 			$toggle_aria_label_close,
 			esc_attr( implode( ' ', $responsive_container_classes ) ),
 			esc_attr( implode( ' ', $open_button_classes ) ),
-			( ! empty( $overlay_inline_styles ) ) ? "style=$overlay_inline_styles" : '',
+			( ! empty( $overlay_inline_styles ) ) ? "style=\"$overlay_inline_styles\"" : '',
 			$toggle_button_content,
 			$toggle_close_button_content,
 			$open_button_directives,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -519,7 +519,7 @@ class WP_Navigation_Block_Renderer {
 			';
 		}
 
-		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );	
+		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>


### PR DESCRIPTION
## What?
- checking if `$colors['overlay_inline_styles']` is not empty then only adding style attribute.

## Why?
https://github.com/WordPress/gutenberg/issues/62358

## How?
```php
( ! empty( esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ) ) ) ? ( 'style="' . esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ) . '"' ) : ''
```

## Testing Instructions
- create page
- add navigation block
- see div with `wp-block-navigation__responsive-container` previously having empty style will not have style attribute.

## Screenshots or screencast <!-- if applicable -->
<img width="1360" alt="Screenshot 2024-06-15 at 23 51 01" src="https://github.com/WordPress/gutenberg/assets/75293077/f5cadbff-3cea-4655-a54f-b3d3166c12c3">

