### PR TITLE
Global Styles: Add style variation partial cache

### DIFF
--- a/backport-changelog/6.6/6857.md
+++ b/backport-changelog/6.6/6857.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6857
+
+* https://github.com/WordPress/gutenberg/pull/62610

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -92,6 +92,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	protected static $theme_json_file_cache = array();
 
 	/**
+	 * Cache of parsed and translated style variation theme.json partials.
+	 *
+	 * @since 6.6.0
+	 * @var array
+	 */
+	protected static $style_variations_cache = array();
+
+	/**
 	 * Processes a file that adheres to the theme.json schema
 	 * and returns an array with its contents, or a void array if none found.
 	 *
@@ -715,7 +723,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	}
 
 	/**
-	 * Determines if a supplied style variation matches the provided scope.
+	 * Determines the scope of a style variation.
 	 *
 	 * For backwards compatibility, if a variation does not define any scope
 	 * related property, e.g. `blockTypes`, it is assumed to be a theme style
@@ -723,37 +731,25 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array  $variation Theme.json shaped style variation object.
-	 * @param string $scope     Scope to check e.g. theme, block etc.
+	 * @param array $variation Theme.json shaped style variation object.
 	 *
-	 * @return boolean
+	 * @return string
 	 */
-	private static function style_variation_has_scope( $variation, $scope ) {
-		if ( 'block' === $scope ) {
-			return isset( $variation['blockTypes'] );
+	protected static function get_style_variation_scope( $variation ) {
+		if ( isset( $variation['blockTypes'] ) ) {
+			return 'block';
 		}
 
-		if ( 'theme' === $scope ) {
-			return ! isset( $variation['blockTypes'] );
-		}
-
-		return false;
+		return 'theme';
 	}
 
 	/**
-	 * Returns the style variations defined by the theme (parent and child).
+	 * Retrieves all style variation partials defined by the theme (parent and child).
 	 *
-	 * @since 6.2.0 Returns parent theme variations if theme is a child.
-	 * @since 6.6.0 Added configurable scope parameter to allow filtering
-	 *              theme.json partial files by the scope to which they
-	 *              can be applied e.g. theme vs block etc.
-	 *
-	 * @param string $scope The scope or type of style variation to retrieve e.g. theme, block etc.
-	 * @return array
+	 * @since 6.6.0
 	 */
-	public static function get_style_variations( $scope = 'theme' ) {
+	protected static function get_style_variation_files() {
 		$variation_files    = array();
-		$variations         = array();
 		$base_directory     = get_stylesheet_directory() . '/styles';
 		$template_directory = get_template_directory() . '/styles';
 		if ( is_dir( $base_directory ) ) {
@@ -772,18 +768,54 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			$variation_files = array_merge( $variation_files, $variation_files_parent );
 		}
 		ksort( $variation_files );
+
+		return $variation_files;
+	}
+
+	/**
+	 * Returns the style variations defined by the theme (parent and child).
+	 *
+	 * @since 6.2.0 Returns parent theme variations if theme is a child.
+	 * @since 6.6.0 Added cache and configurable scope parameter to allow
+	 *              filtering theme.json partial files by the scope to
+	 *              which they can be applied e.g. theme vs block etc.
+	 *
+	 * @param string $scope The scope or type of style variation to retrieve e.g. theme, block etc.
+	 * @return array
+	 */
+	public static function get_style_variations( $scope = 'theme' ) {
+		$theme_dir = get_stylesheet_directory();
+		$locale    = get_locale();
+		if ( isset( static::$style_variations_cache[ $theme_dir ][ $locale ][ $scope ] ) ) {
+			return static::$style_variations_cache[ $theme_dir ][ $locale ][ $scope ];
+		}
+
+		$variation_files = static::get_style_variation_files();
+		$variations      = array(
+			'theme' => array(),
+			'block' => array(),
+		);
+
 		foreach ( $variation_files as $path => $file ) {
 			$decoded_file = self::read_json_file( $path );
-			if ( is_array( $decoded_file ) && static::style_variation_has_scope( $decoded_file, $scope ) ) {
-				$translated = static::translate( $decoded_file, wp_get_theme()->get( 'TextDomain' ) );
-				$variation  = ( new WP_Theme_JSON_Gutenberg( $translated ) )->get_raw_data();
-				if ( empty( $variation['title'] ) ) {
-					$variation['title'] = basename( $path, '.json' );
+			if ( is_array( $decoded_file ) ) {
+				$variation_scope = static::get_style_variation_scope( $decoded_file );
+
+				if ( $variation_scope ) {
+					$translated = static::translate( $decoded_file, wp_get_theme()->get( 'TextDomain' ) );
+					$variation  = ( new WP_Theme_JSON_Gutenberg( $translated ) )->get_raw_data();
+
+					if ( empty( $variation['title'] ) ) {
+						$variation['title'] = basename( $path, '.json' );
+					}
+
+					$variations[ $variation_scope ][] = $variation;
 				}
-				$variations[] = $variation;
 			}
 		}
-		return $variations;
+		static::$style_variations_cache[ $theme_dir ][ $locale ] = $variations;
+
+		return static::$style_variations_cache[ $theme_dir ][ $locale ][ $scope ];
 	}
 
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -786,7 +786,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	public static function get_style_variations( $scope = 'theme' ) {
 		$theme_dir = get_stylesheet_directory();
 		$locale    = get_locale();
-		if ( isset( static::$style_variations_cache[ $theme_dir ][ $locale ][ $scope ] ) ) {
+
+		if (
+			isset( static::$style_variations_cache[ $theme_dir ][ $locale ][ $scope ] ) &&
+			// Variations depend on registered blocks.
+			null !== static::$blocks &&
+			static::has_same_registered_blocks( 'theme' )
+		) {
 			return static::$style_variations_cache[ $theme_dir ][ $locale ][ $scope ];
 		}
 


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/62529

## What?

Adds caching to processed theme.json partials for style variations.

## Why?

With registration of block style variations moved to a separate `init` action, the processing of `/styles` directories, including parsing and translating variation partials, was happening multiple times.

## How?

Processes all variation partials and stores them in a cache keyed by the theme, then locale.

## Testing Instructions

- Unit tests should be passing
- Smoke test display and application of theme style variations in the site editor
- Test section styles are still registered correctly and applying them works
    - Detailed instructions on setting up custom block style variations for testing section styles can be found in [#57908](https://github.com/WordPress/gutenberg/pull/57908)

