### PR TITLE
Update caniuse-lite dependency to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
 				"babel-plugin-transform-remove-console": "6.9.4",
 				"benchmark": "2.1.4",
 				"browserslist": "4.22.2",
-				"caniuse-lite": "1.0.30001579",
+				"caniuse-lite": "1.0.30001636",
 				"chalk": "4.1.1",
 				"change-case": "4.1.2",
 				"client-zip": "^2.4.5",
@@ -21440,9 +21440,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001579",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
-			"integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
+			"version": "1.0.30001636",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
+			"integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -21456,7 +21456,8 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			]
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/capital-case": {
 			"version": "1.0.4",
@@ -72844,9 +72845,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001579",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
-			"integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA=="
+			"version": "1.0.30001636",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
+			"integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg=="
 		},
 		"capital-case": {
 			"version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
 		"babel-plugin-transform-remove-console": "6.9.4",
 		"benchmark": "2.1.4",
 		"browserslist": "4.22.2",
-		"caniuse-lite": "1.0.30001579",
+		"caniuse-lite": "1.0.30001636",
 		"chalk": "4.1.1",
 		"change-case": "4.1.2",
 		"client-zip": "^2.4.5",


### PR DESCRIPTION
Updates the caniuse-lite dependency. This outdated dependency is currently causing unit tests to fail in trunk.