### PR TITLE
Fix toggle active font logic

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -450,7 +450,7 @@ function FontLibraryProvider( { children } ) {
 			font.source
 		);
 
-		if ( isFaceActivated ) {
+		if ( ! isFaceActivated ) {
 			loadFontFaceInBrowser(
 				face,
 				getDisplaySrcFromFontFace( face?.src ),

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -450,14 +450,14 @@ function FontLibraryProvider( { children } ) {
 			font.source
 		);
 
-		if ( ! isFaceActivated ) {
+		if ( isFaceActivated ) {
+			unloadFontFaceInBrowser( face, 'all' );
+		} else {
 			loadFontFaceInBrowser(
 				face,
 				getDisplaySrcFromFontFace( face?.src ),
 				'all'
 			);
-		} else {
-			unloadFontFaceInBrowser( face, 'all' );
 		}
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix toggle active font logic.

## Why?
Because the logic was not working as expected.
Fixes: https://github.com/WordPress/gutenberg/issues/62602 

## How?
By correcting the logic used to load/unload font faces in the browser.

## Testing Instructions
Follow https://github.com/WordPress/gutenberg/issues/62602 

## Screenshots or screencast <!-- if applicable -->
The video featured the fix following https://github.com/WordPress/gutenberg/issues/62602 

[Screencast from 17-06-24 11:25:14.webm](https://github.com/WordPress/gutenberg/assets/1310626/d9ffcfdc-1ca5-4f0f-bc36-ef34f2d933ed)
