### PR TITLE
Update old links in @wordpress/babel-preset-default

### DIFF
--- a/packages/babel-preset-default/README.md
+++ b/packages/babel-preset-default/README.md
@@ -2,7 +2,7 @@
 
 Default [Babel](https://babeljs.io/) preset for WordPress development.
 
-The preset includes configuration which enable language features and syntax extensions targeted for support by WordPress. This includes [ECMAScript proposals](https://github.com/tc39/proposals) which have reached [Stage 4 ("Finished")](https://tc39.es/process-document/), as well as the [JSX syntax extension](https://reactjs.org/docs/introducing-jsx.html). For more information, refer to the [JavaScript Coding Guidelines](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/coding-guidelines.md#javascript).
+The preset includes configuration which enable language features and syntax extensions targeted for support by WordPress. This includes [ECMAScript proposals](https://github.com/tc39/proposals) which have reached [Stage 4 ("Finished")](https://tc39.es/process-document/), as well as the [JSX syntax extension](https://react.dev/learn/writing-markup-with-jsx). For more information, refer to the [JavaScript Coding Guidelines](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/coding-guidelines.md#javascript).
 
 ## Installation
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes JSX syntax extension and JavaScript Coding Guidelines Links to point to the updated one.

## Why?
The link for JSX go to `https://legacy.reactjs.org` and shows `This content is out of date` notice on the site. Similarly the links for JS coding standards shows `404 - page not found`

Visit https://developer.wordpress.org/block-editor/reference-guides/packages/packages-babel-preset-default/ and try to open the link for these two.