### PR TITLE
Raw handling: fix too aggressive indented list removal

### DIFF
--- a/packages/blocks/src/api/raw-handling/list-reducer.js
+++ b/packages/blocks/src/api/raw-handling/list-reducer.js
@@ -53,9 +53,6 @@ export default function listReducer( node ) {
 		if ( prevListItem ) {
 			prevListItem.appendChild( list );
 			parentList.removeChild( parentListItem );
-		} else {
-			parentList.parentNode.insertBefore( list, parentList );
-			parentList.parentNode.removeChild( parentList );
 		}
 	}
 

--- a/packages/blocks/src/api/raw-handling/test/list-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/list-reducer.js
@@ -41,12 +41,6 @@ describe( 'listReducer', () => {
 		expect( deepFilterHTML( input, [ listReducer ] ) ).toEqual( output );
 	} );
 
-	it( 'should remove empty list wrappers', () => {
-		const input = '<ul><li>\n<ul><li>test</li></ul>\n</li></ul>';
-		const output = '<ul><li>test</li></ul>';
-		expect( deepFilterHTML( input, [ listReducer ] ) ).toEqual( output );
-	} );
-
 	it( 'should not remove filled list wrappers', () => {
 		const input = '<ul><li>\ntest\n<ul><li>test</li></ul>\n</li></ul>';
 		expect( deepFilterHTML( input, [ listReducer ] ) ).toEqual( input );

--- a/test/integration/fixtures/documents/mixed-content-out.html
+++ b/test/integration/fixtures/documents/mixed-content-out.html
@@ -1,3 +1,13 @@
 <!-- wp:heading {"level":3} -->
 <h3 class="wp-block-heading">Some heading</h3>
 <!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Content we need to preserve</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #62545, where @saulyz discovered that list item content is stripped when there's an empty list in an empty list item.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Content loss.

Currently indented lists are too aggressively outdented or removed entirely.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removal of unneeded logic.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Includes unit and integration tests.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
