### PR TITLE
env: Ignore `\$schema` key in environment config parsing

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Ignore `$schema` key in environment config parsing ([#62626](https://github.com/WordPress/gutenberg/pull/62626)).
+
 ## 10.1.0 (2024-06-15)
 
 ## 10.0.0 (2024-05-31)

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -417,6 +417,11 @@ async function parseEnvironmentConfig(
 			continue;
 		}
 
+		// The $schema key is a special key that is used to validate the configuration.
+		if ( key === '$schema' ) {
+			continue;
+		}
+
 		// We should also check root-only options for the root config
 		// because these aren't part of the above defaults but are
 		// configuration options that we will parse.

--- a/packages/env/lib/config/test/parse-config.js
+++ b/packages/env/lib/config/test/parse-config.js
@@ -254,6 +254,26 @@ describe( 'parseConfig', () => {
 		} );
 	} );
 
+	it( 'should ignore `$schema` key', async () => {
+		readRawConfigFile.mockImplementation( async ( configFile ) => {
+			if ( configFile === '/test/gutenberg/.wp-env.json' ) {
+				return {
+					$schema: 'test',
+				};
+			}
+
+			if ( configFile === '/test/gutenberg/.wp-env.override.json' ) {
+				return {};
+			}
+
+			throw new Error( 'Invalid File: ' + configFile );
+		} );
+
+		const parsed = await parseConfig( '/test/gutenberg', '/cache' );
+
+		expect( parsed ).toEqual( DEFAULT_CONFIG );
+	} );
+
 	it( 'should override with environment variables', async () => {
 		process.env.WP_ENV_PORT = 123;
 		process.env.WP_ENV_TESTS_PORT = 456;


### PR DESCRIPTION
Fixes #62619

## What?

This PR fixes an exception error when a schema key is defined in the env config file.

## Why?

This key is only used for validation and should be excluded from configuration options.

## Testing Instructions

- Add the `$schema` key to the `.wp-env.json` file.
- Run `npm run wp-env start`.
- No errors should occur.