### PR TITLE
Fix: Unable to remove custom colors on safari. (Try 2)

### DIFF
--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -32,6 +32,9 @@ type FocusNormalizedButton =
 function isFocusNormalizedButton(
 	eventTarget: EventTarget
 ): eventTarget is FocusNormalizedButton {
+	if ( eventTarget instanceof window.SVGElement ) {
+		return !! eventTarget.closest( 'button' );
+	}
 	if ( ! ( eventTarget instanceof window.HTMLElement ) ) {
 		return false;
 	}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/62261
Supersedes: https://github.com/WordPress/gutenberg/pull/62554

The cause of the issue seems to be that on safari while clicking the remove button onStopEditing is also triggered, to overcome this issue we add reference and set it to true when clicking is started.

cc: @noisysocks, @richtabor, @aatanasovdev  in case you can confirm if the issue is also fixed for you.

## Testing Instructions
Use Safari.
Go to Appearance → Editor → Colors → Palette.
Add a custom color and press Done.
Click the button to remove that custom color and see if it works as expected.
