### PR TITLE
Update Private API opt-in string for WP 6.6.

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -162,7 +162,7 @@ do so by opting-in to `@wordpress/private-apis`:
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/block-editor' // Name of the package calling __dangerousOptInToUnstableAPIsOnlyForCoreModules,
 		// (not the name of the package whose APIs you want to access)
 	);

--- a/packages/block-directory/src/lock-unlock.js
+++ b/packages/block-directory/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/block-directory'
 	);

--- a/packages/block-editor/src/lock-unlock.js
+++ b/packages/block-editor/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/block-editor'
 	);

--- a/packages/block-library/src/lock-unlock.js
+++ b/packages/block-library/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/block-library'
 	);

--- a/packages/blocks/src/lock-unlock.js
+++ b/packages/blocks/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/blocks'
 	);

--- a/packages/commands/src/lock-unlock.js
+++ b/packages/commands/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/commands'
 	);

--- a/packages/components/src/lock-unlock.js
+++ b/packages/components/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/components'
 	);

--- a/packages/core-commands/src/lock-unlock.js
+++ b/packages/core-commands/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/core-commands'
 	);

--- a/packages/core-data/src/private-apis.js
+++ b/packages/core-data/src/private-apis.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/core-data'
 	);

--- a/packages/customize-widgets/src/lock-unlock.js
+++ b/packages/customize-widgets/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/customize-widgets'
 	);

--- a/packages/data/src/lock-unlock.js
+++ b/packages/data/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/data'
 	);

--- a/packages/dataviews/src/lock-unlock.ts
+++ b/packages/dataviews/src/lock-unlock.ts
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/dataviews'
 	);

--- a/packages/edit-post/src/lock-unlock.js
+++ b/packages/edit-post/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/edit-post'
 	);

--- a/packages/edit-site/src/lock-unlock.js
+++ b/packages/edit-site/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/edit-site'
 	);

--- a/packages/edit-widgets/src/lock-unlock.js
+++ b/packages/edit-widgets/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/edit-widgets'
 	);

--- a/packages/editor/src/lock-unlock.js
+++ b/packages/editor/src/lock-unlock.js
@@ -4,6 +4,6 @@
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/editor'
 	);

--- a/packages/format-library/src/lock-unlock.js
+++ b/packages/format-library/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/format-library'
 	);

--- a/packages/interface/lock-unlock.js
+++ b/packages/interface/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/interface'
 	);

--- a/packages/patterns/src/lock-unlock.js
+++ b/packages/patterns/src/lock-unlock.js
@@ -4,6 +4,6 @@
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/patterns'
 	);

--- a/packages/preferences/src/lock-unlock.js
+++ b/packages/preferences/src/lock-unlock.js
@@ -4,6 +4,6 @@
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/preferences'
 	);

--- a/packages/private-apis/README.md
+++ b/packages/private-apis/README.md
@@ -12,7 +12,7 @@ Every `@wordpress` package wanting to privately access or expose experimental AP
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/block-editor' // Name of the package calling __dangerousOptInToUnstableAPIsOnlyForCoreModules,
 		// (not the name of the package whose APIs you want to access)
 	);
@@ -22,7 +22,7 @@ Each package may only opt in once. The function name communicates that plugins a
 
 The function will throw an error if the following conditions are not met:
 
-1. The first argument must exactly match the required consent string: `'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.'`.
+1. The first argument must exactly match the required consent string: `'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'`.
 2. The second argument must be a known `@wordpress` package that hasn't yet opted into `@wordpress/private-apis`
 
 Once the opt-in is complete, the obtained `lock()` and `unlock()` utilities enable hiding `__experimental` APIs from the naked eye:
@@ -120,3 +120,4 @@ The final string in this list is the current version.
 
 1. I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.
 2. I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.
+3. I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -56,7 +56,7 @@ const registeredPrivateApis = [];
  * CHANGE MAY OCCUR IN EITHER A MAJOR OR MINOR RELEASE.
  */
 const requiredConsent =
-	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.';
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
 
 /** @type {boolean} */
 let allowReRegistration;

--- a/packages/private-apis/src/test/index.js
+++ b/packages/private-apis/src/test/index.js
@@ -16,7 +16,7 @@ beforeEach( () => {
 } );
 
 const requiredConsent =
-	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.';
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
 
 describe( '__dangerousOptInToUnstableAPIsOnlyForCoreModules', () => {
 	it( 'Should require a consent string', () => {

--- a/packages/reusable-blocks/src/lock-unlock.js
+++ b/packages/reusable-blocks/src/lock-unlock.js
@@ -4,6 +4,6 @@
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
 export const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/reusable-blocks'
 );

--- a/packages/router/src/lock-unlock.js
+++ b/packages/router/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/router'
 	);


### PR DESCRIPTION
## What?

Update the opt-in string for Private APIs for use in WordPress 6.6

## Why?

The opt-in string is intended to be rotated on a regular basis to prevent themes and plugins from opting in to private and unstable APIs.

## How?

Search and replace of the previous string. 

## Testing Instructions
1. Identify code making use of the Private APis within Gutenberg
2. Ensure the code continues to work with the string rotated.
3. Search for the old string `I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.` and ensure it only appears in the history section of the private api's readme file.

### Testing Instructions for Keyboard
N/A 

## Screenshots or screencast <!-- if applicable -->
N/A