### PR TITLE
Editor: Improve Header layout

### DIFF
--- a/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
+++ b/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
@@ -19,23 +19,16 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useReducedMotion } from '@wordpress/compose';
 
-/**
- * Internal dependencies
- */
-import { store as editPostStore } from '../../store';
-
 function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
-	const { isActive, isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
+	const { isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
 		( select ) => {
 			const { getCurrentPostType } = select( editorStore );
-			const { isFeatureActive } = select( editPostStore );
 			const { getEntityRecord, getPostType, isResolving } =
 				select( coreStore );
 			const siteData =
 				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 			const _postType = initialPost?.type || getCurrentPostType();
 			return {
-				isActive: isFeatureActive( 'fullscreenMode' ),
 				isRequestingSiteIcon: isResolving( 'getEntityRecord', [
 					'root',
 					'__unstableBase',
@@ -50,7 +43,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 
 	const disableMotion = useReducedMotion();
 
-	if ( ! isActive || ! postType ) {
+	if ( ! postType ) {
 		return null;
 	}
 
@@ -83,8 +76,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 		buttonIcon = <Icon size="36px" icon={ icon } />;
 	}
 
-	const classes = clsx( {
-		'edit-post-fullscreen-mode-close': true,
+	const classes = clsx( 'edit-post-fullscreen-mode-close', {
 		'has-icon': siteIconUrl,
 	} );
 

--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -2,10 +2,6 @@
 // They need to be updated in both places.
 
 .edit-post-fullscreen-mode-close.components-button {
-	// Do not show the toolbar icon on small screens,
-	// when Fullscreen Mode is not an option in the "More" menu.
-	display: none;
-
 	@include break-medium() {
 		display: flex;
 		align-items: center;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -37,6 +37,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import { SlotFillProvider } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -327,6 +328,12 @@ function Layout( {
 			id: initialPostId,
 		};
 	}, [ initialPostType, initialPostId ] );
+
+	const backButton =
+		useViewportMatch( 'medium' ) && isFullscreenActive ? (
+			<BackButton initialPost={ initialPost } />
+		) : null;
+
 	return (
 		<SlotFillProvider>
 			<ErrorBoundary>
@@ -373,7 +380,7 @@ function Layout( {
 					<InitPatternModal />
 					<PluginArea onError={ onPluginAreaError } />
 					<PostEditorMoreMenu />
-					<BackButton initialPost={ initialPost } />
+					{ backButton }
 					<EditorSnackbars />
 				</Editor>
 			</ErrorBoundary>

--- a/packages/editor/src/components/collapsible-block-toolbar/index.js
+++ b/packages/editor/src/components/collapsible-block-toolbar/index.js
@@ -9,20 +9,12 @@ import clsx from 'clsx';
 import {
 	BlockToolbar,
 	store as blockEditorStore,
-	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { Button, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../../lock-unlock';
-
-const { useHasBlockToolbar } = unlock( blockEditorPrivateApis );
 
 function CollapsableBlockToolbar( { isCollapsed, onToggle } ) {
 	const { blockSelectionStart } = useSelect( ( select ) => {
@@ -31,7 +23,6 @@ function CollapsableBlockToolbar( { isCollapsed, onToggle } ) {
 				select( blockEditorStore ).getBlockSelectionStart(),
 		};
 	}, [] );
-	const hasBlockToolbar = useHasBlockToolbar();
 
 	const hasBlockSelection = !! blockSelectionStart;
 
@@ -41,10 +32,6 @@ function CollapsableBlockToolbar( { isCollapsed, onToggle } ) {
 			onToggle( false );
 		}
 	}, [ blockSelectionStart, onToggle ] );
-
-	if ( ! hasBlockToolbar ) {
-		return null;
-	}
 
 	return (
 		<>

--- a/packages/editor/src/components/collapsible-block-toolbar/index.js
+++ b/packages/editor/src/components/collapsible-block-toolbar/index.js
@@ -16,7 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 
-function CollapsableBlockToolbar( { isCollapsed, onToggle } ) {
+export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 	const { blockSelectionStart } = useSelect( ( select ) => {
 		return {
 			blockSelectionStart:
@@ -60,5 +60,3 @@ function CollapsableBlockToolbar( { isCollapsed, onToggle } ) {
 		</>
 	);
 }
-
-export default CollapsableBlockToolbar;

--- a/packages/editor/src/components/collapsible-block-toolbar/index.js
+++ b/packages/editor/src/components/collapsible-block-toolbar/index.js
@@ -9,12 +9,20 @@ import clsx from 'clsx';
 import {
 	BlockToolbar,
 	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { Button, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useHasBlockToolbar } = unlock( blockEditorPrivateApis );
 
 export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 	const { blockSelectionStart } = useSelect( ( select ) => {
@@ -23,6 +31,7 @@ export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 				select( blockEditorStore ).getBlockSelectionStart(),
 		};
 	}, [] );
+	const hasBlockToolbar = useHasBlockToolbar();
 
 	const hasBlockSelection = !! blockSelectionStart;
 
@@ -32,6 +41,10 @@ export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 			onToggle( false );
 		}
 	}, [ blockSelectionStart, onToggle ] );
+
+	if ( ! hasBlockToolbar ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/packages/editor/src/components/collapsible-block-toolbar/style.scss
+++ b/packages/editor/src/components/collapsible-block-toolbar/style.scss
@@ -74,9 +74,10 @@
 
 	&.is-collapsed {
 		display: none;
+
+		~ .editor-collapsible-block-toolbar__toggle {
+			margin-left: $grid-unit-10;
+		}
 	}
 }
 
-.editor-collapsible-block-toolbar__toggle {
-	margin-left: 2px; // Allow focus ring to be fully visible
-}

--- a/packages/editor/src/components/collapsible-block-toolbar/style.scss
+++ b/packages/editor/src/components/collapsible-block-toolbar/style.scss
@@ -74,10 +74,6 @@
 
 	&.is-collapsed {
 		display: none;
-
-		~ .editor-collapsible-block-toolbar__toggle {
-			margin-left: $grid-unit-10;
-		}
 	}
 }
 

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -10,7 +10,7 @@
 	min-width: 0;
 	background: $gray-100;
 	border-radius: $grid-unit-05;
-	width: min(100%, 416px);
+	width: min(100%, 450px);
 
 	&:hover {
 		background-color: $gray-200;
@@ -24,10 +24,6 @@
 		&:hover {
 			background: $gray-200;
 		}
-	}
-
-	@include break-large() {
-		width: min(100%, 450px);
 	}
 }
 

--- a/packages/editor/src/components/document-tools/style.scss
+++ b/packages/editor/src/components/document-tools/style.scss
@@ -65,12 +65,12 @@
 .editor-document-tools__left {
 	display: inline-flex;
 	align-items: center;
-	padding-left: $grid-unit-20;
 	gap: $grid-unit-10;
 
-	// Some plugins add buttons here despite best practices.
-	// Push them a bit rightwards to fit the top toolbar.
-	margin-right: $grid-unit-10;
+	// Some plugins add buttons here despite best practices — accommodate them with a gap.
+	&:not(:last-child) {
+		margin-inline-end: $grid-unit-10;
+	}
 }
 
 .editor-document-tools .editor-document-tools__left > .editor-document-tools__inserter-toggle.has-icon {

--- a/packages/editor/src/components/header/back-button.js
+++ b/packages/editor/src/components/header/back-button.js
@@ -9,16 +9,16 @@ import {
 // Keeping an old name for backward compatibility.
 const slotName = '__experimentalMainDashboardButton';
 
+export const useHasBackButton = () => {
+	const fills = useSlotFills( slotName );
+	return Boolean( fills && fills.length );
+};
+
 const { Fill, Slot } = createSlotFill( slotName );
 
 const BackButton = Fill;
-const BackButtonSlot = ( { children } ) => {
+const BackButtonSlot = () => {
 	const fills = useSlotFills( slotName );
-	const hasFills = Boolean( fills && fills.length );
-
-	if ( ! hasFills ) {
-		return children;
-	}
 
 	return (
 		<Slot

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -20,7 +20,7 @@ import {
 /**
  * Internal dependencies
  */
-import BackButton from './back-button';
+import BackButton, { useHasBackButton } from './back-button';
 import CollapsibleBlockToolbar from '../collapsible-block-toolbar';
 import DocumentBar from '../document-bar';
 import DocumentTools from '../document-tools';
@@ -101,21 +101,25 @@ function Header( {
 		) : null;
 
 	const showDocumentBar = ! blockToolbar || isBlockToolsCollapsed;
+	const hasBackButton = useHasBackButton();
 
 	// The edit-post-header classname is only kept for backward compatibilty
 	// as some plugins might be relying on its presence.
 	return (
 		<div
 			className={ clsx( 'editor-header edit-post-header', {
+				'has-back-button': hasBackButton,
 				'has-center': isMobileViewport && showDocumentBar,
 			} ) }
 		>
-			<motion.div
-				variants={ backButtonVariations }
-				transition={ { type: 'tween' } }
-			>
-				<BackButton.Slot />
-			</motion.div>
+			{ hasBackButton && (
+				<motion.div
+					variants={ backButtonVariations }
+					transition={ { type: 'tween' } }
+				>
+					<BackButton.Slot />
+				</motion.div>
+			) }
 			<motion.div
 				variants={ toolbarVariations }
 				className="editor-header__toolbar"

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -12,10 +12,7 @@ import { __unstableMotion as motion } from '@wordpress/components';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { useState } from '@wordpress/element';
 import { PinnedItems } from '@wordpress/interface';
-import {
-	store as blockEditorStore,
-	privateApis as blockEditorPrivateApis,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -31,9 +28,6 @@ import PostSavedState from '../post-saved-state';
 import PostViewLink from '../post-view-link';
 import PreviewDropdown from '../preview-dropdown';
 import { store as editorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
-
-const { useHasBlockToolbar } = unlock( blockEditorPrivateApis );
 
 const toolbarVariations = {
 	distractionFreeDisabled: { y: '-50px' },
@@ -92,17 +86,7 @@ function Header( {
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
 
-	const blockToolbar =
-		useHasBlockToolbar() && hasFixedToolbar && isLargeViewport ? (
-			<CollapsibleBlockToolbar
-				isCollapsed={ isBlockToolsCollapsed }
-				onToggle={ setIsBlockToolsCollapsed }
-			/>
-		) : null;
-
-	const showDocumentBar =
-		( ! blockToolbar || isBlockToolsCollapsed ) &&
-		! isTooNarrowForDocumentBar;
+	const hasCenter = isBlockToolsCollapsed && ! isTooNarrowForDocumentBar;
 	const hasBackButton = useHasBackButton();
 
 	// The edit-post-header classname is only kept for backward compatibilty
@@ -111,7 +95,7 @@ function Header( {
 		<div
 			className={ clsx( 'editor-header edit-post-header', {
 				'has-back-button': hasBackButton,
-				'has-center': showDocumentBar,
+				'has-center': hasCenter,
 			} ) }
 		>
 			{ hasBackButton && (
@@ -130,9 +114,14 @@ function Header( {
 				<DocumentTools
 					disableBlockTools={ forceDisableBlockTools || isTextEditor }
 				/>
-				{ blockToolbar }
+				{ hasFixedToolbar && isLargeViewport && (
+					<CollapsibleBlockToolbar
+						isCollapsed={ isBlockToolsCollapsed }
+						onToggle={ setIsBlockToolsCollapsed }
+					/>
+				) }
 			</motion.div>
-			{ ( title || showDocumentBar ) && (
+			{ hasCenter && (
 				<motion.div
 					className="editor-header__center"
 					variants={ toolbarVariations }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -21,7 +21,7 @@ import {
  * Internal dependencies
  */
 import BackButton from './back-button';
-import CollapsableBlockToolbar from '../collapsible-block-toolbar';
+import CollapsibleBlockToolbar from '../collapsible-block-toolbar';
 import DocumentBar from '../document-bar';
 import DocumentTools from '../document-tools';
 import MoreMenu from '../more-menu';
@@ -94,7 +94,7 @@ function Header( {
 
 	const blockToolbar =
 		useHasBlockToolbar() && hasFixedToolbar && isLargeViewport ? (
-			<CollapsableBlockToolbar
+			<CollapsibleBlockToolbar
 				isCollapsed={ isBlockToolsCollapsed }
 				onToggle={ setIsBlockToolsCollapsed }
 			/>

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -61,6 +61,7 @@ function Header( {
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
+	const isMobileViewport = useViewportMatch( 'mobile' );
 	const {
 		isTextEditor,
 		isPublishSidebarOpened,
@@ -106,7 +107,7 @@ function Header( {
 	return (
 		<div
 			className={ clsx( 'editor-header edit-post-header', {
-				'has-center': showDocumentBar,
+				'has-center': isMobileViewport && showDocumentBar,
 			} ) }
 		>
 			<motion.div
@@ -125,7 +126,7 @@ function Header( {
 				/>
 				{ blockToolbar }
 			</motion.div>
-			{ ( title || showDocumentBar ) && (
+			{ isMobileViewport && ( title || showDocumentBar ) && (
 				<motion.div
 					className="editor-header__center"
 					variants={ toolbarVariations }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -61,7 +61,7 @@ function Header( {
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 382px)' );
+	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 403px)' );
 	const {
 		isTextEditor,
 		isPublishSidebarOpened,

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useViewportMatch } from '@wordpress/compose';
+import { useMediaQuery, useViewportMatch } from '@wordpress/compose';
 import { __unstableMotion as motion } from '@wordpress/components';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { useState } from '@wordpress/element';
@@ -61,7 +61,7 @@ function Header( {
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const isMobileViewport = useViewportMatch( 'mobile' );
+	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 382px)' );
 	const {
 		isTextEditor,
 		isPublishSidebarOpened,
@@ -100,7 +100,9 @@ function Header( {
 			/>
 		) : null;
 
-	const showDocumentBar = ! blockToolbar || isBlockToolsCollapsed;
+	const showDocumentBar =
+		( ! blockToolbar || isBlockToolsCollapsed ) &&
+		! isTooNarrowForDocumentBar;
 	const hasBackButton = useHasBackButton();
 
 	// The edit-post-header classname is only kept for backward compatibilty
@@ -109,7 +111,7 @@ function Header( {
 		<div
 			className={ clsx( 'editor-header edit-post-header', {
 				'has-back-button': hasBackButton,
-				'has-center': isMobileViewport && showDocumentBar,
+				'has-center': showDocumentBar,
 			} ) }
 		>
 			{ hasBackButton && (
@@ -130,7 +132,7 @@ function Header( {
 				/>
 				{ blockToolbar }
 			</motion.div>
-			{ isMobileViewport && ( title || showDocumentBar ) && (
+			{ ( title || showDocumentBar ) && (
 				<motion.div
 					className="editor-header__center"
 					variants={ toolbarVariations }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -92,11 +87,7 @@ function Header( {
 	// The edit-post-header classname is only kept for backward compatibilty
 	// as some plugins might be relying on its presence.
 	return (
-		<div
-			className={ clsx( 'editor-header edit-post-header', {
-				'has-center': hasCenter,
-			} ) }
-		>
+		<div className="editor-header edit-post-header">
 			{ hasBackButton && (
 				<motion.div
 					className="editor-header__back-button"

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -94,12 +94,12 @@ function Header( {
 	return (
 		<div
 			className={ clsx( 'editor-header edit-post-header', {
-				'has-back-button': hasBackButton,
 				'has-center': hasCenter,
 			} ) }
 		>
 			{ hasBackButton && (
 				<motion.div
+					className="editor-header__back-button"
 					variants={ backButtonVariations }
 					transition={ { type: 'tween' } }
 				>

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -60,12 +60,10 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	// Grid items will, by default, refuse to shrink below a minimum intrinsic
-	// width. To enable shrinking and thereby truncate child text, hide the
-	// overflow.
-	overflow: hidden;
-	// Make room for the focus ring.
-	padding: 2px;
+	// To enable shrinking and truncating of child text, apply an explicit min-width.
+	min-width: 0;
+	// Clip the box while leaving room for focus rings.
+	clip-path: inset(-2px);
 }
 
 /**

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -27,23 +27,30 @@
 }
 
 .editor-header__toolbar {
-	grid-column: 2 / 3;
+	grid-column: 1 / 3;
+	// When there is no back button or the viewport is <= mobile the margin keeps the content off
+	// the starting edge. Otherwise, it’s overriden to and the parent’s `gap` does the job instead.
+	> :first-child {
+		margin-inline: $grid-unit-20 0;
+	}
+
+	.has-back-button.editor-header & {
+		grid-column: 2 / 3;
+
+		@include break-mobile {
+			> :first-child {
+				margin-inline: 0;
+			}
+		}
+	}
 	display: flex;
 	// Make narrowing to less than content width possible. Block toolbar will hide overflow and allow scrolling on fixed toolbar.
 	min-width: 0;
 	align-items: center;
 	// Clip the box while leaving room for focus rings.
 	clip-path: inset(-2px);
-
-	& > :first-child {
-		margin-inline: $grid-unit-20 0;
-	}
 	@include break-mobile {
 		clip-path: none;
-
-		& > :first-child {
-			margin-inline: 0;
-		}
 	}
 
 	.table-of-contents {

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -218,8 +218,9 @@
 }
 
 .editor-header__post-preview-button {
+	display: none;
 	@include break-small {
-		display: none;
+		display: initial;
 	}
 }
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -53,6 +53,15 @@
 			display: block;
 		}
 	}
+
+	// Add a gap before the block toolbar or its toggle button when collapsed.
+	.editor-collapsible-block-toolbar {
+		margin-inline: $grid-unit 0;
+
+		&.is-collapsed ~ .editor-collapsible-block-toolbar__toggle {
+			margin-inline: $grid-unit 0;
+		}
+	}
 }
 
 .editor-header__center {

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -80,6 +80,11 @@
 	min-width: 0;
 	// Clip the box while leaving room for focus rings.
 	clip-path: inset(-2px);
+	// At less than mobile the header’s `gap` is zero so margins are added to create a smaller
+	// gap around the center’s contents.
+	@media (max-width: #{$break-mobile - 1}) {
+		padding-inline: $grid-unit;
+	}
 }
 
 /**

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -1,8 +1,14 @@
 .editor-header {
 	height: $header-height;
 	background: $white;
-	display: flex;
-	flex-wrap: wrap;
+	display: grid;
+	grid-auto-flow: row;
+	$width-of-four-buttons-and-gap: $grid-unit-50 * 4;
+	grid-template: auto / $header-height minmax($width-of-four-buttons-and-gap, max-content) minmax(min-content, 1fr) $header-height;
+	&.has-center {
+		grid-template: auto / $header-height minmax(min-content, 1fr) 2fr minmax(min-content, 1fr) $header-height;
+	}
+	gap: $grid-unit-20;
 	align-items: center;
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
@@ -15,20 +21,11 @@
 }
 
 .editor-header__toolbar {
+	grid-column: 2 / 3;
 	display: flex;
-	// Allow this area to shrink to fit the toolbar buttons.
-	flex-shrink: 8;
-	// Take up the space of the toolbar so it can be justified to the left side of the toolbar.
-	flex-grow: 3;
-	// Hide the overflow so flex will limit its width. Block toolbar will allow scrolling on fixed toolbar.
-	overflow: hidden;
-	// Leave enough room for the focus ring to show.
-	padding: 2px 0;
+	// Make narrowing to less than content width possible. Block toolbar will hide overflow and allow scrolling on fixed toolbar.
+	min-width: 0;
 	align-items: center;
-	// Allow focus ring to be fully visible on furthest right button.
-	@include break-medium() {
-		padding-right: var(--wp-admin-border-width-focus);
-	}
 
 	.table-of-contents {
 		display: none;
@@ -40,18 +37,16 @@
 }
 
 .editor-header__center {
-	flex-grow: 1;
+	grid-column: 3 / 4;
 	display: flex;
 	justify-content: center;
-	// Flex items will, by default, refuse to shrink below a minimum
-	// intrinsic width. In order to shrink this flexbox item, and
-	// subsequently truncate child text, we set an explicit min-width.
-	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
-	min-width: 0;
-
-	&.is-collapsed {
-		display: none;
-	}
+	align-items: center;
+	// Grid items will, by default, refuse to shrink below a minimum intrinsic
+	// width. To enable shrinking and thereby truncate child text, hide the
+	// overflow.
+	overflow: hidden;
+	// Make room for the focus ring.
+	padding: 2px;
 }
 
 /**
@@ -59,6 +54,11 @@
  */
 
 .editor-header__settings {
+	grid-column: 3 / -1;
+	.has-center & {
+		grid-column: 4 / -1;
+	}
+	justify-self: end;
 	display: inline-flex;
 	align-items: center;
 	flex-wrap: nowrap;

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -3,12 +3,18 @@
 	background: $white;
 	display: grid;
 	grid-auto-flow: row;
-	$width-of-four-buttons-and-gap: $grid-unit-50 * 4;
-	grid-template: auto / $header-height minmax($width-of-four-buttons-and-gap, max-content) minmax(min-content, 1fr) $header-height;
+	grid-template: auto / $header-height minmax(0, max-content) minmax(min-content, 1fr) $header-height;
+	// This class applies when the Document Bar is showing which is from mobile breakpoint unless the
+	// collapsible block toolbar is expanded.
 	&.has-center {
-		grid-template: auto / $header-height minmax(min-content, 1fr) 2fr minmax(min-content, 1fr) $header-height;
+		grid-template: auto / $header-height min-content 1fr min-content $header-height;
+		@include break-medium {
+			grid-template: auto / $header-height minmax(min-content, 1fr) 2fr minmax(min-content, 1fr) $header-height;
+		}
 	}
-	gap: $grid-unit-20;
+	@include break-mobile {
+		gap: $grid-unit-20;
+	}
 	align-items: center;
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
@@ -26,6 +32,19 @@
 	// Make narrowing to less than content width possible. Block toolbar will hide overflow and allow scrolling on fixed toolbar.
 	min-width: 0;
 	align-items: center;
+	// Clip the box while leaving room for focus rings.
+	clip-path: inset(-2px);
+
+	& > :first-child {
+		margin-inline: $grid-unit-20 0;
+	}
+	@include break-mobile {
+		clip-path: none;
+
+		& > :first-child {
+			margin-inline: 0;
+		}
+	}
 
 	.table-of-contents {
 		display: none;

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -83,7 +83,12 @@
 	// At less than mobile the header’s `gap` is zero so margins are added to create a smaller
 	// gap around the center’s contents.
 	@media (max-width: #{$break-mobile - 1}) {
-		padding-inline: $grid-unit;
+		> :first-child {
+			margin-inline-start: $grid-unit;
+		}
+		> :last-child {
+			margin-inline-end: $grid-unit;
+		}
 	}
 }
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -223,9 +223,8 @@
 }
 
 .editor-header__post-preview-button {
-	display: none;
 	@include break-small {
-		display: initial;
+		display: none;
 	}
 }
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -4,8 +4,6 @@
 	display: grid;
 	grid-auto-flow: row;
 	grid-template: auto / $header-height minmax(0, max-content) minmax(min-content, 1fr) $header-height;
-	// This class applies when the Document Bar is showing which is from mobile breakpoint unless the
-	// collapsible block toolbar is expanded.
 	&.has-center {
 		grid-template: auto / $header-height min-content 1fr min-content $header-height;
 		@include break-medium {

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -27,15 +27,17 @@
 .editor-header__toolbar {
 	grid-column: 1 / 3;
 	// When there is no back button or the viewport is <= mobile the margin keeps the content off
-	// the starting edge. Otherwise, it’s overriden to and the parent’s `gap` does the job instead.
+	// the starting edge.
 	> :first-child {
 		margin-inline: $grid-unit-20 0;
 	}
 
-	.has-back-button.editor-header & {
+	// This is the typical case, the back button takes up the first column.
+	.editor-header__back-button + & {
 		grid-column: 2 / 3;
 
 		@include break-mobile {
+			// Clears the margin; at this breakpoint the parent’s `gap` takes its place.
 			> :first-child {
 				margin-inline: 0;
 			}

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -4,7 +4,7 @@
 	display: grid;
 	grid-auto-flow: row;
 	grid-template: auto / $header-height minmax(0, max-content) minmax(min-content, 1fr) $header-height;
-	&.has-center {
+	&:has(> .editor-header__center) {
 		grid-template: auto / $header-height min-content 1fr min-content $header-height;
 		@include break-medium {
 			grid-template: auto / $header-height minmax(min-content, 1fr) 2fr minmax(min-content, 1fr) $header-height;
@@ -98,7 +98,7 @@
 
 .editor-header__settings {
 	grid-column: 3 / -1;
-	.has-center & {
+	.editor-header:has(> .editor-header__center) & {
 		grid-column: 4 / -1;
 	}
 	justify-self: end;


### PR DESCRIPTION
## What?
An improvement to center the Document Bar and prevent layout shifts at > medium breakpoints when switching between page and template.

## Why?
- It seems like the Document Bar is intended to be centered yet it’s not (especially noticeable when editing templates).
- The layout shift while switching between a page and its template spoils the animation a bit.

## How?
Uses grid instead of flex because that was the only way I knew to resiliently center the Document Bar. There is a bit more to it than that but I think it may be better to cover that with some review comments.

## More
The layout shift used to not happen but now in template editing the "View Page" button hides and causes it. Maybe the button shouldn’t hide and instead merely disable https://github.com/WordPress/gutenberg/pull/53913#issuecomment-1697346079 but it still seems like a good idea to make the layout more stable (and truly centered).

## Testing Instructions
1. Open a page in the site or post editor
2. Note the Document Bar is centered in the header
3. Edit the template and note that the Document Bar stays centered
4. Resize to various widths and verify that the responsiveness acceptable throughout

## Screenshots or screencast <!-- if applicable -->

### Layout on trunk editing a page
<img width="1080" alt="near-centered-document-bar" src="https://github.com/WordPress/gutenberg/assets/9000376/dd0c6843-2daa-4371-ad5b-f2926e38d9fb">

### Layout on trunk editing a template
<img width="1080" alt="offset-document-bar-for-template" src="https://github.com/WordPress/gutenberg/assets/9000376/d004f72f-3717-41fe-ac78-601deebac60e">

### Layout on this branch editing a page
<img width="1080" alt="centered-document-bar" src="https://github.com/WordPress/gutenberg/assets/9000376/1b5ae2e2-a145-49e9-b33f-722bd08dcfcf">

Capture of editing a template on the branch omitted because there’s no layout shift.

### Trunk switching between page and template
https://github.com/WordPress/gutenberg/assets/9000376/46c6f410-6bac-475b-a1c3-2eadf997f056

### This branch switching between page and template
https://github.com/WordPress/gutenberg/assets/9000376/84a8b0d1-4828-4a1e-925b-f77697fe6444

