### PR TITLE
Tests: simplify test set up in `WP_Block_Supports_Block_Style_Variations_Test`

### DIFF
--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -59,8 +59,8 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	private $orig_theme_dir;
 
 	public static function tear_down_after_class() {
-        // Reset data after test suite.
-        _gutenberg_clean_theme_json_caches();
+		// Reset data after test suite.
+		_gutenberg_clean_theme_json_caches();
 		parent::tear_down_after_class();
 	}
 

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -58,28 +58,9 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	 */
 	private $orig_theme_dir;
 
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		self::$administrator_id = self::factory()->user->create(
-			array(
-				'role'       => 'administrator',
-				'user_email' => 'administrator@example.com',
-			)
-		);
-
-		static::$property_blocks_cache = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'blocks_cache' );
-		static::$property_blocks_cache->setAccessible( true );
-		static::$property_blocks_cache_orig_value = static::$property_blocks_cache->getValue();
-
-		static::$property_core = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'core' );
-		static::$property_core->setAccessible( true );
-		static::$property_core_orig_value = static::$property_core->getValue();
-	}
-
 	public static function tear_down_after_class() {
-		static::$property_blocks_cache->setValue( null, static::$property_blocks_cache_orig_value );
-		static::$property_core->setValue( null, static::$property_core_orig_value );
+        // Reset data after test suite.
+        _gutenberg_clean_theme_json_caches();
 		parent::tear_down_after_class();
 	}
 

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -58,12 +58,6 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	 */
 	private $orig_theme_dir;
 
-	public static function tear_down_after_class() {
-		// Reset data after test suite.
-		_gutenberg_clean_theme_json_caches();
-		parent::tear_down_after_class();
-	}
-
 	public function set_up() {
 		parent::set_up();
 		$this->theme_root = realpath( dirname( __DIR__ ) . '/data/themedir1' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A PR to simplify test set up in `WP_Block_Supports_Block_Style_Variations_Test`

## How?
~~Clean all JSON caches, including WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data(), after test suite runs, not just after any tests~~

Letting `_gutenberg_clean_theme_json_caches()` do the work. It runs in `tear_down()`.

## Testing Instructions

CI should pass. 

`npm run test:unit:php` should pass locally. 


