### PR TITLE
Theme JSON resolver: read theme.json files from the styles/ folder only once

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -761,7 +761,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 		ksort( $variation_files );
 		foreach ( $variation_files as $path => $file ) {
-			$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
+			$decoded_file = self::read_json_file( $path );
 			if ( is_array( $decoded_file ) && static::style_variation_has_scope( $decoded_file, $scope ) ) {
 				$translated = static::translate( $decoded_file, wp_get_theme()->get( 'TextDomain' ) );
 				$variation  = ( new WP_Theme_JSON_Gutenberg( $translated ) )->get_raw_data();


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Cache reading theme.json files from styles/ folder.

Syncs the following Core patch to Gutenberg:

- https://github.com/WordPress/wordpress-develop/pull/6843

## Why?

From https://github.com/WordPress/wordpress-develop/pull/6843:

> I've realized that, unlike the theme.json files defined by core & theme, we don't cache these — hence we end up reading them a few times from the filesystem.

## How?

From https://github.com/WordPress/wordpress-develop/pull/6843:

> By using the existing read_json_file function instead of using wp_json_file_decode directly.

## Testing Instructions

From https://github.com/WordPress/wordpress-develop/pull/6843:

1. Verify the theme style variations are working as expected.

Go to "Site Editor > Styles" and apply one of them. Verify the changes are reflected in the frontend. 

Do the same from the global styles sidebar in the site editor.

2. Verify the block style variations defined via theme.json are working as expected.

Create a `partial.json` file within the `styles/` folder with the following contents:

```json
{
        "$schema": "https://schemas.wp.org/trunk/theme.json",
        "version": 2,
        "title": "Partial",
        "blockTypes": [ "core/group" ],
        "styles": {
                "color": {
                        "background": "aliceblue"
                }
        }
}
```

Go to any editor, add a group block, and verify there is a "Partial" style variation (Block Settings > Styles). Apply the variation and save the changes. Verify the contents are the expected (background color is aliceblue) — also in the frontend.


## Screenshots or screencast <!-- if applicable -->
