### PR TITLE
Fix e2e tests in dev mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54051,9 +54051,6 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/api-fetch": "file:../api-fetch",
-				"@wordpress/keycodes": "file:../keycodes",
-				"@wordpress/url": "file:../url",
 				"change-case": "^4.1.2",
 				"form-data": "^4.0.0",
 				"get-port": "^5.1.1",
@@ -69225,9 +69222,6 @@
 		"@wordpress/e2e-test-utils-playwright": {
 			"version": "file:packages/e2e-test-utils-playwright",
 			"requires": {
-				"@wordpress/api-fetch": "file:../api-fetch",
-				"@wordpress/keycodes": "file:../keycodes",
-				"@wordpress/url": "file:../url",
 				"change-case": "^4.1.2",
 				"form-data": "^4.0.0",
 				"get-port": "^5.1.1",

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -31,9 +31,6 @@
 	"main": "./build/index.js",
 	"types": "./build-types",
 	"dependencies": {
-		"@wordpress/api-fetch": "file:../api-fetch",
-		"@wordpress/keycodes": "file:../keycodes",
-		"@wordpress/url": "file:../url",
 		"change-case": "^4.1.2",
 		"form-data": "^4.0.0",
 		"get-port": "^5.1.1",

--- a/packages/e2e-test-utils-playwright/src/page-utils/keycodes.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/keycodes.ts
@@ -1,0 +1,48 @@
+/**
+ * This filed is partially copied from @wordpress/keycodes to keep the package
+ * (internal-)dependencies free.
+ */
+
+/**
+ * Keycode for ALT key.
+ */
+export const ALT = 'alt';
+
+/**
+ * Keycode for CTRL key.
+ */
+export const CTRL = 'ctrl';
+
+/**
+ * Keycode for COMMAND key.
+ */
+export const COMMAND = 'meta';
+
+/**
+ * Keycode for SHIFT key.
+ */
+export const SHIFT = 'shift';
+
+/**
+ * Object that contains functions that return the available modifier
+ * depending on platform.
+ */
+export const modifiers: Record<
+	string,
+	( _isApple: () => boolean ) => string[]
+> = {
+	primary: ( _isApple ) => ( _isApple() ? [ COMMAND ] : [ CTRL ] ),
+	primaryShift: ( _isApple ) =>
+		_isApple() ? [ SHIFT, COMMAND ] : [ CTRL, SHIFT ],
+	primaryAlt: ( _isApple ) =>
+		_isApple() ? [ ALT, COMMAND ] : [ CTRL, ALT ],
+	secondary: ( _isApple ) =>
+		_isApple() ? [ SHIFT, ALT, COMMAND ] : [ CTRL, SHIFT, ALT ],
+	access: ( _isApple ) => ( _isApple() ? [ CTRL, ALT ] : [ SHIFT, ALT ] ),
+	ctrl: () => [ CTRL ],
+	alt: () => [ ALT ],
+	ctrlShift: () => [ CTRL, SHIFT ],
+	shift: () => [ SHIFT ],
+	shiftAlt: () => [ SHIFT, ALT ],
+	undefined: () => [],
+};

--- a/packages/e2e-test-utils-playwright/src/page-utils/press-keys.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/press-keys.ts
@@ -8,16 +8,7 @@ import type { Page } from '@playwright/test';
  * Internal dependencies
  */
 import type { PageUtils } from './';
-
-/**
- * WordPress dependencies
- */
-import {
-	modifiers as baseModifiers,
-	SHIFT,
-	ALT,
-	CTRL,
-} from '@wordpress/keycodes';
+import { modifiers as baseModifiers, SHIFT, ALT, CTRL } from './keycodes';
 
 let clipboardDataHolder: {
 	'text/plain': string;

--- a/packages/e2e-test-utils-playwright/tsconfig.json
+++ b/packages/e2e-test-utils-playwright/tsconfig.json
@@ -18,10 +18,5 @@
 		"allowJs": true,
 		"checkJs": false
 	},
-	"references": [
-		{ "path": "../api-fetch" },
-		{ "path": "../keycodes" },
-		{ "path": "../url" }
-	],
 	"include": [ "src/**/*" ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Originally reported in [Slack](https://wordpress.slack.com/archives/C02QB2JS7/p1718367320344229). Since #62398, `npm run dev` no longer produces commonJS code, which breaks running e2e tests in dev mode. This PR fixes that with a duct-tape for now.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's convenient to run e2e tests locally when in development mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It seems like we are only using `@wordpress/keycodes` for now in the `e2e-test-utils-playwright` package. We only have to inline some of the code to fix this issue. Note that this might not be the final solution though, but seems the easiest for now.

We should probably look into other cases as well.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Run `npm run dev`.
2. Run `npm run test:e2e -- --ui`
3. Expect the e2e test UI to start up
