### PR TITLE
Fix cherry-pick script, add missing --repo arg

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -380,15 +380,34 @@ function reportSummaryNextSteps( successes, failures ) {
 function GHcommentAndRemoveLabel( pr ) {
 	const { number, cherryPickHash } = pr;
 	const comment = prComment( cherryPickHash );
+	const repo = 'WordPress/gutenberg';
 	try {
-		cli( 'gh', [ 'pr', 'comment', number, '--body', comment ] );
-		cli( 'gh', [ 'pr', 'edit', number, '--remove-label', LABEL ] );
+		cli( 'gh', [
+			'pr',
+			'comment',
+			number,
+			'--repo',
+			repo,
+			'--body',
+			comment,
+		] );
+		cli( 'gh', [
+			'pr',
+			'edit',
+			number,
+			'--repo',
+			repo,
+			'--remove-label',
+			LABEL,
+		] );
 
 		if ( LABEL === 'Backport to WP Beta/RC' ) {
 			cli( 'gh', [
 				'pr',
 				'edit',
 				number,
+				'--repo',
+				repo,
 				'--add-label',
 				BACKPORT_COMPLETED_LABEL,
 			] );

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -380,34 +380,17 @@ function reportSummaryNextSteps( successes, failures ) {
 function GHcommentAndRemoveLabel( pr ) {
 	const { number, cherryPickHash } = pr;
 	const comment = prComment( cherryPickHash );
-	const repo = 'WordPress/gutenberg';
+	const repo = [ '--repo', 'WordPress/gutenberg' ];
 	try {
-		cli( 'gh', [
-			'pr',
-			'comment',
-			number,
-			'--repo',
-			repo,
-			'--body',
-			comment,
-		] );
-		cli( 'gh', [
-			'pr',
-			'edit',
-			number,
-			'--repo',
-			repo,
-			'--remove-label',
-			LABEL,
-		] );
+		cli( 'gh', [ 'pr', 'comment', number, ...repo, '--body', comment ] );
+		cli( 'gh', [ 'pr', 'edit', number, ...repo, '--remove-label', LABEL ] );
 
 		if ( LABEL === 'Backport to WP Beta/RC' ) {
 			cli( 'gh', [
 				'pr',
 				'edit',
 				number,
-				'--repo',
-				repo,
+				...repo,
 				'--add-label',
 				BACKPORT_COMPLETED_LABEL,
 			] );

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -6,6 +6,7 @@ import readline from 'readline';
 
 import { spawnSync } from 'node:child_process';
 
+const REPO = 'WordPress/gutenberg';
 const LABEL = process.argv[ 2 ] || 'Backport to WP Beta/RC';
 const BACKPORT_COMPLETED_LABEL = 'Backported to WP Core';
 const BRANCH = getCurrentBranch();
@@ -113,7 +114,7 @@ function cli( command, args, pipe = false ) {
  */
 async function fetchPRs() {
 	const { items } = await GitHubFetch(
-		`/search/issues?per_page=100&q=is:pr state:closed sort:updated label:"${ LABEL }" repo:WordPress/gutenberg`
+		`/search/issues?per_page=100&q=is:pr state:closed sort:updated label:"${ LABEL }" repo:${ REPO }`
 	);
 	const PRs = items
 		// eslint-disable-next-line camelcase
@@ -143,7 +144,7 @@ async function fetchPRs() {
 	const PRsWithMergeCommit = [];
 	for ( const PR of PRs ) {
 		const { merge_commit_sha: mergeCommitHash } = await GitHubFetch(
-			'/repos/WordPress/Gutenberg/pulls/' + PR.number
+			`/repos/${ REPO }/pulls/` + PR.number
 		);
 		PRsWithMergeCommit.push( {
 			...PR,
@@ -380,7 +381,7 @@ function reportSummaryNextSteps( successes, failures ) {
 function GHcommentAndRemoveLabel( pr ) {
 	const { number, cherryPickHash } = pr;
 	const comment = prComment( cherryPickHash );
-	const repo = [ '--repo', 'WordPress/gutenberg' ];
+	const repo = [ '--repo', REPO ];
 	try {
 		cli( 'gh', [ 'pr', 'comment', number, ...repo, '--body', comment ] );
 		cli( 'gh', [ 'pr', 'edit', number, ...repo, '--remove-label', LABEL ] );
@@ -446,7 +447,7 @@ function reportFailure( { number, title, error, mergeCommitHash } ) {
  * @return {string} PR URL.
  */
 function prUrl( number ) {
-	return `https://github.com/WordPress/gutenberg/pull/${ number } `;
+	return `https://github.com/${ REPO }/pull/${ number } `;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When cherry-picking for Beta 2 and Beta 3, the script failed to comment and remove labels from PRs with the following error:

```
Error: GraphQL: Could not resolve to a PullRequest with the number of 62529. (repository.pullRequest)
```

Additionally, the script removes and then re-adds the label. See [example](https://github.com/WordPress/gutenberg/pull/62578#issuecomment-2175397346). So I deleted the line that adds the label back, I'm not sure why it's there.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It turns out that the `--repo` arg is missing.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

It was tested in #62641.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
