### PR TITLE
Remove changelog checks for branches other than trunk

### DIFF
--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -4,7 +4,7 @@ on:
     pull_request:
         types: [opened, synchronize, labeled, unlabeled]
         branches:
-            - main
+            - trunk
         paths:
             - 'lib/**'
             - '!lib/load.php'

--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -3,6 +3,8 @@ name: Verify Core Backport Changlog
 on:
     pull_request:
         types: [opened, synchronize, labeled, unlabeled]
+        branches:
+            - main
         paths:
             - 'lib/**'
             - '!lib/load.php'

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -3,6 +3,8 @@ name: OPTIONAL - Verify @wordpress/components CHANGELOG update
 on:
     pull_request:
         types: [opened, synchronize]
+        branches:
+            - main
         paths:
             - 'packages/components/**'
             - '!packages/components/src/**/stories/**'

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -4,7 +4,7 @@ on:
     pull_request:
         types: [opened, synchronize]
         branches:
-            - main
+            - trunk
         paths:
             - 'packages/components/**'
             - '!packages/components/src/**/stories/**'

--- a/lib/init.php
+++ b/lib/init.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Gutenberg's Menu
+ * Gutenberg's Menu.
  *
  * Adds a new wp-admin menu page for the Gutenberg editor.
  *

--- a/lib/init.php
+++ b/lib/init.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Gutenberg's Menu.
+ * Gutenberg's Menu
  *
  * Adds a new wp-admin menu page for the Gutenberg editor.
  *


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We shouldn't run these tests for branches such as #62641.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It will try to match the wrong PR (this one).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Confirm the tests run [here](https://github.com/WordPress/gutenberg/pull/62645/commits/9cc41b118ab64a25055e44fc47d9b8cef326d3e5), confirm they are gone in #62641.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
