### PR TITLE
Fix: a11y text for site editor

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -88,7 +88,7 @@ const SiteHub = memo(
 								<VisuallyHidden as="span">
 									{
 										/* translators: accessibility text */
-										__( '(opens in a new tab)' )
+										__( 'View site (opens in a new tab)' )
 									}
 								</VisuallyHidden>
 							</Button>

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -88,7 +88,7 @@ const SiteHub = memo(
 								<VisuallyHidden as="span">
 									{
 										/* translators: accessibility text */
-										__( 'View site (opens in a new tab)' )
+										__( '(opens in a new tab)' )
 									}
 								</VisuallyHidden>
 							</Button>

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -7,7 +7,11 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	VisuallyHidden,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -78,9 +82,15 @@ const SiteHub = memo(
 								href={ homeUrl }
 								target="_blank"
 								icon={ external }
-								label={ decodeEntities( siteTitle ) }
+								iconPosition="right"
 							>
 								{ decodeEntities( siteTitle ) }
+								<VisuallyHidden as="span">
+									{
+										/* translators: accessibility text */
+										__( '(opens in a new tab)' )
+									}
+								</VisuallyHidden>
 							</Button>
 						</div>
 						<HStack

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -77,7 +77,7 @@ const SiteHub = memo(
 								variant="link"
 								href={ homeUrl }
 								target="_blank"
-								label={ __( 'View site (opens in a new tab)' ) }
+								label={ decodeEntities( siteTitle ) }
 							>
 								{ decodeEntities( siteTitle ) }
 							</Button>

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { memo, forwardRef } from '@wordpress/element';
-import { search } from '@wordpress/icons';
+import { search, external } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 import { filterURLForDisplay } from '@wordpress/url';
@@ -77,6 +77,7 @@ const SiteHub = memo(
 								variant="link"
 								href={ homeUrl }
 								target="_blank"
+								icon={ external }
 								label={ decodeEntities( siteTitle ) }
 							>
 								{ decodeEntities( siteTitle ) }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -16,7 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { memo, forwardRef } from '@wordpress/element';
-import { search, external } from '@wordpress/icons';
+import { search } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 import { filterURLForDisplay } from '@wordpress/url';
@@ -81,8 +81,6 @@ const SiteHub = memo(
 								variant="link"
 								href={ homeUrl }
 								target="_blank"
-								icon={ external }
-								iconPosition="right"
 							>
 								{ decodeEntities( siteTitle ) }
 								<VisuallyHidden as="span">

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -22,17 +22,19 @@
 
 .edit-site-site-hub__title .components-button {
 	color: $gray-200;
-	display: block;
 	flex-grow: 1;
 	font-size: 15px;
 	font-weight: 500;
 	overflow: hidden;
 	// Add space for the ↗ to render.
-	padding-right: 20px;
+	padding-right: $grid-unit-20;
 	position: relative;
 	text-decoration: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	display: flex;
+	flex-direction: row-reverse;
+	align-items: center;
 
 	&:hover,
 	&:focus,
@@ -55,18 +57,18 @@
 		outline-offset: 2px;
 	}
 
-	&::after {
-		content: "";
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24' aria-hidden='true' fill='%23E0E0E0' focusable='false'%3E%3Cpath d='M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z'%3E%3C/path%3E%3C/svg%3E");
-		width: 20px;
-		height: 20px;
-		font-weight: 400;
+	svg {
 		opacity: 0;
-		position: absolute;
-		right: 0;
-		background-size: 20px 20px;
-		transition: opacity 0.1s linear;
+		transition: opacity 0.1s ease-in-out;
 		@include reduce-motion("transition");
+	}
+
+	&:hover {
+		svg {
+			opacity: 1;
+			transition: opacity 0.1s ease-in-out;
+			@include reduce-motion("transition");
+		}
 	}
 
 	&:hover::after,

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -38,15 +38,18 @@
 	&:focus,
 	&:active,
 	&:focus-visible {
+		color: $gray-100;
 		svg {
 			opacity: 1;
-			transition: opacity 0.1s ease-in-out;
 		}
 	}
 
 	svg {
 		opacity: 0;
 		vertical-align: middle;
+		padding-left: 4px;
+		transition: opacity 0.1s ease-in-out;
+		@include reduce-motion("transition");
 	}
 
 	&:focus {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -22,6 +22,7 @@
 
 .edit-site-site-hub__title .components-button {
 	color: $gray-200;
+	display: block;
 	flex-grow: 1;
 	font-size: 15px;
 	font-weight: 500;
@@ -32,14 +33,20 @@
 	text-decoration: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	display: flex;
-	flex-direction: row-reverse;
-	align-items: center;
 
 	&:hover,
 	&:focus,
-	&:active {
-		color: $gray-200;
+	&:active,
+	&:focus-visible {
+		svg {
+			opacity: 1;
+			transition: opacity 0.1s ease-in-out;
+		}
+	}
+
+	svg {
+		opacity: 0;
+		vertical-align: middle;
 	}
 
 	&:focus {
@@ -57,25 +64,6 @@
 		outline-offset: 2px;
 	}
 
-	svg {
-		opacity: 0;
-		transition: opacity 0.1s ease-in-out;
-		@include reduce-motion("transition");
-	}
-
-	&:hover {
-		svg {
-			opacity: 1;
-			transition: opacity 0.1s ease-in-out;
-			@include reduce-motion("transition");
-		}
-	}
-
-	&:hover::after,
-	&:focus::after,
-	&:active::after {
-		opacity: 1;
-	}
 }
 
 .edit-site-site-hub_toggle-command-center {

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -28,7 +28,7 @@
 	font-weight: 500;
 	overflow: hidden;
 	// Add space for the ↗ to render.
-	padding-right: $grid-unit-20;
+	padding-right: 20px;
 	position: relative;
 	text-decoration: none;
 	text-overflow: ellipsis;
@@ -56,11 +56,15 @@
 	}
 
 	&::after {
-		content: "\2197";
+		content: "";
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24' aria-hidden='true' fill='%23E0E0E0' focusable='false'%3E%3Cpath d='M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z'%3E%3C/path%3E%3C/svg%3E");
+		width: 20px;
+		height: 20px;
 		font-weight: 400;
 		opacity: 0;
 		position: absolute;
 		right: 0;
+		background-size: 20px 20px;
 		transition: opacity 0.1s linear;
 		@include reduce-motion("transition");
 	}

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -36,20 +36,8 @@
 
 	&:hover,
 	&:focus,
-	&:active,
-	&:focus-visible {
-		color: $gray-100;
-		svg {
-			opacity: 1;
-		}
-	}
-
-	svg {
-		opacity: 0;
-		vertical-align: middle;
-		padding-left: 4px;
-		transition: opacity 0.1s ease-in-out;
-		@include reduce-motion("transition");
+	&:active {
+		color: $gray-200;
 	}
 
 	&:focus {
@@ -67,6 +55,21 @@
 		outline-offset: 2px;
 	}
 
+	&::after {
+		content: "\2197";
+		font-weight: 400;
+		opacity: 0;
+		position: absolute;
+		right: 0;
+		transition: opacity 0.1s linear;
+		@include reduce-motion("transition");
+	}
+
+	&:hover::after,
+	&:focus::after,
+	&:active::after {
+		opacity: 1;
+	}
 }
 
 .edit-site-site-hub_toggle-command-center {


### PR DESCRIPTION
## What?
- updated aria label text as site text 

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/62644

## How?
- using site title for aria label `label={ decodeEntities( siteTitle ) }`

## Screenshots or screencast <!-- if applicable -->
<img width="1368" alt="Screenshot 2024-06-18 at 15 42 47" src="https://github.com/WordPress/gutenberg/assets/75293077/5402afb2-db46-4121-8c22-935e474cf1d5">


https://github.com/WordPress/gutenberg/assets/75293077/c356aeeb-50c7-4efc-bfcd-2e6b18b7bd06


