### PR TITLE
Add linguist-documentation attribute to docs/ dir

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,6 @@ packages/edit-site/lib/** linguist-vendored
 
 # The changelog.txt file is authored as markdown.
 changelog.txt linguist-language=Markdown
+
+# Flag docs directory as documentation for GitHub stats.
+docs/** linguist-documentation


### PR DESCRIPTION


## What?

Mark `docs/` as documentation for GitHub stats.

## Why?

This will more accurately show the project stats on GitHub:

> [Documentation](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#documentation)
> Just like vendored files, Linguist excludes documentation files from your project's language stats. [documentation.yml](https://github.com/github-linguist/linguist/blob/master/lib/linguist/documentation.yml) lists common documentation paths and excludes them from the language statistics for your repository.

## How?

[Add the `linguist-documentation` git attribute.](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#documentation)

## Testing Instructions
None necessary.