### PR TITLE
Block Hooks API: Refactor Navigation to account for get_hooked_blocks_by_anchor_block

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1512,13 +1512,20 @@ function block_core_navigation_mock_parsed_block( $inner_blocks, $post ) {
  */
 function block_core_navigation_insert_hooked_blocks( $inner_blocks, $post ) {
 	$mock_navigation_block = block_core_navigation_mock_parsed_block( $inner_blocks, $post );
-	$hooked_blocks         = get_hooked_blocks();
 	$before_block_visitor  = null;
 	$after_block_visitor   = null;
 
-	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
-		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $post, 'insert_hooked_blocks' );
-		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $post, 'insert_hooked_blocks' );
+	if ( function_exists('get_hooked_blocks_by_anchor_block') ) {
+		if ( maybe_has_hooked_blocks() ) {
+			$before_block_visitor = make_before_block_visitor( $post, 'insert_hooked_blocks' );
+			$after_block_visitor  = make_after_block_visitor( $post, 'insert_hooked_blocks' );
+		}
+	} else {
+		$hooked_blocks         = get_hooked_blocks();
+		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
+			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $post, 'insert_hooked_blocks' );
+			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $post, 'insert_hooked_blocks' );
+		}
 	}
 
 	return traverse_and_serialize_block( $mock_navigation_block, $before_block_visitor, $after_block_visitor );
@@ -1539,13 +1546,20 @@ function block_core_navigation_insert_hooked_blocks( $inner_blocks, $post ) {
  */
 function block_core_navigation_set_ignored_hooked_blocks_metadata( $inner_blocks, $post ) {
 	$mock_navigation_block = block_core_navigation_mock_parsed_block( $inner_blocks, $post );
-	$hooked_blocks         = get_hooked_blocks();
 	$before_block_visitor  = null;
 	$after_block_visitor   = null;
 
-	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
-		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $post, 'set_ignored_hooked_blocks_metadata' );
-		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $post, 'set_ignored_hooked_blocks_metadata' );
+	if ( function_exists('get_hooked_blocks_by_anchor_block') ) {
+		if ( maybe_has_hooked_blocks() ) {
+			$before_block_visitor = make_before_block_visitor( $post, 'set_ignored_hooked_blocks_metadata' );
+			$after_block_visitor  = make_after_block_visitor( $post, 'set_ignored_hooked_blocks_metadata' );
+		}
+	} else {
+		$hooked_blocks         = get_hooked_blocks();
+		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
+			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $post, 'set_ignored_hooked_blocks_metadata' );
+			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $post, 'set_ignored_hooked_blocks_metadata' );
+		}
 	}
 
 	return traverse_and_serialize_block( $mock_navigation_block, $before_block_visitor, $after_block_visitor );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1515,13 +1515,13 @@ function block_core_navigation_insert_hooked_blocks( $inner_blocks, $post ) {
 	$before_block_visitor  = null;
 	$after_block_visitor   = null;
 
-	if ( function_exists('get_hooked_blocks_by_anchor_block') ) {
+	if ( function_exists( 'get_hooked_blocks_by_anchor_block' ) ) {
 		if ( maybe_has_hooked_blocks() ) {
 			$before_block_visitor = make_before_block_visitor( $post, 'insert_hooked_blocks' );
 			$after_block_visitor  = make_after_block_visitor( $post, 'insert_hooked_blocks' );
 		}
 	} else {
-		$hooked_blocks         = get_hooked_blocks();
+		$hooked_blocks = get_hooked_blocks();
 		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $post, 'insert_hooked_blocks' );
 			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $post, 'insert_hooked_blocks' );
@@ -1549,13 +1549,13 @@ function block_core_navigation_set_ignored_hooked_blocks_metadata( $inner_blocks
 	$before_block_visitor  = null;
 	$after_block_visitor   = null;
 
-	if ( function_exists('get_hooked_blocks_by_anchor_block') ) {
+	if ( function_exists( 'get_hooked_blocks_by_anchor_block' ) ) {
 		if ( maybe_has_hooked_blocks() ) {
 			$before_block_visitor = make_before_block_visitor( $post, 'set_ignored_hooked_blocks_metadata' );
 			$after_block_visitor  = make_after_block_visitor( $post, 'set_ignored_hooked_blocks_metadata' );
 		}
 	} else {
-		$hooked_blocks         = get_hooked_blocks();
+		$hooked_blocks = get_hooked_blocks();
 		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $post, 'set_ignored_hooked_blocks_metadata' );
 			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $post, 'set_ignored_hooked_blocks_metadata' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1517,8 +1517,8 @@ function block_core_navigation_insert_hooked_blocks( $inner_blocks, $post ) {
 
 	if ( function_exists( 'get_hooked_blocks_by_anchor_block' ) ) {
 		if ( maybe_has_hooked_blocks() ) {
-			$before_block_visitor = make_before_block_visitor( $post, 'insert_hooked_blocks' );
-			$after_block_visitor  = make_after_block_visitor( $post, 'insert_hooked_blocks' );
+			$before_block_visitor = make_before_block_visitor( null, $post, 'insert_hooked_blocks' );
+			$after_block_visitor  = make_after_block_visitor( null, $post, 'insert_hooked_blocks' );
 		}
 	} else {
 		$hooked_blocks = get_hooked_blocks();
@@ -1551,8 +1551,8 @@ function block_core_navigation_set_ignored_hooked_blocks_metadata( $inner_blocks
 
 	if ( function_exists( 'get_hooked_blocks_by_anchor_block' ) ) {
 		if ( maybe_has_hooked_blocks() ) {
-			$before_block_visitor = make_before_block_visitor( $post, 'set_ignored_hooked_blocks_metadata' );
-			$after_block_visitor  = make_after_block_visitor( $post, 'set_ignored_hooked_blocks_metadata' );
+			$before_block_visitor = make_before_block_visitor( null, $post, 'set_ignored_hooked_blocks_metadata' );
+			$after_block_visitor  = make_after_block_visitor( null, $post, 'set_ignored_hooked_blocks_metadata' );
 		}
 	} else {
 		$hooked_blocks = get_hooked_blocks();


### PR DESCRIPTION
Related https://github.com/WordPress/wordpress-develop/pull/6584

## What?
Consolidated our approach to getting hooked blocks which means function signatures have changed for the visitor functions. So checking for the existence of `get_hooked_blocks_by_anchor_block` before using it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because the function signatures of the visitor functions have now changed.

## How?
Use `function_exists` before executing code that depends on it.

## Testing Instructions

Follow the below stops for WordPress 6.5/6.6 to ensure no regressions have been introduced, and then again using latest `trunk` of `wordpress-develop` once https://github.com/WordPress/wordpress-develop/pull/6584 has been merged.

1. Add the below code to your themes `functions.php`
2. Load frontend and check the Login/Logout block is an inner block of the core Navigation block and hasn't been added twice.
3. Load the Header template part in the Site Editor and check that the Login/Logout block is present as an inner block of the core Navigation and hasn't been added twice.
4. Make customisations to move the block and check it persists between reloads.
5. Make customisations to remove the block completely and check it persists between reloads.
6. Remove the PHP code added in step 1, and now add the below JSON to the same blocks `block.json` file and retest starting from step 2.

```php
function register_logout_block_as_navigation_last_child( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'core/navigation' && $position === 'last_child' ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'register_logout_block_as_navigation_last_child', 10, 4 );
```

```json
"blockHooks": {
	"core/navigation": "lastChild"
}
```
