### PR TITLE
Convert to blocks: upgrade and remove spans if possible

### DIFF
--- a/packages/blocks/src/api/raw-handling/anchor-reducer.js
+++ b/packages/blocks/src/api/raw-handling/anchor-reducer.js
@@ -1,0 +1,25 @@
+export default function anchorReducer( node ) {
+	if ( node.nodeName === 'A' ) {
+		// In jsdom-jscore, 'node.target' can be null.
+		// TODO: Explore fixing this by patching jsdom-jscore.
+		if ( node.target && node.target.toLowerCase() === '_blank' ) {
+			node.rel = 'noreferrer noopener';
+		} else {
+			node.removeAttribute( 'target' );
+			node.removeAttribute( 'rel' );
+		}
+
+		// Saves anchor elements name attribute as id
+		if ( node.name && ! node.id ) {
+			node.id = node.name;
+		}
+
+		// Keeps id only if there is an internal link pointing to it
+		if (
+			node.id &&
+			! node.ownerDocument.querySelector( `[href="#${ node.id }"]` )
+		) {
+			node.removeAttribute( 'id' );
+		}
+	}
+}

--- a/packages/blocks/src/api/raw-handling/empty-span-remover.js
+++ b/packages/blocks/src/api/raw-handling/empty-span-remover.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { unwrap } from '@wordpress/dom';
+
+export default ( node ) => {
+	// Remove spans with no attributes.
+	if ( node.nodeName === 'SPAN' && ! node.attributes.length ) {
+		unwrap( node );
+	}
+};

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -14,6 +14,8 @@ import specialCommentConverter from './special-comment-converter';
 import listReducer from './list-reducer';
 import blockquoteNormaliser from './blockquote-normaliser';
 import figureContentReducer from './figure-content-reducer';
+import phrasingContentReducer from './phrasing-content-reducer';
+import emptySpanRemover from './empty-span-remover';
 import shortcodeConverter from './shortcode-converter';
 import { deepFilterHTML, getBlockContentSchema } from './utils';
 
@@ -69,9 +71,11 @@ export function rawHandler( { HTML = '' } ) {
 				specialCommentConverter,
 				// Needed to create media blocks.
 				figureContentReducer,
+				phrasingContentReducer,
 				// Needed to create the quote block, which cannot handle text
 				// without wrapper paragraphs.
 				blockquoteNormaliser( { raw: true } ),
+				emptySpanRemover,
 			];
 
 			piece = deepFilterHTML( piece, filters, blockContentSchema );

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -15,6 +15,7 @@ import specialCommentConverter from './special-comment-converter';
 import commentRemover from './comment-remover';
 import isInlineContent from './is-inline-content';
 import phrasingContentReducer from './phrasing-content-reducer';
+import anchorReducer from './anchor-reducer';
 import headRemover from './head-remover';
 import msListConverter from './ms-list-converter';
 import msListIgnore from './ms-list-ignore';
@@ -48,6 +49,7 @@ function filterInlineHTML( HTML ) {
 		googleDocsUIDRemover,
 		msListIgnore,
 		phrasingContentReducer,
+		anchorReducer,
 		commentRemover,
 	] );
 	HTML = removeInvalidHTML( HTML, getPhrasingContentSchema( 'paste' ), {
@@ -193,6 +195,7 @@ export function pasteHandler( {
 				listReducer,
 				imageCorrector,
 				phrasingContentReducer,
+				anchorReducer,
 				specialCommentConverter,
 				commentRemover,
 				iframeRemover,

--- a/packages/blocks/src/api/raw-handling/test/anchor-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/anchor-reducer.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import anchorReducer from '../anchor-reducer';
+import { deepFilterHTML } from '../utils';
+
+describe( 'anchorReducer', () => {
+	it( 'should normalise the rel attribute', () => {
+		const input =
+			'<a href="https://wordpress.org" target="_blank">WordPress</a>';
+		const output =
+			'<a href="https://wordpress.org" target="_blank" rel="noreferrer noopener">WordPress</a>';
+		expect( deepFilterHTML( input, [ anchorReducer ], {} ) ).toEqual(
+			output
+		);
+	} );
+
+	it( 'should only allow target="_blank"', () => {
+		const input =
+			'<a href="https://wordpress.org" target="_self">WordPress</a>';
+		const output = '<a href="https://wordpress.org">WordPress</a>';
+		expect( deepFilterHTML( input, [ anchorReducer ], {} ) ).toEqual(
+			output
+		);
+	} );
+
+	it( 'should remove the rel attribute when target is not set', () => {
+		const input =
+			'<a href="https://wordpress.org" rel="noopener">WordPress</a>';
+		const output = '<a href="https://wordpress.org">WordPress</a>';
+		expect( deepFilterHTML( input, [ anchorReducer ], {} ) ).toEqual(
+			output
+		);
+	} );
+} );

--- a/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
@@ -12,9 +12,7 @@ describe( 'phrasingContentReducer', () => {
 				[ phrasingContentReducer ],
 				{}
 			)
-		).toEqual(
-			'<strong><span style="font-weight:bold">test</span></strong>'
-		);
+		).toEqual( '<strong><span>test</span></strong>' );
 	} );
 
 	it( 'should transform numeric font weight', () => {
@@ -24,9 +22,7 @@ describe( 'phrasingContentReducer', () => {
 				[ phrasingContentReducer ],
 				{}
 			)
-		).toEqual(
-			'<strong><span style="font-weight:700">test</span></strong>'
-		);
+		).toEqual( '<strong><span>test</span></strong>' );
 	} );
 
 	it( 'should transform font style', () => {
@@ -36,7 +32,7 @@ describe( 'phrasingContentReducer', () => {
 				[ phrasingContentReducer ],
 				{}
 			)
-		).toEqual( '<em><span style="font-style:italic">test</span></em>' );
+		).toEqual( '<em><span>test</span></em>' );
 	} );
 
 	it( 'should transform nested formatting', () => {
@@ -46,36 +42,6 @@ describe( 'phrasingContentReducer', () => {
 				[ phrasingContentReducer ],
 				{}
 			)
-		).toEqual(
-			'<strong><em><span style="font-style:italic;font-weight:bold">test</span></em></strong>'
-		);
-	} );
-
-	it( 'should normalise the rel attribute', () => {
-		const input =
-			'<a href="https://wordpress.org" target="_blank">WordPress</a>';
-		const output =
-			'<a href="https://wordpress.org" target="_blank" rel="noreferrer noopener">WordPress</a>';
-		expect(
-			deepFilterHTML( input, [ phrasingContentReducer ], {} )
-		).toEqual( output );
-	} );
-
-	it( 'should only allow target="_blank"', () => {
-		const input =
-			'<a href="https://wordpress.org" target="_self">WordPress</a>';
-		const output = '<a href="https://wordpress.org">WordPress</a>';
-		expect(
-			deepFilterHTML( input, [ phrasingContentReducer ], {} )
-		).toEqual( output );
-	} );
-
-	it( 'should remove the rel attribute when target is not set', () => {
-		const input =
-			'<a href="https://wordpress.org" rel="noopener">WordPress</a>';
-		const output = '<a href="https://wordpress.org">WordPress</a>';
-		expect(
-			deepFilterHTML( input, [ phrasingContentReducer ], {} )
-		).toEqual( output );
+		).toEqual( '<strong><em><span>test</span></em></strong>' );
 	} );
 } );

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -218,3 +218,9 @@ exports[`rawHandler should preserve all paragraphs 1`] = `
 <p></p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`rawHandler should remove convertable spans 1`] = `
+"<!-- wp:paragraph -->
+<p>a</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -569,4 +569,9 @@ describe( 'rawHandler', () => {
 <p style="border: 1px solid tomato;"></p>`;
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
+
+	it( 'should remove convertable spans', () => {
+		const HTML = `<span style="font-weight: 400">a</span>`;
+		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The idea behind "convert to blocks" (compared to past handling) is to preserve content as much as possible. However, at the moment, we are preserving it a bit too much.

* Spans with a normal font weight should be removed.
* Spans with a bold font weight should be converted to `strong`.
* Spins with an italic font style should be converted to `em`.
* `b` should be converted to `strong`.
* `i` should be converted to `em`.
* And so on.
* And remaining spans without any attributes should be removed. If there are remaining attributes, they should be preserved. (Key difference with paste.)

I've separated out the anchor reducer to only run on paste (because it modifies content).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We have core formats for these, which is a better experience.
Spans that do nothing leads to a bad user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I've added an integration test.

Paste this in the code editor.

```
<span style="font-weight: 400">test</span>
```

Switch to visual and click "convert to blocks". There should be no spans.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
