### PR TITLE
Try: Extend site editor

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -20,6 +20,7 @@ import {
 	TEMPLATE_POST_TYPE,
 	PATTERN_TYPES,
 } from '../../utils/constants';
+import SidebarNavigationScreenMainPlugins from './plugins';
 
 export default function SidebarNavigationScreenMain() {
 	const { setEditorCanvasContainerView } = unlock(
@@ -80,6 +81,7 @@ export default function SidebarNavigationScreenMain() {
 						>
 							{ __( 'Patterns' ) }
 						</SidebarNavigationItem>
+						<SidebarNavigationScreenMainPlugins.Slot />
 					</ItemGroup>
 				</>
 			}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/plugins.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/plugins.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill, Slot } = createSlotFill( 'SidebarNavigationScreenMainPlugins' );
+
+const SidebarNavigationScreenMainPlugins = ( { children } ) => {
+	return <Fill>{ children }</Fill>;
+};
+
+SidebarNavigationScreenMainPlugins.Slot = Slot;
+
+export default SidebarNavigationScreenMainPlugins;


### PR DESCRIPTION
## What?
This PR is a rough experiment that demonstrates how we can extend the site editor via plugins.

## Why?
At some point, plugins may want to extend the site editor - add their own route and their own settings page.

## How?
* We're making the site editor routes extensible.
* We're introducing an extensible slot for site editor sidebar menu items
* We're registering a custom route and a custom menu item (ideally, this should all be in a plugin).

This is still WIP, we still have to iron out a bunch of things. This should ideally have a better API, baked into the `registerPlugin` API for example - I'll try things out. We also need to add support for legacy plugin pages, which is its own can of worms.

## Testing Instructions
TBD

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/8436925/bf2e29ab-1a71-4799-b6cb-7f84510ac96c

