### PR TITLE
Rename yieldToMain to splitTask and export from @wordpress/interactivity

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -813,7 +813,8 @@ const { state } = store("myPlugin", {
 As mentioned above with [`wp-on`](#wp-on), [`wp-on-window`](#wp-on-window), and [`wp-on-document`](#wp-on-document), an async action should be used whenever the `async` versions of the aforementioned directives cannot be used due to the action requiring synchronous access to the `event` object. Synchronous access is reqired whenever the action needs to call `event.preventDefault()`, `event.stopPropagation()`, or `event.stopImmediatePropagation()`. To ensure that the action code does not contribute to a long task, you may manually yield to the main thread after calling the synchronous event API. For example:
 
 ```js
-function toMainThread() {
+// Note: In WordPress 6.6 this splitTask function is exported by @wordpress/interactivity.
+function splitTask() {
   return new Promise(resolve => {
     setTimeout(resolve, 0);
   });
@@ -823,7 +824,7 @@ store("myPlugin", {
   actions: {
     handleClick: function* (event) {
       event.preventDefault();
-      yield toMainThread();
+      yield splitTask();
       doTheWork();
     },
   },

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -11,13 +11,7 @@ import { deepSignal, peek, type DeepSignal } from 'deepsignal';
 /**
  * Internal dependencies
  */
-import {
-	useWatch,
-	useInit,
-	kebabToCamelCase,
-	warn,
-	yieldToMain,
-} from './utils';
+import { useWatch, useInit, kebabToCamelCase, warn, splitTask } from './utils';
 import type { DirectiveEntry } from './hooks';
 import { directive, getScope, getEvaluate } from './hooks';
 
@@ -246,7 +240,7 @@ const getGlobalAsyncEventDirective = ( type: 'window' | 'document' ) => {
 				const eventName = entry.suffix.split( '--', 1 )[ 0 ];
 				useInit( () => {
 					const cb = async ( event: Event ) => {
-						await yieldToMain();
+						await splitTask();
 						evaluate( entry, event );
 					};
 					const globalVar = type === 'window' ? window : document;
@@ -361,7 +355,7 @@ export default () => {
 						existingHandler( event );
 					}
 					entries.forEach( async ( entry ) => {
-						await yieldToMain();
+						await splitTask();
 						evaluate( entry, event );
 					} );
 				};

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -25,7 +25,7 @@ export {
 	useLayoutEffect,
 	useCallback,
 	useMemo,
-	yieldToMain,
+	splitTask,
 } from './utils';
 
 export { useState, useRef } from 'preact/hooks';

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -25,6 +25,7 @@ export {
 	useLayoutEffect,
 	useCallback,
 	useMemo,
+	yieldToMain,
 } from './utils';
 
 export { useState, useRef } from 'preact/hooks';

--- a/packages/interactivity/src/init.ts
+++ b/packages/interactivity/src/init.ts
@@ -6,7 +6,7 @@ import { hydrate, type ContainerNode, type ComponentChild } from 'preact';
  * Internal dependencies
  */
 import { toVdom, hydratedIslands } from './vdom';
-import { createRootFragment, yieldToMain } from './utils';
+import { createRootFragment, splitTask } from './utils';
 import { directivePrefix } from './constants';
 
 // Keep the same root fragment for each interactive region node.
@@ -35,11 +35,11 @@ export const init = async () => {
 
 	for ( const node of nodes ) {
 		if ( ! hydratedIslands.has( node ) ) {
-			await yieldToMain();
+			await splitTask();
 			const fragment = getRegionRootFragment( node );
 			const vdom = toVdom( node );
 			initialVdom.set( node, vdom );
-			await yieldToMain();
+			await splitTask();
 			hydrate( vdom, fragment );
 		}
 	}

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -54,7 +54,7 @@ const afterNextFrame = ( callback: () => void ) => {
  *
  * @return Promise
  */
-export const yieldToMain = () => {
+export const splitTask = () => {
 	return new Promise( ( resolve ) => {
 		// TODO: Use scheduler.yield() when available.
 		setTimeout( resolve, 0 );


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/61885

I just realized that the new `yieldToMain` function isn't currently exported by `@wordpress/interactivity`. This should be exported because it allows for directives to reuse this logic to break up their own long tasks when they can't make use of the `wp-async` directive (or even if they do and still are doing a lot of work). 

For example, consider this synchronous `wp-on` directive action which calls `event.preventDefault()` but then does work.

```js
import { store, splitTask } from '@wordpress/interactivity';

store( 'foo', {
	actions: {
		showSomething: function* ( event ) => {
			event.preventDefault();
			showLoadingSpinner();
			yield splitTask();
			const data = fetchData();
			processData( data );
			yield splitTask();
			renderData( data );
		}
} );
```

(Granted: A developer could just re-implement `yieldToMain` on their own.)

<!--Nevertheless, the use of an `async` function here in this example may be invalid and a [generator function should be used instead](https://make.wordpress.org/core/2024/03/04/interactivity-api-dev-note/#:~:text=documentation%20here.-,Async%20actions,-Async%20actions%20should)?-->

If approved and backported, this will need to be mentioned in the doc updates in https://github.com/WordPress/gutenberg/pull/62663, in particular under [Async Actions](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#:~:text=%7D\)%3B-,Async%20actions,-Async%20actions%20should).