### PR TITLE
Dependencies: Upgrade @octokit/webhooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
 				"@geometricpanda/storybook-addon-badges": "2.0.1",
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
-				"@octokit/webhooks-types": "5.6.0",
+				"@octokit/webhooks-types": "5.8.0",
 				"@playwright/test": "1.43.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
@@ -6778,10 +6778,11 @@
 			"license": "MIT"
 		},
 		"node_modules/@octokit/webhooks-types": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.6.0.tgz",
-			"integrity": "sha512-y3MqE6N6Ksg1+YV0sXVpW2WP7Y24h7rUp2hDJuzoqWdKGr7owmRDyHC72INwfCYNzura/vsNPXvc6Xbfp4wGGw==",
-			"dev": true
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
+			"integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@parcel/watcher": {
 			"version": "2.0.4",
@@ -55135,13 +55136,6 @@
 				"aggregate-error": "^3.1.0"
 			}
 		},
-		"packages/project-management-automation/node_modules/@octokit/webhooks-types": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
-			"integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/project-management-automation/node_modules/aggregate-error": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -60736,9 +60730,9 @@
 			"dev": true
 		},
 		"@octokit/webhooks-types": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.6.0.tgz",
-			"integrity": "sha512-y3MqE6N6Ksg1+YV0sXVpW2WP7Y24h7rUp2hDJuzoqWdKGr7owmRDyHC72INwfCYNzura/vsNPXvc6Xbfp4wGGw==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
+			"integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw==",
 			"dev": true
 		},
 		"@parcel/watcher": {
@@ -69926,12 +69920,6 @@
 						"@octokit/webhooks-types": "5.8.0",
 						"aggregate-error": "^3.1.0"
 					}
-				},
-				"@octokit/webhooks-types": {
-					"version": "5.8.0",
-					"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
-					"integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw==",
-					"dev": true
 				},
 				"aggregate-error": {
 					"version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6770,14 +6770,12 @@
 				"@octokit/openapi-types": "^11.2.0"
 			}
 		},
-		"node_modules/@octokit/webhooks": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.1.0.tgz",
-			"integrity": "sha512-kHyYkJkqY/wiP/hp0IT9FhkY5PhnV01co16V2YMRP/Zgnk3Vsy3U5iLAaP6U/0eRIlz5T4LSvkrcfNlfSb3cVQ==",
+		"node_modules/@octokit/webhooks-methods": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-2.0.0.tgz",
+			"integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig==",
 			"dev": true,
-			"dependencies": {
-				"debug": "^4.0.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@octokit/webhooks-types": {
 			"version": "5.6.0",
@@ -55117,11 +55115,55 @@
 				"@actions/github": "^5.0.0",
 				"@babel/runtime": "^7.16.0",
 				"@octokit/request-error": "^2.1.0",
-				"@octokit/webhooks": "7.1.0"
+				"@octokit/webhooks": "^9.26.3"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"packages/project-management-automation/node_modules/@octokit/webhooks": {
+			"version": "9.26.3",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.3.tgz",
+			"integrity": "sha512-DLGk+gzeVq5oK89Bo601txYmyrelMQ7Fi5EnjHE0Xs8CWicy2xkmnJMKptKJrBJpstqbd/9oeDFi/Zj2pudBDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^2.0.2",
+				"@octokit/webhooks-methods": "^2.0.0",
+				"@octokit/webhooks-types": "5.8.0",
+				"aggregate-error": "^3.1.0"
+			}
+		},
+		"packages/project-management-automation/node_modules/@octokit/webhooks-types": {
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
+			"integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/project-management-automation/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"packages/project-management-automation/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"packages/react-i18n": {
@@ -60687,14 +60729,11 @@
 				"@octokit/openapi-types": "^11.2.0"
 			}
 		},
-		"@octokit/webhooks": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.1.0.tgz",
-			"integrity": "sha512-kHyYkJkqY/wiP/hp0IT9FhkY5PhnV01co16V2YMRP/Zgnk3Vsy3U5iLAaP6U/0eRIlz5T4LSvkrcfNlfSb3cVQ==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.0.0"
-			}
+		"@octokit/webhooks-methods": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-2.0.0.tgz",
+			"integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig==",
+			"dev": true
 		},
 		"@octokit/webhooks-types": {
 			"version": "5.6.0",
@@ -69873,7 +69912,43 @@
 				"@actions/github": "^5.0.0",
 				"@babel/runtime": "^7.16.0",
 				"@octokit/request-error": "^2.1.0",
-				"@octokit/webhooks": "7.1.0"
+				"@octokit/webhooks": "^9.26.3"
+			},
+			"dependencies": {
+				"@octokit/webhooks": {
+					"version": "9.26.3",
+					"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.3.tgz",
+					"integrity": "sha512-DLGk+gzeVq5oK89Bo601txYmyrelMQ7Fi5EnjHE0Xs8CWicy2xkmnJMKptKJrBJpstqbd/9oeDFi/Zj2pudBDQ==",
+					"dev": true,
+					"requires": {
+						"@octokit/request-error": "^2.0.2",
+						"@octokit/webhooks-methods": "^2.0.0",
+						"@octokit/webhooks-types": "5.8.0",
+						"aggregate-error": "^3.1.0"
+					}
+				},
+				"@octokit/webhooks-types": {
+					"version": "5.8.0",
+					"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
+					"integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw==",
+					"dev": true
+				},
+				"aggregate-error": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+					"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+					"dev": true,
+					"requires": {
+						"clean-stack": "^2.0.0",
+						"indent-string": "^4.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/react-i18n": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"@geometricpanda/storybook-addon-badges": "2.0.1",
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
-		"@octokit/webhooks-types": "5.6.0",
+		"@octokit/webhooks-types": "5.8.0",
 		"@playwright/test": "1.43.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",

--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Upgrade `@octokit/webhooks` dependency ([#62666](https://github.com/WordPress/gutenberg/pull/62666)).
+
 ## 2.1.0 (2024-06-15)
 
 ## 2.0.0 (2024-05-31)

--- a/packages/project-management-automation/lib/tasks/add-milestone/index.js
+++ b/packages/project-management-automation/lib/tasks/add-milestone/index.js
@@ -6,7 +6,7 @@ const getAssociatedPullRequest = require( '../../get-associated-pull-request' );
 
 /** @typedef {import('@octokit/request-error').RequestError} RequestError */
 /** @typedef {ReturnType<import('@actions/github').getOctokit>} GitHub */
-/** @typedef {import('@octokit/webhooks').WebhookPayloadPush} WebhookPayloadPush */
+/** @typedef {import('@octokit/webhooks-types').EventPayloadMap['push']} WebhookPayloadPush */
 
 /**
  * Number of expected days elapsed between releases.

--- a/packages/project-management-automation/lib/tasks/assign-fixed-issues/index.js
+++ b/packages/project-management-automation/lib/tasks/assign-fixed-issues/index.js
@@ -4,7 +4,7 @@
 const debug = require( '../../debug' );
 
 /** @typedef {ReturnType<import('@actions/github').getOctokit>} GitHub */
-/** @typedef {import('@octokit/webhooks').WebhookPayloadPullRequest} WebhookPayloadPullRequest */
+/** @typedef {import('@octokit/webhooks-types').EventPayloadMap['pull_request']} WebhookPayloadPullRequest */
 
 /**
  * Assigns any issues 'fixed' by a newly opened PR to the author of that PR.
@@ -17,30 +17,33 @@ async function assignFixedIssues( payload, octokit ) {
 		/(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? +(?:\#?|https?:\/\/github\.com\/WordPress\/gutenberg\/issues\/)(\d+)/gi;
 
 	let match;
-	while ( ( match = regex.exec( payload.pull_request.body ) ) ) {
-		const [ , issue ] = match;
 
-		debug(
-			`assign-fixed-issues: Assigning issue #${ issue } to @${ payload.pull_request.user.login }`
-		);
+	if ( payload.pull_request.body ) {
+		while ( ( match = regex.exec( payload.pull_request.body ) ) ) {
+			const [ , issue ] = match;
 
-		await octokit.rest.issues.addAssignees( {
-			owner: payload.repository.owner.login,
-			repo: payload.repository.name,
-			issue_number: +issue,
-			assignees: [ payload.pull_request.user.login ],
-		} );
+			debug(
+				`assign-fixed-issues: Assigning issue #${ issue } to @${ payload.pull_request.user.login }`
+			);
 
-		debug(
-			`assign-fixed-issues: Applying '[Status] In Progress' label to issue #${ issue }`
-		);
+			await octokit.rest.issues.addAssignees( {
+				owner: payload.repository.owner.login,
+				repo: payload.repository.name,
+				issue_number: +issue,
+				assignees: [ payload.pull_request.user.login ],
+			} );
 
-		await octokit.rest.issues.addLabels( {
-			owner: payload.repository.owner.login,
-			repo: payload.repository.name,
-			issue_number: +issue,
-			labels: [ '[Status] In Progress' ],
-		} );
+			debug(
+				`assign-fixed-issues: Applying '[Status] In Progress' label to issue #${ issue }`
+			);
+
+			await octokit.rest.issues.addLabels( {
+				owner: payload.repository.owner.login,
+				repo: payload.repository.name,
+				issue_number: +issue,
+				labels: [ '[Status] In Progress' ],
+			} );
+		}
 	}
 }
 

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
@@ -6,7 +6,7 @@ const getAssociatedPullRequest = require( '../../get-associated-pull-request' );
 const hasWordPressProfile = require( '../../has-wordpress-profile' );
 
 /** @typedef {ReturnType<import('@actions/github').getOctokit>} GitHub */
-/** @typedef {import('@octokit/webhooks').WebhookPayloadPush} WebhookPayloadPush */
+/** @typedef {import('@octokit/webhooks-types').EventPayloadMap['push']} WebhookPayloadPush */
 /** @typedef {import('../../get-associated-pull-request').WebhookPayloadPushCommit} WebhookPayloadPushCommit */
 
 /**

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -4,7 +4,7 @@
 const debug = require( '../../debug' );
 
 /** @typedef {ReturnType<import('@actions/github').getOctokit>} GitHub */
-/** @typedef {import('@octokit/webhooks').WebhookPayloadPullRequest} WebhookPayloadPullRequest */
+/** @typedef {import('@octokit/webhooks-types').EventPayloadMap['pull_request']} WebhookPayloadPullRequest */
 
 /**
  * Assigns the first-time contributor label to PRs.

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -30,7 +30,7 @@
 		"@actions/github": "^5.0.0",
 		"@babel/runtime": "^7.16.0",
 		"@octokit/request-error": "^2.1.0",
-		"@octokit/webhooks": "7.1.0"
+		"@octokit/webhooks": "^9.26.3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/project-management-automation/tsconfig.json
+++ b/packages/project-management-automation/tsconfig.json
@@ -4,10 +4,7 @@
 	"compilerOptions": {
 		"rootDir": "lib",
 		"declarationDir": "build-types",
-		"types": [ "node" ],
-
-		// This is required due to a type error coming from missing types in @actions/github
-		"noImplicitAny": false
+		"types": [ "node" ]
 	},
 	"include": [ "lib/**/*" ]
 }


### PR DESCRIPTION
## What?

Upgrade `@octokit/webhooks` package. This fixes a dependabot security alert. It is uprgraded to the minimum version to fix the alert.

Upgrade `@octokit/webhooks-types` dependency to align with `@octokit/webhooks`.

## Why?

There's a security alert for this dependency, it's a good idea to upgrade.

## Testing Instructions

There are unit tests for the affected package, although I'm not sure how comprehensive.

This package CI action does run on the branch without error: https://github.com/WordPress/gutenberg/actions/runs/9593716196/job/26454749842