### PR TITLE
Latest Comments Block Center Alignment is not working properly

### DIFF
--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -46,6 +46,18 @@ ol.wp-block-latest-comments {
 			margin-left: 3.25em;
 		}
 	}
+
+	.aligncenter & {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		align-items: start;
+
+		.wp-block-latest-comments__comment-meta,
+		.wp-block-latest-comments__comment-excerpt {
+			margin-left: 0;
+		}
+	}
 }
 
 .wp-block-latest-comments__comment-excerpt p {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/62503

This PR addresses the [issue](https://github.com/WordPress/gutenberg/issues/62503) where the Latest Comments block's center alignment was not functioning correctly. By applying a flexbox layout, the content within the block is now properly centered. 

## What?
Fixed center alignment issue in Latest Comments block.

## Why?
To ensure content within the block is properly centered when aligned to the center.

## How?
Applied a flexbox layout to achieve proper center alignment.

## Testing Instructions

1. Add the Latest Comments block to a post/page.
2. Change the alignment to center.
3. Verify that the comments content (meta and excerpt) is centered horizontally.
4. Test responsiveness on different screen sizes to ensure consistent centering.

### Testing Instructions for Keyboard

1. Navigate to the Latest Comments block using keyboard navigation.
2. Change alignment to center using keyboard shortcuts.
3. Verify that the content is visually centered and accessible.

## Screenshots or screencast

### Before:
<img width="1470" alt="Screenshot 2024-06-19 at 2 43 04 PM" src="https://github.com/WordPress/gutenberg/assets/90276347/3f1264c8-a003-48a9-af28-33ab81607d99">


### After:
<img width="1470" alt="Screenshot 2024-06-19 at 2 40 40 PM" src="https://github.com/WordPress/gutenberg/assets/90276347/2ddcc1bb-da79-4e03-ae35-30b6f15a0c13">