### PR TITLE
Site Editor: Improve the frame animation

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -1,15 +1,4 @@
-/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
-::view-transition-old(frame),
-::view-transition-new(frame) {
-  animation-duration: 0;
-}
-/* stylelint-enable */
-
 .edit-site-visual-editor__editor-canvas {
-	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
-	view-transition-name: frame;
-	/* stylelint-enable */
-
 	&.is-focused {
 		outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
 		outline-offset: calc(-2 * var(--wp-admin-border-width-focus));

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -36,6 +36,19 @@
 @import "./components/pagination/style.scss";
 @import "./components/global-styles/variations/style.scss";
 
+/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
+::view-transition-image-pair(root) {
+	isolation: auto;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation: none;
+	mix-blend-mode: normal;
+	display: block;
+}
+/* stylelint-enable */
+
 body.js #wpadminbar {
 	display: none;
 }


### PR DESCRIPTION
Alternative to #62386

## What?

@stokesman raised that the changes in #61579 introduce a regression in the frame animation where during the frame animation, sometimes the header appears separate from the frame.

It looks like it happens only on browsers that support view transitions. My understand of the issue is that we have some things that are using view transitions but others framer motion animation which caused the conflict.

## How?

This PR solves the issue by actually removing the view transition name from the "frame" which was not really needed AFAIK

## Testing Instructions

1- Open the site editor
2- Navigate to "edit" mode 
3- Keep your eyes focused on the header area during the animation and you shouldn't feel like the header got "disconnected" from the frame (hard to describe) :P 