### PR TITLE
Limit pattern shuffling to theme and user patterns only

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -56,7 +56,8 @@ export default function Shuffle( { clientId, as = Container } ) {
 		return patterns.filter( ( pattern ) => {
 			const isCorePattern =
 				pattern.source === 'core' ||
-				( pattern.source?.startsWith( 'pattern-directory' ) && pattern.source !== 'pattern-directory/theme' );
+				( pattern.source?.startsWith( 'pattern-directory' ) &&
+					pattern.source !== 'pattern-directory/theme' );
 			return (
 				// Check if the pattern has only one top level block,
 				// otherwise we may shuffle to pattern that will not allow to continue shuffling.

--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -56,9 +56,7 @@ export default function Shuffle( { clientId, as = Container } ) {
 		return patterns.filter( ( pattern ) => {
 			const isCorePattern =
 				pattern.source === 'core' ||
-				( pattern.source !== 'pattern-directory/theme' &&
-					pattern.source?.startsWith( 'pattern-directory' ) ===
-						true );
+				( pattern.source?.startsWith( 'pattern-directory' ) && pattern.source !== 'pattern-directory/theme' );
 			return (
 				// Check if the pattern has only one top level block,
 				// otherwise we may shuffle to pattern that will not allow to continue shuffling.

--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -63,7 +63,7 @@ export default function Shuffle( { clientId, as = Container } ) {
 				// Check if the pattern has only one top level block,
 				// otherwise we may shuffle to pattern that will not allow to continue shuffling.
 				pattern.blocks.length === 1 &&
-				// We exclude the pattern directory and core patterns that are not theme patterns.
+				// We exclude the core patterns and pattern directory patterns that are not theme patterns.
 				! isCorePattern &&
 				pattern.categories?.some( ( category ) => {
 					return categories.includes( category );

--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -54,10 +54,17 @@ export default function Shuffle( { clientId, as = Container } ) {
 			return EMPTY_ARRAY;
 		}
 		return patterns.filter( ( pattern ) => {
+			const isCorePattern =
+				pattern.source === 'core' ||
+				( pattern.source !== 'pattern-directory/theme' &&
+					pattern.source?.startsWith( 'pattern-directory' ) ===
+						true );
 			return (
 				// Check if the pattern has only one top level block,
 				// otherwise we may shuffle to pattern that will not allow to continue shuffling.
 				pattern.blocks.length === 1 &&
+				// We exclude the pattern directory and core patterns that are not theme patterns.
+				! isCorePattern &&
 				pattern.categories?.some( ( category ) => {
 					return categories.includes( category );
 				} ) &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/60135

This limits shuffling to only patterns added by the theme or the user

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Core patterns or pattern directory patterns may not fit the design of the theme. By excluding them we make the shuffling more consistent with the theme's design

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By checking the source of the pattern. The condition will exclude all patterns from the pattern directory (testing on TT4 I could see patterns with the source `pattern-directory/core` and `pattern-directory/featured`), all core patterns (such as the social icons one) and keep `pattern-directory/theme` patterns (TT4 includes two of those)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- With TT4 installed, open the pattern inserter
- Select Featured > Hero
- With the new pattern selected on canvas, click shuffle. It shouldn't show core patterns that are not theme or user patterns


