### PR TITLE
Add tooltip on typography variations

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -37,6 +37,7 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 					typographyVariations.length &&
 					typographyVariations.map( ( variation, index ) => (
 						<Tooltip key={ index } text={ variation?.title }>
+							{ /* This div is needed for Tooltips to work */ }
 							<div>
 								<Variation
 									variation={ variation }

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -5,6 +5,7 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalVStack as HStack,
 	__experimentalVStack as VStack,
+	Tooltip,
 } from '@wordpress/components';
 
 /**
@@ -35,35 +36,38 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 				{ typographyVariations &&
 					typographyVariations.length &&
 					typographyVariations.map( ( variation, index ) => (
-						<Variation
-							key={ index }
-							variation={ variation }
-							property="typography"
-						>
-							{ ( isFocused ) => (
-								<PreviewIframe
-									label={ variation?.title }
-									isFocused={ isFocused }
+						<Tooltip key={ index } text={ variation?.title }>
+							<div>
+								<Variation
+									variation={ variation }
+									property="typography"
 								>
-									{ ( { ratio, key } ) => (
-										<HStack
-											key={ key }
-											spacing={ 10 * ratio }
-											justify="center"
-											style={ {
-												height: '100%',
-												overflow: 'hidden',
-											} }
+									{ ( isFocused ) => (
+										<PreviewIframe
+											label={ variation?.title }
+											isFocused={ isFocused }
 										>
-											<TypographyExample
-												variation={ variation }
-												fontSize={ 85 * ratio }
-											/>
-										</HStack>
+											{ ( { ratio, key } ) => (
+												<HStack
+													key={ key }
+													spacing={ 10 * ratio }
+													justify="center"
+													style={ {
+														height: '100%',
+														overflow: 'hidden',
+													} }
+												>
+													<TypographyExample
+														variation={ variation }
+														fontSize={ 85 * ratio }
+													/>
+												</HStack>
+											) }
+										</PreviewIframe>
 									) }
-								</PreviewIframe>
-							) }
-						</Variation>
+								</Variation>
+							</div>
+						</Tooltip>
 					) ) }
 			</Grid>
 		</VStack>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracted from [this message](https://github.com/WordPress/gutenberg/pull/62201?notification_referrer_id=NT_kwDOBJ0Pj7QxMDkwNzE4OTk2ODo3NzQwMTk5OQ#issuecomment-2179252356) 

## Why?
To improve the user experience by displaying the title of each typography variations when hovering over them in the site editor's global styles just like it happens with the theme colors.

## How?
This PR adds tooltip to the typography variations in the site editor's global styles to display the title of each preset when hovered over.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to site editor > styles
2. Hover over a typography variation which is located at the end.

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/77401999/c61bde8c-be45-4078-89e5-262ce7d72195

