### PR TITLE
Editor: make VisualEditor a stacking context

### DIFF
--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -3,6 +3,8 @@
 	height: 100%;
 	display: block;
 	background-color: $gray-300;
+	// Make this a stacking context to contain the z-index of children elements.
+	isolation: isolate;
 
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;


### PR DESCRIPTION
## What?
A change to `VisualEditor` so it contains z-indexes of children within it (as a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context))

## Why?
To fix #62639, in which it’s noted that the block toolbar is not actually underneath the editor header and so the header’s shadow disappears behind it.

## How?
Add `isolation: isolate` to the component’s root element.

## Testing Instructions
1. Disable the Top Toolbar.
2. Click any block.
3. Scroll down the canvas.
4. When the block is visible in the canvas, the block toolbar will be docked below the header.
5. Scroll the canvas some more.
6. As the block becomes invisible, the block toolbar will overlap the header.
7. The header shadow should shade the block toolbar.
