### PR TITLE
Performance: block style variations: only calc styles for present inner blocks

### DIFF
--- a/packages/block-editor/src/hooks/block-style-variation.js
+++ b/packages/block-editor/src/hooks/block-style-variation.js
@@ -118,17 +118,42 @@ function useBlockProps( { name, className, clientId } ) {
 		clientId
 	);
 
+	const descendantBlockNames = useSelect(
+		( select ) => {
+			// Avoid a subscription if there is no variation.
+			if ( ! variation ) {
+				return;
+			}
+			const { getClientIdsOfDescendants, getBlockName } =
+				select( blockEditorStore );
+			// Could be moved to a private memoized selector, but this also
+			// makes sure the reference is stable.
+			return JSON.stringify( [
+				...new Set(
+					[ clientId, ...getClientIdsOfDescendants( clientId ) ].map(
+						( id ) => getBlockName( id )
+					)
+				),
+			] );
+		},
+		[ clientId, variation ]
+	);
+
 	const variationStyles = useMemo( () => {
 		if ( ! variation ) {
 			return;
 		}
 
 		const variationConfig = { settings, styles };
+		const names = JSON.parse( descendantBlockNames );
 		const blockSelectors = getBlockSelectors(
-			getBlockTypes(),
+			getBlockTypes().filter( ( blockType ) =>
+				names.includes( blockType.name )
+			),
 			getBlockStyles,
 			clientId
 		);
+
 		const hasBlockGapSupport = false;
 		const hasFallbackGapSupport = true;
 		const disableLayoutStyles = true;
@@ -151,7 +176,14 @@ function useBlockProps( { name, className, clientId } ) {
 				variationStyles: true,
 			}
 		);
-	}, [ variation, settings, styles, getBlockStyles, clientId ] );
+	}, [
+		variation,
+		settings,
+		styles,
+		getBlockStyles,
+		clientId,
+		descendantBlockNames,
+	] );
 
 	useStyleOverride( {
 		id: `variation-${ clientId }`,


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently we generate styles for _all_ block types when a block has a variation. This PR attempts to limit generating styles only for blocks types that are nested within the block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Performance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See things to test in https://github.com/WordPress/gutenberg/pull/57908, everything should work correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
