### PR TITLE
Performance: reduce block support hook calls further with isMatch

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -79,14 +79,7 @@ export function setBackgroundStyleDefaults( backgroundStyle ) {
 	return backgroundStylesWithDefaults;
 }
 
-function useBlockProps( { name, style } ) {
-	if (
-		! hasBackgroundSupport( name ) ||
-		! style?.background?.backgroundImage
-	) {
-		return;
-	}
-
+function useBlockProps( { style } ) {
 	const backgroundStyles = setBackgroundStyleDefaults( style?.background );
 
 	if ( ! backgroundStyles ) {
@@ -184,5 +177,6 @@ export function BackgroundImagePanel( {
 export default {
 	useBlockProps,
 	attributeKeys: [ 'style' ],
+	isMatch: ( { style } ) => !! style?.background?.backgroundImage,
 	hasSupport: hasBackgroundSupport,
 };

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -92,6 +92,7 @@ export const BlockBindingsPanel = ( { name, metadata } ) => {
 export default {
 	edit: BlockBindingsPanel,
 	attributeKeys: [ 'metadata' ],
+	isMatch: ( { metadata } ) => !! metadata?.bindings,
 	hasSupport() {
 		return true;
 	},

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -397,6 +397,7 @@ export default {
 	useBlockProps,
 	addSaveProps,
 	attributeKeys: [ 'borderColor', 'style' ],
+	isMatch: ( { style, borderColor } ) => !! ( style?.border || borderColor ),
 	hasSupport( name ) {
 		return hasBorderSupport( name, 'color' );
 	},

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -404,6 +404,14 @@ export default {
 	useBlockProps,
 	addSaveProps,
 	attributeKeys: [ 'backgroundColor', 'textColor', 'gradient', 'style' ],
+	isMatch: ( { style, backgroundColor, textColor, gradient } ) =>
+		!! (
+			backgroundColor ||
+			textColor ||
+			gradient ||
+			style?.color ||
+			style?.elements
+		),
 	hasSupport: hasColorSupport,
 };
 

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -157,6 +157,7 @@ export function hasDimensionsSupport( blockName, feature = 'any' ) {
 export default {
 	useBlockProps,
 	attributeKeys: [ 'minHeight', 'style' ],
+	isMatch: ( { style, minHeight } ) => !! ( minHeight || style?.dimensions ),
 	hasSupport( name ) {
 		return hasDimensionsSupport( name, 'aspectRatio' );
 	},

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -179,6 +179,7 @@ export default {
 	edit: DuotonePanelPure,
 	useBlockProps,
 	attributeKeys: [ 'style' ],
+	isMatch: ( { style } ) => !! style?.color?.duotone,
 	hasSupport( name ) {
 		return hasBlockSupport( name, 'filter.duotone' );
 	},

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -208,6 +208,8 @@ export default {
 	useBlockProps,
 	addSaveProps,
 	attributeKeys: [ 'fontSize', 'style' ],
+	isMatch: ( { style, fontSize } ) =>
+		!! ( style?.typography?.fontSize || fontSize ),
 	hasSupport( name ) {
 		return hasBlockSupport( name, FONT_SIZE_SUPPORT_KEY );
 	},

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -187,6 +187,7 @@ export default {
 	useBlockProps: useBlockPropsChildLayoutStyles,
 	edit: ChildLayoutControlsPure,
 	attributeKeys: [ 'style' ],
+	isMatch: ( { style } ) => !! style?.layout,
 	hasSupport() {
 		return true;
 	},

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -322,6 +322,7 @@ export default {
 	},
 	useBlockProps,
 	attributeKeys: [ 'style' ],
+	isMatch: ( { style } ) => !! style?.position,
 	hasSupport( name ) {
 		return hasBlockSupport( name, POSITION_SUPPORT_KEY );
 	},

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -361,6 +361,7 @@ export default {
 	hasSupport: hasStyleSupport,
 	addSaveProps,
 	attributeKeys: [ 'style' ],
+	isMatch: ( { style } ) => !! style?.elements,
 	useBlockProps,
 };
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -361,7 +361,6 @@ export default {
 	hasSupport: hasStyleSupport,
 	addSaveProps,
 	attributeKeys: [ 'style' ],
-	isMatch: ( { style } ) => !! style?.elements,
 	useBlockProps,
 };
 

--- a/packages/block-editor/src/hooks/text-align.js
+++ b/packages/block-editor/src/hooks/text-align.js
@@ -116,6 +116,7 @@ export default {
 	useBlockProps,
 	addSaveProps: addAssignedTextAlign,
 	attributeKeys: [ 'style' ],
+	isMatch: ( { style } ) => !! style?.typography?.textAlign,
 	hasSupport( name ) {
 		return hasBlockSupport( name, TEXT_ALIGN_SUPPORT_KEY, false );
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently we only filter block support hook calls when it doesn't match the top level attribute name. The problem is that these attributes have evolved to nested `style` properties, which causes these all of these hooks to match as soon as a block has a style attribute, even if the styles are not relevant.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Performance.

Site editor load patterns: -12.44%, -6.2%, 2.9%, -4.67%
Navigate: -2.47%, -3.39%, -10.28%, -10.87%

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

There's already an `isMatch` function so block support hooks can fine-tune which blocks should match.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
