### PR TITLE
Fixed page list block text-decoration issue in various theme #62687

### DIFF
--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -63,3 +63,9 @@
 .wp-block-page-list__loading-indicator-container {
 	padding: $grid-unit-10 $grid-unit-15;
 }
+
+/* Page List Block a tag CSS */
+
+:where(.mce-content-body[class*="post-type-"], .wp-block-post-content) a {
+	text-decoration: underline;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The "page list" block is not displaying text-decoration(Underline) on editor, front-end, or both sides. So, I have resolved the issue.

## Why?
front-end, or both sides
I think that it should be on both side(Editor & Front-end)
So, I have resolved this issue and added PR.

## How?
I have added all the necessary CSS into the block library styles.

## Testing Instructions
- Type / to choose a block
- Select "Page List" block
- We can see the "text-decoration"( Underline) on editor side.
- Change them and then follow same steps or just refresh the editor side.

### Testing Instructions for Keyboard
I have made this change on Gutenberg plugin file. After that I have added "block library styles" CSS manually into the inspect element for testing purpose and check this issue for all the themes. It looks good.

## Screenshots or screencast <!-- if applicable -->
**Twenty Ten Theme:**
-------------------------
![after-change-twenty-ten-page-list-editor](https://github.com/WordPress/gutenberg/assets/29949460/12e8b600-ea81-487f-9cba-f2ccea9421a4)

**Twenty Twelve Theme:**
----------------------------
![after-change-twenty-twelve-page-list-editor](https://github.com/WordPress/gutenberg/assets/29949460/60009307-2d6b-428b-ab08-e9d15359f662)

**Twenty Nineteen Theme:**
------------------------------
![after-change-twenty-nineteen-page-list-editor](https://github.com/WordPress/gutenberg/assets/29949460/bf1680e4-573e-46b9-950d-8bc5ba230c34)

**Twenty Twenty-one Theme:**
---------------------------------
![after-change-twenty-twenty-one-page-list-editor](https://github.com/WordPress/gutenberg/assets/29949460/e56b256f-d25d-4e6f-9eef-a7c314b90cf1)