### PR TITLE
Project Management Automation: Update action to run on node20

### DIFF
--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Internal
 
 -   Upgrade `@octokit/webhooks` dependency ([#62666](https://github.com/WordPress/gutenberg/pull/62666)).
+-   Update action to run on node20 ([#62695](https://github.com/WordPress/gutenberg/pull/62695)).
 
 ## 2.1.0 (2024-06-15)
 


### PR DESCRIPTION
## What?

Use node20, not the very old, deprecated node12.

## Why?

node12 is outdated, unsupported, and deprecated.

Other PRs will have warnings, [see an example.](https://github.com/WordPress/gutenberg/actions/runs/9596257051)

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20 …
> The following actions uses node12 which is deprecated and will be forced to run on node16 …

## How?

Update the action.

## Testing Instructions

[See it run on CI](https://github.com/WordPress/gutenberg/actions/runs/9596333361). I'm not sure why there's still a node12 warning, maybe that will go away after this is landed.
