### PR TITLE
Update: Followups to the template and template_lock rest api addition.

### DIFF
--- a/backport-changelog/6.6/6864.md
+++ b/backport-changelog/6.6/6864.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/6864
+
+* https://github.com/WordPress/gutenberg/pull/62488
+* https://github.com/WordPress/gutenberg/pull/62696

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -48,7 +48,7 @@ if ( ! function_exists( 'gutenberg_register_wp_rest_post_types_controller_fields
 				},
 				'schema'       => array(
 					'type'        => 'array',
-					'description' => __( 'The template associated with the post type.', 'gutenberg' ),
+					'description' => __( 'The block template associated with the post type, if it exists.', 'gutenberg' ),
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
@@ -67,7 +67,7 @@ if ( ! function_exists( 'gutenberg_register_wp_rest_post_types_controller_fields
 				'schema'       => array(
 					'type'        => 'string',
 					'enum'        => array( 'all', 'insert', 'contentOnly' ),
-					'description' => __( 'The template_lock specified for the post type.', 'gutenberg' ),
+					'description' => __( 'The template_lock associated with the post type, if any.', 'gutenberg' ),
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),


### PR DESCRIPTION
This PR does some follow-ups to https://github.com/WordPress/gutenberg/pull/62488.

Namely improvement of the description in the schema as suggested by @mcsf.
Adds the missing backport changelog referred to by @ellatrix.

## Testing
I added the following test code to a PHP file:

```
function myplugin_register_template() {
    $post_type_object = get_post_type_object( 'page' );
    $post_type_object->template = array(
        array( 'core/image' ),
    );
	$post_type_object->template_lock = 'all';
}
add_action( 'init', 'myplugin_register_template' );
```

I opened the site editor and pasted:
wp.data.select('core').getPostType( 'page' );

I verified that the template and tempalte_lock properties are still included in the response as expected.
