### PR TITLE
Zoom Out: Try click to disengage

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
 import { useMergeRefs, useDisabled } from '@wordpress/compose';
 import warning from '@wordpress/warning';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ import { useIntersectionObserver } from './use-intersection-observer';
 import { useScrollIntoView } from './use-scroll-into-view';
 import { useFlashEditableBlocks } from '../../use-flash-editable-blocks';
 import { canBindBlock } from '../../../hooks/use-bindings-attributes';
+import { store as blockEditorStore } from '../../../store';
 
 /**
  * This hook is used to lightly mark an element as a block element. The element
@@ -74,6 +76,7 @@ import { canBindBlock } from '../../../hooks/use-bindings-attributes';
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
+
 export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const {
 		clientId,
@@ -105,6 +108,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		templateLock,
 	} = useContext( PrivateBlockContext );
 
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 	// translators: %s: Type of block (i.e. Text, Image etc)
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
@@ -154,7 +158,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		hasNegativeMargin = true;
 	}
 
-	return {
+	let clickedBlock;
+	const blockProps = {
 		tabIndex: blockEditingMode === 'disabled' ? -1 : 0,
 		...wrapperProps,
 		...props,
@@ -194,6 +199,16 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		),
 		style: { ...wrapperProps.style, ...props.style, ...bindingsStyle },
 	};
+
+	if ( hasOverlay ) {
+		blockProps.onClick = () => {
+			if ( clickedBlock === clientId ) {
+				__unstableSetEditorMode( 'edit' );
+			}
+			clickedBlock = clientId;
+		};
+	}
+	return blockProps;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is just an experiment to see how it feels to use click to disengage zoom out.

The way it works is that it listens to clicks on a block. If you click the same block more than once in succession then zoom out mode is disengaged.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
