### PR TITLE
Posts list powered by DataViews

### DIFF
--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -24,6 +24,19 @@ function gutenberg_posts_dashboard() {
 }
 
 /**
+ * Redirects to the new posts dashboard page and adds the postType query arg.
+ * TODO: there should be a better way to do this..
+ */
+function gutenberg_add_post_type_arg() {
+    global $pagenow;
+    if ( $pagenow == 'admin.php' && isset( $_GET['page'] ) && $_GET['page'] == 'gutenberg-posts-dashboard' && empty( $_GET['postType'] ) ) {
+        wp_redirect( admin_url( '/admin.php?page=gutenberg-posts-dashboard&postType=post' ) );
+        exit;
+    }
+}
+add_action( 'admin_init', 'gutenberg_add_post_type_arg' );
+
+/**
  * Replaces the default posts menu item with the new posts dashboard.
  */
 function gutenberg_replace_posts_dashboard() {

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -7,6 +7,14 @@
 
 add_action( 'admin_menu', 'gutenberg_replace_posts_dashboard' );
 
+// Default to is-fullscreen-mode to avoid jumps in the UI.
+add_filter(
+	'admin_body_class',
+	static function ( $classes ) {
+		return "$classes is-fullscreen-mode";
+	}
+);
+
 /**
  * Renders the new posts dashboard page.
  */
@@ -15,13 +23,13 @@ function gutenberg_posts_dashboard() {
 	// $current_screen = get_current_screen();
 	// $current_screen->is_block_editor( true );
 
-	// Default to is-fullscreen-mode to avoid jumps in the UI.
-	// add_filter(
-	// 	'admin_body_class',
-	// 	static function ( $classes ) {
-	// 		return "$classes is-fullscreen-mode";
-	// 	}
-	// );
+
+
+	// $indexed_template_types = array();
+	// foreach ( get_default_block_template_types() as $slug => $template_type ) {
+	// 	$template_type['slug']    = (string) $slug;
+	// 	$indexed_template_types[] = $template_type;
+	// }
 
 	$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 	$custom_settings      = array(

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -77,7 +77,6 @@ function gutenberg_posts_dashboard() {
 		)
 	);
 	wp_enqueue_script( 'wp-edit-site' );
-	// wp_enqueue_style( 'wp-edit-site' );
 
 	wp_enqueue_media();
 

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -11,14 +11,67 @@ add_action( 'admin_menu', 'gutenberg_replace_posts_dashboard' );
  * Renders the new posts dashboard page.
  */
 function gutenberg_posts_dashboard() {
+	// Flag that we're loading the block editor.
+	// $current_screen = get_current_screen();
+	// $current_screen->is_block_editor( true );
+
+	// Default to is-fullscreen-mode to avoid jumps in the UI.
+	// add_filter(
+	// 	'admin_body_class',
+	// 	static function ( $classes ) {
+	// 		return "$classes is-fullscreen-mode";
+	// 	}
+	// );
+
+	$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
+	$custom_settings      = array(
+		'siteUrl'                   => site_url(),
+		// 'postsPerPage'              => get_option( 'posts_per_page' ),
+		'styles'                    => get_block_editor_theme_styles(),
+		// 'defaultTemplateTypes'      => $indexed_template_types,
+		// 'defaultTemplatePartAreas'  => get_allowed_block_template_part_areas(),
+		'supportsLayout'            => wp_theme_has_theme_json(),
+		// 'supportsTemplatePartsMode' => ! wp_is_block_theme() && current_theme_supports( 'block-template-parts' ),
+	);
+	$editor_settings = get_block_editor_settings( $custom_settings, $block_editor_context );
+
+	$active_global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+	$active_theme            = get_stylesheet();
+
+	// Preload server-registered block schemas.
+	wp_add_inline_script(
+		'wp-blocks',
+		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+	);
+
+	wp_add_inline_script(
+		'wp-blocks',
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( isset( $editor_settings['blockCategories'] ) ? $editor_settings['blockCategories'] : array() ) ),
+		'after'
+	);
+
+	/** This action is documented in wp-admin/edit-form-blocks.php */
+	do_action( 'enqueue_block_editor_assets' );
 	wp_register_style(
 		'wp-gutenberg-posts-dashboard',
 		gutenberg_url( 'build/edit-site/posts.css', __FILE__ ),
-		array( 'wp-components', 'wp-commands' )
+		array( 'wp-components', 'wp-commands', 'wp-edit-site' )
 	);
 	wp_enqueue_style( 'wp-gutenberg-posts-dashboard' );
-	wp_add_inline_script( 'wp-edit-site', 'window.wp.editSite.initializePostsDashboard( "gutenberg-posts-dashboard" );', 'after' );
+	// wp_add_inline_script( 'wp-edit-site', 'window.wp.editSite.initializePostsDashboard( "gutenberg-posts-dashboard" );', 'after' );
+	wp_add_inline_script(
+		'wp-edit-site',
+		sprintf(
+			'wp.domReady( function() {
+				wp.editSite.initializePostsDashboard( "gutenberg-posts-dashboard", %s );
+			} );',
+			wp_json_encode( $editor_settings )
+		)
+	);
 	wp_enqueue_script( 'wp-edit-site' );
+	// wp_enqueue_style( 'wp-edit-site' );
+
+	wp_enqueue_media();
 
 	echo '<div id="gutenberg-posts-dashboard"></div>';
 }
@@ -29,7 +82,7 @@ function gutenberg_posts_dashboard() {
  */
 function gutenberg_add_post_type_arg() {
     global $pagenow;
-    if ( $pagenow == 'admin.php' && isset( $_GET['page'] ) && $_GET['page'] == 'gutenberg-posts-dashboard' && empty( $_GET['postType'] ) ) {
+    if ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'gutenberg-posts-dashboard' === $_GET['page'] && empty( $_GET['postType'] ) ) {
         wp_redirect( admin_url( '/admin.php?page=gutenberg-posts-dashboard&postType=post' ) );
         exit;
     }

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -25,6 +25,7 @@ function gutenberg_posts_dashboard() {
 		'styles'         => get_block_editor_theme_styles(),
 		'supportsLayout' => wp_theme_has_theme_json(),
 	);
+
 	$editor_settings         = get_block_editor_settings( $custom_settings, $block_editor_context );
 	$active_global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 	$active_theme            = get_stylesheet();
@@ -70,11 +71,11 @@ function gutenberg_posts_dashboard() {
  * Redirects to the new posts dashboard page and adds the postType query arg.
  */
 function gutenberg_add_post_type_arg() {
-    global $pagenow;
-    if ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'gutenberg-posts-dashboard' === $_GET['page'] && empty( $_GET['postType'] ) ) {
-        wp_redirect( admin_url( '/admin.php?page=gutenberg-posts-dashboard&postType=post' ) );
-        exit;
-    }
+	global $pagenow;
+	if ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'gutenberg-posts-dashboard' === $_GET['page'] && empty( $_GET['postType'] ) ) {
+		wp_redirect( admin_url( '/admin.php?page=gutenberg-posts-dashboard&postType=post' ) );
+		exit;
+	}
 }
 add_action( 'admin_init', 'gutenberg_add_post_type_arg' );
 

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -19,43 +19,29 @@ add_filter(
  * Renders the new posts dashboard page.
  */
 function gutenberg_posts_dashboard() {
-	// Flag that we're loading the block editor.
-	// $current_screen = get_current_screen();
-	// $current_screen->is_block_editor( true );
-
-
-
-	// $indexed_template_types = array();
-	// foreach ( get_default_block_template_types() as $slug => $template_type ) {
-	// 	$template_type['slug']    = (string) $slug;
-	// 	$indexed_template_types[] = $template_type;
-	// }
-
 	$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 	$custom_settings      = array(
-		'siteUrl'                   => site_url(),
-		// 'postsPerPage'              => get_option( 'posts_per_page' ),
-		'styles'                    => get_block_editor_theme_styles(),
-		// 'defaultTemplateTypes'      => $indexed_template_types,
-		// 'defaultTemplatePartAreas'  => get_allowed_block_template_part_areas(),
-		'supportsLayout'            => wp_theme_has_theme_json(),
-		// 'supportsTemplatePartsMode' => ! wp_is_block_theme() && current_theme_supports( 'block-template-parts' ),
+		'siteUrl'        => site_url(),
+		'styles'         => get_block_editor_theme_styles(),
+		'supportsLayout' => wp_theme_has_theme_json(),
 	);
-	$editor_settings = get_block_editor_settings( $custom_settings, $block_editor_context );
-
+	$editor_settings         = get_block_editor_settings( $custom_settings, $block_editor_context );
 	$active_global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 	$active_theme            = get_stylesheet();
+
+	$preload_paths = array(
+		array( '/wp/v2/media', 'OPTIONS' ),
+		'/wp/v2/types?context=view',
+		'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
+		'/wp/v2/global-styles/' . $active_global_styles_id,
+		'/wp/v2/global-styles/themes/' . $active_theme,
+	);
+	block_editor_rest_api_preload( $preload_paths, $block_editor_context );
 
 	// Preload server-registered block schemas.
 	wp_add_inline_script(
 		'wp-blocks',
 		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
-	);
-
-	wp_add_inline_script(
-		'wp-blocks',
-		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( isset( $editor_settings['blockCategories'] ) ? $editor_settings['blockCategories'] : array() ) ),
-		'after'
 	);
 
 	/** This action is documented in wp-admin/edit-form-blocks.php */
@@ -66,7 +52,6 @@ function gutenberg_posts_dashboard() {
 		array( 'wp-components', 'wp-commands', 'wp-edit-site' )
 	);
 	wp_enqueue_style( 'wp-gutenberg-posts-dashboard' );
-	// wp_add_inline_script( 'wp-edit-site', 'window.wp.editSite.initializePostsDashboard( "gutenberg-posts-dashboard" );', 'after' );
 	wp_add_inline_script(
 		'wp-edit-site',
 		sprintf(
@@ -77,15 +62,12 @@ function gutenberg_posts_dashboard() {
 		)
 	);
 	wp_enqueue_script( 'wp-edit-site' );
-
 	wp_enqueue_media();
-
 	echo '<div id="gutenberg-posts-dashboard"></div>';
 }
 
 /**
  * Redirects to the new posts dashboard page and adds the postType query arg.
- * TODO: there should be a better way to do this..
  */
 function gutenberg_add_post_type_arg() {
     global $pagenow;

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -18,7 +18,10 @@ import Filters from './filters';
 import Search from './search';
 import { LAYOUT_TABLE, LAYOUT_GRID } from './constants';
 import { VIEW_LAYOUTS } from './layouts';
-import BulkActions from './bulk-actions';
+import {
+	default as BulkActions,
+	useSomeItemHasAPossibleBulkAction,
+} from './bulk-actions';
 import { normalizeFields } from './normalize-fields';
 import BulkActionsToolbar from './bulk-actions-toolbar';
 import type { Action, Field, View, ViewBaseProps } from './types';
@@ -50,22 +53,6 @@ type DataViewsProps< Item > = {
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
 
 const defaultOnSelectionChange = () => {};
-
-function useSomeItemHasAPossibleBulkAction< Item >(
-	actions: Action< Item >[],
-	data: Item[]
-) {
-	return useMemo( () => {
-		return data.some( ( item ) => {
-			return actions.some( ( action ) => {
-				return (
-					action.supportsBulk &&
-					( ! action.isEligible || action.isEligible( item ) )
-				);
-			} );
-		} );
-	}, [ actions, data ] );
-}
 
 export default function DataViews< Item >( {
 	view,

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -263,7 +263,6 @@
 	color: $gray-700;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	display: block;
 	width: 100%;
 
 	a {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -332,11 +332,6 @@
 			.dataviews-view-grid__fields .dataviews-view-grid__field .dataviews-view-grid__field-value {
 				color: $gray-900;
 			}
-
-			.page-pages-preview-field__button::after {
-				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-			}
 		}
 	}
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -196,7 +196,7 @@
 			text-transform: uppercase;
 			font-weight: 500;
 
-			&:has(.dataviews-view-table-header-button) {
+			&:has(.dataviews-view-table-header-button):not(:first-child) {
 				padding-left: $grid-unit-05;
 			}
 		}

--- a/packages/edit-site/src/components/add-new-post/index.js
+++ b/packages/edit-site/src/components/add-new-post/index.js
@@ -16,7 +16,10 @@ import { store as noticesStore } from '@wordpress/notices';
 import { decodeEntities } from '@wordpress/html-entities';
 import { serialize, synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 
-export default function AddNewPageModal( { onSave, onClose } ) {
+// TODO: check how/if to reuse this and make it work for other post types.
+// Currently this creates drafts, so we should look into that..
+// Also lot's of labels need to be updated properly..
+export default function AddNewPostModal( { postType, onSave, onClose } ) {
 	const [ isCreatingPage, setIsCreatingPage ] = useState( false );
 	const [ title, setTitle ] = useState( '' );
 
@@ -33,11 +36,12 @@ export default function AddNewPageModal( { onSave, onClose } ) {
 		}
 		setIsCreatingPage( true );
 		try {
+			// TODO: also check this change.. It was merged(https://github.com/WordPress/gutenberg/pull/62488/) as I was coding this..
 			const pagePostType =
-				await resolveSelect( coreStore ).getPostType( 'page' );
+				await resolveSelect( coreStore ).getPostType( postType );
 			const newPage = await saveEntityRecord(
 				'postType',
-				'page',
+				postType,
 				{
 					status: 'draft',
 					title,
@@ -71,7 +75,7 @@ export default function AddNewPageModal( { onSave, onClose } ) {
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
-					: __( 'An error occurred while creating the page.' );
+					: __( 'An error occurred while creating the item.' );
 
 			createErrorNotice( errorMessage, {
 				type: 'snackbar',

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -136,7 +136,10 @@ export function useSpecificEditorSettings() {
 				templateSlug: _record.slug,
 				canvasMode: getCanvasMode(),
 				settings: getSettings(),
-				postWithTemplate: _context?.postId,
+				postWithTemplate:
+					// TODO: The `postType` check should be removed when the default rendering mode per post type is merged.
+					// @see https://github.com/WordPress/gutenberg/pull/62304/
+					_context?.postId && _context?.postType !== 'post',
 			};
 		},
 		[]

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -114,38 +114,40 @@ function useNavigateToPreviousEntityRecord() {
 
 export function useSpecificEditorSettings() {
 	const onNavigateToEntityRecord = useNavigateToEntityRecord();
-	const { templateSlug, canvasMode, settings, postWithTemplate } = useSelect(
-		( select ) => {
-			const {
-				getEditedPostType,
-				getEditedPostId,
-				getEditedPostContext,
-				getCanvasMode,
-				getSettings,
-			} = unlock( select( editSiteStore ) );
-			const { getEditedEntityRecord } = select( coreStore );
-			const usedPostType = getEditedPostType();
-			const usedPostId = getEditedPostId();
-			const _record = getEditedEntityRecord(
-				'postType',
-				usedPostType,
-				usedPostId
-			);
-			const _context = getEditedPostContext();
-			return {
-				templateSlug: _record.slug,
-				canvasMode: getCanvasMode(),
-				settings: getSettings(),
-				postWithTemplate:
-					// TODO: The `postType` check should be removed when the default rendering mode per post type is merged.
-					// @see https://github.com/WordPress/gutenberg/pull/62304/
-					_context?.postId && _context?.postType !== 'post',
-			};
-		},
-		[]
-	);
+	const {
+		templateSlug,
+		canvasMode,
+		settings,
+		shouldUseTemplateAsDefaultRenderingMode,
+	} = useSelect( ( select ) => {
+		const {
+			getEditedPostType,
+			getEditedPostId,
+			getEditedPostContext,
+			getCanvasMode,
+			getSettings,
+		} = unlock( select( editSiteStore ) );
+		const { getEditedEntityRecord } = select( coreStore );
+		const usedPostType = getEditedPostType();
+		const usedPostId = getEditedPostId();
+		const _record = getEditedEntityRecord(
+			'postType',
+			usedPostType,
+			usedPostId
+		);
+		const _context = getEditedPostContext();
+		return {
+			templateSlug: _record.slug,
+			canvasMode: getCanvasMode(),
+			settings: getSettings(),
+			// TODO: The `postType` check should be removed when the default rendering mode per post type is merged.
+			// @see https://github.com/WordPress/gutenberg/pull/62304/
+			shouldUseTemplateAsDefaultRenderingMode:
+				_context?.postId && _context?.postType !== 'post',
+		};
+	}, [] );
 	const archiveLabels = useArchiveLabel( templateSlug );
-	const defaultRenderingMode = postWithTemplate
+	const defaultRenderingMode = shouldUseTemplateAsDefaultRenderingMode
 		? 'template-locked'
 		: 'post-only';
 	const onNavigateToPreviousEntityRecord =

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -44,12 +44,14 @@ import SiteEditorMoreMenu from '../more-menu';
 import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
 import useEditorTitle from './use-editor-title';
+import { useIsSiteEditorLoading } from '../layout/hooks';
 
 const { Editor, BackButton } = unlock( editorPrivateApis );
 const { useHistory } = unlock( routerPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
 
-export default function EditSiteEditor( { isLoading } ) {
+export default function EditSiteEditor() {
+	const isLoading = useIsSiteEditorLoading();
 	const {
 		editedPostType,
 		editedPostId,

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -221,7 +221,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 										onClick={ () => {
 											setCanvasMode( 'view' );
 											// TODO: this is a temporary solution to navigate to the posts list if we are
-											// come here throught `posts list` and are in focus mode editing a template or template part.
+											// come here through `posts list` and are in focus mode editing a template, template part etc..
 											if (
 												isPostsList &&
 												params?.focusMode

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -47,10 +47,11 @@ import useEditorTitle from './use-editor-title';
 import { useIsSiteEditorLoading } from '../layout/hooks';
 
 const { Editor, BackButton } = unlock( editorPrivateApis );
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
 
-export default function EditSiteEditor() {
+export default function EditSiteEditor( { isPostsList = false } ) {
+	const { params } = useLocation();
 	const isLoading = useIsSiteEditorLoading();
 	const {
 		editedPostType,
@@ -217,9 +218,20 @@ export default function EditSiteEditor() {
 									<Button
 										label={ __( 'Open Navigation' ) }
 										className="edit-site-layout__view-mode-toggle"
-										onClick={ () =>
-											setCanvasMode( 'view' )
-										}
+										onClick={ () => {
+											setCanvasMode( 'view' );
+											// TODO: this is a temporary solution to navigate to the posts list if we are
+											// come here throught `posts list` and are in focus mode editing a template or template part.
+											if (
+												isPostsList &&
+												params?.focusMode
+											) {
+												history.push( {
+													page: 'gutenberg-posts-dashboard',
+													postType: 'post',
+												} );
+											}
+										} }
 									>
 										<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
 									</Button>

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -10,7 +10,7 @@ import { useEffect } from '@wordpress/element';
 import { unlock } from '../../lock-unlock';
 import { useIsSiteEditorLoading } from './hooks';
 import Editor from '../editor';
-import PagePages from '../page-pages';
+import PostsList from '../posts-app/posts-list';
 import PagePatterns from '../page-patterns';
 import PageTemplates from '../page-templates';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
@@ -92,7 +92,7 @@ export default function useLayoutAreas() {
 						content={ <DataViewsSidebarContent /> }
 					/>
 				),
-				content: <PagePages />,
+				content: <PostsList postType={ postType } />,
 				preview: ( isListLayout || canvas === 'edit' ) && (
 					<Editor isLoading={ isSiteEditorLoading } />
 				),
@@ -100,7 +100,7 @@ export default function useLayoutAreas() {
 					canvas === 'edit' ? (
 						<Editor isLoading={ isSiteEditorLoading } />
 					) : (
-						<PagePages />
+						<PostsList postType={ postType } />
 					),
 			},
 			widths: {

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -8,7 +8,6 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { useIsSiteEditorLoading } from './hooks';
 import Editor from '../editor';
 import PostsList from '../posts-app/posts-list';
 import PagePatterns from '../page-patterns';
@@ -74,7 +73,6 @@ function useRedirectOldPaths() {
 }
 
 export default function useLayoutAreas() {
-	const isSiteEditorLoading = useIsSiteEditorLoading();
 	const { params } = useLocation();
 	const { postType, postId, path, layout, isCustom, canvas } = params;
 	useRedirectOldPaths();
@@ -93,12 +91,10 @@ export default function useLayoutAreas() {
 					/>
 				),
 				content: <PostsList postType={ postType } />,
-				preview: ( isListLayout || canvas === 'edit' ) && (
-					<Editor isLoading={ isSiteEditorLoading } />
-				),
+				preview: ( isListLayout || canvas === 'edit' ) && <Editor />,
 				mobile:
 					canvas === 'edit' ? (
-						<Editor isLoading={ isSiteEditorLoading } />
+						<Editor />
 					) : (
 						<PostsList postType={ postType } />
 					),
@@ -119,9 +115,7 @@ export default function useLayoutAreas() {
 					<SidebarNavigationScreenTemplatesBrowse backPath={ {} } />
 				),
 				content: <PageTemplates />,
-				preview: ( isListLayout || canvas === 'edit' ) && (
-					<Editor isLoading={ isSiteEditorLoading } />
-				),
+				preview: ( isListLayout || canvas === 'edit' ) && <Editor />,
 				mobile: <PageTemplates />,
 			},
 			widths: {
@@ -140,9 +134,7 @@ export default function useLayoutAreas() {
 				sidebar: <SidebarNavigationScreenPatterns backPath={ {} } />,
 				content: <PagePatterns />,
 				mobile: <PagePatterns />,
-				preview: canvas === 'edit' && (
-					<Editor isLoading={ isSiteEditorLoading } />
-				),
+				preview: canvas === 'edit' && <Editor />,
 			},
 		};
 	}
@@ -155,10 +147,8 @@ export default function useLayoutAreas() {
 				sidebar: (
 					<SidebarNavigationScreenGlobalStyles backPath={ {} } />
 				),
-				preview: <Editor isLoading={ isSiteEditorLoading } />,
-				mobile: canvas === 'edit' && (
-					<Editor isLoading={ isSiteEditorLoading } />
-				),
+				preview: <Editor />,
+				mobile: canvas === 'edit' && <Editor />,
 			},
 		};
 	}
@@ -174,10 +164,8 @@ export default function useLayoutAreas() {
 							backPath={ { postType: NAVIGATION_POST_TYPE } }
 						/>
 					),
-					preview: <Editor isLoading={ isSiteEditorLoading } />,
-					mobile: canvas === 'edit' && (
-						<Editor isLoading={ isSiteEditorLoading } />
-					),
+					preview: <Editor />,
+					mobile: canvas === 'edit' && <Editor />,
 				},
 			};
 		}
@@ -187,10 +175,8 @@ export default function useLayoutAreas() {
 				sidebar: (
 					<SidebarNavigationScreenNavigationMenus backPath={ {} } />
 				),
-				preview: <Editor isLoading={ isSiteEditorLoading } />,
-				mobile: canvas === 'edit' && (
-					<Editor isLoading={ isSiteEditorLoading } />
-				),
+				preview: <Editor />,
+				mobile: canvas === 'edit' && <Editor />,
 			},
 		};
 	}
@@ -200,10 +186,8 @@ export default function useLayoutAreas() {
 		key: 'default',
 		areas: {
 			sidebar: <SidebarNavigationScreenMain />,
-			preview: <Editor isLoading={ isSiteEditorLoading } />,
-			mobile: canvas === 'edit' && (
-				<Editor isLoading={ isSiteEditorLoading } />
-			),
+			preview: <Editor />,
+			mobile: canvas === 'edit' && <Editor />,
 		},
 	};
 }

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -1,3 +1,6 @@
+// TODO: we need to examine if these styles could be the default styles
+// for every post type and/or how to have different styles for different post types.
+// Example is `posts` and `pages`.
 .edit-site-page-pages__featured-image {
 	height: 100%;
 	object-fit: cover;

--- a/packages/edit-site/src/components/posts-app/index.js
+++ b/packages/edit-site/src/components/posts-app/index.js
@@ -10,29 +10,27 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
+import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
 import Layout from '../layout';
-import Page from '../page';
+import useLayoutAreas from './router';
 import { unlock } from '../../lock-unlock';
 
 const { RouterProvider } = unlock( routerPrivateApis );
 const { GlobalStylesProvider } = unlock( editorPrivateApis );
 
-const defaultRoute = {
-	key: 'index',
-	areas: {
-		sidebar: 'Empty Sidebar',
-		content: <Page>Welcome to Posts</Page>,
-		preview: undefined,
-		mobile: <Page>Welcome to Posts</Page>,
-	},
-};
+function PostsLayout() {
+	// This ensures the edited entity id and type are initialized properly.
+	useInitEditedEntityFromURL();
+	const route = useLayoutAreas();
+	return <Layout route={ route } />;
+}
 
 export default function PostsApp() {
 	return (
 		<GlobalStylesProvider>
 			<UnsavedChangesWarning />
 			<RouterProvider>
-				<Layout route={ defaultRoute } />
+				<PostsLayout />
 			</RouterProvider>
 		</GlobalStylesProvider>
 	);

--- a/packages/edit-site/src/components/posts-app/posts-list.js
+++ b/packages/edit-site/src/components/posts-app/posts-list.js
@@ -177,7 +177,7 @@ function FeaturedImage( { item, viewType } ) {
 			: [ 'thumbnail', 'medium', 'large', 'full' ];
 	const media = hasMedia ? (
 		<Media
-			className="edit-site-page-pages__featured-image"
+			className="posts-list-page__featured-image"
 			id={ item.featured_media }
 			size={ size }
 		/>
@@ -185,11 +185,11 @@ function FeaturedImage( { item, viewType } ) {
 	const renderButton = viewType !== LAYOUT_LIST && ! isDisabled;
 	return (
 		<div
-			className={ `edit-site-page-pages__featured-image-wrapper is-layout-${ viewType }` }
+			className={ `posts-list-page__featured-image-wrapper is-layout-${ viewType }` }
 		>
 			{ renderButton ? (
 				<button
-					className="page-pages-preview-field__button"
+					className="posts-list-page-preview-field__button"
 					type="button"
 					onClick={ onClick }
 					aria-label={ item.title?.rendered || __( '(no title)' ) }
@@ -360,13 +360,13 @@ export default function PostsList( { postType } ) {
 					let suffix = '';
 					if ( item.id === frontPageId ) {
 						suffix = (
-							<span className="edit-site-page-pages__title-badge">
+							<span className="posts-list-page-title-badge">
 								{ __( 'Front Page' ) }
 							</span>
 						);
 					} else if ( item.id === postsPageId ) {
 						suffix = (
-							<span className="edit-site-page-pages__title-badge">
+							<span className="posts-list-page-title-badge">
 								{ __( 'Posts Page' ) }
 							</span>
 						);
@@ -374,7 +374,7 @@ export default function PostsList( { postType } ) {
 
 					return (
 						<HStack
-							className="edit-site-page-pages-title"
+							className="posts-list-page-title"
 							alignment="center"
 							justify="flex-start"
 						>

--- a/packages/edit-site/src/components/posts-app/posts-list.js
+++ b/packages/edit-site/src/components/posts-app/posts-list.js
@@ -304,14 +304,14 @@ export default function PostsList( { postType } ) {
 			const { getEntityRecord, getPostType, canUser } =
 				select( coreStore );
 			const siteSettings = getEntityRecord( 'root', 'site' );
+			const postTypeObject = getPostType( postType );
 			return {
 				frontPageId: siteSettings?.page_on_front,
 				postsPageId: siteSettings?.page_for_posts,
 				labels: getPostType( postType )?.labels,
-				// TODO: check what is the proper way to make this work for any post type..
 				canCreateRecord: canUser(
 					'create',
-					postType === 'page' ? 'pages' : 'posts'
+					postTypeObject?.rest_base || 'posts'
 				),
 			};
 		},

--- a/packages/edit-site/src/components/posts-app/router.js
+++ b/packages/edit-site/src/components/posts-app/router.js
@@ -1,0 +1,82 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { useIsSiteEditorLoading } from '../layout/hooks';
+import Editor from '../editor';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+import PostsList from '../posts-app/posts-list';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+export default function useLayoutAreas() {
+	const isSiteEditorLoading = useIsSiteEditorLoading();
+	const { params = {} } = useLocation();
+	const { postType, layout, canvas } = params;
+	const labels = useSelect(
+		( select ) => {
+			return select( coreStore ).getPostType( postType )?.labels;
+		},
+		[ postType ]
+	);
+
+	// Posts list.
+	if ( [ 'page', 'post' ].includes( postType ) ) {
+		const isListLayout = layout === 'list' || ! layout;
+		return {
+			key: 'pages',
+			areas: {
+				sidebar: (
+					<SidebarNavigationScreen
+						title={ labels?.name }
+						backPath={ {} }
+						content={ <DataViewsSidebarContent /> }
+					/>
+				),
+				content: <PostsList postType={ postType } />,
+				preview: ( isListLayout || canvas === 'edit' ) && (
+					<Editor isLoading={ isSiteEditorLoading } />
+				),
+				mobile:
+					canvas === 'edit' ? (
+						<Editor isLoading={ isSiteEditorLoading } />
+					) : (
+						<PostsList postType={ postType } />
+					),
+			},
+			widths: {
+				content: isListLayout ? 380 : undefined,
+			},
+		};
+	}
+
+	// const defaultRoute = {
+	// 	key: 'index',
+	// 	areas: {
+	// 		sidebar: 'Empty Sidebar',
+	// 		content: <PostsList />,
+	// 		preview: undefined,
+	// 		mobile: <Page>Welcome to Posts</Page>,
+	// 	},
+	// };
+	// Fallback shows the home page preview
+	return {
+		key: 'default',
+		areas: {
+			sidebar: <SidebarNavigationScreenMain />,
+			preview: <Editor isLoading={ isSiteEditorLoading } />,
+			mobile: canvas === 'edit' && (
+				<Editor isLoading={ isSiteEditorLoading } />
+			),
+		},
+	};
+}

--- a/packages/edit-site/src/components/posts-app/router.js
+++ b/packages/edit-site/src/components/posts-app/router.js
@@ -9,7 +9,6 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { useIsSiteEditorLoading } from '../layout/hooks';
 import Editor from '../editor';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
@@ -19,7 +18,6 @@ import PostsList from '../posts-app/posts-list';
 const { useLocation } = unlock( routerPrivateApis );
 
 export default function useLayoutAreas() {
-	const isSiteEditorLoading = useIsSiteEditorLoading();
 	const { params = {} } = useLocation();
 	const { postType, layout, canvas } = params;
 	const labels = useSelect(
@@ -30,25 +28,23 @@ export default function useLayoutAreas() {
 	);
 
 	// Posts list.
-	if ( [ 'page', 'post' ].includes( postType ) ) {
+	if ( [ 'post' ].includes( postType ) ) {
 		const isListLayout = layout === 'list' || ! layout;
 		return {
-			key: 'pages',
+			key: 'posts-list',
 			areas: {
 				sidebar: (
 					<SidebarNavigationScreen
 						title={ labels?.name }
-						backPath={ {} }
+						// backPath={ {} }
 						content={ <DataViewsSidebarContent /> }
 					/>
 				),
 				content: <PostsList postType={ postType } />,
-				preview: ( isListLayout || canvas === 'edit' ) && (
-					<Editor isLoading={ isSiteEditorLoading } />
-				),
+				preview: ( isListLayout || canvas === 'edit' ) && <Editor />,
 				mobile:
 					canvas === 'edit' ? (
-						<Editor isLoading={ isSiteEditorLoading } />
+						<Editor />
 					) : (
 						<PostsList postType={ postType } />
 					),
@@ -59,24 +55,13 @@ export default function useLayoutAreas() {
 		};
 	}
 
-	// const defaultRoute = {
-	// 	key: 'index',
-	// 	areas: {
-	// 		sidebar: 'Empty Sidebar',
-	// 		content: <PostsList />,
-	// 		preview: undefined,
-	// 		mobile: <Page>Welcome to Posts</Page>,
-	// 	},
-	// };
 	// Fallback shows the home page preview
 	return {
 		key: 'default',
 		areas: {
 			sidebar: <SidebarNavigationScreenMain />,
-			preview: <Editor isLoading={ isSiteEditorLoading } />,
-			mobile: canvas === 'edit' && (
-				<Editor isLoading={ isSiteEditorLoading } />
-			),
+			preview: <Editor />,
+			mobile: canvas === 'edit' && <Editor />,
 		},
 	};
 }

--- a/packages/edit-site/src/components/posts-app/router.js
+++ b/packages/edit-site/src/components/posts-app/router.js
@@ -41,10 +41,12 @@ export default function useLayoutAreas() {
 					/>
 				),
 				content: <PostsList postType={ postType } />,
-				preview: ( isListLayout || canvas === 'edit' ) && <Editor />,
+				preview: ( isListLayout || canvas === 'edit' ) && (
+					<Editor isPostsList />
+				),
 				mobile:
 					canvas === 'edit' ? (
-						<Editor />
+						<Editor isPostsList />
 					) : (
 						<PostsList postType={ postType } />
 					),
@@ -60,8 +62,8 @@ export default function useLayoutAreas() {
 		key: 'default',
 		areas: {
 			sidebar: <SidebarNavigationScreenMain />,
-			preview: <Editor />,
-			mobile: canvas === 'edit' && <Editor />,
+			preview: <Editor isPostsList />,
+			mobile: canvas === 'edit' && <Editor isPostsList />,
 		},
 	};
 }

--- a/packages/edit-site/src/components/posts-app/router.js
+++ b/packages/edit-site/src/components/posts-app/router.js
@@ -36,7 +36,7 @@ export default function useLayoutAreas() {
 				sidebar: (
 					<SidebarNavigationScreen
 						title={ labels?.name }
-						// backPath={ {} }
+						isRoot
 						content={ <DataViewsSidebarContent /> }
 					/>
 				),

--- a/packages/edit-site/src/components/posts-app/style.scss
+++ b/packages/edit-site/src/components/posts-app/style.scss
@@ -1,19 +1,16 @@
-// TODO: we need to examine if these styles could be the default styles
-// for every post type and/or how to have different styles for different post types.
-// Example is `posts` and `pages`.
-.edit-site-page-pages__featured-image {
+.posts-list-page__featured-image {
 	height: 100%;
 	object-fit: cover;
 	width: 100%;
 }
 
-.edit-site-page-pages__featured-image-wrapper {
+.posts-list-page__featured-image-wrapper {
 	height: 100%;
 	width: 100%;
 	border-radius: $grid-unit-05;
 
-	&.is-layout-table:not(:has(.page-pages-preview-field__button)),
-	&.is-layout-table .page-pages-preview-field__button {
+	&.is-layout-table:not(:has(.posts-list-page-preview-field__button)),
+	&.is-layout-table .posts-list-page-preview-field__button {
 		width: $grid-unit-40;
 		height: $grid-unit-40;
 		display: block;
@@ -36,7 +33,7 @@
 	}
 }
 
-.page-pages-preview-field__button {
+.posts-list-page-preview-field__button {
 	box-shadow: none;
 	border: none;
 	padding: 0;
@@ -55,12 +52,19 @@
 	}
 }
 
-.edit-site-page-pages-title span {
+.dataviews-view-grid__card.is-selected {
+	.posts-list-page-preview-field__button::after {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+	}
+}
+
+.posts-list-page-title span {
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
 
-.edit-site-page-pages__title-badge {
+.posts-list-page-title-badge {
 	background: $gray-100;
 	color: $gray-700;
 	padding: 0 $grid-unit-05;

--- a/packages/edit-site/src/components/sidebar-dataviews/add-new-view.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/add-new-view.js
@@ -19,7 +19,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  * Internal dependencies
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
-import { DEFAULT_VIEWS } from './default-views';
+import { useDefaultViews } from './default-views';
 import { unlock } from '../../lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
@@ -29,6 +29,7 @@ function AddNewItemModalContent( { type, setIsAdding } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const [ title, setTitle ] = useState( '' );
 	const [ isSaving, setIsSaving ] = useState( false );
+	const DEFAULT_VIEWS = useDefaultViews( { postType: type } );
 	return (
 		<form
 			onSubmit={ async ( event ) => {

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+
 import {
 	trash,
 	pages,
@@ -11,6 +12,9 @@ import {
 	pending,
 	notAllowed,
 } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -36,7 +40,7 @@ export const DEFAULT_CONFIG_PER_VIEW_TYPE = {
 	},
 };
 
-const DEFAULT_PAGE_BASE = {
+const DEFAULT_POST_BASE = {
 	type: LAYOUT_LIST,
 	search: '',
 	filters: [],
@@ -54,103 +58,114 @@ const DEFAULT_PAGE_BASE = {
 	},
 };
 
-export const DEFAULT_VIEWS = {
-	page: [
-		{
-			title: __( 'All pages' ),
-			slug: 'all',
-			icon: pages,
-			view: DEFAULT_PAGE_BASE,
+export function useDefaultViews( { postType } ) {
+	const labels = useSelect(
+		( select ) => {
+			const { getPostType } = select( coreStore );
+			return getPostType( postType )?.labels;
 		},
-		{
-			title: __( 'Published' ),
-			slug: 'published',
-			icon: published,
-			view: {
-				...DEFAULT_PAGE_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'publish',
+		[ postType ]
+	);
+	return useMemo( () => {
+		return {
+			[ postType ]: [
+				{
+					title: labels?.all_items || __( 'All items' ),
+					slug: 'all',
+					icon: pages,
+					view: DEFAULT_POST_BASE,
+				},
+				{
+					title: __( 'Published' ),
+					slug: 'published',
+					icon: published,
+					view: {
+						...DEFAULT_POST_BASE,
+						filters: [
+							{
+								field: 'status',
+								operator: OPERATOR_IS_ANY,
+								value: 'publish',
+							},
+						],
 					},
-				],
-			},
-		},
-		{
-			title: __( 'Scheduled' ),
-			slug: 'future',
-			icon: scheduled,
-			view: {
-				...DEFAULT_PAGE_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'future',
+				},
+				{
+					title: __( 'Scheduled' ),
+					slug: 'future',
+					icon: scheduled,
+					view: {
+						...DEFAULT_POST_BASE,
+						filters: [
+							{
+								field: 'status',
+								operator: OPERATOR_IS_ANY,
+								value: 'future',
+							},
+						],
 					},
-				],
-			},
-		},
-		{
-			title: __( 'Drafts' ),
-			slug: 'drafts',
-			icon: drafts,
-			view: {
-				...DEFAULT_PAGE_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'draft',
+				},
+				{
+					title: __( 'Drafts' ),
+					slug: 'drafts',
+					icon: drafts,
+					view: {
+						...DEFAULT_POST_BASE,
+						filters: [
+							{
+								field: 'status',
+								operator: OPERATOR_IS_ANY,
+								value: 'draft',
+							},
+						],
 					},
-				],
-			},
-		},
-		{
-			title: __( 'Pending' ),
-			slug: 'pending',
-			icon: pending,
-			view: {
-				...DEFAULT_PAGE_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'pending',
+				},
+				{
+					title: __( 'Pending' ),
+					slug: 'pending',
+					icon: pending,
+					view: {
+						...DEFAULT_POST_BASE,
+						filters: [
+							{
+								field: 'status',
+								operator: OPERATOR_IS_ANY,
+								value: 'pending',
+							},
+						],
 					},
-				],
-			},
-		},
-		{
-			title: __( 'Private' ),
-			slug: 'private',
-			icon: notAllowed,
-			view: {
-				...DEFAULT_PAGE_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'private',
+				},
+				{
+					title: __( 'Private' ),
+					slug: 'private',
+					icon: notAllowed,
+					view: {
+						...DEFAULT_POST_BASE,
+						filters: [
+							{
+								field: 'status',
+								operator: OPERATOR_IS_ANY,
+								value: 'private',
+							},
+						],
 					},
-				],
-			},
-		},
-		{
-			title: __( 'Trash' ),
-			slug: 'trash',
-			icon: trash,
-			view: {
-				...DEFAULT_PAGE_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'trash',
+				},
+				{
+					title: __( 'Trash' ),
+					slug: 'trash',
+					icon: trash,
+					view: {
+						...DEFAULT_POST_BASE,
+						filters: [
+							{
+								field: 'status',
+								operator: OPERATOR_IS_ANY,
+								value: 'trash',
+							},
+						],
 					},
-				],
-			},
-		},
-	],
-};
+				},
+			],
+		};
+	}, [ labels, postType ] );
+}

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -2,13 +2,12 @@
  * WordPress dependencies
  */
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
-
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+
 /**
  * Internal dependencies
  */
-
-import { DEFAULT_VIEWS } from './default-views';
+import { useDefaultViews } from './default-views';
 import { unlock } from '../../lock-unlock';
 const { useLocation } = unlock( routerPrivateApis );
 import DataViewItem from './dataview-item';
@@ -18,6 +17,7 @@ export default function DataViewsSidebarContent() {
 	const {
 		params: { postType, activeView = 'all', isCustom = 'false' },
 	} = useLocation();
+	const DEFAULT_VIEWS = useDefaultViews( { postType } );
 	if ( ! postType ) {
 		return null;
 	}

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -27,7 +27,7 @@ const postTypesWithoutParentTemplate = [
 	PATTERN_TYPES.user,
 ];
 
-const authorizedPostTypes = [ 'page' ];
+const authorizedPostTypes = [ 'page', 'post' ];
 
 function useResolveEditedEntityAndContext( { postId, postType } ) {
 	const {
@@ -213,7 +213,8 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 		if ( postType && postId && authorizedPostTypes.includes( postType ) ) {
 			return { postType, postId };
 		}
-
+		// TODO: for post types lists we should probably not render the front page, but maybe a placeholder
+		// with a message like "Select a page" or something similar.
 		if ( homepageId ) {
 			return { postType: 'page', postId: homepageId };
 		}

--- a/packages/edit-site/src/posts.js
+++ b/packages/edit-site/src/posts.js
@@ -6,6 +6,7 @@ import { createRoot, StrictMode } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+// import { initializeEditor } from './index';
 import PostsApp from './components/posts-app';
 
 /**
@@ -16,6 +17,7 @@ export function initializePostsDashboard( id ) {
 	if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
 		return;
 	}
+	// initializeEditor( 'site-editor', {} );
 	const target = document.getElementById( id );
 	const root = createRoot( target );
 

--- a/packages/edit-site/src/posts.js
+++ b/packages/edit-site/src/posts.js
@@ -1,7 +1,26 @@
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
+import {
+	registerCoreBlocks,
+	__experimentalGetCoreBlocks,
+	__experimentalRegisterExperimentalCoreBlocks,
+} from '@wordpress/block-library';
+import { dispatch } from '@wordpress/data';
 import { createRoot, StrictMode } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
+import { store as preferencesStore } from '@wordpress/preferences';
+import {
+	registerLegacyWidgetBlock,
+	registerWidgetGroupBlock,
+} from '@wordpress/widgets';
+
+/**
+ * Internal dependencies
+ */
+import './hooks';
+import { store as editSiteStore } from './store';
 
 /**
  * Internal dependencies
@@ -11,15 +30,66 @@ import PostsApp from './components/posts-app';
 
 /**
  * Initializes the "Posts Dashboard"
- * @param {string} id DOM element id.
+ * @param {string} id       ID of the root element to render the screen in.
+ * @param {Object} settings Editor settings.
  */
-export function initializePostsDashboard( id ) {
+export function initializePostsDashboard( id, settings ) {
 	if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
 		return;
 	}
-	// initializeEditor( 'site-editor', {} );
 	const target = document.getElementById( id );
 	const root = createRoot( target );
+
+	dispatch( blocksStore ).reapplyBlockTypeFilters();
+	const coreBlocks = __experimentalGetCoreBlocks().filter(
+		( { name } ) => name !== 'core/freeform'
+	);
+	registerCoreBlocks( coreBlocks );
+	dispatch( blocksStore ).setFreeformFallbackBlockName( 'core/html' );
+	registerLegacyWidgetBlock( { inserter: false } );
+	registerWidgetGroupBlock( { inserter: false } );
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		__experimentalRegisterExperimentalCoreBlocks( {
+			enableFSEBlocks: true,
+		} );
+	}
+
+	// We dispatch actions and update the store synchronously before rendering
+	// so that we won't trigger unnecessary re-renders with useEffect.
+	dispatch( preferencesStore ).setDefaults( 'core/edit-site', {
+		welcomeGuide: true,
+		welcomeGuideStyles: true,
+		welcomeGuidePage: true,
+		welcomeGuideTemplate: true,
+	} );
+
+	dispatch( preferencesStore ).setDefaults( 'core', {
+		allowRightClickOverrides: true,
+		distractionFree: false,
+		editorMode: 'visual',
+		fixedToolbar: false,
+		focusMode: false,
+		inactivePanels: [],
+		keepCaretInsideBlock: false,
+		openPanels: [ 'post-status' ],
+		showBlockBreadcrumbs: true,
+		showListViewByDefault: false,
+	} );
+
+	dispatch( editSiteStore ).updateSettings( settings );
+
+	// Keep the defaultTemplateTypes in the core/editor settings too,
+	// so that they can be selected with core/editor selectors in any editor.
+	// This is needed because edit-site doesn't initialize with EditorProvider,
+	// which internally uses updateEditorSettings as well.
+	dispatch( editorStore ).updateEditorSettings( {
+		defaultTemplateTypes: settings.defaultTemplateTypes,
+		defaultTemplatePartAreas: settings.defaultTemplatePartAreas,
+	} );
+
+	// Prevent the default browser action for files dropped outside of dropzones.
+	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
+	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
 	root.render(
 		<StrictMode>

--- a/packages/edit-site/src/posts.js
+++ b/packages/edit-site/src/posts.js
@@ -9,7 +9,6 @@ import {
 } from '@wordpress/block-library';
 import { dispatch } from '@wordpress/data';
 import { createRoot, StrictMode } from '@wordpress/element';
-import { store as editorStore } from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	registerLegacyWidgetBlock,
@@ -25,7 +24,6 @@ import { store as editSiteStore } from './store';
 /**
  * Internal dependencies
  */
-// import { initializeEditor } from './index';
 import PostsApp from './components/posts-app';
 
 /**
@@ -77,15 +75,6 @@ export function initializePostsDashboard( id, settings ) {
 	} );
 
 	dispatch( editSiteStore ).updateSettings( settings );
-
-	// Keep the defaultTemplateTypes in the core/editor settings too,
-	// so that they can be selected with core/editor selectors in any editor.
-	// This is needed because edit-site doesn't initialize with EditorProvider,
-	// which internally uses updateEditorSettings as well.
-	dispatch( editorStore ).updateEditorSettings( {
-		defaultTemplateTypes: settings.defaultTemplateTypes,
-		defaultTemplatePartAreas: settings.defaultTemplatePartAreas,
-	} );
 
 	// Prevent the default browser action for files dropped outside of dropzones.
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );

--- a/packages/edit-site/src/posts.scss
+++ b/packages/edit-site/src/posts.scss
@@ -7,6 +7,7 @@
 @import "./components/site-hub/style.scss";
 @import "./components/site-icon/style.scss";
 @import "./components/editor-canvas-container/style.scss";
+@import "./components/posts-app/style.scss";
 @import "./components/resizable-frame/style.scss";
 
 @include wordpress-admin-schemes();

--- a/packages/edit-site/src/posts.scss
+++ b/packages/edit-site/src/posts.scss
@@ -44,4 +44,12 @@ body {
 		min-height: 0;
 		position: static;
 	}
+
+	.components-editor-notices__snackbar {
+		position: fixed;
+		right: 0;
+		bottom: 16px;
+		padding-left: 16px;
+		padding-right: 16px;
+	}
 }

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -29,6 +29,7 @@
 @import "./components/site-icon/style.scss";
 @import "./components/style-book/style.scss";
 @import "./components/editor-canvas-container/style.scss";
+@import "./components/posts-app/style.scss";
 @import "./components/resizable-frame/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";
 @import "./components/global-styles/font-library-modal/style.scss";

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -7,7 +7,6 @@
 @import "./components/global-styles/screen-revisions/style.scss";
 @import "./components/global-styles-sidebar/style.scss";
 @import "./components/page/style.scss";
-@import "./components/page-pages/style.scss";
 @import "./components/page-patterns/style.scss";
 @import "./components/page-templates/style.scss";
 @import "./components/table/style.scss";

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -304,8 +304,8 @@ async function draftNewPage( page ) {
 	await page.getByRole( 'button', { name: 'Pages' } ).click();
 	await page.getByRole( 'button', { name: 'Add new page' } ).click();
 	await page
-		.locator( 'role=dialog[name="Draft a new page"i]' )
-		.locator( 'role=textbox[name="Page title"i]' )
+		.locator( 'role=dialog[name="Draft new: page"i]' )
+		.locator( 'role=textbox[name="title"i]' )
 		.fill( TEST_PAGE_TITLE );
 	await page.keyboard.press( 'Enter' );
 	await expect(

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -7,8 +7,8 @@ async function draftNewPage( page ) {
 	await page.getByRole( 'button', { name: 'Pages' } ).click();
 	await page.getByRole( 'button', { name: 'Add new page' } ).click();
 	await page
-		.locator( 'role=dialog[name="Draft a new page"i]' )
-		.locator( 'role=textbox[name="Page title"i]' )
+		.locator( 'role=dialog[name="Draft new: page"i]' )
+		.locator( 'role=textbox[name="title"i]' )
 		.fill( 'Test Page' );
 	await page.keyboard.press( 'Enter' );
 	await expect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/62371

This PR explores the addition of Data Views for the new experimental `posts` list under `Gutenberg->posts` menu.
This is just a starting point, but wanted to have it on GH to start some discussions.

What this PR does for now is the start of making an abstraction that could be used for any post type, but we need to do it at least for `posts` and `pages` for now.

Maybe the notable things for now to discuss are:
1. When we'll choose to edit an item, should it load the `post` or the `site` editor? I've started by having as a goal to load the site editor. This has nuances though. Do we want to have for example global styles in a the editor of the post? Additionally the editor adds some extra settings during initialization (`initializeEditor`) that are needed here too. How can we abstract this to be reused what's needed.
2. Design wise, we're also aiming towards having the `categories, tags`, etc.. in the sidebar where we would load the lists for the taxonomies. How does this affect the current `views` we have(`drafts, published, etc..`)? Should we consider changing placement of these views into the frame, which might also simplify some shared information that were wanted for views. An example is the number of items per view, which is not possible right now.


### Notes
1. We would need a similar API with `usePostActions` for fields. Now we are reusing the exact same code for the `posts` list and the existing `pages` list in site editor. So testing the `pages` list that works as before is also part of this PR to avoid regressions.
