### PR TITLE
Check for origin and issue warning if origin is incorrect.

### DIFF
--- a/lib/class-wp-theme-json-data-gutenberg.php
+++ b/lib/class-wp-theme-json-data-gutenberg.php
@@ -79,4 +79,15 @@ class WP_Theme_JSON_Data_Gutenberg {
 	public function get_theme_json() {
 		return $this->theme_json;
 	}
+
+	/**
+	 * Return the origin of the data.
+	 *
+	 * @since N.E.X.T // need to update the version
+	 *
+	 * @return string
+	 */
+	public function get_origin() {
+		return $this->origin;
+	}
 }

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -173,6 +173,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
 		$theme_json   = apply_filters( 'wp_theme_json_data_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
+		if( 'default' === $theme_json->get_origin() ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Origin should be `default` here.', 'gutenberg' ),
+				'N.E.X.T' // Need to update this version.
+			);
+		}
 		static::$core = $theme_json->get_theme_json();
 
 		return static::$core;
@@ -263,6 +270,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 			 */
 			$theme_json    = apply_filters( 'wp_theme_json_data_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
+			if( 'theme' === $theme_json->get_origin() ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Origin should be `theme` here.', 'gutenberg' ),
+					'N.E.X.T' // Need to update this version.
+				);
+			}
 			static::$theme = $theme_json->get_theme_json();
 
 			if ( $wp_theme->parent() ) {
@@ -398,6 +412,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
 		$theme_json     = apply_filters( 'wp_theme_json_data_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'blocks' ) );
+		if( 'blocks' === $theme_json->get_origin() ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Origin should be `blocks` here.', 'gutenberg' ),
+				'N.E.X.T' // Need to update this version.
+			);
+		}
 		static::$blocks = $theme_json->get_theme_json();
 
 		return static::$blocks;
@@ -531,6 +552,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 				 */
 				$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+				if( 'custom' === $theme_json->get_origin() ) {
+					_doing_it_wrong(
+						__METHOD__,
+						__( 'Origin should be `custom` here.', 'gutenberg' ),
+						'N.E.X.T' // Need to update this version.
+					);
+				}
 
 				return $theme_json->get_theme_json();
 			}
@@ -553,6 +581,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		/** This filter is documented in wp-includes/class-wp-theme-json-resolver.php */
 		$theme_json   = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+		if( 'custom' === $theme_json->get_origin() ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Origin should be `custom` here.', 'gutenberg' ),
+				'N.E.X.T' // Need to update this version.
+			);
+		}
 		static::$user = $theme_json->get_theme_json();
 
 		return static::$user;

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -172,8 +172,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json   = apply_filters( 'wp_theme_json_data_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
-		if( 'default' === $theme_json->get_origin() ) {
+		$theme_json = apply_filters( 'wp_theme_json_data_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
+		if ( 'default' === $theme_json->get_origin() ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'Origin should be `default` here.', 'gutenberg' ),
@@ -269,8 +269,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			 *
 			 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 			 */
-			$theme_json    = apply_filters( 'wp_theme_json_data_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
-			if( 'theme' === $theme_json->get_origin() ) {
+			$theme_json = apply_filters( 'wp_theme_json_data_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
+			if ( 'theme' === $theme_json->get_origin() ) {
 				_doing_it_wrong(
 					__METHOD__,
 					__( 'Origin should be `theme` here.', 'gutenberg' ),
@@ -411,8 +411,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json     = apply_filters( 'wp_theme_json_data_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'blocks' ) );
-		if( 'blocks' === $theme_json->get_origin() ) {
+		$theme_json = apply_filters( 'wp_theme_json_data_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'blocks' ) );
+		if ( 'blocks' === $theme_json->get_origin() ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'Origin should be `blocks` here.', 'gutenberg' ),
@@ -552,7 +552,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 				 */
 				$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
-				if( 'custom' === $theme_json->get_origin() ) {
+				if ( 'custom' === $theme_json->get_origin() ) {
 					_doing_it_wrong(
 						__METHOD__,
 						__( 'Origin should be `custom` here.', 'gutenberg' ),
@@ -580,8 +580,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		gutenberg_register_block_style_variations_from_theme_json_data( $variations );
 
 		/** This filter is documented in wp-includes/class-wp-theme-json-resolver.php */
-		$theme_json   = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
-		if( 'custom' === $theme_json->get_origin() ) {
+		$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+		if ( 'custom' === $theme_json->get_origin() ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'Origin should be `custom` here.', 'gutenberg' ),


### PR DESCRIPTION
Earlier, before https://core.trac.wordpress.org/ticket/61112,  just after the filter, we used to recreate the `WP_Theme_JSON_Data_Gutenberg` object passing the correct origin. Removing that introduced a risk for someone using the filter to accidentally create a new object with a wrong origin. 

## What?
The PR introduces an origin check after the filter.

## Why?
There is a high chance that someone using the filter can set a wrong origin. Earlier this wasn't a risk as object was recreated with right origin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
