### PR TITLE
Global Styles: Include spacing rules as part of typography variations

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -114,7 +114,7 @@ export function useSupportedStyles( name, element ) {
 
 export function useColorVariations() {
 	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
-		property: 'color',
+		properties: [ 'color' ],
 	} );
 	/*
 	 * Filter out variations with no settings or styles.
@@ -134,7 +134,7 @@ export function useColorVariations() {
 export function useTypographyVariations() {
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			property: 'typography',
+			properties: [ 'typography', 'spacing' ],
 		} );
 	/*
 	 * Filter out variations with no settings or styles.

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -13,7 +13,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import PreviewStyles from './preview-styles';
 import Variation from './variations/variation';
-import { isVariationWithSingleProperty } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { isVariationWithProperties } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../lock-unlock';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
@@ -33,11 +33,14 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		).__experimentalGetCurrentThemeGlobalStylesVariations();
 	}, [] );
 
-	// Filter out variations that are of single property type, i.e. color or typography variations.
-	const multiplePropertyVariations = variations?.filter( ( variation ) => {
+	// Filter out variations that are color or typography variations.
+	const fullStyleVariations = variations?.filter( ( variation ) => {
 		return (
-			! isVariationWithSingleProperty( variation, 'color' ) &&
-			! isVariationWithSingleProperty( variation, 'typography' )
+			! isVariationWithProperties( variation, [ 'color' ] ) &&
+			! isVariationWithProperties( variation, [
+				'typography',
+				'spacing',
+			] )
 		);
 	} );
 
@@ -48,7 +51,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				settings: {},
 				styles: {},
 			},
-			...( multiplePropertyVariations ?? [] ),
+			...( fullStyleVariations ?? [] ),
 		];
 		return [
 			...withEmptyVariation.map( ( variation ) => {
@@ -105,7 +108,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				};
 			} ),
 		];
-	}, [ multiplePropertyVariations, userStyles?.blocks, userStyles?.css ] );
+	}, [ fullStyleVariations, userStyles?.blocks, userStyles?.css ] );
 
 	return (
 		<Grid

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -16,7 +16,7 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
-import { filterObjectByProperty } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { filterObjectByProperties } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../../lock-unlock';
 
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
@@ -28,7 +28,7 @@ export default function Variation( {
 	variation,
 	children,
 	isPill,
-	property,
+	properties,
 	showTooltip,
 } ) {
 	const [ isFocused, setIsFocused ] = useState( false );
@@ -36,8 +36,8 @@ export default function Variation( {
 
 	const context = useMemo( () => {
 		let merged = mergeBaseAndUserConfigs( base, variation );
-		if ( property ) {
-			merged = filterObjectByProperty( merged, property );
+		if ( properties ) {
+			merged = filterObjectByProperties( merged, properties );
 		}
 		return {
 			user: variation,
@@ -45,7 +45,7 @@ export default function Variation( {
 			merged,
 			setUserConfig: () => {},
 		};
-	}, [ variation, base, property ] );
+	}, [ variation, base, properties ] );
 
 	const selectVariation = () => setUserConfig( variation );
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -31,7 +31,7 @@ export default function ColorVariations( { title, gap = 2 } ) {
 						key={ index }
 						variation={ variation }
 						isPill
-						property="color"
+						properties={ [ 'color' ] }
 						showTooltip
 					>
 						{ () => <StylesPreviewColors /> }

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -38,7 +38,7 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 						<Variation
 							key={ index }
 							variation={ variation }
-							property="typography"
+							properties={ [ 'typography', 'spacing' ] }
 							showTooltip
 						>
 							{ ( isFocused ) => (

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -18,14 +18,14 @@ const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 
 /**
- * Removes all instances of a property from an object.
+ * Removes all instances of properties from an object.
  *
- * @param {Object} object   The object to remove the property from.
- * @param {string} property The property to remove.
+ * @param {Object} object     The object to remove the properties from.
+ * @param {string} properties The properties to remove.
  * @return {Object} The modified object.
  */
-export function removePropertyFromObject( object, property ) {
-	if ( ! property || typeof property !== 'string' ) {
+export function removePropertiesFromObject( object, properties ) {
+	if ( ! properties || typeof properties !== 'object' ) {
 		return object;
 	}
 
@@ -38,25 +38,25 @@ export function removePropertyFromObject( object, property ) {
 	}
 
 	for ( const key in object ) {
-		if ( key === property ) {
+		if ( properties.includes( key ) ) {
 			delete object[ key ];
 		} else if ( typeof object[ key ] === 'object' ) {
-			removePropertyFromObject( object[ key ], property );
+			removePropertiesFromObject( object[ key ], properties );
 		}
 	}
 	return object;
 }
 
 /**
- * Fetches the current theme style variations that contain only the specified property
+ * Fetches the current theme style variations that contain only the specified properties
  * and merges them with the user config.
  *
- * @param {Object} props          Object of hook args.
- * @param {string} props.property The property to filter by.
+ * @param {Object} props            Object of hook args.
+ * @param {string} props.properties The properties to filter by.
  * @return {Object[]|*} The merged object.
  */
 export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
-	property,
+	properties,
 } ) {
 	const { variationsFromTheme } = useSelect( ( select ) => {
 		const _variationsFromTheme =
@@ -74,51 +74,54 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		const clonedUserVariation = cloneDeep( userVariation );
 
 		// Get user variation and remove the settings for the given property.
-		const userVariationWithoutProperty = removePropertyFromObject(
+		const userVariationWithoutProperties = removePropertiesFromObject(
 			clonedUserVariation,
-			property
+			properties
 		);
-		userVariationWithoutProperty.title = __( 'Default' );
+		userVariationWithoutProperties.title = __( 'Default' );
 
-		const variationsWithSinglePropertyAndBase = variationsFromTheme
+		const variationsWithPropertiesAndBase = variationsFromTheme
 			.filter( ( variation ) => {
-				return isVariationWithSingleProperty( variation, property );
+				return isVariationWithProperties( variation, properties );
 			} )
 			.map( ( variation ) => {
 				return mergeBaseAndUserConfigs(
-					userVariationWithoutProperty,
+					userVariationWithoutProperties,
 					variation
 				);
 			} );
 
 		return [
-			userVariationWithoutProperty,
-			...variationsWithSinglePropertyAndBase,
+			userVariationWithoutProperties,
+			...variationsWithPropertiesAndBase,
 		];
-	}, [ property, userVariation, variationsFromTheme ] );
+	}, [ properties, userVariation, variationsFromTheme ] );
 }
 
 /**
- * Returns a new object, with properties specified in `property`,
+ * Returns a new object, with properties specified in `properties` array.,
  * maintain the original object tree structure.
- * The function is recursive, so it will perform a deep search for the given property.
- * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the property is `test`.
+ * The function is recursive, so it will perform a deep search for the given properties.
+ * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the properties are  `[ 'test' ]`.
  *
- * @param {Object} object   The object to filter
- * @param {Object} property The property to filter by
+ * @param {Object} object     The object to filter
+ * @param {Array}  properties The properties to filter by
  * @return {Object} The merged object.
  */
-export const filterObjectByProperty = ( object, property ) => {
+export const filterObjectByProperties = ( object, properties ) => {
 	if ( ! object ) {
 		return {};
 	}
 
 	const newObject = {};
 	Object.keys( object ).forEach( ( key ) => {
-		if ( key === property ) {
+		if ( properties.includes( key ) ) {
 			newObject[ key ] = object[ key ];
 		} else if ( typeof object[ key ] === 'object' ) {
-			const newFilter = filterObjectByProperty( object[ key ], property );
+			const newFilter = filterObjectByProperties(
+				object[ key ],
+				properties
+			);
 			if ( Object.keys( newFilter ).length ) {
 				newObject[ key ] = newFilter;
 			}
@@ -128,23 +131,23 @@ export const filterObjectByProperty = ( object, property ) => {
 };
 
 /**
- * Compares a style variation to the same variation filtered by a single property.
- * Returns true if the variation contains only the property specified.
+ * Compares a style variation to the same variation filtered by the specified properties.
+ * Returns true if the variation contains only the properties specified.
  *
- * @param {Object} variation The variation to compare.
- * @param {string} property  The property to compare.
- * @return {boolean} Whether the variation contains only a single property.
+ * @param {Object} variation  The variation to compare.
+ * @param {string} properties The properties to compare.
+ * @return {boolean} Whether the variation contains only the specified properties.
  */
-export function isVariationWithSingleProperty( variation, property ) {
-	const variationWithProperty = filterObjectByProperty(
+export function isVariationWithProperties( variation, properties ) {
+	const variationWithProperties = filterObjectByProperties(
 		cloneDeep( variation ),
-		property
+		properties
 	);
 
 	return (
-		JSON.stringify( variationWithProperty?.styles ) ===
+		JSON.stringify( variationWithProperties?.styles ) ===
 			JSON.stringify( variation?.styles ) &&
-		JSON.stringify( variationWithProperty?.settings ) ===
+		JSON.stringify( variationWithProperties?.settings ) ===
 			JSON.stringify( variation?.settings )
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Includes spacing as part of typography presets. Fixes #61214.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Spacing is an important part of typography styles, so we should treat these rules as part of the typography variation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Several functions have been expanded to take an array of properties rather than a single property:
- `useCurrentMergeThemeStyleVariationsWithUserConfig`
- `isVariationWithSingleProperty` -> `isVariationWithProperties`
- `filterObjectByProperty` -> `filterObjectByProperties`
- `removePropertyFromObject` -> `removePropertiesFromObject`

## Testing Instructions
1. Using TT4 add a new style variation that contains only typography and spacing rules. [Here's an example](https://gist.github.com/scruffian/3dab906ee04d3c1c689bb08d23198f84).
2. Open the Site Editor
3. Go to Global Styles > Typography
4. You should see a new typography variation under "Presets"

## Screenshots or screencast <!-- if applicable -->
<img width="288" alt="Screenshot 2024-06-21 at 10 50 45" src="https://github.com/WordPress/gutenberg/assets/275961/e9812734-c22d-4ca7-9382-9b20d286d77a">

