### PR TITLE
Documentation: add `VisualEditorGlobalKeyboardShortcuts` docs

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -322,7 +322,7 @@ _Returns_
 
 ### EditorKeyboardShortcuts
 
-Component handles the keyboard shortcuts for the editor.
+Handles the keyboard shortcuts for the editor.
 
 It provides functionality for various keyboard shortcuts such as toggling editor mode, toggling distraction-free mode, undo/redo, saving the post, toggling list view, and toggling the sidebar.
 
@@ -1616,9 +1616,9 @@ _Returns_
 
 ### TextEditorGlobalKeyboardShortcuts
 
-Component handles the global keyboard shortcuts for the Text editor.
+Handles the keyboard shortcuts for the editor.
 
-It provides functionality for various keyboard shortcuts such as toggling editor mode, toggling distraction-free mode, undo/redo.
+It provides functionality for various keyboard shortcuts such as toggling editor mode, toggling distraction-free mode, undo/redo, saving the post, toggling list view, and toggling the sidebar.
 
 ### ThemeSupportCheck
 
@@ -1725,7 +1725,9 @@ _Type_
 
 ### VisualEditorGlobalKeyboardShortcuts
 
-Undocumented declaration.
+Handles the keyboard shortcuts for the editor.
+
+It provides functionality for various keyboard shortcuts such as toggling editor mode, toggling distraction-free mode, undo/redo, saving the post, toggling list view, and toggling the sidebar.
 
 ### Warning
 

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -12,7 +12,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '../../store';
 
 /**
- * Component handles the keyboard shortcuts for the editor.
+ * Handles the keyboard shortcuts for the editor.
  *
  * It provides functionality for various keyboard shortcuts such as toggling editor mode,
  * toggling distraction-free mode, undo/redo, saving the post, toggling list view,

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -105,12 +105,21 @@ export { default as CharacterCount } from './character-count';
 export { default as EditorProvider } from './provider';
 
 export * from './deprecated';
+
+/**
+ * Handles the keyboard shortcuts for the editor.
+ *
+ * It provides functionality for various keyboard shortcuts such as toggling editor mode,
+ * toggling distraction-free mode, undo/redo, saving the post, toggling list view,
+ * and toggling the sidebar.
+ */
 export const VisualEditorGlobalKeyboardShortcuts = EditorKeyboardShortcuts;
 
 /**
- * Component handles the global keyboard shortcuts for the Text editor.
+ * Handles the keyboard shortcuts for the editor.
  *
  * It provides functionality for various keyboard shortcuts such as toggling editor mode,
- * toggling distraction-free mode, undo/redo.
+ * toggling distraction-free mode, undo/redo, saving the post, toggling list view,
+ * and toggling the sidebar.
  */
 export const TextEditorGlobalKeyboardShortcuts = EditorKeyboardShortcuts;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Last item of: https://github.com/WordPress/gutenberg/issues/60358
Add docs for `VisualEditorGlobalKeyboardShortcuts` component. Documentation for these three components is the same because VisualEditorGlobalKeyboardShortcuts and TextEditorGlobalKeyboardShortcuts are aliases of EditorKeyboardShortcuts.