### PR TITLE
Position BlockToolbar below all of the selected block's descendants

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -20,7 +20,7 @@ import {
  */
 import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import usePopoverScroll from './use-popover-scroll';
-import { rectUnion, getVisibleBoundingRect } from '../../utils/dom';
+import { rectUnion, getVisibleElementBounds } from '../../utils/dom';
 
 const MAX_POPOVER_RECOMPUTE_COUNTER = Number.MAX_SAFE_INTEGER;
 
@@ -90,10 +90,10 @@ function BlockPopover(
 			getBoundingClientRect() {
 				return lastSelectedElement
 					? rectUnion(
-							getVisibleBoundingRect( selectedElement ),
-							getVisibleBoundingRect( lastSelectedElement )
+							getVisibleElementBounds( selectedElement ),
+							getVisibleElementBounds( lastSelectedElement )
 					  )
-					: getVisibleBoundingRect( selectedElement );
+					: getVisibleElementBounds( selectedElement );
 			},
 			contextElement: selectedElement,
 		};

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -20,6 +20,7 @@ import {
  */
 import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import usePopoverScroll from './use-popover-scroll';
+import { rectUnion, getVisibleBoundingRect } from '../../utils/dom';
 
 const MAX_POPOVER_RECOMPUTE_COUNTER = Number.MAX_SAFE_INTEGER;
 
@@ -87,34 +88,12 @@ function BlockPopover(
 
 		return {
 			getBoundingClientRect() {
-				const selectedBCR = selectedElement.getBoundingClientRect();
-				const lastSelectedBCR =
-					lastSelectedElement?.getBoundingClientRect();
-
-				// Get the biggest rectangle that encompasses completely the currently
-				// selected element and the last selected element:
-				// - for top/left coordinates, use the smaller numbers
-				// - for the bottom/right coordinates, use the largest numbers
-				const left = Math.min(
-					selectedBCR.left,
-					lastSelectedBCR?.left ?? Infinity
-				);
-				const top = Math.min(
-					selectedBCR.top,
-					lastSelectedBCR?.top ?? Infinity
-				);
-				const right = Math.max(
-					selectedBCR.right,
-					lastSelectedBCR.right ?? -Infinity
-				);
-				const bottom = Math.max(
-					selectedBCR.bottom,
-					lastSelectedBCR.bottom ?? -Infinity
-				);
-				const width = right - left;
-				const height = bottom - top;
-
-				return new window.DOMRect( left, top, width, height );
+				return lastSelectedElement
+					? rectUnion(
+							getVisibleBoundingRect( selectedElement ),
+							getVisibleBoundingRect( lastSelectedElement )
+					  )
+					: getVisibleBoundingRect( selectedElement );
 			},
 			contextElement: selectedElement,
 		};

--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -49,7 +49,7 @@ export default function BlockToolbarPopover( {
 
 	const popoverProps = useBlockToolbarPopoverProps( {
 		contentElement: __unstableContentRef?.current,
-		clientId,
+		clientId: capturingClientId || clientId,
 	} );
 
 	return (

--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -47,15 +47,19 @@ export default function BlockToolbarPopover( {
 		isToolbarForcedRef.current = false;
 	} );
 
+	// If the block has a parent with __experimentalCaptureToolbars enabled,
+	// the toolbar should be positioned over the topmost capturing parent.
+	const clientIdToPositionOver = capturingClientId || clientId;
+
 	const popoverProps = useBlockToolbarPopoverProps( {
 		contentElement: __unstableContentRef?.current,
-		clientId: capturingClientId || clientId,
+		clientId: clientIdToPositionOver,
 	} );
 
 	return (
 		! isTyping && (
 			<BlockPopover
-				clientId={ capturingClientId || clientId }
+				clientId={ clientIdToPositionOver }
 				bottomClientId={ lastClientId }
 				className={ clsx( 'block-editor-block-list__block-popover', {
 					'is-insertion-point-visible': isInsertionPointVisible,

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -17,7 +17,7 @@ import {
 import { store as blockEditorStore } from '../../store';
 import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import { hasStickyOrFixedPositionValue } from '../../hooks/position';
-import { getVisibleBoundingRect } from '../../utils/dom';
+import { getVisibleElementBounds } from '../../utils/dom';
 
 const COMMON_PROPS = {
 	placement: 'top-start',
@@ -68,7 +68,7 @@ function getProps(
 	// Get how far the content area has been scrolled.
 	const scrollTop = scrollContainer?.scrollTop || 0;
 
-	const blockRect = getVisibleBoundingRect( selectedBlockElement );
+	const blockRect = getVisibleElementBounds( selectedBlockElement );
 	const contentRect = contentElement.getBoundingClientRect();
 
 	// Get the vertical position of top of the visible content area.

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -17,6 +17,7 @@ import {
 import { store as blockEditorStore } from '../../store';
 import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import { hasStickyOrFixedPositionValue } from '../../hooks/position';
+import { getVisibleBoundingRect } from '../../utils/dom';
 
 const COMMON_PROPS = {
 	placement: 'top-start',
@@ -67,7 +68,7 @@ function getProps(
 	// Get how far the content area has been scrolled.
 	const scrollTop = scrollContainer?.scrollTop || 0;
 
-	const blockRect = selectedBlockElement.getBoundingClientRect();
+	const blockRect = getVisibleBoundingRect( selectedBlockElement );
 	const contentRect = contentElement.getBoundingClientRect();
 
 	// Get the vertical position of top of the visible content area.

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -95,7 +95,12 @@ function rectIntersect( rect1, rect2 ) {
  * @return {boolean} Whether the element is visible.
  */
 function isElementVisible( element ) {
-	const style = window.getComputedStyle( element );
+	const viewport = element.ownerDocument.defaultView;
+	if ( ! viewport ) {
+		return false;
+	}
+
+	const style = viewport.getComputedStyle( element );
 	if (
 		style.display === 'none' ||
 		style.visibility === 'hidden' ||
@@ -140,6 +145,11 @@ function isElementVisible( element ) {
  * @return {DOMRect} Bounding client rect.
  */
 export function getVisibleBoundingRect( element ) {
+	const viewport = element.ownerDocument.defaultView;
+	if ( ! viewport ) {
+		return new window.DOMRect();
+	}
+
 	let bounds = element.getBoundingClientRect();
 
 	const stack = [ element ];
@@ -158,8 +168,8 @@ export function getVisibleBoundingRect( element ) {
 	const viewportRect = new window.DOMRect(
 		0,
 		0,
-		window.innerWidth,
-		window.innerHeight
+		viewport.innerWidth,
+		viewport.innerHeight
 	);
 	return rectIntersect( bounds, viewportRect );
 }

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -57,3 +57,101 @@ export function getBlockClientId( node ) {
 
 	return blockNode.id.slice( 'block-'.length );
 }
+
+/**
+ * Returns the union of two DOMRect objects.
+ *
+ * @param {DOMRect} rect1 First rectangle.
+ * @param {DOMRect} rect2 Second rectangle.
+ * @return {DOMRect} Union of the two rectangles.
+ */
+export function rectUnion( rect1, rect2 ) {
+	const left = Math.min( rect1.left, rect2.left );
+	const top = Math.min( rect1.top, rect2.top );
+	const right = Math.max( rect1.right, rect2.right );
+	const bottom = Math.max( rect1.bottom, rect2.bottom );
+	return new window.DOMRect( left, top, right - left, bottom - top );
+}
+
+/**
+ * Returns the intersection of two DOMRect objects.
+ *
+ * @param {DOMRect} rect1 First rectangle.
+ * @param {DOMRect} rect2 Second rectangle.
+ * @return {DOMRect} Intersection of the two rectangles.
+ */
+function rectIntersect( rect1, rect2 ) {
+	const left = Math.max( rect1.left, rect2.left );
+	const top = Math.max( rect1.top, rect2.top );
+	const right = Math.min( rect1.right, rect2.right );
+	const bottom = Math.min( rect1.bottom, rect2.bottom );
+	return new window.DOMRect( left, top, right - left, bottom - top );
+}
+
+/**
+ * Returns whether an element is visible.
+ *
+ * @param {Element} element Element.
+ * @return {boolean} Whether the element is visible.
+ */
+function isElementVisible( element ) {
+	const style = window.getComputedStyle( element );
+	if (
+		style.display === 'none' ||
+		style.visibility === 'hidden' ||
+		style.opacity === '0'
+	) {
+		return false;
+	}
+
+	const bounds = element.getBoundingClientRect();
+	return (
+		bounds.width > 0 &&
+		bounds.height > 0 &&
+		bounds.right >= 0 &&
+		bounds.bottom >= 0 &&
+		bounds.left <= window.innerWidth &&
+		bounds.top <= window.innerHeight
+	);
+}
+
+/**
+ * Returns the rect of the element that is visible in the viewport.
+ *
+ * Visible nested elements, including elements that overflow the parent, are
+ * taken into account. The returned rect is clipped to the viewport.
+ *
+ * This function is useful for calculating the visible area of a block that
+ * contains nested elements that overflow the block, e.g. the Navigation block,
+ * which can contain overflowing Submenu blocks.
+ *
+ * The returned rect is suitable for passing to the Popover component to
+ * position the popover relative to the visible area of the block.
+ *
+ * @param {Element} element Element.
+ * @return {DOMRect} Bounding client rect.
+ */
+export function getVisibleBoundingRect( element ) {
+	let bounds = element.getBoundingClientRect();
+
+	const stack = [ element ];
+	let currentElement;
+
+	while ( ( currentElement = stack.pop() ) ) {
+		for ( const child of currentElement.children ) {
+			if ( isElementVisible( child ) ) {
+				const childBounds = child.getBoundingClientRect();
+				bounds = rectUnion( bounds, childBounds );
+				stack.push( child );
+			}
+		}
+	}
+
+	const viewportRect = new window.DOMRect(
+		0,
+		0,
+		window.innerWidth,
+		window.innerHeight
+	);
+	return rectIntersect( bounds, viewportRect );
+}

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -105,14 +105,22 @@ function isElementVisible( element ) {
 	}
 
 	const bounds = element.getBoundingClientRect();
-	return (
-		bounds.width > 0 &&
-		bounds.height > 0 &&
-		bounds.right >= 0 &&
-		bounds.bottom >= 0 &&
-		bounds.left <= window.innerWidth &&
-		bounds.top <= window.innerHeight
-	);
+
+	if ( bounds.width === 0 || bounds.height === 0 ) {
+		return false;
+	}
+
+	// wp-components visually hides elements by setting their width and
+	// height to 1px and positioning them off-screen.
+	if (
+		bounds.width === 1 &&
+		bounds.height === 1 &&
+		( bounds.left < 0 || bounds.top < 0 )
+	) {
+		return false;
+	}
+
+	return true;
 }
 
 /**

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -74,21 +74,6 @@ export function rectUnion( rect1, rect2 ) {
 }
 
 /**
- * Returns the intersection of two DOMRect objects.
- *
- * @param {DOMRect} rect1 First rectangle.
- * @param {DOMRect} rect2 Second rectangle.
- * @return {DOMRect} Intersection of the two rectangles.
- */
-function rectIntersect( rect1, rect2 ) {
-	const left = Math.max( rect1.left, rect2.left );
-	const top = Math.max( rect1.top, rect2.top );
-	const right = Math.min( rect1.right, rect2.right );
-	const bottom = Math.min( rect1.bottom, rect2.bottom );
-	return new window.DOMRect( left, top, right - left, bottom - top );
-}
-
-/**
  * Returns whether an element is visible.
  *
  * @param {Element} element Element.
@@ -129,22 +114,22 @@ function isElementVisible( element ) {
 }
 
 /**
- * Returns the rect of the element that is visible in the viewport.
+ * Returns the rect of the element including all visible nested elements.
  *
  * Visible nested elements, including elements that overflow the parent, are
- * taken into account. The returned rect is clipped to the viewport.
+ * taken into account.
  *
  * This function is useful for calculating the visible area of a block that
  * contains nested elements that overflow the block, e.g. the Navigation block,
  * which can contain overflowing Submenu blocks.
  *
- * The returned rect is suitable for passing to the Popover component to
- * position the popover relative to the visible area of the block.
+ * The returned rect represents the full extent of the element and its visible
+ * children, which may extend beyond the viewport.
  *
  * @param {Element} element Element.
- * @return {DOMRect} Bounding client rect.
+ * @return {DOMRect} Bounding client rect of the element and its visible children.
  */
-export function getVisibleBoundingRect( element ) {
+export function getVisibleElementBounds( element ) {
 	const viewport = element.ownerDocument.defaultView;
 	if ( ! viewport ) {
 		return new window.DOMRect();
@@ -165,11 +150,5 @@ export function getVisibleBoundingRect( element ) {
 		}
 	}
 
-	const viewportRect = new window.DOMRect(
-		0,
-		0,
-		viewport.innerWidth,
-		viewport.innerHeight
-	);
-	return rectIntersect( bounds, viewportRect );
+	return bounds;
 }

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -85,27 +85,21 @@ function isElementVisible( element ) {
 		return false;
 	}
 
+	// Check for <VisuallyHidden> component.
+	if ( element.classList.contains( 'components-visually-hidden' ) ) {
+		return false;
+	}
+
+	const bounds = element.getBoundingClientRect();
+	if ( bounds.width === 0 || bounds.height === 0 ) {
+		return false;
+	}
+
 	const style = viewport.getComputedStyle( element );
 	if (
 		style.display === 'none' ||
 		style.visibility === 'hidden' ||
 		style.opacity === '0'
-	) {
-		return false;
-	}
-
-	const bounds = element.getBoundingClientRect();
-
-	if ( bounds.width === 0 || bounds.height === 0 ) {
-		return false;
-	}
-
-	// wp-components visually hides elements by setting their width and
-	// height to 1px and positioning them off-screen.
-	if (
-		bounds.width === 1 &&
-		bounds.height === 1 &&
-		( bounds.left < 0 || bounds.top < 0 )
 	) {
 		return false;
 	}

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -112,16 +112,11 @@ function isElementVisible( element ) {
 		return false;
 	}
 
-	const style = viewport.getComputedStyle( element );
-	if (
-		style.display === 'none' ||
-		style.visibility === 'hidden' ||
-		style.opacity === '0'
-	) {
-		return false;
-	}
-
-	return true;
+	return element.checkVisibility( {
+		opacityProperty: true,
+		contentVisibilityAuto: true,
+		visibilityProperty: true,
+	} );
 }
 
 /**

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -92,7 +92,7 @@ export function rectUnion( rect1, rect2, containerRect ) {
 	 * horizontal limits of the container in which an element is supposed to be "visible".
 	 * For example, if an element is positioned -10px to the left of the window x value (0),
 	 * this function discounts the negative overhang because it's not visible and
-	 * therefore to be counted in the visible calculations.
+	 * therefore not to be counted in the visibility calculations.
 	 * Top and bottom values are not accounted for to accommodate vertical scroll.
 	 */
 	if ( containerRect ) {

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -58,13 +58,6 @@ export function getBlockClientId( node ) {
 	return blockNode.id.slice( 'block-'.length );
 }
 
-/*
- * Cache for rectUnion() return values.
- * When popovers are present on the canvas,
- * this calculation function is called
- * multiple times with the same values.
- */
-const rectUnionCache = new Map();
 /**
  * Calculates the union of two rectangles, and optionally constrains this union within a containerRect's
  * left and right values.
@@ -76,12 +69,6 @@ const rectUnionCache = new Map();
  * @return {DOMRect} Union of the two rectangles.
  */
 export function rectUnion( rect1, rect2, containerRect ) {
-	const cacheKey = JSON.stringify( { rect1, rect2, containerRect } );
-
-	if ( rectUnionCache.has( cacheKey ) ) {
-		return rectUnionCache.get( cacheKey );
-	}
-
 	let left = Math.min( rect1.left, rect2.left );
 	let right = Math.max( rect1.right, rect2.right );
 	const bottom = Math.max( rect1.bottom, rect2.bottom );
@@ -100,11 +87,7 @@ export function rectUnion( rect1, rect2, containerRect ) {
 		right = Math.min( right, containerRect.right );
 	}
 
-	const result = new window.DOMRect( left, top, right - left, bottom - top );
-
-	rectUnionCache.set( cacheKey, result );
-
-	return result;
+	return new window.DOMRect( left, top, right - left, bottom - top );
 }
 
 /**


### PR DESCRIPTION
## What, why, how
Fixes https://github.com/WordPress/gutenberg/issues/40382.

Currently `BlockToolbar` positions itself around a block's bounds using `element.getBoundingClientRect()`.

The problem with this is that it doesn't take into account nested elements that overflow the block. For example, Submenu blocks within a Navigation block will overflow the Navigation block when the user hovers over a menu item. This causes the toolbar to be positioned on top of the Submenu which results in a very unusable experience. 

This PR is basically a refresh of @getdave's approach in https://github.com/WordPress/gutenberg/pull/40625, though I've tried to make things a bit more generic.

Instead of using `element.getBoundingClientRect()` we recurse through `element`'s descendants and compute the block's bounds by taking a union of the root rect and all descendent rects. Hidden elements are ignored. This results in a rect that corresponds to what the user _sees_ of the block.

This logic is applied in two places: 1) `BlockPopover` where the `Popover` components `anchor` is computed; and 2) `useBlockToolbarPopover` which decides whether or not to set `flip` and `shift` on the `Popover` depending on whether the block is too close to the header.

## Testing Instructions
1. Install and activate _Emptytheme_, or use the Create Block Theme plugin to create a new empty theme.
2. Go to Appearance → Editor and edit the default template.
3. Insert a Navigation block into the first position in the header template part.
4. Edit the Navigation block and add a submenu to one of the navigation items.
5. Try to edit the submenu. The block toolbar should not obscure your cursor.

Also need to test that the block popover appears correctly for other blocks in other instances.

## Screenshots or screencast 

Before:

https://github.com/WordPress/gutenberg/assets/612155/ffdbeb04-e7c7-42ec-bbb5-ec80af1962a3

After:

https://github.com/WordPress/gutenberg/assets/612155/a21339a4-d4e4-4c49-843c-6e6cdb302a8d