### PR TITLE
[TRY] When running the GB plugin, remove core hooks related to blocks.

### DIFF
--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -142,7 +142,32 @@ module.exports = [
 							transform: ( content ) => {
 								const prefix = 'gutenberg_';
 								const classSuffix = 'Gutenberg';
+								let coreHooks = '';
 								content = content.toString();
+
+								coreHooks = content.match(
+									/^add_(action|filter)\(.*\);/gm
+								);
+
+								if ( coreHooks ) {
+									coreHooks = coreHooks.join( '\n\t\t' );
+									coreHooks = coreHooks.replaceAll(
+										'add_action',
+										'remove_action'
+									);
+									coreHooks = coreHooks.replaceAll(
+										'add_filter',
+										'remove_filter'
+									);
+
+									coreHooks =
+										"\n// Prevent core hooks from firing.\nadd_action(\n\t'init',\n\tfunction() {\n\t\t" +
+										coreHooks +
+										'\n\t},\n\t5\n);\n';
+								} else {
+									// Restore to a string
+									coreHooks = '';
+								}
 
 								// Within content, search and prefix any function calls from the
 								// `prefixFunctions` list. This is needed because some functions
@@ -213,7 +238,7 @@ module.exports = [
 										.replace(
 											/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
 											'$1, 20'
-										)
+										) + coreHooks
 								);
 							},
 							noErrorOnMissing: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Modifying the build script to de-register Core hooks when running the plugin

See #62713.

## Why?

This prevents interference from WordPress Core when modifying the behaviour of functions such as [`register_block_core_footnotes_post_meta()`](https://github.com/WordPress/gutenberg/blob/ca96667e5e2030cb0a7bdfe18b9048fd74deafbb/packages/block-library/src/footnotes/index.php#L86-L107)


## How?

It removes hooks registered by WordPress-Develop on the `init` hook at priority `5`. Using the Footnotes block as an example, the following code is appended to the end of the built file.

```php
// Prevent core hooks from firing.
add_action(
	'init',
	function() {
		remove_action( 'init', 'register_block_core_footnotes' );
		remove_action( 'init', 'register_block_core_footnotes_post_meta', 20 );
		remove_filter( '_wp_post_revision_fields', 'wp_add_footnotes_to_revision' );
		remove_filter( '_wp_post_revision_field_footnotes', 'wp_get_footnotes_from_revision', 10, 3 );
	},
	5
);
```

**How is it broken?**

It's currently broken due to when `gutenberg_reregister_core_block_types` runs. It currently runs at `init, 10` (the default priority). By the time these files are included the hook attempting to de-register the core blocks has already run.

I experimented with running it earlier but that led to issues in which the Gutenberg blocks would be registered prior to the Core blocks. That resulted in a lot of duplicate block registration warnings.

@gziolo @youknowriad I understand you worked on the build script, if you have suggestions for how to fix this I'd really appreciate it. 

## Testing Instructions

TBA: Need to get this working first.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->
