### PR TITLE
Release automation: try cherry-picking automation

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -11,30 +11,43 @@ jobs:
         runs-on: ubuntu-latest
         if: github.event.pull_request.merged == true
         steps:
+            - name: Determine if label should trigger cherry-pick
+              id: label-check
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const labels = context.payload.pull_request.labels.map(label => label.name);
+                      console.log(`Labels: ${labels}`);
+                      const regex = /^Backport to WP ([0-9]+\.[0-9]+) Beta\/RC$/;
+                      let matched = false;
+                      for (const label of labels) {
+                        const match = label.match(regex);
+                        if (match) {
+                          const version = match[1];
+                          console.log(`Matched label: ${label}`);
+                          console.log(`Extracted version: ${version}`);
+                          core.exportVariable('cherry_pick', 'true');
+                          core.exportVariable('version', version);
+                          matched = true;
+                          break;
+                        }
+                      }
+                      if (!matched) {
+                        core.exportVariable('cherry_pick', 'false');
+                      }
+
             - name: Checkout repository
+              if: env.cherry_pick == 'true'
               uses: actions/checkout@v2
               with:
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
                   fetch-depth: 0
 
             - name: Set up Git
+              if: env.cherry_pick == 'true'
               run: |
                   git config --global user.name "Gutenberg Repository Automation"
                   git config --global user.email "gutenberg@wordpress.org"
-
-            - name: Determine if label should trigger cherry-pick
-              id: label-check
-              run: |
-                  LABELS=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
-                  echo "$LABELS"
-                  for LABEL in $LABELS; do
-                    if [[ "$LABEL" =~ ^Backport\ to\ WP\ ([0-9]+\.[0-9]+)\ Beta/RC$ ]]; then
-                      VERSION=${BASH_REMATCH[1]}
-                      echo "cherry_pick=true" >> $GITHUB_ENV
-                      echo "version=$VERSION" >> $GITHUB_ENV
-                      exit 0
-                    fi
-                  done
-                  echo "cherry_pick=false" >> $GITHUB_ENV
 
             - name: Cherry-pick the commit
               id: cherry-pick
@@ -42,39 +55,56 @@ jobs:
               run: |
                   TARGET_BRANCH="wp/${{ env.version }}"
                   COMMIT_SHA=$(jq -r '.pull_request.merge_commit_sha' "$GITHUB_EVENT_PATH")
+                  echo "Target branch: $TARGET_BRANCH"
+                  echo "Commit SHA: $COMMIT_SHA"
                   git checkout $TARGET_BRANCH
                   git cherry-pick $COMMIT_SHA || echo "cherry-pick-failed" > result
                   if [ -f result ] && grep -q "cherry-pick-failed" result; then
                     echo "conflict=true" >> $GITHUB_ENV
                     git cherry-pick --abort
                   else
-                    git push origin $TARGET_BRANCH
+                    NEW_COMMIT_SHA=$(git rev-parse HEAD)
                     echo "conflict=false" >> $GITHUB_ENV
+                    echo "commit_sha=$NEW_COMMIT_SHA" >> $GITHUB_ENV
+                    git push origin $TARGET_BRANCH
                   fi
 
             - name: Remove cherry-pick label
               if: env.cherry_pick == 'true' && env.conflict == 'false'
-              uses: actions/github-script@v6
+              uses: actions/github-script@v7
               with:
                   script: |
-                      const prNumber = ${{ github.event.pull_request.number }};
-                      const label = `Backport to WP ${{ env.version }} Beta/RC`;
-                      await github.issues.removeLabel({
+                      const prNumber = context.issue.number;
+                      const version = process.env.version;
+                      console.log(`prNumber: ${prNumber}`);
+                      console.log(`version: ${version}`);
+                      const oldLabel = `Backport to WP ${version} Beta/RC`;
+                      const newLabel = `Backported to WP Core`;
+                      await github.rest.issues.removeLabel({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
-                        name: label
+                        name: oldLabel
+                      });
+                      await github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                        labels: [newLabel]
                       });
 
             - name: Comment on the PR
               if: env.cherry_pick == 'true' && env.conflict == 'false'
-              uses: actions/github-script@v6
+              uses: actions/github-script@v7
               with:
                   script: |
-                      const prNumber = ${{ github.event.pull_request.number }};
-                      const commitSha = '${{ steps.cherry-pick.outputs.commit_sha }}';
-                      const targetBranch = `wp/${{ env.version }}`;
-                      await github.issues.createComment({
+                      const prNumber = context.issue.number;
+                      const commitSha = process.env.commit_sha;
+                      const targetBranch = `wp/${process.env.version}`;
+                      console.log(`prNumber: ${prNumber}`);
+                      console.log(`commitSha: ${commitSha}`);
+                      console.log(`targetBranch: ${targetBranch}`);
+                      await github.rest.issues.createComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
@@ -83,12 +113,14 @@ jobs:
 
             - name: Comment on the PR about conflict
               if: env.cherry_pick == 'true' && env.conflict == 'true'
-              uses: actions/github-script@v6
+              uses: actions/github-script@v7
               with:
                   script: |
-                      const prNumber = ${{ github.event.pull_request.number }};
-                      const targetBranch = `wp/${{ env.version }}`;
-                      await github.issues.createComment({
+                      const prNumber = context.issue.number;
+                      const targetBranch = `wp/${process.env.version}`;
+                      console.log(`prNumber: ${prNumber}`);
+                      console.log(`targetBranch: ${targetBranch}`);
+                      await github.rest.issues.createComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -1,0 +1,95 @@
+name: Auto Cherry-Pick
+
+on:
+    pull_request:
+        types: [closed, labeled]
+        branches:
+            - try/cherry-pick-automation-trunk # To be replaced with "trunk".
+
+jobs:
+    cherry-pick:
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.merged == true
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Git
+              run: |
+                  git config --global user.name "Gutenberg Repository Automation"
+                  git config --global user.email "gutenberg@wordpress.org"
+
+            - name: Determine if label should trigger cherry-pick
+              id: label-check
+              run: |
+                  LABELS=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
+                  for LABEL in $LABELS; do
+                    if [[ "$LABEL" =~ ^Backport\ to\ WP\ ([0-9]+\.[0-9]+)\ Beta/RC$ ]]; then
+                      VERSION=${BASH_REMATCH[1]}
+                      echo "::set-output name=cherry_pick::true"
+                      echo "::set-output name=version::$VERSION"
+                      exit 0
+                    fi
+                  done
+                  echo "::set-output name=cherry_pick::false"
+
+            - name: Cherry-pick the commit
+              id: cherry-pick
+              if: steps.label-check.outputs.cherry_pick == 'true'
+              run: |
+                  TARGET_BRANCH="wp/${{ steps.label-check.outputs.version }}"
+                  COMMIT_SHA=$(jq -r '.pull_request.merge_commit_sha' "$GITHUB_EVENT_PATH")
+                  git checkout $TARGET_BRANCH
+                  git cherry-pick $COMMIT_SHA || echo "cherry-pick-failed" > result
+                  if [ -f result ] && grep -q "cherry-pick-failed" result; then
+                    echo "::set-output name=conflict::true"
+                    git cherry-pick --abort
+                  else
+                    git push origin $TARGET_BRANCH
+                    echo "::set-output name=conflict::false"
+                  fi
+
+            - name: Remove cherry-pick label
+              if: steps.label-check.outputs.cherry_pick == 'true' && steps.cherry-pick.outputs.conflict == 'false'
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const prNumber = ${{ github.event.pull_request.number }};
+                      const label = `Backport to WP ${{ steps.label-check.outputs.version }} Beta/RC`;
+                      await github.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                        name: label
+                      });
+
+            - name: Comment on the PR
+              if: steps.label-check.outputs.cherry_pick == 'true' && steps.cherry-pick.outputs.conflict == 'false'
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const prNumber = ${{ github.event.pull_request.number }};
+                      const commitSha = '${{ steps.cherry-pick.outputs.commit_sha }}';
+                      const targetBranch = `wp/${{ steps.label-check.outputs.version }}`;
+                      await github.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${commitSha}`
+                      });
+
+            - name: Comment on the PR about conflict
+              if: steps.label-check.outputs.cherry_pick == 'true' && steps.cherry-pick.outputs.conflict == 'true'
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const prNumber = ${{ github.event.pull_request.number }};
+                      const targetBranch = `wp/${{ steps.label-check.outputs.version }}`;
+                      await github.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                        body: `There was a conflict while trying to cherry-pick the commit to the ${targetBranch} branch. Please resolve the conflict manually and create a PR to the ${targetBranch} branch.`
+                      });

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -25,39 +25,40 @@ jobs:
               id: label-check
               run: |
                   LABELS=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
+                  echo "$LABELS"
                   for LABEL in $LABELS; do
                     if [[ "$LABEL" =~ ^Backport\ to\ WP\ ([0-9]+\.[0-9]+)\ Beta/RC$ ]]; then
                       VERSION=${BASH_REMATCH[1]}
-                      echo "::set-output name=cherry_pick::true"
-                      echo "::set-output name=version::$VERSION"
+                      echo "cherry_pick=true" >> $GITHUB_ENV
+                      echo "version=$VERSION" >> $GITHUB_ENV
                       exit 0
                     fi
                   done
-                  echo "::set-output name=cherry_pick::false"
+                  echo "cherry_pick=false" >> $GITHUB_ENV
 
             - name: Cherry-pick the commit
               id: cherry-pick
-              if: steps.label-check.outputs.cherry_pick == 'true'
+              if: env.cherry_pick == 'true'
               run: |
-                  TARGET_BRANCH="wp/${{ steps.label-check.outputs.version }}"
+                  TARGET_BRANCH="wp/${{ env.version }}"
                   COMMIT_SHA=$(jq -r '.pull_request.merge_commit_sha' "$GITHUB_EVENT_PATH")
                   git checkout $TARGET_BRANCH
                   git cherry-pick $COMMIT_SHA || echo "cherry-pick-failed" > result
                   if [ -f result ] && grep -q "cherry-pick-failed" result; then
-                    echo "::set-output name=conflict::true"
+                    echo "conflict=true" >> $GITHUB_ENV
                     git cherry-pick --abort
                   else
                     git push origin $TARGET_BRANCH
-                    echo "::set-output name=conflict::false"
+                    echo "conflict=false" >> $GITHUB_ENV
                   fi
 
             - name: Remove cherry-pick label
-              if: steps.label-check.outputs.cherry_pick == 'true' && steps.cherry-pick.outputs.conflict == 'false'
+              if: env.cherry_pick == 'true' && env.conflict == 'false'
               uses: actions/github-script@v6
               with:
                   script: |
                       const prNumber = ${{ github.event.pull_request.number }};
-                      const label = `Backport to WP ${{ steps.label-check.outputs.version }} Beta/RC`;
+                      const label = `Backport to WP ${{ env.version }} Beta/RC`;
                       await github.issues.removeLabel({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -66,13 +67,13 @@ jobs:
                       });
 
             - name: Comment on the PR
-              if: steps.label-check.outputs.cherry_pick == 'true' && steps.cherry-pick.outputs.conflict == 'false'
+              if: env.cherry_pick == 'true' && env.conflict == 'false'
               uses: actions/github-script@v6
               with:
                   script: |
                       const prNumber = ${{ github.event.pull_request.number }};
                       const commitSha = '${{ steps.cherry-pick.outputs.commit_sha }}';
-                      const targetBranch = `wp/${{ steps.label-check.outputs.version }}`;
+                      const targetBranch = `wp/${{ env.version }}`;
                       await github.issues.createComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -81,12 +82,12 @@ jobs:
                       });
 
             - name: Comment on the PR about conflict
-              if: steps.label-check.outputs.cherry_pick == 'true' && steps.cherry-pick.outputs.conflict == 'true'
+              if: env.cherry_pick == 'true' && env.conflict == 'true'
               uses: actions/github-script@v6
               with:
                   script: |
                       const prNumber = ${{ github.event.pull_request.number }};
-                      const targetBranch = `wp/${{ steps.label-check.outputs.version }}`;
+                      const targetBranch = `wp/${{ env.version }}`;
                       await github.issues.createComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -4,7 +4,7 @@ on:
     pull_request:
         types: [closed, labeled]
         branches:
-            - try/cherry-pick-automation-trunk # To be replaced with "trunk".
+            - trunk
 
 # Ensure that new jobs wait for the previous job to finish.
 concurrency:

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -6,6 +6,11 @@ on:
         branches:
             - try/cherry-pick-automation-trunk # To be replaced with "trunk".
 
+# Ensure that new jobs wait for the previous job to finish.
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
 jobs:
     cherry-pick:
         runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The idea is to have a designated label `Backport to WP 6.6 Beta/RC` and once a PR against trunk is merged with that label, it automatically cherry-picks that PR into the right release branch, removes the label, and comments on the PR. It should also work if the label is applied after merge. If there is a conflict, it will comment on the PR to make a PR against the `wp/*` manually.

## Why?

Cherry-picking can be tedious, and it would be good to cherry-pick as soon as PRs are merged into trunk. That way conflicts can be detected and addressed early.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See the workflow for details in logic.

To see it in action, this is the latest version: https://github.com/WordPress/gutenberg/pull/62735#issuecomment-2182500147

Also, jobs will wait for the last one to finish so the checkout are always fresh.

![image](https://github.com/WordPress/gutenberg/assets/4710635/26334733-b544-477f-828d-cf7088d16b54)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I will attempt to create two branches that are based on this one:
* [`wp/0.0`](https://github.com/WordPress/gutenberg/tree/wp/0.0), to test if PRs get cherry-picked.
* [`try/cherry-pick-automation-trunk`](https://github.com/WordPress/gutenberg/tree/try/cherry-pick-automation-trunk) to simulate trunk.

Then I will create a few PRs against `try/cherry-pick-automation-trunk` to test if they get cherry-picked:
* ✅ One applying the label before merge: #62731
* ✅ One applying the label after merge: https://github.com/WordPress/gutenberg/pull/62735#issuecomment-2182500147
* ✅ One with a conflict. It works: https://github.com/WordPress/gutenberg/pull/62724#issuecomment-2182323507

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
