### PR TITLE
Eslint-plugin: Add method-signature-style TypeScript lint rule

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   `CustomSelectControlV2`: fix trigger button font size. ([#63131](https://github.com/WordPress/gutenberg/pull/63131))
 -   Extract `TimeInput` component from `TimePicker` ([#60613](https://github.com/WordPress/gutenberg/pull/60613)).
 -   `TimeInput`: Add `label` prop ([#63106](https://github.com/WordPress/gutenberg/pull/63106)).
+-   Method style type signatures have been changed to function style ([#62718](https://github.com/WordPress/gutenberg/pull/62718)).
 
 ## 28.2.0 (2024-06-26)
 

--- a/packages/components/src/menu-items-choice/types.ts
+++ b/packages/components/src/menu-items-choice/types.ts
@@ -20,7 +20,8 @@ export type MenuItemsChoiceProps = {
 	 * Callback function to be called with the selected choice when user
 	 * selects a new choice.
 	 */
-	onSelect( value: string ): void;
+	onSelect: ( value: string ) => void;
+
 	/**
 	 * Callback function to be called with a choice when user
 	 * hovers over a new choice (will be empty on mouse leave).

--- a/packages/components/src/resizable-box/resize-tooltip/utils.ts
+++ b/packages/components/src/resizable-box/resize-tooltip/utils.ts
@@ -25,7 +25,7 @@ interface UseResizeLabelProps {
 interface UseResizeLabelArgs {
 	axis?: Axis;
 	fadeTimeout: number;
-	onResize( data: { width: number | null; height: number | null } ): void;
+	onResize: ( data: { width: number | null; height: number | null } ) => void;
 	position: Position;
 	showPx: boolean;
 }

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Method style type signatures have been changed to function style ([#62718](https://github.com/WordPress/gutenberg/pull/62718)).
+
 ## 7.2.0 (2024-06-26)
 
 ## 7.1.0 (2024-06-15)

--- a/packages/compose/src/utils/debounce/index.ts
+++ b/packages/compose/src/utils/debounce/index.ts
@@ -59,7 +59,7 @@ export interface DebouncedFunc< T extends ( ...args: any[] ) => any > {
 	/**
 	 * Throw away any pending invocation of the debounced function.
 	 */
-	cancel(): void;
+	cancel: () => void;
 
 	/**
 	 * If there is a pending invocation of the debounced function, invoke it immediately and return
@@ -68,7 +68,7 @@ export interface DebouncedFunc< T extends ( ...args: any[] ) => any > {
 	 * Otherwise, return the value from the last invocation, or undefined if the debounced function
 	 * was never invoked.
 	 */
-	flush(): ReturnType< T > | undefined;
+	flush: () => ReturnType< T > | undefined;
 }
 
 /**

--- a/packages/compose/src/utils/observable-map/index.ts
+++ b/packages/compose/src/utils/observable-map/index.ts
@@ -1,8 +1,8 @@
 export type ObservableMap< K, V > = {
-	get( name: K ): V | undefined;
-	set( name: K, value: V ): void;
-	delete( name: K ): void;
-	subscribe( name: K, listener: () => void ): () => void;
+	get: ( name: K ) => V | undefined;
+	set: ( name: K, value: V ) => void;
+	delete: ( name: K ) => void;
+	subscribe: ( name: K, listener: () => void ) => () => void;
 };
 
 /**

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### New features
 
-- Added a new `DataForm` component to render controls from a given configuration (fields, form), and data.
+-   Added a new `DataForm` component to render controls from a given configuration (fields, form), and data.
+
+### Internal
+
+-   Method style type signatures have been changed to function style ([#62718](https://github.com/WordPress/gutenberg/pull/62718)).
 
 ## 2.2.0 (2024-06-26)
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -406,7 +406,7 @@ export interface ViewBaseProps< Item > {
 	fields: NormalizedField< Item >[];
 	getItemId: ( item: Item ) => string;
 	isLoading?: boolean;
-	onChangeView( view: View ): void;
+	onChangeView: ( view: View ) => void;
 	onSelectionChange: SetSelection;
 	selection: string[];
 	setOpenedFilter: ( fieldId: string ) => void;

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Add [`@typescript-eslint/method-signature-style` rule](https://typescript-eslint.io/rules/method-signature-style) to the recommended TypeScript ruleset ([#62718](https://github.com/WordPress/gutenberg/pull/62718)).
+
 ## 19.2.0 (2024-06-26)
 
 ## 19.1.0 (2024-06-15)

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -60,6 +60,7 @@ if ( isPackageInstalled( 'typescript' ) ) {
 				// no-shadow doesn't work correctly in TS, so let's use a TS-dedicated version instead.
 				'no-shadow': 'off',
 				'@typescript-eslint/no-shadow': 'error',
+				'@typescript-eslint/method-signature-style': 'error',
 			},
 		},
 	];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Add the [method-signature-style](https://typescript-eslint.io/rules/method-signature-style) to the recommended TypeScript rule set.

## Why?

This subtle change is not obvious but can dramatically weaken (or strengthen) the type system.

```ts
type Rec = Record<string, unknown>;

interface Post extends Rec { status: string; }

interface Base<T> {
  isEligibleMethod(item: T): boolean;
  isEligibleFunc: (item: T) => boolean;
}

const base: Base<Rec> = {
  // Using the "method" type syntax above weakens the type checking.
  // This is not a type error!!!
  isEligibleMethod: (item: Post) => item.status.startsWith('foo'),

  // This is a type error as expected.
  isEligibleFunc: (item: Post) => item.status.startsWith('foo'),
}

// With method, we could trigger runtime type errors that seem obviously wrong:
base.isEligibleMethod({}); // Cannot read properties of undefined (reading 'startsWith')
```

See https://typescript-eslint.io/rules/method-signature-style

This was discovered in https://github.com/WordPress/gutenberg/pull/62647#discussion_r1647980168 with the help of @jsnajdr.

## How?

Add and enable the rule in the recommended TypeScript rule set.

## Testing Instructions

CI passes.