### PR TITLE
Adds comment on blocks resource referencing wp_block post type.

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -55,6 +55,7 @@ export default function AddNewPattern() {
 				?.add_new_item,
 			addNewTemplatePartLabel: getPostType( TEMPLATE_PART_POST_TYPE )
 				?.labels?.add_new_item,
+			// Blocks refers to the wp_block post type, this checks the ability to create a post of that type.
 			canCreatePattern: canUser( 'create', 'blocks' ),
 			canCreateTemplatePart: canUser( 'create', 'template-parts' ),
 		};

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -85,6 +85,7 @@ export default function PatternConvertButton( {
 						hasBlockSupport( block.name, 'reusable', true )
 				) &&
 				// Hide when current doesn't have permission to do that.
+				// Blocks refers to the wp_block post type, this checks the ability to create a post of that type.
 				!! canUser( 'create', 'blocks' );
 
 			return _canConvert;

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -92,6 +92,7 @@ export default function ReusableBlockConvertButton( {
 						hasBlockSupport( block.name, 'reusable', true )
 				) &&
 				// Hide when current doesn't have permission to do that.
+				// Blocks refers to the wp_block post type, this checks the ability to create a post of that type.
 				!! canUser( 'create', 'blocks' );
 
 			return _canConvert;


### PR DESCRIPTION
Addresses a comment by @carolinan on https://github.com/WordPress/gutenberg/pull/62633#discussion_r1648299258 that I missed addressing.
It makes it clear 'blocks' resource references wp_blocks post type. I also added the comment to other places where it could be applied.

