### PR TITLE
Add writing mode support to other blocks

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -93,6 +93,7 @@
 			"__experimentalTextTransform": true,
 			"__experimentalTextDecoration": true,
 			"__experimentalLetterSpacing": true,
+			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -44,6 +44,7 @@
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
+			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -55,6 +55,7 @@
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
+			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -51,6 +51,7 @@
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
 			"__experimentalTextDecoration": true,
+			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Partially addresses https://github.com/WordPress/gutenberg/issues/62693

This PR brings support for writing mode on more blocks. In particular: the button, verse, site tagline and site title blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/50822 we introduced this new control for headings and paragraphs. There are other blocks that could use this new option. Let's discuss if there's other blocks that we could include

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just enabling the prop on block.json

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Insert the updated blocks on a template or a post. The new options should show under typography / orientation.
- Check that changing the orientation behaves as expected in the editor and frontend
- Check that changing the values for this in theme.json is also applied to the blocks. For example:

```
	"styles": {
		"blocks": {
			"core/site-title": {
				"typography": {
					"writingMode": "vertical-rl"
				}
			},
			"core/site-tagline": {
				"typography": {
					"writingMode": "vertical-rl"
				}
			},
			"core/verse": {
				"typography": {
					"writingMode": "vertical-rl"
				}
			}
		},
		"elements": {
			"button": {
				"typography": {
					"writingMode": "vertical-rl"
				}
			}
		}
	}
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1313" alt="Screenshot 2024-06-21 at 16 21 48" src="https://github.com/WordPress/gutenberg/assets/3593343/2a13a220-b6a2-417d-bcb3-8b5a4af5dfdb">
