### PR TITLE
Button block: Fix fatal error on WordPress 6.4

### DIFF
--- a/lib/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php
+++ b/lib/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php
@@ -2447,5 +2447,4 @@ class Gutenberg_HTML_Tag_Processor_6_4 {
 
 		return true;
 	}
-
 }

--- a/lib/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php
+++ b/lib/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php
@@ -2447,4 +2447,5 @@ class Gutenberg_HTML_Tag_Processor_6_4 {
 
 		return true;
 	}
+
 }

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -18,6 +18,7 @@
  */
 function render_block_core_button( $attributes, $content ) {
 	$p = new Gutenberg_HTML_Tag_Processor_6_5( $content );
+
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a
 	 * `<div>` wrapper. Find the a or button tag.

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -17,6 +17,9 @@
  * @return string The block content.
  */
 function render_block_core_button( $attributes, $content ) {
+	if ( ! is_wp_version_compatible( '6.5' ) ) {
+		return $content;
+	}
 	$p = new WP_HTML_Tag_Processor( $content );
 
 	/*

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -18,8 +18,10 @@
  */
 function render_block_core_button( $attributes, $content ) {
 	// TODO: Remove conditional when 6.6 is released.
-	$p = ( ! is_wp_version_compatible( '6.5' ) && defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN )
-		? new Gutenberg_HTML_Tag_Processor_6_5( $content ) : new WP_HTML_Tag_Processor( $content );
+	if ( ! is_wp_version_compatible( '6.5' ) && defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		return $content;
+	}
+	$p = new WP_HTML_Tag_Processor( $content );
 
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -17,12 +17,7 @@
  * @return string The block content.
  */
 function render_block_core_button( $attributes, $content ) {
-	// TODO: Remove this line when 6.6 releases.
-	if ( ! is_wp_version_compatible( '6.5' ) ) {
-		return $content;
-	}
-	$p = new WP_HTML_Tag_Processor( $content );
-
+	$p = new Gutenberg_HTML_Tag_Processor_6_5( $content );
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a
 	 * `<div>` wrapper. Find the a or button tag.

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -17,6 +17,7 @@
  * @return string The block content.
  */
 function render_block_core_button( $attributes, $content ) {
+	// TODO: Remove this line when 6.6 releases.
 	if ( ! is_wp_version_compatible( '6.5' ) ) {
 		return $content;
 	}

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -17,7 +17,9 @@
  * @return string The block content.
  */
 function render_block_core_button( $attributes, $content ) {
-	$p = new Gutenberg_HTML_Tag_Processor_6_5( $content );
+	// TODO: Remove conditional when 6.6 is released.
+	$p = ( ! is_wp_version_compatible( '6.5' ) && defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN )
+		? new Gutenberg_HTML_Tag_Processor_6_5( $content ) : new WP_HTML_Tag_Processor( $content );
 
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
For at least one month, Gutenberg should be compatible with WordPress 6.4

A block bindings [commit](https://github.com/WordPress/gutenberg/commit/9c3dabc595101bd285723a4fac266c132fbd489c) added a render PHP for the button block. And is using a `WP_HTML_Tag_Processor` method that doesn't exist in 6.4.

6.5 compatibility Tag processor contains it.

## Screenshots or screencast <!-- if applicable -->

Without the fix:
![Screenshot 2024-06-21 at 11 58 59](https://github.com/WordPress/gutenberg/assets/37012961/189a3305-f2ff-41c3-bcbd-b5eb69533263)

With the fix:
![Screenshot 2024-06-21 at 11 59 24](https://github.com/WordPress/gutenberg/assets/37012961/b119d9a9-8022-4c2c-9fef-b8e2945cee5c)
