### PR TITLE
Block Hooks API: Update Template Part block for first and last child hooked blocks

### DIFF
--- a/lib/compat/wordpress-6.7/block-template-utils.php
+++ b/lib/compat/wordpress-6.7/block-template-utils.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Inject ignoredHookedBlocks metadata attributes into a template or template part.
+ *
+ * Given an object that represents a `wp_template` or `wp_template_part` post object
+ * prepared for inserting or updating the database, locate all blocks that have
+ * hooked blocks, and inject a `metadata.ignoredHookedBlocks` attribute into the anchor
+ * blocks to reflect the latter.
+ *
+ * @access private
+ *
+ * @param stdClass        $changes    An object representing a template or template part
+ *                                    prepared for inserting or updating the database.
+ * @param WP_REST_Request $deprecated Deprecated. Not used.
+ * @return stdClass|WP_Error The updated object representing a template or template part.
+ */
+function gutenberg_inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated = null ) {
+	if ( null !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '6.5.3' );
+	}
+
+	$hooked_blocks = get_hooked_blocks();
+	if ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) {
+		return $changes;
+	}
+
+	$meta  = isset( $changes->meta_input ) ? $changes->meta_input : array();
+	$terms = isset( $changes->tax_input ) ? $changes->tax_input : array();
+
+	if ( empty( $changes->ID ) ) {
+		// There's no post object for this template in the database for this template yet.
+		$post = $changes;
+	} else {
+		// Find the existing post object.
+		$post = get_post( $changes->ID );
+
+		// If the post is a revision, use the parent post's post_name and post_type.
+		$post_id = wp_is_post_revision( $post );
+		if ( $post_id ) {
+			$parent_post     = get_post( $post_id );
+			$post->post_name = $parent_post->post_name;
+			$post->post_type = $parent_post->post_type;
+		}
+
+		// Apply the changes to the existing post object.
+		$post = (object) array_merge( (array) $post, (array) $changes );
+
+		$type_terms        = get_the_terms( $changes->ID, 'wp_theme' );
+		$terms['wp_theme'] = ! is_wp_error( $type_terms ) && ! empty( $type_terms ) ? $type_terms[0]->name : null;
+	}
+
+	// Required for the WP_Block_Template. Update the post object with the current time.
+	$post->post_modified = current_time( 'mysql' );
+
+	// If the post_author is empty, set it to the current user.
+	if ( empty( $post->post_author ) ) {
+		$post->post_author = get_current_user_id();
+	}
+
+    $wp_post = new WP_Post( $post );
+
+	if ( 'wp_template_part' === $post->post_type && ! isset( $terms['wp_template_part_area'] ) ) {
+		$area_terms                     = get_the_terms( $changes->ID, 'wp_template_part_area' );
+		$terms['wp_template_part_area'] = ! is_wp_error( $area_terms ) && ! empty( $area_terms ) ? $area_terms[0]->name : null;
+
+        /**
+		 * Hooked blocks that are ignored from a template part as first_child or last_child
+		 * are not inserted into the template part's content because they have no parent block.
+		 * Instead, they are inserted into the postmeta.
+		*/
+		gutenberg_update_ignored_hooked_blocks_postmeta( $wp_post );
+	}
+
+	$template = _build_block_template_object_from_post_object( $wp_post, $terms, $meta );
+
+	if ( is_wp_error( $template ) ) {
+		return $template;
+	}
+
+	$changes->post_content = apply_block_hooks_to_content( $changes->post_content, $template, 'set_ignored_hooked_blocks_metadata' );
+
+	return $changes;
+}
+
+add_filter( 'rest_pre_insert_wp_template_part', 'gutenberg_inject_ignored_hooked_blocks_metadata_attributes' );

--- a/lib/compat/wordpress-6.7/blocks.php
+++ b/lib/compat/wordpress-6.7/blocks.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Updates the wp_postmeta with the list of ignored hooked blocks where the inner blocks are stored as post content.
+ * Currently only supports `wp_navigation` and `wp_template_part` post types.
+ *
+ * @access private
+ *
+ * @param stdClass $post Post object.
+ * @return stdClass The updated post object.
+ */
+function gutenberg_update_ignored_hooked_blocks_postmeta( $post ) {
+	/*
+	 * In this scenario the user has likely tried to create a navigation via the REST API.
+	 * In which case we won't have a post ID to work with and store meta against.
+	 */
+	if ( empty( $post->ID ) ) {
+		return $post;
+	}
+
+	/*
+	 * Skip meta generation when consumers intentionally update specific Navigation fields
+	 * and omit the content update.
+	 */
+	if ( ! isset( $post->post_content ) ) {
+		return $post;
+	}
+
+    $post_type_to_block_name_map = array(
+		'wp_navigation'    => 'core/navigation',
+		'wp_template_part' => 'core/template-part',
+	);
+
+	/*
+	 * Skip meta generation when the post content is not in the above map.
+	 */
+	if ( ! isset( $post->post_type ) || ! isset( $post_type_to_block_name_map[ $post->post_type ] ) ) {
+		return $post;
+	}
+
+    $parent_block_name = $post_type_to_block_name_map[ $post->post_type ];
+	$attributes = array();
+
+	$ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$ignored_hooked_blocks  = json_decode( $ignored_hooked_blocks, true );
+		$attributes['metadata'] = array(
+			'ignoredHookedBlocks' => $ignored_hooked_blocks,
+		);
+	}
+
+	$markup = get_comment_delimited_block_content(
+        $parent_block_name,
+		$attributes,
+		$post->post_content
+	);
+
+	$serialized_block = apply_block_hooks_to_content( $markup, get_post( $post->ID ), 'set_ignored_hooked_blocks_metadata' );
+	$root_block       = parse_blocks( $serialized_block )[0];
+
+	$ignored_hooked_blocks = isset( $root_block['attrs']['metadata']['ignoredHookedBlocks'] )
+		? $root_block['attrs']['metadata']['ignoredHookedBlocks']
+		: array();
+
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$existing_ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );
+		if ( ! empty( $existing_ignored_hooked_blocks ) ) {
+			$existing_ignored_hooked_blocks = json_decode( $existing_ignored_hooked_blocks, true );
+			$ignored_hooked_blocks          = array_unique( array_merge( $ignored_hooked_blocks, $existing_ignored_hooked_blocks ) );
+		}
+		update_post_meta( $post->ID, '_wp_ignored_hooked_blocks', json_encode( $ignored_hooked_blocks ) );
+	}
+
+	$post->post_content = remove_serialized_parent_block( $serialized_block );
+	return $post;
+}
+
+if ( ! has_filter( 'rest_pre_insert_wp_template_part', 'update_ignored_hooked_blocks_postmeta' ) ) {
+    add_filter( 'rest_pre_insert_wp_template_part', 'gutenberg_update_ignored_hooked_blocks_postmeta' );
+}

--- a/lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php
+++ b/lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Templates_Controller_6_7 class
+ *
+ * @package    gutenberg
+ */
+
+/**
+ * Gutenberg_REST_Templates_Controller_6_7 class
+ */
+class Gutenberg_REST_Templates_Controller_6_7 extends Gutenberg_REST_Templates_Controller_6_6 {
+	/**
+	 * Add revisions to the response.
+	 *
+	 * @param WP_Block_Template $item    Template instance.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$template = $item;
+
+		$response = parent::prepare_item_for_response( $item, $request );
+
+		/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
+		return apply_filters( "rest_prepare_{$this->post_type}", $response, $template, $request );
+	}
+}

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -1,0 +1,25 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+if ( ! function_exists( 'wp_api_template_response_filter_controller' ) ) {
+	/**
+	 * Hook in to the template and template part post types and modify the
+	 * access control for the rest endpoint to allow lower user roles to access
+	 * the templates and template parts.
+	 *
+	 * @param array  $args Current registered post type args.
+	 * @param string $post_type Name of post type.
+	 *
+	 * @return array
+	 */
+	function wp_api_template_response_filter_controller( $args, $post_type ) {
+		if ( 'wp_template' === $post_type || 'wp_template_part' === $post_type ) {
+			$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_6_7';
+		}
+		return $args;
+	}
+}
+add_filter( 'register_post_type_args', 'wp_api_template_response_filter_controller', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -51,6 +51,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';
 	require __DIR__ . '/compat/wordpress-6.6/rest-api.php';
 
+	// WordPress 6.7 compat.
+	require __DIR__ . '/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php';
+	require __DIR__ . '/compat/wordpress-6.7/rest-api.php';
+	require __DIR__ . '/compat/wordpress-6.7/blocks.php';
+	require __DIR__ . '/compat/wordpress-6.7/block-template-utils.php';
+
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';
 	require_once __DIR__ . '/class-wp-rest-edit-site-export-controller-gutenberg.php';


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60854

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a proof of concept exploring various ways to allow insertion of `first_child` and `last_child` insertions of hooked blocks into template parts. You can find another approach here https://github.com/WordPress/wordpress-develop/pull/6867

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently inserting hooked blocks as `first_child` and `last_child` is not possible

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

```php
function register_logout_block_as_hooked_block( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( 'core/template-part' === $anchor_block && 'first_child' === $position ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'register_logout_block_as_hooked_block', 10, 4 );
```

## Screenshots or screencast <!-- if applicable -->
