### PR TITLE
CustomSelectControl V2: fix setting initial value and reacting to external controlled updates

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Internal
 
 -   `CustomSelectControl`: align unit tests for v1 and legacy v2 versions. ([#62706](https://github.com/WordPress/gutenberg/pull/62706))
--   `CustomSelectControl`: fix handling of extra option attributes in the `onChange` callbacks and when forwarding them to the option DOM elements. ([#62255](https://github.com/WordPress/gutenberg/pull/62255))
+-   `CustomSelectControlV2`: fix handling of extra option attributes in the `onChange` callbacks and when forwarding them to the option DOM elements. ([#62255](https://github.com/WordPress/gutenberg/pull/62255))
+-   `CustomSelectControlV2`: fix setting initial value and reacting to external controlled updates. ([#62733](https://github.com/WordPress/gutenberg/pull/62733))
 
 ## 28.1.0 (2024-06-15)
 

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -51,6 +51,12 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 			};
 			onChange( changeObject );
 		},
+		value: value?.name,
+		// Setting the first option as a default value when no value is provided
+		// is already done natively by the underlying Ariakit component,
+		// but doing this explicitly avoids the `onChange` callback from firing
+		// on initial render, thus making this implementation closer to the v1.
+		defaultValue: options[ 0 ]?.name,
 	} );
 
 	const children = options.map(

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -292,33 +292,21 @@ describe.each( [
 			} )
 		);
 
-		// NOTE: legacy CustomSelectControl doesn't fire onChange
-		// at this point in time.
-		expect( mockOnChange ).toHaveBeenNthCalledWith(
-			1,
-			expect.objectContaining( {
-				inputValue: '',
-				isOpen: false,
-				selectedItem: { key: 'flower1', name: 'violets' },
-				type: '',
-			} )
-		);
-
 		await click(
 			screen.getByRole( 'option', {
 				name: 'aquamarine',
 			} )
 		);
 
-		expect( mockOnChange ).toHaveBeenNthCalledWith(
-			2,
+		expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+		expect( mockOnChange ).toHaveBeenLastCalledWith(
 			expect.objectContaining( {
 				inputValue: '',
 				isOpen: false,
 				selectedItem: expect.objectContaining( {
 					name: 'aquamarine',
 				} ),
-				type: '',
+				type: expect.any( String ),
 			} )
 		);
 	} );
@@ -336,23 +324,11 @@ describe.each( [
 			} )
 		).toHaveFocus();
 
-		// NOTE: legacy CustomSelectControl doesn't fire onChange
-		// at this point in time.
-		expect( mockOnChange ).toHaveBeenNthCalledWith(
-			1,
-			expect.objectContaining( {
-				selectedItem: expect.objectContaining( {
-					key: 'flower1',
-					name: 'violets',
-				} ),
-			} )
-		);
-
 		await type( 'p' );
 		await press.Enter();
 
-		expect( mockOnChange ).toHaveBeenNthCalledWith(
-			2,
+		expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+		expect( mockOnChange ).toHaveBeenLastCalledWith(
 			expect.objectContaining( {
 				selectedItem: expect.objectContaining( {
 					key: 'flower3',
@@ -387,10 +363,7 @@ describe.each( [
 
 		await click( optionWithCustomAttributes );
 
-		// NOTE: legacy CustomSelectControl doesn't fire onChange
-		// on first render, and so at this point in time `onChangeMock`
-		// would be called only once.
-		expect( onChangeMock ).toHaveBeenCalledTimes( 2 );
+		expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
 		expect( onChangeMock ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				selectedItem: expect.objectContaining( {

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -83,11 +83,48 @@ const ControlledCustomSelectControl = ( {
 	);
 };
 
+it( 'Should apply external controlled updates', async () => {
+	const mockOnChange = jest.fn();
+	const { rerender } = render(
+		<UncontrolledCustomSelectControl
+			{ ...legacyProps }
+			value={ legacyProps.options[ 0 ] }
+			onChange={ mockOnChange }
+		/>
+	);
+
+	const currentSelectedItem = screen.getByRole( 'combobox', {
+		expanded: false,
+	} );
+
+	expect( currentSelectedItem ).toHaveTextContent(
+		legacyProps.options[ 0 ].name
+	);
+
+	expect( mockOnChange ).not.toHaveBeenCalled();
+
+	rerender(
+		<UncontrolledCustomSelectControl
+			{ ...legacyProps }
+			value={ legacyProps.options[ 1 ] }
+		/>
+	);
+
+	expect( currentSelectedItem ).toHaveTextContent(
+		legacyProps.options[ 1 ].name
+	);
+
+	// Necessary to wait for onChange to potentially fire
+	await sleep();
+
+	expect( mockOnChange ).not.toHaveBeenCalled();
+} );
+
 describe.each( [
 	[ 'Uncontrolled', UncontrolledCustomSelectControl ],
 	[ 'Controlled', ControlledCustomSelectControl ],
 ] )( 'CustomSelectControl (%s)', ( ...modeAndComponent ) => {
-	const [ mode, Component ] = modeAndComponent;
+	const [ , Component ] = modeAndComponent;
 
 	it( 'Should select the first option when no explicit initial value is passed without firing onChange', async () => {
 		const mockOnChange = jest.fn();
@@ -126,34 +163,6 @@ describe.each( [
 
 		expect( mockOnChange ).not.toHaveBeenCalled();
 	} );
-
-	// Using the "Uncontrolled" version of the component
-	// in order to apply controlled logic directly in the test
-	if ( mode === 'Uncontrolled' ) {
-		it( 'Should apply external controlled updates', async () => {
-			const { rerender } = render(
-				<Component
-					{ ...legacyProps }
-					value={ legacyProps.options[ 0 ] }
-				/>
-			);
-
-			const currentSelectedItem = screen.getByRole( 'combobox', {
-				expanded: false,
-			} );
-
-			expect( currentSelectedItem ).toHaveTextContent( 'violets' );
-
-			rerender(
-				<Component
-					{ ...legacyProps }
-					value={ legacyProps.options[ 1 ] }
-				/>
-			);
-
-			expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
-		} );
-	}
 
 	it( 'Should replace the initial selection when a new item is selected', async () => {
 		render( <Component { ...legacyProps } /> );

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -134,7 +134,7 @@ describe.each( [
 			screen.getByRole( 'combobox', {
 				expanded: false,
 			} )
-		).toHaveTextContent( 'violets' );
+		).toHaveTextContent( legacyProps.options[ 0 ].name );
 
 		// Necessary to wait for onChange to potentially fire
 		await sleep();
@@ -156,7 +156,7 @@ describe.each( [
 			screen.getByRole( 'combobox', {
 				expanded: false,
 			} )
-		).toHaveTextContent( 'amber' );
+		).toHaveTextContent( legacyProps.options[ 3 ].name );
 
 		// Necessary to wait for onChange to potentially fire
 		await sleep();
@@ -502,7 +502,9 @@ describe.each( [
 			await press.ArrowDown();
 			await press.Enter();
 
-			expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
+			expect( currentSelectedItem ).toHaveTextContent(
+				legacyProps.options[ 1 ].name
+			);
 		} );
 
 		it( 'Should be able to type characters to select matching options', async () => {
@@ -536,7 +538,9 @@ describe.each( [
 			await sleep();
 			await press.Tab();
 			expect( currentSelectedItem ).toHaveFocus();
-			expect( currentSelectedItem ).toHaveTextContent( 'violets' );
+			expect( currentSelectedItem ).toHaveTextContent(
+				legacyProps.options[ 0 ].name
+			);
 
 			// Ideally we would test a multi-character typeahead, but anything more than a single character is flaky
 			await type( 'a' );

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -285,13 +285,7 @@ describe.each( [
 		const user = userEvent.setup();
 		const mockOnChange = jest.fn();
 
-		render(
-			<Component
-				{ ...props }
-				value={ props.options[ 0 ] }
-				onChange={ mockOnChange }
-			/>
-		);
+		render( <Component { ...props } onChange={ mockOnChange } /> );
 
 		await user.click(
 			screen.getByRole( 'button', {
@@ -299,32 +293,21 @@ describe.each( [
 			} )
 		);
 
-		// DIFFERENCE WITH V2: NOT CALLED
-		// expect( mockOnChange ).toHaveBeenNthCalledWith(
-		// 	1,
-		// 	expect.objectContaining( {
-		// 		inputValue: '',
-		// 		isOpen: false,
-		// 		selectedItem: { key: 'flower1', name: 'violets' },
-		// 		type: '',
-		// 	} )
-		// );
-
 		await user.click(
 			screen.getByRole( 'option', {
 				name: 'aquamarine',
 			} )
 		);
 
-		expect( mockOnChange ).toHaveBeenNthCalledWith(
-			1,
+		expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+		expect( mockOnChange ).toHaveBeenLastCalledWith(
 			expect.objectContaining( {
 				inputValue: '',
 				isOpen: false,
 				selectedItem: expect.objectContaining( {
 					name: 'aquamarine',
 				} ),
-				type: '__item_click__',
+				type: expect.any( String ),
 			} )
 		);
 	} );
@@ -345,8 +328,8 @@ describe.each( [
 		await user.keyboard( 'p' );
 		await user.keyboard( '{enter}' );
 
-		expect( mockOnChange ).toHaveBeenNthCalledWith(
-			1,
+		expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+		expect( mockOnChange ).toHaveBeenLastCalledWith(
 			expect.objectContaining( {
 				selectedItem: expect.objectContaining( {
 					key: 'flower3',

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -123,7 +123,7 @@ describe.each( [
 			screen.getByRole( 'button', {
 				expanded: false,
 			} )
-		).toHaveTextContent( 'violets' );
+		).toHaveTextContent( props.options[ 0 ].name );
 
 		expect( mockOnChange ).not.toHaveBeenCalled();
 	} );
@@ -142,7 +142,7 @@ describe.each( [
 			screen.getByRole( 'button', {
 				expanded: false,
 			} )
-		).toHaveTextContent( 'amber' );
+		).toHaveTextContent( props.options[ 3 ].name );
 
 		expect( mockOnChange ).not.toHaveBeenCalled();
 	} );
@@ -489,7 +489,9 @@ describe.each( [
 			await user.keyboard( '{arrowdown}' );
 			await user.keyboard( '{enter}' );
 
-			expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
+			expect( currentSelectedItem ).toHaveTextContent(
+				props.options[ 1 ].name
+			);
 		} );
 
 		it( 'Should be able to type characters to select matching options', async () => {

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -81,11 +81,39 @@ const ControlledCustomSelectControl = ( {
 	);
 };
 
+it( 'Should apply external controlled updates', async () => {
+	const mockOnChange = jest.fn();
+	const { rerender } = render(
+		<UncontrolledCustomSelectControl
+			{ ...props }
+			value={ props.options[ 0 ] }
+			onChange={ mockOnChange }
+		/>
+	);
+
+	const currentSelectedItem = screen.getByRole( 'button', {
+		expanded: false,
+	} );
+
+	expect( currentSelectedItem ).toHaveTextContent( props.options[ 0 ].name );
+
+	rerender(
+		<UncontrolledCustomSelectControl
+			{ ...props }
+			value={ props.options[ 1 ] }
+		/>
+	);
+
+	expect( currentSelectedItem ).toHaveTextContent( props.options[ 1 ].name );
+
+	expect( mockOnChange ).not.toHaveBeenCalled();
+} );
+
 describe.each( [
 	[ 'Uncontrolled', UncontrolledCustomSelectControl ],
 	[ 'Controlled', ControlledCustomSelectControl ],
 ] )( 'CustomSelectControl %s', ( ...modeAndComponent ) => {
-	const [ mode, Component ] = modeAndComponent;
+	const [ , Component ] = modeAndComponent;
 
 	it( 'Should select the first option when no explicit initial value is passed without firing onChange', () => {
 		const mockOnChange = jest.fn();
@@ -118,26 +146,6 @@ describe.each( [
 
 		expect( mockOnChange ).not.toHaveBeenCalled();
 	} );
-
-	// Using the "Uncontrolled" version of the component
-	// in order to apply controlled logic directly in the test
-	if ( mode === 'Uncontrolled' ) {
-		it( 'Should apply external controlled updates', async () => {
-			const { rerender } = render(
-				<Component { ...props } value={ props.options[ 0 ] } />
-			);
-
-			const currentSelectedItem = screen.getByRole( 'button', {
-				expanded: false,
-			} );
-
-			expect( currentSelectedItem ).toHaveTextContent( 'violets' );
-
-			rerender( <Component { ...props } value={ props.options[ 1 ] } /> );
-
-			expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
-		} );
-	}
 
 	it( 'Should replace the initial selection when a new item is selected', async () => {
 		const user = userEvent.setup();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Supersedes #62308
Depends on #62255

Fixes how the `CustomSelectControlV2` legacy adapter behaves around its initial value (and consequent firing of the `onChange` callback)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Align the behaviour of v2 legacy adapter as closely as possible to the v1
- Fixing a bug where the initial value was not always correctly set and external controlled updates were not correctly applied

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Pass explicit `value` and `defaultValue` to the `useStore` call in the legacy adapter. This has two consequences:
- by setting `value` explicitly, we fix the controlled updates bug
- by setting `defaultValue` explicitly to the first option, we don't rely on Ariakit's internal automatic selection and thus we avoid firing the `onChange` callback on initial render

I edited existing unit tests and added a few more in both the v1 and the v2 legacy adapter to cover those changes and ensure that the two components behave the same.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Read and code review the changes in the unit tests, making sure that they reflect the correct expected behavior
- Make sure that the unit tests pass
- Undo this PR's changes to `packages/components/src/custom-select-control-v2/legacy-component/index.tsx`
- Run unit tests, check that they fail

Additionally, check testing instructions from #62308 