### PR TITLE
Editor: Fix blocked Post Publish Panel buttons on mobile

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -196,7 +196,7 @@
 	position: fixed;
 	z-index: z-index(".editor-post-publish-panel");
 	background: $white;
-	top: 0;
+	top: $admin-bar-height-big;
 	bottom: 0;
 	right: 0;
 	left: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/62738.

There's a small regression introduced by https://github.com/WordPress/gutenberg/pull/62237 where on mobile viewport, the `Publish` and `Cancel` buttons are not visible.

| Before | After |
|--------|--------|
| ![Markup on 2024-06-21 at 12:43:44](https://github.com/WordPress/gutenberg/assets/25105483/16cf293d-faf5-4fbd-8160-7b62f94d2559) | ![Markup on 2024-06-21 at 12:45:00](https://github.com/WordPress/gutenberg/assets/25105483/be965f58-086f-4a84-accf-0905436b02cc) | 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without the fix, the `Publish` and `Cancel` buttons are not visible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By setting `.editor-post-publish-panel`'s `top` property to `$admin-bar-height-big` - as it used to be

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Switch to mobile view.
2. Start creating a new post.
3. Add some content and click the `Publish` button.
4. The `Publish` and `Cancel` buttons should be visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

Shared above.