### PR TITLE
PR template: add before/after table

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,7 @@ https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 <!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
 
 ## Screenshots or screencast <!-- if applicable -->
+
+|Before|After|
+|-|-|
+||| 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,8 @@ https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 
 ## Screenshots or screencast <!-- if applicable -->
 
+<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
+
 |Before|After|
 |-|-|
 |<!-- Before screenshot here -->|<!-- After screenshot here -->|

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,4 @@ https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 
 |Before|After|
 |-|-|
-||| 
+|<!-- Before screenshot here -->|<!-- After screenshot here -->|


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a Before/After table to the PR template in the screenshot section.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

* I'm a bit tired of having to write out the table structure all the time.
* People may not be aware that it's possible to use tables to display screenshots side-by-side.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a Markdown table skeleton.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
