### PR TITLE
Global Styles: Allow block variations to be included in color and typography presets.

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -114,7 +114,7 @@ export function useSupportedStyles( name, element ) {
 
 export function useColorVariations() {
 	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
-		property: 'color',
+		properties: [ 'color' ],
 	} );
 	/*
 	 * Filter out variations with no settings or styles.
@@ -134,7 +134,7 @@ export function useColorVariations() {
 export function useTypographyVariations() {
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			property: 'typography',
+			properties: [ 'typography', 'spacing' ],
 		} );
 	/*
 	 * Filter out variations with no settings or styles.

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -134,7 +134,7 @@ export function useColorVariations() {
 export function useTypographyVariations() {
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			properties: [ 'typography', 'spacing' ],
+			properties: [ 'typography' ],
 		} );
 	/*
 	 * Filter out variations with no settings or styles.

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -13,7 +13,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import PreviewStyles from './preview-styles';
 import Variation from './variations/variation';
-import { isVariationWithSingleProperty } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { isVariationWithProperties } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../lock-unlock';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
@@ -33,11 +33,14 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		).__experimentalGetCurrentThemeGlobalStylesVariations();
 	}, [] );
 
-	// Filter out variations that are of single property type, i.e. color or typography variations.
-	const multiplePropertyVariations = variations?.filter( ( variation ) => {
+	// Filter out variations that are color or typography variations.
+	const fullStyleVariations = variations?.filter( ( variation ) => {
 		return (
-			! isVariationWithSingleProperty( variation, 'color' ) &&
-			! isVariationWithSingleProperty( variation, 'typography' )
+			! isVariationWithProperties( variation, [ 'color' ] ) &&
+			! isVariationWithProperties( variation, [
+				'typography',
+				'spacing',
+			] )
 		);
 	} );
 
@@ -48,7 +51,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				settings: {},
 				styles: {},
 			},
-			...( multiplePropertyVariations ?? [] ),
+			...( fullStyleVariations ?? [] ),
 		];
 		return [
 			...withEmptyVariation.map( ( variation ) => {
@@ -105,7 +108,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				};
 			} ),
 		];
-	}, [ multiplePropertyVariations, userStyles?.blocks, userStyles?.css ] );
+	}, [ fullStyleVariations, userStyles?.blocks, userStyles?.css ] );
 
 	return (
 		<Grid

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -15,7 +15,7 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
-import { filterObjectByProperty } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { filterObjectByProperties } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../../lock-unlock';
 
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
@@ -23,14 +23,19 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
 
-export default function Variation( { variation, children, isPill, property } ) {
+export default function Variation( {
+	variation,
+	children,
+	isPill,
+	properties,
+} ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
 
 	const context = useMemo( () => {
 		let merged = mergeBaseAndUserConfigs( base, variation );
-		if ( property ) {
-			merged = filterObjectByProperty( merged, property );
+		if ( properties ) {
+			merged = filterObjectByProperties( merged, properties );
 		}
 		return {
 			user: variation,
@@ -38,7 +43,7 @@ export default function Variation( { variation, children, isPill, property } ) {
 			merged,
 			setUserConfig: () => {},
 		};
-	}, [ variation, base, property ] );
+	}, [ variation, base, properties ] );
 
 	const selectVariation = () => setUserConfig( variation );
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -31,7 +31,7 @@ export default function ColorVariations( { title, gap = 2 } ) {
 						key={ index }
 						variation={ variation }
 						isPill
-						property="color"
+						properties={ [ 'color' ] }
 					>
 						{ () => <StylesPreviewColors /> }
 					</Variation>

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -38,7 +38,7 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 						<Variation
 							key={ index }
 							variation={ variation }
-							property="typography"
+							properties={ [ 'typography', 'spacing' ] }
 						>
 							{ ( isFocused ) => (
 								<PreviewIframe

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -38,7 +38,7 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 						<Variation
 							key={ index }
 							variation={ variation }
-							properties={ [ 'typography', 'spacing' ] }
+							properties={ [ 'typography' ] }
 						>
 							{ ( isFocused ) => (
 								<PreviewIframe

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -18,14 +18,14 @@ const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 
 /**
- * Removes all instances of a property from an object.
+ * Removes all instances of properties from an object.
  *
- * @param {Object} object   The object to remove the property from.
- * @param {string} property The property to remove.
+ * @param {Object} object     The object to remove the properties from.
+ * @param {string} properties The properties to remove.
  * @return {Object} The modified object.
  */
-export function removePropertyFromObject( object, property ) {
-	if ( ! property || typeof property !== 'string' ) {
+export function removePropertiesFromObject( object, properties ) {
+	if ( ! properties || typeof properties !== 'object' ) {
 		return object;
 	}
 
@@ -38,25 +38,25 @@ export function removePropertyFromObject( object, property ) {
 	}
 
 	for ( const key in object ) {
-		if ( key === property ) {
+		if ( properties.includes( key ) ) {
 			delete object[ key ];
 		} else if ( typeof object[ key ] === 'object' ) {
-			removePropertyFromObject( object[ key ], property );
+			removePropertiesFromObject( object[ key ], properties );
 		}
 	}
 	return object;
 }
 
 /**
- * Fetches the current theme style variations that contain only the specified property
+ * Fetches the current theme style variations that contain only the specified properties
  * and merges them with the user config.
  *
- * @param {Object} props          Object of hook args.
- * @param {string} props.property The property to filter by.
+ * @param {Object} props            Object of hook args.
+ * @param {string} props.properties The properties to filter by.
  * @return {Object[]|*} The merged object.
  */
 export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
-	property,
+	properties,
 } ) {
 	const { variationsFromTheme } = useSelect( ( select ) => {
 		const _variationsFromTheme =
@@ -74,51 +74,54 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		const clonedUserVariation = cloneDeep( userVariation );
 
 		// Get user variation and remove the settings for the given property.
-		const userVariationWithoutProperty = removePropertyFromObject(
+		const userVariationWithoutProperties = removePropertiesFromObject(
 			clonedUserVariation,
-			property
+			properties
 		);
-		userVariationWithoutProperty.title = __( 'Default' );
+		userVariationWithoutProperties.title = __( 'Default' );
 
-		const variationsWithSinglePropertyAndBase = variationsFromTheme
+		const variationsWithPropertiesAndBase = variationsFromTheme
 			.filter( ( variation ) => {
-				return isVariationWithSingleProperty( variation, property );
+				return isVariationWithProperties( variation, properties );
 			} )
 			.map( ( variation ) => {
 				return mergeBaseAndUserConfigs(
-					userVariationWithoutProperty,
+					userVariationWithoutProperties,
 					variation
 				);
 			} );
 
 		return [
-			userVariationWithoutProperty,
-			...variationsWithSinglePropertyAndBase,
+			userVariationWithoutProperties,
+			...variationsWithPropertiesAndBase,
 		];
-	}, [ property, userVariation, variationsFromTheme ] );
+	}, [ properties, userVariation, variationsFromTheme ] );
 }
 
 /**
- * Returns a new object, with properties specified in `property`,
+ * Returns a new object, with properties specified in `properties` array.,
  * maintain the original object tree structure.
- * The function is recursive, so it will perform a deep search for the given property.
- * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the property is `test`.
+ * The function is recursive, so it will perform a deep search for the given properties.
+ * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the properties are  `[ 'test' ]`.
  *
- * @param {Object} object   The object to filter
- * @param {Object} property The property to filter by
+ * @param {Object} object     The object to filter
+ * @param {Array}  properties The properties to filter by
  * @return {Object} The merged object.
  */
-export const filterObjectByProperty = ( object, property ) => {
+export const filterObjectByProperties = ( object, properties ) => {
 	if ( ! object ) {
 		return {};
 	}
 
 	const newObject = {};
 	Object.keys( object ).forEach( ( key ) => {
-		if ( key === property ) {
+		if ( properties.includes( key ) ) {
 			newObject[ key ] = object[ key ];
 		} else if ( typeof object[ key ] === 'object' ) {
-			const newFilter = filterObjectByProperty( object[ key ], property );
+			const newFilter = filterObjectByProperties(
+				object[ key ],
+				properties
+			);
 			if ( Object.keys( newFilter ).length ) {
 				newObject[ key ] = newFilter;
 			}
@@ -128,23 +131,23 @@ export const filterObjectByProperty = ( object, property ) => {
 };
 
 /**
- * Compares a style variation to the same variation filtered by a single property.
- * Returns true if the variation contains only the property specified.
+ * Compares a style variation to the same variation filtered by the specified properties.
+ * Returns true if the variation contains only the properties specified.
  *
- * @param {Object} variation The variation to compare.
- * @param {string} property  The property to compare.
- * @return {boolean} Whether the variation contains only a single property.
+ * @param {Object} variation  The variation to compare.
+ * @param {string} properties The properties to compare.
+ * @return {boolean} Whether the variation contains only the specified properties.
  */
-export function isVariationWithSingleProperty( variation, property ) {
-	const variationWithProperty = filterObjectByProperty(
+export function isVariationWithProperties( variation, properties ) {
+	const variationWithProperties = filterObjectByProperties(
 		cloneDeep( variation ),
-		property
+		properties
 	);
 
 	return (
-		JSON.stringify( variationWithProperty?.styles ) ===
+		JSON.stringify( variationWithProperties?.styles ) ===
 			JSON.stringify( variation?.styles ) &&
-		JSON.stringify( variationWithProperty?.settings ) ===
+		JSON.stringify( variationWithProperties?.settings ) ===
 			JSON.stringify( variation?.settings )
 	);
 }

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -141,7 +141,7 @@ export const filterObjectByProperties = ( object, properties ) => {
 export function isVariationWithProperties( variation, properties ) {
 	const variationWithProperties = filterObjectByProperties(
 		cloneDeep( variation ),
-		properties
+		[ ...properties, 'title', 'blockTypes' ] // Always include title and blockTypes as they are needed for block variations.
 	);
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Block variations require two extra properties - `blockTypes` and `title`. In trunk this means they aren't treated as "pure" color or typography variations, because they have these extra properties.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
These properties are configuration rather than style rules, so we should ignore them when determining if a style variation is only targetting colors / typography.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Takes a lot of the work from https://github.com/WordPress/gutenberg/pull/62709 but uses it to make an exception for the properties.

## Testing Instructions
1. Switch to the assembler theme (https://github.com/Automattic/themes/tree/trunk/assembler)
2. Open the Site Editor > Styles
3. Confirm that as well as many style variations you also see color presets (this is not the case in trunk

## Screenshots or screencast <!-- if applicable -->
<img width="353" alt="Screenshot 2024-06-21 at 13 27 17" src="https://github.com/WordPress/gutenberg/assets/275961/f2741c16-0327-4c55-aed3-152944f3686c">
