### PR TITLE
Cover: Update min-height control.

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -73,15 +73,16 @@ function CoverHeightInput( {
 
 	return (
 		<UnitControl
-			label={ __( 'Minimum height of cover' ) }
+			label={ __( 'Minimum height' ) }
 			id={ inputId }
 			isResetValueOnUnitChange
 			min={ min }
 			onChange={ handleOnChange }
 			onUnitChange={ onUnitChange }
-			__unstableInputWidth="80px"
+			__unstableInputWidth="calc(50% - 4px)"
 			units={ units }
 			value={ computedValue }
+			size="__unstable-large"
 		/>
 	);
 }

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -79,7 +79,6 @@ function CoverHeightInput( {
 			min={ min }
 			onChange={ handleOnChange }
 			onUnitChange={ onUnitChange }
-			__unstableInputWidth="calc(50% - 4px)"
 			units={ units }
 			value={ computedValue }
 			size="__unstable-large"
@@ -300,6 +299,7 @@ export default function CoverInspectorControls( {
 			) }
 			<InspectorControls group="dimensions">
 				<ToolsPanelItem
+					className="single-column"
 					hasValue={ () => !! minHeight }
 					label={ __( 'Minimum height' ) }
 					onDeselect={ () =>

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -372,10 +372,10 @@ describe( 'Cover block', () => {
 					} )
 				);
 				await userEvent.clear(
-					screen.getByLabelText( 'Minimum height of cover' )
+					screen.getByLabelText( 'Minimum height' )
 				);
 				await userEvent.type(
-					screen.getByLabelText( 'Minimum height of cover' ),
+					screen.getByLabelText( 'Minimum height' ),
 					'300'
 				);
 

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -158,7 +158,7 @@ test.describe( 'Cover', () => {
 
 		// Ensure there the default value for the minimum height of cover is undefined.
 		const defaultHeightValue = await coverBlockEditorSettings
-			.getByLabel( 'Minimum height of cover' )
+			.getByLabel( 'Minimum height' )
 			.inputValue();
 		expect( defaultHeightValue ).toBeFalsy();
 


### PR DESCRIPTION
## What?

The Cover block has a min-height control using legacy input size, and a label, "Minimum height of cover", redundant since it's only ever showin inside the inspector for the cover block:

![before](https://github.com/WordPress/gutenberg/assets/1204802/e80d4f4b-9021-4d78-a985-7fba981c409f)

This PR updates the input to be the new default size, and larger unit selector, and changes the label to read "Minimum height":

![after](https://github.com/WordPress/gutenberg/assets/1204802/98d8dd80-a065-4546-9ed7-8aeebdaeb69c)

For comparison, here's the image width/height controls:

![image](https://github.com/WordPress/gutenberg/assets/1204802/5974a223-0d73-48b5-8a3e-415493dd1cca)

## Testing Instructions

Insert a cover block, test the min-height inspector control.