### PR TITLE
Add letter spacing inheritance for the navigation block

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -300,6 +300,7 @@ button.wp-block-navigation-item__content {
 	color: currentColor;
 	font-size: inherit;
 	font-family: inherit;
+	letter-spacing: inherit;
 	line-height: inherit;
 	font-style: inherit;
 	font-weight: inherit;


### PR DESCRIPTION
## What?
Adds inheritance of letter spacing for the navigation block.

## Why?
The navigation block uses `inherit` definitions to support typography styles. The `letter-spacing` definition is missing.

## How?
Adds the necessary line.

## Testing Instructions
```html
<!-- wp:navigation {"ref":60591,"style":{"typography":{"letterSpacing":"0.1em"}}} /-->
```

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast
Before:
<img width="1469" alt="Screenshot 2024-06-21 at 9 03 03 AM" src="https://github.com/WordPress/gutenberg/assets/1750577/cc6e6adf-8e67-4c33-96f8-ac1e4474f986">

After:
<img width="1470" alt="Screenshot 2024-06-21 at 9 03 11 AM" src="https://github.com/WordPress/gutenberg/assets/1750577/ee2a3e4d-6835-4e9b-b0dd-b640e1532b3a">
