### PR TITLE
Pattern overrides: disallow override for image with caption/href

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -426,6 +426,9 @@ export default function Image( {
 		</InspectorControls>
 	);
 
+	const arePatternOverridesEnabled =
+		metadata?.bindings?.__default?.source === 'core/pattern-overrides';
+
 	const {
 		lockUrlControls = false,
 		lockHrefControls = false,
@@ -470,7 +473,7 @@ export default function Image( {
 				lockHrefControls:
 					// Disable editing the link of the URL if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the link on the frontend.
-					hasParentPattern,
+					hasParentPattern || arePatternOverridesEnabled,
 				lockCaption:
 					// Disable editing the caption if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the caption on the frontend.
@@ -964,16 +967,20 @@ export default function Image( {
 		<>
 			{ controls }
 			{ img }
-
-			<Caption
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				isSelected={ isSingleSelected }
-				insertBlocksAfter={ insertBlocksAfter }
-				label={ __( 'Image caption text' ) }
-				showToolbarButton={ isSingleSelected && hasNonContentControls }
-				readOnly={ lockCaption }
-			/>
+			{ /* Don't add caption component and controls in images with pattern overrides */ }
+			{ ! arePatternOverridesEnabled && (
+				<Caption
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					isSelected={ isSingleSelected }
+					insertBlocksAfter={ insertBlocksAfter }
+					label={ __( 'Image caption text' ) }
+					showToolbarButton={
+						isSingleSelected && hasNonContentControls
+					}
+					readOnly={ lockCaption }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -967,6 +967,7 @@ export default function Image( {
 		<>
 			{ controls }
 			{ img }
+
 			<Caption
 				attributes={ attributes }
 				setAttributes={ setAttributes }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -967,20 +967,19 @@ export default function Image( {
 		<>
 			{ controls }
 			{ img }
-			{ /* Don't add caption component and controls in images with pattern overrides */ }
-			{ ! arePatternOverridesEnabled && (
-				<Caption
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					isSelected={ isSingleSelected }
-					insertBlocksAfter={ insertBlocksAfter }
-					label={ __( 'Image caption text' ) }
-					showToolbarButton={
-						isSingleSelected && hasNonContentControls
-					}
-					readOnly={ lockCaption }
-				/>
-			) }
+			<Caption
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				isSelected={ isSingleSelected }
+				insertBlocksAfter={ insertBlocksAfter }
+				label={ __( 'Image caption text' ) }
+				showToolbarButton={
+					isSingleSelected &&
+					hasNonContentControls &&
+					! arePatternOverridesEnabled
+				}
+				readOnly={ lockCaption }
+			/>
 		</>
 	);
 }

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -23,6 +23,10 @@ const {
 	PATTERN_SYNC_TYPES,
 } = unlock( patternsPrivateApis );
 
+const UNSUPPORTED_ATTRIBUTES = {
+	'core/image': [ 'caption', 'href' ],
+};
+
 /**
  * Override the default edit UI to include a new block inspector control for
  * assigning a partial syncing controls to supported blocks in the pattern editor.
@@ -34,9 +38,16 @@ const {
  */
 const withPatternOverrideControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const isSupportedBlock = Object.keys(
-			PARTIAL_SYNCING_SUPPORTED_BLOCKS
-		).includes( props.name );
+		let isSupportedBlock =
+			!! PARTIAL_SYNCING_SUPPORTED_BLOCKS[ props.name ];
+
+		if ( isSupportedBlock ) {
+			const unsupportedAttributes =
+				UNSUPPORTED_ATTRIBUTES[ props.name ] || [];
+			isSupportedBlock = ! unsupportedAttributes.some(
+				( attribute ) => props.attributes[ attribute ]?.length
+			);
+		}
 
 		return (
 			<>

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -23,10 +23,6 @@ const {
 	PATTERN_SYNC_TYPES,
 } = unlock( patternsPrivateApis );
 
-const UNSUPPORTED_ATTRIBUTES = {
-	'core/image': [ 'caption', 'href' ],
-};
-
 /**
  * Override the default edit UI to include a new block inspector control for
  * assigning a partial syncing controls to supported blocks in the pattern editor.
@@ -38,16 +34,8 @@ const UNSUPPORTED_ATTRIBUTES = {
  */
 const withPatternOverrideControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		let isSupportedBlock =
+		const isSupportedBlock =
 			!! PARTIAL_SYNCING_SUPPORTED_BLOCKS[ props.name ];
-
-		if ( isSupportedBlock ) {
-			const unsupportedAttributes =
-				UNSUPPORTED_ATTRIBUTES[ props.name ] || [];
-			isSupportedBlock = ! unsupportedAttributes.some(
-				( attribute ) => props.attributes[ attribute ]?.length
-			);
-		}
 
 		return (
 			<>

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -101,10 +101,6 @@ function PatternOverridesControls( {
 						variant="secondary"
 						aria-haspopup="dialog"
 						onClick={ () => {
-							if ( hasUnsupportedImageAttributes ) {
-								return;
-							}
-
 							if ( allowOverrides ) {
 								setShowDisallowOverridesModal( true );
 							} else {

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -31,7 +31,11 @@ function addBindings( bindings ) {
 	};
 }
 
-function PatternOverridesControls( { attributes, setAttributes } ) {
+function PatternOverridesControls( {
+	attributes,
+	setAttributes,
+	name: blockName,
+} ) {
 	const controlId = useId();
 	const [ showAllowOverridesModal, setShowAllowOverridesModal ] =
 		useState( false );
@@ -71,15 +75,25 @@ function PatternOverridesControls( { attributes, setAttributes } ) {
 		return null;
 	}
 
+	const hasUnsupportedImageAttributes =
+		blockName === 'core/image' &&
+		( !! attributes.caption?.length || !! attributes.href?.length );
+
+	const helpText = hasUnsupportedImageAttributes
+		? __(
+				`Overrides currently don't support image captions or links. Remove the caption or link first before enabling overrides.`
+		  )
+		: __(
+				'Allow changes to this block throughout instances of this pattern.'
+		  );
+
 	return (
 		<>
 			<InspectorControls group="advanced">
 				<BaseControl
 					id={ controlId }
 					label={ __( 'Overrides' ) }
-					help={ __(
-						'Allow changes to this block throughout instances of this pattern.'
-					) }
+					help={ helpText }
 				>
 					<Button
 						__next40pxDefaultSize
@@ -87,12 +101,18 @@ function PatternOverridesControls( { attributes, setAttributes } ) {
 						variant="secondary"
 						aria-haspopup="dialog"
 						onClick={ () => {
+							if ( hasUnsupportedImageAttributes ) {
+								return;
+							}
+
 							if ( allowOverrides ) {
 								setShowDisallowOverridesModal( true );
 							} else {
 								setShowAllowOverridesModal( true );
 							}
 						} }
+						disabled={ hasUnsupportedImageAttributes }
+						__experimentalIsFocusable
 					>
 						{ allowOverrides
 							? __( 'Disable overrides' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #62287 (the remainder of it, the other part was fixed by #62471)

When creating pattern overrides, disallow creating an override for an image with either a caption or href/link.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's not supported by block bindings right now.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Select an image with a caption (non empty), click the three dots and create a pattern.
* Edit original, then select the image again.
* Open the inspector, click Advanced, make sure that there is no override button.
* You could also repeat these steps for an image without a caption, and make sure the button is there.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
