### PR TITLE
Keep default padding on nested sub-menus

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -318,7 +318,7 @@ button.wp-block-navigation-item__content {
 // We pad it to include the arrow icon in the clickable area.
 // The padding can be blanket for click, since you can't set click and hide the icon.
 // This is only applied to the submenu in the page list block.
-.wp-block-navigation-item.open-on-click .wp-block-navigation-submenu__toggle {
+.wp-block-navigation__container > .wp-block-navigation-item.open-on-click > .wp-block-navigation-submenu__toggle {
 	padding-left: 0; // Remove the browser default padding.
 	padding-right: 0.6em + 0.25em; // Same size as icon plus margin.
 


### PR DESCRIPTION
## What?
Modifies the selector that manages submenu padding.

## Why?
Nested submenus are missing necessary padding to visually align with other menu items.

## How?
Changes the selector to only target top-level submenus.

## Testing Instructions
Create a navigation block:
Level 1
- Level 2 (A)
- - Level 3
- Level 2 (B)

Notice how "Level 2 (A)" has no padding-left while "Level 2 (B)" does.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast
Before:
<img width="1470" alt="Screenshot 2024-06-21 at 9 24 29 AM" src="https://github.com/WordPress/gutenberg/assets/1750577/1116164b-b210-4fc4-95de-a0834da4b771">

After:
<img width="1470" alt="Screenshot 2024-06-21 at 9 24 15 AM" src="https://github.com/WordPress/gutenberg/assets/1750577/406852c7-8883-4389-8209-625912934bc9">
