### PR TITLE
 Add unit support for image block height and width

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -355,14 +355,17 @@ export default function Image( {
 		);
 	}
 
+	const [ lightboxSetting, availableUnits ] = useSettings(
+		'lightbox',
+		'spacing.units'
+	);
+
 	// TODO: Can allow more units after figuring out how they should interact
 	// with the ResizableBox and ImageEditor components. Calculations later on
 	// for those components are currently assuming px units.
 	const dimensionsUnitsOptions = useCustomUnits( {
-		availableUnits: [ 'px' ],
+		availableUnits: availableUnits || [ 'px', '%', 'vw', 'em', 'rem' ],
 	} );
-
-	const [ lightboxSetting ] = useSettings( 'lightbox' );
 
 	const showLightboxSetting =
 		// If a block-level override is set, we should give users the option to


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/55059

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Width/height control have only `PX` unit enabled in Image block settings.
  
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Go to editor
- Add image block
- go to block setting, and look for height/width control
- Control have other dimension units

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="278" alt="image" src="https://github.com/WordPress/gutenberg/assets/61308756/2e0686cf-07a6-4e9a-a27a-d17dbf9dc3ad">
