### PR TITLE
Update: Reverse backport changes on post type REST API changes.

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -42,13 +42,13 @@ if ( ! function_exists( 'gutenberg_register_wp_rest_post_types_controller_fields
 			array(
 				'get_callback' => function ( $item ) {
 					$post_type = get_post_type_object( $item['slug'] );
-					if ( ! empty( $post_type ) && ! empty( $post_type->template ) ) {
-						return $post_type->template;
+					if ( ! empty( $post_type ) ) {
+						return $post_type->template ?? array();
 					}
 				},
 				'schema'       => array(
 					'type'        => 'array',
-					'description' => __( 'The block template associated with the post type, if it exists.', 'gutenberg' ),
+					'description' => __( 'The block template associated with the post type.', 'gutenberg' ),
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
@@ -60,14 +60,14 @@ if ( ! function_exists( 'gutenberg_register_wp_rest_post_types_controller_fields
 			array(
 				'get_callback' => function ( $item ) {
 					$post_type = get_post_type_object( $item['slug'] );
-					if ( ! empty( $post_type ) && ! empty( $post_type->template_lock ) && false !== $post_type->template_lock ) {
-						return $post_type->template_lock;
+					if ( ! empty( $post_type ) ) {
+						return ! empty( $post_type->template_lock ) ? $post_type->template_lock : false;
 					}
 				},
 				'schema'       => array(
-					'type'        => 'string',
-					'enum'        => array( 'all', 'insert', 'contentOnly' ),
-					'description' => __( 'The template_lock associated with the post type, if any.', 'gutenberg' ),
+					'type'        => array( 'string', 'boolean' ),
+					'enum'        => array( 'all', 'insert', 'contentOnly', false ),
+					'description' => __( 'The template_lock associated with the post type, or false if none.', 'gutenberg' ),
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),

--- a/packages/edit-site/src/components/add-new-page/index.js
+++ b/packages/edit-site/src/components/add-new-page/index.js
@@ -42,14 +42,15 @@ export default function AddNewPageModal( { onSave, onClose } ) {
 					status: 'draft',
 					title,
 					slug: title || __( 'No title' ),
-					content: !! pagePostType.template
-						? serialize(
-								synchronizeBlocksWithTemplate(
-									[],
-									pagePostType.template
-								)
-						  )
-						: undefined,
+					content:
+						!! pagePostType.template && pagePostType.template.length
+							? serialize(
+									synchronizeBlocksWithTemplate(
+										[],
+										pagePostType.template
+									)
+							  )
+							: undefined,
 				},
 				{ throwOnError: true }
 			);


### PR DESCRIPTION
While iterating on the core merge of https://github.com/WordPress/wordpress-develop/pull/6865 we made some changes, this PR brings the changes back to Gutenberg and adapts a JS condition to match the default of the template being an empty array instead of null as it was before.
