### PR TITLE
Fix: Check permissions on duplicate pattern and template part actions.

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1038,13 +1038,16 @@ export const duplicateTemplatePartAction = {
 };
 
 export function usePostActions( { postType, onActionPerformed, context } ) {
-	const { defaultActions, postTypeObject } = useSelect(
+	const { defaultActions, postTypeObject, userCanCreatePostType } = useSelect(
 		( select ) => {
-			const { getPostType } = select( coreStore );
+			const { getPostType, canUser } = select( coreStore );
 			const { getEntityActions } = unlock( select( editorStore ) );
+			const _postTypeObject = getPostType( postType );
+			const resource = _postTypeObject?.rest_base || '';
 			return {
-				postTypeObject: getPostType( postType ),
+				postTypeObject: _postTypeObject,
 				defaultActions: getEntityActions( 'postType', postType ),
+				userCanCreatePostType: canUser( 'create', resource ),
 			};
 		},
 		[ postType ]
@@ -1073,8 +1076,10 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 				  ! isPattern &&
 				  duplicatePostAction
 				: false,
-			isTemplateOrTemplatePart && duplicateTemplatePartAction,
-			isPattern && duplicatePatternAction,
+			isTemplateOrTemplatePart &&
+				userCanCreatePostType &&
+				duplicateTemplatePartAction,
+			isPattern && userCanCreatePostType && duplicatePatternAction,
 			supportsTitle && renamePostAction,
 			isPattern && exportPatternAsJSONAction,
 			isTemplateOrTemplatePart ? resetTemplateAction : restorePostAction,
@@ -1141,6 +1146,7 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		return actions;
 	}, [
 		defaultActions,
+		userCanCreatePostType,
 		isTemplateOrTemplatePart,
 		isPattern,
 		postTypeObject?.viewable,


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/62633.
Adds permission checks on the duplicate pattern and template_part actions.

We can not test the check on template_part because it depends on the edit_theme_options capability and as of right now, the user can never see template parts if the capability is not present, but for consistency and in case things change, we should have the check.

## Testing Instructions
I pasted the following test code that removes the ability to create patterns (while still allowing to edit them).
```
add_filter(
	'register_wp_block_post_type_args',
	function ( $args ) {
		$args['capabilities']['create_posts'] = 'nonexistent_capability';

		return $args;
	},
);
```
I went to wp-admin/site-editor.php?postType=wp_block and I tried to duplicate a pattern and verified the UI did not show that option.