### PR TITLE
Social Icons: Add examples for Social Link variations.

### DIFF
--- a/packages/block-library/src/social-link/variations.js
+++ b/packages/block-library/src/social-link/variations.js
@@ -341,16 +341,22 @@ const variations = [
 ];
 
 /**
- * Add `isActive` function to all `social link` variations, if not defined.
- * `isActive` function is used to find a variation match from a created
- *  Block by providing its attributes.
+ * Add `isActive` and `example` properties to all Social Link variations, if not defined.
  */
 variations.forEach( ( variation ) => {
-	if ( variation.isActive ) {
-		return;
+	if ( ! variation.isActive ) {
+		variation.isActive = ( blockAttributes, variationAttributes ) =>
+			blockAttributes.service === variationAttributes.service;
 	}
-	variation.isActive = ( blockAttributes, variationAttributes ) =>
-		blockAttributes.service === variationAttributes.service;
+
+	if ( ! variation.example ) {
+		variation.example = {
+			attributes: {
+				service: variation.name,
+				url: '#',
+			},
+		};
+	}
 } );
 
 export default variations;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The variations for the Social Link block do not have the `example` property set, which causes the block inserter to display the message `No preview available`. This PR fixes that. 

## How?
The following code to adds example content to each variation.  I've set `#` for the `url` property since unlinked icons have opacity applied. 

```
if ( ! variation.example ) {
	variation.example = {
		attributes: {
			service: variation.name,
			url: '#',
		},
	};
}
```

## Testing Instructions
1. Add a Social Icons block to a post
2. Click to add an icon and then click "Browse all" and the block inserter will open on the left
3. Hover over the available icons, and you will now see the icon preview

## Screenshots or screencast <!-- if applicable -->

| Before | After | 
|-|-|
|<img width="706" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/51ed1499-0a5d-4cd7-a090-874645e5bc20">|<img width="709" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/549dc2b4-8154-4875-af04-2fc224f9b55e">|

The preview is not the best, but it's better than displaying no preview at all. 
