### PR TITLE
Site Editor: don't render empty body tag 

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -110,14 +110,12 @@ export default function EditSiteEditor( { isLoading } ) {
 			{
 				// Forming a "block formatting context" to prevent margin collapsing.
 				// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-
-				css: `body{${
+				css:
 					canvasMode === 'view'
-						? `min-height: 100vh; ${
+						? `body{min-height: 100vh; ${
 								currentPostIsTrashed ? '' : 'cursor: pointer;'
-						  }`
-						: ''
-				}}}`,
+						  }}`
+						: undefined,
 			},
 		],
 		[ settings.styles, canvasMode, currentPostIsTrashed ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix trailing curly brace, and only render margin collapsing CSS on the body tag in canvas view mode.

## Why?

To prevent `body{}}` from being rendered in the Site Editor in "edit" mode. 

<img width="453" alt="Screenshot 2024-06-23 at 11 34 23 AM" src="https://github.com/WordPress/gutenberg/assets/6458278/af0ec949-cb9d-4285-b215-a9914a0c5e16">


## How?
Only building the CSS string when the Site Editor canvas mode is "view". 

I think that preserves the original intention of https://github.com/WordPress/gutenberg/pull/62146/files#diff-53f39da7a5f1f996f5359a2dd7b2747fb3d60a494523dd73dba946fab8e82592R144

## Testing Instructions

Head over to the Site Editor. View the source of the Editor frame. Inside the body tag you should see the body rule

<img width="491" alt="Screenshot 2024-06-23 at 11 52 53 AM" src="https://github.com/WordPress/gutenberg/assets/6458278/46db7cde-4283-4928-8906-5bc6ffa93923">

Now enter edit mode. 

The body tag should not be there.





