### PR TITLE
Only apply output buffer filter when in final phase

### DIFF
--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -86,14 +86,17 @@ add_filter( 'gutenberg_template_output_buffer', '_gutenberg_add_client_side_navi
  */
 function _gutenberg_buffer_template_output( string $passthrough ): string {
 	ob_start(
-		static function ( string $output ): string {
-			/**
-			 * Filters the template output buffer prior to sending to the client.
-			 *
-			 * @param string $output Output buffer.
-			 * @return string Filtered output buffer.
-			 */
-			return (string) apply_filters( 'gutenberg_template_output_buffer', $output );
+		static function ( string $output, ?int $phase ): string {
+			if ( $phase & PHP_OUTPUT_HANDLER_FINAL ) {
+				/**
+				 * Filters the template output buffer prior to sending to the client.
+				 *
+				 * @param string $output Output buffer.
+				 * @return string Filtered output buffer.
+				 */
+				$output = (string) apply_filters( 'gutenberg_template_output_buffer', $output );
+			}
+			return $output;
 		}
 	);
 	return $passthrough;


### PR DESCRIPTION
As [suggested](https://github.com/WordPress/gutenberg/pull/61212#issuecomment-2150662611) by @nextend in a follow-up to https://github.com/WordPress/gutenberg/pull/61212:

> We use output buffering in our 900k+ plugin and based on my experience I suggest the following changes:
> 
> ```php
> <?php
> function _gutenberg_buffer_template_output( string $passthrough ): string {
> 	ob_start(
> 		static function ( string $output, ?int $phase): string {
> 
> 			if ($phase & PHP_OUTPUT_HANDLER_FINAL) {
> 				/**
> 			 	* Filters the template output buffer prior to sending to the client.
> 			 	*
> 			 	* @param string $output Output buffer.
> 				 * @return string Filtered output buffer.
> 				 */
> 				return (string) apply_filters( 'gutenberg_template_output_buffer', $output );
> 			}
> 
> 			return $output;
> 		}
> 	);
> 	return $passthrough;
> }
> ```
> 
> As I remember these are related when `ob_clean` and `ob_flush` called during the output buffer is open. It skips the processing of the output when its dropped.

