### PR TITLE
Update react.js regarding useEffect old url

### DIFF
--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -170,7 +170,7 @@ export { useDebugValue };
 export { useDeferredValue };
 
 /**
- * @see https://reactjs.org/docs/hooks-reference.html#useeffect
+ * @see https://react.dev/reference/react/useEffect
  */
 export { useEffect };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update auto generated url of useEffect to new site url

## Why?
When user reading doc regarding useEffect it reference to the old url.

## How?
I update old url to new url manually

## Testing Instructions
Open this url https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/#useeffect
Click on the related link. It should be https://react.dev/reference/react/useEffect
