### PR TITLE
Pattern overrides: Remove caption and href from images with overrides

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -426,6 +426,9 @@ export default function Image( {
 		</InspectorControls>
 	);
 
+	const isPatternOverridesEnabled =
+		metadata?.bindings?.__default?.source === 'core/pattern-overrides';
+
 	const {
 		lockUrlControls = false,
 		lockHrefControls = false,
@@ -470,11 +473,11 @@ export default function Image( {
 				lockHrefControls:
 					// Disable editing the link of the URL if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the link on the frontend.
-					hasParentPattern,
+					hasParentPattern || isPatternOverridesEnabled,
 				lockCaption:
 					// Disable editing the caption if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the caption on the frontend.
-					hasParentPattern,
+					hasParentPattern || isPatternOverridesEnabled,
 				lockAltControls:
 					!! altBinding &&
 					! altBindingSource?.canUserEditValue( {
@@ -965,15 +968,20 @@ export default function Image( {
 			{ controls }
 			{ img }
 
-			<Caption
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				isSelected={ isSingleSelected }
-				insertBlocksAfter={ insertBlocksAfter }
-				label={ __( 'Image caption text' ) }
-				showToolbarButton={ isSingleSelected && hasNonContentControls }
-				readOnly={ lockCaption }
-			/>
+			{ /* Don't add caption in images with pattern overrides until it is supported. */ }
+			{ ! isPatternOverridesEnabled && (
+				<Caption
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					isSelected={ isSingleSelected }
+					insertBlocksAfter={ insertBlocksAfter }
+					label={ __( 'Image caption text' ) }
+					showToolbarButton={
+						isSingleSelected && hasNonContentControls
+					}
+					readOnly={ lockCaption }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -31,6 +31,7 @@ export default function save( { attributes } ) {
 		linkTarget,
 		sizeSlug,
 		title,
+		metadata,
 	} = attributes;
 
 	const newRel = ! rel ? undefined : rel;
@@ -70,9 +71,13 @@ export default function save( { attributes } ) {
 		/>
 	);
 
+	const isPatternOverridesEnabled =
+		metadata?.bindings?.__default?.source === 'core/pattern-overrides';
+
 	const figure = (
 		<>
-			{ href ? (
+			{ /* Don't add links in images with pattern overrides until they are supported. */ }
+			{ href && ! isPatternOverridesEnabled ? (
 				<a
 					className={ linkClass }
 					href={ href }
@@ -84,7 +89,8 @@ export default function save( { attributes } ) {
 			) : (
 				image
 			) }
-			{ ! RichText.isEmpty( caption ) && (
+			{ /* Don't add caption in images with pattern overrides until it is supported. */ }
+			{ ! RichText.isEmpty( caption ) && ! isPatternOverridesEnabled && (
 				<RichText.Content
 					className={ __experimentalGetElementClassName( 'caption' ) }
 					tagName="figcaption"


### PR DESCRIPTION
This is a potential different alternative approach to https://github.com/WordPress/gutenberg/pull/62747, although I must say I am not sure which one is better. Probably the other pull request seems safer.

## What?

Fixes https://github.com/WordPress/gutenberg/issues/62287 (the remainder of it, the other part was fixed by https://github.com/WordPress/gutenberg/pull/62471)

When creating pattern overrides, remove caption and href from images when the "Enable Overrides" option is checked.

## Why?
Because it's not supported by block bindings right now.

## How?
Changing the save function to remove them when bindings are in the attributes and changing the edit to hide the controls.

## Testing Instructions
1. Add an image in a post and add a caption and link on it.
2. Create synced pattern, giving it a name.
3. Save it and check it shows properly in the frontend, with the caption and the link.
4. Go to "Edit original" to modify the pattern and click on "Enable overrides".
5. After giving it a name, check that the link and caption controls are hidden.
6. Save and check that the link wrapper and the figcaption elements don’t exist.
