### PR TITLE
Image Block: fix Aspect Ratio button position

### DIFF
--- a/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
+++ b/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
@@ -78,7 +78,6 @@ export default function AspectRatioDropdown( { toggleProps } ) {
 			label={ __( 'Aspect Ratio' ) }
 			popoverProps={ POPOVER_PROPS }
 			toggleProps={ toggleProps }
-			className="wp-block-image__aspect-ratio"
 		>
 			{ ( { onClose } ) => (
 				<>

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -176,19 +176,6 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
-.wp-block-image__aspect-ratio {
-	height: $grid-unit-60 - $border-width - $border-width;
-	margin-bottom: -$grid-unit-10;
-	display: flex;
-	align-items: center;
-
-	.components-button {
-		width: $button-size;
-		padding-left: 0;
-		padding-right: 0;
-	}
-}
-
 .wp-block-image__toolbar_content_textarea {
 	// Corresponds to the size of the textarea in the block inspector.
 	width: 250px;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR fixes the position of the Aspect Ratio button in the block toolbar of the image block. This issue only occurs when the Top Toolbar is enabled.

![aspect-ratio](https://github.com/WordPress/gutenberg/assets/54422211/427d0f05-5e34-45f2-a6de-4eae116e6b1c)

## Why?

This issue appears to have first appeared in WP6.5. It was probably caused by a styling change to the header block toolbar starting with #57444.

## How?

Removed the styles specific to this button. These styles were added about 4 years ago in #23677. Maybe the styles don't fit the current block toolbar.

## Testing Instructions

- Insert an image block and apply an image.
- Click the Crop button.
- Whether the Top Toolbar is enabled or not. All button positions should be correct.