### PR TITLE
Flex dimensions: Rename "Fill" to "Grow".

### DIFF
--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -12,7 +12,7 @@ import {
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -142,17 +142,26 @@ function FlexControls( {
 				<ToggleGroupControlOption
 					key="fit"
 					value="fit"
-					label={ __( 'Fit' ) }
+					label={ _x(
+						'Fit',
+						'Intrinsic block width in flex layout'
+					) }
 				/>
 				<ToggleGroupControlOption
 					key="fill"
 					value="fill"
-					label={ __( 'Grow' ) }
+					label={ _x(
+						'Grow',
+						'Block with expanding width in flex layout'
+					) }
 				/>
 				<ToggleGroupControlOption
 					key="fixed"
 					value="fixed"
-					label={ __( 'Fixed' ) }
+					label={ _x(
+						'Fixed',
+						'Block with fixed width in flex layout'
+					) }
 				/>
 			</ToggleGroupControl>
 			{ selfStretch === 'fixed' && (

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -147,7 +147,7 @@ function FlexControls( {
 				<ToggleGroupControlOption
 					key="fill"
 					value="fill"
-					label={ __( 'Fill' ) }
+					label={ __( 'Grow' ) }
 				/>
 				<ToggleGroupControlOption
 					key="fixed"


### PR DESCRIPTION
## What?

Flex tools have a dimensions control that lets you choose between Fit, Fill and Fixed:

![before](https://github.com/WordPress/gutenberg/assets/1204802/886a7fe7-dab5-4eb9-b326-ae8beac1ddab)

This PR renames "Fill" to "Grow":

![after](https://github.com/WordPress/gutenberg/assets/1204802/6f4ed3ac-e19b-40e7-bfb4-4541d1f107dd)

## Why?

* As background image tools and color controls expand and possibly consolidate (see also #62752), the word "Fill" is increasingly going to refer to background-fills, rather than the behavior of filling out space.
* "Grow" both matches some of the flex properties it works with, but it also intuitively suggests its behavior in a way that's arguably less clear with "Fill". 

Here's a menu-design use case, as an example:

![menu test](https://github.com/WordPress/gutenberg/assets/1204802/504080de-a280-46bc-93c4-21660b79a5f4)

In that GIF, a horizontal navigation menu featureing a site title, a menu, and a button is built. In this, the site title is set to "fill", so it pushes the navigation menu and the button to the right most side of the header, accomplishing the desire design. But it would easily be confused in this case, to suggest that "fill" should fill the available space, and not also imply pushing the other content rightwards. Whereas "Grow" does suggest filling the available space, but also implies pushing other contents aside.

## Testing Instructions

Insert a row block with a couple of child blocks. View the inspetor for a child block, and see "Grow" instead of "Fill".
