### PR TITLE
Skip failing image block test

### DIFF
--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -293,7 +293,10 @@ test.describe( 'Image', () => {
 		).toMatchSnapshot();
 	} );
 
-	test( 'allows changing aspect ratio using the crop tools', async ( {
+	// Reason - skipped temporarily until this issue is fixed:
+	// https://github.com/WordPress/wordpress-develop/pull/6875#issuecomment-2185694119
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'allows changing aspect ratio using the crop tools', async ( {
 		editor,
 		page,
 		imageBlockUtils,


### PR DESCRIPTION
As mentioned in slack, this test is currently failing due to a WP Core change - https://wordpress.slack.com/archives/C02QB2JS7/p1719209877579299

I'm proposing temporarily skipping it to unblock PR merges.
