### PR TITLE
Move Sticky toggle to status popover

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1289,7 +1289,7 @@ _Returns_
 
 ### PostSticky
 
-Renders the PostSticky component. It provide toggle control for the sticky post feature.
+Renders the PostSticky component. It provides a checkbox control for the sticky post feature.
 
 _Returns_
 

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -10,9 +10,6 @@ import {
 	TextControl,
 	RadioControl,
 } from '@wordpress/components';
-/**
- * Internal dependencies
- */
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -10,6 +10,10 @@ import {
 	TextControl,
 	RadioControl,
 } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import PostStickyPanel from '../post-sticky';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
@@ -281,6 +285,7 @@ export default function PostStatus() {
 											) }
 										</VStack>
 									) }
+									<PostStickyPanel />
 								</VStack>
 							</form>
 						</>

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -13,7 +13,6 @@ import {
 /**
  * Internal dependencies
  */
-import PostStickyPanel from '../post-sticky';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
@@ -31,6 +30,7 @@ import {
 	NAVIGATION_POST_TYPE,
 } from '../../store/constants';
 import PostPanelRow from '../post-panel-row';
+import PostSticky from '../post-sticky';
 import { PrivatePostSchedule } from '../post-schedule';
 import { store as editorStore } from '../../store';
 
@@ -285,7 +285,7 @@ export default function PostStatus() {
 											) }
 										</VStack>
 									) }
-									<PostStickyPanel />
+									<PostSticky />
 								</VStack>
 							</form>
 						</>

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, VisuallyHidden } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -10,7 +10,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import PostStickyCheck from './check';
 import { store as editorStore } from '../../store';
-import PostPanelRow from '../post-panel-row';
 
 /**
  * Renders the PostSticky component. It provide toggle control for the sticky post feature.
@@ -27,16 +26,14 @@ export default function PostSticky() {
 
 	return (
 		<PostStickyCheck>
-			<PostPanelRow label={ __( 'Sticky' ) }>
-				<ToggleControl
-					className="editor-post-sticky__toggle-control"
-					label={
-						<VisuallyHidden>{ __( 'Sticky' ) }</VisuallyHidden>
-					}
-					checked={ postSticky }
-					onChange={ () => editPost( { sticky: ! postSticky } ) }
-				/>
-			</PostPanelRow>
+			<CheckboxControl
+				className="editor-post-sticky__toggle-control"
+				label={ __( 'Sticky' ) }
+				help={ __( 'Pin this post to the top of the blog' ) }
+				checked={ postSticky }
+				onChange={ () => editPost( { sticky: ! postSticky } ) }
+				__nextHasNoMarginBottom
+			/>
 		</PostStickyCheck>
 	);
 }

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -12,7 +12,7 @@ import PostStickyCheck from './check';
 import { store as editorStore } from '../../store';
 
 /**
- * Renders the PostSticky component. It provide toggle control for the sticky post feature.
+ * Renders the PostSticky component. It provides a checkbox control for the sticky post feature.
  *
  * @return {Component} The component to be rendered.
  */
@@ -27,7 +27,7 @@ export default function PostSticky() {
 	return (
 		<PostStickyCheck>
 			<CheckboxControl
-				className="editor-post-sticky__toggle-control"
+				className="editor-post-sticky__checkbox-control"
 				label={ __( 'Sticky' ) }
 				help={ __( 'Pin this post to the top of the blog' ) }
 				checked={ postSticky }

--- a/packages/editor/src/components/post-sticky/style.scss
+++ b/packages/editor/src/components/post-sticky/style.scss
@@ -1,4 +1,4 @@
-.editor-post-sticky__toggle-control {
+.editor-post-sticky__checkbox-control {
 	border-top: $border-width solid $gray-200;
 	padding-top: $grid-unit-20;
 }

--- a/packages/editor/src/components/post-sticky/style.scss
+++ b/packages/editor/src/components/post-sticky/style.scss
@@ -1,3 +1,4 @@
 .editor-post-sticky__toggle-control {
-	padding: 6px 12px;
+	border-top: $border-width solid $gray-200;
+	padding-top: $grid-unit-20;
 }

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -21,7 +21,6 @@ import PostLastEditedPanel from '../post-last-edited-panel';
 import PostPanelSection from '../post-panel-section';
 import PostSchedulePanel from '../post-schedule/panel';
 import PostStatusPanel from '../post-status';
-import PostStickyPanel from '../post-sticky';
 import PostSyncStatus from '../post-sync-status';
 import PostTemplatePanel from '../post-template/panel';
 import PostURLPanel from '../post-url/panel';
@@ -84,7 +83,6 @@ export default function PostSummary( { onActionPerformed } ) {
 										<PostsPerPage />
 										<SiteDiscussion />
 										<PostFormatPanel />
-										<PostStickyPanel />
 									</VStack>
 									<TemplateAreas />
 									{ fills }

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -125,13 +125,13 @@ test.describe( 'Sidebar', () => {
 		const postDiscussionPanel = page.getByRole( 'button', {
 			name: 'Change discussion options',
 		} );
-		const postSummarySection = page.getByRole( 'button', {
+		const postAutorPanel = page.getByRole( 'button', {
 			name: 'admin',
 		} );
 
 		await expect( postExcerptPanel ).toBeVisible();
 		await expect( postFeaturedImagePanel ).toBeVisible();
-		await expect( postSummarySection ).toBeVisible();
+		await expect( postAutorPanel ).toBeVisible();
 		await expect( postDiscussionPanel ).toHaveCount( 1 );
 
 		await page.evaluate( () => {
@@ -149,7 +149,7 @@ test.describe( 'Sidebar', () => {
 		await expect( documentSettingsPanels ).toHaveCount( 1 );
 		await expect( postExcerptPanel ).toBeHidden();
 		await expect( postFeaturedImagePanel ).toBeHidden();
-		await expect( postSummarySection ).toBeHidden();
+		await expect( postAutorPanel ).toBeHidden();
 		await expect( postDiscussionPanel ).toHaveCount( 0 );
 	} );
 } );

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -125,8 +125,8 @@ test.describe( 'Sidebar', () => {
 		const postDiscussionPanel = page.getByRole( 'button', {
 			name: 'Change discussion options',
 		} );
-		const postSummarySection = page.getByRole( 'checkbox', {
-			name: 'Sticky',
+		const postSummarySection = page.getByRole( 'button', {
+			name: 'admin',
 		} );
 
 		await expect( postExcerptPanel ).toBeVisible();

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -125,13 +125,13 @@ test.describe( 'Sidebar', () => {
 		const postDiscussionPanel = page.getByRole( 'button', {
 			name: 'Change discussion options',
 		} );
-		const postAutorPanel = page.getByRole( 'button', {
+		const postAuthorPanel = page.getByRole( 'button', {
 			name: 'admin',
 		} );
 
 		await expect( postExcerptPanel ).toBeVisible();
 		await expect( postFeaturedImagePanel ).toBeVisible();
-		await expect( postAutorPanel ).toBeVisible();
+		await expect( postAuthorPanel ).toBeVisible();
 		await expect( postDiscussionPanel ).toHaveCount( 1 );
 
 		await page.evaluate( () => {
@@ -149,7 +149,7 @@ test.describe( 'Sidebar', () => {
 		await expect( documentSettingsPanels ).toHaveCount( 1 );
 		await expect( postExcerptPanel ).toBeHidden();
 		await expect( postFeaturedImagePanel ).toBeHidden();
-		await expect( postAutorPanel ).toBeHidden();
+		await expect( postAuthorPanel ).toBeHidden();
 		await expect( postDiscussionPanel ).toHaveCount( 0 );
 	} );
 } );


### PR DESCRIPTION
## What?
Move the 'Sticky' toggle to the 'Status & visibility' popover in the post editing UX.

## Why?
1. Marking a post as sticky is a relatively infrequent exercise, this change gives more appropriate prominence to the UI
2. By moving the option to the Status popover we have more room to inform users about what the option actually does
3. Sticky status feels conceptually at home in a panel titled 'Status & visibility'.

## Testing Instructions
1. Edit a post
2. Observe the sticky toggle now resides in the Status & visibility popover.

| Before | After |
| --- | --- |
| <img width="280" alt="Screenshot 2024-06-24 at 11 24 40" src="https://github.com/WordPress/gutenberg/assets/846565/21eec6aa-170e-4cea-bf6f-f17c12d073d7"> | <img width="653" alt="Screenshot 2024-06-24 at 11 23 39" src="https://github.com/WordPress/gutenberg/assets/846565/f41dcfd3-f8b1-407e-90cb-11b3fac95cff"> |
