### PR TITLE
Post Date Block: Fix PHP warning error

### DIFF
--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -44,7 +44,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	 */
 	if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
 		if ( get_the_modified_date( 'Ymdhi', $post_ID ) > get_the_date( 'Ymdhi', $post_ID ) ) {
-			if ( 'human-diff' === $attributes['format'] ) {
+			if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
 				// translators: %s: human-readable time difference.
 				$formatted_date = sprintf( __( '%s ago', 'gutenberg' ), human_time_diff( get_post_timestamp( $post_ID, 'modified' ) ) );
 			} else {


### PR DESCRIPTION
Fixes #62763
Follow-up #62298

## What?
This PR fixes a PHP warning error that occurs when "Display last modified date" in the Post Date block is enabled.

```
Warning: Undefined array key "format" in /var/www/html/wp-content/plugins/gutenberg/build/block-library/blocks/post-date.php on line 47
```

## Why?

In #62298, the relative time format was added. However, it seems that a check for undefined was missing in one place.

## Testing Instructions

- Insert a Post Date block into a post and enable "Display last modified date". Do not disable "Default format". Alternatively, use the HTML below:
  ```html
  <!-- wp:post-date {"displayType":"modified"} /-->
  ```


- No errors should occur on the front end.
