### PR TITLE
Fix: List view renders an empty menu when no actions are eligible.

### DIFF
--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -184,7 +184,7 @@ function ListItem< Item extends AnyItem >( {
 						</HStack>
 					</CompositeItem>
 				</div>
-				{ actions?.length > 0 && (
+				{ eligibleActions?.length > 0 && (
 					<HStack
 						spacing={ 1 }
 						justify="flex-end"


### PR DESCRIPTION
If no actions are eligible on the list view we render an empty menu. We are checking for actions?.length while we should check for eligibleActions?.length. This PR fixes the issue.

## Testing Instructions
I pasted the following code snippet:
```
function remove_edit_delete_post_capability( $caps, $cap, $user_id, $args ) {
    if ( 'edit_post' === $cap || 'delete_post' === $cap) {
        // Get the current user object
        $current_user = wp_get_current_user();
        // Check if the current user is the user we want to remove the capability from
        if ( $current_user->ID == $user_id ) {
            // Remove the 'delete_post' capability
            // It's done by returning a capability that the user does not have, for example 'do_not_allow'
            $caps[] = 'do_not_allow';
        }
    }

    return $caps;
}
add_filter( 'map_meta_cap', 'remove_edit_delete_post_capability', 10, 4 );
```

I went to the trash pages section `wp-admin/site-editor.php?postType=page&layout=list&activeView=trash`
I verified the actions menu is not available. On trunk it is and renders an empty menu:
<img width="239" alt="Screenshot 2024-06-21 at 17 25 03" src="https://github.com/WordPress/gutenberg/assets/11271197/d313f793-9b0e-44f7-a40e-95998334ddfd">
