### PR TITLE
Fix: DataViews: Active template is not highlighted properly in list view

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -39,6 +39,7 @@ import AddNewPageModal from '../add-new-page';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
+import { usePostIdLinkInSelection } from './utils';
 
 const { usePostActions } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -199,37 +200,6 @@ function FeaturedImage( { item, viewType } ) {
 			) }
 		</div>
 	);
-}
-
-function usePostIdLinkInSelection(
-	selection,
-	setSelection,
-	isLoadingItems,
-	items
-) {
-	const {
-		params: { postId },
-	} = useLocation();
-	const [ postIdToSelect, setPostIdToSelect ] = useState( postId );
-	useEffect( () => {
-		if ( postId ) {
-			setPostIdToSelect( postId );
-		}
-	}, [ postId ] );
-
-	useEffect( () => {
-		if ( ! postIdToSelect ) {
-			return;
-		}
-		// Only try to select an item if the loading is complete and we have items.
-		if ( ! isLoadingItems && items && items.length ) {
-			// If the item is not in the current selection, select it.
-			if ( selection.length !== 1 || selection[ 0 ] !== postIdToSelect ) {
-				setSelection( [ postIdToSelect ] );
-			}
-			setPostIdToSelect( undefined );
-		}
-	}, [ postIdToSelect, selection, setSelection, isLoadingItems, items ] );
 }
 
 export default function PagePages() {

--- a/packages/edit-site/src/components/page-pages/utils.js
+++ b/packages/edit-site/src/components/page-pages/utils.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+// Used on PagePages and PageTemplates.
+export function usePostIdLinkInSelection(
+	selection,
+	setSelection,
+	isLoadingItems,
+	items
+) {
+	const {
+		params: { postId },
+	} = useLocation();
+	const [ postIdToSelect, setPostIdToSelect ] = useState( postId );
+	useEffect( () => {
+		if ( postId ) {
+			setPostIdToSelect( postId );
+		}
+	}, [ postId ] );
+
+	useEffect( () => {
+		if ( ! postIdToSelect ) {
+			return;
+		}
+		// Only try to select an item if the loading is complete and we have items.
+		if ( ! isLoadingItems && items && items.length ) {
+			// If the item is not in the current selection, select it.
+			if ( selection.length !== 1 || selection[ 0 ] !== postIdToSelect ) {
+				setSelection( [ postIdToSelect ] );
+			}
+			setPostIdToSelect( undefined );
+		}
+	}, [ postIdToSelect, selection, setSelection, isLoadingItems, items ] );
+}

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -44,6 +44,7 @@ import {
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
+import { usePostIdLinkInSelection } from '../page-pages/utils';
 
 const { usePostActions } = unlock( editorPrivateApis );
 
@@ -222,6 +223,8 @@ export default function PageTemplates() {
 		} ) );
 	}, [ activeView ] );
 
+	const [ selection, setSelection ] = useState( [] );
+
 	const { records, isResolving: isLoadingData } = useEntityRecords(
 		'postType',
 		TEMPLATE_POST_TYPE,
@@ -229,6 +232,9 @@ export default function PageTemplates() {
 			per_page: -1,
 		}
 	);
+
+	usePostIdLinkInSelection( selection, setSelection, isLoadingData, records );
+
 	const history = useHistory();
 	const onSelectionChange = useCallback(
 		( items ) => {
@@ -369,6 +375,8 @@ export default function PageTemplates() {
 				view={ view }
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
+				selection={ selection }
+				setSelection={ setSelection }
 			/>
 		</Page>
 	);


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/62378.
Applies the same approach we had to highlight the active page to the templates.



Move the already existing hook usePostIdLinkInSelection to a utils file with a comment it is now used in PagePages and PageTemplates.
Uses the hook in the templates list.


## Testing Instructions
Go to wp-admin/site-editor.php?postType=wp_template&layout=list&postId=twentytwentyfour%2F%2Fhome (twentytwentyfour%2F%2Fhome needs to be a valid template id)
Verify the active template is highlighted properly (on trunk it is not).
