### PR TITLE
Create Block: Add missing changelog entries

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,9 +4,17 @@
 
 ## 4.44.0 (2024-06-15)
 
+### Bug fix
+
+-   Pin the `@wordpress/scripts` version to a version supported by WordPress 6.5 ([#62234](https://github.com/WordPress/gutenberg/pull/62234)).
+
 ## 4.43.0 (2024-05-31)
 
 ## 4.42.0 (2024-05-16)
+
+### Breaking Change
+
+-   Increase the minimum required Node.js version to v20.10.0 matching the support defined for Gutenberg and WordPress core ([#61430](https://github.com/WordPress/gutenberg/pull/61430)).
 
 ## 4.41.0 (2024-05-02)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up for #61430 and #61430.

Raised by @fabiankaegy in https://github.com/WordPress/gutenberg/pull/61430#issuecomment-2172596305.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> The way this was released means that any tool that isn't yet on node 20 broke when NPM updated the dependency if it was installed with the default ^ version selector.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add  missing changelog entries.