### PR TITLE
Fix: Crash when moving pages to trash or switching views.

### DIFF
--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -7,7 +7,13 @@ import type { ComponentType } from 'react';
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import {
+	useMemo,
+	useState,
+	useCallback,
+	useEffect,
+	useRef,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -92,8 +98,13 @@ export default function DataViews< Item extends AnyItem >( {
 	}
 	const [ openedFilter, setOpenedFilter ] = useState< string | null >( null );
 
+	const lastUpdatedSelectionBecauseOfItemRemoval = useRef< string[] >( [] );
+
 	useEffect( () => {
+		// We compare against lastUpdatedSelectionBecauseOfItemRemoval to make sure we don't trigger
+		// multiple set selection calls in loop for the same selection array that needs a change.
 		if (
+			selection !== lastUpdatedSelectionBecauseOfItemRemoval.current &&
 			selection.length > 0 &&
 			selection.some(
 				( id ) => ! data.some( ( item ) => getItemId( item ) === id )
@@ -108,8 +119,9 @@ export default function DataViews< Item extends AnyItem >( {
 					newSelection.includes( getItemId( item ) )
 				)
 			);
+			lastUpdatedSelectionBecauseOfItemRemoval.current = selection;
 		}
-	}, [ selection, data, getItemId, onSelectionChange ] );
+	}, [ selection, data, getItemId, onSelectionChange, setSelection ] );
 
 	const onSetSelection = useCallback(
 		( items: Item[] ) => {


### PR DESCRIPTION
This PR fixes a series of crashes that are happening in the trunk and WP beta.
We had some logic to remove an item from the selection if the item is not part of the view anymore.
But for the same selection change until the state was in fact updated we may have been doing multiple setState calls in a loop. This PR fixes the issue by using a reference and storing the selection that was updated because of an item being removed if the effect is called again with the same previous selection that triggered the setState call we don't reexecute the effect.

## Testing Instructions
- Go to the pages of the draft view `wp-admin/site-editor.php?postType=page&activeView=drafts` click on a page to select it , and move it to trash. Verify there is no crash (on trunk it crashes).
- Go to the pages of the draft view `wp-admin/site-editor.php?postType=page&activeView=drafts`, click on a page to select it, and then switch to the trash view.  Verify there is no crash (on the trunk it crashes).

Create a user template if you don't have one already.
Go to the templates list view, `site-editor.php?postType=wp_template&layout=list`
Select a user template.
Delete the user template, and verify there is no crash (on the trunk it crashes).