### PR TITLE
Cache theme and core data

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -158,12 +158,30 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds core data.
 	 */
 	public static function get_core_data() {
+		$can_use_cached = ! wp_is_development_mode( 'theme' );
+		if ( $can_use_cached ) {
+			$cache_key = 'core_data';
+			if ( null === static::$core ) {
+				$cache_value = static::get_cache_data( $cache_key );
+				if ( $cache_value ) {
+					// Defined in this function below.
+					$theme_json   = apply_filters( 'wp_theme_json_data_default', $cache_value );
+					static::$core = $theme_json->get_theme_json();
+				}
+			}
+		}
+
 		if ( null !== static::$core && static::has_same_registered_blocks( 'core' ) ) {
 			return static::$core;
 		}
 
 		$config = static::read_json_file( __DIR__ . '/theme.json' );
 		$config = static::translate( $config );
+
+		$theme_json = new WP_Theme_JSON_Data_Gutenberg( $config, 'default' );
+		if ( $can_use_cached ) {
+			static::set_cache_data( $cache_key, $theme_json );
+		}
 
 		/**
 		 * Filters the default data provided by WordPress for global styles & settings.
@@ -172,7 +190,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json   = apply_filters( 'wp_theme_json_data_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
+		$theme_json   = apply_filters( 'wp_theme_json_data_default', $theme_json );
 		static::$core = $theme_json->get_theme_json();
 
 		return static::$core;
@@ -193,6 +211,17 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			return false;
 		}
 
+		$can_use_cached = ! wp_is_development_mode( 'theme' );
+		if ( $can_use_cached ) {
+			$cache_key = 'registered_blocks_cache';
+			if ( static::is_block_cache_empty() ) {
+				$cache = static::get_cache_data( $cache_key );
+				if ( $cache ) {
+					static::$blocks_cache = $cache;
+				}
+			}
+		}
+
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();
 
@@ -206,6 +235,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			static::$blocks_cache[ $origin ][ $block_name ] = true;
 		}
 
+		if ( $can_use_cached ) {
+			static::set_cache_data( $cache_key, static::$blocks_cache );
+		}
 		return false;
 	}
 
@@ -237,6 +269,31 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
+
+		$can_use_cached = ! wp_is_development_mode( 'theme' );
+		if ( $can_use_cached ) {
+			$cache_key = 'theme_data';
+			if ( null === static::$theme ) {
+				$cache_value = static::get_cache_data( $cache_key );
+				if ( $cache_value ) {
+					// Defined in this function below.
+					$theme_json    = apply_filters( 'wp_theme_json_data_theme', $cache_value );
+					static::$theme = $theme_json->get_theme_json();
+
+					$wp_theme = wp_get_theme();
+					if ( $wp_theme->parent() ) {
+						$parent_theme_json_file = $wp_theme->parent()->get_file_path( 'theme.json' );
+						if ( $theme_json_file !== $parent_theme_json_file && is_readable( $parent_theme_json_file ) ) {
+							$parent_theme_json_data = static::read_json_file( $parent_theme_json_file );
+							$parent_theme_json_data = static::translate( $parent_theme_json_data, $wp_theme->parent()->get( 'TextDomain' ) );
+							$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
+							$parent_theme->merge( static::$theme );
+							static::$theme = $parent_theme;
+						}
+					}
+				}
+			}
+		}
 
 		if ( null === static::$theme || ! static::has_same_registered_blocks( 'theme' ) ) {
 			$wp_theme        = wp_get_theme();
@@ -271,6 +328,11 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			$theme_json_data = static::inject_variations_from_block_style_variation_files( $theme_json_data, $variations );
 			$theme_json_data = static::inject_variations_from_block_styles_registry( $theme_json_data );
 
+			$theme_json = new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' );
+			if ( $can_use_cached ) {
+				static::set_cache_data( $cache_key, $theme_json );
+			}
+
 			/**
 			 * Filters the data provided by the theme for global styles and settings.
 			 *
@@ -278,7 +340,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			 *
 			 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 			 */
-			$theme_json    = apply_filters( 'wp_theme_json_data_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
+			$theme_json    = apply_filters( 'wp_theme_json_data_theme', $theme_json );
 			static::$theme = $theme_json->get_theme_json();
 
 			if ( $wp_theme->parent() ) {
@@ -710,6 +772,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		static::$user                     = null;
 		static::$user_custom_post_type_id = null;
 		static::$i18n_schema              = null;
+		delete_site_transient( 'wp_theme_json_resolver_cache' );
 	}
 
 	/**
@@ -950,5 +1013,56 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		return $data;
+	}
+
+
+	/**
+	 * Retrieves persistent cache data of this class for given key.
+	 *
+	 * @since 6.7.0
+	 * @param string $cache_key The key to get the cache from.
+	 * @return mixed The cache value.
+	 */
+	private static function get_cache_data( $cache_key ) {
+		$cache = get_site_transient( 'wp_theme_json_resolver_cache' );
+		if ( $cache && isset( $cache[ $cache_key ] ) ) {
+			return $cache[ $cache_key ];
+		}
+		return false;
+	}
+
+	/**
+	 * Set persistent cache for given key.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param string $cache_key Cache key.
+	 * @param mixed $value The value to set in the cache.
+	 * @return bool True if the value was set, false otherwise.
+	 */
+	private static function set_cache_data( $cache_key, $value ) {
+		// This should be inexpensive as DB only happenes once per pageload.
+		$cache = get_site_transient( 'wp_theme_json_resolver_cache' );
+		if ( null === $cache ) {
+			$cache = array();
+		}
+		$cache[ $cache_key ] = $value;
+		return set_site_transient( 'wp_theme_json_resolver_cache', $cache, 10 * MINUTE_IN_SECONDS );
+	}
+
+	/**
+	 * Checks if block cache is fully empty.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return bool True if block cache is empty, false otherwise.
+	 */
+	private static function is_block_cache_empty() {
+		foreach ( static::$blocks_cache as $origin => $blocks ) {
+			if ( ! empty( $blocks ) ) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -280,7 +280,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					$theme_json    = apply_filters( 'wp_theme_json_data_theme', $cache_value );
 					static::$theme = $theme_json->get_theme_json();
 
-					$wp_theme = wp_get_theme();
+					$wp_theme        = wp_get_theme();
+					$theme_json_file = $wp_theme->get_file_path( 'theme.json' );
 					if ( $wp_theme->parent() ) {
 						$parent_theme_json_file = $wp_theme->parent()->get_file_path( 'theme.json' );
 						if ( $theme_json_file !== $parent_theme_json_file && is_readable( $parent_theme_json_file ) ) {
@@ -1058,7 +1059,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return bool True if block cache is empty, false otherwise.
 	 */
 	private static function is_block_cache_empty() {
-		foreach ( static::$blocks_cache as $origin => $blocks ) {
+		foreach ( static::$blocks_cache as $blocks ) {
 			if ( ! empty( $blocks ) ) {
 				return false;
 			}


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/59600

## What?
Caching persistently inside `get_theme_data` and `get_core_data` is estimated to provide a performance benefit of at least ~2%. Block data from `theme` and `core` are relatively static, so they can be persistently cached for a shorter period.

## Why?
For faster load time.

## How?
By caching and skipping constructor calls to `WP_Theme_JSON | WP_Theme_JSON_Gutenberg`, which is costly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
