### PR TITLE
DataViews: remove selection correcting, set initial state

### DIFF
--- a/packages/dataviews/src/bulk-actions.tsx
+++ b/packages/dataviews/src/bulk-actions.tsx
@@ -172,12 +172,10 @@ function ActionsMenuGroup< Item extends AnyItem >( {
 	);
 }
 
-const EMPTY_SELECTION: string[] = [];
-
 export default function BulkActions< Item extends AnyItem >( {
 	data,
 	actions,
-	selection = EMPTY_SELECTION,
+	selection,
 	onSelectionChange,
 	getItemId,
 }: BulkActionsProps< Item > ) {

--- a/packages/dataviews/src/bulk-actions.tsx
+++ b/packages/dataviews/src/bulk-actions.tsx
@@ -7,7 +7,7 @@ import {
 	Modal,
 } from '@wordpress/components';
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import { useMemo, useState, useCallback } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
 
 /**
@@ -172,10 +172,12 @@ function ActionsMenuGroup< Item extends AnyItem >( {
 	);
 }
 
+const EMPTY_SELECTION: string[] = [];
+
 export default function BulkActions< Item extends AnyItem >( {
 	data,
 	actions,
-	selection,
+	selection = EMPTY_SELECTION,
 	onSelectionChange,
 	getItemId,
 }: BulkActionsProps< Item > ) {
@@ -196,8 +198,6 @@ export default function BulkActions< Item extends AnyItem >( {
 	}, [ data, bulkActions ] );
 
 	const numberSelectableItems = selectableItems.length;
-	const areAllSelected =
-		selection && selection.length === numberSelectableItems;
 
 	const selectedItems = useMemo( () => {
 		return data.filter( ( item ) =>
@@ -205,28 +205,7 @@ export default function BulkActions< Item extends AnyItem >( {
 		);
 	}, [ selection, data, getItemId ] );
 
-	const hasNonSelectableItemSelected = useMemo( () => {
-		return selectedItems.some( ( item ) => {
-			return ! selectableItems.includes( item );
-		} );
-	}, [ selectedItems, selectableItems ] );
-	useEffect( () => {
-		if ( hasNonSelectableItemSelected ) {
-			onSelectionChange(
-				selectedItems.filter( ( selectedItem ) => {
-					return selectableItems.some( ( item ) => {
-						return getItemId( selectedItem ) === getItemId( item );
-					} );
-				} )
-			);
-		}
-	}, [
-		hasNonSelectableItemSelected,
-		selectedItems,
-		selectableItems,
-		getItemId,
-		onSelectionChange,
-	] );
+	const areAllSelected = selectedItems.length === numberSelectableItems;
 
 	if ( bulkActions.length === 0 ) {
 		return null;
@@ -245,15 +224,15 @@ export default function BulkActions< Item extends AnyItem >( {
 						variant="tertiary"
 						size="compact"
 					>
-						{ selection.length
+						{ selectedItems.length
 							? sprintf(
 									/* translators: %d: Number of items. */
 									_n(
 										'Edit %d item',
 										'Edit %d items',
-										selection.length
+										selectedItems.length
 									),
-									selection.length
+									selectedItems.length
 							  )
 							: __( 'Bulk edit' ) }
 					</Button>

--- a/packages/dataviews/src/bulk-actions.tsx
+++ b/packages/dataviews/src/bulk-actions.tsx
@@ -200,10 +200,12 @@ export default function BulkActions< Item extends AnyItem >( {
 	const numberSelectableItems = selectableItems.length;
 
 	const selectedItems = useMemo( () => {
-		return data.filter( ( item ) =>
-			selection.includes( getItemId( item ) )
+		return data.filter(
+			( item ) =>
+				selection.includes( getItemId( item ) ) &&
+				selectableItems.includes( item )
 		);
-	}, [ selection, data, getItemId ] );
+	}, [ selection, data, getItemId, selectableItems ] );
 
 	const areAllSelected = selectedItems.length === numberSelectableItems;
 

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -7,7 +7,7 @@ import type { ComponentType } from 'react';
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import { useMemo, useState, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -91,25 +91,6 @@ export default function DataViews< Item extends AnyItem >( {
 		setSelection = setSelectionState;
 	}
 	const [ openedFilter, setOpenedFilter ] = useState< string | null >( null );
-
-	useEffect( () => {
-		if (
-			selection.length > 0 &&
-			selection.some(
-				( id ) => ! data.some( ( item ) => getItemId( item ) === id )
-			)
-		) {
-			const newSelection = selection.filter( ( id ) =>
-				data.some( ( item ) => getItemId( item ) === id )
-			);
-			setSelection( newSelection );
-			onSelectionChange(
-				data.filter( ( item ) =>
-					newSelection.includes( getItemId( item ) )
-				)
-			);
-		}
-	}, [ selection, data, getItemId, onSelectionChange ] );
 
 	const onSetSelection = useCallback(
 		( items: Item[] ) => {

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -108,6 +108,11 @@ export default function DataViews< Item extends AnyItem >( {
 		actions,
 		data
 	);
+	const _selection = useMemo( () => {
+		return selection.filter( ( id ) =>
+			data.some( ( item ) => getItemId( item ) === id )
+		);
+	}, [ selection, data, getItemId ] );
 	return (
 		<div className="dataviews-wrapper">
 			<HStack
@@ -141,7 +146,7 @@ export default function DataViews< Item extends AnyItem >( {
 							actions={ actions }
 							data={ data }
 							onSelectionChange={ onSetSelection }
-							selection={ selection }
+							selection={ _selection }
 							getItemId={ getItemId }
 						/>
 					) }
@@ -160,7 +165,7 @@ export default function DataViews< Item extends AnyItem >( {
 				isLoading={ isLoading }
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSetSelection }
-				selection={ selection }
+				selection={ _selection }
 				setOpenedFilter={ setOpenedFilter }
 				view={ view }
 			/>
@@ -174,7 +179,7 @@ export default function DataViews< Item extends AnyItem >( {
 					<BulkActionsToolbar
 						data={ data }
 						actions={ actions }
-						selection={ selection }
+						selection={ _selection }
 						onSelectionChange={ onSetSelection }
 						getItemId={ getItemId }
 					/>

--- a/packages/dataviews/src/single-selection-checkbox.tsx
+++ b/packages/dataviews/src/single-selection-checkbox.tsx
@@ -29,7 +29,7 @@ export default function SingleSelectionCheckbox< Item extends AnyItem >( {
 	disabled,
 }: SingleSelectionCheckboxProps< Item > ) {
 	const id = getItemId( item );
-	const isSelected = selection.includes( id );
+	const isSelected = ! disabled && selection.includes( id );
 	let selectionLabel;
 	if ( primaryField?.getValue && item ) {
 		// eslint-disable-next-line @wordpress/valid-sprintf

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -75,6 +75,7 @@ interface BulkSelectionCheckboxProps< Item extends AnyItem > {
 	onSelectionChange: ( items: Item[] ) => void;
 	data: Item[];
 	actions: Action< Item >[];
+	getItemId: ( item: Item ) => string;
 }
 
 interface TableRowProps< Item extends AnyItem > {
@@ -249,6 +250,7 @@ function BulkSelectionCheckbox< Item extends AnyItem >( {
 	onSelectionChange,
 	data,
 	actions,
+	getItemId,
 }: BulkSelectionCheckboxProps< Item > ) {
 	const selectableItems = useMemo( () => {
 		return data.filter( ( item ) => {
@@ -259,13 +261,16 @@ function BulkSelectionCheckbox< Item extends AnyItem >( {
 			);
 		} );
 	}, [ data, actions ] );
-	const areAllSelected = selection.length === selectableItems.length;
+	const selectedItems = data.filter( ( item ) =>
+		selection.includes( getItemId( item ) )
+	);
+	const areAllSelected = selectedItems.length === selectableItems.length;
 	return (
 		<CheckboxControl
 			className="dataviews-view-table-selection-checkbox"
 			__nextHasNoMarginBottom
 			checked={ areAllSelected }
-			indeterminate={ ! areAllSelected && !! selection.length }
+			indeterminate={ ! areAllSelected && !! selectedItems.length }
 			onChange={ () => {
 				if ( areAllSelected ) {
 					onSelectionChange( [] );
@@ -495,6 +500,7 @@ function ViewTable< Item extends AnyItem >( {
 									onSelectionChange={ onSelectionChange }
 									data={ data }
 									actions={ actions }
+									getItemId={ getItemId }
 								/>
 							</th>
 						) }

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -298,7 +298,7 @@ function TableRow< Item extends AnyItem >( {
 	data,
 }: TableRowProps< Item > ) {
 	const hasPossibleBulkAction = useHasAPossibleBulkAction( actions, item );
-	const isSelected = selection.includes( id );
+	const isSelected = hasPossibleBulkAction && selection.includes( id );
 
 	const [ isHovered, setIsHovered ] = useState( false );
 
@@ -328,6 +328,9 @@ function TableRow< Item extends AnyItem >( {
 				isTouchDevice.current = true;
 			} }
 			onClick={ () => {
+				if ( ! hasPossibleBulkAction ) {
+					return;
+				}
 				if (
 					! isTouchDevice.current &&
 					document.getSelection()?.type !== 'Range'

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -261,8 +261,10 @@ function BulkSelectionCheckbox< Item extends AnyItem >( {
 			);
 		} );
 	}, [ data, actions ] );
-	const selectedItems = data.filter( ( item ) =>
-		selection.includes( getItemId( item ) )
+	const selectedItems = data.filter(
+		( item ) =>
+			selection.includes( getItemId( item ) ) &&
+			selectableItems.includes( item )
 	);
 	const areAllSelected = selectedItems.length === selectableItems.length;
 	return (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -201,6 +201,10 @@ function FeaturedImage( { item, viewType } ) {
 	);
 }
 
+function getItemId( item ) {
+	return item.id.toString();
+}
+
 export default function PagePages() {
 	const postType = 'page';
 	const [ view, setView ] = useView( postType );
@@ -464,9 +468,27 @@ export default function PagePages() {
 		[ authors, view.type, frontPageId, postsPageId ]
 	);
 
+	const onActionPerformed = useCallback(
+		( actionId, items ) => {
+			if (
+				actionId === 'move-to-trash' ||
+				actionId === 'permanently-delete'
+			) {
+				setSelection(
+					selection.filter(
+						( id ) =>
+							! items.some( ( item ) => getItemId( item ) === id )
+					)
+				);
+			}
+		},
+		[ selection, setSelection ]
+	);
+
 	const postTypeActions = usePostActions( {
 		postType: 'page',
 		context: 'list',
+		onActionPerformed,
 	} );
 	const editAction = useEditPostAction();
 	const actions = useMemo(
@@ -538,7 +560,7 @@ export default function PagePages() {
 				selection={ selection }
 				setSelection={ setSelection }
 				onSelectionChange={ onSelectionChange }
-				getItemId={ ( item ) => item.id.toString() }
+				getItemId={ getItemId }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -39,6 +39,7 @@ import AddNewPageModal from '../add-new-page';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
+import { usePrevious } from '@wordpress/compose';
 
 const { usePostActions } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -274,16 +275,19 @@ export default function PagePages() {
 		totalPages,
 	} = useEntityRecords( 'postType', postType, queryArgs );
 
+	const ids = pages?.map( ( page ) => getItemId( page ) ) ?? [];
+	const prevIds = usePrevious( ids ) ?? [];
+	const deletedIds = prevIds.filter( ( id ) => ! ids.includes( id ) );
+	const postIdWasDeleted = deletedIds.includes( postId );
+
 	useEffect( () => {
-		const postIdWasDeleted =
-			pages && ! pages.find( ( page ) => getItemId( page ) === postId );
 		if ( postIdWasDeleted ) {
 			history.push( {
 				...history.getLocationWithParams().params,
 				postId: undefined,
 			} );
 		}
-	}, [ pages, postId, history ] );
+	}, [ postIdWasDeleted, history ] );
 
 	const { records: authors, isResolving: isLoadingAuthors } =
 		useEntityRecords( 'root', 'user', { per_page: -1 } );

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -474,15 +474,15 @@ export default function PagePages() {
 				actionId === 'move-to-trash' ||
 				actionId === 'permanently-delete'
 			) {
-				setSelection(
-					selection.filter(
+				setSelection( ( _selection ) =>
+					_selection.filter(
 						( id ) =>
 							! items.some( ( item ) => getItemId( item ) === id )
 					)
 				);
 			}
 		},
-		[ selection, setSelection ]
+		[ setSelection ]
 	);
 
 	const postTypeActions = usePostActions( {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -474,15 +474,15 @@ export default function PagePages() {
 				actionId === 'move-to-trash' ||
 				actionId === 'permanently-delete'
 			) {
-				setSelection( ( _selection ) =>
-					_selection.filter(
+				setSelection(
+					selection.filter(
 						( id ) =>
 							! items.some( ( item ) => getItemId( item ) === id )
 					)
 				);
 			}
 		},
-		[ setSelection ]
+		[ selection, setSelection ]
 	);
 
 	const postTypeActions = usePostActions( {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -201,43 +201,14 @@ function FeaturedImage( { item, viewType } ) {
 	);
 }
 
-function usePostIdLinkInSelection(
-	selection,
-	setSelection,
-	isLoadingItems,
-	items
-) {
-	const {
-		params: { postId },
-	} = useLocation();
-	const [ postIdToSelect, setPostIdToSelect ] = useState( postId );
-	useEffect( () => {
-		if ( postId ) {
-			setPostIdToSelect( postId );
-		}
-	}, [ postId ] );
-
-	useEffect( () => {
-		if ( ! postIdToSelect ) {
-			return;
-		}
-		// Only try to select an item if the loading is complete and we have items.
-		if ( ! isLoadingItems && items && items.length ) {
-			// If the item is not in the current selection, select it.
-			if ( selection.length !== 1 || selection[ 0 ] !== postIdToSelect ) {
-				setSelection( [ postIdToSelect ] );
-			}
-			setPostIdToSelect( undefined );
-		}
-	}, [ postIdToSelect, selection, setSelection, isLoadingItems, items ] );
-}
-
 export default function PagePages() {
 	const postType = 'page';
 	const [ view, setView ] = useView( postType );
 	const history = useHistory();
-
-	const [ selection, setSelection ] = useState( [] );
+	const {
+		params: { postId },
+	} = useLocation();
+	const [ selection, setSelection ] = useState( [ postId ] );
 
 	const onSelectionChange = useCallback(
 		( items ) => {
@@ -298,8 +269,6 @@ export default function PagePages() {
 		totalItems,
 		totalPages,
 	} = useEntityRecords( 'postType', postType, queryArgs );
-
-	usePostIdLinkInSelection( selection, setSelection, isLoadingPages, pages );
 
 	const { records: authors, isResolving: isLoadingAuthors } =
 		useEntityRecords( 'root', 'user', { per_page: -1 } );

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -274,6 +274,16 @@ export default function PagePages() {
 		totalPages,
 	} = useEntityRecords( 'postType', postType, queryArgs );
 
+	useEffect( () => {
+		if ( pages && ! pages.find( ( page ) => page.id === +postId ) ) {
+			// remove the post id from the url in case it was deleted.
+			history.push( {
+				...history.getLocationWithParams().params,
+				postId: undefined,
+			} );
+		}
+	}, [ pages, postId, history ] );
+
 	const { records: authors, isResolving: isLoadingAuthors } =
 		useEntityRecords( 'root', 'user', { per_page: -1 } );
 
@@ -468,33 +478,9 @@ export default function PagePages() {
 		[ authors, view.type, frontPageId, postsPageId ]
 	);
 
-	const onActionPerformed = useCallback(
-		( actionId, items ) => {
-			if (
-				actionId === 'move-to-trash' ||
-				actionId === 'permanently-delete'
-			) {
-				const { params } = history.getLocationWithParams();
-				if (
-					items.some(
-						( item ) => getItemId( item ) === params.postId
-					)
-				) {
-					// remove the post id from the url in case it was deleted.
-					history.push( {
-						...params,
-						postId: undefined,
-					} );
-				}
-			}
-		},
-		[ history ]
-	);
-
 	const postTypeActions = usePostActions( {
 		postType: 'page',
 		context: 'list',
-		onActionPerformed,
 	} );
 	const editAction = useEditPostAction();
 	const actions = useMemo(

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -275,8 +275,9 @@ export default function PagePages() {
 	} = useEntityRecords( 'postType', postType, queryArgs );
 
 	useEffect( () => {
-		if ( pages && ! pages.find( ( page ) => page.id === +postId ) ) {
-			// remove the post id from the url in case it was deleted.
+		const postIdWasDeleted =
+			pages && ! pages.find( ( page ) => getItemId( page ) === postId );
+		if ( postIdWasDeleted ) {
 			history.push( {
 				...history.getLocationWithParams().params,
 				postId: undefined,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -474,8 +474,12 @@ export default function PagePages() {
 				actionId === 'move-to-trash' ||
 				actionId === 'permanently-delete'
 			) {
-				if ( items.some( ( item ) => getItemId( item ) === postId ) ) {
-					const { params } = history.getLocationWithParams();
+				const { params } = history.getLocationWithParams();
+				if (
+					items.some(
+						( item ) => getItemId( item ) === params.postId
+					)
+				) {
 					// remove the post id from the url in case it was deleted.
 					history.push( {
 						...params,
@@ -484,7 +488,7 @@ export default function PagePages() {
 				}
 			}
 		},
-		[ history, postId ]
+		[ history ]
 	);
 
 	const postTypeActions = usePostActions( {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -474,15 +474,17 @@ export default function PagePages() {
 				actionId === 'move-to-trash' ||
 				actionId === 'permanently-delete'
 			) {
-				setSelection(
-					selection.filter(
-						( id ) =>
-							! items.some( ( item ) => getItemId( item ) === id )
-					)
-				);
+				if ( items.some( ( item ) => getItemId( item ) === postId ) ) {
+					const { params } = history.getLocationWithParams();
+					// remove the post id from the url in case it was deleted.
+					history.push( {
+						...params,
+						postId: undefined,
+					} );
+				}
 			}
 		},
-		[ selection, setSelection ]
+		[ history, postId ]
 	);
 
 	const postTypeActions = usePostActions( {

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1143,18 +1143,12 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 					const existingCallback = actions[ i ].callback;
 					actions[ i ] = {
 						...actions[ i ],
-						callback: ( items, argsObject ) => {
-							existingCallback( items, {
-								...argsObject,
-								onActionPerformed: ( _items ) => {
-									if ( argsObject.onActionPerformed ) {
-										argsObject.onActionPerformed( _items );
-									}
-									onActionPerformed(
-										actions[ i ].id,
-										_items
-									);
-								},
+						callback: ( items, { _onActionPerformed } ) => {
+							existingCallback( items, ( _items ) => {
+								if ( _onActionPerformed ) {
+									_onActionPerformed( _items );
+								}
+								onActionPerformed( actions[ i ].id, _items );
 							} );
 						},
 					};

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1143,12 +1143,18 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 					const existingCallback = actions[ i ].callback;
 					actions[ i ] = {
 						...actions[ i ],
-						callback: ( items, { _onActionPerformed } ) => {
-							existingCallback( items, ( _items ) => {
-								if ( _onActionPerformed ) {
-									_onActionPerformed( _items );
-								}
-								onActionPerformed( actions[ i ].id, _items );
+						callback: ( items, argsObject ) => {
+							existingCallback( items, {
+								...argsObject,
+								onActionPerformed: ( _items ) => {
+									if ( argsObject.onActionPerformed ) {
+										argsObject.onActionPerformed( _items );
+									}
+									onActionPerformed(
+										actions[ i ].id,
+										_items
+									);
+								},
 							} );
 						},
 					};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Just trying this as an alternative to both #62787 and #62792.

If DataViews doesn't try to correct the selection when items don't exist or are removed (I think that should be the concern of the implementor), then we can also simply set an initial state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Reduces the amount of state setting in effects, which reduces the probability of infinite loops.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
