### PR TITLE
Global Styles: Add block variations to the isactive style variation calculation

### DIFF
--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -18,7 +18,8 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { filterObjectByProperty } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../../lock-unlock';
 
-const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
+const { mergeBaseAndUserConfigs, useResolvedBlockStyleVariationsConfig } =
+	unlock( editorPrivateApis );
 const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
@@ -49,9 +50,15 @@ export default function Variation( { variation, children, isPill, property } ) {
 		}
 	};
 
+	const varitationWithBlockStyleVariation =
+		useResolvedBlockStyleVariationsConfig( variation );
 	const isActive = useMemo(
-		() => areGlobalStyleConfigsEqual( user, variation ),
-		[ user, variation ]
+		() =>
+			areGlobalStyleConfigsEqual(
+				user,
+				varitationWithBlockStyleVariation
+			),
+		[ user, varitationWithBlockStyleVariation ]
 	);
 
 	let label = variation?.title;

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -39,7 +39,7 @@ export function mergeBaseAndUserConfigs( base, user ) {
  * @param {Object} userConfig Current user origin global styles data.
  * @return {Object} Updated global styles data.
  */
-function useResolvedBlockStyleVariationsConfig( userConfig ) {
+export function useResolvedBlockStyleVariationsConfig( userConfig ) {
 	const { getBlockStyles } = useSelect( blocksStore );
 	const sharedVariations = userConfig?.styles?.blocks?.variations;
 

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -22,6 +22,7 @@ import ResizableEditor from './components/resizable-editor';
 import {
 	mergeBaseAndUserConfigs,
 	GlobalStylesProvider,
+	useResolvedBlockStyleVariationsConfig,
 } from './components/global-styles-provider';
 
 const { store: interfaceStore, ...remainingInterfaceApis } = interfaceApis;
@@ -41,7 +42,7 @@ lock( privateApis, {
 	ToolsMoreMenuGroup,
 	ViewMoreMenuGroup,
 	ResizableEditor,
-
+	useResolvedBlockStyleVariationsConfig,
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.
 	useBlockEditorSettings,
 	interfaceStore,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/62758.

This processes style variation previews in the same way that we process variations when they are committed so that they are formatted the same way and can be detected as the same.

## Why?
This is necessary so that style variations are marked as active:
<img width="281" alt="Screenshot 2024-06-24 at 15 46 20" src="https://github.com/WordPress/gutenberg/assets/275961/2d999a02-8215-4ab9-8423-04d2a9886532">

## How?
Process the style variation with `useResolvedBlockStyleVariationsConfig` before comparing it to the saved user variation.

There are some other possibilities for how to solve this:
1. We could move the `useResolvedBlockStyleVariationsConfig` call to inside `areGlobalStyleConfigsEqual` so that other uses of this function benefit from the change.
2. We could move `useResolvedBlockStyleVariationsConfig` up the call stack so that the variation is processed before this point.

## Testing Instructions
1. Switch to a theme that contains a style variation which has block styles (I'm using Assembler)
2. Select a style variation
3. Check that the selected variation is highlighted as the active variation.


## Screenshots or screencast <!-- if applicable -->
<img width="281" alt="Screenshot 2024-06-24 at 15 46 20" src="https://github.com/WordPress/gutenberg/assets/275961/2d999a02-8215-4ab9-8423-04d2a9886532">
