### PR TITLE
Navigation block: Fix submenu not opening on macOS Safari

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -828,7 +828,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 		$tags->set_attribute( 'data-wp-interactive', 'core/navigation' );
 		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu" }' );
 		$tags->set_attribute( 'data-wp-watch', 'callbacks.initMenu' );
-		$tags->set_attribute( 'data-wp-on-async--focusout', 'actions.handleMenuFocusout' );
+		$tags->set_attribute( 'data-wp-on--focusout', 'actions.handleMenuFocusout' );
 		$tags->set_attribute( 'data-wp-on--keydown', 'actions.handleMenuKeydown' );
 
 		// This is a fix for Safari. Without it, Safari doesn't change the active


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

This pull request fixes an issue in Safari Desktop (macOS) where submenus do not open upon clicking due to a change in https://github.com/WordPress/gutenberg/pull/62160.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Right now (Gutenberg 18.6), the submenus that have the "Open on Click" option do not open on Safari Desktop.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For now, I have simply reverted the change that causes the submenus to stop opening. I haven't investigated exactly why it happens yet.

It took us a while to figure out how to make the focus logic work properly in Safari since it functions completely differently than in Chrome and Firefox. That logic is also not as clean and straightforward as we would like:

- https://github.com/WordPress/gutenberg/pull/55198

I think for now we could leave this event handler as asynchronous to fix this bug and take a closer look at the Safari focus logic in a subsequent PR.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Add a menu with a submenu
- Activate the option "Open on click"
- Use Safari macOS
- Test that the submenu opens on click
- Test that the rest of features/accessibility work as usual
