### PR TITLE
CustomSelectControlV2: Add root element wrapper

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))
+
 ## 28.2.0 (2024-06-26)
 
 ### Enhancements

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -92,7 +92,7 @@ function _CustomSelect(
 	} = props;
 
 	return (
-		<>
+		<div>
 			{ hideLabelFromVision ? ( // TODO: Replace with BaseControl
 				<VisuallyHidden as="label">{ label }</VisuallyHidden>
 			) : (
@@ -116,7 +116,7 @@ function _CustomSelect(
 					</CustomSelectContext.Provider>
 				</Styled.SelectPopover>
 			</InputBase>
-		</>
+		</div>
 	);
 }
 

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -88,11 +88,13 @@ function _CustomSelect(
 		label,
 		size,
 		store,
+		className,
 		...restProps
 	} = props;
 
 	return (
-		<div>
+		// Where should `restProps` be forwarded to?
+		<div className={ className }>
 			{ hideLabelFromVision ? ( // TODO: Replace with BaseControl
 				<VisuallyHidden as="label">{ label }</VisuallyHidden>
 			) : (

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -3,6 +3,7 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import * as Ariakit from '@ariakit/react';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 		onChange,
 		size = 'default',
 		value,
+		className: classNameProp,
 		...restProps
 	} = props;
 
@@ -122,6 +124,10 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 			}
 			size={ translatedSize }
 			store={ store }
+			className={ clsx(
+				'components-custom-select-control',
+				classNameProp
+			) }
 			{ ...restProps }
 		>
 			{ children }

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -51,6 +51,10 @@ export type CustomSelectButtonProps = {
 
 export type _CustomSelectProps = CustomSelectButtonProps & {
 	/**
+	 * Additional className added to the root wrapper element.
+	 */
+	className?: string;
+	/**
 	 * The child elements. This should be composed of `CustomSelectItem` components.
 	 */
 	children: React.ReactNode;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #62424

Add a root element wrapper to `CustomSelectControlV2`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- To fix layout bugs where outer CSS rules "leak" to the internal elements of `CustomSelectControl` (eg. if the parent has `display: flex`, which is what happens when using `CustomSelectControl` as a direct child of `ToolsPanelItem`)
- For legacy reasons, in order to have a  place where to apply the `components-custom-select-control` className

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding a root element wrapper (ie a `div`) instead of a React Fragment, wrapping label + button under one element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### In the editor

To test in the editor, apply this patch

<details>

<summary>Click to expand</summary>

```diff
diff --git a/packages/block-editor/src/components/font-appearance-control/index.js b/packages/block-editor/src/components/font-appearance-control/index.js
index 18e814ad23..1340396c86 100644
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -1,10 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { CustomSelectControl } from '@wordpress/components';
+import {
+	CustomSelectControl,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { CustomSelectControlV2Legacy } = unlock( componentsPrivateApis );
+
 const FONT_STYLES = [
 	{
 		name: _x( 'Regular', 'font style' ),
@@ -205,7 +215,7 @@ export default function FontAppearanceControl( props ) {
 
 	return (
 		hasStylesOrWeights && (
-			<CustomSelectControl
+			<CustomSelectControlV2Legacy
 				{ ...otherProps }
 				className="components-font-appearance-control"
 				label={ label }
diff --git a/packages/components/src/private-apis.ts b/packages/components/src/private-apis.ts
index f55373664e..9a26b7c7e3 100644
--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -14,6 +14,7 @@ import {
 	useCompositeStore as useCompositeStoreV2,
 } from './composite/v2';
 import { default as CustomSelectControl } from './custom-select-control';
+import { default as CustomSelectControlV2Legacy } from './custom-select-control-v2/legacy-component';
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
 import { createPrivateSlotFill } from './slot-fill';
 import {
@@ -40,6 +41,7 @@ lock( privateApis, {
 	CompositeRowV2,
 	useCompositeStoreV2,
 	CustomSelectControl,
+	CustomSelectControlV2Legacy,
 	__experimentalPopoverLegacyPositionToPlacement,
 	createPrivateSlotFill,
 	ComponentsContext,


```
</details>

2. Load the post editor
3. Select the block, and in the block toolbar, add the "Appearance" controls in the typography section
4. Notice how the label now has bottom margin

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2024-06-25 at 10 54 05](https://github.com/WordPress/gutenberg/assets/1083581/9507a34e-f437-4a19-8770-829cf04f8671) | ![Screenshot 2024-06-25 at 10 54 45](https://github.com/WordPress/gutenberg/assets/1083581/6efd79d9-7be2-4e90-946e-055caba400c4) | 
