### PR TITLE
Fix: extra `wp-block-navigation` getting on `ul` tag

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -162,7 +162,7 @@ class WP_Navigation_Block_Renderer {
 	/**
 	 * Returns the inner container attributes.
 	 *
-	 * @since 6.6.0
+	 * @since 6.7.0
 	 *
 	 * @param array $extra_attributes The extra attributes to add.
 	 * @param string $exclude_class The class to exclude.


### PR DESCRIPTION
## What?
- created function similar to `get_block_wrapper_attributes` which support extra parameter to exclude some class.

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/62690

## How?
- as `get_block_wrapper_attributes` enters default block class, which causes issues by having the block class on the inner container if it's used.

## Testing Instructions
- create navigation menu
- check `ul` tag 
- now there will not be `wp-block-navigation` class which should only be present on main navigation wrapper

## Screenshots or screencast <!-- if applicable -->
<img width="700" alt="Screenshot 2024-06-25 at 00 13 53" src="https://github.com/WordPress/gutenberg/assets/75293077/f182a792-e3a2-4479-80d0-c49b23337761">
