### PR TITLE
Fix: Don't send meta on the duplicate action just because of empty foonotes.

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -765,7 +765,6 @@ const useDuplicatePostAction = ( postType ) => {
 									? item.content
 									: item.content.raw,
 							excerpt: item.excerpt.raw,
-							meta: item.meta,
 							parent: item.parent,
 							password: item.password,
 							template: item.template,
@@ -774,6 +773,24 @@ const useDuplicatePostAction = ( postType ) => {
 							menu_order: item.menu_order,
 							ping_status: item.ping_status,
 						};
+						if ( item.meta ) {
+							const metaKeys = Object.keys( item.meta );
+							if ( metaKeys.length > 0 ) {
+								const { footnotes, ...restMeta } = item.meta;
+								if (
+									footnotes ||
+									Object.keys( restMeta ).length > 0
+								) {
+									newItemOject.meta = footnotes
+										? {
+												footnotes,
+												...restMeta,
+										  }
+										: restMeta;
+								}
+							}
+						}
+
 						const assignablePropertiesPrefix = 'wp:action-assign-';
 						// Get all the properties that the current user is able to assign normally author, categories, tags,
 						// and custom taxonomies.

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -64,7 +64,7 @@ const duplicatePost: Action< BasePost > = {
 
 			const isTemplate = item.type === 'wp_template';
 
-			const newItemObject = {
+			const newItemObject: Record< string, unknown > = {
 				status: isTemplate ? 'publish' : 'draft',
 				title: item.title,
 				slug: isTemplate ? item.slug : item.title || __( 'No title' ),
@@ -77,7 +77,6 @@ const duplicatePost: Action< BasePost > = {
 					typeof item.excerpt === 'string'
 						? item.excerpt
 						: item.excerpt?.raw,
-				meta: item.meta,
 				parent: item.parent,
 				password: item.password,
 				template: item.template,
@@ -86,6 +85,20 @@ const duplicatePost: Action< BasePost > = {
 				menu_order: item.menu_order,
 				ping_status: item.ping_status,
 			};
+			if ( item.meta ) {
+				const metaKeys = Object.keys( item.meta );
+				if ( metaKeys.length > 0 ) {
+					const { footnotes, ...restMeta } = item.meta;
+					if (
+						footnotes ||
+						Object.keys( restMeta ).length > 0
+					) {
+						newItemObject.meta = footnotes
+							? { footnotes, ...restMeta }
+							: restMeta;
+					}
+				}
+			}
 			const assignablePropertiesPrefix = 'wp:action-assign-';
 			// Get all the properties that the current user is able to assign normally author, categories, tags,
 			// and custom taxonomies.


### PR DESCRIPTION
Even if a post has no footnotes its meta-object is {footnotes: ''}. So on duplicate if the post has a meta object equal to {footnotes: ''} there is no need to pass the meta object on the API request at all. This PR does that.

This change addresses an issue/bug where if the user has no edit_post capability (but still has the create_post capability so can duplicate a post) we throw an error message on duplicate saying the user is unable to change the footnotes meta property, even if the page has no footnotes.


## Testing Instructions
I pasted the following PHP code to remove the edit_post capability:
```
function remove_edit_delete_post_capability( $caps, $cap, $user_id, $args ) {
    if ( 'edit_post' === $cap || 'delete_post' === $cap) {
        // Get the current user object
        $current_user = wp_get_current_user();
        // Check if the current user is the user we want to remove the capability from
        if ( $current_user->ID == $user_id ) {
            // Remove the 'delete_post' capability
            // It's done by returning a capability that the user does not have, for example 'do_not_allow'
            $caps[] = 'do_not_allow';
        }
    }

    return $caps;
}
add_filter( 'map_meta_cap4', 'remove_edit_delete_post_capability', 10, 4 );
```

I went to the pages list `wp-admin/site-editor.php?postType=page` and duplicated a page. I verified there were no errors (on trunk there is an error related to footnotes).