### PR TITLE
Global Styles: Remove obsolete hook resolving shared block style variations

### DIFF
--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -7,17 +7,15 @@ import { isPlainObject } from 'is-plain-object';
 /**
  * WordPress dependencies
  */
-import { registerBlockStyle, store as blocksStore } from '@wordpress/blocks';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import setNestedValue from '../../utils/set-nested-value';
 
 const { GlobalStylesContext, cleanEmptyObject } = unlock(
 	blockEditorPrivateApis
@@ -30,85 +28,6 @@ export function mergeBaseAndUserConfigs( base, user ) {
 		// to override the old array (no merging).
 		isMergeableObject: isPlainObject,
 	} );
-}
-
-/**
- * Resolves shared block style variation definitions from the user origin
- * under their respective block types and registers the block style if required.
- *
- * @param {Object} userConfig Current user origin global styles data.
- * @return {Object} Updated global styles data.
- */
-function useResolvedBlockStyleVariationsConfig( userConfig ) {
-	const { getBlockStyles } = useSelect( blocksStore );
-	const sharedVariations = userConfig?.styles?.blocks?.variations;
-
-	// Collect block style variation definitions to merge and unregistered
-	// block styles for automatic registration.
-	const [ userConfigToMerge, unregisteredStyles ] = useMemo( () => {
-		if ( ! sharedVariations ) {
-			return [];
-		}
-
-		const variationsConfigToMerge = {};
-		const unregisteredBlockStyles = [];
-
-		Object.entries( sharedVariations ).forEach(
-			( [ variationName, variation ] ) => {
-				if ( ! variation?.blockTypes?.length ) {
-					return;
-				}
-
-				variation.blockTypes.forEach( ( blockName ) => {
-					const blockStyles = getBlockStyles( blockName );
-					const registeredBlockStyle = blockStyles.find(
-						( { name } ) => name === variationName
-					);
-
-					if ( ! registeredBlockStyle ) {
-						unregisteredBlockStyles.push( [
-							blockName,
-							{
-								name: variationName,
-								label: variationName,
-							},
-						] );
-					}
-
-					const path = [
-						'styles',
-						'blocks',
-						blockName,
-						'variations',
-						variationName,
-					];
-					setNestedValue( variationsConfigToMerge, path, variation );
-				} );
-			}
-		);
-
-		return [ variationsConfigToMerge, unregisteredBlockStyles ];
-	}, [ sharedVariations, getBlockStyles ] );
-
-	// Automatically register missing block styles from variations.
-	useEffect(
-		() =>
-			unregisteredStyles?.forEach( ( unregisteredStyle ) =>
-				registerBlockStyle( ...unregisteredStyle )
-			),
-		[ unregisteredStyles ]
-	);
-
-	// Merge shared block style variation definitions into overall user config.
-	const updatedConfig = useMemo( () => {
-		if ( ! userConfigToMerge ) {
-			return userConfig;
-		}
-
-		return deepmerge( userConfigToMerge, userConfig );
-	}, [ userConfigToMerge, userConfig ] );
-
-	return updatedConfig;
 }
 
 function useGlobalStylesUserConfig() {
@@ -199,7 +118,7 @@ function useGlobalStylesUserConfig() {
 				options
 			);
 		},
-		[ globalStylesId ]
+		[ globalStylesId, editEntityRecord, getEditedEntityRecord ]
 	);
 
 	return [ isReady, config, setConfig ];
@@ -219,28 +138,26 @@ export function useGlobalStylesContext() {
 	const [ isUserConfigReady, userConfig, setUserConfig ] =
 		useGlobalStylesUserConfig();
 	const [ isBaseConfigReady, baseConfig ] = useGlobalStylesBaseConfig();
-	const userConfigWithVariations =
-		useResolvedBlockStyleVariationsConfig( userConfig );
 
 	const mergedConfig = useMemo( () => {
-		if ( ! baseConfig || ! userConfigWithVariations ) {
+		if ( ! baseConfig || ! userConfig ) {
 			return {};
 		}
 
-		return mergeBaseAndUserConfigs( baseConfig, userConfigWithVariations );
-	}, [ userConfigWithVariations, baseConfig ] );
+		return mergeBaseAndUserConfigs( baseConfig, userConfig );
+	}, [ userConfig, baseConfig ] );
 
 	const context = useMemo( () => {
 		return {
 			isReady: isUserConfigReady && isBaseConfigReady,
-			user: userConfigWithVariations,
+			user: userConfig,
 			base: baseConfig,
 			merged: mergedConfig,
 			setUserConfig,
 		};
 	}, [
 		mergedConfig,
-		userConfigWithVariations,
+		userConfig,
 		baseConfig,
 		setUserConfig,
 		isUserConfigReady,


### PR DESCRIPTION
## What?

This PR removes an obsolete hook: `useResolvedBlockStyleVariationsConfig`

## Why?

With the recent shift from `styles.blocks.variations` to `styles.variations` in #62712, the `useResolvedBlockStyleVariationsConfig` no longer had an effect and isn't required for a couple of reasons:

- Block style variations defined within theme style variations must now be registered directly by the theme i.e. they are no longer automatically registered.
- The theme.json class now unwraps or resolves the shared variation definitions on instantiation so by the time the user config is retrieved here the work this hook did has already been done.

## How?

- Remove `useResolvedBlockStyleVariationsConfig`

## Testing Instructions

1. Setup a theme to register a block style variation via either a theme.json partial or using `register_block_style` (example partial snippet below)
2. Redefine the shared block style variation in a theme style variation via `styles.variations`
3. In the site editor apply the variation to a block and ensure the partial's styles apply
4. Confirm switching to the theme style variation applies its customized block style variation styles
5. Tweak the block style variation via Styles > Blocks > Block Type > Variation
6. Create a post in the post editor applying the same block style variation to a block, confirming the correct styles
7. Make sure the site editor and post editor applied variations are reflected correctly on the frontend
