### PR TITLE
Fix: Active template is not highlighted properly in list view.

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -186,7 +186,9 @@ function Preview( { item, viewType } ) {
 
 export default function PageTemplates() {
 	const { params } = useLocation();
-	const { activeView = 'all', layout } = params;
+	const { activeView = 'all', layout, postId } = params;
+	const [ selection, setSelection ] = useState( [ postId ] );
+
 	const defaultView = useMemo( () => {
 		const usedType = layout ?? DEFAULT_VIEW.type;
 		return {
@@ -369,6 +371,8 @@ export default function PageTemplates() {
 				view={ view }
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
+				selection={ selection }
+				setSelection={ setSelection }
 			/>
 		</Page>
 	);


### PR DESCRIPTION
New version of https://github.com/WordPress/gutenberg/pull/62787 after changes in https://github.com/WordPress/gutenberg/pull/62796.

Makes the selection state of templates managed like the one of pages and sets the initial selection state to the postId.

## Testing Instructions
Go to wp-admin/site-editor.php?postType=wp_template&layout=list&postId=twentytwentyfour%2F%2Fhome (twentytwentyfour%2F%2Fhome needs to be a valid template id)
Verify the active template is highlighted properly (on trunk it is not).
