### PR TITLE
Show publish panel only in edit mode

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -207,7 +207,6 @@ export default function EditSiteEditor( { isLoading } ) {
 					extraSidebarPanels={
 						! isEditingPage && <PluginTemplateSettingPanel.Slot />
 					}
-					isEditMode={ isEditMode }
 				>
 					{ isEditMode && (
 						<BackButton>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -207,6 +207,7 @@ export default function EditSiteEditor( { isLoading } ) {
 					extraSidebarPanels={
 						! isEditingPage && <PluginTemplateSettingPanel.Slot />
 					}
+					isEditMode={ isEditMode }
 				>
 					{ isEditMode && (
 						<BackButton>

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -58,6 +58,7 @@ export default function EditorInterface( {
 	forceDisableBlockTools,
 	title,
 	iframeProps,
+	isEditMode = true,
 } ) {
 	const {
 		mode,
@@ -212,14 +213,18 @@ export default function EditorInterface( {
 				)
 			}
 			actions={
-				<SavePublishPanels
-					closeEntitiesSavedStates={ closeEntitiesSavedStates }
-					isEntitiesSavedStatesOpen={ entitiesSavedStatesCallback }
-					setEntitiesSavedStatesCallback={
-						setEntitiesSavedStatesCallback
-					}
-					forceIsDirtyPublishPanel={ forceIsDirty }
-				/>
+				isEditMode ? (
+					<SavePublishPanels
+						closeEntitiesSavedStates={ closeEntitiesSavedStates }
+						isEntitiesSavedStatesOpen={
+							entitiesSavedStatesCallback
+						}
+						setEntitiesSavedStatesCallback={
+							setEntitiesSavedStatesCallback
+						}
+						forceIsDirtyPublishPanel={ forceIsDirty }
+					/>
+				) : undefined
 			}
 			shortcuts={ {
 				previous: previousShortcut,

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -58,7 +58,6 @@ export default function EditorInterface( {
 	forceDisableBlockTools,
 	title,
 	iframeProps,
-	isEditMode = true,
 } ) {
 	const {
 		mode,
@@ -213,7 +212,7 @@ export default function EditorInterface( {
 				)
 			}
 			actions={
-				isEditMode ? (
+				! isPreviewMode ? (
 					<SavePublishPanels
 						closeEntitiesSavedStates={ closeEntitiesSavedStates }
 						isEntitiesSavedStatesOpen={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/62702

>In the editor, you can use the tab key to focus on the "Open publish panel" button that appears in the bottom right. Clicking this button will show the Publish panel.

This PR fixes that by only rendering this when we're in edit mode, which is the default for post editor.



## Testing Instructions
1. In site editor using the `tab` key you shouldn't be able to reproduce this:

https://github.com/WordPress/gutenberg/assets/54422211/a2352eb5-ba1e-4699-b1f0-d7e297eeb542

2. Using `tab` key in post editor should work as before and show the `open publish panel` button.
