### PR TITLE
WIP: Block bindings - add an API to determine whether a binding source is active and use it for pattern overrides

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -462,6 +462,10 @@ _Returns_
 
 -   `Array|string`: A list of blocks or a string, depending on `handlerMode`.
 
+### privateApis
+
+Private @wordpress/blocks APIs.
+
 ### rawHandler
 
 Converts an HTML string to known blocks.

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -11,3 +11,4 @@
 export { store } from './store';
 export * from './api';
 export * from './deprecated';
+export { privateApis } from './private-apis';

--- a/packages/blocks/src/private-apis.js
+++ b/packages/blocks/src/private-apis.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { lock } from './lock-unlock';
+import { isBindingSourceActiveKey } from './store/constants';
+
+/**
+ * Private @wordpress/blocks APIs.
+ */
+export const privateApis = {};
+lock( privateApis, {
+	isBindingSourceActiveKey,
+} );

--- a/packages/blocks/src/store/constants.js
+++ b/packages/blocks/src/store/constants.js
@@ -1,1 +1,3 @@
 export const STORE_NAME = 'core/blocks';
+
+export const isBindingSourceActiveKey = Symbol( 'isActive' );

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -49,12 +49,6 @@ export function addUnprocessedBlockType( name, blockType ) {
 export function registerBlockBindingsSource( source ) {
 	return {
 		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
-		sourceName: source.name,
-		sourceLabel: source.label,
-		getValue: source.getValue,
-		setValue: source.setValue,
-		setValues: source.setValues,
-		getPlaceholder: source.getPlaceholder,
-		canUserEditValue: source.canUserEditValue,
+		source,
 	};
 }

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { omit } from '../api/utils';
+import { isBindingSourceActiveKey } from './constants';
 
 /**
  * @typedef {Object} WPBlockCategory
@@ -373,15 +374,18 @@ export function collections( state = {}, action ) {
 
 export function blockBindingsSources( state = {}, action ) {
 	if ( action.type === 'REGISTER_BLOCK_BINDINGS_SOURCE' ) {
+		const { source } = action;
 		return {
 			...state,
-			[ action.sourceName ]: {
-				label: action.sourceLabel,
-				getValue: action.getValue,
-				setValue: action.setValue,
-				setValues: action.setValues,
-				getPlaceholder: action.getPlaceholder,
-				canUserEditValue: action.canUserEditValue || ( () => false ),
+			[ source.name ]: {
+				label: source.label,
+				getValue: source.getValue,
+				setValue: source.setValue,
+				setValues: source.setValues,
+				getPlaceholder: source.getPlaceholder,
+				canUserEditValue: source.canUserEditValue || ( () => false ),
+				[ isBindingSourceActiveKey ]:
+					source[ isBindingSourceActiveKey ],
 			},
 		};
 	}

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -796,99 +796,49 @@ test.describe( 'Pattern Overrides', () => {
 	} );
 
 	test( 'blocks with the same name should be synced', async ( {
-		page,
 		admin,
 		requestUtils,
 		editor,
 	} ) => {
-		let patternId;
 		const sharedName = 'Shared Name';
-
-		await test.step( 'create a pattern with synced blocks with the same name', async () => {
-			const { id } = await requestUtils.createBlock( {
-				title: 'Blocks with the same name',
-				content: `<!-- wp:heading {"metadata":{"name":"${ sharedName }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+		const { id: patternId } = await requestUtils.createBlock( {
+			title: 'Blocks with the same name',
+			content: `<!-- wp:heading {"metadata":{"name":"${ sharedName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 			<h2>default name</h2>
 			<!-- /wp:heading -->
-			<!-- wp:paragraph {"metadata":{"name":"${ sharedName }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+			<!-- wp:paragraph {"metadata":{"name":"${ sharedName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 			<p>default content</p>
 			<!-- /wp:paragraph -->
-			<!-- wp:paragraph {"metadata":{"name":"${ sharedName }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+			<!-- wp:paragraph {"metadata":{"name":"${ sharedName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 			<p>default content</p>
 			<!-- /wp:paragraph -->`,
-				status: 'publish',
-			} );
-			await admin.visitSiteEditor( {
-				postId: id,
-				postType: 'wp_block',
-				canvas: 'edit',
-			} );
+			status: 'publish',
+		} );
+		await admin.createNewPost();
 
-			const headingBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Heading',
-			} );
-			const firstParagraph = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Paragraph',
-				} )
-				.first();
-			const secondParagraph = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Paragraph',
-				} )
-				.last();
-
-			// Update the content of one of the blocks.
-			await headingBlock.fill( 'updated content' );
-
-			// Check that every content has been updated.
-			for ( const block of [
-				headingBlock,
-				firstParagraph,
-				secondParagraph,
-			] ) {
-				await expect( block ).toHaveText( 'updated content' );
-			}
-
-			await page
-				.getByRole( 'region', { name: 'Editor top bar' } )
-				.getByRole( 'button', { name: 'Save' } )
-				.click();
-
-			await expect(
-				page.getByRole( 'button', { name: 'Dismiss this notice' } )
-			).toBeVisible();
-
-			patternId = new URL( page.url() ).searchParams.get( 'postId' );
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: { ref: patternId },
 		} );
 
-		await test.step( 'create a post and insert the pattern with synced values', async () => {
-			await admin.createNewPost();
-
-			await editor.insertBlock( {
-				name: 'core/block',
-				attributes: { ref: patternId },
-			} );
-
-			const headingBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Heading',
-			} );
-			const firstParagraph = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Paragraph',
-				} )
-				.first();
-			const secondParagraph = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Paragraph',
-				} )
-				.last();
-
-			await firstParagraph.fill( 'overriden content' );
-			await expect( headingBlock ).toHaveText( 'overriden content' );
-			await expect( firstParagraph ).toHaveText( 'overriden content' );
-			await expect( secondParagraph ).toHaveText( 'overriden content' );
+		const headingBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Heading',
 		} );
+		const firstParagraph = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} )
+			.first();
+		const secondParagraph = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} )
+			.last();
+
+		await firstParagraph.fill( 'overriden content' );
+		await expect( headingBlock ).toHaveText( 'overriden content' );
+		await expect( firstParagraph ).toHaveText( 'overriden content' );
+		await expect( secondParagraph ).toHaveText( 'overriden content' );
 	} );
 
 	// https://github.com/WordPress/gutenberg/issues/61610.


### PR DESCRIPTION
## What?
Proposes adding an `isActive` API for binding sources. At the moment this is added as a private API while it can be assessed.

## Why?
Most of the time the pattern overrides block bindings don't need to be processed, the block bindings only become active when there's a parent pattern block. 

When editing the original pattern, there are bindings present in the block markup that are processed but shouldn't need to be. As an example, the `getValue` callback requires an early return:
https://github.com/WordPress/gutenberg/blob/82598f94a50d5b34df56b40db770c86f50989b1d/packages/editor/src/bindings/pattern-overrides.js#L17-L19

And the `setValues` callback requires some code to allow editing source patterns (setting attributes for the blocks in the patterns:
https://github.com/WordPress/gutenberg/blob/82598f94a50d5b34df56b40db770c86f50989b1d/packages/editor/src/bindings/pattern-overrides.js#L48-L66

Block bindings already has code to do this where it falls back to calling `setAttributes`, so this PR removes that code:
https://github.com/WordPress/gutenberg/blob/82598f94a50d5b34df56b40db770c86f50989b1d/packages/block-editor/src/hooks/use-bindings-attributes.js#L234

Both of the above bits of code require some work by block bindings to get to that point, all of which isn't needed if the code can return earlier.

## How?
Allows a new `isActive` function to be added to binding sources. In this PR it's set to private.

For pattern overrides, this function returns `true` whenever the `pattern/overrides` block context is present. When it returns `false` it indicates the block isn't within a pattern. In the block binding code, the source is filtered out, and it allows pattern override bindings to be skipped.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
