### PR TITLE
CustomSelectControlV2: fix popover styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))
+-   `CustomSelectControlV2`: fix popover styles. ([#62821](https://github.com/WordPress/gutenberg/pull/62821))
 
 ## 28.2.0 (2024-06-26)
 

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -109,6 +109,10 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	background: ${ COLORS.theme.background };
 	border: 1px solid ${ COLORS.theme.foreground };
 
+	/* Same as popover component */
+	/* TODO: is there a way to read the sass variable? */
+	z-index: 1000000;
+
 	max-height: min( var( --popover-available-height, 360px ), 360px );
 	flex-direction: column;
 	overflow: auto;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -109,6 +109,11 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	background: ${ COLORS.theme.background };
 	border: 1px solid ${ COLORS.theme.foreground };
 
+	max-height: min( var( --popover-available-height, 360px ), 360px );
+	flex-direction: column;
+	overflow: auto;
+	overscroll-behavior: contain;
+
 	&[data-focus-visible] {
 		outline: none; // outline will be on the trigger, rather than the popover
 	}

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -105,8 +105,11 @@ export const Select = styled( Ariakit.Select, {
 } );
 
 export const SelectPopover = styled( Ariakit.SelectPopover )`
+	display: flex;
+	flex-direction: column;
+
+	background-color: ${ COLORS.theme.background };
 	border-radius: 2px;
-	background: ${ COLORS.theme.background };
 	border: 1px solid ${ COLORS.theme.foreground };
 
 	/* Same as popover component */

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -112,8 +112,7 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	border-radius: 2px;
 	border: 1px solid ${ COLORS.theme.foreground };
 
-	/* Same as popover component */
-	/* TODO: is there a way to read the sass variable? */
+	/* z-index(".components-popover") */
 	z-index: 1000000;
 
 	max-height: min( var( --popover-available-height, 400px ), 400px );

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -113,8 +113,7 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	/* TODO: is there a way to read the sass variable? */
 	z-index: 1000000;
 
-	max-height: min( var( --popover-available-height, 360px ), 360px );
-	flex-direction: column;
+	max-height: min( var( --popover-available-height, 400px ), 400px );
 	overflow: auto;
 	overscroll-behavior: contain;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #62424

Fix popover styles of `CustomSelectControlV2` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- To fix bugs related to the popover size and z stacking
- To match more closely behavior and look of V1 component

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Adding `max-height` and `overflow` styles (in addition to the `--popover-available-height` Ariakit CSS variable) to make sure that the popover doesn't get too tall
- Adding a `z-index` matching the V1 component (and the legacy `Popover`)
- Switch to `display: flex` (it feels more appropriate for the layout we want to implement, and it handles better extra white space)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### In the editor

To test in the editor, apply this patch

<details>

<summary>Click to expand</summary>

```diff
diff --git a/packages/block-editor/src/components/font-appearance-control/index.js b/packages/block-editor/src/components/font-appearance-control/index.js
index 18e814ad23..1340396c86 100644
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -1,10 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { CustomSelectControl } from '@wordpress/components';
+import {
+	CustomSelectControl,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { CustomSelectControlV2Legacy } = unlock( componentsPrivateApis );
+
 const FONT_STYLES = [
 	{
 		name: _x( 'Regular', 'font style' ),
@@ -205,7 +215,7 @@ export default function FontAppearanceControl( props ) {
 
 	return (
 		hasStylesOrWeights && (
-			<CustomSelectControl
+			<CustomSelectControlV2Legacy
 				{ ...otherProps }
 				className="components-font-appearance-control"
 				label={ label }
diff --git a/packages/components/src/private-apis.ts b/packages/components/src/private-apis.ts
index f55373664e..9a26b7c7e3 100644
--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -14,6 +14,7 @@ import {
 	useCompositeStore as useCompositeStoreV2,
 } from './composite/v2';
 import { default as CustomSelectControl } from './custom-select-control';
+import { default as CustomSelectControlV2Legacy } from './custom-select-control-v2/legacy-component';
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
 import { createPrivateSlotFill } from './slot-fill';
 import {
@@ -40,6 +41,7 @@ lock( privateApis, {
 	CompositeRowV2,
 	useCompositeStoreV2,
 	CustomSelectControl,
+	CustomSelectControlV2Legacy,
 	__experimentalPopoverLegacyPositionToPlacement,
 	createPrivateSlotFill,
 	ComponentsContext,


```
</details>

2. Load the post editor
3. Select the block, and in the block toolbar, add the "Appearance" controls in the typography section
4. Open the select popover


| Before (trunk) | After applying `height` + `overflow` fixees | After applying `z-index` fix |
|---|---|---|
| ![Screenshot 2024-06-25 at 12 03 04](https://github.com/WordPress/gutenberg/assets/1083581/dce90d51-14b0-4611-b188-564b68532a5d) | ![Screenshot 2024-06-25 at 12 04 36](https://github.com/WordPress/gutenberg/assets/1083581/8862cdff-bab6-486f-b8a2-e60f14e837bb) | ![Screenshot 2024-06-25 at 12 05 21](https://github.com/WordPress/gutenberg/assets/1083581/658279d3-1308-486a-8b2e-c43dc37bc2d0) |

### Known issues

The V2 version of the component automatically "flips" the popover to render on top of the trigger if there isn't enough space below it. In the specific example of the block toolbar, this causes a small visual glitch when the browser's viewport is short enough to cause the flip:

![Screenshot 2024-06-25 at 12 13 32](https://github.com/WordPress/gutenberg/assets/1083581/87dfe892-1bc6-4cf2-b1c0-e28bc3952923)

This glitch happens because the block toolbar's header has `position: sticky`, which causes it to render on top of the select popover despite a lower `z-index`. I haven't looked too much into it, but this feels like an issue that shouldn't be solved at the `CustomSelectControl` level (should we leverage popover slots?)