### PR TITLE
CustomSelectControlV2: fix item styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Internal
 
 -   `CustomSelectControlV2`: prevent keyboard event propagation in legacy wrapper. ([#62907](https://github.com/WordPress/gutenberg/pull/62907))
+-   `CustomSelectControlV2`: fix item styles ([#62825](https://github.com/WordPress/gutenberg/pull/62825))
 -   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))
 -   `CustomSelectControlV2`: fix popover styles. ([#62821](https://github.com/WordPress/gutenberg/pull/62821))
 -   `CustomSelectControlV2`: fix trigger text alignment in RTL languages ([#62869](https://github.com/WordPress/gutenberg/pull/62869)).

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -133,7 +133,9 @@ export const SelectItem = styled( Ariakit.SelectItem )`
 	justify-content: space-between;
 	padding: ${ ITEM_PADDING };
 	font-size: ${ CONFIG.fontSize };
-	line-height: 2.15rem; // TODO: Remove this in default but keep for back-compat in legacy
+	// Legacy line height is 28px.
+	// TODO: reassess for non-legacy v2
+	line-height: calc( 28px / ${ CONFIG.fontSize } );
 	&[data-active-item] {
 		background-color: ${ COLORS.theme.gray[ 300 ] };
 	}

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -137,6 +137,8 @@ export const SelectItem = styled( Ariakit.SelectItem )`
 	// TODO: reassess for non-legacy v2
 	line-height: calc( 28px / ${ CONFIG.fontSize } );
 
+	user-select: none;
+
 	&[aria-disabled='true'] {
 		opacity: 0.5;
 	}

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -136,6 +136,11 @@ export const SelectItem = styled( Ariakit.SelectItem )`
 	// Legacy line height is 28px.
 	// TODO: reassess for non-legacy v2
 	line-height: calc( 28px / ${ CONFIG.fontSize } );
+
+	&[aria-disabled='true'] {
+		opacity: 0.5;
+	}
+
 	&[data-active-item] {
 		background-color: ${ COLORS.theme.gray[ 300 ] };
 	}

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -93,6 +93,7 @@ export const Select = styled( Ariakit.Select, {
 		font-family: inherit;
 		font-size: ${ CONFIG.fontSize };
 		text-align: start;
+		user-select: none;
 		width: 100%;
 
 		&[data-focus-visible] {
@@ -136,7 +137,7 @@ export const SelectItem = styled( Ariakit.SelectItem )`
 	// Legacy line height is 28px.
 	// TODO: reassess for non-legacy v2
 	line-height: calc( 28px / ${ CONFIG.fontSize } );
-
+	scroll-margin: ${ space( 1 ) };
 	user-select: none;
 
 	&[aria-disabled='true'] {

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -140,7 +140,7 @@ export const SelectItem = styled( Ariakit.SelectItem )`
 	user-select: none;
 
 	&[aria-disabled='true'] {
-		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	&[data-active-item] {

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -134,9 +134,8 @@ export const SelectItem = styled( Ariakit.SelectItem )`
 	justify-content: space-between;
 	padding: ${ ITEM_PADDING };
 	font-size: ${ CONFIG.fontSize };
-	// Legacy line height is 28px.
-	// TODO: reassess for non-legacy v2
-	line-height: calc( 28px / ${ CONFIG.fontSize } );
+	// TODO: reassess line-height for non-legacy v2
+	line-height: 28px;
 	scroll-margin: ${ space( 1 ) };
 	user-select: none;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Fix items (options) styles of `CustomSelectControlV2` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- To fix visual bugs
- To match more closely look of V1 component
- To add quality of life improvements

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Update V2 items in order to match the same line height of the V1 version
- Add `disabled` styles
- Added `user-select: none` to trigger button and option items
- Added `scroll-margin` to improve scroll experience when selecting items that are out of view in the popover

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Compare V1 and V2 (legacy) of `CustomSelectControl`, make sure that the items in the select popover now render with the same line height (28px).
- Try to select with the cursor the text of the items in the select popover — V2 should prevent text selection

| V1 | V2 before (trunk) | V2 after (this PR) |
|---|---|---|
| ![Screenshot 2024-06-25 at 13 13 47](https://github.com/WordPress/gutenberg/assets/1083581/86b1f169-8306-49dd-8d77-5206908cd9a0) | ![Screenshot 2024-06-25 at 13 14 27](https://github.com/WordPress/gutenberg/assets/1083581/d613ecaa-6d10-4777-b62f-733de1cf64e6) | ![Screenshot 2024-06-25 at 13 23 21](https://github.com/WordPress/gutenberg/assets/1083581/5a7ccf76-8546-44d5-9980-e4c1534e38ad) |