### PR TITLE
Global Styles: Simplify code to fetch color and typography variation

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -9,12 +9,10 @@ import a11yPlugin from 'colord/plugins/a11y';
  */
 import { store as blocksStore } from '@wordpress/blocks';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../lock-unlock';
 import { useSelect } from '@wordpress/data';
 
@@ -110,43 +108,4 @@ export function useSupportedStyles( name, element ) {
 	);
 
 	return supportedPanels;
-}
-
-export function useColorVariations() {
-	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
-		properties: [ 'color' ],
-	} );
-	/*
-	 * Filter out variations with no settings or styles.
-	 */
-	return colorVariations?.length
-		? colorVariations.filter( ( variation ) => {
-				const { settings, styles, title } = variation;
-				return (
-					title === __( 'Default' ) || // Always preseve the default variation.
-					Object.keys( settings ).length > 0 ||
-					Object.keys( styles ).length > 0
-				);
-		  } )
-		: [];
-}
-
-export function useTypographyVariations() {
-	const typographyVariations =
-		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			properties: [ 'typography' ],
-		} );
-	/*
-	 * Filter out variations with no settings or styles.
-	 */
-	return typographyVariations?.length
-		? typographyVariations.filter( ( variation ) => {
-				const { settings, styles, title } = variation;
-				return (
-					title === __( 'Default' ) || // Always preseve the default variation.
-					Object.keys( settings ).length > 0 ||
-					Object.keys( styles ).length > 0
-				);
-		  } )
-		: [];
 }

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -10,12 +10,14 @@ import {
  * Internal dependencies
  */
 import StylesPreviewColors from '../preview-colors';
-import { useColorVariations } from '../hooks';
+import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import Subtitle from '../subtitle';
 import Variation from './variation';
 
 export default function ColorVariations( { title, gap = 2 } ) {
-	const colorVariations = useColorVariations();
+	const propertiesToFilter = [ 'color' ];
+	const colorVariations =
+		useCurrentMergeThemeStyleVariationsWithUserConfig( propertiesToFilter );
 
 	// Return null if there is only one variation (the default).
 	if ( colorVariations?.length <= 1 ) {
@@ -31,7 +33,7 @@ export default function ColorVariations( { title, gap = 2 } ) {
 						key={ index }
 						variation={ variation }
 						isPill
-						properties={ [ 'color' ] }
+						properties={ propertiesToFilter }
 						showTooltip
 					>
 						{ () => <StylesPreviewColors /> }

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -9,13 +9,17 @@ import {
 /**
  * Internal dependencies
  */
+
 import StylesPreviewTypography from '../preview-typography';
-import { useTypographyVariations } from '../hooks';
+import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import Variation from './variation';
 import Subtitle from '../subtitle';
 
 export default function TypographyVariations( { title, gap = 2 } ) {
-	const typographyVariations = useTypographyVariations();
+	const propertiesToFilter = 'typography';
+	const typographyVariations =
+		useCurrentMergeThemeStyleVariationsWithUserConfig( propertiesToFilter );
+
 	// Return null if there is only one variation (the default).
 	if ( typographyVariations?.length <= 1 ) {
 		return null;
@@ -34,7 +38,7 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 						<Variation
 							key={ index }
 							variation={ variation }
-							properties={ [ 'typography' ] }
+							properties={ propertiesToFilter }
 							showTooltip
 						>
 							{ () => (

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -16,7 +16,7 @@ import Variation from './variation';
 import Subtitle from '../subtitle';
 
 export default function TypographyVariations( { title, gap = 2 } ) {
-	const propertiesToFilter = 'typography';
+	const propertiesToFilter = [ 'typography' ];
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( propertiesToFilter );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -26,10 +26,7 @@ import useGlobalStylesRevisions from '../global-styles/screen-revisions/use-glob
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
 import ColorVariations from '../global-styles/variations/variations-color';
 import TypographyVariations from '../global-styles/variations/variations-typography';
-import {
-	useColorVariations,
-	useTypographyVariations,
-} from '../global-styles/hooks';
+import { useCurrentMergeThemeStyleVariationsWithUserConfig } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
 const noop = () => {};
 
@@ -75,8 +72,12 @@ function SidebarNavigationScreenGlobalStylesContent() {
 		};
 	}, [] );
 
-	const colorVariations = useColorVariations();
-	const typographyVariations = useTypographyVariations();
+	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( [
+		'color',
+	] );
+	const typographyVariations =
+		useCurrentMergeThemeStyleVariationsWithUserConfig( [ 'typography' ] );
+
 	const gap = 3;
 
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -50,6 +50,23 @@ export function removePropertiesFromObject( object, properties ) {
 }
 
 /**
+ * Checks whether a style variation is empty.
+ *
+ * @param {Object} variation          A style variation object.
+ * @param {string} variation.title    The title of the variation.
+ * @param {Object} variation.settings The settings of the variation.
+ * @param {Object} variation.styles   The styles of the variation.
+ * @return {boolean} Whether the variation is empty.
+ */
+function isEmptyStyleVariation( { title, settings, styles } ) {
+	return (
+		title === __( 'Default' ) || // Always preseve the default variation.
+		Object.keys( settings ).length > 0 ||
+		Object.keys( styles ).length > 0
+	);
+}
+
+/**
  * Fetches the current theme style variations that contain only the specified properties
  * and merges them with the user config.
  *
@@ -72,7 +89,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 	}, [] );
 	const { user: userVariation } = useContext( GlobalStylesContext );
 
-	return useMemo( () => {
+	const variationsByProperty = useMemo( () => {
 		const clonedUserVariation = cloneDeep( userVariation );
 
 		// Get user variation and remove the settings for the given property.
@@ -98,6 +115,15 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 			...variationsWithPropertiesAndBase,
 		];
 	}, [ properties.toString(), userVariation, variationsFromTheme ] );
+
+	/*
+	 * Filter out variations with no settings or styles.
+	 */
+	return variationsByProperty?.length
+		? variationsByProperty.filter( ( variation ) =>
+				isEmptyStyleVariation( variation )
+		  )
+		: [];
 }
 
 /**

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -60,9 +60,9 @@ export function removePropertiesFromObject( object, properties ) {
  */
 function isEmptyStyleVariation( { title, settings, styles } ) {
 	return (
-		title === __( 'Default' ) || // Always preserve the default variation.
-		Object.keys( settings ).length > 0 ||
-		Object.keys( styles ).length > 0
+		title !== __( 'Default' ) && // Always preserve the default variation.
+		Object.keys( settings ).length === 0 &&
+		Object.keys( styles ).length === 0
 	);
 }
 
@@ -120,8 +120,8 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 	 * Filter out variations with no settings or styles.
 	 */
 	return variationsByProperty?.length
-		? variationsByProperty.filter( ( variation ) =>
-				isEmptyStyleVariation( variation )
+		? variationsByProperty.filter(
+				( variation ) => ! isEmptyStyleVariation( variation )
 		  )
 		: [];
 }

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -60,7 +60,7 @@ export function removePropertiesFromObject( object, properties ) {
  */
 function hasThemeVariation( { title, settings, styles } ) {
 	return (
-		title !== __( 'Default' ) || // Always preserve the default variation.
+		title === __( 'Default' ) || // Always preserve the default variation.
 		Object.keys( settings ).length > 0 ||
 		Object.keys( styles ).length > 0
 	);
@@ -70,13 +70,12 @@ function hasThemeVariation( { title, settings, styles } ) {
  * Fetches the current theme style variations that contain only the specified properties
  * and merges them with the user config.
  *
- * @param {Object}   props            Object of hook args.
- * @param {string[]} props.properties The properties to filter by.
+ * @param {string[]} properties The properties to filter by.
  * @return {Object[]|*} The merged object.
  */
-export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
-	properties = [],
-} ) {
+export function useCurrentMergeThemeStyleVariationsWithUserConfig(
+	properties = []
+) {
 	const { variationsFromTheme } = useSelect( ( select ) => {
 		const _variationsFromTheme =
 			select(

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -89,7 +89,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 	}, [] );
 	const { user: userVariation } = useContext( GlobalStylesContext );
 
-	const variationsByProperty = useMemo( () => {
+	return useMemo( () => {
 		const clonedUserVariation = cloneDeep( userVariation );
 
 		// Get user variation and remove the settings for the given property.
@@ -110,20 +110,20 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 				);
 			} );
 
-		return [
+		const variationsByProperty = [
 			userVariationWithoutProperties,
 			...variationsWithPropertiesAndBase,
 		];
-	}, [ properties.toString(), userVariation, variationsFromTheme ] );
 
-	/*
-	 * Filter out variations with no settings or styles.
-	 */
-	return variationsByProperty?.length
-		? variationsByProperty.filter(
-				( variation ) => ! isEmptyStyleVariation( variation )
-		  )
-		: [];
+		/*
+		 * Filter out variations with no settings or styles.
+		 */
+		return variationsByProperty?.length
+			? variationsByProperty.filter(
+					( variation ) => ! isEmptyStyleVariation( variation )
+			  )
+			: [];
+	}, [ properties.toString(), userVariation, variationsFromTheme ] );
 }
 
 /**

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -60,7 +60,7 @@ export function removePropertiesFromObject( object, properties ) {
  */
 function isEmptyStyleVariation( { title, settings, styles } ) {
 	return (
-		title === __( 'Default' ) || // Always preseve the default variation.
+		title === __( 'Default' ) || // Always preserve the default variation.
 		Object.keys( settings ).length > 0 ||
 		Object.keys( styles ).length > 0
 	);

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -110,7 +110,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 				);
 			} );
 
-		const variationsByProperty = [
+		const variationsByProperties = [
 			userVariationWithoutProperties,
 			...variationsWithPropertiesAndBase,
 		];
@@ -118,8 +118,8 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		/*
 		 * Filter out variations with no settings or styles.
 		 */
-		return variationsByProperty?.length
-			? variationsByProperty.filter( hasThemeVariation )
+		return variationsByProperties?.length
+			? variationsByProperties.filter( hasThemeVariation )
 			: [];
 	}, [ properties.toString(), userVariation, variationsFromTheme ] );
 }

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -119,9 +119,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		 * Filter out variations with no settings or styles.
 		 */
 		return variationsByProperty?.length
-			? variationsByProperty.filter(
-					( variation ) => ! isEmptyStyleVariation( variation )
-			  )
+			? variationsByProperty.filter( hasThemeVariation )
 			: [];
 	}, [ properties.toString(), userVariation, variationsFromTheme ] );
 }

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -88,6 +88,8 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig(
 	}, [] );
 	const { user: userVariation } = useContext( GlobalStylesContext );
 
+	const propertiesAsString = properties.toString();
+
 	return useMemo( () => {
 		const clonedUserVariation = cloneDeep( userVariation );
 
@@ -120,7 +122,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig(
 		return variationsByProperties?.length
 			? variationsByProperties.filter( hasThemeVariation )
 			: [];
-	}, [ properties.toString(), userVariation, variationsFromTheme ] );
+	}, [ propertiesAsString, userVariation, variationsFromTheme ] );
 }
 
 /**

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -58,11 +58,11 @@ export function removePropertiesFromObject( object, properties ) {
  * @param {Object} variation.styles   The styles of the variation.
  * @return {boolean} Whether the variation is empty.
  */
-function isEmptyStyleVariation( { title, settings, styles } ) {
+function hasThemeVariation( { title, settings, styles } ) {
 	return (
-		title !== __( 'Default' ) && // Always preserve the default variation.
-		Object.keys( settings ).length === 0 &&
-		Object.keys( styles ).length === 0
+		title !== __( 'Default' ) || // Always preserve the default variation.
+		Object.keys( settings ).length > 0 ||
+		Object.keys( styles ).length > 0
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small refactor to simplify this code and share more code between the two variations.

## Why?
Less code means less maintenance and fewer bugs.

## How?
Remove `useColorVariations` and `useTypographyVariations` and call `useCurrentMergeThemeStyleVariationsWithUserConfig` directly instead.

## Testing Instructions
0. Switch to a theme that uses color and typography variations (I'm using a modified TT4 with this variation: https://gist.github.com/scruffian/3dab906ee04d3c1c689bb08d23198f84)
1. Open the site editor
2. Open Global Styles > Typography
3. Check you can still see the list of Typography variations
4. Open Global Styles > Colors > Palette
5. Check you can still see the list of Color variations

## Screenshots or screencast <!-- if applicable -->

<img width="299" alt="Screenshot 2024-06-25 at 13 11 47" src="https://github.com/WordPress/gutenberg/assets/275961/f4a75f81-f3a1-4853-a089-f768e9b1de70">
<img width="308" alt="Screenshot 2024-06-25 at 13 12 04" src="https://github.com/WordPress/gutenberg/assets/275961/26223d6d-36f0-4e40-ad27-3b4b6d5c44bf">
