### PR TITLE
Pattern overrides: Fix aspect ratio not working in image with overrides

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -176,6 +176,20 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					}
 
 					const keptAttributes = { ...nextAttributes };
+
+					// Don't update caption and href in pattern overrides until they are supported.
+					if ( hasPatternOverridesDefaultBinding ) {
+						delete keptAttributes?.caption;
+						delete keptAttributes?.href;
+					}
+
+					// Don't run bindings logic when a block is using pattern overrides but
+					// the user is editing the original pattern.
+					if ( ! hasParentPattern ) {
+						setAttributes( keptAttributes );
+						return;
+					}
+
 					const updatesBySource = new Map();
 
 					// Loop only over the updated attributes to avoid modifying the bound ones that haven't changed.
@@ -232,20 +246,13 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						}
 					}
 
+					// Only apply normal attribute updates to blocks
+					// that have partial bindings. Currently this is
+					// only skipped for pattern overrides sources.
 					if (
-						// Don't update non-connected attributes if the block is using pattern overrides
-						// and the editing is happening while using the pattern (not editing the original).
-						! (
-							hasPatternOverridesDefaultBinding &&
-							hasParentPattern
-						) &&
+						! hasPatternOverridesDefaultBinding &&
 						Object.keys( keptAttributes ).length
 					) {
-						// Don't update caption and href until they are supported.
-						if ( hasPatternOverridesDefaultBinding ) {
-							delete keptAttributes?.caption;
-							delete keptAttributes?.href;
-						}
 						setAttributes( keptAttributes );
 					}
 				} );

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -179,7 +179,10 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 					// Don't run bindings logic when a block is using pattern overrides but
 					// the user is editing the original pattern.
-					if ( ! hasParentPattern ) {
+					if (
+						! hasParentPattern &&
+						hasPatternOverridesDefaultBinding
+					) {
 						// Don't update caption and href in pattern overrides until they are supported.
 						delete keptAttributes?.caption;
 						delete keptAttributes?.href;

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -93,12 +93,10 @@ export function canBindAttribute( blockName, attributeName ) {
 export const withBlockBindingSupport = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const registry = useRegistry();
-		const { name, clientId, context } = props;
-		const sources = useSelect(
-			( select ) =>
-				unlock( select( blocksStore ) ).getAllBlockBindingsSources(),
-			[]
+		const sources = useSelect( ( select ) =>
+			unlock( select( blocksStore ) ).getAllBlockBindingsSources()
 		);
+		const { name, clientId, context } = props;
 		const hasParentPattern = !! props.context[ 'pattern/overrides' ];
 		const hasPatternOverridesDefaultBinding =
 			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ]
@@ -163,7 +161,6 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					}
 
 					const keptAttributes = { ...nextAttributes };
-
 					const updatesBySource = new Map();
 
 					// Loop only over the updated attributes to avoid modifying the bound ones that haven't changed.

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -177,15 +177,13 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 					const keptAttributes = { ...nextAttributes };
 
-					// Don't update caption and href in pattern overrides until they are supported.
-					if ( hasPatternOverridesDefaultBinding ) {
-						delete keptAttributes?.caption;
-						delete keptAttributes?.href;
-					}
-
 					// Don't run bindings logic when a block is using pattern overrides but
 					// the user is editing the original pattern.
 					if ( ! hasParentPattern ) {
+						// Don't update caption and href in pattern overrides until they are supported.
+						delete keptAttributes?.caption;
+						delete keptAttributes?.href;
+
 						setAttributes( keptAttributes );
 						return;
 					}

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -216,13 +216,30 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						}
 					}
 
-					// Only apply normal attribute updates to blocks
-					// that have partial bindings. Currently this is
-					// only skipped for pattern overrides sources.
-					if (
-						! hasPatternOverridesDefaultBinding &&
-						Object.keys( keptAttributes ).length
-					) {
+					// Don't update block attributes connected to pattern overrides.
+					if ( hasPatternOverridesDefaultBinding ) {
+						// Skip caption and href until they are supported.
+						const attributesToSkip = [ 'caption', 'href' ];
+						// Skip supported attributes that are not bound to other sources.
+						BLOCK_BINDINGS_ALLOWED_BLOCKS[ name ].forEach(
+							( attr ) => {
+								// Ensure it is bound to pattern overrides.
+								if (
+									bindings?.[ attr ]?.source ===
+									'core/pattern-overrides'
+								) {
+									attributesToSkip.push( attr );
+								}
+							}
+						);
+
+						// Remove attributes from the list.
+						attributesToSkip.forEach(
+							( attr ) => delete keptAttributes[ attr ]
+						);
+					}
+
+					if ( Object.keys( keptAttributes ).length ) {
 						setAttributes( keptAttributes );
 					}
 				} );

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -233,7 +233,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					}
 
 					if (
-						// Don't update non-connected attributes when using if the block is overriden
+						// Don't update non-connected attributes if the block is using pattern overrides
 						// and the editing is happening while using the pattern (not editing the original).
 						! (
 							hasPatternOverridesDefaultBinding &&

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -11,7 +11,6 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
-import { store as blockEditorStore } from '../store';
 
 /** @typedef {import('@wordpress/compose').WPHigherOrderComponent} WPHigherOrderComponent */
 /** @typedef {import('@wordpress/blocks').WPBlockSettings} WPBlockSettings */
@@ -95,24 +94,12 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const registry = useRegistry();
 		const { name, clientId, context } = props;
-		const { sources, hasParentPattern } = useSelect(
-			( select ) => {
-				const { getAllBlockBindingsSources } = unlock(
-					select( blocksStore )
-				);
-				const { getBlockParentsByBlockName } = unlock(
-					select( blockEditorStore )
-				);
-
-				return {
-					sources: getAllBlockBindingsSources(),
-					hasParentPattern:
-						getBlockParentsByBlockName( clientId, 'core/block' )
-							.length > 0,
-				};
-			},
-			[ clientId ]
+		const sources = useSelect(
+			( select ) =>
+				unlock( select( blocksStore ) ).getAllBlockBindingsSources(),
+			[]
 		);
+		const hasParentPattern = !! props.context[ 'pattern/overrides' ];
 		const hasPatternOverridesDefaultBinding =
 			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ]
 				?.source === 'core/pattern-overrides';
@@ -254,12 +241,13 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			[
 				registry,
 				bindings,
-				name,
-				clientId,
-				context,
-				setAttributes,
-				sources,
 				hasPatternOverridesDefaultBinding,
+				hasParentPattern,
+				setAttributes,
+				name,
+				sources,
+				context,
+				clientId,
 			]
 		);
 

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -177,20 +177,6 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 					const keptAttributes = { ...nextAttributes };
 
-					// Don't run bindings logic when a block is using pattern overrides but
-					// the user is editing the original pattern.
-					if (
-						! hasParentPattern &&
-						hasPatternOverridesDefaultBinding
-					) {
-						// Don't update caption and href in pattern overrides until they are supported.
-						delete keptAttributes?.caption;
-						delete keptAttributes?.href;
-
-						setAttributes( keptAttributes );
-						return;
-					}
-
 					const updatesBySource = new Map();
 
 					// Loop only over the updated attributes to avoid modifying the bound ones that haven't changed.
@@ -247,13 +233,20 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						}
 					}
 
-					// Only apply normal attribute updates to blocks
-					// that have partial bindings. Currently this is
-					// only skipped for pattern overrides sources.
 					if (
-						! hasPatternOverridesDefaultBinding &&
+						// Don't update non-connected attributes if the block is using pattern overrides
+						// and the editing is happening while overriding the pattern (not editing the original).
+						! (
+							hasPatternOverridesDefaultBinding &&
+							hasParentPattern
+						) &&
 						Object.keys( keptAttributes ).length
 					) {
+						// Don't update caption and href until they are supported.
+						if ( hasPatternOverridesDefaultBinding ) {
+							delete keptAttributes?.caption;
+							delete keptAttributes?.href;
+						}
 						setAttributes( keptAttributes );
 					}
 				} );

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -238,13 +238,13 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			[
 				registry,
 				bindings,
+				name,
+				clientId,
+				context,
+				setAttributes,
+				sources,
 				hasPatternOverridesDefaultBinding,
 				hasParentPattern,
-				setAttributes,
-				name,
-				sources,
-				context,
-				clientId,
 			]
 		);
 

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -12,8 +12,12 @@
 			"type": "number"
 		},
 		"content": {
-			"type": "object"
+			"type": "object",
+			"default": {}
 		}
+	},
+	"providesContext": {
+		"pattern/overrides": "content"
 	},
 	"supports": {
 		"customClassName": false,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -443,16 +443,12 @@ export default function Image( {
 				return {};
 			}
 			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
-			const { getBlockParentsByBlockName } = unlock(
-				select( blockEditorStore )
-			);
 			const {
 				url: urlBinding,
 				alt: altBinding,
 				title: titleBinding,
 			} = metadata?.bindings || {};
-			const hasParentPattern =
-				getBlockParentsByBlockName( clientId, 'core/block' ).length > 0;
+			const hasParentPattern = !! context[ 'pattern/overrides' ];
 			const urlBindingSource = getBlockBindingsSource(
 				urlBinding?.source
 			);
@@ -508,7 +504,12 @@ export default function Image( {
 					: __( 'Connected to dynamic data' ),
 			};
 		},
-		[ clientId, isSingleSelected, metadata?.bindings ]
+		[
+			arePatternOverridesEnabled,
+			context,
+			isSingleSelected,
+			metadata?.bindings,
+		]
 	);
 
 	const showUrlInput =

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -9,23 +9,22 @@ const CONTENT = 'content';
 export default {
 	name: 'core/pattern-overrides',
 	label: _x( 'Pattern Overrides', 'block bindings source' ),
-	getValue( { registry, clientId, attributeName } ) {
-		const { getBlockAttributes, getBlockParentsByBlockName } =
-			registry.select( blockEditorStore );
+	getValue( { registry, clientId, context, attributeName } ) {
+		const patternOverridesContent = context[ 'pattern/overrides' ];
+		const { getBlockAttributes } = registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
-		const [ patternClientId ] = getBlockParentsByBlockName(
-			clientId,
-			'core/block',
-			true
-		);
+
+		if ( ! patternOverridesContent ) {
+			return currentBlockAttributes[ attributeName ];
+		}
 
 		const overridableValue =
-			getBlockAttributes( patternClientId )?.[ CONTENT ]?.[
+			patternOverridesContent?.[
 				currentBlockAttributes?.metadata?.name
 			]?.[ attributeName ];
 
 		// If there is no pattern client ID, or it is not overwritten, return the default value.
-		if ( ! patternClientId || overridableValue === undefined ) {
+		if ( overridableValue === undefined ) {
 			return currentBlockAttributes[ attributeName ];
 		}
 

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -14,6 +14,8 @@ import { store as blocksStore } from '@wordpress/blocks';
 import { store as editorStore } from '../store';
 import { unlock } from '../lock-unlock';
 
+/** @typedef {import('@wordpress/blocks').WPBlockSettings} WPBlockSettings */
+
 const {
 	PatternOverridesControls,
 	ResetOverridesControl,
@@ -46,7 +48,8 @@ const withPatternOverrideControls = createHigherOrderComponent(
 				{ isSupportedBlock && <PatternOverridesBlockControls /> }
 			</>
 		);
-	}
+	},
+	'withPatternOverrideControls'
 );
 
 // Split into a separate component to avoid a store subscription

--- a/test/integration/fixtures/blocks/core__block.json
+++ b/test/integration/fixtures/blocks/core__block.json
@@ -3,7 +3,8 @@
 		"name": "core/block",
 		"isValid": true,
 		"attributes": {
-			"ref": 123
+			"ref": 123,
+			"content": {}
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/62814.

In order to do so, it includes the changes from [this pull request](https://github.com/WordPress/gutenberg/pull/62861),  where block context is used to detect presence of parent pattern for overrides.

## Why?
As reported in the mentioned issue, the aspect ratio, and other attributes, don't work as expected when editing an image with pattern overrides.

## How?
Ensuring that we only skip setting non-bound attributes when users are actually overriding a pattern, and not when they are editing the original one. To do so, it check if the block has a parent pattern with the code of [this other pull request](https://github.com/WordPress/gutenberg/pull/62861).

## Testing Instructions
There are three main issues to consider:

* **Aspect ratio works as expected**.
1. Create a pattern
2. Add an image block
3. Enable bindings for the image block
4. Upload an image to the block
5. Try adjusting Aspect Ratio, observe it works.

**Before**

https://github.com/WordPress/gutenberg/assets/34552881/7f935bb6-7f19-4cba-ae1b-d3d511779c73

**After**

https://github.com/WordPress/gutenberg/assets/34552881/1e675341-a4a4-4a2e-a2c1-fdfcf41c73e7


* **Ensure caption is not added while replacing the original image in a post**

1. Add an image block by picking an image from the Media Library that does not have a caption.
2. Click create a synced pattern from the block toolbar.
3. Select the Pattern and choose 'Edit original'.
4. In the pattern editor, select the Image block and "Enable overrides" in the Advanced section.
5. Go back to the post editor.
6. Replace the image with one from the Media Library that does have a caption.
7. Check that the new image does not have a caption.

* **Ensure caption is not added when replacing the image in the original pattern**.

1. Add an image block by picking an image from the Media Library that does not have a caption.
2. Click create a synced pattern from the block toolbar.
3. Select the Pattern and choose 'Edit original'.
4. In the pattern editor, select the Image block and "Enable overrides" in the Advanced section.
6. Replace the image with one from the Media Library that does have a caption.
7. Check that the new image does not have a caption.