### PR TITLE
Global Styles: Make a shared component for typography and color preview

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview-typography.js
+++ b/packages/edit-site/src/components/global-styles/preview-typography.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalHStack as HStack } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import TypographyExample from './typography-example';
+import PreviewIframe from './preview-iframe';
+
+const StylesPreviewTypography = ( { variation, isFocused, withHoverView } ) => {
+	return (
+		<PreviewIframe
+			label={ variation.title }
+			isFocused={ isFocused }
+			withHoverView={ withHoverView }
+		>
+			{ ( { ratio, key } ) => (
+				<HStack
+					key={ key }
+					spacing={ 10 * ratio }
+					justify="center"
+					style={ {
+						height: '100%',
+						overflow: 'hidden',
+					} }
+				>
+					<TypographyExample
+						variation={ variation }
+						fontSize={ 85 * ratio }
+					/>
+				</HStack>
+			) }
+		</PreviewIframe>
+	);
+};
+
+export default StylesPreviewTypography;

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -29,24 +29,22 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 				gap={ gap }
 				className="edit-site-global-styles-style-variations-container"
 			>
-				{ typographyVariations &&
-					typographyVariations.length &&
-					typographyVariations.map( ( variation, index ) => {
-						return (
-							<Variation
-								key={ index }
-								variation={ variation }
-								property="typography"
-								showTooltip
-							>
-								{ () => (
-									<StylesPreviewTypography
-										variation={ variation }
-									/>
-								) }
-							</Variation>
-						);
-					} ) }
+				{ typographyVariations.map( ( variation, index ) => {
+					return (
+						<Variation
+							key={ index }
+							variation={ variation }
+							property="typography"
+							showTooltip
+						>
+							{ () => (
+								<StylesPreviewTypography
+									variation={ variation }
+								/>
+							) }
+						</Variation>
+					);
+				} ) }
 			</Grid>
 		</VStack>
 	);

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -3,22 +3,19 @@
  */
 import {
 	__experimentalGrid as Grid,
-	__experimentalVStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import StylesPreviewTypography from '../preview-typography';
 import { useTypographyVariations } from '../hooks';
-import TypographyExample from '../typography-example';
-import PreviewIframe from '../preview-iframe';
 import Variation from './variation';
 import Subtitle from '../subtitle';
 
 export default function TypographyVariations( { title, gap = 2 } ) {
 	const typographyVariations = useTypographyVariations();
-
 	// Return null if there is only one variation (the default).
 	if ( typographyVariations?.length <= 1 ) {
 		return null;
@@ -34,38 +31,22 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 			>
 				{ typographyVariations &&
 					typographyVariations.length &&
-					typographyVariations.map( ( variation, index ) => (
-						<Variation
-							key={ index }
-							variation={ variation }
-							property="typography"
-							showTooltip
-						>
-							{ ( isFocused ) => (
-								<PreviewIframe
-									label={ variation?.title }
-									isFocused={ isFocused }
-								>
-									{ ( { ratio, key } ) => (
-										<HStack
-											key={ key }
-											spacing={ 10 * ratio }
-											justify="center"
-											style={ {
-												height: '100%',
-												overflow: 'hidden',
-											} }
-										>
-											<TypographyExample
-												variation={ variation }
-												fontSize={ 85 * ratio }
-											/>
-										</HStack>
-									) }
-								</PreviewIframe>
-							) }
-						</Variation>
-					) ) }
+					typographyVariations.map( ( variation, index ) => {
+						return (
+							<Variation
+								key={ index }
+								variation={ variation }
+								property="typography"
+								showTooltip
+							>
+								{ () => (
+									<StylesPreviewTypography
+										variation={ variation }
+									/>
+								) }
+							</Variation>
+						);
+					} ) }
 			</Grid>
 		</VStack>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Use the same approach to display typography variations that we use for color variations.

## Why?
If we use a similar approach to display these presets it will be easier to update them to have shared components. This will be possible once https://github.com/WordPress/gutenberg/pull/62827 is merged.

## How?
Creates a new `StylesPreviewTypography` component similar to `StylesPreviewColors`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
0. Switch to a theme that uses color and typography variations (I'm using a modified TT4 with this variation: https://gist.github.com/scruffian/3dab906ee04d3c1c689bb08d23198f84)
1. Open the site editor
2. Open Global Styles > Typography
3. Check you can still see the list of Typography variations

