### PR TITLE
Docs/iAPI: Fix wrong code snippet in data-wp-run example

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -535,13 +535,14 @@ import { store, useState, useEffect } from '@wordpress/interactivity';
 
 // Unlike `data-wp-init` and `data-wp-watch`, you can use any hooks inside
 // `data-wp-run` callbacks.
-const useInView = ( ref ) => {
+const useInView = () => {
   const [ inView, setInView ] = useState( false );
   useEffect( () => {
+    const { ref } = getElement();
     const observer = new IntersectionObserver( ( [ entry ] ) => {
       setInView( entry.isIntersecting );
     } );
-    if ( ref ) observer.observe( ref );
+    observer.observe( ref );
     return () => ref && observer.unobserve( ref );
   }, []);
   return inView;
@@ -550,8 +551,7 @@ const useInView = ( ref ) => {
 store( 'myPlugin', {
   callbacks: {
     logInView: () => {
-      const { ref } = getElement();
-      const isInView = useInView( ref );
+      const isInView = useInView();
       useEffect( () => {
         if ( isInView ) {
           console.log( 'Inside' );

--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -538,7 +538,7 @@ import { store, useState, useEffect } from '@wordpress/interactivity';
 const useInView = () => {
   const [ inView, setInView ] = useState( false );
   useEffect( () => {
-    const { ref } = getElement();
+    const { ref } = getElement();
     const observer = new IntersectionObserver( ( [ entry ] ) => {
       setInView( entry.isIntersecting );
     } );
@@ -564,6 +564,8 @@ store( 'myPlugin', {
 } );
 ```
 </details>
+
+It's important to note that, similar to (P)React components, the `ref` from `getElement()` is `null` during the first render. To properly access the DOM element reference, you typically need to use an effect-like hook such as `useEffect`, `useInit`, or `useWatch`. This ensures that the `getElement()` runs after the component has been mounted and the `ref` is available.
 
 ### `wp-key`
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Fix a wrong code snippet in the `data-wp-run` example.

Discovered by @fabiankaegy and reported in Slack: https://wordpress.slack.com/archives/C071CRKGKUP/p1719289120450429

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `data-wp-run` callbacks run in the body of the Preact component, and `ref` is basically a `useRef` hook, which means that `ref` is `null` on the first render.

All this means that, in contrary to how it works in `data-wp-watch` and `data-wp-init`, which are basically fancy versions of `useEffect`, you need to access `ref` inside a `useEffect`-like hook (`useEffect`, `useInit`, `useWatch`…) when you use `data-wp-run`, exactly like you would use it in (P)React:

```js
const Comp = () => {
  const ref = useRef();
  console.log(ref.current); // null on first render
  useEffect(() => {
    console.log(ref.current); // it's fine here
  });
  return <div ref={ref}>...</div>;
};
```

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In this specific example, I moved the `getElement()` call to the `useEffect` hook of the `useInView` hook, so `ref` is not `null` anymore.
