### PR TITLE
Site Editor: Fix JS error in 6.6 when loading the frong page

### DIFF
--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -58,6 +58,10 @@ function Editor( {
 		[ postType, postId, templateId ]
 	);
 
+	if ( ! post ) {
+		return null;
+	}
+
 	return (
 		<ExperimentalEditorProvider
 			post={ post }


### PR DESCRIPTION
closes #62834 

Note that this PR targets wp/6.6 directly as a fix is already available in trunk.

## What?

This PR prevents a JS error in the site editor while the page is still being loaded.
This exact fix is actually already on trunk and was first introduce in #62339

## Testing Instructions

- Use a theme that has a "front-page.html" template or create this template manually
- Set a static page as front page 
- Open the site editor
- In wp/6.6 branch a JS error is triggered and the site editor doesn't load but with this PR it's fixed.
