### PR TITLE
CustomSelectControlV2: fix select popover content overflow

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))
 -   `CustomSelectControlV2`: fix popover styles. ([#62821](https://github.com/WordPress/gutenberg/pull/62821))
 -   `CustomSelectControlV2`: fix trigger text alignment in RTL languages ([#62869](https://github.com/WordPress/gutenberg/pull/62869)).
+-   `CustomSelectControlV2`: fix select popover content overflow. ([#62844](https://github.com/WordPress/gutenberg/pull/62844))
 
 ## 28.2.0 (2024-06-26)
 

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -112,7 +112,12 @@ function _CustomSelect(
 					size={ size }
 					store={ store }
 				/>
-				<Styled.SelectPopover gutter={ 12 } store={ store } sameWidth>
+				<Styled.SelectPopover
+					gutter={ 12 }
+					store={ store }
+					sameWidth
+					slide={ false }
+				>
 					<CustomSelectContext.Provider value={ { store } }>
 						{ children }
 					</CustomSelectContext.Provider>

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -119,6 +119,9 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	overflow: auto;
 	overscroll-behavior: contain;
 
+	// The smallest size without overflowing the container.
+	min-width: min-content;
+
 	&[data-focus-visible] {
 		outline: none; // outline will be on the trigger, rather than the popover
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Set a minimum width for the `CustomSelectControl` V2's select popover

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To avoid content overflowing or horizontal scrolling inside the popover

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- add `min-width: fit-content` to the popover wrapper to avoid the content from overflowing
- set the prop `slide={false}` on Ariakit's `SelectPopover` to keep the popover anchored to its trigger while scrolling the page horizontally

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Apply these changes:

<details>
<summary>Click to expand</summary>

```diff
diff --git a/packages/components/src/custom-select-control/stories/index.story.tsx b/packages/components/src/custom-select-control/stories/index.story.tsx
index 8ff9a023c5..e9f21cfa0f 100644
--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -90,7 +90,7 @@ WithLongLabels.args = {
 		},
 		{
 			key: 'reallylonglabel2',
-			name: 'But they can take a long time to type.',
+			name: 'Buttheycantakealongtimetotype.',
 		},
 		{
 			key: 'reallylonglabel3',

```
</details>

2. Load the `CustomSelectControlV2` Legacy "With Long Labels" story
3. Open the select dropdown and resize the page horizontally — make sure that the popover stops resizing once it reaches its minimum allowed width, and that the popover content never overflows / causes horizontal scroll inside the popover
4. Load the same "With Long Labels" story, but for the V1 version of the component, and make sure that the behaviour is the same.

## Screenshots or screencast <!-- if applicable -->

| Version | screencast |
|---|---|
| V1 | <video src="https://github.com/WordPress/gutenberg/assets/1083581/0c8fd2b4-4c97-4ded-bfa6-ae3a786cab82" /> | 
| V2, before (trunk) | <video src="https://github.com/WordPress/gutenberg/assets/1083581/fdeac798-1397-46e9-b677-a155771b15d4" /> |
| V2, after (this PR) | <video src="https://github.com/WordPress/gutenberg/assets/1083581/693f5c9f-198e-4f64-a5db-ce21503e17c6" /> |

