### PR TITLE
Global Styles: Allow variations to be filtered by multiple properties

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -114,7 +114,7 @@ export function useSupportedStyles( name, element ) {
 
 export function useColorVariations() {
 	const colorVariations = useCurrentMergeThemeStyleVariationsWithUserConfig( {
-		property: 'color',
+		properties: [ 'color' ],
 	} );
 	/*
 	 * Filter out variations with no settings or styles.
@@ -134,7 +134,7 @@ export function useColorVariations() {
 export function useTypographyVariations() {
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			property: 'typography',
+			properties: [ 'typography', 'spacing' ],
 		} );
 	/*
 	 * Filter out variations with no settings or styles.

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -134,7 +134,7 @@ export function useColorVariations() {
 export function useTypographyVariations() {
 	const typographyVariations =
 		useCurrentMergeThemeStyleVariationsWithUserConfig( {
-			properties: [ 'typography', 'spacing' ],
+			properties: [ 'typography' ],
 		} );
 	/*
 	 * Filter out variations with no settings or styles.

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -13,7 +13,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import PreviewStyles from './preview-styles';
 import Variation from './variations/variation';
-import { isVariationWithSingleProperty } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { isVariationWithProperties } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../lock-unlock';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
@@ -33,11 +33,14 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		).__experimentalGetCurrentThemeGlobalStylesVariations();
 	}, [] );
 
-	// Filter out variations that are of single property type, i.e. color or typography variations.
-	const multiplePropertyVariations = variations?.filter( ( variation ) => {
+	// Filter out variations that are color or typography variations.
+	const fullStyleVariations = variations?.filter( ( variation ) => {
 		return (
-			! isVariationWithSingleProperty( variation, 'color' ) &&
-			! isVariationWithSingleProperty( variation, 'typography' )
+			! isVariationWithProperties( variation, [ 'color' ] ) &&
+			! isVariationWithProperties( variation, [
+				'typography',
+				'spacing',
+			] )
 		);
 	} );
 
@@ -48,7 +51,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				settings: {},
 				styles: {},
 			},
-			...( multiplePropertyVariations ?? [] ),
+			...( fullStyleVariations ?? [] ),
 		];
 		return [
 			...withEmptyVariation.map( ( variation ) => {
@@ -105,7 +108,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				};
 			} ),
 		];
-	}, [ multiplePropertyVariations, userStyles?.blocks, userStyles?.css ] );
+	}, [ fullStyleVariations, userStyles?.blocks, userStyles?.css ] );
 
 	return (
 		<Grid

--- a/packages/edit-site/src/components/global-styles/variations/variation.js
+++ b/packages/edit-site/src/components/global-styles/variations/variation.js
@@ -16,7 +16,7 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
-import { filterObjectByProperty } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { filterObjectByProperties } from '../../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 import { unlock } from '../../../lock-unlock';
 
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
@@ -28,7 +28,7 @@ export default function Variation( {
 	variation,
 	children,
 	isPill,
-	property,
+	properties,
 	showTooltip,
 } ) {
 	const [ isFocused, setIsFocused ] = useState( false );
@@ -36,8 +36,8 @@ export default function Variation( {
 
 	const context = useMemo( () => {
 		let merged = mergeBaseAndUserConfigs( base, variation );
-		if ( property ) {
-			merged = filterObjectByProperty( merged, property );
+		if ( properties ) {
+			merged = filterObjectByProperties( merged, properties );
 		}
 		return {
 			user: variation,
@@ -45,7 +45,7 @@ export default function Variation( {
 			merged,
 			setUserConfig: () => {},
 		};
-	}, [ variation, base, property ] );
+	}, [ variation, base, properties ] );
 
 	const selectVariation = () => setUserConfig( variation );
 

--- a/packages/edit-site/src/components/global-styles/variations/variations-color.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-color.js
@@ -31,7 +31,7 @@ export default function ColorVariations( { title, gap = 2 } ) {
 						key={ index }
 						variation={ variation }
 						isPill
-						property="color"
+						properties={ [ 'color' ] }
 						showTooltip
 					>
 						{ () => <StylesPreviewColors /> }

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -38,7 +38,7 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 						<Variation
 							key={ index }
 							variation={ variation }
-							properties={ [ 'typography', 'spacing' ] }
+							properties={ [ 'typography' ] }
 							showTooltip
 						>
 							{ ( isFocused ) => (

--- a/packages/edit-site/src/components/global-styles/variations/variations-typography.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-typography.js
@@ -38,7 +38,7 @@ export default function TypographyVariations( { title, gap = 2 } ) {
 						<Variation
 							key={ index }
 							variation={ variation }
-							property="typography"
+							properties={ [ 'typography', 'spacing' ] }
 							showTooltip
 						>
 							{ ( isFocused ) => (

--- a/packages/edit-site/src/hooks/use-theme-style-variations/test/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/test/use-theme-style-variations-by-property.js
@@ -2,11 +2,11 @@
  * Internal dependencies
  */
 import {
-	filterObjectByProperty,
-	removePropertyFromObject,
+	filterObjectByProperties,
+	removePropertiesFromObject,
 } from '../use-theme-style-variations-by-property';
 
-describe( 'filterObjectByProperty', () => {
+describe( 'filterObjectByProperties', () => {
 	const noop = () => {};
 	test.each( [
 		{
@@ -14,21 +14,21 @@ describe( 'filterObjectByProperty', () => {
 				foo: 'bar',
 				array: [ 1, 3, 4 ],
 			},
-			property: 'array',
+			properties: [ 'array' ],
 			expected: { array: [ 1, 3, 4 ] },
 		},
 		{
 			object: {
 				foo: 'bar',
 			},
-			property: 'does-not-exist',
+			properties: [ 'does-not-exist' ],
 			expected: {},
 		},
 		{
 			object: {
 				foo: 'bar',
 			},
-			property: false,
+			properties: false,
 			expected: {},
 		},
 		{
@@ -39,7 +39,7 @@ describe( 'filterObjectByProperty', () => {
 					},
 				},
 			},
-			property: 'null',
+			properties: [ 'null' ],
 			expected: {
 				dig: {
 					deeper: {
@@ -52,19 +52,19 @@ describe( 'filterObjectByProperty', () => {
 			object: {
 				function: noop,
 			},
-			property: 'function',
+			properties: [ 'function' ],
 			expected: {
 				function: noop,
 			},
 		},
 		{
 			object: [],
-			property: 'something',
+			properties: [ 'something' ],
 			expected: {},
 		},
 		{
 			object: {},
-			property: undefined,
+			properties: undefined,
 			expected: {},
 		},
 		{
@@ -74,7 +74,7 @@ describe( 'filterObjectByProperty', () => {
 					array: [ 1, 3, 4 ],
 				},
 			},
-			property: 'nested-object-foo',
+			properties: [ 'nested-object-foo' ],
 			expected: {
 				'nested-object': {
 					'nested-object-foo': 'bar',
@@ -82,15 +82,15 @@ describe( 'filterObjectByProperty', () => {
 			},
 		},
 	] )(
-		'should filter object by $property',
-		( { expected, object, property } ) => {
-			const result = filterObjectByProperty( object, property );
+		'should filter object by $properties',
+		( { expected, object, properties } ) => {
+			const result = filterObjectByProperties( object, properties );
 			expect( result ).toEqual( expected );
 		}
 	);
 } );
 
-describe( 'removePropertyFromObject', () => {
+describe( 'removePropertiesFromObject', () => {
 	const mockBaseVariation = {
 		settings: {
 			typography: {
@@ -188,34 +188,38 @@ describe( 'removePropertyFromObject', () => {
 		},
 	};
 
-	it( 'should return with no property', () => {
+	it( 'should return with no properties', () => {
 		const object = { test: 'me' };
-		expect( removePropertyFromObject( object, undefined ) ).toEqual(
+		expect( removePropertiesFromObject( object, undefined ) ).toEqual(
 			object
 		);
 	} );
 
-	it( 'should return with non-string property', () => {
+	it( 'should return with non-string properties', () => {
 		const object = { test: 'you' };
-		expect( removePropertyFromObject( object, true ) ).toEqual( object );
+		expect( removePropertiesFromObject( object, true ) ).toEqual( object );
 	} );
 
 	it( 'should return with empty object', () => {
 		const object = {};
-		expect( removePropertyFromObject( object, 'color' ) ).toEqual( object );
+		expect( removePropertiesFromObject( object, [ 'color' ] ) ).toEqual(
+			object
+		);
 	} );
 
 	it( 'should return with null', () => {
-		expect( removePropertyFromObject( null, 'color' ) ).toEqual( null );
+		expect( removePropertiesFromObject( null, [ 'color' ] ) ).toEqual(
+			null
+		);
 	} );
 
-	it( 'should remove the specified property from the object', () => {
+	it( 'should remove the specified properties from the object', () => {
 		expect(
-			removePropertyFromObject(
+			removePropertiesFromObject(
 				{
 					...mockBaseVariation,
 				},
-				'typography'
+				[ 'typography' ]
 			)
 		).toEqual( {
 			settings: {

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -18,14 +18,14 @@ const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 
 /**
- * Removes all instances of a property from an object.
+ * Removes all instances of properties from an object.
  *
- * @param {Object} object   The object to remove the property from.
- * @param {string} property The property to remove.
+ * @param {Object} object     The object to remove the properties from.
+ * @param {string} properties The properties to remove.
  * @return {Object} The modified object.
  */
-export function removePropertyFromObject( object, property ) {
-	if ( ! property || typeof property !== 'string' ) {
+export function removePropertiesFromObject( object, properties ) {
+	if ( ! properties || typeof properties !== 'object' ) {
 		return object;
 	}
 
@@ -38,25 +38,25 @@ export function removePropertyFromObject( object, property ) {
 	}
 
 	for ( const key in object ) {
-		if ( key === property ) {
+		if ( properties.includes( key ) ) {
 			delete object[ key ];
 		} else if ( typeof object[ key ] === 'object' ) {
-			removePropertyFromObject( object[ key ], property );
+			removePropertiesFromObject( object[ key ], properties );
 		}
 	}
 	return object;
 }
 
 /**
- * Fetches the current theme style variations that contain only the specified property
+ * Fetches the current theme style variations that contain only the specified properties
  * and merges them with the user config.
  *
- * @param {Object} props          Object of hook args.
- * @param {string} props.property The property to filter by.
+ * @param {Object} props            Object of hook args.
+ * @param {string} props.properties The properties to filter by.
  * @return {Object[]|*} The merged object.
  */
 export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
-	property,
+	properties,
 } ) {
 	const { variationsFromTheme } = useSelect( ( select ) => {
 		const _variationsFromTheme =
@@ -74,51 +74,54 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 		const clonedUserVariation = cloneDeep( userVariation );
 
 		// Get user variation and remove the settings for the given property.
-		const userVariationWithoutProperty = removePropertyFromObject(
+		const userVariationWithoutProperties = removePropertiesFromObject(
 			clonedUserVariation,
-			property
+			properties
 		);
-		userVariationWithoutProperty.title = __( 'Default' );
+		userVariationWithoutProperties.title = __( 'Default' );
 
-		const variationsWithSinglePropertyAndBase = variationsFromTheme
+		const variationsWithPropertiesAndBase = variationsFromTheme
 			.filter( ( variation ) => {
-				return isVariationWithSingleProperty( variation, property );
+				return isVariationWithProperties( variation, properties );
 			} )
 			.map( ( variation ) => {
 				return mergeBaseAndUserConfigs(
-					userVariationWithoutProperty,
+					userVariationWithoutProperties,
 					variation
 				);
 			} );
 
 		return [
-			userVariationWithoutProperty,
-			...variationsWithSinglePropertyAndBase,
+			userVariationWithoutProperties,
+			...variationsWithPropertiesAndBase,
 		];
-	}, [ property, userVariation, variationsFromTheme ] );
+	}, [ properties, userVariation, variationsFromTheme ] );
 }
 
 /**
- * Returns a new object, with properties specified in `property`,
+ * Returns a new object, with properties specified in `properties` array.,
  * maintain the original object tree structure.
- * The function is recursive, so it will perform a deep search for the given property.
- * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the property is `test`.
+ * The function is recursive, so it will perform a deep search for the given properties.
+ * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the properties are  `[ 'test' ]`.
  *
- * @param {Object} object   The object to filter
- * @param {Object} property The property to filter by
+ * @param {Object} object     The object to filter
+ * @param {Array}  properties The properties to filter by
  * @return {Object} The merged object.
  */
-export const filterObjectByProperty = ( object, property ) => {
+export const filterObjectByProperties = ( object, properties ) => {
 	if ( ! object ) {
 		return {};
 	}
 
 	const newObject = {};
 	Object.keys( object ).forEach( ( key ) => {
-		if ( key === property ) {
+		if ( properties.includes( key ) ) {
 			newObject[ key ] = object[ key ];
 		} else if ( typeof object[ key ] === 'object' ) {
-			const newFilter = filterObjectByProperty( object[ key ], property );
+			const newFilter = filterObjectByProperties(
+				object[ key ],
+				properties
+			);
 			if ( Object.keys( newFilter ).length ) {
 				newObject[ key ] = newFilter;
 			}
@@ -128,23 +131,23 @@ export const filterObjectByProperty = ( object, property ) => {
 };
 
 /**
- * Compares a style variation to the same variation filtered by a single property.
- * Returns true if the variation contains only the property specified.
+ * Compares a style variation to the same variation filtered by the specified properties.
+ * Returns true if the variation contains only the properties specified.
  *
- * @param {Object} variation The variation to compare.
- * @param {string} property  The property to compare.
- * @return {boolean} Whether the variation contains only a single property.
+ * @param {Object} variation  The variation to compare.
+ * @param {string} properties The properties to compare.
+ * @return {boolean} Whether the variation contains only the specified properties.
  */
-export function isVariationWithSingleProperty( variation, property ) {
-	const variationWithProperty = filterObjectByProperty(
+export function isVariationWithProperties( variation, properties ) {
+	const variationWithProperties = filterObjectByProperties(
 		cloneDeep( variation ),
-		property
+		properties
 	);
 
 	return (
-		JSON.stringify( variationWithProperty?.styles ) ===
+		JSON.stringify( variationWithProperties?.styles ) ===
 			JSON.stringify( variation?.styles ) &&
-		JSON.stringify( variationWithProperty?.settings ) ===
+		JSON.stringify( variationWithProperties?.settings ) ===
 			JSON.stringify( variation?.settings )
 	);
 }

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -111,7 +111,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
  * @return {Object} The merged object.
  */
 export const filterObjectByProperties = ( object, properties ) => {
-	if ( ! object ) {
+	if ( ! object || ! properties?.length ) {
 		return {};
 	}
 

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -14,7 +14,9 @@ import { __ } from '@wordpress/i18n';
 import cloneDeep from '../../utils/clone-deep';
 import { unlock } from '../../lock-unlock';
 
-const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
+const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
+	blockEditorPrivateApis
+);
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 
 /**
@@ -144,10 +146,5 @@ export function isVariationWithProperties( variation, properties ) {
 		properties
 	);
 
-	return (
-		JSON.stringify( variationWithProperties?.styles ) ===
-			JSON.stringify( variation?.styles ) &&
-		JSON.stringify( variationWithProperties?.settings ) ===
-			JSON.stringify( variation?.settings )
-	);
+	return areGlobalStyleConfigsEqual( variationWithProperties, variation );
 }

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -20,8 +20,8 @@ const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 /**
  * Removes all instances of properties from an object.
  *
- * @param {Object} object     The object to remove the properties from.
- * @param {string} properties The properties to remove.
+ * @param {Object}   object     The object to remove the properties from.
+ * @param {string[]} properties The properties to remove.
  * @return {Object} The modified object.
  */
 export function removePropertiesFromObject( object, properties ) {
@@ -51,8 +51,8 @@ export function removePropertiesFromObject( object, properties ) {
  * Fetches the current theme style variations that contain only the specified properties
  * and merges them with the user config.
  *
- * @param {Object} props            Object of hook args.
- * @param {string} props.properties The properties to filter by.
+ * @param {Object}   props            Object of hook args.
+ * @param {string[]} props.properties The properties to filter by.
  * @return {Object[]|*} The merged object.
  */
 export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
@@ -104,8 +104,8 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
  * The function is recursive, so it will perform a deep search for the given properties.
  * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the properties are  `[ 'test' ]`.
  *
- * @param {Object} object     The object to filter
- * @param {string[]}  properties The properties to filter by
+ * @param {Object}   object     The object to filter
+ * @param {string[]} properties The properties to filter by
  * @return {Object} The merged object.
  */
 export const filterObjectByProperties = ( object, properties ) => {
@@ -134,7 +134,7 @@ export const filterObjectByProperties = ( object, properties ) => {
  * Compares a style variation to the same variation filtered by the specified properties.
  * Returns true if the variation contains only the properties specified.
  *
- * @param {Object} variation  The variation to compare.
+ * @param {Object}   variation  The variation to compare.
  * @param {string[]} properties The properties to compare.
  * @return {boolean} Whether the variation contains only the specified properties.
  */

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -135,7 +135,7 @@ export const filterObjectByProperties = ( object, properties ) => {
  * Returns true if the variation contains only the properties specified.
  *
  * @param {Object} variation  The variation to compare.
- * @param {string} properties The properties to compare.
+ * @param {string[]} properties The properties to compare.
  * @return {boolean} Whether the variation contains only the specified properties.
  */
 export function isVariationWithProperties( variation, properties ) {

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -95,7 +95,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
 			userVariationWithoutProperties,
 			...variationsWithPropertiesAndBase,
 		];
-	}, [ properties, userVariation, variationsFromTheme ] );
+	}, [ properties.toString(), userVariation, variationsFromTheme ] );
 }
 
 /**

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -56,7 +56,7 @@ export function removePropertiesFromObject( object, properties ) {
  * @return {Object[]|*} The merged object.
  */
 export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
-	properties,
+	properties = [],
 } ) {
 	const { variationsFromTheme } = useSelect( ( select ) => {
 		const _variationsFromTheme =

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -25,7 +25,7 @@ const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
  * @return {Object} The modified object.
  */
 export function removePropertiesFromObject( object, properties ) {
-	if ( ! properties || typeof properties !== 'object' ) {
+	if ( ! properties?.length ) {
 		return object;
 	}
 

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -105,7 +105,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig( {
  * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the properties are  `[ 'test' ]`.
  *
  * @param {Object} object     The object to filter
- * @param {Array}  properties The properties to filter by
+ * @param {string[]}  properties The properties to filter by
  * @return {Object} The merged object.
  */
 export const filterObjectByProperties = ( object, properties ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This updates several functions to allow presets to incorporate several properties.

## Why?
This was originally proppsed as part of https://github.com/WordPress/gutenberg/pull/62709, and was also part of https://github.com/WordPress/gutenberg/pull/62741. It's not clear what direction we want to go with this, but this code maintains the same functionality while adding flexibility by allowing you to provide an array to these functions rather than a string.

## How?
Update several functions to accept an array rather than a string.

## Testing Instructions
0. Use a theme with style variations (like TT4)
1. Open the Site Editor
2. Open Global Styles
3. Check that you can still see color variations and style variations and that there are no typography variations.
