### PR TITLE
CustomSelectControl V2: allow wrapping item hint to new line

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))
 -   `CustomSelectControlV2`: fix popover styles. ([#62821](https://github.com/WordPress/gutenberg/pull/62821))
 -   `CustomSelectControlV2`: fix trigger text alignment in RTL languages ([#62869](https://github.com/WordPress/gutenberg/pull/62869)).
+-   `CustomSelectControlV2`: allow wrapping item hint to new line ([#62848](https://github.com/WordPress/gutenberg/pull/62848)).
 -   `CustomSelectControlV2`: fix select popover content overflow. ([#62844](https://github.com/WordPress/gutenberg/pull/62844))
 -   Extract `TimeInput` component from `TimePicker` ([#60613](https://github.com/WordPress/gutenberg/pull/60613)).
 

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -78,7 +78,14 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 					value={ name }
 					children={ __experimentalHint ? withHint : name }
 					style={ style }
-					className={ className }
+					className={ clsx(
+						// Legacy classnames
+						'components-custom-select-control__item',
+						className,
+						{
+							'has-hint': !! __experimentalHint,
+						}
+					) }
 				/>
 			);
 		}

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -65,9 +65,7 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 		( { name, key, __experimentalHint, style, className } ) => {
 			const withHint = (
 				<Styled.WithHintItemWrapper>
-					<Styled.WithHintItemContent>
-						{ name }
-					</Styled.WithHintItemContent>
+					<span>{ name }</span>
 					<Styled.WithHintItemHint className="components-custom-select-control__item-hint">
 						{ __experimentalHint }
 					</Styled.WithHintItemHint>

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -64,12 +64,12 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	const children = options.map(
 		( { name, key, __experimentalHint, style, className } ) => {
 			const withHint = (
-				<Styled.WithHintWrapper>
-					<span>{ name }</span>
-					<Styled.ExperimentalHintItem className="components-custom-select-control__item-hint">
+				<Styled.ItemHintWrapper>
+					<Styled.ItemHintContent>{ name }</Styled.ItemHintContent>
+					<Styled.ItemHint className="components-custom-select-control__item-hint">
 						{ __experimentalHint }
-					</Styled.ExperimentalHintItem>
-				</Styled.WithHintWrapper>
+					</Styled.ItemHint>
+				</Styled.ItemHintWrapper>
 			);
 
 			return (

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -64,12 +64,14 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	const children = options.map(
 		( { name, key, __experimentalHint, style, className } ) => {
 			const withHint = (
-				<Styled.ItemHintWrapper>
-					<Styled.ItemHintContent>{ name }</Styled.ItemHintContent>
-					<Styled.ItemHint className="components-custom-select-control__item-hint">
+				<Styled.WithHintItemWrapper>
+					<Styled.WithHintItemContent>
+						{ name }
+					</Styled.WithHintItemContent>
+					<Styled.WithHintItemHint className="components-custom-select-control__item-hint">
 						{ __experimentalHint }
-					</Styled.ItemHint>
-				</Styled.ItemHintWrapper>
+					</Styled.WithHintItemHint>
+				</Styled.WithHintItemWrapper>
 			);
 
 			return (

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -66,7 +66,10 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 			const withHint = (
 				<Styled.WithHintItemWrapper>
 					<span>{ name }</span>
-					<Styled.WithHintItemHint className="components-custom-select-control__item-hint">
+					<Styled.WithHintItemHint
+					// TODO: Legacy classname. Add V1 styles are removed from the codebase
+					// className="components-custom-select-control__item-hint"
+					>
 						{ __experimentalHint }
 					</Styled.WithHintItemHint>
 				</Styled.WithHintItemWrapper>
@@ -79,12 +82,13 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 					children={ __experimentalHint ? withHint : name }
 					style={ style }
 					className={ clsx(
-						// Legacy classnames
-						'components-custom-select-control__item',
-						className,
-						{
-							'has-hint': !! __experimentalHint,
-						}
+						// TODO: Legacy classname. Add V1 styles are removed from the codebase
+						// 'components-custom-select-control__item',
+						className
+						// TODO: Legacy classname. Add V1 styles are removed from the codebase
+						// {
+						// 	'has-hint': __experimentalHint,
+						// }
 					) }
 				/>
 			);
@@ -101,7 +105,10 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
 				{ currentValue }
-				<Styled.SelectedExperimentalHintItem className="components-custom-select-control__hint">
+				<Styled.SelectedExperimentalHintItem
+				// TODO: Legacy classname. Add V1 styles are removed from the codebase
+				// className="components-custom-select-control__hint"
+				>
 					{ currentHint?.__experimentalHint }
 				</Styled.SelectedExperimentalHintItem>
 			</Styled.SelectedExperimentalHintWrapper>
@@ -132,7 +139,8 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 			size={ translatedSize }
 			store={ store }
 			className={ clsx(
-				'components-custom-select-control',
+				// TODO: Legacy classname. Add V1 styles are removed from the codebase
+				// 'components-custom-select-control',
 				classNameProp
 			) }
 			isLegacy

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -21,10 +21,11 @@ const truncateStyles = css`
 	white-space: nowrap;
 `;
 
-export const WithHintWrapper = styled.div`
+export const ItemHintWrapper = styled.div`
 	display: flex;
 	justify-content: space-between;
 	flex: 1;
+	flex-wrap: wrap;
 `;
 
 export const SelectedExperimentalHintWrapper = styled.div`
@@ -36,7 +37,11 @@ export const SelectedExperimentalHintItem = styled.span`
 	margin-inline-start: ${ space( 2 ) };
 `;
 
-export const ExperimentalHintItem = styled.span`
+export const ItemHintContent = styled.span`
+	padding-inline-end: ${ space( 4 ) };
+`;
+
+export const ItemHint = styled.span`
 	color: ${ COLORS.theme.gray[ 600 ] };
 	text-align: right;
 	margin-inline-end: ${ space( 1 ) };

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -44,7 +44,7 @@ export const ItemHintContent = styled.span`
 export const ItemHint = styled.span`
 	color: ${ COLORS.theme.gray[ 600 ] };
 	text-align: right;
-	margin-inline-end: ${ space( 1 ) };
+	padding-inline-end: ${ space( 1 ) };
 `;
 
 export const SelectLabel = styled( Ariakit.SelectLabel )`

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -168,5 +168,6 @@ export const ItemHint = styled.span`
 		text-align: initial;
 		line-height: ${ CONFIG.fontLineHeightBase };
 		padding-inline-end: ${ space( 1 ) };
+		margin-block: ${ space( 1 ) };
 	}
 `;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -139,14 +139,6 @@ const truncateStyles = css`
 	white-space: nowrap;
 `;
 
-export const ItemHintWrapper = styled.div`
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	flex-wrap: wrap;
-	flex: 1;
-`;
-
 export const SelectedExperimentalHintWrapper = styled.div`
 	${ truncateStyles }
 `;
@@ -156,11 +148,19 @@ export const SelectedExperimentalHintItem = styled.span`
 	margin-inline-start: ${ space( 2 ) };
 `;
 
-export const ItemHintContent = styled.span`
+export const WithHintItemWrapper = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	flex: 1;
+`;
+
+export const WithHintItemContent = styled.span`
 	padding-inline-end: ${ space( 4 ) };
 `;
 
-export const ItemHint = styled.span`
+export const WithHintItemHint = styled.span`
 	// Necessary to override V1 styles passed via the legacy
 	// '.components-custom-select-control__item-hint' class
 	${ SelectItem } && {

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -18,7 +18,7 @@ const ITEM_PADDING = space( 2 );
 export const SelectLabel = styled( Ariakit.SelectLabel )`
 	font-size: 11px;
 	font-weight: 500;
-	line-height: 1.4;
+	line-height: ${ CONFIG.fontLineHeightBase };
 	text-transform: uppercase;
 	margin-bottom: ${ space( 2 ) };
 `;
@@ -166,7 +166,7 @@ export const ItemHint = styled.span`
 	${ SelectItem } && {
 		color: ${ COLORS.theme.gray[ 600 ] };
 		text-align: initial;
-		line-height: 1.4;
+		line-height: ${ CONFIG.fontLineHeightBase };
 		padding-inline-end: ${ space( 1 ) };
 	}
 `;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -102,27 +102,23 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 `;
 
 export const SelectItem = styled( Ariakit.SelectItem )`
-	// Necessary to override V1 styles passed via the legacy
-	// '.components-custom-select-control__item' class
-	&& {
-		cursor: default;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: ${ ITEM_PADDING };
-		font-size: ${ CONFIG.fontSize };
-		// TODO: reassess line-height for non-legacy v2
-		line-height: 28px;
-		scroll-margin: ${ space( 1 ) };
-		user-select: none;
+	cursor: default;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: ${ ITEM_PADDING };
+	font-size: ${ CONFIG.fontSize };
+	// TODO: reassess line-height for non-legacy v2
+	line-height: 28px;
+	scroll-margin: ${ space( 1 ) };
+	user-select: none;
 
-		&[aria-disabled='true'] {
-			cursor: not-allowed;
-		}
+	&[aria-disabled='true'] {
+		cursor: not-allowed;
+	}
 
-		&[data-active-item] {
-			background-color: ${ COLORS.theme.gray[ 300 ] };
-		}
+	&[data-active-item] {
+		background-color: ${ COLORS.theme.gray[ 300 ] };
 	}
 `;
 
@@ -159,12 +155,8 @@ export const WithHintItemWrapper = styled.div`
 `;
 
 export const WithHintItemHint = styled.span`
-	// Necessary to override V1 styles passed via the legacy
-	// '.components-custom-select-control__item-hint' class
-	${ SelectItem } && {
-		color: ${ COLORS.theme.gray[ 600 ] };
-		text-align: initial;
-		line-height: ${ CONFIG.fontLineHeightBase };
-		padding-inline-end: ${ space( 1 ) };
-	}
+	color: ${ COLORS.theme.gray[ 600 ] };
+	text-align: initial;
+	line-height: ${ CONFIG.fontLineHeightBase };
+	padding-inline-end: ${ space( 1 ) };
 `;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -154,10 +154,8 @@ export const WithHintItemWrapper = styled.div`
 	align-items: center;
 	flex-wrap: wrap;
 	flex: 1;
-`;
-
-export const WithHintItemContent = styled.span`
-	padding-inline-end: ${ space( 4 ) };
+	column-gap: ${ space( 4 ) };
+	row-gap: ${ space( 1 ) };
 `;
 
 export const WithHintItemHint = styled.span`
@@ -168,6 +166,5 @@ export const WithHintItemHint = styled.span`
 		text-align: initial;
 		line-height: ${ CONFIG.fontLineHeightBase };
 		padding-inline-end: ${ space( 1 ) };
-		margin-block: ${ space( 1 ) };
 	}
 `;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -151,7 +151,6 @@ export const WithHintItemWrapper = styled.div`
 	flex-wrap: wrap;
 	flex: 1;
 	column-gap: ${ space( 4 ) };
-	row-gap: ${ space( 1 ) };
 `;
 
 export const WithHintItemHint = styled.span`
@@ -159,4 +158,5 @@ export const WithHintItemHint = styled.span`
 	text-align: initial;
 	line-height: ${ CONFIG.fontLineHeightBase };
 	padding-inline-end: ${ space( 1 ) };
+	margin-block: ${ space( 1 ) };
 `;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -15,38 +15,6 @@ import type { CustomSelectButtonSize } from './types';
 
 const ITEM_PADDING = space( 2 );
 
-const truncateStyles = css`
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-`;
-
-export const ItemHintWrapper = styled.div`
-	display: flex;
-	justify-content: space-between;
-	flex: 1;
-	flex-wrap: wrap;
-`;
-
-export const SelectedExperimentalHintWrapper = styled.div`
-	${ truncateStyles }
-`;
-
-export const SelectedExperimentalHintItem = styled.span`
-	color: ${ COLORS.theme.gray[ 600 ] };
-	margin-inline-start: ${ space( 2 ) };
-`;
-
-export const ItemHintContent = styled.span`
-	padding-inline-end: ${ space( 4 ) };
-`;
-
-export const ItemHint = styled.span`
-	color: ${ COLORS.theme.gray[ 600 ] };
-	text-align: right;
-	padding-inline-end: ${ space( 1 ) };
-`;
-
 export const SelectLabel = styled( Ariakit.SelectLabel )`
 	font-size: 11px;
 	font-weight: 500;
@@ -134,22 +102,27 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 `;
 
 export const SelectItem = styled( Ariakit.SelectItem )`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: ${ ITEM_PADDING };
-	font-size: ${ CONFIG.fontSize };
-	// TODO: reassess line-height for non-legacy v2
-	line-height: 28px;
-	scroll-margin: ${ space( 1 ) };
-	user-select: none;
+	// Necessary to override V1 styles passed via the legacy
+	// '.components-custom-select-control__item' class
+	&& {
+		cursor: default;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: ${ ITEM_PADDING };
+		font-size: ${ CONFIG.fontSize };
+		// TODO: reassess line-height for non-legacy v2
+		line-height: 28px;
+		scroll-margin: ${ space( 1 ) };
+		user-select: none;
 
-	&[aria-disabled='true'] {
-		cursor: not-allowed;
-	}
+		&[aria-disabled='true'] {
+			cursor: not-allowed;
+		}
 
-	&[data-active-item] {
-		background-color: ${ COLORS.theme.gray[ 300 ] };
+		&[data-active-item] {
+			background-color: ${ COLORS.theme.gray[ 300 ] };
+		}
 	}
 `;
 
@@ -158,4 +131,41 @@ export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
 	align-items: center;
 	margin-inline-start: ${ ITEM_PADDING };
 	font-size: 24px; // Size of checkmark icon
+`;
+
+const truncateStyles = css`
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+`;
+
+export const ItemHintWrapper = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	flex: 1;
+`;
+
+export const SelectedExperimentalHintWrapper = styled.div`
+	${ truncateStyles }
+`;
+
+export const SelectedExperimentalHintItem = styled.span`
+	color: ${ COLORS.theme.gray[ 600 ] };
+	margin-inline-start: ${ space( 2 ) };
+`;
+
+export const ItemHintContent = styled.span`
+	padding-inline-end: ${ space( 4 ) };
+`;
+
+export const ItemHint = styled.span`
+	// Necessary to override V1 styles passed via the legacy
+	// '.components-custom-select-control__item-hint' class
+	${ SelectItem } && {
+		color: ${ COLORS.theme.gray[ 600 ] };
+		text-align: right;
+		padding-inline-end: ${ space( 1 ) };
+	}
 `;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -165,7 +165,8 @@ export const ItemHint = styled.span`
 	// '.components-custom-select-control__item-hint' class
 	${ SelectItem } && {
 		color: ${ COLORS.theme.gray[ 600 ] };
-		text-align: right;
+		text-align: initial;
+		line-height: 1.4;
 		padding-inline-end: ${ space( 1 ) };
 	}
 `;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Improve how inidivual item hints are rendered for the `CustomSelectControl` V2 legacy adapter, by allowing the hint to wrap below the item's content, instead of being forced on the same line.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Even if the previous layout is how the V1 component behaves, it does not produce good-looking UI when the select popover is narrow. And it often overridden in the editor via custom style overrides anyway, which is bad.

These changes basically bring to the component the overrides that were applied in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using flexbox to allow the hint to break the line and render below the item's content.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Storybook

1. Apply the following patch

<details>

<summary>Click to show diff</summary>

```diff
diff --git a/packages/components/src/custom-select-control/stories/index.story.tsx b/packages/components/src/custom-select-control/stories/index.story.tsx
index 8ff9a023c5..4636fd34d3 100644
--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -111,7 +111,8 @@ WithHints.args = {
 		{
 			key: 'medium',
 			name: 'Medium',
-			__experimentalHint: '250x250',
+			__experimentalHint:
+				'A long hint, which ultimately could have been just "250x250"',
 		},
 		{
 			key: 'large',

```
</details>

2. Load the "With Hints" storybook example for the V2 legacy adapter
3. Resize the window and check the new hint wrapping behaviour
4. Compare it with the same storybook example for the V1 component

| V1 | V2 legacy adapter - before (trunk) | V2 legacy adapter - after (this PR) |
|---|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/2a350164-8e92-479a-86bd-939a38add268" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/96e06334-3e2d-47e6-886c-359f45a2f981" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/59b58335-ad85-47dd-915d-f7d8f3cd6631" /> |

### Editor

First, apply the following patch 

<details>

<summary>Click to show diff</summary>

```diff
diff --git a/packages/block-editor/src/components/date-format-picker/index.js b/packages/block-editor/src/components/date-format-picker/index.js
index 19ec0bf8c2..f71cdd5e48 100644
--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -8,11 +8,18 @@ import {
 	TextControl,
 	ExternalLink,
 	VisuallyHidden,
-	CustomSelectControl,
 	ToggleControl,
 	__experimentalVStack as VStack,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { CustomSelectControlV2Legacy } = unlock( componentsPrivateApis );
+
 // So that we illustrate the different formats in the dropdown properly, show a date that is
 // somwhat recent, has a day greater than 12, and a month with more than three letters.
 const exampleDate = new Date();
@@ -128,7 +135,7 @@ function NonDefaultControls( { format, onChange } ) {
 
 	return (
 		<VStack>
-			<CustomSelectControl
+			<CustomSelectControlV2Legacy
 				label={ __( 'Choose a format' ) }
 				options={ [ ...suggestedOptions, customOption ] }
 				value={
diff --git a/packages/block-editor/src/components/date-format-picker/style.scss b/packages/block-editor/src/components/date-format-picker/style.scss
index d1ad52408d..748e43bb8d 100644
--- a/packages/block-editor/src/components/date-format-picker/style.scss
+++ b/packages/block-editor/src/components/date-format-picker/style.scss
@@ -4,13 +4,4 @@
 
 .block-editor-date-format-picker__custom-format-select-control__custom-option {
 	border-top: 1px solid $gray-300;
-
-	&.has-hint {
-		grid-template-columns: auto 30px;
-	}
-
-	.components-custom-select-control__item-hint {
-		grid-row: 2;
-		text-align: left;
-	}
 }
diff --git a/packages/block-editor/src/hooks/position.js b/packages/block-editor/src/hooks/position.js
index a5d4a0cb43..b184afca46 100644
--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -26,7 +26,9 @@ import { cleanEmptyObject, useStyleOverride } from './utils';
 import { unlock } from '../lock-unlock';
 import { store as blockEditorStore } from '../store';
 
-const { CustomSelectControl } = unlock( componentsPrivateApis );
+const { CustomSelectControl, CustomSelectControlV2Legacy } = unlock(
+	componentsPrivateApis
+);
 
 const POSITION_SUPPORT_KEY = 'position';
 
@@ -287,7 +289,7 @@ export function PositionPanelPure( {
 						__nextHasNoMarginBottom
 						help={ stickyHelpText }
 					>
-						<CustomSelectControl
+						<CustomSelectControlV2Legacy
 							__next40pxDefaultSize
 							className="block-editor-hooks__position-selection__select-control"
 							label={ __( 'Position' ) }
diff --git a/packages/block-editor/src/hooks/position.scss b/packages/block-editor/src/hooks/position.scss
index b3bd6b1b9e..552ee8cf7c 100644
--- a/packages/block-editor/src/hooks/position.scss
+++ b/packages/block-editor/src/hooks/position.scss
@@ -3,16 +3,3 @@
 		display: none;
 	}
 }
-
-.block-editor-hooks__position-selection__select-control__option {
-	&.has-hint {
-		grid-template-columns: auto 30px;
-		line-height: $default-line-height;
-		margin-bottom: 0;
-	}
-
-	.components-custom-select-control__item-hint {
-		grid-row: 2;
-		text-align: left;
-	}
-}
diff --git a/packages/components/src/private-apis.ts b/packages/components/src/private-apis.ts
index f55373664e..9a26b7c7e3 100644
--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -14,6 +14,7 @@ import {
 	useCompositeStore as useCompositeStoreV2,
 } from './composite/v2';
 import { default as CustomSelectControl } from './custom-select-control';
+import { default as CustomSelectControlV2Legacy } from './custom-select-control-v2/legacy-component';
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
 import { createPrivateSlotFill } from './slot-fill';
 import {
@@ -40,6 +41,7 @@ lock( privateApis, {
 	CompositeRowV2,
 	useCompositeStoreV2,
 	CustomSelectControl,
+	CustomSelectControlV2Legacy,
 	__experimentalPopoverLegacyPositionToPlacement,
 	createPrivateSlotFill,
 	ComponentsContext,


```
</details>


#### DateFormat picker

1. In the post editor, add a "Posts List" block
2. Pick a template which features the post data (most do)
3. Select the post date block, and in the sidebar interact with the date format (you may have to toggle off the "Default format" toggle)
4. Scroll the list of date format options all the way to the bottom, where the "Custom" option is 
5. Make sure that the layout matches what's currently on `trunk`

| V1 | V2 legacy adapter - before (trunk) | V2 legacy adapter - after (this PR) |
|---|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/0f44a6f2-ab77-472b-8624-58feb64c31e9" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/788ccbc6-86c3-4e92-972e-99ed15a0b1bd" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/7228d681-d724-431a-8461-48cc95acfc8b" /> |

#### Position picker

1. In the post editor, add a "Group" block
2. Select the group block, and in the sidebar expand the "Position" panel
3. Open the position select, and notice the Sticky option 
5. Make sure that the layout matches what's currently on `trunk`

| V1 | V2 legacy adapter - before (trunk) | V2 legacy adapter - after (this PR) |
|---|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/a12d7b89-7e7d-4973-ad5f-be87705bfcd9" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/8e580767-c426-414b-a462-53af2652a012" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/84403aba-8ac9-4c99-8a78-7cd468e24d2b" /> |


#### Known bugs

There are several known layout bugs related to `CustomSelectControlV2` — most of them are addressed in separate PRs (see #55023). When reviewing this PR, please focus only on the layout of option item hints.