### PR TITLE
CustomSelectControlV2: tweak item inline padding based on size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `CustomSelectControlV2`: prevent keyboard event propagation in legacy wrapper. ([#62907](https://github.com/WordPress/gutenberg/pull/62907))
 -   `CustomSelectControlV2`: fix item styles ([#62825](https://github.com/WordPress/gutenberg/pull/62825))
 -   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))
+-   `CustomSelectControlV2`: tweak item inline padding based on size ([#62850](https://github.com/WordPress/gutenberg/pull/62850)).
 -   `CustomSelectControlV2`: fix popover styles. ([#62821](https://github.com/WordPress/gutenberg/pull/62821))
 -   `CustomSelectControlV2`: fix trigger text alignment in RTL languages ([#62869](https://github.com/WordPress/gutenberg/pull/62869)).
 -   `CustomSelectControlV2`: allow wrapping item hint to new line ([#62848](https://github.com/WordPress/gutenberg/pull/62848)).

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -107,6 +107,8 @@ function _CustomSelect(
 			[ isLegacy ]
 		);
 
+	const contextValue = useMemo( () => ( { store, size } ), [ store, size ] );
+
 	return (
 		// Where should `restProps` be forwarded to?
 		<div className={ className }>
@@ -134,7 +136,7 @@ function _CustomSelect(
 					slide={ false }
 					onKeyDown={ onSelectPopoverKeyDown }
 				>
-					<CustomSelectContext.Provider value={ { store } }>
+					<CustomSelectContext.Provider value={ contextValue }>
 						{ children }
 					</CustomSelectContext.Provider>
 				</Styled.SelectPopover>

--- a/packages/components/src/custom-select-control-v2/item.tsx
+++ b/packages/components/src/custom-select-control-v2/item.tsx
@@ -17,7 +17,11 @@ export function CustomSelectItem( {
 }: WordPressComponentProps< CustomSelectItemProps, 'div', false > ) {
 	const customSelectContext = useContext( CustomSelectContext );
 	return (
-		<Styled.SelectItem store={ customSelectContext?.store } { ...props }>
+		<Styled.SelectItem
+			store={ customSelectContext?.store }
+			size={ customSelectContext?.size ?? 'default' }
+			{ ...props }
+		>
 			{ children ?? props.value }
 			<Styled.SelectedItemCheck>
 				<Icon icon={ check } />

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -19,6 +19,54 @@ const INLINE_PADDING = {
 	default: 16, // space(4)
 };
 
+const getSelectSize = (
+	size: NonNullable< CustomSelectButtonSize[ 'size' ] >,
+	heightProperty: 'minHeight' | 'height'
+) => {
+	const sizes = {
+		compact: {
+			[ heightProperty ]: 32,
+			paddingInlineStart: INLINE_PADDING.compact,
+			paddingInlineEnd: INLINE_PADDING.compact + chevronIconSize,
+		},
+		default: {
+			[ heightProperty ]: 40,
+			paddingInlineStart: INLINE_PADDING.default,
+			paddingInlineEnd: INLINE_PADDING.default + chevronIconSize,
+		},
+		small: {
+			[ heightProperty ]: 24,
+			paddingInlineStart: INLINE_PADDING.small,
+			paddingInlineEnd: INLINE_PADDING.small + chevronIconSize,
+		},
+	};
+
+	return sizes[ size ] || sizes.default;
+};
+
+const getSelectItemSize = (
+	size: NonNullable< CustomSelectButtonSize[ 'size' ] >
+) => {
+	// Used to visually align the checkmark with the chevron
+	const checkmarkCorrection = 6;
+	const sizes = {
+		compact: {
+			paddingInlineStart: INLINE_PADDING.compact,
+			paddingInlineEnd: INLINE_PADDING.compact - checkmarkCorrection,
+		},
+		default: {
+			paddingInlineStart: INLINE_PADDING.default,
+			paddingInlineEnd: INLINE_PADDING.default - checkmarkCorrection,
+		},
+		small: {
+			paddingInlineStart: INLINE_PADDING.small,
+			paddingInlineEnd: INLINE_PADDING.small - checkmarkCorrection,
+		},
+	};
+
+	return sizes[ size ] || sizes.default;
+};
+
 export const SelectLabel = styled( Ariakit.SelectLabel )`
 	font-size: 11px;
 	font-weight: 500;
@@ -30,38 +78,14 @@ export const SelectLabel = styled( Ariakit.SelectLabel )`
 export const Select = styled( Ariakit.Select, {
 	// Do not forward `hasCustomRenderProp` to the underlying Ariakit.Select component
 	shouldForwardProp: ( prop ) => prop !== 'hasCustomRenderProp',
-} )( ( {
-	size,
-	hasCustomRenderProp,
-}: {
-	size: NonNullable< CustomSelectButtonSize[ 'size' ] >;
-	hasCustomRenderProp: boolean;
-} ) => {
-	const heightProperty = hasCustomRenderProp ? 'minHeight' : 'height';
-
-	const getSize = () => {
-		const sizes = {
-			compact: {
-				[ heightProperty ]: 32,
-				paddingInlineStart: INLINE_PADDING.compact,
-				paddingInlineEnd: INLINE_PADDING.compact + chevronIconSize,
-			},
-			default: {
-				[ heightProperty ]: 40,
-				paddingInlineStart: INLINE_PADDING.default,
-				paddingInlineEnd: INLINE_PADDING.default + chevronIconSize,
-			},
-			small: {
-				[ heightProperty ]: 24,
-				paddingInlineStart: INLINE_PADDING.small,
-				paddingInlineEnd: INLINE_PADDING.small + chevronIconSize,
-			},
-		};
-
-		return sizes[ size ] || sizes.default;
-	};
-
-	return css`
+} )(
+	( {
+		size,
+		hasCustomRenderProp,
+	}: {
+		size: NonNullable< CustomSelectButtonSize[ 'size' ] >;
+		hasCustomRenderProp: boolean;
+	} ) => css`
 		display: block;
 		background-color: ${ COLORS.theme.background };
 		border: none;
@@ -77,10 +101,10 @@ export const Select = styled( Ariakit.Select, {
 			outline: none; // handled by InputBase component
 		}
 
-		${ getSize() }
+		${ getSelectSize( size, hasCustomRenderProp ? 'minHeight' : 'height' ) }
 		${ ! hasCustomRenderProp && truncateStyles }
-	`;
-} );
+	`
+);
 
 export const SelectPopover = styled( Ariakit.SelectPopover )`
 	display: flex;
@@ -105,33 +129,12 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	}
 `;
 
-export const SelectItem = styled( Ariakit.SelectItem )( ( {
-	size,
-}: {
-	size: NonNullable< CustomSelectButtonSize[ 'size' ] >;
-} ) => {
-	const getSize = () => {
-		// Used to visually align the checkmark with the chevron
-		const checkmarkCorrection = 6;
-		const sizes = {
-			compact: {
-				paddingInlineStart: INLINE_PADDING.compact,
-				paddingInlineEnd: INLINE_PADDING.compact - checkmarkCorrection,
-			},
-			default: {
-				paddingInlineStart: INLINE_PADDING.default,
-				paddingInlineEnd: INLINE_PADDING.default - checkmarkCorrection,
-			},
-			small: {
-				paddingInlineStart: INLINE_PADDING.small,
-				paddingInlineEnd: INLINE_PADDING.small - checkmarkCorrection,
-			},
-		};
-
-		return sizes[ size ] || sizes.default;
-	};
-
-	return css`
+export const SelectItem = styled( Ariakit.SelectItem )(
+	( {
+		size,
+	}: {
+		size: NonNullable< CustomSelectButtonSize[ 'size' ] >;
+	} ) => css`
 		cursor: default;
 		display: flex;
 		align-items: center;
@@ -143,8 +146,6 @@ export const SelectItem = styled( Ariakit.SelectItem )( ( {
 		scroll-margin: ${ space( 1 ) };
 		user-select: none;
 
-		${ getSize() }
-
 		&[aria-disabled='true'] {
 			cursor: not-allowed;
 		}
@@ -152,8 +153,10 @@ export const SelectItem = styled( Ariakit.SelectItem )( ( {
 		&[data-active-item] {
 			background-color: ${ COLORS.theme.gray[ 300 ] };
 		}
-	`;
-} );
+
+		${ getSelectItemSize( size ) }
+	`
+);
 
 export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
 	display: flex;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -101,26 +101,53 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	}
 `;
 
-export const SelectItem = styled( Ariakit.SelectItem )`
-	cursor: default;
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: ${ ITEM_PADDING };
-	font-size: ${ CONFIG.fontSize };
-	// TODO: reassess line-height for non-legacy v2
-	line-height: 28px;
-	scroll-margin: ${ space( 1 ) };
-	user-select: none;
+export const SelectItem = styled( Ariakit.SelectItem )( ( {
+	size,
+}: {
+	size: NonNullable< CustomSelectButtonSize[ 'size' ] >;
+} ) => {
+	const getSize = () => {
+		const sizes = {
+			compact: {
+				paddingInlineStart: space( 2 ),
+				paddingInlineEnd: space( 1 ),
+			},
+			default: {
+				paddingInlineStart: space( 4 ),
+				paddingInlineEnd: space( 3 ),
+			},
+			small: {
+				paddingInlineStart: space( 2 ),
+				paddingInlineEnd: space( 1 ),
+			},
+		};
 
-	&[aria-disabled='true'] {
-		cursor: not-allowed;
-	}
+		return sizes[ size ] || sizes.default;
+	};
 
-	&[data-active-item] {
-		background-color: ${ COLORS.theme.gray[ 300 ] };
-	}
-`;
+	return css`
+		cursor: default;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: ${ ITEM_PADDING };
+		font-size: ${ CONFIG.fontSize };
+		// TODO: reassess line-height for non-legacy v2
+		line-height: 28px;
+		scroll-margin: ${ space( 1 ) };
+		user-select: none;
+
+		${ getSize() }
+
+		&[aria-disabled='true'] {
+			cursor: not-allowed;
+		}
+
+		&[data-active-item] {
+			background-color: ${ COLORS.theme.gray[ 300 ] };
+		}
+	`;
+} );
 
 export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
 	display: flex;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -13,7 +13,11 @@ import { space } from '../utils/space';
 import { chevronIconSize } from '../select-control/styles/select-control-styles';
 import type { CustomSelectButtonSize } from './types';
 
-const ITEM_PADDING = space( 2 );
+const INLINE_PADDING = {
+	compact: 8, // space(2)
+	small: 8, // space(2)
+	default: 16, // space(4)
+};
 
 export const SelectLabel = styled( Ariakit.SelectLabel )`
 	font-size: 11px;
@@ -39,18 +43,18 @@ export const Select = styled( Ariakit.Select, {
 		const sizes = {
 			compact: {
 				[ heightProperty ]: 32,
-				paddingInlineStart: 8,
-				paddingInlineEnd: 8 + chevronIconSize,
+				paddingInlineStart: INLINE_PADDING.compact,
+				paddingInlineEnd: INLINE_PADDING.compact + chevronIconSize,
 			},
 			default: {
 				[ heightProperty ]: 40,
-				paddingInlineStart: 16,
-				paddingInlineEnd: 16 + chevronIconSize,
+				paddingInlineStart: INLINE_PADDING.default,
+				paddingInlineEnd: INLINE_PADDING.default + chevronIconSize,
 			},
 			small: {
 				[ heightProperty ]: 24,
-				paddingInlineStart: 8,
-				paddingInlineEnd: 8 + chevronIconSize,
+				paddingInlineStart: INLINE_PADDING.small,
+				paddingInlineEnd: INLINE_PADDING.small + chevronIconSize,
 			},
 		};
 
@@ -107,18 +111,20 @@ export const SelectItem = styled( Ariakit.SelectItem )( ( {
 	size: NonNullable< CustomSelectButtonSize[ 'size' ] >;
 } ) => {
 	const getSize = () => {
+		// Used to visually align the checkmark with the chevron
+		const checkmarkCorrection = 6;
 		const sizes = {
 			compact: {
-				paddingInlineStart: space( 2 ),
-				paddingInlineEnd: space( 1 ),
+				paddingInlineStart: INLINE_PADDING.compact,
+				paddingInlineEnd: INLINE_PADDING.compact - checkmarkCorrection,
 			},
 			default: {
-				paddingInlineStart: space( 4 ),
-				paddingInlineEnd: space( 3 ),
+				paddingInlineStart: INLINE_PADDING.default,
+				paddingInlineEnd: INLINE_PADDING.default - checkmarkCorrection,
 			},
 			small: {
-				paddingInlineStart: space( 2 ),
-				paddingInlineEnd: space( 1 ),
+				paddingInlineStart: INLINE_PADDING.small,
+				paddingInlineEnd: INLINE_PADDING.small - checkmarkCorrection,
 			},
 		};
 
@@ -130,10 +136,10 @@ export const SelectItem = styled( Ariakit.SelectItem )( ( {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		padding: ${ ITEM_PADDING };
 		font-size: ${ CONFIG.fontSize };
 		// TODO: reassess line-height for non-legacy v2
 		line-height: 28px;
+		padding-block: ${ space( 2 ) };
 		scroll-margin: ${ space( 1 ) };
 		user-select: none;
 
@@ -152,7 +158,7 @@ export const SelectItem = styled( Ariakit.SelectItem )( ( {
 export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
 	display: flex;
 	align-items: center;
-	margin-inline-start: ${ ITEM_PADDING };
+	margin-inline-start: ${ space( 2 ) };
 	font-size: 24px; // Size of checkmark icon
 `;
 

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -12,8 +12,6 @@ export type CustomSelectStore = {
 	store: Ariakit.SelectStore;
 };
 
-export type CustomSelectContext = CustomSelectStore | undefined;
-
 type CustomSelectSize< Size = 'compact' | 'default' > = {
 	/**
 	 * The size of the control.
@@ -26,6 +24,10 @@ type CustomSelectSize< Size = 'compact' | 'default' > = {
 export type CustomSelectButtonSize = CustomSelectSize<
 	'compact' | 'default' | 'small'
 >;
+
+export type CustomSelectContext =
+	| ( CustomSelectStore & CustomSelectButtonSize )
+	| undefined;
 
 export type CustomSelectButtonProps = {
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023 

Match the `CustomSelectControl` V2 item inline padding with the dropdown trigger (button)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For better visual polish, and to match the V1 version of the component

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Forward the `size` prop from the root component to the item component via internal context
- Use the `size` to apply the same horizontal padding that is applied to the select trigger button

In the process, I also refactored some common inline padding values to a separate variable

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the `CustomSelectControlV2` Storybook example
- open the select dropdown and observe the horizontal spacing on the trigger button and each option item
- tweak the `size` prop (and, optionally, the `__next40pxDefaultSize` prop)
- make sure that the spacing around all items is well aligned

## Screenshots or screencast <!-- if applicable -->

| V1 | V2 before (trunk) | V2 after (this PR) |
|---|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/c3baafa6-c570-4ce9-8f77-e7eff98fac32" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/9da0ed87-3189-4446-bcb3-0661817a5bc7" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/7679b6b6-43ad-430b-be23-a066a34c7592" /> |
