### PR TITLE
Generic name for previous version of WP tests.

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -240,6 +240,7 @@ jobs:
                   npm run wp-env run tests-wordpress php -i
                   npm run wp-env run tests-wordpress /var/www/html/wp-content/plugins/gutenberg/vendor/bin/phpunit -- --version
                   npm run wp-env run tests-wordpress locale -a
+                  npm run wp-env run tests-cli wp core version
 
             - name: Running single site unit tests
               if: ${{ ! matrix.multisite }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -158,15 +158,15 @@ jobs:
                 include:
                     # Test with the previous WP version.
                     - php: '7.2'
-                      wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}
+                      wordpress: 'Previous'
                     - php: '7.4'
-                      wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}
+                      wordpress: 'Previous'
                     - php: '8.2'
-                      wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}
+                      wordpress: 'Previosu'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}
-            WP_ENV_CORE: ${{ matrix.wordpress == '' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wordpress ) }}
+            WP_ENV_CORE: ${{ matrix.wordpress == '' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', needs.compute-previous-wordpress-version.outputs.previous-wordpress-version ) }}
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -158,11 +158,11 @@ jobs:
                 include:
                     # Test with the previous WP version.
                     - php: '7.2'
-                      wordpress: 'Previous'
+                      wordpress: 'previous major version'
                     - php: '7.4'
-                      wordpress: 'Previous'
+                      wordpress: 'previous major version'
                     - php: '8.2'
-                      wordpress: 'Previosu'
+                      wordpress: 'previous major version'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Modifies the job name for running the PHP Unit tests against the previous version of WordPress to be version agnostic.

Instead of being named `PHP x.x (WP x.x.x)...` they are named `PHP x.x (WP previous major version)...`

## Why?

Each time a new version of WordPress is released, the list of required actions in this repo's settings become out of date and need to be updated. This causes expected jobs to fail to report on pull requests, stalling the potential for merging.

> [!Warning]
>
> After merge, this will require updating the list of expected jobs in the settings. 
> 
> The goal is that this will be the last time this is required.

## How?

Replaces the WordPress matrix version number with `previous major version` and determines what that is when setting the `WP_ENV_CORE` environment variable.

Debug information is added to the docker containers to run `wp core version` and log the version being tested to the logs.


## Testing Instructions
1. Review the Unit tests job (Click Checks > Unit Tests)
2. Ensure the jobs title PHP Unit tests previous major version are running the previous major version
3. Once a previous major version of WP receives a version bump, confirm that the version is bumped in the unit tests.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->
