### PR TITLE
Revert "Skip failing image block test (#62781)"

### DIFF
--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -293,10 +293,7 @@ test.describe( 'Image', () => {
 		).toMatchSnapshot();
 	} );
 
-	// Reason - skipped temporarily until this issue is fixed:
-	// https://github.com/WordPress/wordpress-develop/pull/6875#issuecomment-2185694119
-	// eslint-disable-next-line playwright/no-skipped-test
-	test.skip( 'allows changing aspect ratio using the crop tools', async ( {
+	test( 'allows changing aspect ratio using the crop tools', async ( {
 		editor,
 		page,
 		imageBlockUtils,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Continued from https://github.com/WordPress/gutenberg/pull/62781. Re-enable the skipped image e2e test.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Now that the upstream commit has been reverted, we can reenable this test to help us catch some regressions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Re-enable the test by removing `test.skip`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
CI should pass.

## Screenshots or screencast <!-- if applicable -->
N/A