### PR TITLE
DataViews: remove the AnyItem type

### DIFF
--- a/packages/dataviews/src/bulk-actions-toolbar.tsx
+++ b/packages/dataviews/src/bulk-actions-toolbar.tsx
@@ -18,24 +18,24 @@ import { useRegistry } from '@wordpress/data';
  * Internal dependencies
  */
 import { ActionWithModal } from './item-actions';
-import type { Action, AnyItem } from './types';
+import type { Action } from './types';
 import type { ActionTriggerProps } from './item-actions';
 
-interface ActionButtonProps< Item extends AnyItem > {
+interface ActionButtonProps< Item > {
 	action: Action< Item >;
 	selectedItems: Item[];
 	actionInProgress: string | null;
 	setActionInProgress: ( actionId: string | null ) => void;
 }
 
-interface ToolbarContentProps< Item extends AnyItem > {
+interface ToolbarContentProps< Item > {
 	selection: string[];
 	actionsToShow: Action< Item >[];
 	selectedItems: Item[];
 	onSelectionChange: ( selection: Item[] ) => void;
 }
 
-interface BulkActionsToolbarProps< Item extends AnyItem > {
+interface BulkActionsToolbarProps< Item > {
 	data: Item[];
 	selection: string[];
 	actions: Action< Item >[];
@@ -62,7 +62,7 @@ const SNACKBAR_VARIANTS = {
 	},
 };
 
-function ActionTrigger< Item extends AnyItem >( {
+function ActionTrigger< Item >( {
 	action,
 	onClick,
 	isBusy,
@@ -87,7 +87,7 @@ function ActionTrigger< Item extends AnyItem >( {
 
 const EMPTY_ARRAY: [] = [];
 
-function ActionButton< Item extends AnyItem >( {
+function ActionButton< Item >( {
 	action,
 	selectedItems,
 	actionInProgress,
@@ -125,7 +125,7 @@ function ActionButton< Item extends AnyItem >( {
 	);
 }
 
-function renderToolbarContent< Item extends AnyItem >(
+function renderToolbarContent< Item >(
 	selection: string[],
 	actionsToShow: Action< Item >[],
 	selectedItems: Item[],
@@ -179,7 +179,7 @@ function renderToolbarContent< Item extends AnyItem >(
 	);
 }
 
-function ToolbarContent< Item extends AnyItem >( {
+function ToolbarContent< Item >( {
 	selection,
 	actionsToShow,
 	selectedItems,
@@ -214,7 +214,7 @@ function ToolbarContent< Item extends AnyItem >( {
 	return buttons.current;
 }
 
-export default function BulkActionsToolbar< Item extends AnyItem >( {
+export default function BulkActionsToolbar< Item >( {
 	data,
 	selection,
 	actions = EMPTY_ARRAY,

--- a/packages/dataviews/src/bulk-actions.tsx
+++ b/packages/dataviews/src/bulk-actions.tsx
@@ -14,7 +14,7 @@ import { useRegistry } from '@wordpress/data';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
-import type { Action, ActionModal, AnyItem } from './types';
+import type { Action, ActionModal } from './types';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -23,26 +23,26 @@ const {
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
-interface ActionWithModalProps< Item extends AnyItem > {
+interface ActionWithModalProps< Item > {
 	action: ActionModal< Item >;
 	selectedItems: Item[];
 	setActionWithModal: ( action?: ActionModal< Item > ) => void;
 	onMenuOpenChange: ( isOpen: boolean ) => void;
 }
 
-interface BulkActionsItemProps< Item extends AnyItem > {
+interface BulkActionsItemProps< Item > {
 	action: Action< Item >;
 	selectedItems: Item[];
 	setActionWithModal: ( action?: ActionModal< Item > ) => void;
 }
 
-interface ActionsMenuGroupProps< Item extends AnyItem > {
+interface ActionsMenuGroupProps< Item > {
 	actions: Action< Item >[];
 	selectedItems: Item[];
 	setActionWithModal: ( action?: ActionModal< Item > ) => void;
 }
 
-interface BulkActionsProps< Item extends AnyItem > {
+interface BulkActionsProps< Item > {
 	data: Item[];
 	actions: Action< Item >[];
 	selection: string[];
@@ -50,7 +50,7 @@ interface BulkActionsProps< Item extends AnyItem > {
 	getItemId: ( item: Item ) => string;
 }
 
-export function useHasAPossibleBulkAction< Item extends AnyItem >(
+export function useHasAPossibleBulkAction< Item >(
 	actions: Action< Item >[],
 	item: Item
 ) {
@@ -64,7 +64,7 @@ export function useHasAPossibleBulkAction< Item extends AnyItem >(
 	}, [ actions, item ] );
 }
 
-export function useSomeItemHasAPossibleBulkAction< Item extends AnyItem >(
+export function useSomeItemHasAPossibleBulkAction< Item >(
 	actions: Action< Item >[],
 	data: Item[]
 ) {
@@ -80,7 +80,7 @@ export function useSomeItemHasAPossibleBulkAction< Item extends AnyItem >(
 	}, [ actions, data ] );
 }
 
-function ActionWithModal< Item extends AnyItem >( {
+function ActionWithModal< Item >( {
 	action,
 	selectedItems,
 	setActionWithModal,
@@ -115,7 +115,7 @@ function ActionWithModal< Item extends AnyItem >( {
 	);
 }
 
-function BulkActionItem< Item extends AnyItem >( {
+function BulkActionItem< Item >( {
 	action,
 	selectedItems,
 	setActionWithModal,
@@ -150,7 +150,7 @@ function BulkActionItem< Item extends AnyItem >( {
 	);
 }
 
-function ActionsMenuGroup< Item extends AnyItem >( {
+function ActionsMenuGroup< Item >( {
 	actions,
 	selectedItems,
 	setActionWithModal,
@@ -172,7 +172,7 @@ function ActionsMenuGroup< Item extends AnyItem >( {
 	);
 }
 
-export default function BulkActions< Item extends AnyItem >( {
+export default function BulkActions< Item >( {
 	data,
 	actions,
 	selection,

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -21,9 +21,11 @@ import { VIEW_LAYOUTS } from './layouts';
 import BulkActions from './bulk-actions';
 import { normalizeFields } from './normalize-fields';
 import BulkActionsToolbar from './bulk-actions-toolbar';
-import type { Action, AnyItem, Field, View, ViewBaseProps } from './types';
+import type { Action, Field, View, ViewBaseProps } from './types';
 
-interface DataViewsProps< Item extends AnyItem > {
+type ItemWithId = { id: string };
+
+type DataViewsProps< Item > = {
 	view: View;
 	onChangeView: ( view: View ) => void;
 	fields: Field< Item >[];
@@ -31,7 +33,6 @@ interface DataViewsProps< Item extends AnyItem > {
 	searchLabel?: string;
 	actions?: Action< Item >[];
 	data: Item[];
-	getItemId?: ( item: Item ) => string;
 	isLoading?: boolean;
 	paginationInfo: {
 		totalItems: number;
@@ -41,12 +42,15 @@ interface DataViewsProps< Item extends AnyItem > {
 	selection?: string[];
 	setSelection?: ( selection: string[] ) => void;
 	onSelectionChange?: ( items: Item[] ) => void;
-}
+} & ( Item extends ItemWithId
+	? { getItemId?: ( item: Item ) => string }
+	: { getItemId: ( item: Item ) => string } );
 
-const defaultGetItemId = ( item: AnyItem ) => item.id;
+const defaultGetItemId = ( item: ItemWithId ) => item.id;
+
 const defaultOnSelectionChange = () => {};
 
-function useSomeItemHasAPossibleBulkAction< Item extends AnyItem >(
+function useSomeItemHasAPossibleBulkAction< Item >(
 	actions: Action< Item >[],
 	data: Item[]
 ) {
@@ -62,7 +66,7 @@ function useSomeItemHasAPossibleBulkAction< Item extends AnyItem >(
 	}, [ actions, data ] );
 }
 
-export default function DataViews< Item extends AnyItem >( {
+export default function DataViews< Item >( {
 	view,
 	onChangeView,
 	fields,

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -15,7 +15,7 @@ import {
 	OPERATOR_IS_NOT_ALL,
 } from './constants';
 import { normalizeFields } from './normalize-fields';
-import type { Field, AnyItem, View } from './types';
+import type { Field, View } from './types';
 
 function normalizeSearchInput( input = '' ) {
 	return removeAccents( input.trim().toLowerCase() );
@@ -32,7 +32,7 @@ const EMPTY_ARRAY: [] = [];
  *
  * @return Filtered, sorted and paginated data.
  */
-export function filterSortAndPaginate< Item extends AnyItem >(
+export function filterSortAndPaginate< Item >(
 	data: Item[],
 	view: View,
 	fields: Field< Item >[]

--- a/packages/dataviews/src/filters.tsx
+++ b/packages/dataviews/src/filters.tsx
@@ -12,9 +12,9 @@ import AddFilter from './add-filter';
 import ResetFilters from './reset-filters';
 import { sanitizeOperators } from './utils';
 import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from './constants';
-import type { AnyItem, NormalizedField, NormalizedFilter, View } from './types';
+import type { NormalizedField, NormalizedFilter, View } from './types';
 
-interface FiltersProps< Item extends AnyItem > {
+interface FiltersProps< Item > {
 	fields: NormalizedField< Item >[];
 	view: View;
 	onChangeView: ( view: View ) => void;
@@ -22,7 +22,7 @@ interface FiltersProps< Item extends AnyItem > {
 	setOpenedFilter: ( openedFilter: string | null ) => void;
 }
 
-function _Filters< Item extends AnyItem >( {
+function _Filters< Item >( {
 	fields,
 	view,
 	onChangeView,

--- a/packages/dataviews/src/item-actions.tsx
+++ b/packages/dataviews/src/item-actions.tsx
@@ -21,7 +21,7 @@ import { useRegistry } from '@wordpress/data';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
-import type { Action, ActionModal as ActionModalType, AnyItem } from './types';
+import type { Action, ActionModal as ActionModalType } from './types';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -31,42 +31,41 @@ const {
 	kebabCase,
 } = unlock( componentsPrivateApis );
 
-export interface ActionTriggerProps< Item extends AnyItem > {
+export interface ActionTriggerProps< Item > {
 	action: Action< Item >;
 	onClick: MouseEventHandler;
 	isBusy?: boolean;
 	items: Item[];
 }
 
-interface ActionModalProps< Item extends AnyItem > {
+interface ActionModalProps< Item > {
 	action: ActionModalType< Item >;
 	items: Item[];
 	closeModal?: () => void;
 }
 
-interface ActionWithModalProps< Item extends AnyItem >
-	extends ActionModalProps< Item > {
+interface ActionWithModalProps< Item > extends ActionModalProps< Item > {
 	ActionTrigger: ( props: ActionTriggerProps< Item > ) => ReactElement;
 	isBusy?: boolean;
 }
 
-interface ActionsDropdownMenuGroupProps< Item extends AnyItem > {
+interface ActionsDropdownMenuGroupProps< Item > {
 	actions: Action< Item >[];
 	item: Item;
 }
 
-interface ItemActionsProps< Item extends AnyItem > {
+interface ItemActionsProps< Item > {
 	item: Item;
 	actions: Action< Item >[];
 	isCompact?: boolean;
 }
 
-interface CompactItemActionsProps< Item extends AnyItem > {
+interface CompactItemActionsProps< Item > {
 	item: Item;
 	actions: Action< Item >[];
 }
 
-function ButtonTrigger< Item extends AnyItem >( {
+function ButtonTrigger< Item >( {
 	action,
 	onClick,
 	items,
@@ -84,7 +83,7 @@ function ButtonTrigger< Item extends AnyItem >( {
 	);
 }
 
-function DropdownMenuItemTrigger< Item extends AnyItem >( {
+function DropdownMenuItemTrigger< Item >( {
 	action,
 	onClick,
 	items,
@@ -101,7 +100,7 @@ function DropdownMenuItemTrigger< Item extends AnyItem >( {
 	);
 }
 
-export function ActionModal< Item extends AnyItem >( {
+export function ActionModal< Item >( {
 	action,
 	items,
 	closeModal,
@@ -124,7 +123,7 @@ export function ActionModal< Item extends AnyItem >( {
 	);
 }
 
-export function ActionWithModal< Item extends AnyItem >( {
+export function ActionWithModal< Item >( {
 	action,
 	items,
 	ActionTrigger,
@@ -153,7 +152,7 @@ export function ActionWithModal< Item extends AnyItem >( {
 	);
 }
 
-export function ActionsDropdownMenuGroup< Item extends AnyItem >( {
+export function ActionsDropdownMenuGroup< Item >( {
 	actions,
 	item,
 }: ActionsDropdownMenuGroupProps< Item > ) {
@@ -186,7 +185,7 @@ export function ActionsDropdownMenuGroup< Item extends AnyItem >( {
 	);
 }
 
-export default function ItemActions< Item extends AnyItem >( {
+export default function ItemActions< Item >( {
 	item,
 	actions,
 	isCompact,
@@ -247,7 +246,7 @@ export default function ItemActions< Item extends AnyItem >( {
 	);
 }
 
-function CompactItemActions< Item extends AnyItem >( {
+function CompactItemActions< Item >( {
 	item,
 	actions,
 }: CompactItemActionsProps< Item > ) {

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { Field, AnyItem, NormalizedField } from './types';
+import type { Field, NormalizedField, ItemRecord } from './types';
 
 /**
  * Apply default values and normalize the fields config.
@@ -9,11 +9,13 @@ import type { Field, AnyItem, NormalizedField } from './types';
  * @param fields Fields config.
  * @return Normalized fields config.
  */
-export function normalizeFields< Item extends AnyItem >(
+export function normalizeFields< Item >(
 	fields: Field< Item >[]
 ): NormalizedField< Item >[] {
 	return fields.map( ( field ) => {
-		const getValue = field.getValue || ( ( { item } ) => item[ field.id ] );
+		const getValue =
+			field.getValue ||
+			( ( { item }: { item: ItemRecord } ) => item[ field.id ] );
 
 		return {
 			...field,

--- a/packages/dataviews/src/single-selection-checkbox.tsx
+++ b/packages/dataviews/src/single-selection-checkbox.tsx
@@ -7,9 +7,9 @@ import { CheckboxControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import type { Field, AnyItem } from './types';
+import type { Field } from './types';
 
-interface SingleSelectionCheckboxProps< Item extends AnyItem > {
+interface SingleSelectionCheckboxProps< Item > {
 	selection: string[];
 	onSelectionChange: ( selection: Item[] ) => void;
 	item: Item;
@@ -19,7 +19,7 @@ interface SingleSelectionCheckboxProps< Item extends AnyItem > {
 	disabled: boolean;
 }
 
-export default function SingleSelectionCheckbox< Item extends AnyItem >( {
+export default function SingleSelectionCheckbox< Item >( {
 	selection,
 	onSelectionChange,
 	item,

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -37,12 +37,12 @@ export type Operator =
 	| 'isAll'
 	| 'isNotAll';
 
-export type AnyItem = Record< string, any >;
+export type ItemRecord = Record< string, unknown >;
 
 /**
  * A dataview field for a specific property of a data type.
  */
-export interface Field< Item extends AnyItem > {
+export type Field< Item > = {
 	/**
 	 * The unique identifier of the field.
 	 */
@@ -52,12 +52,6 @@ export interface Field< Item extends AnyItem > {
 	 * The label of the field. Defaults to the id.
 	 */
 	header?: string;
-
-	/**
-	 * Callback used to retrieve the value of the field from the item.
-	 * Defaults to `item[ field.id ]`.
-	 */
-	getValue?: ( args: { item: Item } ) => any;
 
 	/**
 	 * Callback used to render the field. Defaults to `field.getValue`.
@@ -103,17 +97,34 @@ export interface Field< Item extends AnyItem > {
 	 * Filter config for the field.
 	 */
 	filterBy?: FilterByConfig | undefined;
-}
+} & ( Item extends ItemRecord
+	? {
+			/**
+			 * Callback used to retrieve the value of the field from the item.
+			 * Defaults to `item[ field.id ]`.
+			 */
+			getValue?: ( args: { item: Item } ) => any;
+	  }
+	: {
+			/**
+			 * Callback used to retrieve the value of the field from the item.
+			 * Defaults to `item[ field.id ]`.
+			 */
+			getValue: ( args: { item: Item } ) => any;
+	  } );
 
-export type NormalizedField< Item extends AnyItem > = Field< Item > &
-	Required< Pick< Field< Item >, 'header' | 'getValue' | 'render' > >;
+export type NormalizedField< Item > = Field< Item > & {
+	header: string;
+	getValue: ( args: { item: Item } ) => any;
+	render: ( args: { item: Item } ) => ReactNode;
+};
 
 /**
  * A collection of dataview fields for a data type.
  */
-export type Fields< Item extends AnyItem > = Field< Item >[];
+export type Fields< Item > = Field< Item >[];
 
-export type Data< Item extends AnyItem > = Item[];
+export type Data< Item > = Item[];
 
 /**
  * The filters applied to the dataset.
@@ -279,7 +290,7 @@ export interface ViewGrid extends ViewBase {
 
 export type View = ViewList | ViewGrid | ViewTable;
 
-interface ActionBase< Item extends AnyItem > {
+interface ActionBase< Item > {
 	/**
 	 * The unique identifier of the action.
 	 */
@@ -325,8 +336,7 @@ interface ActionBase< Item extends AnyItem > {
 	supportsBulk?: boolean;
 }
 
-export interface ActionModal< Item extends AnyItem >
-	extends ActionBase< Item > {
+export interface ActionModal< Item > extends ActionBase< Item > {
 	/**
 	 * Modal to render when the action is triggered.
 	 */
@@ -351,8 +361,7 @@ export interface ActionModal< Item extends AnyItem >
 	modalHeader?: string;
 }
 
-export interface ActionButton< Item extends AnyItem >
-	extends ActionBase< AnyItem > {
+export interface ActionButton< Item > extends ActionBase< Item > {
 	/**
 	 * The callback to execute when the action is triggered.
 	 */
@@ -365,11 +374,9 @@ export interface ActionButton< Item extends AnyItem >
 	) => void;
 }
 
-export type Action< Item extends AnyItem > =
-	| ActionModal< Item >
-	| ActionButton< Item >;
+export type Action< Item > = ActionModal< Item > | ActionButton< Item >;
 
-export interface ViewBaseProps< Item extends AnyItem > {
+export interface ViewBaseProps< Item > {
 	actions: Action< Item >[];
 	data: Item[];
 	fields: NormalizedField< Item >[];
@@ -382,22 +389,19 @@ export interface ViewBaseProps< Item extends AnyItem > {
 	view: View;
 }
 
-export interface ViewTableProps< Item extends AnyItem >
-	extends ViewBaseProps< Item > {
+export interface ViewTableProps< Item > extends ViewBaseProps< Item > {
 	view: ViewTable;
 }
 
-export interface ViewListProps< Item extends AnyItem >
-	extends ViewBaseProps< Item > {
+export interface ViewListProps< Item > extends ViewBaseProps< Item > {
 	view: ViewList;
 }
 
-export interface ViewGridProps< Item extends AnyItem >
-	extends ViewBaseProps< Item > {
+export interface ViewGridProps< Item > extends ViewBaseProps< Item > {
 	view: ViewGrid;
 }
 
-export type ViewProps< Item extends AnyItem > =
+export type ViewProps< Item > =
 	| ViewTableProps< Item >
 	| ViewGridProps< Item >
 	| ViewListProps< Item >;

--- a/packages/dataviews/src/utils.ts
+++ b/packages/dataviews/src/utils.ts
@@ -8,11 +8,9 @@ import {
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
 } from './constants';
-import type { AnyItem, NormalizedField } from './types';
+import type { NormalizedField } from './types';
 
-export function sanitizeOperators< Item extends AnyItem >(
-	field: NormalizedField< Item >
-) {
+export function sanitizeOperators< Item >( field: NormalizedField< Item > ) {
 	let operators = field.filterBy?.operators;
 
 	// Assign default values.

--- a/packages/dataviews/src/view-actions.tsx
+++ b/packages/dataviews/src/view-actions.tsx
@@ -20,7 +20,7 @@ import { settings } from '@wordpress/icons';
 import { unlock } from './lock-unlock';
 import { SORTING_DIRECTIONS, sortLabels } from './constants';
 import { VIEW_LAYOUTS } from './layouts';
-import type { AnyItem, NormalizedField, View } from './types';
+import type { NormalizedField, View } from './types';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -42,19 +42,19 @@ interface PageSizeMenuProps {
 	onChangeView: ( view: View ) => void;
 }
 
-interface FieldsVisibilityMenuProps< Item extends AnyItem > {
+interface FieldsVisibilityMenuProps< Item > {
 	view: View;
 	onChangeView: ( view: View ) => void;
 	fields: NormalizedField< Item >[];
 }
 
-interface SortMenuProps< Item extends AnyItem > {
+interface SortMenuProps< Item > {
 	fields: NormalizedField< Item >[];
 	view: View;
 	onChangeView: ( view: View ) => void;
 }
 
-interface ViewActionsProps< Item extends AnyItem > {
+interface ViewActionsProps< Item > {
 	fields: NormalizedField< Item >[];
 	view: View;
 	onChangeView: ( view: View ) => void;
@@ -161,7 +161,7 @@ function PageSizeMenu( { view, onChangeView }: PageSizeMenuProps ) {
 	);
 }
 
-function FieldsVisibilityMenu< Item extends AnyItem >( {
+function FieldsVisibilityMenu< Item >( {
 	view,
 	onChangeView,
 	fields,
@@ -215,7 +215,7 @@ function FieldsVisibilityMenu< Item extends AnyItem >( {
 	);
 }
 
-function SortMenu< Item extends AnyItem >( {
+function SortMenu< Item >( {
 	fields,
 	view,
 	onChangeView,
@@ -303,7 +303,7 @@ function SortMenu< Item extends AnyItem >( {
 	);
 }
 
-function _ViewActions< Item extends AnyItem >( {
+function _ViewActions< Item >( {
 	fields,
 	view,
 	onChangeView,

--- a/packages/dataviews/src/view-grid.tsx
+++ b/packages/dataviews/src/view-grid.tsx
@@ -22,9 +22,9 @@ import { __ } from '@wordpress/i18n';
 import ItemActions from './item-actions';
 import SingleSelectionCheckbox from './single-selection-checkbox';
 import { useHasAPossibleBulkAction } from './bulk-actions';
-import type { Action, AnyItem, NormalizedField, ViewGridProps } from './types';
+import type { Action, NormalizedField, ViewGridProps } from './types';
 
-interface GridItemProps< Item extends AnyItem > {
+interface GridItemProps< Item > {
 	selection: string[];
 	data: Item[];
 	onSelectionChange: ( items: Item[] ) => void;
@@ -38,7 +38,7 @@ interface GridItemProps< Item extends AnyItem > {
 	columnFields?: string[];
 }
 
-function GridItem< Item extends AnyItem >( {
+function GridItem< Item >( {
 	selection,
 	data,
 	onSelectionChange,
@@ -187,7 +187,7 @@ function GridItem< Item extends AnyItem >( {
 	);
 }
 
-export default function ViewGrid< Item extends AnyItem >( {
+export default function ViewGrid< Item >( {
 	actions,
 	data,
 	fields,

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -33,11 +33,11 @@ import { useRegistry } from '@wordpress/data';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
-import type { Action, AnyItem, NormalizedField, ViewListProps } from './types';
+import type { Action, NormalizedField, ViewListProps } from './types';
 
 import { ActionsDropdownMenuGroup, ActionModal } from './item-actions';
 
-interface ListViewItemProps< Item extends AnyItem > {
+interface ListViewItemProps< Item > {
 	actions: Action< Item >[];
 	id?: string;
 	isSelected: boolean;
@@ -57,7 +57,7 @@ const {
 	DropdownMenuV2: DropdownMenu,
 } = unlock( componentsPrivateApis );
 
-function ListItem< Item extends AnyItem >( {
+function ListItem< Item >( {
 	actions,
 	id,
 	isSelected,
@@ -303,9 +303,7 @@ function ListItem< Item extends AnyItem >( {
 	);
 }
 
-export default function ViewList< Item extends AnyItem >(
-	props: ViewListProps< Item >
-) {
+export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	const {
 		actions,
 		data,

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -46,7 +46,6 @@ import {
 } from './bulk-actions';
 import type {
 	Action,
-	AnyItem,
 	NormalizedField,
 	SortDirection,
 	ViewTable as ViewTableType,
@@ -62,7 +61,7 @@ const {
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
-interface HeaderMenuProps< Item extends AnyItem > {
+interface HeaderMenuProps< Item > {
 	field: NormalizedField< Item >;
 	view: ViewTableType;
 	onChangeView: ( view: ViewTableType ) => void;
@@ -70,7 +69,7 @@ interface HeaderMenuProps< Item extends AnyItem > {
 	setOpenedFilter: ( fieldId: string ) => void;
 }
 
-interface BulkSelectionCheckboxProps< Item extends AnyItem > {
+interface BulkSelectionCheckboxProps< Item > {
 	selection: string[];
 	onSelectionChange: ( items: Item[] ) => void;
 	data: Item[];
@@ -78,7 +77,7 @@ interface BulkSelectionCheckboxProps< Item extends AnyItem > {
 	getItemId: ( item: Item ) => string;
 }
 
-interface TableRowProps< Item extends AnyItem > {
+interface TableRowProps< Item > {
 	hasBulkActions: boolean;
 	item: Item;
 	actions: Action< Item >[];
@@ -102,7 +101,7 @@ function WithDropDownMenuSeparators( { children }: { children: ReactNode } ) {
 		) );
 }
 
-const _HeaderMenu = forwardRef( function HeaderMenu< Item extends AnyItem >(
+const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	{
 		field,
 		view,
@@ -240,12 +239,12 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item extends AnyItem >(
 } );
 
 // @ts-expect-error Lift the `Item` type argument through the forwardRef.
-const HeaderMenu: < Item extends AnyItem >(
+const HeaderMenu: < Item >(
 	props: PropsWithoutRef< HeaderMenuProps< Item > > &
 		RefAttributes< HTMLButtonElement >
 ) => ReturnType< typeof _HeaderMenu > = _HeaderMenu;
 
-function BulkSelectionCheckbox< Item extends AnyItem >( {
+function BulkSelectionCheckbox< Item >( {
 	selection,
 	onSelectionChange,
 	data,
@@ -287,7 +286,7 @@ function BulkSelectionCheckbox< Item extends AnyItem >( {
 	);
 }
 
-function TableRow< Item extends AnyItem >( {
+function TableRow< Item >( {
 	hasBulkActions,
 	item,
 	actions,
@@ -425,7 +424,7 @@ function TableRow< Item extends AnyItem >( {
 	);
 }
 
-function ViewTable< Item extends AnyItem >( {
+function ViewTable< Item >( {
 	actions,
 	data,
 	fields,

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import type { Action, AnyItem } from '@wordpress/dataviews';
+import type { Action } from '@wordpress/dataviews';
 
-export function registerEntityAction< Item extends AnyItem >(
+export function registerEntityAction< Item >(
 	kind: string,
 	name: string,
 	config: Action< Item >


### PR DESCRIPTION
Removes the `AnyItem` type from dataviews, as it turns out that `Item` can be completely generic without any constraints.

Fixes several type errors that the removal revealed. Correct types for the `getItemId` and `getValue` getters that can be optional only for some `Item` subtypes because the default getter is not 100% generic. Also uses the `getItemId` function instead of non-generic `item.id` in `ViewList`.

Inspired by this discussion: https://github.com/WordPress/gutenberg/pull/62647#discussion_r1648576427

My plan is that we can finish and merge this PR after #62647 is landed.