### PR TITLE
Section Styles: Clean up block style variation filters

### DIFF
--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -274,19 +274,3 @@ function gutenberg_register_block_style_variations_from_theme_json_partials( $va
 		}
 	}
 }
-
-// DO NOT BACKPORT TO CORE.
-// To be removed when core has backported this PR.
-if ( function_exists( 'wp_resolve_block_style_variations_from_styles_registry' ) ) {
-	remove_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_styles_registry' );
-}
-if ( function_exists( 'wp_resolve_block_style_variations_from_primary_theme_json' ) ) {
-	remove_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_primary_theme_json' );
-}
-if ( function_exists( 'wp_resolve_block_style_variations_from_theme_json_partials' ) ) {
-	remove_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_theme_json_partials' );
-}
-if ( function_exists( 'wp_resolve_block_style_variations_from_theme_style_variation' ) ) {
-	remove_filter( 'wp_theme_json_data_user', 'wp_resolve_block_style_variations_from_theme_style_variation' );
-}
-// END OF DO NOT BACKPORT TO CORE.


### PR DESCRIPTION
## What?

Removes block style variation filters that were initially added to core for 6.6 but ultimately removed in https://github.com/WordPress/wordpress-develop/pull/6873.

## Why?

The functions don't exist and the filters are never ended up in core so there's nothing to remove in Gutenberg. The removal of the filters should have been removed before landing https://github.com/WordPress/gutenberg/pull/62712.

## How?

Delete lines.

## Testing Instructions

1. Defines block style variations via the different sources below:
   - `register_block_style`
   - Theme.json partial file under `/styles` directory including `blockTypes`
   - Within a theme style variation under `styles.variations` (must be registered via either of the above two methods)
       - Define a block style variation within a theme style variation following the example snippet below
       - It could be an override for a variation defined by `register_block_style` or theme.json partial in prior steps
       - Alternatively, simply register a block style using `register_block_style`, passing only the `name` and `label` in the `style_properties` array. This registration will mean the theme style variation's definition is not sanitized.
2. Check that the block style variations still apply and are displayed correctly.


<details>
<summary><strong>`register_block_style` Example</strong></summary>

```php
gutenberg_register_block_style(
	array( 'core/group', 'core/columns' ),
	array(
		'name'       => 'section-b',
		'label'      => __( 'Section B' ),
		'style_data' => array(
			'color'    => array(
				'background' => '#4f6f52',
				'text'       => '#d2e3c8',
			),
			'blocks'   => array(
				'core/group' => array(
					'color' => array(
						'background' => '#739072',
						'text'       => '#e3eedd',
					),
				),
			),
			'elements' => array(
				'link' => array(
					'color'  => array(
						'text' => '#ead196',
					),
					':hover' => array(
						'color' => array(
							'text' => '#ebd9b4',
						),
					),
				),
			),
		),
	)
);

```
</details>

<details>
<summary><strong>Theme.json Partial Example</strong></summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"title": "Section A",
	"slug": "section-a",
	"blockTypes": [ "core/group" ],
	"styles": {
		"color": {
			"background": "slategrey",
			"text": "snow"
		},
		"blocks": {
			"core/group": {
				"color": {
					"background": "darkslategrey",
					"text": "whitesmoke"
				}
			}
		}
	}
}
```
</details>


<details>
<summary><strong>Theme Style Variation Example (`styles.variations`)</strong></summary>

```json
{

	"styles": {
		"variations": {
			"section-a": {
				"color": {
					"background": "var(--wp--preset--color--theme-2)",
					"text": "var(--wp--preset--color--theme-5)"
				},
				"blocks": {
					"core/group": {
						"color": {
							"background": "var(--wp--preset--color--theme-4)",
							"text": "var(--wp--preset--color--theme-2)"
						}
					}
				}
			}
		}
	}
}
```
</details>

Alternatively, confirm that the removed filters don't exist in core and are safe to remove since  https://github.com/WordPress/wordpress-develop/pull/6873 was committed.


## Screenshots or screencast <!-- if applicable -->

No visual changes.