### PR TITLE
Section Styles: Prevent frontend filters in admin

### DIFF
--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -55,6 +55,10 @@ function gutenberg_get_block_style_variation_name_from_class( $class_string ) {
  * @return array The parsed block with block style variation classname added.
  */
 function gutenberg_render_block_style_variation_support_styles( $parsed_block ) {
+	if ( is_admin() ) {
+		return $parsed_block;
+	}
+
 	$classes    = $parsed_block['attrs']['className'] ?? null;
 	$variations = gutenberg_get_block_style_variation_name_from_class( $classes );
 
@@ -120,9 +124,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 	);
 
 	// Turn off filter that excludes block nodes. They are needed here for the variation's inner block types.
-	if ( ! is_admin() ) {
-		remove_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
-	}
+	remove_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
 
 	// Temporarily prevent variation instance from being sanitized while processing theme.json.
 	$styles_registry = WP_Block_Styles_Registry::get_instance();
@@ -143,9 +145,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 	$styles_registry->unregister( $parsed_block['blockName'], $variation_instance );
 
 	// Restore filter that excludes block nodes.
-	if ( ! is_admin() ) {
-		add_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
-	}
+	add_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
 
 	if ( empty( $variation_styles ) ) {
 		return $parsed_block;
@@ -178,7 +178,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
  * @return string                Filtered block content.
  */
 function gutenberg_render_block_style_variation_class_name( $block_content, $block ) {
-	if ( ! $block_content || empty( $block['attrs']['className'] ) ) {
+	if ( is_admin() || ! $block_content || empty( $block['attrs']['className'] ) ) {
 		return $block_content;
 	}
 


### PR DESCRIPTION
## What?

Adds an early return for the block style variation PHP filters when in the admin.

## Why?

When in either editor, a JS hook is required given the style variations applied to blocks can be changed, blocks moved around within nested variations etc.

## How?

For the two filters used to process the block style variations, return early `is_admin()` is true.

## Testing Instructions

1. Defines block style variations via the different sources below:
   - `register_block_style`
   - Theme.json partial file under `/styles` directory including `blockTypes`
   - Within a theme style variation under `styles.variations` (must be registered via either of the above two methods)
2. Check that the block style variations still apply and are displayed correctly in both editors and the frontend

## Screenshots or screencast <!-- if applicable -->

There should be no visual changes.
