### PR TITLE
Use block context to detect presence of parent pattern for overrides

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -99,7 +99,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 				unlock( select( blocksStore ) ).getAllBlockBindingsSources(),
 			[]
 		);
-		const hasParentPattern = !! props.context.patternOverridesContent;
+		const hasParentPattern = !! props.context[ 'pattern/overrides' ];
 		const hasPatternOverridesDefaultBinding =
 			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ]
 				?.source === 'core/pattern-overrides';
@@ -281,7 +281,7 @@ function shimAttributeSource( settings, name ) {
 		...settings,
 		edit: withBlockBindingSupport( settings.edit ),
 		// TODO - move this to be located with pattern overrides code.
-		usesContext: [ 'patternOverridesContent', ...settings?.usesContext ],
+		usesContext: [ 'pattern/overrides', ...settings?.usesContext ],
 	};
 }
 

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -280,8 +280,6 @@ function shimAttributeSource( settings, name ) {
 	return {
 		...settings,
 		edit: withBlockBindingSupport( settings.edit ),
-		// TODO - move this to be located with pattern overrides code.
-		usesContext: [ 'pattern/overrides', ...settings?.usesContext ],
 	};
 }
 

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -12,8 +12,12 @@
 			"type": "number"
 		},
 		"content": {
-			"type": "object"
+			"type": "object",
+			"default": {}
 		}
+	},
+	"providesContext": {
+		"patternOverridesContent": "content"
 	},
 	"supports": {
 		"customClassName": false,

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -17,7 +17,7 @@
 		}
 	},
 	"providesContext": {
-		"patternOverridesContent": "content"
+		"pattern/overrides": "content"
 	},
 	"supports": {
 		"customClassName": false,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -443,16 +443,12 @@ export default function Image( {
 				return {};
 			}
 			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
-			const { getBlockParentsByBlockName } = unlock(
-				select( blockEditorStore )
-			);
 			const {
 				url: urlBinding,
 				alt: altBinding,
 				title: titleBinding,
 			} = metadata?.bindings || {};
-			const hasParentPattern =
-				getBlockParentsByBlockName( clientId, 'core/block' ).length > 0;
+			const hasParentPattern = !! context.patternOverridesContent;
 			const urlBindingSource = getBlockBindingsSource(
 				urlBinding?.source
 			);
@@ -508,7 +504,12 @@ export default function Image( {
 					: __( 'Connected to dynamic data' ),
 			};
 		},
-		[ clientId, isSingleSelected, metadata?.bindings ]
+		[
+			arePatternOverridesEnabled,
+			context,
+			isSingleSelected,
+			metadata?.bindings,
+		]
 	);
 
 	const showUrlInput =

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -448,7 +448,7 @@ export default function Image( {
 				alt: altBinding,
 				title: titleBinding,
 			} = metadata?.bindings || {};
-			const hasParentPattern = !! context.patternOverridesContent;
+			const hasParentPattern = !! context[ 'pattern/overrides' ];
 			const urlBindingSource = getBlockBindingsSource(
 				urlBinding?.source
 			);

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -10,7 +10,7 @@ export default {
 	name: 'core/pattern-overrides',
 	label: _x( 'Pattern Overrides', 'block bindings source' ),
 	getValue( { registry, clientId, context, attributeName } ) {
-		const { patternOverridesContent } = context;
+		const patternOverridesContent = context[ 'pattern/overrides' ];
 		const { getBlockAttributes } = registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
 

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -9,23 +9,22 @@ const CONTENT = 'content';
 export default {
 	name: 'core/pattern-overrides',
 	label: _x( 'Pattern Overrides', 'block bindings source' ),
-	getValue( { registry, clientId, attributeName } ) {
-		const { getBlockAttributes, getBlockParentsByBlockName } =
-			registry.select( blockEditorStore );
+	getValue( { registry, clientId, context, attributeName } ) {
+		const { patternOverridesContent } = context;
+		const { getBlockAttributes } = registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
-		const [ patternClientId ] = getBlockParentsByBlockName(
-			clientId,
-			'core/block',
-			true
-		);
+
+		if ( ! patternOverridesContent ) {
+			return currentBlockAttributes[ attributeName ];
+		}
 
 		const overridableValue =
-			getBlockAttributes( patternClientId )?.[ CONTENT ]?.[
+			patternOverridesContent?.[
 				currentBlockAttributes?.metadata?.name
 			]?.[ attributeName ];
 
 		// If there is no pattern client ID, or it is not overwritten, return the default value.
-		if ( ! patternClientId || overridableValue === undefined ) {
+		if ( overridableValue === undefined ) {
 			return currentBlockAttributes[ attributeName ];
 		}
 

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -114,28 +114,3 @@ addFilter(
 	'core/editor/with-pattern-override-controls',
 	withPatternOverrideControls
 );
-
-/**
- * Adds `useContext` for pattern overrides to blocks that support it.
- *
- * @param {WPBlockSettings} settings Registered block settings.
- * @param {string}          name     Block name.
- * @return {WPBlockSettings} Filtered block settings.
- */
-function shimPatternOverridesContext( settings, name ) {
-	if ( ! PARTIAL_SYNCING_SUPPORTED_BLOCKS[ name ] ) {
-		return settings;
-	}
-
-	return {
-		...settings,
-		// TODO - move this to be located with pattern overrides code.
-		usesContext: [ 'pattern/overrides', ...settings?.usesContext ],
-	};
-}
-
-addFilter(
-	'blocks.registerBlockType',
-	'core/editor/pattern-overrides/shim-pattern-overrides-context',
-	shimPatternOverridesContext
-);

--- a/test/integration/fixtures/blocks/core__block.json
+++ b/test/integration/fixtures/blocks/core__block.json
@@ -3,7 +3,8 @@
 		"name": "core/block",
 		"isValid": true,
 		"attributes": {
-			"ref": 123
+			"ref": 123,
+			"content": {}
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Based on the branch from #62828, tries using block context to detect a parent pattern as an alternative to using selectors and traversing up the block tree.

## Why?
Improved performance.

This also more closely matches the server implementation.

## How?
- Adds a `providesContext` to the pattern block's block.json, providing the `content` attribute
- Adds a default value for the `content` attribute so that it's always truthy (the code can consistently check for a parent pattern using the attribute.
- Adds `usesContext` for the content attribute to all supported block binding blocks
- Replaces the code that traverses the block hierarchy for a simpler `context` check.

## Testing Instructions
Follow the testing instructions in #62828
