### PR TITLE
Editor: Fix duplicate save panels

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -203,11 +203,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 					customSaveButton={
 						_isPreviewingTheme && <SaveButton size="compact" />
 					}
-					customSavePanel={
-						( _isPreviewingTheme || canvasMode === 'view' ) && (
-							<SavePanel />
-						)
-					}
+					customSavePanel={ _isPreviewingTheme && <SavePanel /> }
 					forceDisableBlockTools={ ! hasDefaultEditorCanvasView }
 					title={ title }
 					icon={ icon }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -40,6 +40,7 @@ import {
 	useHasEditorCanvasContainer,
 } from '../editor-canvas-container';
 import SaveButton from '../save-button';
+import SavePanel from '../save-panel';
 import SiteEditorMoreMenu from '../more-menu';
 import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
@@ -201,6 +202,11 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 					enableRegionNavigation={ false }
 					customSaveButton={
 						_isPreviewingTheme && <SaveButton size="compact" />
+					}
+					customSavePanel={
+						( _isPreviewingTheme || canvasMode === 'view' ) && (
+							<SavePanel />
+						)
 					}
 					forceDisableBlockTools={ ! hasDefaultEditorCanvasView }
 					title={ title }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -37,7 +37,6 @@ import { store as editSiteStore } from '../../store';
 import SiteHub from '../site-hub';
 import ResizableFrame from '../resizable-frame';
 import { unlock } from '../../lock-unlock';
-import SavePanel from '../save-panel';
 import KeyboardShortcutsRegister from '../keyboard-shortcuts/register';
 import KeyboardShortcutsGlobal from '../keyboard-shortcuts/global';
 import { useIsSiteEditorLoading } from './hooks';
@@ -236,8 +235,6 @@ export default function Layout( { route } ) {
 						</div>
 					) }
 				</div>
-
-				<SavePanel />
 			</div>
 		</>
 	);

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -43,6 +43,7 @@ import { useIsSiteEditorLoading } from './hooks';
 import useMovingAnimation from './animation';
 import SidebarContent from '../sidebar';
 import SaveHub from '../save-hub';
+import SavePanel from '../save-panel';
 import useSyncCanvasModeWithURL from '../sync-state-with-url/use-sync-canvas-mode-with-url';
 
 const { useCommands } = unlock( coreCommandsPrivateApis );
@@ -162,6 +163,7 @@ export default function Layout( { route } ) {
 											{ areas.sidebar }
 										</SidebarContent>
 										<SaveHub />
+										<SavePanel />
 									</motion.div>
 								) }
 							</AnimatePresence>

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -55,6 +55,7 @@ export default function EditorInterface( {
 	disableIframe,
 	autoFocus,
 	customSaveButton,
+	customSavePanel,
 	forceDisableBlockTools,
 	title,
 	icon,
@@ -214,7 +215,7 @@ export default function EditorInterface( {
 				)
 			}
 			actions={
-				! isPreviewMode ? (
+				customSavePanel || (
 					<SavePublishPanels
 						closeEntitiesSavedStates={ closeEntitiesSavedStates }
 						isEntitiesSavedStatesOpen={
@@ -225,7 +226,7 @@ export default function EditorInterface( {
 						}
 						forceIsDirtyPublishPanel={ forceIsDirty }
 					/>
-				) : undefined
+				)
 			}
 			shortcuts={ {
 				previous: previousShortcut,

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -215,18 +215,22 @@ export default function EditorInterface( {
 				)
 			}
 			actions={
-				customSavePanel || (
-					<SavePublishPanels
-						closeEntitiesSavedStates={ closeEntitiesSavedStates }
-						isEntitiesSavedStatesOpen={
-							entitiesSavedStatesCallback
-						}
-						setEntitiesSavedStatesCallback={
-							setEntitiesSavedStatesCallback
-						}
-						forceIsDirtyPublishPanel={ forceIsDirty }
-					/>
-				)
+				! isPreviewMode
+					? customSavePanel || (
+							<SavePublishPanels
+								closeEntitiesSavedStates={
+									closeEntitiesSavedStates
+								}
+								isEntitiesSavedStatesOpen={
+									entitiesSavedStatesCallback
+								}
+								setEntitiesSavedStatesCallback={
+									setEntitiesSavedStatesCallback
+								}
+								forceIsDirtyPublishPanel={ forceIsDirty }
+							/>
+					  )
+					: undefined
 			}
 			shortcuts={ {
 				previous: previousShortcut,

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -28,20 +28,25 @@ export default function SavePublishPanels( {
 } ) {
 	const { closePublishSidebar, togglePublishSidebar } =
 		useDispatch( editorStore );
-	const {
-		publishSidebarOpened,
-		hasNonPostEntityChanges,
-		hasPostMetaChanges,
-	} = useSelect(
-		( select ) => ( {
-			publishSidebarOpened:
-				select( editorStore ).isPublishSidebarOpened(),
-			hasNonPostEntityChanges:
-				select( editorStore ).hasNonPostEntityChanges(),
-			hasPostMetaChanges: unlock(
-				select( editorStore )
-			).hasPostMetaChanges(),
-		} ),
+	const { publishSidebarOpened, isPublishable, isDirty } = useSelect(
+		( select ) => {
+			const {
+				isPublishSidebarOpened,
+				isEditedPostPublishable,
+				isCurrentPostPublished,
+				isEditedPostDirty,
+				hasNonPostEntityChanges: _hasNonPostEntityChanges,
+			} = select( editorStore );
+			return {
+				publishSidebarOpened: isPublishSidebarOpened(),
+				isPublishable:
+					! isCurrentPostPublished() && isEditedPostPublishable(),
+				isDirty:
+					_hasNonPostEntityChanges() ||
+					isEditedPostDirty() ||
+					unlock( select( editorStore ) ).hasPostMetaChanges(),
+			};
+		},
 		[]
 	);
 
@@ -62,20 +67,7 @@ export default function SavePublishPanels( {
 				PostPublishExtension={ PluginPostPublishPanel.Slot }
 			/>
 		);
-	} else if ( hasNonPostEntityChanges || hasPostMetaChanges ) {
-		unmountableContent = (
-			<div className="editor-layout__toggle-entities-saved-states-panel">
-				<Button
-					variant="secondary"
-					className="editor-layout__toggle-entities-saved-states-panel-button"
-					onClick={ openEntitiesSavedStates }
-					aria-expanded={ false }
-				>
-					{ __( 'Open save panel' ) }
-				</Button>
-			</div>
-		);
-	} else {
+	} else if ( isPublishable ) {
 		unmountableContent = (
 			<div className="editor-layout__toggle-publish-panel">
 				<Button
@@ -85,6 +77,21 @@ export default function SavePublishPanels( {
 					aria-expanded={ false }
 				>
 					{ __( 'Open publish panel' ) }
+				</Button>
+			</div>
+		);
+	} else {
+		unmountableContent = (
+			<div className="editor-layout__toggle-entities-saved-states-panel">
+				<Button
+					variant="secondary"
+					className="editor-layout__toggle-entities-saved-states-panel-button"
+					onClick={ openEntitiesSavedStates }
+					aria-expanded={ false }
+					disabled={ ! isDirty }
+					__experimentalIsFocusable
+				>
+					{ __( 'Open save panel' ) }
 				</Button>
 			</div>
 		);

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -28,27 +28,30 @@ export default function SavePublishPanels( {
 } ) {
 	const { closePublishSidebar, togglePublishSidebar } =
 		useDispatch( editorStore );
-	const { publishSidebarOpened, isPublishable, isDirty } = useSelect(
-		( select ) => {
-			const {
-				isPublishSidebarOpened,
-				isEditedPostPublishable,
-				isCurrentPostPublished,
-				isEditedPostDirty,
-				hasNonPostEntityChanges: _hasNonPostEntityChanges,
-			} = select( editorStore );
-			return {
-				publishSidebarOpened: isPublishSidebarOpened(),
-				isPublishable:
-					! isCurrentPostPublished() && isEditedPostPublishable(),
-				isDirty:
-					_hasNonPostEntityChanges() ||
-					isEditedPostDirty() ||
-					unlock( select( editorStore ) ).hasPostMetaChanges(),
-			};
-		},
-		[]
-	);
+	const {
+		publishSidebarOpened,
+		isPublishable,
+		isDirty,
+		hasOtherEntitiesChanges,
+	} = useSelect( ( select ) => {
+		const {
+			isPublishSidebarOpened,
+			isEditedPostPublishable,
+			isCurrentPostPublished,
+			isEditedPostDirty,
+			hasNonPostEntityChanges,
+		} = select( editorStore );
+		const _hasOtherEntitiesChanges =
+			hasNonPostEntityChanges() ||
+			unlock( select( editorStore ) ).hasPostMetaChanges();
+		return {
+			publishSidebarOpened: isPublishSidebarOpened(),
+			isPublishable:
+				! isCurrentPostPublished() && isEditedPostPublishable(),
+			isDirty: _hasOtherEntitiesChanges || isEditedPostDirty(),
+			hasOtherEntitiesChanges: _hasOtherEntitiesChanges,
+		};
+	}, [] );
 
 	const openEntitiesSavedStates = useCallback(
 		() => setEntitiesSavedStatesCallback( true ),
@@ -67,7 +70,7 @@ export default function SavePublishPanels( {
 				PostPublishExtension={ PluginPostPublishPanel.Slot }
 			/>
 		);
-	} else if ( isPublishable ) {
+	} else if ( isPublishable && ! hasOtherEntitiesChanges ) {
 		unmountableContent = (
 			<div className="editor-layout__toggle-publish-panel">
 				<Button

--- a/test/e2e/specs/editor/various/multi-entity-saving.spec.js
+++ b/test/e2e/specs/editor/various/multi-entity-saving.spec.js
@@ -138,12 +138,12 @@ test.describe( 'Editor - Multi-entity save flow', () => {
 		await expect( saveButton ).toBeEnabled();
 
 		// Verify multi-entity saving not enabled.
-		await expect( openSavePanel ).toBeHidden();
+		await expect( publishPanel ).toBeHidden();
 
 		await siteTitleField.fill( `${ originalSiteTitle }!` );
 
 		// Multi-entity saving should be enabled.
-		await expect( openSavePanel ).toBeVisible();
+		await expect( openSavePanel ).toBeEnabled();
 	} );
 
 	test( 'Site blocks should save individually', async ( {

--- a/test/e2e/specs/editor/various/switch-to-draft.spec.js
+++ b/test/e2e/specs/editor/various/switch-to-draft.spec.js
@@ -57,7 +57,9 @@ test.describe( 'Clicking "Switch to draft" on a published/scheduled post/page', 
 							.getByRole( 'button', { name: 'Close Settings' } )
 							.click();
 					}
-					await page.getByRole( 'button', { name: 'Save' } ).click();
+					await page
+						.getByRole( 'button', { name: 'Save', exact: true } )
+						.click();
 					await expect(
 						page.getByRole( 'button', {
 							name: 'Dismiss this notice',

--- a/test/e2e/specs/editor/various/switch-to-draft.spec.js
+++ b/test/e2e/specs/editor/various/switch-to-draft.spec.js
@@ -58,6 +58,7 @@ test.describe( 'Clicking "Switch to draft" on a published/scheduled post/page', 
 							.click();
 					}
 					await page
+						.getByRole( 'region', { name: 'Editor top bar' } )
 						.getByRole( 'button', { name: 'Save', exact: true } )
 						.click();
 					await expect(

--- a/test/e2e/specs/site-editor/multi-entity-saving.spec.js
+++ b/test/e2e/specs/site-editor/multi-entity-saving.spec.js
@@ -41,7 +41,7 @@ test.describe( 'Site Editor - Multi-entity save flow', () => {
 		).toBeEnabled();
 		await expect(
 			page
-				.getByRole( 'region', { name: 'Save panel' } )
+				.getByRole( 'region', { name: 'Editor publish' } )
 				.getByRole( 'button', { name: 'Open save panel' } )
 		).toBeVisible();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/62694
Related: https://github.com/WordPress/gutenberg/pull/62813
Also fixes: https://github.com/WordPress/gutenberg/issues/62702

This PR does a couple of things:
1. In site editor we would render two `save panels` and you could `tab` through both of them. Here I render only one and for now I followed the same approach we take for the `customSaveButton`. We pass the custom save panel only when we are previewing a theme and always render the site editor's save panel in sidebar and not in its layout component. This eventually should be handled in the `editor` package probably without needing to pass these extra custom save button and panel.

https://github.com/WordPress/gutenberg/assets/16275880/85df6563-d83f-4781-aa91-38a9030a927d

 


2. Currently the default save panel would be to `open publish panel` and here I changed it to `open save panel` which makes more sense in most cases, since an entity couldn't be `publishable` at all. This fixes [this comment](https://github.com/WordPress/gutenberg/issues/62702#issuecomment-2188441995) too.


https://github.com/WordPress/gutenberg/assets/16275880/bd8b477b-7f12-4d4a-87d2-e8d68e3e3a80


3. Added some extra checks to properly disable the default `open save panel` button.

## Testing Instructions
1. No regression for this PR: https://github.com/WordPress/gutenberg/pull/62813. When in `view` mode in site editor we shouldn't be able to navigate to a save panel using tab.
2. No rendering of two save panels. This can be tested in site editor.
3. The default save panel is `open save panel` and is disabled when needs to.
5. Previewing and activating themes in site editor works as before with any combination of other changes or not.
6. In site editor the `save button` in the left sidebar should work exactly as before and render the save changes modal and save properly

