### PR TITLE
Update new release issue template to remove core editor chat item

### DIFF
--- a/.github/ISSUE_TEMPLATE/New_release.md
+++ b/.github/ISSUE_TEMPLATE/New_release.md
@@ -23,7 +23,6 @@ This issue is to provide visibility on the progress of the release process of Gu
 
 ### RC Day - {Weekday, Month, Date}
 
--   [ ] _Optional:_ Attend `#core-editor` meeting (14:00UTC)
 -   [ ] Post a message in `#core-editor` channel to let folks know you are starting the RC release process
 -   [ ] Organize and Label PRs on the relevant milestone
 -   [ ] Start the release process by triggering the `rc` [workflow](https://developer.wordpress.org/block-editor/contributors/code/release/#running-workflow)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the item "Attend `#core-editor` meeting (14:00UTC)" from the release issue. The core editor meeting no longer happens, so this step is no longer needed
