### PR TITLE
Data views: Fix filter chip contrast

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -759,7 +759,7 @@
 		padding: 0 $grid-unit-15;
 		height: $grid-unit-40;
 		background: $gray-100;
-		color: $gray-700;
+		color: $gray-800;
 		position: relative;
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/62760.

## What?
Darken the text color for unset filter chips.

## Why?
To meet contrast requirements.

## Testing Instructions
1. Navigate to a data view in the Site Editor, e.g. Pages
2. Add a filter
3. Observe that the text in resting state for the filter button is now `#2c2c2c` (`$gray-800`).

| Before | After |
| --- | --- |
| <img width="487" alt="Screenshot 2024-06-26 at 10 37 02" src="https://github.com/WordPress/gutenberg/assets/846565/12a4b6fa-f91d-48d7-a3b9-41612bcec3af"> | <img width="475" alt="Screenshot 2024-06-26 at 10 36 42" src="https://github.com/WordPress/gutenberg/assets/846565/2f2b47aa-35ca-4917-9ee0-9f0f90ff95a8"> |


