### PR TITLE
Add SizeControl component

### DIFF
--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -13,14 +13,6 @@ import { useState, useMemo, forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Button } from '../button';
-import RangeControl from '../range-control';
-import { Flex, FlexItem } from '../flex';
-import {
-	default as UnitControl,
-	parseQuantityAndUnitFromRawValue,
-	useCustomUnits,
-} from '../unit-control';
 import { VisuallyHidden } from '../visually-hidden';
 import { getCommonSizeUnit } from './utils';
 import type { FontSizePickerProps } from './types';
@@ -34,9 +26,8 @@ import {
 import { Spacer } from '../spacer';
 import FontSizePickerSelect from './font-size-picker-select';
 import FontSizePickerToggleGroup from './font-size-picker-toggle-group';
+import SizeControl, { DEFAULT_UNITS } from '../size-control';
 import { T_SHIRT_NAMES } from './constants';
-
-const DEFAULT_UNITS = [ 'px', 'em', 'rem', 'vw', 'vh' ];
 
 const UnforwardedFontSizePicker = (
 	props: FontSizePickerProps,
@@ -49,15 +40,11 @@ const UnforwardedFontSizePicker = (
 		disableCustomFontSizes = false,
 		onChange,
 		size = 'default',
-		units: unitsProp = DEFAULT_UNITS,
+		units = DEFAULT_UNITS,
 		value,
 		withSlider = false,
 		withReset = true,
 	} = props;
-
-	const units = useCustomUnits( {
-		availableUnits: unitsProp,
-	} );
 
 	const shouldUseSelectControl = fontSizes.length > 5;
 	const selectedFontSize = fontSizes.find(
@@ -106,14 +93,6 @@ const UnforwardedFontSizePicker = (
 	// to select px values and onChange() is always called with number values.
 	const hasUnits =
 		typeof value === 'string' || typeof fontSizes[ 0 ]?.size === 'string';
-
-	const [ valueQuantity, valueUnit ] = parseQuantityAndUnitFromRawValue(
-		value,
-		units
-	);
-	const isValueUnitRelative =
-		!! valueUnit && [ 'em', 'rem', 'vw', 'vh' ].includes( valueUnit );
-	const isDisabled = value === undefined;
 
 	return (
 		<Container ref={ ref } className="components-font-size-picker">
@@ -201,85 +180,16 @@ const UnforwardedFontSizePicker = (
 					/>
 				) }
 				{ ! disableCustomFontSizes && showCustomValueControl && (
-					<Flex className="components-font-size-picker__custom-size-control">
-						<FlexItem isBlock>
-							<UnitControl
-								__next40pxDefaultSize={ __next40pxDefaultSize }
-								label={ __( 'Custom' ) }
-								labelPosition="top"
-								hideLabelFromVision
-								value={ value }
-								onChange={ ( newValue ) => {
-									if ( newValue === undefined ) {
-										onChange?.( undefined );
-									} else {
-										onChange?.(
-											hasUnits
-												? newValue
-												: parseInt( newValue, 10 )
-										);
-									}
-								} }
-								size={ size }
-								units={ hasUnits ? units : [] }
-								min={ 0 }
-							/>
-						</FlexItem>
-						{ withSlider && (
-							<FlexItem isBlock>
-								<Spacer marginX={ 2 } marginBottom={ 0 }>
-									<RangeControl
-										__nextHasNoMarginBottom
-										__next40pxDefaultSize={
-											__next40pxDefaultSize
-										}
-										className="components-font-size-picker__custom-input"
-										label={ __( 'Custom Size' ) }
-										hideLabelFromVision
-										value={ valueQuantity }
-										initialPosition={ fallbackFontSize }
-										withInputField={ false }
-										onChange={ ( newValue ) => {
-											if ( newValue === undefined ) {
-												onChange?.( undefined );
-											} else if ( hasUnits ) {
-												onChange?.(
-													newValue +
-														( valueUnit ?? 'px' )
-												);
-											} else {
-												onChange?.( newValue );
-											}
-										} }
-										min={ 0 }
-										max={ isValueUnitRelative ? 10 : 100 }
-										step={ isValueUnitRelative ? 0.1 : 1 }
-									/>
-								</Spacer>
-							</FlexItem>
-						) }
-						{ withReset && (
-							<FlexItem>
-								<Button
-									disabled={ isDisabled }
-									__experimentalIsFocusable
-									onClick={ () => {
-										onChange?.( undefined );
-									} }
-									variant="secondary"
-									__next40pxDefaultSize
-									size={
-										size === '__unstable-large' ||
-										props.__next40pxDefaultSize
-											? 'default'
-											: 'small'
-									}
-								>
-									{ __( 'Reset' ) }
-								</Button>
-							</FlexItem>
-						) }
-					</Flex>
+					<SizeControl
+						__next40pxDefaultSize={ __next40pxDefaultSize }
+						value={ value }
+						units={ units }
+						hasUnit={ hasUnits }
+						withSlider={ withSlider }
+						withReset={ withReset }
+						fallbackValue={ fallbackFontSize }
+						onChange={ onChange }
+					/>
 				) }
 			</div>
 		</Container>

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
  * Internal dependencies
  */
 import FontSizePicker from '../';
-import type { FontSize } from '../types';
+import type { Size } from '../../size-control/types';
 
 describe( 'FontSizePicker', () => {
 	test.each( [
@@ -474,7 +474,7 @@ describe( 'FontSizePicker', () => {
 		commonTests( fontSizes );
 	} );
 
-	function commonToggleGroupTests( fontSizes: FontSize[] ) {
+	function commonToggleGroupTests( fontSizes: Size[] ) {
 		it( 'defaults to M when value is 16px', () => {
 			render(
 				<FontSizePicker
@@ -501,7 +501,7 @@ describe( 'FontSizePicker', () => {
 		);
 	}
 
-	function commonSelectTests( fontSizes: FontSize[] ) {
+	function commonSelectTests( fontSizes: Size[] ) {
 		it( 'shows custom input when Custom is selected', async () => {
 			const user = userEvent.setup();
 			const onChange = jest.fn();
@@ -519,7 +519,7 @@ describe( 'FontSizePicker', () => {
 		} );
 	}
 
-	function commonTests( fontSizes: FontSize[] ) {
+	function commonTests( fontSizes: Size[] ) {
 		it( 'shows custom input when value is unknown', () => {
 			render( <FontSizePicker fontSizes={ fontSizes } value="3px" /> );
 			expect( screen.getByLabelText( 'Custom' ) ).toBeInTheDocument();

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -1,4 +1,12 @@
-export type FontSizePickerProps = {
+/**
+ * Internal dependencies
+ */
+import type { SizeControlBaseProps, Size } from '../size-control/types';
+
+export type FontSizePickerProps = Omit<
+	SizeControlBaseProps,
+	'fallbackValue' | 'hasUnit'
+> & {
 	/**
 	 * If `true`, it will not be possible to choose a custom fontSize. The user
 	 * will be forced to pick one of the pre-defined sizes passed in fontSizes.
@@ -15,82 +23,7 @@ export type FontSizePickerProps = {
 	 * An array of font size objects. The object should contain properties size,
 	 * name, and slug.
 	 */
-	fontSizes?: FontSize[];
-	/**
-	 * A function that receives the new font size value.
-	 * If onChange is called without any parameter, it should reset the value,
-	 * attending to what reset means in that context, e.g., set the font size to
-	 * undefined or set the font size a starting value.
-	 */
-	onChange?: (
-		value: number | string | undefined,
-		selectedItem?: FontSize
-	) => void;
-	/**
-	 * Available units for custom font size selection.
-	 *
-	 * @default `[ 'px', 'em', 'rem' ]`
-	 */
-	units?: string[];
-	/**
-	 * The current font size value.
-	 */
-	value?: number | string;
-	/**
-	 * If `true`, the UI will contain a slider, instead of a numeric text input
-	 * field. If `false`, no slider will be present.
-	 *
-	 * @default false
-	 */
-	withSlider?: boolean;
-	/**
-	 * If `true`, a reset button will be displayed alongside the input field
-	 * when a custom font size is active. Has no effect when
-	 * `disableCustomFontSizes` or `withSlider` is `true`.
-	 *
-	 * @default true
-	 */
-	withReset?: boolean;
-	/**
-	 * Start opting into the new margin-free styles that will become the default
-	 * in a future version, currently scheduled to be WordPress 6.4. (The prop
-	 * can be safely removed once this happens.)
-	 *
-	 * @default false
-	 * @deprecated Default behavior since WP 6.5. Prop can be safely removed.
-	 * @ignore
-	 */
-	__nextHasNoMarginBottom?: boolean;
-	/**
-	 * Start opting into the larger default height that will become the default size in a future version.
-	 *
-	 * @default false
-	 */
-	__next40pxDefaultSize?: boolean;
-	/**
-	 * Size of the control.
-	 *
-	 * @default 'default'
-	 */
-	size?: 'default' | '__unstable-large';
-};
-
-export type FontSize = {
-	/**
-	 * The property `size` contains a number with the font size value, in `px` or
-	 * a string specifying the font size CSS property that should be used eg:
-	 * "13px", "1em", or "clamp(12px, 5vw, 100px)".
-	 */
-	size: number | string;
-	/**
-	 * The `name` property includes a label for that font size e.g.: `Small`.
-	 */
-	name?: string;
-	/**
-	 * The `slug` property is a string with a unique identifier for the font
-	 * size. Used for the class generation process.
-	 */
-	slug: string;
+	fontSizes?: Size[];
 };
 
 export type FontSizePickerSelectProps = Pick<
@@ -109,7 +42,7 @@ export type FontSizePickerSelectProps = Pick<
 export type FontSizePickerSelectOption = {
 	key: string;
 	name: string;
-	value?: FontSize[ 'size' ];
+	value?: Size[ 'size' ];
 	__experimentalHint?: string;
 };
 

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -6,7 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { FontSizePickerProps, FontSize } from './types';
+import type { Size } from '../size-control/types';
+import type { FontSizePickerProps } from './types';
 import { parseQuantityAndUnitFromRawValue } from '../unit-control';
 
 /**
@@ -31,7 +32,7 @@ export function isSimpleCssValue(
  * @param fontSizes List of font sizes.
  * @return The common unit, or null.
  */
-export function getCommonSizeUnit( fontSizes: FontSize[] ) {
+export function getCommonSizeUnit( fontSizes: Size[] ) {
 	const [ firstFontSize, ...otherFontSizes ] = fontSizes;
 	if ( ! firstFontSize ) {
 		return null;

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -26,6 +26,7 @@ import {
 	DropdownMenuItemLabel as DropdownMenuItemLabelV2,
 	DropdownMenuItemHelpText as DropdownMenuItemHelpTextV2,
 } from './dropdown-menu-v2';
+import SizeControl from './size-control';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import Tabs from './tabs';
@@ -53,5 +54,6 @@ lock( privateApis, {
 	DropdownMenuSeparatorV2,
 	DropdownMenuItemLabelV2,
 	DropdownMenuItemHelpTextV2,
+	SizeControl,
 	kebabCase,
 } );

--- a/packages/components/src/size-control/index.tsx
+++ b/packages/components/src/size-control/index.tsx
@@ -1,0 +1,160 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { BaseControl, useBaseControlProps } from '../base-control';
+import type { WordPressComponentProps } from '../context/wordpress-component';
+import { Button } from '../button';
+import RangeControl from '../range-control';
+import { Flex, FlexItem } from '../flex';
+import type { SizeControlProps } from './types';
+import {
+	default as UnitControl,
+	parseQuantityAndUnitFromRawValue,
+	useCustomUnits,
+} from '../unit-control';
+
+import { Spacer } from '../spacer';
+
+export const DEFAULT_UNITS = [ 'px', 'em', 'rem', 'vw', 'vh' ];
+
+function UnforwardedSizeControl(
+	props: WordPressComponentProps< SizeControlProps, 'input', true >,
+	ref: ForwardedRef< HTMLInputElement >
+) {
+	const { baseControlProps } = useBaseControlProps( props );
+
+	const instanceId = useInstanceId( UnforwardedSizeControl );
+	const id = `size-control-${ instanceId }`;
+
+	const {
+		__next40pxDefaultSize = true,
+		__nextHasNoMarginBottom = true,
+		hasUnit = true,
+		value,
+		disabled,
+		size = 'default',
+		units: unitsProp = DEFAULT_UNITS,
+		withSlider = true,
+		withReset = true,
+		onChange,
+		fallbackValue,
+	} = props;
+
+	const units = useCustomUnits( {
+		availableUnits: unitsProp,
+	} );
+
+	const [ valueQuantity, valueUnit ] = parseQuantityAndUnitFromRawValue(
+		value,
+		units
+	);
+	const isValueUnitRelative =
+		!! valueUnit && [ 'em', 'rem', 'vw', 'vh' ].includes( valueUnit );
+
+	const handleValueChange = ( newValue: string | number | undefined ) => {
+		// On Reset
+		if ( newValue === undefined ) {
+			onChange?.( undefined );
+			return;
+		}
+
+		// If the component is initalized as a unitless value (for retrocompatibility)
+		if ( ! hasUnit ) {
+			onChange?.( parseInt( String( newValue ), 10 ) );
+			return;
+		}
+
+		// Parse the new value and unit.
+		const [ newQuantity, newUnit ] = parseQuantityAndUnitFromRawValue(
+			newValue,
+			units
+		);
+		onChange?.(
+			// If the new value is empty or couldn't be parsed, pass the raw value received.
+			newQuantity ? newQuantity + ( newUnit ?? 'px' ) : newValue
+		);
+	};
+
+	return (
+		<BaseControl { ...baseControlProps } id={ id }>
+			<Flex className="components-size-control__custom-size-control">
+				<FlexItem isBlock>
+					<UnitControl
+						id={ id }
+						__next40pxDefaultSize={ __next40pxDefaultSize }
+						disabled={ disabled }
+						label={ __( 'Custom' ) }
+						labelPosition="top"
+						hideLabelFromVision
+						value={ value }
+						onChange={ handleValueChange }
+						size={ size }
+						units={ units }
+						min={ 0 }
+					/>
+				</FlexItem>
+				{ withSlider && (
+					<FlexItem isBlock>
+						<Spacer marginX={ 2 } marginBottom={ 0 }>
+							<RangeControl
+								disabled={ disabled }
+								__next40pxDefaultSize={ __next40pxDefaultSize }
+								__nextHasNoMarginBottom={
+									__nextHasNoMarginBottom
+								}
+								className="components-size-control__custom-input"
+								label={ __( 'Custom Size' ) }
+								hideLabelFromVision
+								value={ valueQuantity }
+								initialPosition={ fallbackValue }
+								withInputField={ false }
+								onChange={ handleValueChange }
+								min={ 0 }
+								max={ isValueUnitRelative ? 10 : 100 }
+								step={ isValueUnitRelative ? 0.1 : 1 }
+								ref={ ref }
+							/>
+						</Spacer>
+					</FlexItem>
+				) }
+				{ withReset && (
+					<FlexItem>
+						<Button
+							disabled={ ! value || disabled }
+							__experimentalIsFocusable
+							__next40pxDefaultSize={ __next40pxDefaultSize }
+							onClick={ () => {
+								onChange?.( undefined );
+							} }
+							variant="secondary"
+							size={
+								size === '__unstable-large' ||
+								__next40pxDefaultSize
+									? 'default'
+									: 'small'
+							}
+						>
+							{ __( 'Reset' ) }
+						</Button>
+					</FlexItem>
+				) }
+			</Flex>
+		</BaseControl>
+	);
+}
+
+export const SizeControl = forwardRef( UnforwardedSizeControl );
+
+export default SizeControl;

--- a/packages/components/src/size-control/stories/index.story.tsx
+++ b/packages/components/src/size-control/stories/index.story.tsx
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryFn } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import SizeControl from '..';
+import type { SizeControlProps } from '../types';
+
+const meta: Meta< typeof SizeControl > = {
+	title: 'Components (Experimental)/SizeControl',
+	tags: [ 'status-private' ],
+	component: SizeControl,
+	argTypes: {
+		value: { control: { type: null } },
+	},
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+		controls: { expanded: true },
+		docs: { canvas: { sourceState: 'shown' } },
+	},
+};
+
+export default meta;
+
+const Template: StoryFn< typeof SizeControl > = ( args: SizeControlProps ) => {
+	const [ value, setValue ] = useState( args.value );
+
+	return (
+		<SizeControl
+			{ ...args }
+			value={ value }
+			onChange={ ( val ) => {
+				// If it's resetting, use the fallbackValue
+				const newValue = val ?? '16px';
+				setValue( newValue );
+				action( 'onChange' )( newValue );
+			} }
+		/>
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	value: '16px',
+	size: 'default',
+	units: [ 'px', 'em', 'rem', 'vw', 'vh' ],
+	label: 'Size Control Label',
+};
+
+export const Disabled = Template.bind( {} );
+Disabled.args = {
+	value: '16px',
+	size: 'default',
+	units: [ 'px', 'em', 'rem', 'vw', 'vh' ],
+	label: 'Size Control Label',
+	disabled: true,
+};
+
+export const WithReset = Template.bind( {} );
+WithReset.args = {
+	value: '16px',
+	withReset: true,
+	size: 'default',
+	units: [ 'px', 'em', 'rem', 'vw', 'vh' ],
+	label: 'Size Control Label',
+};
+
+export const WithoutSlider = Template.bind( {} );
+WithoutSlider.args = {
+	value: '16px',
+	withSlider: false,
+	size: 'default',
+	units: [ 'px', 'em', 'rem', 'vw', 'vh' ],
+	label: 'Size Control Label',
+};
+
+export const CustomUnits = Template.bind( {} );
+CustomUnits.args = {
+	value: '16%',
+	size: 'default',
+	units: [ '%', 'em' ],
+	label: 'Size Control Label',
+};

--- a/packages/components/src/size-control/test/index.tsx
+++ b/packages/components/src/size-control/test/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import SizeControl from '../';
+
+describe( 'SizeControl', () => {
+	test.each( [
+		// Use units when initial value uses units.
+		{ value: '12px', expectedValue: '80px' },
+		// Use a different unit than the default px.
+		{ value: '12em', expectedValue: '80em' },
+		// Don't use units when initial value does not use units.
+		{ value: 12, expectedValue: 80, hasUnit: false },
+	] )(
+		'should call onChange( $expectedValue ) after user types 80 when value is $value',
+		async ( { value, expectedValue, hasUnit } ) => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+			render(
+				<SizeControl
+					value={ value }
+					onChange={ onChange }
+					label="Size Control"
+					hasUnit={ hasUnit }
+				/>
+			);
+			const input = screen.getByLabelText( 'Size Control' );
+			await user.clear( input );
+			await user.type( input, '80' );
+			expect( onChange ).toHaveBeenCalledTimes( 3 ); // Once for the clear, then once per keystroke.
+			expect( onChange ).toHaveBeenCalledWith( expectedValue );
+		}
+	);
+
+	it( 'does not display a slider when withSlider is false', async () => {
+		render( <SizeControl withSlider={ false } /> );
+		expect(
+			screen.queryByLabelText( 'Custom Size' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'allows a slider by default', async () => {
+		const onChange = jest.fn();
+		render( <SizeControl value="16px" onChange={ onChange } /> );
+
+		const sliderInput = screen.getByLabelText( 'Custom Size' );
+		fireEvent.change( sliderInput, {
+			target: { value: 80 },
+		} );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( '80px' );
+	} );
+
+	it( 'allows reset by default', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		render( <SizeControl value="16px" onChange={ onChange } /> );
+		await user.click( screen.getByRole( 'button', { name: 'Reset' } ) );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( undefined );
+	} );
+
+	it( 'does not allow reset when withReset is false', async () => {
+		render( <SizeControl withReset={ false } /> );
+		expect(
+			screen.queryByRole( 'button', { name: 'Reset' } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/components/src/size-control/types.ts
+++ b/packages/components/src/size-control/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Internal dependencies
+ */
+import type { BaseControlProps } from '../base-control/types';
+
+export type Size = {
+	/**
+	 * The property `size` contains a number with the font size value, in `px` or
+	 * a string specifying the font size CSS property that should be used eg:
+	 * "13px", "1em", or "clamp(12px, 5vw, 100px)".
+	 */
+	size: number | string;
+	/**
+	 * The `name` property includes a label for that size e.g.: `Small`.
+	 */
+	name?: string;
+	/**
+	 * The `slug` property is a string with a unique identifier for the font
+	 * size. Used for the class generation process.
+	 */
+	slug: string;
+};
+
+export type SizeControlBaseProps = {
+	/**
+	 * If no value exists, this prop defines the starting position for the font
+	 * size picker slider. Only relevant if `withSlider` is `true`.
+	 */
+	fallbackValue?: number;
+	/**
+	 * A function that receives the new font size value.
+	 * If onChange is called without any parameter, it should reset the value,
+	 * attending to what reset means in that context, e.g., set the font size to
+	 * undefined or set the font size a starting value.
+	 */
+	onChange?: (
+		value: number | string | undefined,
+		selectedItem?: Size
+	) => void;
+	/**
+	 * Available units for custom font size selection.
+	 *
+	 * @default `[ 'px', 'em', 'rem' ]`
+	 */
+	units?: string[];
+	/**
+	 * The current font size value.
+	 */
+	value?: number | string;
+	/**
+	 * If `true`, the UI will contain a slider, instead of a numeric text input
+	 * field. If `false`, no slider will be present.
+	 *
+	 * @default true
+	 */
+	withSlider?: boolean;
+	/**
+	 * If `true`, a reset button will be displayed alongside the input field
+	 * when a custom font size is active. Has no effect when
+	 *
+	 * @default true
+	 */
+	withReset?: boolean;
+	/**
+	 * Start opting into the larger default height that will become the default size in a future version.
+	 *
+	 * @default false
+	 */
+	__next40pxDefaultSize?: boolean;
+	/**
+	 * Size of the control.
+	 *
+	 * @default 'default'
+	 */
+	size?: 'default' | '__unstable-large';
+	/**
+	 * If the control should handle values with units.
+	 *
+	 * @default true
+	 */
+	hasUnit?: boolean;
+};
+
+export type SizeControlProps = SizeControlBaseProps &
+	Omit< BaseControlProps, 'children' >;


### PR DESCRIPTION
## What?
Provide a new UI component to define a size.

This PR extracts a part of the FontSizePicker controller and makes it a new independent controller that can be used inside the FontSizePicker controller and as a stand-alone controller.

## Why?
The new SizeControl provides an agnostic UI to define a size that could be used to define not only font sizes but spacings and probably other settings.  

Most of the SizeControl component UI and logic already exist inside the FontSizePicker control, making it impossible to reuse them outside of it. 

This component could be used in the implementation of these two interfaces:
- https://github.com/WordPress/gutenberg/issues/61987
- https://github.com/WordPress/gutenberg/issues/61986

## How?
Extracting the UI and logic from FontSizePicker and making it a stand-alone component, simplifying the logic where possible.

## Testing Instructions
- Run unit tests
- Use the storybook stories of the SizeControl component.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/1310626/d779fd1e-e01d-44a4-8ff8-c3ee04c19daf)


See screencasts of the component in use in https://github.com/WordPress/gutenberg/pull/62328