### PR TITLE
Fix Latest Post Block padding/spacing issue when its background color is changed

### DIFF
--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -27,3 +27,7 @@
 		border-radius: $radius-block-ui;
 	}
 }
+
+.editor-styles-wrapper ul.block-editor-block-list__block.wp-block-latest-posts.wp-block-latest-posts__list {
+	padding: 0;
+}

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -12,7 +12,7 @@
 	}
 	&.wp-block-latest-posts__list {
 		list-style: none;
-		padding-left: 0;
+		padding: 0;
 
 		li {
 			clear: both;
@@ -40,6 +40,14 @@
 					margin-right: 0;
 				}
 			}
+		}
+	}
+
+	li:last-of-type {
+		.wp-block-latest-posts__post-excerpt,
+		.wp-block-latest-posts__post-full-content,
+		.wp-block-latest-posts__post-full-content p {
+			margin-bottom: 0;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the padding/space issue in the Latest Posts block that occurs when changing its background color. The fix ensures that no extra space is added on both the editor and frontend sides when the background color is modified.

## Why?
When we add background color to the Latest Posts block, extra spacing is added to the content, which is visible on the editor side but not on the frontend side. This discrepancy between the editor view and the frontend view creates confusion for users and makes it difficult to accurately design and preview the layout of pages using this block.

## How?
The implementation involves adjusting the CSS for the Latest Posts block to prevent additional padding/spacing from being applied when a background color is set. 

## Testing Instructions
1. Open the block editor and create a new post or page.
2. Insert a Latest Posts block.
3. In the block settings sidebar, change the background color of the Latest Posts block to any color.
4. Observe that no extra padding or space is added around the block content in the editor view.
5. Preview the post/page on the frontend and confirm that the layout matches the editor view without any extra spacing.
6. Try different background colors and ensure the spacing remains correct in all cases, both in the editor and on the frontend.
7. Test with different numbers of posts.

## Screenshots or screencast <!-- if applicable -->
### Twenty Thirteen
<img width="747" alt="2013-be" src="https://github.com/WordPress/gutenberg/assets/64325240/9fd0e8aa-1d9c-4936-a001-d1d8332d7090">
<img width="720" alt="2013-fe" src="https://github.com/WordPress/gutenberg/assets/64325240/6e9b2553-da42-4df5-8194-8f5297d281e1">

### Twenty Sixteen
<img width="735" alt="2016-be" src="https://github.com/WordPress/gutenberg/assets/64325240/f45ef22e-1e6d-4e4f-809d-2062e5cc75b8">
<img width="664" alt="2016-fe" src="https://github.com/WordPress/gutenberg/assets/64325240/54728f44-ab81-4f82-a8f5-68a429d1021e">

### Twenty Nineteen
<img width="695" alt="2019-be" src="https://github.com/WordPress/gutenberg/assets/64325240/51b929b2-0159-4dc1-92f9-9ddf8b345d59">
<img width="777" alt="2019-fe" src="https://github.com/WordPress/gutenberg/assets/64325240/4761ff53-0a8c-4dbf-8d7a-a3280f0913a0">

### Twenty Twenty
<img width="725" alt="2020-be" src="https://github.com/WordPress/gutenberg/assets/64325240/e70e6359-13cc-4f84-b6a7-468270144e16">
<img width="704" alt="2020-fe" src="https://github.com/WordPress/gutenberg/assets/64325240/b8c63014-f88f-4f5b-9c45-92dbf448af00">

### Twenty Twenty-Two
<img width="849" alt="2022-be" src="https://github.com/WordPress/gutenberg/assets/64325240/05e6871a-0bd3-4d9c-b4ea-5486cd195233">
<img width="799" alt="2022-fe" src="https://github.com/WordPress/gutenberg/assets/64325240/3fbdf815-3178-410b-b51d-c11160293e37">

### Twenty Twenty-Three
<img width="778" alt="2023-be" src="https://github.com/WordPress/gutenberg/assets/64325240/46b41e1e-d349-4861-9184-8da64e625949">
<img width="770" alt="2023-fe" src="https://github.com/WordPress/gutenberg/assets/64325240/086f250d-3a43-4453-a384-b4cb34d99992">

### Twenty Twenty-Four
<img width="699" alt="2024-be" src="https://github.com/WordPress/gutenberg/assets/64325240/6365f172-b699-43f8-b372-5c755198c0e2">
<img width="752" alt="2024-fe" src="https://github.com/WordPress/gutenberg/assets/64325240/31aab718-3a63-4aea-bb1b-8a20608a9fab">

#### Adding padding to Latest Posts Block
<img width="1225" alt="2024-pd-be" src="https://github.com/WordPress/gutenberg/assets/64325240/5e218a93-838d-4d0e-b426-249048fbdede">
<img width="769" alt="2024-pd-fe" src="https://github.com/WordPress/gutenberg/assets/64325240/d0f0281d-b436-4db1-a74f-f6b4519d686e">


