### PR TITLE
CustomSelectControl V2: fix trigger text alignment in RTL languages

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))
 -   `CustomSelectControlV2`: fix popover styles. ([#62821](https://github.com/WordPress/gutenberg/pull/62821))
+-   `CustomSelectControlV2`: fix trigger text alignment in RTL languages ([#62869](https://github.com/WordPress/gutenberg/pull/62869)).
 
 ## 28.2.0 (2024-06-26)
 

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -92,7 +92,7 @@ export const Select = styled( Ariakit.Select, {
 		cursor: pointer;
 		font-family: inherit;
 		font-size: ${ CONFIG.fontSize };
-		text-align: left;
+		text-align: start;
 		width: 100%;
 
 		&[data-focus-visible] {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023 

Allow the text on the `CustomSelectControlV2` trigger button to follow RTL text alignment.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Following user preferences when using the component in a RTL environment

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using logical properties instead of physical (`text-align: start` instead of `text-align: left`)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Load storybook examples for `CustomSelectControlV2`
- Via the Storybook top toolbar controls, change the text direction from LTR to RTL
- Observe how the select trigger button label aligns correctly to the right (while on `trunk` is would stay on the left)

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2024-06-26 at 13 29 50](https://github.com/WordPress/gutenberg/assets/1083581/da576bf3-b163-47d9-9805-a20c5a5fa958) | ![Screenshot 2024-06-26 at 13 28 46](https://github.com/WordPress/gutenberg/assets/1083581/fd864cab-bca1-418a-844c-4d55dbe98207) |
