### PR TITLE
DataViews: make `view.hiddenFields` optional

### DIFF
--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -216,7 +216,7 @@ interface ViewBase {
 	/**
 	 * The hidden fields.
 	 */
-	hiddenFields: string[];
+	hiddenFields?: string[];
 }
 
 export interface ViewTable extends ViewBase {

--- a/packages/dataviews/src/view-grid.tsx
+++ b/packages/dataviews/src/view-grid.tsx
@@ -206,7 +206,7 @@ export default function ViewGrid< Item extends AnyItem >( {
 	const { visibleFields, badgeFields } = fields.reduce(
 		( accumulator: Record< string, NormalizedField< Item >[] >, field ) => {
 			if (
-				view.hiddenFields.includes( field.id ) ||
+				view.hiddenFields?.includes( field.id ) ||
 				[ view.layout.mediaField, view.layout.primaryField ].includes(
 					field.id
 				)

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -329,7 +329,7 @@ export default function ViewList< Item extends AnyItem >(
 	);
 	const visibleFields = fields.filter(
 		( field ) =>
-			! view.hiddenFields.includes( field.id ) &&
+			! view.hiddenFields?.includes( field.id ) &&
 			! [ view.layout.primaryField, view.layout.mediaField ].includes(
 				field.id
 			)

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -223,9 +223,9 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item extends AnyItem >(
 							onHide( field );
 							onChangeView( {
 								...view,
-								hiddenFields: view.hiddenFields?.concat(
-									field.id
-								),
+								hiddenFields: (
+									view.hiddenFields ?? []
+								).concat( field.id ),
 							} );
 						} }
 					>

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -223,7 +223,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item extends AnyItem >(
 							onHide( field );
 							onChangeView( {
 								...view,
-								hiddenFields: view.hiddenFields.concat(
+								hiddenFields: view.hiddenFields?.concat(
 									field.id
 								),
 							} );
@@ -473,7 +473,7 @@ function ViewTable< Item extends AnyItem >( {
 	};
 	const visibleFields = fields.filter(
 		( field ) =>
-			! view.hiddenFields.includes( field.id ) &&
+			! view.hiddenFields?.includes( field.id ) &&
 			! [ view.layout.mediaField ].includes( field.id )
 	);
 	const hasData = !! data?.length;

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -76,7 +76,6 @@ const DEFAULT_VIEW = {
 	search: '',
 	page: 1,
 	perPage: 20,
-	hiddenFields: [],
 	layout: {
 		...defaultConfigPerViewType[ LAYOUT_GRID ],
 	},


### PR DESCRIPTION
## What?

This PR makes the `view.hiddenFields` config optional.

## Why?

It should not be required to provide an empty `hiddenFields` array it the consumer doesn't have any hidden fields.

## How?

- Update the `hiddenFields` type to optional.
- Make sure all views consider the optional case when they derive the `visibleFields`.
- Remove it from the `DEFAULT_VIEW` config.

## Testing Instructions

Visit "Site Editor > Patterns" and verify everything works as expected.

Before this PR, if the `hiddenFields` property was removed from here (https://github.com/WordPress/gutenberg/pull/62876/commits/468c294f6668d8835b4af652b9a0cfc8c376e3f6) the Patterns page would not load.