### PR TITLE
Fix buttonless table header alignment

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -191,10 +191,14 @@
 			box-shadow: inset 0 -#{$border-width} 0 $gray-100;
 			padding-top: $grid-unit-10;
 			padding-bottom: $grid-unit-10;
+			padding-left: $grid-unit-15;
 			font-size: 11px;
 			text-transform: uppercase;
 			font-weight: 500;
-			padding-left: $grid-unit-05;
+
+			&:has(.dataviews-view-table-header-button) {
+				padding-left: $grid-unit-05;
+			}
 		}
 	}
 	tbody {


### PR DESCRIPTION
## What?
Fix the alignment of table headers not containing a button with the content in the column below.

## Why?
* Improve legibility.
* Reduce tension between checkbox and header.

## How?
Adjust padding values based on whether the`th` includes a button. When there is a button, the padding is reduced (to account for the inherent padding of the button). When there's no button the padding is increased to achieve alignment.

## Testing Instructions
1. Navigate to 'My Patterns'.
2. Switch to table layout.
3. Check that the 'Preview' table header is aligned with the previews below.
4. Ensure there are no regressions across other table views.

| Before | After |
| --- | --- |
| <img width="379" alt="Screenshot 2024-06-26 at 15 33 21" src="https://github.com/WordPress/gutenberg/assets/846565/1a8d930e-9997-4084-903c-5321ae8a7e6f"> | <img width="399" alt="Screenshot 2024-06-26 at 15 33 53" src="https://github.com/WordPress/gutenberg/assets/846565/8e609796-a2f2-4f0e-8486-56ce3c311182"> |
