### PR TITLE
Tabs: add vertical indicator animation

### DIFF
--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -36,22 +36,20 @@ export const TabListWrapper = styled.div`
 		outline-offset: -1px;
 	}
 	&:not( [aria-orientation='vertical'] )::after {
-		left: var( --indicator-left );
 		bottom: 0;
+		left: var( --indicator-left );
 		width: var( --indicator-width );
 		height: 0;
 		border-bottom: var( --wp-admin-border-width-focus ) solid
 			${ COLORS.theme.accent };
 	}
 	&[aria-orientation='vertical']::after {
-		/* Temporarily hidden, context: https://github.com/WordPress/gutenberg/pull/60560#issuecomment-2126670072 */
-		opacity: 0;
-
-		right: 0;
+		z-index: -1;
+		left: 0;
+		width: 100%;
 		top: var( --indicator-top );
 		height: var( --indicator-height );
-		border-right: var( --wp-admin-border-width-focus ) solid
-			${ COLORS.theme.accent };
+		background-color: ${ COLORS.theme.gray[ 100 ] };
 	}
 `;
 

--- a/packages/preferences/src/components/preferences-modal-tabs/style.scss
+++ b/packages/preferences/src/components/preferences-modal-tabs/style.scss
@@ -6,31 +6,6 @@ $vertical-tabs-width: 160px;
 	// Aligns button text instead of button box.
 	left: $grid-unit-20;
 	width: $vertical-tabs-width;
-
-	&::after {
-		content: none !important;
-	}
-}
-
-.preferences__tabs-tab {
-	border-radius: $radius-block-ui;
-	font-weight: 400;
-
-	&[aria-selected="true"] {
-		background: $gray-100;
-		box-shadow: none;
-		font-weight: 500;
-	}
-
-	&[role="tab"]:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		// Windows high contrast mode.
-		outline: 2px solid transparent;
-	}
-
-	&:focus-visible::before {
-		content: none;
-	}
 }
 
 .preferences__tabs-tabpanel {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Added an animated vertical tabs indicator (related: https://github.com/WordPress/gutenberg/pull/60560#issuecomment-2126452564). I also removed the style overrides from one instance (block editor preferences dialog) where it was a complete match. Tested other overrides and they look correct to me.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the existing animation system.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check out the Storybook story for vertical tabs, or instances of vertical tabs in Gutenberg.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Focus it and use up/down arrow keys.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/8862967/ffbe765c-6e3f-4399-b889-cd7c2a7cd993

Preferences dialog - before:

https://github.com/WordPress/gutenberg/assets/8862967/b55740fa-fe6e-4c4b-9226-acb4e293febe

Preferences dialog - after:

https://github.com/WordPress/gutenberg/assets/8862967/cf07b184-29da-4d92-b721-d9a6130b3ac5

With `prefers-reduced-motion`:

https://github.com/WordPress/gutenberg/assets/8862967/1f9a2f52-daa4-43e2-8c6e-7da22c4dcafa