### PR TITLE
Fix extra scrollbar when a popover extends past the viewport.

### DIFF
--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -19,7 +19,7 @@
 
 	// In the iframed canvas this keeps extra scrollbars from appearing (when block toolbars overflow). In the
 	// legacy (non-iframed) canvas, overflow must not be hidden in order to maintain support for sticky positioning.
-	.is-iframed {
+	&.is-iframed {
 		overflow: hidden;
 	}
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -82,9 +82,10 @@ html.interface-interface-skeleton__html-container {
 	display: flex;
 	flex-direction: column;
 
-	// Hide the Y overflow to avoid an extra scrollbar when an active popover
-	// extends vertically beyond the viewport.
-	overflow-y: auto;
+	// On Mobile the header is fixed to keep HTML as scrollable.
+	// Beyond the medium breakpoint, we allow the sidebar.
+	// The sidebar should scroll independently, so enable scroll here also.
+	overflow: auto;
 
 	// On Safari iOS on smaller viewports lack of a z-index causes the background
 	// to "bleed" through the header.

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -82,10 +82,9 @@ html.interface-interface-skeleton__html-container {
 	display: flex;
 	flex-direction: column;
 
-	// On Mobile the header is fixed to keep HTML as scrollable.
-	// Beyond the medium breakpoint, we allow the sidebar.
-	// The sidebar should scroll independently, so enable scroll here also.
-	overflow: auto;
+	// Hide the Y overflow to avoid an extra scrollbar when an active popover
+	// extends vertically beyond the viewport.
+	overflow-y: hidden;
 
 	// On Safari iOS on smaller viewports lack of a z-index causes the background
 	// to "bleed" through the header.

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -84,7 +84,7 @@ html.interface-interface-skeleton__html-container {
 
 	// Hide the Y overflow to avoid an extra scrollbar when an active popover
 	// extends vertically beyond the viewport.
-	overflow-y: hidden;
+	overflow-y: auto;
 
 	// On Safari iOS on smaller viewports lack of a z-index causes the background
 	// to "bleed" through the header.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When an active popover inside `interface-skeleton__content` extends vertically past the viewport, an extra scrollbar appears on trunk. This can be reproduced with the following steps:

* Make sure scrollbars are enabled at all times in your computer settings;
* Add a Grid block to a post or template, and add enough content inside it that it becomes scrollable;
* Make sure either the Grid or one of its children are selected, and scroll to a point where the Grid is partially hidden beyond the bottom edge of the viewport;
* See the extra vertical scrollbar appear.

The overflow rule being changed here has been around for a long time so I want to make sure this change doesn't break anything else 😅 
My testing shows everything working correctly: both editor canvas and sidebar are still scrollable and look as expected. I think the overflow may have been set to auto to unset its default `visible`, because when setting it to `visible` things do look a bit funny. If that's the extent of what the overflow is doing, this change should be safe enough.

Before:

<img width="1058" alt="Screenshot 2024-06-27 at 11 24 40 AM" src="https://github.com/WordPress/gutenberg/assets/8096000/ef018f57-bc0e-4f61-a494-def9cd75eca5">


After:

<img width="971" alt="Screenshot 2024-06-27 at 11 33 02 AM" src="https://github.com/WordPress/gutenberg/assets/8096000/9156da93-9619-4e8d-bdfd-f0c4f611f017">

