### PR TITLE
Cherry pick automation: fix for forks

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -28,6 +28,7 @@ jobs:
                   script: |
                       const commit_sha = context.payload.pull_request ? context.payload.pull_request.merge_commit_sha : context.sha;
                       console.log(`Commit SHA: ${commit_sha}`);
+                      core.exportVariable('commit_sha', commit_sha);
                       const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -84,19 +85,18 @@ jobs:
               if: env.cherry_pick == 'true'
               run: |
                   TARGET_BRANCH="wp/${{ env.version }}"
-                  COMMIT_SHA=$(jq -r '.after' "$GITHUB_EVENT_PATH")
+                  COMMIT_SHA="${{ env.commit_sha }}"
                   echo "Target branch: $TARGET_BRANCH"
                   echo "Commit SHA: $COMMIT_SHA"
                   git checkout $TARGET_BRANCH
                   git cherry-pick $COMMIT_SHA || echo "cherry-pick-failed" > result
                   if [ -f result ] && grep -q "cherry-pick-failed" result; then
                     echo "conflict=true" >> $GITHUB_ENV
-                    echo "commit_sha=$COMMIT_SHA" >> $GITHUB_ENV
                     git cherry-pick --abort
                   else
-                    NEW_COMMIT_SHA=$(git rev-parse HEAD)
+                    CHERRY_PICK_SHA=$(git rev-parse HEAD)
                     echo "conflict=false" >> $GITHUB_ENV
-                    echo "commit_sha=$NEW_COMMIT_SHA" >> $GITHUB_ENV
+                    echo "cherry_pick_sha=$CHERRY_PICK_SHA" >> $GITHUB_ENV
                     git push origin $TARGET_BRANCH
                   fi
 
@@ -130,16 +130,16 @@ jobs:
               with:
                   script: |
                       const prNumber = process.env.pr_number;
-                      const commitSha = process.env.commit_sha;
+                      const cherryPickSha = process.env.cherry_pick_sha;
                       const targetBranch = `wp/${process.env.version}`;
                       console.log(`prNumber: ${prNumber}`);
-                      console.log(`commitSha: ${commitSha}`);
+                      console.log(`cherryPickSha: ${cherryPickSha}`);
                       console.log(`targetBranch: ${targetBranch}`);
                       await github.rest.issues.createComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
-                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${commitSha}`
+                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${cherryPickSha}`
                       });
 
             - name: Comment on the PR about conflict

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -4,6 +4,11 @@ on:
     push:
         branches:
             - trunk
+    # We also want to attempt cherry-picking when a PR is labeled after the PR
+    # is merged.
+    pull_request:
+        types:
+            - labeled
 
 # Ensure that new jobs wait for the previous job to finish.
 concurrency:
@@ -13,16 +18,20 @@ concurrency:
 jobs:
     cherry-pick:
         runs-on: ubuntu-latest
+        # When in the context of a PR, ensure the PR is merged.
+        if: github.event.pull_request == null || github.event.pull_request.merged == true
         steps:
             - name: Determine if label should trigger cherry-pick
               id: label-check
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
               with:
                   script: |
+                      const commit_sha = context.payload.pull_request ? context.payload.pull_request.merge_commit_sha : context.sha;
+                      console.log(`Commit SHA: ${commit_sha}`);
                       const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
-                        commit_sha: context.sha,
+                        commit_sha,
                       });
                       if (prs.data.length === 0) {
                         console.log(`No PR found for commit ${context.sha}.`);

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -1,10 +1,9 @@
 name: Auto Cherry-Pick
 
 on:
-    pull_request:
-        types: [closed, labeled]
+    push:
         branches:
-            - trunk
+            - test/trunk
 
 # Ensure that new jobs wait for the previous job to finish.
 concurrency:
@@ -14,14 +13,31 @@ concurrency:
 jobs:
     cherry-pick:
         runs-on: ubuntu-latest
-        if: github.event.pull_request.merged == true
         steps:
             - name: Determine if label should trigger cherry-pick
               id: label-check
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
               with:
                   script: |
-                      const labels = context.payload.pull_request.labels.map(label => label.name);
+                      const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        commit_sha: context.sha,
+                      });
+                      if (prs.data.length === 0) {
+                        console.log(`No PR found for commit ${context.sha}.`);
+                        return;
+                      }
+                      const pr_number = prs.data[0].number;
+                      console.log(`PR: ${pr_number}`);
+                      core.exportVariable('pr_number', pr_number);
+
+                      const pr = await github.rest.pulls.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: pr_number,
+                      });
+                      const labels = pr.data.labels.map(label => label.name);
                       console.log(`Labels: ${labels}`);
                       const regex = /^Backport to WP ([0-9]+\.[0-9]+) Beta\/RC$/;
                       let matched = false;
@@ -59,7 +75,7 @@ jobs:
               if: env.cherry_pick == 'true'
               run: |
                   TARGET_BRANCH="wp/${{ env.version }}"
-                  COMMIT_SHA=$(jq -r '.pull_request.merge_commit_sha' "$GITHUB_EVENT_PATH")
+                  COMMIT_SHA=$(jq -r '.after' "$GITHUB_EVENT_PATH")
                   echo "Target branch: $TARGET_BRANCH"
                   echo "Commit SHA: $COMMIT_SHA"
                   git checkout $TARGET_BRANCH
@@ -80,7 +96,7 @@ jobs:
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
               with:
                   script: |
-                      const prNumber = context.issue.number;
+                      const prNumber = process.env.pr_number;
                       const version = process.env.version;
                       console.log(`prNumber: ${prNumber}`);
                       console.log(`version: ${version}`);
@@ -104,7 +120,7 @@ jobs:
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
               with:
                   script: |
-                      const prNumber = context.issue.number;
+                      const prNumber = process.env.pr_number;
                       const commitSha = process.env.commit_sha;
                       const targetBranch = `wp/${process.env.version}`;
                       console.log(`prNumber: ${prNumber}`);
@@ -122,7 +138,7 @@ jobs:
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
               with:
                   script: |
-                      const prNumber = context.issue.number;
+                      const prNumber = process.env.pr_number;
                       const commitSha = process.env.commit_sha;
                       const targetBranch = `wp/${process.env.version}`;
                       console.log(`prNumber: ${prNumber}`);

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -3,7 +3,7 @@ name: Auto Cherry-Pick
 on:
     push:
         branches:
-            - test/trunk
+            - trunk
 
 # Ensure that new jobs wait for the previous job to finish.
 concurrency:

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -7,8 +7,9 @@ on:
     # We also want to attempt cherry-picking when a PR is labeled after the PR
     # is merged.
     pull_request:
-        types:
-            - labeled
+        types: [labeled]
+        branches:
+            - trunk
 
 # Ensure that new jobs wait for the previous job to finish.
 concurrency:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This workflow was introduced in #62716, and it generally works well. The problem is that when a PR is merged from a fork, the workflow runs in the context of that fork and lacks the token.

The idea of this PR is to move automation from PRs to pushes. I'll first test this on a `test/trunk` branch.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it doesn't currently work for PRs from forks, such as #62857.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

It works:

* I created a `test/trunk` branch with this new workflow.
* I created a PR for it with the label `Backport to WP 0.0 Beta/RC`, merged it, and it was correctly cherry-picked: 
  * Workflow run: https://github.com/WordPress/gutenberg/actions/runs/9691420804/job/26742868834
  * Comment: https://github.com/WordPress/gutenberg/pull/62903#issuecomment-2193863431
  
Labelling after a merge still works too, but worth noting that labelling after will still not work on forks because this workflow must run on the PR:
* Workflow run: https://github.com/WordPress/gutenberg/actions/runs/9692818737/job/26746955238
* Comment: https://github.com/WordPress/gutenberg/pull/62910#issuecomment-2194041795

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
