### PR TITLE
Manual cherry pick of #62768 to wp/6.6

### DIFF
--- a/packages/block-editor/src/hooks/block-style-variation.js
+++ b/packages/block-editor/src/hooks/block-style-variation.js
@@ -16,6 +16,7 @@ import {
 import { useStyleOverride } from './utils';
 import { store as blockEditorStore } from '../store';
 import { globalStylesDataKey } from '../store/private-keys';
+import { unlock } from '../lock-unlock';
 
 const VARIATION_PREFIX = 'is-style-';
 
@@ -59,7 +60,127 @@ function getVariationNameFromClass( className, registeredStyles = [] ) {
 	return null;
 }
 
-function useBlockSyleVariation( name, variation, clientId ) {
+// A helper component to apply a style override using the useStyleOverride hook.
+function OverrideStyles( { override } ) {
+	useStyleOverride( override );
+}
+
+/**
+ * This component is used to generate new block style variation overrides
+ * based on an incoming theme config. If a matching style is found in the config,
+ * a new override is created and returned. The overrides can be used in conjunction with
+ * useStyleOverride to apply the new styles to the editor. Its use is
+ * subject to change.
+ *
+ * @param {Object} props        Props.
+ * @param {Object} props.config A global styles object, containing settings and styles.
+ * @return {JSX.Element|undefined} An array of new block variation overrides.
+ */
+export function __unstableBlockStyleVariationOverridesWithConfig( { config } ) {
+	const { getBlockStyles, overrides } = useSelect(
+		( select ) => ( {
+			getBlockStyles: select( blocksStore ).getBlockStyles,
+			overrides: unlock( select( blockEditorStore ) ).getStyleOverrides(),
+		} ),
+		[]
+	);
+	const { getBlockName } = useSelect( blockEditorStore );
+
+	const overridesWithConfig = useMemo( () => {
+		if ( ! overrides?.length ) {
+			return;
+		}
+		const newOverrides = [];
+		const overriddenClientIds = [];
+		for ( const [ , override ] of overrides ) {
+			if (
+				override?.variation &&
+				override?.clientId &&
+				/*
+				 * Because this component overwrites existing style overrides,
+				 * filter out any overrides that are already present in the store.
+				 */
+				! overriddenClientIds.includes( override.clientId )
+			) {
+				const blockName = getBlockName( override.clientId );
+				const configStyles =
+					config?.styles?.blocks?.[ blockName ]?.variations?.[
+						override.variation
+					];
+				if ( configStyles ) {
+					const variationConfig = {
+						settings: config?.settings,
+						// The variation style data is all that is needed to generate
+						// the styles for the current application to a block. The variation
+						// name is updated to match the instance specific class name.
+						styles: {
+							blocks: {
+								[ blockName ]: {
+									variations: {
+										[ `${ override.variation }-${ override.clientId }` ]:
+											configStyles,
+									},
+								},
+							},
+						},
+					};
+					const blockSelectors = getBlockSelectors(
+						getBlockTypes(),
+						getBlockStyles,
+						override.clientId
+					);
+					const hasBlockGapSupport = false;
+					const hasFallbackGapSupport = true;
+					const disableLayoutStyles = true;
+					const disableRootPadding = true;
+					const variationStyles = toStyles(
+						variationConfig,
+						blockSelectors,
+						hasBlockGapSupport,
+						hasFallbackGapSupport,
+						disableLayoutStyles,
+						disableRootPadding,
+						{
+							blockGap: false,
+							blockStyles: true,
+							layoutStyles: false,
+							marginReset: false,
+							presets: false,
+							rootPadding: false,
+							variationStyles: true,
+						}
+					);
+					newOverrides.push( {
+						id: `${ override.variation }-${ override.clientId }`,
+						css: variationStyles,
+						__unstableType: 'variation',
+						variation: override.variation,
+						// The clientId will be stored with the override and used to ensure
+						// the order of overrides matches the order of blocks so that the
+						// correct CSS cascade is maintained.
+						clientId: override.clientId,
+					} );
+					overriddenClientIds.push( override.clientId );
+				}
+			}
+		}
+		return newOverrides;
+	}, [ config, overrides, getBlockStyles, getBlockName ] );
+
+	if ( ! overridesWithConfig || ! overridesWithConfig.length ) {
+		return;
+	}
+
+	return (
+		<>
+			{ overridesWithConfig.map( ( override ) => (
+				<OverrideStyles key={ override.id } override={ override } />
+			) ) }
+		</>
+	);
+}
+
+function useBlockStyleVariation( name, variation, clientId ) {
 	// Prefer global styles data in GlobalStylesContext, which are available
 	// if in the site editor. Otherwise fall back to whatever is in the
 	// editor settings and available in the post editor.
@@ -112,7 +233,7 @@ function useBlockProps( { name, className, clientId } ) {
 	const variation = getVariationNameFromClass( className, registeredStyles );
 	const variationClass = `${ VARIATION_PREFIX }${ variation }-${ clientId }`;
 
-	const { settings, styles } = useBlockSyleVariation(
+	const { settings, styles } = useBlockStyleVariation(
 		name,
 		variation,
 		clientId
@@ -157,6 +278,7 @@ function useBlockProps( { name, className, clientId } ) {
 		id: `variation-${ clientId }`,
 		css: variationStyles,
 		__unstableType: 'variation',
+		variation,
 		// The clientId will be stored with the override and used to ensure
 		// the order of overrides matches the order of blocks so that the
 		// correct CSS cascade is maintained.

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -88,3 +88,4 @@ export { getTypographyClassesAndStyles } from './use-typography-props';
 export { getGapCSSValue } from './gap';
 export { useCachedTruthy } from './use-cached-truthy';
 export { useZoomOut } from './use-zoom-out';
+export { __unstableBlockStyleVariationOverridesWithConfig } from './block-style-variation';

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -140,6 +140,7 @@ export function useStyleOverride( {
 	css,
 	assets,
 	__unstableType,
+	variation,
 	clientId,
 } = {} ) {
 	const { setStyleOverride, deleteStyleOverride } = unlock(
@@ -159,6 +160,7 @@ export function useStyleOverride( {
 			css,
 			assets,
 			__unstableType,
+			variation,
 			clientId,
 		};
 		// Batch updates to style overrides to avoid triggering cascading renders

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -20,7 +20,11 @@ import { cleanEmptyObject, useStyleOverride } from './hooks/utils';
 import BlockQuickNavigation from './components/block-quick-navigation';
 import { LayoutStyle } from './components/block-list/layout';
 import { BlockRemovalWarningModal } from './components/block-removal-warning-modal';
-import { useLayoutClasses, useLayoutStyles } from './hooks';
+import {
+	useLayoutClasses,
+	useLayoutStyles,
+	__unstableBlockStyleVariationOverridesWithConfig,
+} from './hooks';
 import DimensionsTool from './components/dimensions-tool';
 import ResolutionTool from './components/resolution-tool';
 import TextAlignmentControl from './components/text-alignment-control';
@@ -88,4 +92,5 @@ lock( privateApis, {
 	PrivatePublishDateTimePicker,
 	useSpacingSizes,
 	useBlockDisplayTitle,
+	__unstableBlockStyleVariationOverridesWithConfig,
 } );

--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -25,6 +25,7 @@ const {
 	ExperimentalBlockEditorProvider,
 	GlobalStylesContext,
 	useGlobalStylesOutputWithConfig,
+	__unstableBlockStyleVariationOverridesWithConfig,
 } = unlock( blockEditorPrivateApis );
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 
@@ -74,7 +75,6 @@ function Revisions( { userConfig, blocks } ) {
 				name="revisions"
 				tabIndex={ 0 }
 			>
-				<EditorStyles styles={ editorStyles } />
 				<style>
 					{
 						// Forming a "block formatting context" to prevent margin collapsing.
@@ -88,6 +88,14 @@ function Revisions( { userConfig, blocks } ) {
 						settings={ settings }
 					>
 						<BlockList renderAppender={ false } />
+						{ /*
+						 * Styles are printed inside the block editor provider,
+						 * so they can access any registered style overrides.
+						 */ }
+						<EditorStyles styles={ editorStyles } />
+						<__unstableBlockStyleVariationOverridesWithConfig
+							config={ mergedConfig }
+						/>
 					</ExperimentalBlockEditorProvider>
 				</Disabled>
 			</Iframe>

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -1,0 +1,366 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const TEST_PAGE_TITLE = 'Test Page for Block Style Variations';
+test.use( {
+	siteEditorBlockStyleVariations: async ( { page, editor }, use ) => {
+		await use( new SiteEditorBlockStyleVariations( { page, editor } ) );
+	},
+} );
+
+test.describe( 'Block Style Variations', () => {
+	let stylesPostId;
+	test.beforeAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.activateTheme(
+				'gutenberg-test-themes/style-variations'
+			),
+		] );
+		stylesPostId = await requestUtils.getCurrentThemeGlobalStylesPostId();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deleteAllPages(),
+		] );
+	} );
+
+	test.beforeEach( async ( { requestUtils, admin } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPages(),
+			admin.visitSiteEditor(),
+		] );
+	} );
+
+	test( 'apply block styles variations to nested blocks', async ( {
+		editor,
+		page,
+	} ) => {
+		await draftNewPage( page );
+		await addPageContent( editor, page );
+		const firstGroup = editor.canvas
+			.locator( '[data-type="core/group"]' )
+			.first();
+		const secondGroup = editor.canvas
+			.locator( '[data-type="core/group"]' )
+			.nth( 1 );
+		const thirdGroup = editor.canvas
+			.locator( '[data-type="core/group"]' )
+			.nth( 2 );
+
+		// Apply a block style to the parent Group block.
+		await editor.selectBlocks( firstGroup );
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Style Variation A' } )
+			.click();
+
+		// Check parent styles have variation A styles.
+		await expect( firstGroup ).toHaveCSS( 'border-style', 'dotted' );
+		await expect( firstGroup ).toHaveCSS( 'border-width', '1px' );
+
+		// Check nested child and grandchild group block variation A inherited styles.
+		await expect( secondGroup ).toHaveCSS( 'border-style', 'solid' );
+		await expect( secondGroup ).toHaveCSS( 'border-width', '11px' );
+		await expect( thirdGroup ).toHaveCSS( 'border-style', 'solid' );
+		await expect( thirdGroup ).toHaveCSS( 'border-width', '11px' );
+
+		// Apply a block style to the nested child Group block.
+		await editor.selectBlocks( secondGroup );
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Style Variation B' } )
+			.click();
+
+		// Check nested child styles have variation B styles.
+		await expect( secondGroup ).toHaveCSS( 'border-style', 'dashed' );
+		await expect( secondGroup ).toHaveCSS( 'border-width', '2px' );
+
+		// Check nested grandchild Group block variation B inherited styles.
+		await expect( thirdGroup ).toHaveCSS( 'border-style', 'groove' );
+		await expect( thirdGroup ).toHaveCSS( 'border-width', '22px' );
+
+		// Apply a block style to the nested grandchild Group block.
+		await editor.selectBlocks( thirdGroup );
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Style Variation A' } )
+			.click();
+
+		// Check that the child's inner block styles from variation B are overridden by the grandchild's block style variation A.
+		await expect( thirdGroup ).toHaveCSS( 'border-style', 'dotted' );
+		await expect( thirdGroup ).toHaveCSS( 'border-width', '1px' );
+	} );
+
+	test( 'update block style variations in global styles and check revisions match styles', async ( {
+		editor,
+		page,
+		siteEditorBlockStyleVariations,
+	} ) => {
+		await draftNewPage( page );
+		await addPageContent( editor, page );
+		const firstGroup = editor.canvas
+			.locator( '[data-type="core/group"]' )
+			.first();
+		const secondGroup = editor.canvas
+			.locator( '[data-type="core/group"]' )
+			.nth( 1 );
+		const thirdGroup = editor.canvas
+			.locator( '[data-type="core/group"]' )
+			.nth( 2 );
+
+		// Apply a block style to the parent Group block.
+		await editor.selectBlocks( firstGroup );
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Style Variation A' } )
+			.click();
+
+		// Apply a block style to the first, nested Group block.
+		await editor.selectBlocks( secondGroup );
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Style Variation B' } )
+			.click();
+
+		// Update user global styles with new block style variation values.
+		// First revision.
+		await siteEditorBlockStyleVariations.saveRevision( stylesPostId, {
+			blocks: {
+				'core/group': {
+					variations: {
+						'block-style-variation-a': {
+							border: {
+								width: '3px',
+								style: 'outset',
+							},
+						},
+						'block-style-variation-b': {
+							border: {
+								width: '4px',
+								style: 'double',
+							},
+						},
+					},
+				},
+			},
+		} );
+		// The save button has been re-enabled.
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Save' } )
+		).toBeEnabled();
+		// Second revision (current).
+		await siteEditorBlockStyleVariations.saveRevision( stylesPostId, {
+			blocks: {
+				'core/group': {
+					variations: {
+						'block-style-variation-a': {
+							border: {
+								width: '7px',
+								style: 'dotted',
+							},
+						},
+						'block-style-variation-b': {
+							border: {
+								width: '8px',
+								style: 'dotted',
+							},
+						},
+					},
+				},
+			},
+		} );
+
+		// Check parent styles.
+		await expect( firstGroup ).toHaveCSS( 'border-style', 'dotted' );
+		await expect( firstGroup ).toHaveCSS( 'border-width', '7px' );
+
+		// Check nested child styles.
+		await expect( secondGroup ).toHaveCSS( 'border-style', 'dotted' );
+		await expect( secondGroup ).toHaveCSS( 'border-width', '8px' );
+
+		// Check nested grandchild group block inherited styles.
+		await expect( thirdGroup ).toHaveCSS( 'border-style', 'groove' );
+		await expect( thirdGroup ).toHaveCSS( 'border-width', '22px' );
+
+		// The initial revision styles should match the editor canvas.
+		await siteEditorBlockStyleVariations.openStylesPanel();
+		const revisionsButton = page.getByRole( 'button', {
+			name: 'Revisions',
+			exact: true,
+		} );
+		await revisionsButton.click();
+		await expect(
+			page.locator( 'iframe[name="revisions"]' )
+		).toBeVisible();
+		const revisionIframe = page.frameLocator( '[name="revisions"]' );
+
+		const revisionFirstGroup = revisionIframe
+			.getByRole( 'document', {
+				name: 'Block: Content',
+			} )
+			.locator( '[data-type="core/group"]' )
+			.first();
+		const revisionSecondGroup = revisionIframe
+			.getByRole( 'document', {
+				name: 'Block: Content',
+			} )
+			.locator( '[data-type="core/group"]' )
+			.nth( 1 );
+		const revisionThirdGroup = revisionIframe
+			.getByRole( 'document', {
+				name: 'Block: Content',
+			} )
+			.locator( '[data-type="core/group"]' )
+			.nth( 2 );
+
+		// Check parent styles have current revision.
+		await expect( revisionFirstGroup ).toHaveCSS(
+			'border-style',
+			'dotted'
+		);
+		await expect( revisionFirstGroup ).toHaveCSS( 'border-width', '7px' );
+
+		// Check nested child styles have current revision.
+		await expect( revisionSecondGroup ).toHaveCSS(
+			'border-style',
+			'dotted'
+		);
+		await expect( revisionSecondGroup ).toHaveCSS( 'border-width', '8px' );
+
+		// Check nested grandchild group block inherited styles from current revision.
+		await expect( revisionThirdGroup ).toHaveCSS(
+			'border-style',
+			'groove'
+		);
+		await expect( revisionThirdGroup ).toHaveCSS( 'border-width', '22px' );
+
+		// Click on previous revision.
+		await page
+			.getByRole( 'button', {
+				name: /^Changes saved by /,
+			} )
+			.nth( 1 )
+			.click();
+
+		// Check parent styles have previous revision.
+		await expect( revisionFirstGroup ).toHaveCSS( 'border-width', '3px' );
+
+		// Check nested child style have previous revision.
+		await expect( revisionSecondGroup ).toHaveCSS(
+			'border-style',
+			'double'
+		);
+		await expect( revisionSecondGroup ).toHaveCSS( 'border-width', '4px' );
+
+		// Check nested grandchild group block inherited styles from previous revision.
+		await expect( revisionThirdGroup ).toHaveCSS(
+			'border-style',
+			'groove'
+		);
+		await expect( revisionThirdGroup ).toHaveCSS( 'border-width', '22px' );
+	} );
+} );
+
+class SiteEditorBlockStyleVariations {
+	constructor( { page, editor } ) {
+		this.page = page;
+		this.editor = editor;
+	}
+
+	async openStylesPanel() {
+		await this.page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Styles' } )
+			.click();
+	}
+
+	async saveRevision( stylesPostId, styles = {}, settings = {} ) {
+		await this.page.evaluate(
+			async ( [ _stylesPostId, _styles, _settings ] ) => {
+				window.wp.data
+					.dispatch( 'core' )
+					.editEntityRecord( 'root', 'globalStyles', _stylesPostId, {
+						id: _stylesPostId,
+						settings: _settings,
+						styles: _styles,
+					} );
+			},
+			[ stylesPostId, styles, settings ]
+		);
+		await this.editor.saveSiteEditorEntities();
+	}
+}
+
+async function draftNewPage( page ) {
+	await page.getByRole( 'button', { name: 'Pages' } ).click();
+	await page.getByRole( 'button', { name: 'Add new page' } ).click();
+	await page
+		.locator( 'role=dialog[name="Draft a new page"i]' )
+		.locator( 'role=textbox[name="Page title"i]' )
+		.fill( TEST_PAGE_TITLE );
+	await page.keyboard.press( 'Enter' );
+	await expect(
+		page.locator(
+			`role=button[name="Dismiss this notice"i] >> text='"${ TEST_PAGE_TITLE }" successfully created.'`
+		)
+	).toBeVisible();
+}
+
+// Create a Group block with 2 nested Group blocks.
+async function addPageContent( editor, page ) {
+	const inserterButton = page.locator(
+		'role=button[name="Toggle block inserter"i]'
+	);
+	await inserterButton.click();
+	await page.type(
+		'role=searchbox[name="Search for blocks and patterns"i]',
+		'Group'
+	);
+	await page.click(
+		'role=listbox[name="Blocks"i] >> role=option[name="Group"i]'
+	);
+	await editor.canvas
+		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
+		.click();
+	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
+	await page.click(
+		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
+	);
+	await page.keyboard.type( 'Parent Group Block with a Paragraph' );
+	await page.keyboard.press( 'Enter' );
+	await page.keyboard.type( '/group' );
+	await expect(
+		page.locator( 'role=option[name="Group"i][selected]' )
+	).toBeVisible();
+	await page.keyboard.press( 'Enter' );
+	await editor.canvas
+		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
+		.click();
+	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
+	await page.click(
+		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
+	);
+	await page.keyboard.type( 'Child Group Block with a Paragraph' );
+	await page.keyboard.press( 'Enter' );
+	await page.keyboard.type( '/group' );
+	await expect(
+		page.locator( 'role=option[name="Group"i][selected]' )
+	).toBeVisible();
+	await page.keyboard.press( 'Enter' );
+	await editor.canvas
+		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
+		.click();
+	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
+	await page.click(
+		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
+	);
+	await page.keyboard.type( 'Grandchild Group Block with a Paragraph' );
+	await page.getByRole( 'button', { name: 'Publish', exact: true } ).click();
+}

--- a/test/gutenberg-test-themes/style-variations/block-templates/singular.html
+++ b/test/gutenberg-test-themes/style-variations/block-templates/singular.html
@@ -1,0 +1,2 @@
+<!-- wp:post-title /-->
+<!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/test/gutenberg-test-themes/style-variations/styles/block-style-variation-a.json
+++ b/test/gutenberg-test-themes/style-variations/styles/block-style-variation-a.json
@@ -1,0 +1,20 @@
+{
+	"version": 3,
+	"title": "Block Style Variation A",
+	"slug": "block-style-variation-a",
+	"blockTypes": [ "core/group" ],
+	"styles": {
+		"border": {
+			"width": "1px",
+			"style": "dotted"
+		},
+		"blocks": {
+			"core/group": {
+				"border": {
+					"width": "11px",
+					"style": "solid"
+				}
+			}
+		}
+	}
+}

--- a/test/gutenberg-test-themes/style-variations/styles/block-style-variation-b.json
+++ b/test/gutenberg-test-themes/style-variations/styles/block-style-variation-b.json
@@ -1,0 +1,20 @@
+{
+	"version": 3,
+	"title": "Block Style Variation B",
+	"slug": "block-style-variation-b",
+	"blockTypes": [ "core/group" ],
+	"styles": {
+		"border": {
+			"width": "2px",
+			"style": "dashed"
+		},
+		"blocks": {
+			"core/group": {
+				"border": {
+					"width": "22px",
+					"style": "groove"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION


## What?

A manual cherry pick of the following PRs to `wp/6.6`

- https://github.com/WordPress/gutenberg/pull/62768
- https://github.com/WordPress/gutenberg/pull/62464

## Why?

There was a tiny conflict because the hook name change in #62464 was not cherry-picked into `wp/6.6`


## Testing Instructions
Smoke test according to test instructions in https://github.com/WordPress/gutenberg/pull/62768
