### PR TITLE
CustomSelectControl V2: prevent keyboard event propagation in legacy wrapper

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Internal
 
+-   `CustomSelectControlV2`: prevent keyboard event propagation in legacy wrapper. ([#62907](https://github.com/WordPress/gutenberg/pull/62907))
 -   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))
 -   `CustomSelectControlV2`: fix popover styles. ([#62821](https://github.com/WordPress/gutenberg/pull/62821))
 -   `CustomSelectControlV2`: fix trigger text alignment in RTL languages ([#62869](https://github.com/WordPress/gutenberg/pull/62869)).

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -14,6 +14,7 @@ import type {
 	CustomSelectStore,
 	CustomSelectButtonProps,
 	CustomSelectButtonSize,
+	_CustomSelectInternalProps,
 	_CustomSelectProps,
 } from './types';
 import type { WordPressComponentProps } from '../context';
@@ -80,7 +81,10 @@ const CustomSelectButton = ( {
 };
 
 function _CustomSelect(
-	props: _CustomSelectProps & CustomSelectStore & CustomSelectButtonSize
+	props: _CustomSelectInternalProps &
+		_CustomSelectProps &
+		CustomSelectStore &
+		CustomSelectButtonSize
 ) {
 	const {
 		children,

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -93,6 +93,16 @@ function _CustomSelect(
 		...restProps
 	} = props;
 
+	const onSelectPopoverKeyDown: React.KeyboardEventHandler< HTMLDivElement > =
+		useCallback(
+			( e ) => {
+				if ( isLegacy ) {
+					e.stopPropagation();
+				}
+			},
+			[ isLegacy ]
+		);
+
 	return (
 		// Where should `restProps` be forwarded to?
 		<div className={ className }>
@@ -118,6 +128,7 @@ function _CustomSelect(
 					store={ store }
 					sameWidth
 					slide={ false }
+					onKeyDown={ onSelectPopoverKeyDown }
 				>
 					<CustomSelectContext.Provider value={ { store } }>
 						{ children }

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createContext, useMemo } from '@wordpress/element';
+import { createContext, useCallback, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -89,6 +89,7 @@ function _CustomSelect(
 		size,
 		store,
 		className,
+		isLegacy = false,
 		...restProps
 	} = props;
 

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -128,6 +128,7 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 				'components-custom-select-control',
 				classNameProp
 			) }
+			isLegacy
 			{ ...restProps }
 		>
 			{ children }

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -454,8 +454,7 @@ describe.each( [
 	} );
 
 	describe( 'Keyboard behavior and accessibility', () => {
-		// skip reason: legacy v2 doesn't currently implement this behavior
-		it.skip( 'Captures the keypress event and does not let it propagate', async () => {
+		it( 'Captures the keypress event and does not let it propagate', async () => {
 			const onKeyDown = jest.fn();
 
 			render(

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -68,6 +68,10 @@ export type _CustomSelectProps = CustomSelectButtonProps & {
 	 * Accessible label for the control.
 	 */
 	label: string;
+	/**
+	 * True if the consumer is emulating the legacy component behavior and look
+	 */
+	isLegacy?: boolean;
 };
 
 export type CustomSelectProps = _CustomSelectProps &

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -75,6 +75,8 @@ export type _CustomSelectProps = CustomSelectButtonProps & {
 };
 
 export type CustomSelectProps = _CustomSelectProps &
+	// TODO: is it necessary to pass CustomSelectButtonProps, since
+	// they are already part of _CustomSelectProps?
 	CustomSelectButtonProps &
 	CustomSelectSize;
 

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -49,6 +49,15 @@ export type CustomSelectButtonProps = {
 	value?: string | string[];
 };
 
+// Props only exposed on the internal implementation
+export type _CustomSelectInternalProps = {
+	/**
+	 * True if the consumer is emulating the legacy component behavior and look
+	 */
+	isLegacy?: boolean;
+};
+
+// Props that are exposed in exported components
 export type _CustomSelectProps = CustomSelectButtonProps & {
 	/**
 	 * Additional className added to the root wrapper element.
@@ -68,17 +77,9 @@ export type _CustomSelectProps = CustomSelectButtonProps & {
 	 * Accessible label for the control.
 	 */
 	label: string;
-	/**
-	 * True if the consumer is emulating the legacy component behavior and look
-	 */
-	isLegacy?: boolean;
 };
 
-export type CustomSelectProps = _CustomSelectProps &
-	// TODO: is it necessary to pass CustomSelectButtonProps, since
-	// they are already part of _CustomSelectProps?
-	CustomSelectButtonProps &
-	CustomSelectSize;
+export type CustomSelectProps = _CustomSelectProps & CustomSelectSize;
 
 /**
  * The legacy object structure for the options array.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023 

Prevent keyboard events propagation from the select popover in `CustomSelectControlV2` legacy wrapper

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To align the behavior of the V2 legacy wrapper to the V1 version of the component. Here's more [context](https://github.com/WordPress/gutenberg/pull/30557) to why the V1 stops event propagation.

> [!NOTE]  
> I personally think that this behaviour is non-standard and shouldn't be retained for the V2 (non-legacy) version of the component.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Introduced a way for the internal V2 implementation to know whether its consumer is "legacy" or not
- when in "legacy" mode, stopped `keydown` event propagation on the select dropdown
- restored legacy V2 unit tests that make sure that the V2 legacy wrapper behaves like the V1 component

> [!Tip]  
> The "legacy" flag introduced in this PR can be further explored to trigger more differences in behaviour and styles as we further define specs of the V2 (non-legacy) version.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Make sure that the un-skipped unit test for the V2 legacy wrapper passes
- In Storybook:
  1. Load the default Storybook example for the V2 legacy wrapper
  2. Open the select dropdown and press the "S" key — the "Small" element should be highlighted, but the Storybook sidebar should not toggle its opened/closed state
  3. The same should be true when testing the V1 version of the component
  4. Do the same on the `trunk` version of Storybook for the V2 legacy wrapper, and notice how the sidebar toggles between opened and closed

