### PR TITLE
Fix second scrollbar when editing patterns in the post editor

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -31,11 +31,13 @@ body.js.block-editor-page {
 	}
 }
 
-// Target the editor UI excluding the visual editor contents, metaboxes and custom fields areas.
+// Target the editor UI excluding the non-iframed visual editor contents, metaboxes
+//  and custom fields areas.
 .editor-header,
 .editor-text-editor,
 .editor-sidebar,
-.editor-post-publish-panel {
+.editor-post-publish-panel,
+.edit-post-visual-editor.is-iframed {
 	@include reset;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Two scrollbars can appear in the post editor when editing patterns.

## Why?
In the site editor `box-sizing: border-box` is applied universally by a reset rule which results in the site editor not having this issue:
https://github.com/WordPress/gutenberg/blob/1998f1f9837dca4e5186198b4e45565c97fc3245/packages/edit-site/src/style.scss#L69-L70

In the post editor, the same reset rule is applied more carefully to ensure reset styles don't leak into the non-iframed editor:
https://github.com/WordPress/gutenberg/blob/1998f1f9837dca4e5186198b4e45565c97fc3245/packages/edit-post/src/style.scss#L34-L40

Because of this, the `.edit-post-visual-editor` element doesn't have `box-sizing: border-box` and its padding can cause an overflow.

## How?
To fix it, I've added `.edit-post-visual-editor.is-iframed` to the list of elements that receive the reset styles.

Unfortunately there are still other issues, like the scrollbar reappearing when there's a notice and the custom fields UI being incorrectly positions, but I'll save those for issues.

## Testing Instructions
1. Open the post editor and insert a synced pattern or create a new one (add some blocks, select them and choose 'Create pattern' from the block settings menu)
2. Select 'Edit original' from the block toolbar to edit the pattern
3. Add enough blocks to the pattern to cause a scrollbar

Expected: there's only one scrollbar

## Screenshots or screencast <!-- if applicable -->
Before: 
![Screenshot 2024-06-27 at 3 54 37 pm](https://github.com/WordPress/gutenberg/assets/677833/2ca67f18-d90d-4dfd-8ea0-6c6fe80a9aae)

After: 
![Screenshot 2024-06-27 at 3 53 46 pm](https://github.com/WordPress/gutenberg/assets/677833/27ab2082-4d06-4cef-b2b0-0330bdf8b7f5)
