### PR TITLE
Fix variable name in color directive example for Interactivity API

### DIFF
--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -231,7 +231,7 @@ const directivePriorities: Record< string, number > = {};
  * ```js
  * directive(
  *   'color', // Name without prefix and suffix.
- *   ( { directives: { color }, ref, evaluate } ) =>
+ *   ( { directives: { color: colors }, ref, evaluate } ) =>
  *     colors.forEach( ( color ) => {
  *       if ( color.suffix = 'text' ) {
  *         ref.style.setProperty(


### PR DESCRIPTION
## What?
This PR corrects a variable name in the color directive example code for the Interactivity API.

## Why?
The current example code contains a minor error where 'color' is used instead of 'colors' in the destructured parameter. This could lead to confusion for developers trying to implement the color directive. By fixing this, I ensure that the documentation accurately reflects the correct usage of the API.

## How?
The implementation involves a simple change in the example code:
- Changed `{ directives: { color } }` to `{ directives: { color: colors } }` in the destructured parameter of the directive function.
- Path is `packages/interactivity/src/hooks.tsx` line 234.

## Testing Instructions

### Testing Instructions for Keyboard

## Screenshots or screencast
