### PR TITLE
Update block.json schema

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -294,12 +294,12 @@
 						},
 						"heading": {
 							"type": "boolean",
-							"description": "This property adds block controls which allow the user to set heading colors in a block, heading color is disabled by default.\n\nHeading color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.heading, its attributes definition is extended to include the style attribute",
+							"description": "This property adds block controls which allow the user to set heading colors in a block. Heading color is disabled by default.\n\nHeading color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.heading, its attributes definition is extended to include the style attribute",
 							"default": false
 						},
 						"button": {
 							"type": "boolean",
-							"description": "This property adds block controls which allow the user to set button colors in a block, button color is disabled by default.\n\nButton color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.heading, its attributes definition is extended to include the style attribute",
+							"description": "This property adds block controls which allow the user to set button colors in a block. Button color is disabled by default.\n\nButton color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.button, its attributes definition is extended to include the style attribute",
 							"default": false
 						},
 						"enableContrastChecker": {
@@ -342,6 +342,22 @@
 						"duotone": {
 							"type": "boolean",
 							"description": "Allow blocks to define a duotone filter.",
+							"default": false
+						}
+					}
+				},
+				"background": {
+					"type": "object",
+					"description": "This value signals that a block supports some of the CSS style properties related to background. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific background property, its attributes definition is extended to include the style attribute.",
+					"properties": {
+						"backgroundImage": {
+							"type": "boolean",
+							"description": "Allow blocks to define a background image.",
+							"default": false
+						},
+						"backgroundSize": {
+							"type": "boolean",
+							"description": "Allow blocks to define values related to the size of a background image, including size, position, and repeat controls",
 							"default": false
 						}
 					}
@@ -466,6 +482,11 @@
 									"type": "boolean",
 									"description": "For the `flex` layout type only, determines display of the orientation control in the block toolbar.",
 									"default": true
+								},
+								"allowCustomContentAndWideSize": {
+									"type": "boolean",
+									"description": "For the `constrained` layout type only, determines display of the custom content and wide size controls in the block sidebar.",
+									"default": true
 								}
 							}
 						}
@@ -556,10 +577,12 @@
 					}
 				},
 				"shadow": {
+					"default": false,
 					"description": "Allow blocks to define a box shadow.",
 					"oneOf": [
 						{
-							"type": "boolean"
+							"type": "boolean",
+							"description": "Defines whether a box shadow is enabled or not."
 						},
 						{
 							"type": "object"
@@ -581,6 +604,31 @@
 							"default": false
 						}
 					}
+				},
+				"interactivity": {
+					"description": "Indicates if the block is using Interactivity API features.",
+					"oneOf": [
+						{
+							"type": "boolean",
+							"description": "Indicates whether the block is using the Interactivity API directives.",
+							"default": false
+						},
+						{
+							"type": "object",
+							"properties": {
+								"clientNavigation": {
+									"type": "boolean",
+									"description": "Indicates whether a block is compatible with the Interactivity API client-side navigation.\n\nSet it to true only if the block is not interactive or if it is interactive using the Interactivity API. Set it to false if the block is interactive but uses vanilla JS, jQuery or another JS framework/library other than the Interactivity API.",
+									"default": false
+								},
+								"interactive": {
+									"type": "boolean",
+									"description": "Indicates whether the block is using the Interactivity API directives.",
+									"default": false
+								}
+							}
+						}
+					]
 				}
 			},
 			"additionalProperties": true
@@ -681,31 +729,6 @@
 							}
 						}
 					]
-				},
-				"interactivity": {
-					"description": "Indicates if the block is using Interactivity API features.",
-					"oneOf": [
-						{
-							"type": "boolean",
-							"description": "Indicates whether the block is using the Interactivity API directives.",
-							"default": false
-						},
-						{
-							"type": "object",
-							"properties": {
-								"clientNavigation": {
-									"type": "boolean",
-									"description": "Indicates whether a block is compatible with the Interactivity API client-side navigation.\n\nSet it to true only if the block is not interactive or if it is interactive using the Interactivity API. Set it to false if the block is interactive but uses vanilla JS, jQuery or another JS framework/library other than the Interactivity API.",
-									"default": false
-								},
-								"interactive": {
-									"type": "boolean",
-									"description": "Indicates whether the block is using the Interactivity API directives.",
-									"default": false
-								}
-							}
-						}
-					]
 				}
 			}
 		},
@@ -789,6 +812,20 @@
 		},
 		"viewScript": {
 			"description": "Block type frontend script definition. It will be enqueued only when viewing the content on the front of the site.",
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			]
+		},
+		"viewScriptModule": {
+			"description": "Block type frontend script module definition. It will be enqueued only when viewing the content on the front of the site.",
 			"oneOf": [
 				{
 					"type": "string"


### PR DESCRIPTION
> [!NOTE]
> This PR is not for the `trunk` branch. It is for fixing a block.json schema issue in the **WP 6.5** branch.

## What?
This PR is to fix missing fields, inconsistencies, etc. in block.json schema in WP6.5.

## How?

I looked at the diff between the two branches, `wp/6.5` and `WP/6.6` (see [this comment](https://github.com/WordPress/gutenberg/issues/62780#issuecomment-2194152994)) and added missing fields and fixed existing fields.

The fields that were changed, why they were changed, and the associated PR are below.

- `supports.color.heading`, `supports.color.button`: Fix description grammar
  - #59862
- `supports.background`: Add missing fields
  - #53934
  - #57005
  - #59127
- `supports.layout.allowCustomContentAndWideSize`: Add missing fields
  - #56236
  - #59736
- `supports.shadow`: Adding default value and description
  - #58306
  - #58910
- `supports.interactivity`: The location is incorrect
  - #58132
  - #59166
- `viewScriptModule`: Add missing fields
  - #58203
  - #59060

## Testing Instructions

Create a JSON file like the one below:

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/6.5-fix-block-json-schema/schemas/json/block.json"
}
```

The code editor should now correctly display the changes made in this PR.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/54422211/7d455401-524b-47e1-8068-42d809a90a03)

