### PR TITLE
Patterns: Avoid mapping template parts objects to patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -31,6 +31,7 @@ import { useEntityRecords } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { parse } from '@wordpress/blocks';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -54,6 +55,7 @@ import PatternsHeader from './header';
 import { useLink } from '../routes/link';
 import { useAddedBy } from '../page-templates/hooks';
 import { useEditPostAction } from '../dataviews-actions';
+import { defaultGetTitle } from './search-items';
 
 const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis
@@ -201,8 +203,7 @@ function Title( { item } ) {
 		postId: isUserPattern || isTemplatePart ? item.id : item.name,
 		canvas: 'edit',
 	} );
-	const title =
-		typeof item.title === 'string' ? item.title : item.title.rendered;
+	const title = decodeEntities( defaultGetTitle( item ) );
 	return (
 		<HStack alignment="center" justify="flex-start" spacing={ 2 }>
 			<Flex

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -120,7 +120,7 @@ function Preview( { item, viewType } ) {
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const { onClick } = useLink( {
 		postType: item.type,
-		postId: isUserPattern ? item.id : item.name,
+		postId: isUserPattern || isTemplatePart ? item.id : item.name,
 		canvas: 'edit',
 	} );
 	const blocks = useMemo( () => {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -418,7 +418,7 @@ export default function DataviewsPatterns() {
 					fields={ fields }
 					actions={ actions }
 					data={ data || EMPTY_ARRAY }
-					getItemId={ ( item ) => item.name }
+					getItemId={ ( item ) => item.name ?? item.id }
 					isLoading={ isResolving }
 					view={ view }
 					onChangeView={ onChangeView }

--- a/packages/edit-site/src/components/page-patterns/search-items.js
+++ b/packages/edit-site/src/components/page-patterns/search-items.js
@@ -20,11 +20,14 @@ import {
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,
 	PATTERN_TYPES,
+	TEMPLATE_PART_POST_TYPE,
 } from '../../utils/constants';
 
 // Default search helpers.
-const defaultGetName = ( item ) => item.name || '';
-const defaultGetTitle = ( item ) => item.title;
+const defaultGetName = ( item ) =>
+	item.type !== TEMPLATE_PART_POST_TYPE ? item.name || '' : '';
+const defaultGetTitle = ( item ) =>
+	typeof item.title === 'string' ? item.title : item.title.rendered;
 const defaultGetDescription = ( item ) => item.description || '';
 const defaultGetKeywords = ( item ) => item.keywords || [];
 const defaultHasCategory = () => false;

--- a/packages/edit-site/src/components/page-patterns/search-items.js
+++ b/packages/edit-site/src/components/page-patterns/search-items.js
@@ -26,7 +26,7 @@ import {
 // Default search helpers.
 const defaultGetName = ( item ) =>
 	item.type !== TEMPLATE_PART_POST_TYPE ? item.name || '' : '';
-const defaultGetTitle = ( item ) =>
+export const defaultGetTitle = ( item ) =>
 	typeof item.title === 'string' ? item.title : item.title.rendered;
 const defaultGetDescription = ( item ) => item.description || '';
 const defaultGetKeywords = ( item ) => item.keywords || [];

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -53,8 +53,7 @@ function isTemplateRemovable( template ) {
 	// than the one returned from the endpoint. This is why we need to check for
 	// two props whether is custom or has a theme file.
 	return (
-		[ template?.source ].includes( TEMPLATE_ORIGINS.custom ) &&
-		! template.has_theme_file &&
+		template?.source === TEMPLATE_ORIGINS.custom &&
 		! template?.has_theme_file
 	);
 }

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -61,7 +61,10 @@ function isTemplateRemovable( template ) {
 const canDeleteOrReset = ( item ) => {
 	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
 	const isUserPattern = item.type === PATTERN_TYPES.user;
-	return isUserPattern || ( isTemplatePart && item.isCustom );
+	return (
+		isUserPattern ||
+		( isTemplatePart && item.source === TEMPLATE_ORIGINS.custom )
+	);
 };
 
 function getItemTitle( item ) {
@@ -629,8 +632,7 @@ const renamePostAction = {
 		// two props whether is custom or has a theme file.
 		const isCustomPattern =
 			isUserPattern ||
-			( isTemplatePart &&
-				( post.isCustom || post.source === TEMPLATE_ORIGINS.custom ) );
+			( isTemplatePart && post.source === TEMPLATE_ORIGINS.custom );
 		const hasThemeFile = post?.has_theme_file;
 		return isCustomPattern && ! hasThemeFile;
 	},

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1040,9 +1040,7 @@ export const duplicateTemplatePartAction = {
 				sprintf(
 					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
 					__( '"%s" duplicated.' ),
-					typeof item.title === 'string'
-						? item.title
-						: item.title.rendered
+					getItemTitle( item )
 				),
 				{ type: 'snackbar', id: 'edit-site-patterns-success' }
 			);

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1053,7 +1053,7 @@ export const duplicateTemplatePartAction = {
 				defaultTitle={ sprintf(
 					/* translators: %s: Existing template part title */
 					__( '%s (Copy)' ),
-					item.title
+					getItemTitle( item )
 				) }
 				onCreate={ onTemplatePartSuccess }
 				onError={ closeModal }

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -370,9 +370,7 @@ export const revertTemplate =
 export const removeTemplates =
 	( items ) =>
 	async ( { registry } ) => {
-		const isResetting = items.every(
-			( item ) => !! item && item.has_theme_file
-		);
+		const isResetting = items.every( ( item ) => item?.has_theme_file );
 
 		const promiseResult = await Promise.allSettled(
 			items.map( ( item ) => {

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -371,10 +371,7 @@ export const removeTemplates =
 	( items ) =>
 	async ( { registry } ) => {
 		const isResetting = items.every(
-			( item ) =>
-				!! item &&
-				( item.has_theme_file ||
-					( item.templatePart && item.templatePart.has_theme_file ) )
+			( item ) => !! item && item.has_theme_file
 		);
 
 		const promiseResult = await Promise.allSettled(

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -81,7 +81,7 @@ test.describe( 'Site editor url navigation', () => {
 			.getByRole( 'region', {
 				name: 'Patterns content',
 			} )
-			.getByLabel( 'header', { exact: true } )
+			.getByText( 'header', { exact: true } )
 			.click();
 		await expect(
 			page.getByRole( 'region', { name: 'Editor content' } )


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/59659
Unblocks #62913 

## What?

When working on a the dataviews extensibility actions. I noticed that some of the post type actions receive objects that are not actual post types, they are temporary objects that were created for the purpose of rendering template parts in the patterns page. We were mapping template parts to weird objects that resemble patterns.

For me this is not something we should be doing because:

 - We'll be creating temporary objects whose type is very unclear.
 - the actions are supposed to be generic and used both in dataviews and also in the editor. Which means that sometimes they get the normal templatePart object. I think there's a high chance that some of the actions are currently broken in the editor in trunk because of this.

## How?

This PR just removes that mapping and tries to update all the places where that mapping was necessary. The code is a bit hard to follow, so there's a chance that I missed some places. Some help testing everything is needed.

Unrelated: I was not able to test the template parts actions menu in the editor because I was not able to open template parts in the editor (I'll investigate this separately)

**Note** I noticed that there's also mapping happening between registered patterns (theme patterns) and saved patterns (user patterns). I think for these as well, we should be removing the mapping.

## Testing Instructions

1- Use the different filters, fields and actions in the template parts dataviews. 
