### PR TITLE
ApiFetch: Remove i18n package dependency

### DIFF
--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Remove dependency on `@wordpress/i18n` ([#tbd](tbd)).
+
 ## 7.2.0 (2024-06-26)
 
 ## 7.1.0 (2024-06-15)

--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Remove dependency on `@wordpress/i18n` ([#tbd](tbd)).
+-   Remove dependency on `@wordpress/i18n` ([#62934](https://github.com/WordPress/gutenberg/pull/62934)).
 
 ## 7.2.0 (2024-06-26)
 

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -29,7 +29,6 @@
 	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url"
 	},
 	"publishConfig": {

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import createNonceMiddleware from './middlewares/nonce';
@@ -128,7 +123,7 @@ const defaultFetchHandler = ( nextOptions ) => {
 			// Unfortunately the message might depend on the browser.
 			throw {
 				code: 'fetch_error',
-				message: __( 'You are probably offline.' ),
+				message: 'You are probably offline.',
 			};
 		}
 	);

--- a/packages/api-fetch/src/middlewares/media-upload.js
+++ b/packages/api-fetch/src/middlewares/media-upload.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import {
@@ -75,9 +70,8 @@ const mediaUploadMiddleware = ( options, next ) => {
 					if ( options.parse !== false ) {
 						return Promise.reject( {
 							code: 'post_process',
-							message: __(
-								'Media upload failed. If this is a photo or a large image, please scale it down and try again.'
-							),
+							message:
+								'Media upload failed. If this is a photo or a large image, please scale it down and try again.',
 						} );
 					}
 

--- a/packages/api-fetch/src/utils/response.js
+++ b/packages/api-fetch/src/utils/response.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Parses the apiFetch response.
  *
  * @param {Response} response
@@ -33,7 +28,7 @@ const parseResponse = ( response, shouldParseResponse = true ) => {
 const parseJsonAndNormalizeError = ( response ) => {
 	const invalidJsonError = {
 		code: 'invalid_json',
-		message: __( 'The response is not a valid JSON response.' ),
+		message: 'The response is not a valid JSON response.',
 	};
 
 	if ( ! response || ! response.json ) {
@@ -77,7 +72,7 @@ export function parseAndThrowError( response, shouldParseResponse = true ) {
 	return parseJsonAndNormalizeError( response ).then( ( error ) => {
 		const unknownError = {
 			code: 'unknown_error',
-			message: __( 'An unknown error occurred.' ),
+			message: 'An unknown error occurred.',
 		};
 
 		throw error || unknownError;

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -5,7 +5,7 @@
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},
-	"references": [ { "path": "../i18n" }, { "path": "../url" } ],
+	"references": [ { "path": "../url" } ],
 	"include": [ "src/**/*" ],
 	"exclude": [ "**/test/**/*" ]
 }


### PR DESCRIPTION

## What?

Remove `api-fetch` package's dependency on `i18n`.

## Why?

The primary reason to remove this is to unblock work on an api-fetch module: https://core.trac.wordpress.org/ticket/60647

This package is for making api calls and there's not a strong motivation to localize most strings. None of the localized texts are end-user-facing. This dependency was only used to localize error messages targeted at developers. Other packages, for example hooks, do not localize these types of messages:

https://github.com/WordPress/gutenberg/blob/fe67010143b20d23349051e80110aa1424e79999/packages/hooks/src/validateHookName.js#L19

Every dependency may increase the amount of JavaScript required on the client, so removing a dependency like this may improve the performance of sites using `apiFetch`.


## How?

Remove the i18n dependency and use static strings instead of localized ones.

## Testing Instructions
CI passes.
