### PR TITLE
Login/out block: Add example of the block

### DIFF
--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -17,6 +17,9 @@
 			"default": true
 		}
 	},
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"className": true,
 		"spacing": {

--- a/packages/block-library/src/loginout/index.js
+++ b/packages/block-library/src/loginout/index.js
@@ -16,6 +16,9 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {
+		viewportWidth: 350,
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/loginout/index.js
+++ b/packages/block-library/src/loginout/index.js
@@ -16,9 +16,6 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
-	example: {
-		viewportWidth: 350,
-	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a basic example to the `core/loginout` block.

Part of https://github.com/WordPress/gutenberg/issues/30029

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because it was showing empty before

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I define a viewport size for the example

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the block inserter and search for the login block, hover over it and you'll see the example

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


<img width="683" alt="Screenshot 2024-06-27 at 19 03 46" src="https://github.com/WordPress/gutenberg/assets/3593343/e46a8959-8b8e-48e2-b2d5-76940b2f798a">
