### PR TITLE
Post editor: Fix triple scrollbars in device previews

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,8 +1,3 @@
-.editor-visual-editor {
-	flex: 1 0 auto;
-	height: auto;
-}
-
 .edit-post-layout__metaboxes {
 	flex-shrink: 0;
 	clear: both;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,3 +1,8 @@
+.edit-post-layout.has-metaboxes .edit-post-visual-editor {
+	flex: 1 0 auto;
+	height: auto;
+}
+
 .edit-post-layout__metaboxes {
 	flex-shrink: 0;
 	clear: both;


### PR DESCRIPTION
## What?
Fixes #62911

A fix for a regression in the Post editor where device previews create three scrolling areas.

## Why?
In WP 6.5 device previews in the Post editor don’t have three scrolling areas.

## How?
Revises a selector to more selectively apply some styles that cause the issue. The styles appear to only be helpful when metaboxes are present.

## Testing Instructions
1. Open the Post editor
2. Select either "Tablet" or "Mobile" preview
3. If the Device preview is shorter than your browser’s viewport, shorten the browser window until it does not contain the full height of the device preview.
4. Observe there are only two scrollbars

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="990" alt="image" src="https://github.com/WordPress/gutenberg/assets/9000376/2bafb27c-0fd6-46d5-a2fb-694c3a71349d">

### After
<img width="990" alt="image" src="https://github.com/WordPress/gutenberg/assets/9000376/9fbdf5ed-b193-4d60-8f32-0ce55f0e5d0d">

## More about the issue
As best I can tell this came about from introducing the "Zoom out" experiment. While that is still an experiment it did introduce markup and style changes that are present even when not opting into the experiment. Testing [WP nightly in playground](https://playground.wordpress.net/?php=8.0&wp=nightly&storage=none) I can reproduce the issue:
<img width="1280" alt="image" src="https://github.com/WordPress/gutenberg/assets/9000376/a4afa0a6-31d2-401a-9afb-8694cbde5ba9">
