### PR TITLE
Fix typo to be preposition, not verb, in some package comments and documentations

### DIFF
--- a/packages/components/src/higher-order/with-spoken-messages/index.tsx
+++ b/packages/components/src/higher-order/with-spoken-messages/index.tsx
@@ -7,7 +7,7 @@ import { speak } from '@wordpress/a11y';
 /** @typedef {import('react').ComponentType} ComponentType */
 
 /**
- * A Higher Order Component used to be provide speak and debounced speak
+ * A Higher Order Component used to provide speak and debounced speak
  * functions.
  *
  * @see https://developer.wordpress.org/block-editor/packages/packages-a11y/#speak

--- a/packages/components/src/higher-order/with-spoken-messages/index.tsx
+++ b/packages/components/src/higher-order/with-spoken-messages/index.tsx
@@ -7,8 +7,7 @@ import { speak } from '@wordpress/a11y';
 /** @typedef {import('react').ComponentType} ComponentType */
 
 /**
- * A Higher Order Component used to provide speak and debounced speak
- * functions.
+ * A Higher Order Component used to provide speak and debounced speak functions.
  *
  * @see https://developer.wordpress.org/block-editor/packages/packages-a11y/#speak
  *

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -602,7 +602,7 @@ _Returns_
 
 ### withInstanceId
 
-A Higher Order Component used to be provide a unique instance ID by component.
+A Higher Order Component used to provide a unique instance ID by component.
 
 ### withSafeTimeout
 

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -11,7 +11,7 @@ import useInstanceId from '../../hooks/use-instance-id';
 type InstanceIdProps = { instanceId: string | number };
 
 /**
- * A Higher Order Component used to be provide a unique instance ID by
+ * A Higher Order Component used to provide a unique instance ID by
  * component.
  */
 const withInstanceId = createHigherOrderComponent(

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -11,8 +11,7 @@ import useInstanceId from '../../hooks/use-instance-id';
 type InstanceIdProps = { instanceId: string | number };
 
 /**
- * A Higher Order Component used to provide a unique instance ID by
- * component.
+ * A Higher Order Component used to provide a unique instance ID by component.
  */
 const withInstanceId = createHigherOrderComponent(
 	< C extends WithInjectedProps< C, InstanceIdProps > >(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix typos

## Why?
For excellence!

## How?
Using ed(1), the standard text editor. 

## Testing Instructions
Look at the words and see if they make sense.