### PR TITLE
Ensure disable overrides button is active for image blocks with captions or links

### DIFF
--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -44,7 +44,7 @@ function PatternOverridesControls( {
 
 	const hasName = !! attributes.metadata?.name;
 	const defaultBindings = attributes.metadata?.bindings?.__default;
-	const allowOverrides =
+	const hasOverrides =
 		hasName && defaultBindings?.source === PATTERN_OVERRIDES_BINDING_SOURCE;
 	const isConnectedToOtherSources =
 		defaultBindings?.source &&
@@ -79,13 +79,14 @@ function PatternOverridesControls( {
 		blockName === 'core/image' &&
 		( !! attributes.caption?.length || !! attributes.href?.length );
 
-	const helpText = hasUnsupportedImageAttributes
-		? __(
-				`Overrides currently don't support image captions or links. Remove the caption or link first before enabling overrides.`
-		  )
-		: __(
-				'Allow changes to this block throughout instances of this pattern.'
-		  );
+	const helpText =
+		! hasOverrides && hasUnsupportedImageAttributes
+			? __(
+					`Overrides currently don't support image captions or links. Remove the caption or link first before enabling overrides.`
+			  )
+			: __(
+					'Allow changes to this block throughout instances of this pattern.'
+			  );
 
 	return (
 		<>
@@ -101,16 +102,18 @@ function PatternOverridesControls( {
 						variant="secondary"
 						aria-haspopup="dialog"
 						onClick={ () => {
-							if ( allowOverrides ) {
+							if ( hasOverrides ) {
 								setShowDisallowOverridesModal( true );
 							} else {
 								setShowAllowOverridesModal( true );
 							}
 						} }
-						disabled={ hasUnsupportedImageAttributes }
+						disabled={
+							! hasOverrides && hasUnsupportedImageAttributes
+						}
 						__experimentalIsFocusable
 					>
-						{ allowOverrides
+						{ hasOverrides
 							? __( 'Disable overrides' )
 							: __( 'Enable overrides' ) }
 					</Button>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In #62747, the 'Enable Overrides' button was disabled for image blocks with captions or links within patterns, as they're not supported:
![Screenshot 2024-06-28 at 12 37 09 pm](https://github.com/WordPress/gutenberg/assets/677833/f5ce5711-ea81-42b7-9575-a198b479a4b1)

The code for this change also incorrectly applies the same treatment to the 'Disable overrides' version of the button when such a block already has overrides (a user would've been able to add these in the gutenberg plugin or WP6.6 beta before that PR was merged):
![Screenshot 2024-06-28 at 12 39 08 pm](https://github.com/WordPress/gutenberg/assets/677833/5d7b1e80-08e9-499f-9088-bfa4bee6d262)

These users should still be able to remove overrides.

## How?
Makes a small adjustment to the conditions for the button to also check the `hasOverrides` variable.

## Testing Instructions
1. Create a synced pattern
2. Switch to the code editor mode and add the following markup:
```html
<!-- wp:image {"aspectRatio":"16/9","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://pd.w.org/2023/07/44364b18862589f06.53436652.jpg" alt="" style="aspect-ratio:16/9;object-fit:cover"/><figcaption class="wp-element-caption">Test</figcaption></figure>
<!-- /wp:image -->
<!-- wp:image {"aspectRatio":"16/9","scale":"cover","sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"image"}} -->
<figure class="wp-block-image size-large"><img src="https://pd.w.org/2023/07/44364b18862589f06.53436652.jpg" alt="" style="aspect-ratio:16/9;object-fit:cover"/><figcaption class="wp-element-caption">Test</figcaption></figure>
<!-- /wp:image -->
```
3. Select the first image block. It doesn't have overrides enabled, but because it has captions it should show this button in the advanced inspector tools:
![Screenshot 2024-06-28 at 12 53 40 pm](https://github.com/WordPress/gutenberg/assets/677833/a0656f4a-d377-4374-a432-a1a4685ff9db)
4. Select the first image block. It *does* have overrides enabled and even though it has captions it allows disabling overrides in the advanced inspector tools:
![Screenshot 2024-06-28 at 12 55 08 pm](https://github.com/WordPress/gutenberg/assets/677833/8b800d12-2db5-4768-9ef5-05554b18b89a)