### PR TITLE
List: maintain nested list on parent item removal

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -90,20 +90,25 @@ export default function useMerge( clientId, onMerge ) {
 				// also need to move any nested list items. Check if there's a
 				// listed list, and append its nested list items to the current
 				// list.
-				const [ nestedListClientIdB ] = getBlockOrder( clientIdB );
-				if ( nestedListClientIdB ) {
-					const [ nestedListClientIdA ] = getBlockOrder( clientIdA );
-					if ( ! nestedListClientIdA ) {
+				const [ nestedListClientId ] = getBlockOrder( clientIdB );
+				if ( nestedListClientId ) {
+					// If we are merging with the previous list item, and the
+					// previous list item does not have nested list, move the
+					// nested list to the previous list item.
+					if (
+						getPreviousBlockClientId( clientIdB ) === clientIdA &&
+						! getBlockOrder( clientIdA ).length
+					) {
 						moveBlocksToPosition(
-							[ nestedListClientIdB ],
+							[ nestedListClientId ],
 							clientIdB,
 							clientIdA
 						);
 					} else {
 						moveBlocksToPosition(
-							getBlockOrder( nestedListClientIdB ),
-							nestedListClientIdB,
-							nestedListClientIdA
+							getBlockOrder( nestedListClientId ),
+							nestedListClientId,
+							getBlockRootClientId( clientIdA )
 						);
 					}
 				}

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -90,13 +90,22 @@ export default function useMerge( clientId, onMerge ) {
 				// also need to move any nested list items. Check if there's a
 				// listed list, and append its nested list items to the current
 				// list.
-				const [ nestedListClientId ] = getBlockOrder( clientIdB );
-				if ( nestedListClientId ) {
-					moveBlocksToPosition(
-						getBlockOrder( nestedListClientId ),
-						nestedListClientId,
-						getBlockRootClientId( clientIdA )
-					);
+				const [ nestedListClientIdB ] = getBlockOrder( clientIdB );
+				if ( nestedListClientIdB ) {
+					const [ nestedListClientIdA ] = getBlockOrder( clientIdA );
+					if ( ! nestedListClientIdA ) {
+						moveBlocksToPosition(
+							[ nestedListClientIdB ],
+							clientIdB,
+							clientIdA
+						);
+					} else {
+						moveBlocksToPosition(
+							getBlockOrder( nestedListClientIdB ),
+							nestedListClientIdB,
+							nestedListClientIdA
+						);
+					}
 				}
 				mergeBlocks( clientIdA, clientIdB );
 			} );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1549,4 +1549,64 @@ test.describe( 'List (@firefox)', () => {
 			await expect.poll( editor.getBlocks ).toMatchObject( end );
 		} );
 	} );
+
+	test( 'should leave nested list intact when deleting the parent item', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/list',
+			innerBlocks: [
+				{
+					name: 'core/list-item',
+					attributes: { content: '1' },
+				},
+				{
+					name: 'core/list-item',
+					attributes: { content: '' },
+					innerBlocks: [
+						{
+							name: 'core/list',
+							innerBlocks: [
+								{
+									name: 'core/list-item',
+									attributes: { content: 'a' },
+								},
+							],
+						},
+					],
+				},
+				{ name: 'core/list-item', attributes: { content: '3' } },
+			],
+		} );
+
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: '1' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'a' },
+									},
+								],
+							},
+						],
+					},
+					{ name: 'core/list-item', attributes: { content: '3' } },
+				],
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Best reviewed [without whitespace changes](https://github.com/WordPress/gutenberg/pull/62949/files?diff=split&w=1).

Currently, when removing a parent item, the nested list items are appended at the bottom of the list instead of preserved at the position.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Note that right now, in trunk, not only does the indentation disappear, the indented list item is also moved to the bottom! If you have a long nested list, it feels like your content _disappears_.

|Before|After|
|-|-|
|![list-before](https://github.com/WordPress/gutenberg/assets/4710635/4bc7ff33-f655-4316-b675-8822b72289af)|![list-after](https://github.com/WordPress/gutenberg/assets/4710635/523971a1-dc8e-4fcf-a5e8-f49efa0a936a)|

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See GIF. Create this setup:

* 1
    *  
    * 2
* 3

And press Backspace twice from the empty list item.
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
