### PR TITLE
Ensure device previews extra scrollbar only appears when needed

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -11,6 +11,7 @@
 .block-editor-iframe__scale-container {
 	width: 100%;
 	height: 100%;
+	display: flex;
 }
 
 .block-editor-iframe__scale-container.is-zoomed-out {


### PR DESCRIPTION
## What?
A small improvement to go alongside #62940.

I noticed even though that PR removes the third scrollbar, there are still often two even when the device fully fits in the browser window, and scrolling the second one doesn't do anything useful.

## Why?
The issue seems to be with the `.block-editor-iframe__scale-container`, which always extends beyond the browser viewport when Mobile/Tablet view is active. 

## How?
I'm no css expert, but adding `display: flex` is an easy way to make it fit in the screen, with no obvious repercussions.

## Testing Instructions
1. Test both the post and the site editor with long post style content
2. Activate the mobile/tablet views ensuring your browser viewport is bigger than the views
3. Check that there's only one scrollbar alongside the content
4. Now reduce the size of your browser window to be smaller than the device view
5. A second scrollbar should appear allowing you to view the full device.

Also do a general smoke test of things like:
- Editing patterns
- Style book
- Code editor mode
- The Widget editor

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-06-28 at 3 38 47 pm](https://github.com/WordPress/gutenberg/assets/677833/6b2bb6d4-8f18-4541-aa63-be5c2b9dc8f3)
