### PR TITLE
Block categories - ensure that categories are unique by slug.

### DIFF
--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -329,11 +329,11 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 	switch ( action.type ) {
 		case 'SET_CATEGORIES':
 			// Ensure, that categories are unique by slug.
-			const categories = new Map();
-			(action.categories || []).forEach( (category) => {
-				categories.set(category.slug, category);
-			});
-			return [...categories.values()];
+			const uniqueCategories = new Map();
+			( action.categories || [] ).forEach( ( category ) => {
+				uniqueCategories.set( category.slug, category );
+			} );
+			return [ ...uniqueCategories.values() ];
 		case 'UPDATE_CATEGORY': {
 			if (
 				! action.category ||

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -328,7 +328,12 @@ export const groupingBlockName = createBlockNameSetterReducer(
 export function categories( state = DEFAULT_CATEGORIES, action ) {
 	switch ( action.type ) {
 		case 'SET_CATEGORIES':
-			return action.categories || [];
+			// Ensure, that categories are unique by slug.
+			const categories = new Map();
+			(action.categories || []).forEach( (category) => {
+				categories.set(category.slug, category);
+			});
+			return [...categories.values()];
 		case 'UPDATE_CATEGORY': {
 			if (
 				! action.category ||

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -420,6 +420,22 @@ describe( 'categories', () => {
 		expect( state ).toEqual( [ { slug: 'wings', title: 'Wings' } ] );
 	} );
 
+	it( 'should ensure, that categories are unique by slug', () => {
+		const original = deepFreeze( [
+			{ slug: 'chicken', title: 'Chicken' },
+		] );
+
+		const state = categories( original, {
+			type: 'SET_CATEGORIES',
+			categories: [ { slug: 'chicken', title: 'Another chicken' } ],
+		} );
+
+		expect( state ).toEqual( [
+			{ slug: 'chicken', title: 'Another chicken' },
+		] );
+		expect( state.length ).toBe( 1 );
+	} );
+
 	it( 'should add the category icon', () => {
 		const original = deepFreeze( [
 			{


### PR DESCRIPTION
Fixes #50061

## What?
Block categories can be registered through backend by hooking into the "block_categories_all"-filter or through frontend by calling `wp.blocks.setCategories()`. Both require an array of `WPBlockCategory` elements. This change aims for making the `categories: WPBlockCategory[]` with unique entries by slug to avoid rendering in Block Inserter all Blocks duplicated.

See also: #50061

----

## Testing Instructions
Go to "New Post" (or "Edit Post"), open DevTools and insert following:

```ts
const cateogries = wp.blocks.getCategories();
wp.blocks.setCategories( [
    ... cateogries, 
    ... [ {'slug':'theme', 'title': 'My title'}, {'slug':'theme', 'title': 'Meeeh'} ] 
);
```

Open afterwards the "Block Inserter". You will see now "Theme", "My Title" and "Meeeh" with exactly 3 times the same Blocks. With this fix we ensure, that only 1 Group is shown with the Blocks.


----

## Open Questions

Right now, the last entry "wins". Should we show a message ( `console.info()`?) when an entry is overwritten by a matching slug?