### PR TITLE
Block Bindings: Replace `useSelect` hook that calls no selectors with `useMemo`

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -109,7 +109,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 				),
 			[ props.attributes.metadata?.bindings, name ]
 		);
-		const boundAttributes = useSelect( () => {
+		const boundAttributes = useMemo( () => {
 			if ( ! bindings ) {
 				return;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small PR that updates what I think was originally a typo, replacing `useSelect` with `useMemo`

## Why?
I couldn't see any reason to use `useSelect`. Either the selectors were refactored away, or it was intended to be a `useMemo`.

## Testing Instructions
There's no impact, apart from maybe some very minor performance gains?
