### PR TITLE
Update method for changing the content in 'editor-modes' e2e test

### DIFF
--- a/test/e2e/specs/editor/various/editor-modes.spec.js
+++ b/test/e2e/specs/editor/various/editor-modes.spec.js
@@ -164,15 +164,9 @@ test.describe( 'Editing modes (visual/HTML)', () => {
 		// Open the code editor.
 		await pageUtils.pressKeys( 'secondary+M' );
 
-		const textbox = page.getByRole( 'textbox', {
-			name: 'Type text or HTML',
-		} );
-
-		// Change content by typing.
-		await textbox.fill( '' );
-		await textbox.focus();
-
-		await page.keyboard.type( `<!-- wp:paragraph -->
+		// Change the content.
+		await page.getByRole( 'textbox', { name: 'Type text or HTML' } )
+			.fill( `<!-- wp:paragraph -->
 <p>abc</p>
 <!-- /wp:paragraph -->` );
 


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/58841#discussion_r1592380820.

PR updates the method for changing the post content in a text editor and uses `locator.fill()`. This avoids parsing warnings generated by typing action.

## Why?
Reduces unnecessary noise generated by e2e tests, which might hide an actual issue.

## Testing Instructions
CI checks are green.
