### PR TITLE
Styles specificity: allow comment form input overrides

### DIFF
--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -1,3 +1,18 @@
+// Allow these default styles to be overridden by global styles.
+:where(.wp-block-post-comments-form) {
+	textarea,
+	input:not([type="submit"]) {
+		border: 1px solid $gray-600;
+		font-size: 1em;
+		font-family: inherit;
+	}
+
+	textarea,
+	input:not([type="submit"]):not([type="checkbox"]) {
+		padding: calc(0.667em + 2px); // The extra 2px is added to match outline buttons.
+	}
+}
+
 .wp-block-post-comments-form {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
@@ -29,18 +44,6 @@
 		display: inline-block;
 		text-align: center;
 		overflow-wrap: break-word;
-	}
-
-	textarea,
-	input:not([type="submit"]) {
-		border: 1px solid $gray-600;
-		font-size: 1em;
-		font-family: inherit;
-	}
-
-	textarea,
-	input:not([type="submit"]):not([type="checkbox"]) {
-		padding: calc(0.667em + 2px); // The extra 2px is added to match outline buttons.
 	}
 
 	.comment-form {

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -8,7 +8,7 @@
 	}
 
 	textarea,
-	input:not([type="submit"]):not([type="checkbox"]) {
+	input:where(:not([type="submit"]):not([type="checkbox"])) {
 		padding: calc(0.667em + 2px); // The extra 2px is added to match outline buttons.
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Similar to #63049.

See https://github.com/WordPress/gutenberg/issues/62679#issuecomment-2180421157

Apparently, global styles allows for overrides with completely custom CSS, which means comment form input and textarea CSS should be possible to override. The problem of course is that the global styles specificity is forced at 0-1-0, while the default styles are higher. This PR lowers them.

Knowing that basically any CSS property can be modified with global styles through custom CSS makes me wonder if we should reduce _all_ block styles to 0-1-0.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes remaining issue from #62679.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Lower specificity to 0-1-0.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Ensure this theme rule works:

```
:root :where(.wp-block-post-comments-form textarea, .wp-block-post-comments-form input) {
    border: 1px solid red;
}
```

<img width="1031" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/24b82286-1bfd-43ca-94ff-cccf5d6f9f2c">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
