### PR TITLE
Format Library: Clean up 'Highlight' format components

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { RichTextToolbarButton, useSettings } from '@wordpress/block-editor';
 import {
 	Icon,
@@ -66,21 +66,13 @@ function TextColorEdit( {
 		'color.palette'
 	);
 	const [ isAddingColor, setIsAddingColor ] = useState( false );
-	const enableIsAddingColor = useCallback(
-		() => setIsAddingColor( true ),
-		[ setIsAddingColor ]
-	);
-	const disableIsAddingColor = useCallback(
-		() => setIsAddingColor( false ),
-		[ setIsAddingColor ]
-	);
 	const colorIndicatorStyle = useMemo(
 		() =>
 			fillComputedColors(
 				contentRef.current,
 				getActiveColors( value, name, colors )
 			),
-		[ value, colors ]
+		[ contentRef, value, colors ]
 	);
 
 	const hasColorsToChoose = colors.length || ! allowCustomControl;
@@ -107,7 +99,7 @@ function TextColorEdit( {
 				// If has no colors to choose but a color is active remove the color onClick.
 				onClick={
 					hasColorsToChoose
-						? enableIsAddingColor
+						? () => setIsAddingColor( true )
 						: () => onChange( removeFormat( value, name ) )
 				}
 				role="menuitemcheckbox"
@@ -115,7 +107,7 @@ function TextColorEdit( {
 			{ isAddingColor && (
 				<InlineColorUI
 					name={ name }
-					onClose={ disableIsAddingColor }
+					onClose={ () => setIsAddingColor( false ) }
 					activeAttributes={ activeAttributes }
 					value={ value }
 					onChange={ onChange }

--- a/packages/format-library/src/text-color/index.native.js
+++ b/packages/format-library/src/text-color/index.native.js
@@ -7,7 +7,7 @@ import { StyleSheet, View } from 'react-native';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import {
 	BlockControls,
 	useSettings,
@@ -72,32 +72,16 @@ function TextColorEdit( {
 	const [ allowCustomControl ] = useSettings( 'color.custom' );
 	const colors = useMobileGlobalStylesColors();
 	const [ isAddingColor, setIsAddingColor ] = useState( false );
-	const enableIsAddingColor = useCallback(
-		() => setIsAddingColor( true ),
-		[ setIsAddingColor ]
-	);
-	const disableIsAddingColor = useCallback(
-		() => setIsAddingColor( false ),
-		[ setIsAddingColor ]
-	);
 	const colorIndicatorStyle = useMemo(
 		() =>
 			fillComputedColors(
 				contentRef,
 				getActiveColors( value, name, colors )
 			),
-		[ value, colors ]
+		[ contentRef, value, colors ]
 	);
 
 	const hasColorsToChoose = colors.length || ! allowCustomControl;
-
-	const onPressButton = useCallback( () => {
-		if ( hasColorsToChoose ) {
-			enableIsAddingColor();
-		} else {
-			onChange( removeFormat( value, name ) );
-		}
-	}, [ hasColorsToChoose, value ] );
 
 	const outlineStyle = [
 		usePreferredColorSchemeStyle(
@@ -153,14 +137,18 @@ function TextColorEdit( {
 							customContainerStyles,
 						} }
 						// If has no colors to choose but a color is active remove the color onClick
-						onClick={ onPressButton }
+						onClick={
+							hasColorsToChoose
+								? () => setIsAddingColor( true )
+								: () => onChange( removeFormat( value, name ) )
+						}
 					/>
 				</ToolbarGroup>
 			</BlockControls>
 			{ isAddingColor && (
 				<InlineColorUI
 					name={ name }
-					onClose={ disableIsAddingColor }
+					onClose={ () => setIsAddingColor( false ) }
 					activeAttributes={ activeAttributes }
 					value={ value }
 					onChange={ onChange }

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	applyFormat,
@@ -129,14 +129,6 @@ function ColorPicker( { name, property, value, onChange } ) {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().colors ?? [];
 	}, [] );
-	const onColorChange = useCallback(
-		( color ) => {
-			onChange(
-				setColors( value, name, colors, { [ property ]: color } )
-			);
-		},
-		[ colors, onChange, property ]
-	);
 	const activeColors = useMemo(
 		() => getActiveColors( value, name, colors ),
 		[ name, value, colors ]
@@ -145,7 +137,11 @@ function ColorPicker( { name, property, value, onChange } ) {
 	return (
 		<ColorPalette
 			value={ activeColors[ property ] }
-			onChange={ onColorChange }
+			onChange={ ( color ) => {
+				onChange(
+					setColors( value, name, colors, { [ property ]: color } )
+				);
+			} }
 		/>
 	);
 }


### PR DESCRIPTION
## What?
PR makes the following updates to the "Highlight" format components:

* Fix React ESLint warnings. These are always helpful, especially after we land #61788.
* Removes unnecessary callback memoization. None of the components require memoized callbacks.

## Why?
It's just a routine maintenance.

## Testing Instructions
1. Open a post or page.
2. Insert a paragraph block.
3. Add some text.
4. Confirm text highlighting works as before.

The feature also has test coverage.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-06-28 at 13 51 12](https://github.com/WordPress/gutenberg/assets/240569/2ef1a74b-d06d-45f7-a59f-1f6dea29f60c)