### PR TITLE
Post content block: Add example of the block

### DIFF
--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -7,6 +7,9 @@
 	"description": "Displays the contents of a post or page.",
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType", "queryId" ],
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a basic example to the `core/post-content` block.

Part of https://github.com/WordPress/gutenberg/issues/30029

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it was showing empty before

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I define a viewport size for the example

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the block inserter and search for the content block, hover over it and you'll see the example. This block is only available on the site editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="713" alt="Screenshot 2024-06-28 at 12 10 59" src="https://github.com/WordPress/gutenberg/assets/3593343/faeca7c1-4756-44ff-96ba-595166be413e">
