### PR TITLE
Fix UnitControl select disabled state colors

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- `UnitControl`: Fix colors when disabled. ([#62970](https://github.com/WordPress/gutenberg/pull/62970))
+### Bug Fixes
+
+-   `UnitControl`: Fix colors when disabled. ([#62970](https://github.com/WordPress/gutenberg/pull/62970))
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `UnitControl`: Fix colors when disabled. ([#62970](https://github.com/WordPress/gutenberg/pull/62970))
+
 ### Internal
 
 -   `CustomSelectControlV2`: add root element wrapper. ([#62803](https://github.com/WordPress/gutenberg/pull/62803))

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -114,7 +114,6 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 			align-items: center;
 
 			&:where( :not( :disabled ) ):hover {
-				color: ${ COLORS.ui.borderFocus };
 				box-shadow: inset 0 0 0
 					${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };
 				outline: ${ CONFIG.borderWidth } solid transparent; // For High Contrast Mode

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -113,7 +113,7 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 			justify-content: center;
 			align-items: center;
 
-			&:not( :disabled ):hover {
+			&:where( :not( :disabled ) ):hover {
 				color: ${ COLORS.ui.borderFocus };
 				box-shadow: inset 0 0 0
 					${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -40,12 +40,15 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 			box-sizing: border-box;
 			padding: 2px 1px;
 			width: 20px;
-			color: ${ COLORS.gray[ 800 ] };
 			font-size: 8px;
 			line-height: 1;
 			letter-spacing: -0.5px;
 			text-transform: uppercase;
 			text-align-last: center;
+
+			&:not( :disabled ) {
+				color: ${ COLORS.gray[ 800 ] };
+			}
 		`,
 		default: css`
 			box-sizing: border-box;
@@ -54,13 +57,17 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 			height: 24px;
 			margin-inline-end: ${ space( 2 ) };
 			padding: ${ space( 1 ) };
-			color: ${ COLORS.theme.accent };
+
 			font-size: 13px;
 			line-height: 1;
 			text-align-last: center;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
+
+			&:not( :disabled ) {
+				color: ${ COLORS.theme.accent };
+			}
 		`,
 	};
 
@@ -106,7 +113,7 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 			justify-content: center;
 			align-items: center;
 
-			&:hover {
+			&:not( :disabled ):hover {
 				color: ${ COLORS.ui.borderFocus };
 				box-shadow: inset 0 0 0
 					${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };


### PR DESCRIPTION
## What?
Fix UnitControl select disabled state colors

## Why?
Fixes: https://github.com/WordPress/gutenberg/issues/62969

## How?
Render the accent colors when the component is not disabled.

## Testing Instructions
See https://github.com/WordPress/gutenberg/issues/62969


## Screenshots or screencast <!-- if applicable -->

### Before
[Screencast from 28-06-24 14:41:30.webm](https://github.com/WordPress/gutenberg/assets/1310626/52bae4ca-4e9a-450d-816f-0b5f8f141ac6)

### After
[Screencast from 28-06-24 14:38:27.webm](https://github.com/WordPress/gutenberg/assets/1310626/0568089b-2910-4ae0-bc4f-dac28ef3b692)
