### PR TITLE
Data views list layout: Fix action alignment

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -448,7 +448,7 @@
 		&.is-hovered,
 		&:focus-within {
 			.dataviews-view-list__item-actions {
-				padding-right: $grid-unit-40;
+				padding-right: $grid-unit-30;
 
 				.components-button {
 					opacity: 1;


### PR DESCRIPTION
## What?
Update the alignment of action icons in list layout so that they align with other icon buttons (view options & pagination).

| Before | After |
| --- | --- |
| <img width="432" alt="Screenshot 2024-06-28 at 12 12 01" src="https://github.com/WordPress/gutenberg/assets/846565/b509d579-8f7e-49db-beea-10942eba865d"> | <img width="433" alt="Screenshot 2024-06-28 at 12 12 08" src="https://github.com/WordPress/gutenberg/assets/846565/5734e4a3-3a28-4767-9a55-47e8c1fb8b63"> |
