### PR TITLE
Components: Fix the 'useUpdateEffect' hook in strict mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `UnitControl`: Fix colors when disabled. ([#62970](https://github.com/WordPress/gutenberg/pull/62970))
+-   `useUpdateEffect`: Correctly track mounted state in strict mode. ([#62974](https://github.com/WordPress/gutenberg/pull/62974))
 
 ### Internal
 

--- a/packages/components/src/utils/hooks/use-update-effect.js
+++ b/packages/components/src/utils/hooks/use-update-effect.js
@@ -6,7 +6,7 @@ import { useRef, useEffect } from '@wordpress/element';
 /**
  * A `React.useEffect` that will not run on the first render.
  * Source:
- * https://github.com/ariakit/ariakit/blob/reakit/packages/reakit-utils/src/useUpdateEffect.ts
+ * https://github.com/ariakit/ariakit/blob/main/packages/ariakit-react-core/src/utils/hooks.ts
  *
  * @param {import('react').EffectCallback} effect
  * @param {import('react').DependencyList} deps
@@ -25,6 +25,13 @@ function useUpdateEffect( effect, deps ) {
 		// see https://github.com/WordPress/gutenberg/pull/41166
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, deps );
+
+	useEffect(
+		() => () => {
+			mounted.current = false;
+		},
+		[]
+	);
 }
 
 export default useUpdateEffect;


### PR DESCRIPTION
## What?
PR fixes the `useUpdateEffect` hook to avoid running effects on the mount when the strict mode is enabled.

Fixes: #62898.
Fixes: a bug in `FocalPointPicker` displaying a grid overlay on the mount. It should only be visible when changing the values.

## Why?
The hook didn't account for the extra run in strict mode.

Note: The hook is used by the panel body component and handles "scroll-into-view" after the initial render. The bug was only visible in the Customize > Widgets editor.

https://github.com/WordPress/gutenberg/blob/237e09dd2f3a57fecf987d09e917ab79519248b3/packages/components/src/panel/body.tsx#L62-L80

## How?
Sync the fix from the Ariakit library - [packages/ariakit-utils/src/hooks.ts](https://github.com/ariakit/ariakit/pull/1534/files#diff-e6728d8fcfa9463494bb1548a7f78a4e4d46ab95cbeffc7148a60f50deffd09a)

## Testing Instructions

### Customize Widgets
1. Activate a classic theme like Twenty Twenty One
2. Go to Customize > Widgets
3. Select a non-paragraph block

### Focal Pointer
1. Open a post.
2. Add the Cover block and select the image.
3. Switch between Post and Block sidebars while the cover block is selected.
4. Confirm that the grid overlay isn't rendered when the focal pointer is first displayed.

### Testing Instructions for Keyboard
Sames

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/2c925190-2529-40ee-a072-8822a9e83f52

