### PR TITLE
Post Author blocks: Add example and preview

### DIFF
--- a/packages/block-library/src/post-author-biography/block.json
+++ b/packages/block-library/src/post-author-biography/block.json
@@ -12,6 +12,9 @@
 		}
 	},
 	"usesContext": [ "postType", "postId" ],
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"spacing": {
 			"margin": true,

--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -20,6 +20,9 @@
 		}
 	},
 	"usesContext": [ "postType", "postId" ],
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -34,13 +34,6 @@
 		}
 	},
 	"usesContext": [ "postType", "postId", "queryId" ],
-	"example": {
-		"viewportWidth": 350,
-		"attributes": {
-			"showBio": true,
-			"byline": "Posted by"
-		}
-	},
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -34,6 +34,13 @@
 		}
 	},
 	"usesContext": [ "postType", "postId", "queryId" ],
+	"example": {
+		"viewportWidth": 350,
+		"attributes": {
+			"showBio": true,
+			"byline": "Posted by"
+		}
+	},
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/packages/block-library/src/post-author/index.js
+++ b/packages/block-library/src/post-author/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { postAuthor as icon } from '@wordpress/icons';
 
 /**
@@ -15,6 +16,13 @@ export { metadata, name };
 
 export const settings = {
 	icon,
+	example: {
+		viewportWidth: 350,
+		attributes: {
+			showBio: true,
+			byline: __( 'Posted by' ),
+		},
+	},
 	edit,
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a basic example to the `core/post-author`, `core/post-author-biography` and `core/post-author-name` blocks.

Part of https://github.com/WordPress/gutenberg/issues/30029

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it was showing empty before

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I define a viewport size for the example and add some text for the byline. Please let me know if we should change the text here

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Open the block inserter and search for the author block, hover over all 3 of the blocks and you'll see the examples

## Screenshots or screencast <!-- if applicable -->

![Screen Capture on 2024-06-28 at 16-00-00](https://github.com/WordPress/gutenberg/assets/3593343/421989b8-b9db-4416-b083-4eed67604cb2)
