### PR TITLE
Refactor Post Date Relative Time Rendering for Future Dates

### DIFF
--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -23,8 +23,14 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	$post_ID = $block->context['postId'];
 
 	if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
-		// translators: %s: human-readable time difference.
-		$formatted_date = sprintf( __( '%s ago', 'gutenberg' ), human_time_diff( get_post_timestamp( $post_ID ) ) );
+		$post_timestamp = get_post_timestamp( $post_ID );
+		if ( $post_timestamp > time() ) {
+			// translators: %s: human-readable time difference.
+			$formatted_date = sprintf( __( '%s from now', 'gutenberg' ), human_time_diff( $post_timestamp ) );
+		} else {
+			// translators: %s: human-readable time difference.
+			$formatted_date = sprintf( __( '%s ago', 'gutenberg' ), human_time_diff( $post_timestamp ) );
+		}
 	} else {
 		$formatted_date = get_the_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $post_ID );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: #62976 

## Why?
When you have a Date block on a post, schedule the post to the future, and then preview the post, the Date block shows a past date, even though the editor showed a relative future-tense date.

## How?
This PR modifies the post date block's relative time format rendering logic to correctly display future dates using `%s from now` format alongside existing `%s ago` handling.

## Testing Instructions
1. Add the Date Block
2. Select the last option in CHOOSE A FORMAT
3. Schedule the post for a future date
4. Preview the post

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/77401999/41fc582d-1557-403d-94c8-3f300fc6e3bc
