### PR TITLE
Conditionally call focus with getEditorRegion

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -74,7 +74,7 @@ function BlockBreadcrumb( { rootLabelText } ) {
 
 							clearSelectedBlock();
 
-							getEditorRegion( blockEditor ).focus();
+							getEditorRegion( blockEditor )?.focus();
 						} }
 					>
 						{ rootLabel }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -162,7 +162,7 @@ export default function BlockTools( {
 			) {
 				event.preventDefault();
 				clearSelectedBlock();
-				getEditorRegion( __unstableContentRef.current ).focus();
+				getEditorRegion( __unstableContentRef.current )?.focus();
 			}
 		} else if ( isMatch( 'core/block-editor/collapse-list-view', event ) ) {
 			// If focus is currently within a text field, such as a rich text block or other editable field,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Code quality fix to address the possibility of calling `focus()` on a null value from getEditorRegion. [h/t to @ellatrix for catching this](https://github.com/WordPress/gutenberg/pull/62595#discussion_r1658260375).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Code quality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
add a `?` to not call focus unless we have an element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Select a block
- Click the root "Template" button in the footer
- Focus should not be visible on the canvas as it uses focus-visible (only shows focus if activated via moving to it via keyboard), but focus should be there.
- Tab to check focus is at the top of the editor.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

#### Escape from Select Mode
- Edit the canvas
- Press Escape to enter navigation mode
- Press Escape again to clear focus
- Blue focus ring should be on the canvas

#### Footer template button
- Select a block
- Tab many times to the root "Template" button in the footer
- Focus should be visible on the canvas




## Screenshots or screencast <!-- if applicable -->
