### PR TITLE
Block Bindings: Output granular post meta changes in a list inside save panel

### DIFF
--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -68,7 +68,7 @@ function getTranslation( key ) {
  * @param {string} parentPath     A key/value pair object of block names and their rendered titles.
  * @return {string[]}             An array of paths whose values have changed.
  */
-function deepCompare( changedObject, originalObject, parentPath = '' ) {
+export function deepCompare( changedObject, originalObject, parentPath = '' ) {
 	// We have two non-object values to compare.
 	if ( ! isObject( changedObject ) && ! isObject( originalObject ) ) {
 		/*

--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -68,7 +68,7 @@ function getTranslation( key ) {
  * @param {string} parentPath     A key/value pair object of block names and their rendered titles.
  * @return {string[]}             An array of paths whose values have changed.
  */
-export function deepCompare( changedObject, originalObject, parentPath = '' ) {
+function deepCompare( changedObject, originalObject, parentPath = '' ) {
 	// We have two non-object values to compare.
 	if ( ! isObject( changedObject ) && ! isObject( originalObject ) ) {
 		/*

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -17,14 +17,14 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 	const { name, kind, title, key } = record;
 
 	// Handle templates that might use default descriptive titles.
-	const { entityRecordTitle, hasPostMetaChanges } = useSelect(
+	const { entityRecordTitle, postMetaChanges } = useSelect(
 		( select ) => {
 			if ( 'postType' !== kind || 'wp_template' !== name ) {
 				return {
 					entityRecordTitle: title,
-					hasPostMetaChanges: unlock(
+					postMetaChanges: unlock(
 						select( editorStore )
-					).hasPostMetaChanges( name, key ),
+					).getPostMetaChanges( name, key ),
 				};
 			}
 
@@ -38,9 +38,9 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 					select( editorStore ).__experimentalGetTemplateInfo(
 						template
 					).title,
-				hasPostMetaChanges: unlock(
+				postMetaChanges: unlock(
 					select( editorStore )
-				).hasPostMetaChanges( name, key ),
+				).getPostMetaChanges( name, key ),
 			};
 		},
 		[ name, kind, title, key ]
@@ -58,10 +58,17 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 					onChange={ onChange }
 				/>
 			</PanelRow>
-			{ hasPostMetaChanges && (
-				<ul className="entities-saved-states__changes">
-					<li>{ __( 'Post Meta.' ) }</li>
-				</ul>
+			{ Object.keys( postMetaChanges ).length > 0 && (
+				<div className="entities-saved-states__changes">
+					<p>Post Meta</p>
+					<ul>
+						{ Object.keys( postMetaChanges ).map(
+							( postMetaKey ) => (
+								<li key={ postMetaKey }>{ postMetaKey }</li>
+							)
+						) }
+					</ul>
+				</div>
 			) }
 		</>
 	);

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -58,15 +58,13 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 					onChange={ onChange }
 				/>
 			</PanelRow>
-			{ Object.keys( postMetaChanges ).length > 0 && (
+			{ postMetaChanges.length > 0 && (
 				<div className="entities-saved-states__changes">
 					<p>Post Meta</p>
 					<ul>
-						{ Object.keys( postMetaChanges ).map(
-							( postMetaKey ) => (
-								<li key={ postMetaKey }>{ postMetaKey }</li>
-							)
-						) }
+						{ postMetaChanges.map( ( postMeta ) => (
+							<li key={ postMeta }>{ postMeta }</li>
+						) ) }
 					</ul>
 				</div>
 			) }

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -17,7 +17,7 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 	const { name, kind, title, key } = record;
 
 	// Handle templates that might use default descriptive titles.
-	const selectResults = useSelect(
+	const { entityRecordTitle, postMetaChanges } = useSelect(
 		( select ) => {
 			const _postMetaChanges = unlock(
 				select( editorStore )
@@ -45,8 +45,6 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 		},
 		[ name, kind, title, key ]
 	);
-
-	const { entityRecordTitle, postMetaChanges } = selectResults;
 
 	return (
 		<>

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -17,14 +17,16 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 	const { name, kind, title, key } = record;
 
 	// Handle templates that might use default descriptive titles.
-	const { entityRecordTitle, postMetaChanges } = useSelect(
+	const selectResults = useSelect(
 		( select ) => {
+			const _postMetaChanges = unlock(
+				select( editorStore )
+			).getPostMetaChanges();
+
 			if ( 'postType' !== kind || 'wp_template' !== name ) {
 				return {
 					entityRecordTitle: title,
-					postMetaChanges: unlock(
-						select( editorStore )
-					).getPostMetaChanges( name, key ),
+					postMetaChanges: _postMetaChanges,
 				};
 			}
 
@@ -38,13 +40,13 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 					select( editorStore ).__experimentalGetTemplateInfo(
 						template
 					).title,
-				postMetaChanges: unlock(
-					select( editorStore )
-				).getPostMetaChanges( name, key ),
+				postMetaChanges: _postMetaChanges,
 			};
 		},
 		[ name, kind, title, key ]
 	);
+
+	const { entityRecordTitle, postMetaChanges } = selectResults;
 
 	return (
 		<>

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -24,9 +24,13 @@
 	color: $gray-700;
 	font-size: $helptext-font-size;
 	margin: $grid-unit-10 $grid-unit-20 0 $grid-unit-20;
-	list-style: disc;
 
-	li {
-		margin-bottom: $grid-unit-05;
+	ul {
+		list-style: disc;
+		margin: $grid-unit-10 $grid-unit-30 0 $grid-unit-30;
+
+		li {
+			margin-bottom: $grid-unit-05;
+		}
 	}
 }

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -61,8 +61,7 @@ export class PostPublishButton extends Component {
 			// TODO: Explore how to manage `getPostMetaChanges` and pre-publish workflow properly.
 			if (
 				( hasNonPostEntityChanges ||
-					( Object.keys( postMetaChanges ).length > 0 &&
-						isPublished ) ) &&
+					( postMetaChanges.length > 0 && isPublished ) ) &&
 				setEntitiesSavedStatesCallback
 			) {
 				// The modal for multiple entity saving will open,

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -48,7 +48,7 @@ export class PostPublishButton extends Component {
 		return ( ...args ) => {
 			const {
 				hasNonPostEntityChanges,
-				hasPostMetaChanges,
+				postMetaChanges,
 				setEntitiesSavedStatesCallback,
 				isPublished,
 			} = this.props;
@@ -58,10 +58,11 @@ export class PostPublishButton extends Component {
 			// We also need to check that the `setEntitiesSavedStatesCallback`
 			// prop was passed. See https://github.com/WordPress/gutenberg/pull/37383
 			//
-			// TODO: Explore how to manage `hasPostMetaChanges` and pre-publish workflow properly.
+			// TODO: Explore how to manage `getPostMetaChanges` and pre-publish workflow properly.
 			if (
 				( hasNonPostEntityChanges ||
-					( hasPostMetaChanges && isPublished ) ) &&
+					( Object.keys( postMetaChanges ).length > 0 &&
+						isPublished ) ) &&
 				setEntitiesSavedStatesCallback
 			) {
 				// The modal for multiple entity saving will open,
@@ -226,7 +227,7 @@ export default compose( [
 			isSavingNonPostEntityChanges,
 			getEditedPostAttribute,
 			getPostEdits,
-			hasPostMetaChanges,
+			getPostMetaChanges,
 		} = unlock( select( editorStore ) );
 		return {
 			isSaving: isSavingPost(),
@@ -244,7 +245,7 @@ export default compose( [
 			postStatus: getEditedPostAttribute( 'status' ),
 			postStatusHasChanged: getPostEdits()?.status,
 			hasNonPostEntityChanges: hasNonPostEntityChanges(),
-			hasPostMetaChanges: hasPostMetaChanges(),
+			postMetaChanges: getPostMetaChanges(),
 			isSavingNonPostEntityChanges: isSavingNonPostEntityChanges(),
 		};
 	} ),

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -61,7 +61,9 @@ export class PostPublishButton extends Component {
 			// TODO: Explore how to manage `getPostMetaChanges` and pre-publish workflow properly.
 			if (
 				( hasNonPostEntityChanges ||
-					( postMetaChanges.length > 0 && isPublished ) ) &&
+					( postMetaChanges &&
+						postMetaChanges.length > 0 &&
+						isPublished ) ) &&
 				setEntitiesSavedStatesCallback
 			) {
 				// The modal for multiple entity saving will open,

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -43,7 +43,7 @@ export default function SavePublishPanels( {
 		} = select( editorStore );
 		const _hasOtherEntitiesChanges =
 			hasNonPostEntityChanges() ||
-			unlock( select( editorStore ) ).hasPostMetaChanges();
+			unlock( select( editorStore ) ).getPostMetaChanges().length > 0;
 		return {
 			publishSidebarOpened: isPublishSidebarOpened(),
 			isPublishable:
@@ -52,7 +52,6 @@ export default function SavePublishPanels( {
 			hasOtherEntitiesChanges: _hasOtherEntitiesChanges,
 		};
 	}, [] );
-
 	const openEntitiesSavedStates = useCallback(
 		() => setEntitiesSavedStatesCallback( true ),
 		[]

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -23,6 +23,7 @@ import {
 import { TEMPLATE_PART_POST_TYPE } from './constants';
 import { getFilteredTemplatePartBlocks } from './utils/get-filtered-template-parts';
 import { getEntityActions as _getEntityActions } from '../dataviews/store/private-selectors';
+import { deepCompare } from '../../../block-editor/src/components/global-styles/get-global-styles-changes';
 
 const EMPTY_INSERTION_POINT = {
 	rootClientId: undefined,
@@ -165,21 +166,10 @@ export const getPostMetaChanges = createRegistrySelector(
 		);
 
 		if ( ! original?.meta || ! edits?.meta ) {
-			return {};
+			return [];
 		}
 
-		const keys = Object.keys( original.meta );
-		const differences = {};
-		for ( const key of keys ) {
-			if ( key === 'footnotes' ) {
-				continue;
-			}
-			if ( original.meta[ key ] !== edits.meta[ key ] ) {
-				differences[ key ] = edits.meta[ key ];
-			}
-		}
-
-		return differences;
+		return deepCompare( edits.meta, original.meta );
 	}
 );
 

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -211,7 +211,9 @@ export const getPostMetaChanges = createRegistrySelector(
 			return [];
 		}
 
-		return deepCompare( edits.meta, original.meta );
+		return deepCompare( edits.meta, original.meta ).filter(
+			( item ) => item !== 'footnotes'
+		);
 	}
 );
 

--- a/packages/is-shallow-equal/src/objects.js
+++ b/packages/is-shallow-equal/src/objects.js
@@ -1,4 +1,29 @@
 /**
+ * Internal dependencies
+ */
+import isShallowEqualArrays from './arrays';
+
+/**
+ * Checks for shallow array equality and returns true if the two values are equal, or false otherwise.
+ *
+ * @param {any} a
+ * @param {any} b
+ *
+ * @return {boolean} Whether the two values are equal.
+ */
+function isEqual( a, b ) {
+	if ( Array.isArray( a ) && Array.isArray( b ) ) {
+		return isShallowEqualArrays( a, b );
+	}
+
+	if ( a === b ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Returns true if the two objects are shallow equal, or false otherwise.
  *
  * @param {import('.').ComparableObject} a First object to compare.
@@ -31,7 +56,7 @@ export default function isShallowEqualObjects( a, b ) {
 			//
 			// Example: isShallowEqualObjects( { a: undefined }, { b: 5 } )
 			( aValue === undefined && ! b.hasOwnProperty( key ) ) ||
-			aValue !== b[ key ]
+			! isEqual( aValue, b[ key ] )
 		) {
 			return false;
 		}

--- a/packages/is-shallow-equal/src/objects.js
+++ b/packages/is-shallow-equal/src/objects.js
@@ -4,7 +4,8 @@
 import isShallowEqualArrays from './arrays';
 
 /**
- * Checks for shallow array equality and returns true if the two values are equal, or false otherwise.
+ * Returns true if the two values are equal, or false otherwise.
+ * Includes a check for shallow array equality.
  *
  * @param {any} a
  * @param {any} b


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR granularly outputs post metadata changes in the save panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Begins addressing https://github.com/WordPress/gutenberg/issues/62938
We want to give users better visibility on what is being saved when post metadata is modified.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It renames the existing `hasPostMetaChanges` to `getPostMetaChangs` and compares the original post object's `meta` property to the modified one.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
<details>
<summary>1. Register some post meta fields by adding this snippet to your theme's functions.php</summary>

```php
add_action( 'init', 'test_block_bindings' );

function test_block_bindings() {
	register_meta(
		'post',
		'text_field_1',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'sanitize_callback' => 'wp_strip_all_tags',
			'default'           => 'bindings value 1',
		)
	);

	register_meta(	
		'post',
		'text_field_2',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'sanitize_callback' => 'wp_strip_all_tags',
			'default'           => 'bindings value 2',
		)
	);

	register_meta(
		'post',
		'text_field_3',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'sanitize_callback' => 'wp_strip_all_tags',
			'default'           => 'bindings value 3',
		)
	);
}
```

</details>


<details>

<summary>2. In published post, add paragraph blocks bound to the custom fields using the Code Editor</summary>

```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field_1"}}}}} -->
<p>Bound Paragraph 1 more editing test</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field_2"}}}}} -->
<p>Bound Paragraph 2 test</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field_3"}}}}} -->
<p>Bound paragraph 2</p>
<!-- /wp:paragraph -->
```

</details>
 
3. Override the paragraph contents by typing into the bound paragraphs.

4. Press Save and see that an indicator for the meta changes is shown in the save panel.

Repeat the same for the heading, image, and button blocks.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="279" alt="Screenshot 2024-06-28 at 6 02 53 PM" src="https://github.com/WordPress/gutenberg/assets/5360536/c89418c1-285b-4521-93fe-1135ec912ea6">