### PR TITLE
Device previews: avoid needless overflow and include bottom margin in overflow

### DIFF
--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -1,6 +1,7 @@
 iframe[name="editor-canvas"] {
 	box-sizing: border-box;
 	width: 100%;
+	max-width: 100%;
 	height: 100%;
 	display: block;
 	background-color: transparent;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -6,6 +6,7 @@
 	width: 100%;
 	height: 100%;
 	overflow-x: hidden;
+	display: flex;
 }
 
 .block-editor-iframe__scale-container {
@@ -17,7 +18,7 @@
 	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
 	$prev-container-width: var(--wp-block-editor-iframe-zoom-out-prev-container-width, 100vw);
 	width: $prev-container-width;
-	margin-left: calc(-1 * (#{$prev-container-width} - #{$container-width}) / 2);
+	margin-inline: calc(-1 * (#{$prev-container-width} - #{$container-width}) / 2);
 }
 
 .block-editor-iframe__html {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,8 +1,3 @@
-.edit-post-layout.has-metaboxes .edit-post-visual-editor {
-	flex: 1 0 auto;
-	height: auto;
-}
-
 .edit-post-layout__metaboxes {
 	flex-shrink: 0;
 	clear: both;

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -1,6 +1,6 @@
 .editor-visual-editor {
 	position: relative;
-	height: 100%;
+	flex: 1 0 auto;
 	display: block;
 	background-color: $gray-300;
 	// Make this a stacking context to contain the z-index of children elements.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A fix to make the device previews work as shipped in 6.5.

## Why?
Currently device previews create vertical overflow/scrollbars in the interface content area even if the area is taller than the device preview. Additionally, when the content area is shorter, the overflow doesn’t contain the bottom margin of the device preview (as it did in 6.5).

## How?
Making it so the bottom margin of the device preview (iframe) is not clipped by removing the `overflow: hidden` rule on `VisualEditor`. That would regress another recently fixed issue #62894, so the overflow of block toolbars is prevented with inline styles on `BlockTools`. There’s a bit more to it but I’ll add detail here or in review comments later.

## Testing Instructions
1. Test both the post and the site editor with long post style content
2. Activate the mobile/tablet views ensuring your browser viewport is bigger than the views
3. Check that there's only one scrollbar alongside the content
4. Now reduce the size of your browser window to be smaller than the device view
5. A second scrollbar should appear allowing you to view the full device and its bottom margin
6. Resize your browser horizontally to be narrower than the device preview
7. Observe that the canvas narrows to fit as well and that it’s scrollbar is not obscured by the content area’s scrollbar

Also do a general smoke test of things like:
- Inserting patterns with the zoom out experiment enabled
- Editing patterns
- Style book
- Code editor mode
- The Widget editor

## Screenshots or screencast <!-- if applicable -->
### Device preview in 6.5

https://github.com/WordPress/gutenberg/assets/9000376/56225958-13f3-4d85-8018-85176ce07795

I'll add comparison recording of trunk later, this branch should be just like the one above.