### PR TITLE
DataViews: Restore preview focus outline in grid layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -340,7 +340,6 @@
 		aspect-ratio: 1/1;
 		background-color: $gray-100;
 		border-radius: $grid-unit-05;
-		overflow: hidden;
 		position: relative;
 
 		img {

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -35,13 +35,6 @@
 		display: flex;
 		flex-direction: column;
 		height: 100%;
-		border-radius: 3px 3px 0 0;
-
-		&.is-viewtype-grid {
-			.block-editor-block-preview__container {
-				border-radius: 3px 3px 0 0;
-			}
-		}
 
 		&.is-viewtype-table {
 			width: 96px;
@@ -62,7 +55,7 @@
 			cursor: pointer;
 			overflow: hidden;
 			height: 100%;
-			border-radius: 3px 3px 0 0;
+			border-radius: $grid-unit-05;
 
 			&:focus-visible {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -2,7 +2,6 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	border-radius: 3px 3px 0 0;
 
 	.page-templates-preview-field__button {
 		box-shadow: none;
@@ -13,7 +12,7 @@
 		cursor: pointer;
 		overflow: hidden;
 		height: 100%;
-		border-radius: 3px;
+		border-radius: $grid-unit-05;
 
 		&:focus-visible {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
@@ -31,10 +30,6 @@
 	&.is-viewtype-grid {
 		.block-editor-block-preview__container {
 			height: 100%;
-		}
-
-		.page-templates-preview-field__button {
-			border-radius: 3px 3px 0 0;
 		}
 	}
 

--- a/packages/edit-site/src/components/posts-app/style.scss
+++ b/packages/edit-site/src/components/posts-app/style.scss
@@ -43,7 +43,7 @@
 	overflow: hidden;
 	height: 100%;
 	width: 100%;
-	border-radius: 3px 3px 0 0;
+	border-radius: $grid-unit-05;
 
 	&:focus-visible {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);


### PR DESCRIPTION
Fixes #62958

## What?

This PR fixes an issue where the focus outline was not displayed on the preview button in the grid layout.

## Why?

This issue is probably related to #61159 where we unboxed grid items. The box-shadow is invisible because `overflow: hidden` is applied to the preview button wrapper `.dataviews-view-grid__media`.

## How?

I removed `overhidden:flow` and adjusted the rounded corners. The preview button itself already has `overflow: hidden`, so there should be no problem with the current unboxed style.

## Testing Instructions

- Switch to a grid layout in Patterns, Templates, or Pages view.
- Use the keyboard to focus on the Preview button.
- You should see a focus outline.
- Test different variations, such as items with less content and items with background color, to make sure they all work correctly.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/a7afc919-fd01-4d78-8135-8d39a74ea034

