### PR TITLE
Styles specificity: fix link styles override issue in navigation block

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -52,7 +52,7 @@ $navigation-icon-size: 24px;
 	// Otherwise, a link color set by a parent group can override the value.
 	// This also fixes an issue where a navigation with an explicitly set color is overridden
 	// by link colors defined in Global Styles.
-	.wp-block-navigation-item__content.wp-block-navigation-item__content {
+	:where(.wp-block-navigation-item__content.wp-block-navigation-item__content) {
 		color: inherit;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
FIxes: #62987 

## Why?
See this [comment](https://github.com/WordPress/gutenberg/issues/62987#issue-2381410388)

## How?
Decreases the specificity of Navigation block link styles

## Testing Instructions
<details>
<summary>1. Add code below into theme.json file.</summary>
<br>

```
{
	"styles": {
		"blocks": {
			"core/navigation": {
				"elements": {
					"link": {
						"color": {
							"text": "var(--wp--preset--color--contrast)"
						},
						":hover": {
							"color": {
								"text": "var(--wp--preset--color--primary)"
							}
						}
					}
				}
			}
		}
	}
}
```

</details>

2. Hover links in Navigation block on front end.
3. Check that theme.json style will get applied instead of core block style.
