### PR TITLE
Updated Rule Hook URL

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -796,7 +796,7 @@ _Returns_
 
 Custom react hook for retrieving props from registered selectors.
 
-In general, this custom React hook follows the [rules of hooks](https://reactjs.org/docs/hooks-rules.html).
+In general, this custom React hook follows the [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
 
 _Usage_
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -235,7 +235,7 @@ function useMappingSelect( suspense, mapSelect, deps ) {
  * Custom react hook for retrieving props from registered selectors.
  *
  * In general, this custom React hook follows the
- * [rules of hooks](https://reactjs.org/docs/hooks-rules.html).
+ * [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
  *
  * @template {MapSelect | StoreDescriptor<any>} T
  * @param {T}         mapSelect Function called on every state change. The returned value is


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/62994

https://reactjs.org/docs/hooks-rules.html doc link is Outdated and won’t be updated,  so updated this with new documentation link https://react.dev/reference/rules/rules-of-hooks