### PR TITLE
Font Library: Store font subdirectory in post meta.

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -917,8 +917,8 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 			$new_path = $path;
 
 			$fonts_dir = wp_get_font_dir();
-			if ( str_starts_with( $new_path, $fonts_dir['path'] ) ) {
-				$new_path = str_replace( $fonts_dir, '', $new_path );
+			if ( str_starts_with( $new_path, $fonts_dir['basedir'] ) ) {
+				$new_path = str_replace( $fonts_dir['basedir'], '', $new_path );
 				$new_path = ltrim( $new_path, '/' );
 			}
 

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -360,7 +360,7 @@ if ( ! function_exists( '_wp_before_delete_font_face' ) ) {
 		}
 
 		$font_files = get_post_meta( $post_id, '_wp_font_face_file', false );
-		$font_dir   = wp_get_font_dir()['path'];
+		$font_dir   = untrailingslashit( wp_get_font_dir()['basedir'] );
 
 		foreach ( $font_files as $font_file ) {
 			wp_delete_file( $font_dir . '/' . $font_file );


### PR DESCRIPTION
## What?
Stores the font file sub-directory in the `wp_font_face` post meta. Similar to attachments, only the portion of the path relative to the base directory is stored.

## Why?
This ensures the files can be deleted alongside their post on sites using a plugin to store font files in sub-directories. Previously running such a plugin would result in the files remaining on the file system post delete.

## How?
Backports https://github.com/WordPress/wordpress-develop/commit/a033cf15d23e9b32485e468110c707e0f7458e37

## Testing Instructions
1. Configure site to run on WordPress 6.4 to ensure the font directory is using the Gutenberg settings.
2. Add the mini-plugin below to your mu-plugins folder
3. Upload a font/sideload from Google 
4. Observe the font file is stored in a sub-directory
5. Observe the font file's sub-directory is not stored in the post meta
6. Wait 30 seconds for a tick of the mu-plugin
7. Delete the font via the font library
8. Ensure the font file is deleted. (Edited because I initially put the reproduction step here 🤦)
9. Remove the min-plugin from your mu-plugins to avoid confusion later.

Testing mini-plugin:

```php
add_filter( 'font_dir', function ( $font_dir ) {
        /*
         * Change sub-directory every 30 seconds
         *
         * POC only, a more likely use is to get the `fontFamily` from the API
         * request or the currently active theme and use either of those values
         * to generate a unique sub-directory.
         *
         * The POC is simply to allow for easier testing by setting a new
         * sub-directory every 30 seconds.
         */
        $subdir = '/' . (string) floor( time() / 30 );
        $font_dir['subdir'] = $subdir;
        $font_dir['path'] .= $subdir;
        $font_dir['url'] .= $subdir;
        return $font_dir;
} );
```

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
