### PR TITLE
Site Editor: patterns and templates cannot be edited from sidebar mobile view

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -75,6 +75,7 @@ function useRedirectOldPaths() {
 export default function useLayoutAreas() {
 	const { params } = useLocation();
 	const { postType, postId, path, layout, isCustom, canvas } = params;
+	const hasEditCanvasMode = canvas === 'edit';
 	useRedirectOldPaths();
 
 	// Page list
@@ -91,13 +92,12 @@ export default function useLayoutAreas() {
 					/>
 				),
 				content: <PostsList postType={ postType } />,
-				preview: ( isListLayout || canvas === 'edit' ) && <Editor />,
-				mobile:
-					canvas === 'edit' ? (
-						<Editor />
-					) : (
-						<PostsList postType={ postType } />
-					),
+				preview: ( isListLayout || hasEditCanvasMode ) && <Editor />,
+				mobile: hasEditCanvasMode ? (
+					<Editor />
+				) : (
+					<PostsList postType={ postType } />
+				),
 			},
 			widths: {
 				content: isListLayout ? 380 : undefined,
@@ -115,8 +115,8 @@ export default function useLayoutAreas() {
 					<SidebarNavigationScreenTemplatesBrowse backPath={ {} } />
 				),
 				content: <PageTemplates />,
-				preview: ( isListLayout || canvas === 'edit' ) && <Editor />,
-				mobile: <PageTemplates />,
+				preview: ( isListLayout || hasEditCanvasMode ) && <Editor />,
+				mobile: hasEditCanvasMode ? <Editor /> : <PageTemplates />,
 			},
 			widths: {
 				content: isListLayout ? 380 : undefined,
@@ -133,8 +133,8 @@ export default function useLayoutAreas() {
 			areas: {
 				sidebar: <SidebarNavigationScreenPatterns backPath={ {} } />,
 				content: <PagePatterns />,
-				mobile: <PagePatterns />,
-				preview: canvas === 'edit' && <Editor />,
+				mobile: hasEditCanvasMode ? <Editor /> : <PagePatterns />,
+				preview: hasEditCanvasMode && <Editor />,
 			},
 		};
 	}
@@ -148,7 +148,7 @@ export default function useLayoutAreas() {
 					<SidebarNavigationScreenGlobalStyles backPath={ {} } />
 				),
 				preview: <Editor />,
-				mobile: canvas === 'edit' && <Editor />,
+				mobile: hasEditCanvasMode && <Editor />,
 			},
 		};
 	}
@@ -165,7 +165,7 @@ export default function useLayoutAreas() {
 						/>
 					),
 					preview: <Editor />,
-					mobile: canvas === 'edit' && <Editor />,
+					mobile: hasEditCanvasMode && <Editor />,
 				},
 			};
 		}
@@ -176,7 +176,7 @@ export default function useLayoutAreas() {
 					<SidebarNavigationScreenNavigationMenus backPath={ {} } />
 				),
 				preview: <Editor />,
-				mobile: canvas === 'edit' && <Editor />,
+				mobile: hasEditCanvasMode && <Editor />,
 			},
 		};
 	}
@@ -187,7 +187,7 @@ export default function useLayoutAreas() {
 		areas: {
 			sidebar: <SidebarNavigationScreenMain />,
 			preview: <Editor />,
-			mobile: canvas === 'edit' && <Editor />,
+			mobile: hasEditCanvasMode && <Editor />,
 		},
 	};
 }

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -21,7 +21,7 @@ export const setCanvasMode =
 				registry.dispatch( editorStore ).setDeviceType( 'Desktop' );
 				registry
 					.dispatch( blockEditorStore )
-					.__unstableSetEditorMode( mode );
+					.__unstableSetEditorMode( 'edit' );
 				const isPublishSidebarOpened = registry
 					.select( editorStore )
 					.isPublishSidebarOpened();

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -13,15 +13,15 @@ import { store as editorStore } from '@wordpress/editor';
 export const setCanvasMode =
 	( mode ) =>
 	( { registry, dispatch } ) => {
+		const isMediumOrBigger =
+			window.matchMedia( '(min-width: 782px)' ).matches;
 		const switchCanvasMode = () => {
 			registry.batch( () => {
-				const isMediumOrBigger =
-					window.matchMedia( '(min-width: 782px)' ).matches;
 				registry.dispatch( blockEditorStore ).clearSelectedBlock();
 				registry.dispatch( editorStore ).setDeviceType( 'Desktop' );
 				registry
 					.dispatch( blockEditorStore )
-					.__unstableSetEditorMode( 'edit' );
+					.__unstableSetEditorMode( mode );
 				const isPublishSidebarOpened = registry
 					.select( editorStore )
 					.isPublishSidebarOpened();
@@ -59,7 +59,11 @@ export const setCanvasMode =
 			} );
 		};
 
-		if ( ! document.startViewTransition ) {
+		/*
+		 * Skip transition in mobile, otherwise it crashes the browser.
+		 * See: https://github.com/WordPress/gutenberg/pull/63002.
+		 */
+		if ( ! isMediumOrBigger || ! document.startViewTransition ) {
 			switchCanvasMode();
 		} else {
 			document.documentElement.classList.add(


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/62932
Fixes https://github.com/WordPress/gutenberg/issues/62649

Specifically, this PR addressing the following:

1. Clicking on Edit from the Site Editor sidebar in "view" mode does not redirect to the editor.
2. Clicking on the WP logo once in edit mode crashes the browser

cc @oandregal to make sure everything from https://github.com/WordPress/gutenberg/pull/60689 still works

## Why?

So that clicking Edit on Templates and Patterns in the data views redirects the browser to the block editor in edit mode.

Also, to avoid crashing the browser.

## How?
In the mobile area prop in the Site Editor router, check for `canvas === 'edit'` and render the Editor component.

Skip using `document.startViewTransition` in mobile view when switching canvas modes.


## Testing Instructions

1. Fire up this branch and head to the Site Editor
3. Ensure your browser is narrower than `782px` wide to trigger the mobile view
4. Open the Templates sidebar panel
5. Click on a template or click on "Edit" in the ellipsis menu
6. The page should redirect to the editor
7. Click on the WP logo to return to "view" mode. The browser shouldn't crash. This primarily affected Chrome browsers for me, but it be related to the fact that `document.startViewTransition` doesn't have [full support outside Chrome](https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition).
8. Repeat the above for custom patterns and template parts


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/6458278/4d612d5c-ca98-467c-87ef-b923afd77c03


### After

https://github.com/WordPress/gutenberg/assets/6458278/a86453be-2a20-4795-abef-510904ef592f

