### PR TITLE
Fix typo in column block fixture file

### DIFF
--- a/test/integration/fixtures/blocks/core__column.html
+++ b/test/integration/fixtures/blocks/core__column.html
@@ -7,4 +7,4 @@
 	<p>Column One, Paragraph Two</p>
 	<!-- /wp:paragraph -->
 </div>
-<!-- /wp:columns -->
+<!-- /wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #59145

## Why?
As explained in the issue, there's a typo in the file. It doesn't seem to cause any issues as the block parser is fairly relaxed about closing tags in this situation, and still parsed and serialized the block correctly.

## How?
Fix the typo. I did also regenerate the fixtures, but they're exactly the same, so there's no changes.