### PR TITLE
Post featured image: add example of the block

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -58,6 +58,9 @@
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"align": [ "left", "right", "center", "wide", "full" ],
 		"color": {

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -61,7 +61,8 @@
 	"example": {
 		"viewportWidth": 350,
 		"attributes": {
-			"width": 300
+			"width": 300,
+			"height": 150
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -59,7 +59,10 @@
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],
 	"example": {
-		"viewportWidth": 350
+		"viewportWidth": 350,
+		"attributes": {
+			"width": 300
+		}
 	},
 	"supports": {
 		"align": [ "left", "right", "center", "wide", "full" ],

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -59,11 +59,7 @@
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],
 	"example": {
-		"viewportWidth": 350,
-		"attributes": {
-			"width": 300,
-			"height": 150
-		}
+		"viewportWidth": 350
 	},
 	"supports": {
 		"align": [ "left", "right", "center", "wide", "full" ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add an example to the `core/post-featured-image` block.

Part of https://github.com/WordPress/gutenberg/issues/30029

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it was showing empty before

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By defining a viewport width size for the example

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a post and add a featured image to it.
Open the block inserter and search for the featured image block, hover over it and you'll see the example. It should show the current post's featured image.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1586" alt="Screenshot 2024-07-01 at 12 13 24" src="https://github.com/WordPress/gutenberg/assets/3593343/cafe58b6-7910-4d51-a798-7b0c952ce066">
