### PR TITLE
Image block: Ensure extenders that rely on media ids in block html are supported by block bindings

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -6,35 +6,6 @@
  */
 
 /**
- * Handles backwards compatibility for Gallery Blocks,
- * whose images feature a `data-id` attribute.
- *
- * Now that the Gallery Block contains inner Image Blocks,
- * we add a custom `data-id` attribute before rendering the gallery
- * so that the Image Block can pick it up in its render_callback.
- *
- * @since 5.9.0
- *
- * @param array $parsed_block The block being rendered.
- * @return array The migrated block object.
- */
-function block_core_gallery_data_id_backcompatibility( $parsed_block ) {
-	if ( 'core/gallery' === $parsed_block['blockName'] ) {
-		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
-			if ( 'core/image' === $inner_block['blockName'] ) {
-				if ( ! isset( $parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] ) && isset( $inner_block['attrs']['id'] ) ) {
-					$parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] = esc_attr( $inner_block['attrs']['id'] );
-				}
-			}
-		}
-	}
-
-	return $parsed_block;
-}
-
-add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' );
-
-/**
  * Renders the `core/gallery` block on the server.
  *
  * @since 6.0.0

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -6,6 +6,35 @@
  */
 
 /**
+ * Handles backwards compatibility for Gallery Blocks,
+ * whose images feature a `data-id` attribute.
+ *
+ * Now that the Gallery Block contains inner Image Blocks,
+ * we add a custom `data-id` attribute before rendering the gallery
+ * so that the Image Block can pick it up in its render_callback.
+ *
+ * @since 5.9.0
+ *
+ * @param array $parsed_block The block being rendered.
+ * @return array The migrated block object.
+ */
+function block_core_gallery_data_id_backcompatibility( $parsed_block ) {
+	if ( 'core/gallery' === $parsed_block['blockName'] ) {
+		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+			if ( 'core/image' === $inner_block['blockName'] ) {
+				if ( ! isset( $parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] ) && isset( $inner_block['attrs']['id'] ) ) {
+					$parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] = esc_attr( $inner_block['attrs']['id'] );
+				}
+			}
+		}
+	}
+
+	return $parsed_block;
+}
+
+add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' );
+
+/**
  * Renders the `core/gallery` block on the server.
  *
  * @since 6.0.0

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -39,7 +39,7 @@ function render_block_core_image( $attributes, $content, $block ) {
 		// If there's a mismatch with the 'wp-image-' class and the actual id, the id was
 		// probably overridden by block bindings. Update it to the correct value.
 		// See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
-		$image_classes = $p->get_attribute( 'class' );
+		$image_classes     = $p->get_attribute( 'class' );
 		$expected_id_class = "wp-image-$id";
 		if ( is_string( $image_classes ) && ! str_contains( $image_classes, $expected_id_class ) ) {
 			$image_classes = preg_replace( '/wp-image-(\d+)/', "wp-image-$id", $image_classes );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -35,8 +35,8 @@ function render_block_core_image( $attributes, $content, $block ) {
 		// If there's a mismatch with the 'wp-image-' class and the actual id, the id was
 		// probably overridden by block bindings. Update it to the correct value.
 		// See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
-		$id = $attributes['id'];
-		$image_classnames  = $p->get_attribute( 'class' );
+		$id                       = $attributes['id'];
+		$image_classnames         = $p->get_attribute( 'class' );
 		$class_with_binding_value = "wp-image-$id";
 		if ( is_string( $image_classnames ) && ! str_contains( $image_classnames, $class_with_binding_value ) ) {
 			$image_classnames = preg_replace( '/wp-image-(\d+)/', $class_with_binding_value, $image_classnames );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -31,11 +31,17 @@ function render_block_core_image( $attributes, $content, $block ) {
 	if ( isset( $attributes['id'] ) ) {
 		$id = $attributes['id'];
 
+		// Use block context to detect whether the block is nested in a gallery.
+		// As the context names are very generic, check multiple array keys to
+		// reduce the chance a non-gallery parent is providing the same context.
+		$is_gallery_child = array_key_exists( 'allowResize', $block->context )
+			&& array_key_exists( 'imageCrop', $block->context )
+			&& array_key_exists( 'fixedHeight', $block->context );
+
 		// Adds the data-id="$id" attribute to the img element to provide backwards
 		// compatibility for the Gallery Block, which now wraps Image Blocks within
 		// innerBlocks. The data-id attribute is added in a core/gallery
 		// `render_block_data` hook.
-		$is_gallery_child = array_key_exists( 'allowResize', $block->context );
 		if ( $is_gallery_child ) {
 			$p->set_attribute( 'data-id', $id );
 		}

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -49,11 +49,11 @@ function render_block_core_image( $attributes, $content, $block ) {
 		// If there's a mismatch with the 'wp-image-' class and the actual id, the id was
 		// probably overridden by block bindings. Update it to the correct value.
 		// See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
-		$image_classes     = $p->get_attribute( 'class' );
+		$image_classnames  = $p->get_attribute( 'class' );
 		$expected_id_class = "wp-image-$id";
-		if ( is_string( $image_classes ) && ! str_contains( $image_classes, $expected_id_class ) ) {
-			$image_classes = preg_replace( '/wp-image-(\d+)/', "wp-image-$id", $image_classes );
-			$p->set_attribute( 'class', $image_classes );
+		if ( is_string( $image_classnames ) && ! str_contains( $image_classnames, $expected_id_class ) ) {
+			$image_classnames = preg_replace( '/wp-image-(\d+)/', "wp-image-$id", $image_classnames );
+			$p->set_attribute( 'class', $image_classnames );
 		}
 	}
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -36,6 +36,20 @@ function render_block_core_image( $attributes, $content, $block ) {
 		$p->set_attribute( 'data-id', $attributes['data-id'] );
 	}
 
+	// If there's a mismatch with the 'wp-image-' classname and the actual id, the id
+	// was probably overridden by pattern overrides. Update it to the correct value.
+	// See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
+	if ( isset( $attributes['id'] ) ) {
+		$id = $attributes['id'];
+		$image_classes = $p->get_attribute( 'class' ) ?? '';
+		$expected_id_class = "wp-image-$id";
+
+		if ( ! empty( $image_classes ) && ! str_contains( $image_classes, $expected_id_class ) ) {
+			$image_classes = preg_replace( '/wp-image-(\d+)/', "wp-image-$id", $image_classes );
+			$p->set_attribute( 'class', $image_classes );
+		}
+	}
+
 	$link_destination  = isset( $attributes['linkDestination'] ) ? $attributes['linkDestination'] : 'none';
 	$lightbox_settings = block_core_image_get_lightbox_settings( $block->parsed_block );
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -44,27 +44,16 @@ function render_block_core_image( $attributes, $content, $block ) {
 		}
 	}
 
-	// For backwards compatibility, the data-id html attribute is only
-	// set for image blocks nested in a gallery.
-	// `data-id` is an attribute set by the gallery block using a filter,
-	// so checkings it's set serves this purpose.
+	// For backwards compatibility, the data-id html attribute is only set for
+	// image blocks nested in a gallery. Detect if the image is in a gallery by
+	// checking the data-id attribute.
+	// See the `block_core_gallery_data_id_backcompatibility` function.
 	if ( isset( $attributes['data-id'] ) ) {
-		$data_id;
-
-		if ( $has_id_binding ) {
-			// If there is a binding for the id, use the `id` attribute.
-			// This ensures the `data-id` html attribute contains the correct
-			// block binding value since the `data-id` block attribute does
-			// not support bindings.
-			$data_id = $attributes['id'];
-		} else {
-			// If there are no bindings for the id, for backward compatibility
-			// use the `data-id` attribute added by the gallery block.
-			// This attribute may be filtered by third parties to change what's
-			// stored in the data-id html attribute.
-			$data_id = $attributes['data-id'];
-		}
-
+		// If there's a binding for the `id`, the `id` attribute is used for the
+		// value, since `data-id` does not support block bindings.
+		// Else the `data-id` is used for backwards compatibility, since
+		// third parties may be filtering its value.
+		$data_id = $has_id_binding ? $attributes['id'] : $attributes['data-id'];
 		$p->set_attribute( 'data-id', $data_id );
 	}
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -29,12 +29,16 @@ function render_block_core_image( $attributes, $content, $block ) {
 	}
 
 	if ( isset( $attributes['id'] ) ) {
+		$id = $attributes['id'];
+
 		// Adds the data-id="$id" attribute to the img element to provide backwards
 		// compatibility for the Gallery Block, which now wraps Image Blocks within
 		// innerBlocks. The data-id attribute is added in a core/gallery
 		// `render_block_data` hook.
-		$id = $attributes['id'];
-		$p->set_attribute( 'data-id', $id );
+		$is_gallery_child = array_key_exists( 'allowResize', $block->context );
+		if ( $is_gallery_child ) {
+			$p->set_attribute( 'data-id', $id );
+		}
 
 		// If there's a mismatch with the 'wp-image-' class and the actual id, the id was
 		// probably overridden by block bindings. Update it to the correct value.

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -28,23 +28,20 @@ function render_block_core_image( $attributes, $content, $block ) {
 		return '';
 	}
 
-	if ( isset( $attributes['data-id'] ) ) {
+	if ( isset( $attributes['id'] ) ) {
 		// Adds the data-id="$id" attribute to the img element to provide backwards
 		// compatibility for the Gallery Block, which now wraps Image Blocks within
 		// innerBlocks. The data-id attribute is added in a core/gallery
 		// `render_block_data` hook.
-		$p->set_attribute( 'data-id', $attributes['data-id'] );
-	}
-
-	// If there's a mismatch with the 'wp-image-' classname and the actual id, the id
-	// was probably overridden by pattern overrides. Update it to the correct value.
-	// See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
-	if ( isset( $attributes['id'] ) ) {
 		$id = $attributes['id'];
-		$image_classes = $p->get_attribute( 'class' ) ?? '';
-		$expected_id_class = "wp-image-$id";
+		$p->set_attribute( 'data-id', $id );
 
-		if ( ! empty( $image_classes ) && ! str_contains( $image_classes, $expected_id_class ) ) {
+		// If there's a mismatch with the 'wp-image-' class and the actual id, the id was
+		// probably overridden by pattern overrides. Update it to the correct value.
+		// See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
+		$image_classes = $p->get_attribute( 'class' );
+		$expected_id_class = "wp-image-$id";
+		if ( is_string( $image_classes ) && ! str_contains( $image_classes, $expected_id_class ) ) {
 			$image_classes = preg_replace( '/wp-image-(\d+)/', "wp-image-$id", $image_classes );
 			$p->set_attribute( 'class', $image_classes );
 		}

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -28,32 +28,34 @@ function render_block_core_image( $attributes, $content, $block ) {
 		return '';
 	}
 
-	if ( isset( $attributes['id'] ) ) {
-		$id = $attributes['id'];
+	/*
+	 * The data-id attribute is added in a core/gallery
+	 * `render_block_data` hook.
+	 */
+	if ( isset( $attributes['data-id'] ) ) {
+		// The initial id when the block was parsed.
+		$initial_id = $attributes['data-id'];
+		/*
+		 * The id attribute could change during rendering while applying block bindings.
+		 * If data-id attribute exists, it is safe to assume that
+		 * id attribute is also present.
+		 */
+		$rendered_id = $attributes['id'];
+		/*
+		 * Adds the data-id="$id" attribute to the img element to provide backwards
+		 * compatibility for the Gallery Block, which now wraps Image Blocks within
+		 * innerBlocks.
+		 */
+		$p->set_attribute( 'data-id', $rendered_id );
 
-		// Use block context to detect whether the block is nested in a gallery.
-		// As the context names are very generic, check multiple array keys to
-		// reduce the chance a non-gallery parent is providing the same context.
-		$is_gallery_child = array_key_exists( 'allowResize', $block->context )
-			&& array_key_exists( 'imageCrop', $block->context )
-			&& array_key_exists( 'fixedHeight', $block->context );
-
-		// Adds the data-id="$id" attribute to the img element to provide backwards
-		// compatibility for the Gallery Block, which now wraps Image Blocks within
-		// innerBlocks. The data-id attribute is added in a core/gallery
-		// `render_block_data` hook.
-		if ( $is_gallery_child ) {
-			$p->set_attribute( 'data-id', $id );
-		}
-
-		// If there's a mismatch with the 'wp-image-' class and the actual id, the id was
-		// probably overridden by block bindings. Update it to the correct value.
-		// See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
-		$image_classnames  = $p->get_attribute( 'class' );
-		$expected_id_class = "wp-image-$id";
-		if ( is_string( $image_classnames ) && ! str_contains( $image_classnames, $expected_id_class ) ) {
-			$image_classnames = preg_replace( '/wp-image-(\d+)/', "wp-image-$id", $image_classnames );
-			$p->set_attribute( 'class', $image_classnames );
+		/*
+		 * If the id has changed, it was probably overridden by block bindings.
+		 * Update it to the correct value.
+		 * See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
+		 */
+		if ( $initial_id !== $rendered_id ) {
+			$p->remove_class( 'wp-image-' . $attributes['data-id'] );
+			$p->add_class( 'wp-image-' . $rendered_id );
 		}
 	}
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -37,7 +37,7 @@ function render_block_core_image( $attributes, $content, $block ) {
 		$p->set_attribute( 'data-id', $id );
 
 		// If there's a mismatch with the 'wp-image-' class and the actual id, the id was
-		// probably overridden by pattern overrides. Update it to the correct value.
+		// probably overridden by block bindings. Update it to the correct value.
 		// See https://github.com/WordPress/gutenberg/issues/62886 for why this is needed.
 		$image_classes = $p->get_attribute( 'class' );
 		$expected_id_class = "wp-image-$id";

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -796,8 +796,7 @@ test.describe( 'Pattern Overrides', () => {
 		expect( patternInnerBlocks[ 0 ].attributes.link ).toBe( undefined );
 	} );
 
-	// eslint-disable-next-line playwright/expect-expect
-	test( 'image block classname and data-id attributes contain the correct media ids', async ( {
+	test( 'image block classname and data-id attributes contain the correct media ids when used in a gallery', async ( {
 		admin,
 		editor,
 		page,
@@ -860,6 +859,70 @@ test.describe( 'Pattern Overrides', () => {
 			'data-id',
 			`${ overrideImageId }`
 		);
+		await expect( imageBlock ).toHaveAttribute(
+			'class',
+			`wp-image-${ overrideImageId }`
+		);
+	} );
+
+	test( 'image block classname contains the correct media id and has no data-id attribute when used as a standalone image', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		// Upload two images, one for the original pattern, one for the override.
+		const { id: originalImageId, source_url: originalImageSrc } =
+			await requestUtils.uploadMedia(
+				path.resolve(
+					process.cwd(),
+					'test/e2e/assets/10x10_e2e_test_image_z9T8jK.png'
+				)
+			);
+		const { id: overrideImageId, source_url: overrideImageSrc } =
+			await requestUtils.uploadMedia(
+				path.resolve(
+					process.cwd(),
+					'test/e2e/assets/1024x768_e2e_test_image_size.jpeg'
+				)
+			);
+		const overrideName = 'test';
+
+		// Might be overkill, but check that the ids are actually different.
+		expect( overrideImageId ).not.toBe( originalImageId );
+
+		// Create a pattern with a gallery that has a single image with pattern overrides enabled.
+		// It has media that is not yet uploaded.
+		const { id } = await requestUtils.createBlock( {
+			title: 'Pattern',
+			content: `<!-- wp:image {"id":${ originalImageId },"sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"${ overrideName }"}} -->
+<figure class="wp-block-image size-large"><img src="${ originalImageSrc }" alt="" class="wp-image-${ originalImageId }"/></figure>
+<!-- /wp:image -->`,
+			status: 'publish',
+		} );
+
+		// Insert the pattern into a new post, overriding the image via the pattern block attributes.
+		await admin.createNewPost();
+		const imageAlt = 'Overridden Image';
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: {
+				ref: id,
+				content: {
+					[ overrideName ]: {
+						id: overrideImageId,
+						url: overrideImageSrc,
+						alt: imageAlt,
+					},
+				},
+			},
+		} );
+
+		// Check the image attributes on the frontend.
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+		const imageBlock = page.getByAltText( imageAlt );
+		await expect( imageBlock ).not.toHaveAttribute( 'data-id' );
 		await expect( imageBlock ).toHaveAttribute(
 			'class',
 			`wp-image-${ overrideImageId }`

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -18,6 +18,7 @@ test.describe( 'Pattern Overrides', () => {
 
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllBlocks();
+		await requestUtils.deleteAllMedia();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
@@ -793,6 +794,76 @@ test.describe( 'Pattern Overrides', () => {
 		// Link is an unsupported attribute, so should be undefined, even though
 		// the image block tries to set its attribute.
 		expect( patternInnerBlocks[ 0 ].attributes.link ).toBe( undefined );
+	} );
+
+	// eslint-disable-next-line playwright/expect-expect
+	test( 'image block classname and data-id attributes contain the correct media ids', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		// Upload two images, one for the original pattern, one for the override.
+		const { id: originalImageId, source_url: originalImageSrc } =
+			await requestUtils.uploadMedia(
+				path.resolve(
+					process.cwd(),
+					'test/e2e/assets/10x10_e2e_test_image_z9T8jK.png'
+				)
+			);
+		const { id: overrideImageId, source_url: overrideImageSrc } =
+			await requestUtils.uploadMedia(
+				path.resolve(
+					process.cwd(),
+					'test/e2e/assets/1024x768_e2e_test_image_size.jpeg'
+				)
+			);
+		const overrideName = 'test';
+
+		// Might be overkill, but check that the ids are actually different.
+		expect( overrideImageId ).not.toBe( originalImageId );
+
+		// Create a pattern with a gallery that has a single image with pattern overrides enabled.
+		// It has media that is not yet uploaded.
+		const { id } = await requestUtils.createBlock( {
+			title: 'Pattern',
+			content: `<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":${ originalImageId },"sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"${ overrideName }"}} -->
+<figure class="wp-block-image size-large"><img src="${ originalImageSrc }" alt="" class="wp-image-${ originalImageId }"/></figure>
+<!-- /wp:image --></figure>
+<!-- /wp:gallery -->`,
+			status: 'publish',
+		} );
+
+		// Insert the pattern into a new post, overriding the image via the pattern block attributes.
+		await admin.createNewPost();
+		const imageAlt = 'Overridden Image';
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: {
+				ref: id,
+				content: {
+					[ overrideName ]: {
+						id: overrideImageId,
+						url: overrideImageSrc,
+						alt: imageAlt,
+					},
+				},
+			},
+		} );
+
+		// Check the image attributes on the frontend.
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+		const imageBlock = page.getByAltText( imageAlt );
+		await expect( imageBlock ).toHaveAttribute(
+			'data-id',
+			`${ overrideImageId }`
+		);
+		await expect( imageBlock ).toHaveAttribute(
+			'class',
+			`wp-image-${ overrideImageId }`
+		);
 	} );
 
 	test( 'blocks with the same name should be synced', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #62886

## What?
The image block outputs the image id in its markup in a couple of places—a `data-id` attribute (which only appears for images in galleries) and a `wp-image-123` classname.

When pattern overrides (and to some extend, other types of block binding) are used, these ids can be incorrect in the front-end. The html will still show the id from the original pattern and not for the overridden image. 

## Why?
In a couple of issues, it's mentioned how these are used by extenders to add additional features to the image block:
- [Gallery Refactor: Restore data-id attribute for image blocks](https://github.com/WordPress/gutenberg/issues/35907#top)
- [Synced Pattern Overrides: Image metadata like data-permalink, data-image-title, keeps original image data](https://github.com/WordPress/gutenberg/issues/62886#top)

## How?
Dynamically update the markup of the image block to use the correct ids.

For the classname, a new bit of code is added that detects a mismatch for the id, and if so updates the classname.

For the data attribute, the defacto `id` attribute is used instead of the injected `data-id` attribute, since it'll have the correct value.

## Testing Instructions
1. Create a new post
2. Add a gallery that contains an image from your media library.
3. Take note of the image id (go to the code editor and look for the image block's `id` attribute)
4. Back in the visual editor, select the gallery and create a synced pattern from it (Block toolbar > Options > Create pattern)
5. Select 'Edit original' from the pattern block's toolbar to edit the pattern
6. Select the image block in the gallery, and from the Advanced inspector tools, select 'Enable overrides'. 
7. In the dialog, give the override any name and enable it.
8. Save the pattern and select the 'Back' button from the editor top bar to go back to the post originally being edited
9. Select the image again, and replace the image with a different one from your media library
10. Take a note of the new image id (go to the code editor and find the id in the `wp:block` `content` attribute)
11. Preview the post
12. Inspect the image, it should have a `data-id` attribtue and `wp-image-` class that reflect the id you noted in step 10.
