### PR TITLE
Add note about postcss-urlrebase package patch

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -29,3 +29,10 @@ No notes.
 ### `patches/react-native+0.73.3.patch`
 
 No notes.
+
+### `patches/postcss-urlrebase+1.3.0.patch`
+
+This package uses a `URL` global value but imports the Node.js `URL` type. Remove the
+Node.js-specific type import to use the global URL type available in both browsers and Node.js.
+
+This fixes a type issue where some Gutenberg packages use postcss in the browser.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Add a note about the recently added patch for `postcss-urlrebase` package.

See https://github.com/WordPress/gutenberg/pull/62913#discussion_r1660924273.

Related: https://github.com/strarsis/postcss-urlrebase/pull/2


## Why?

It's helpful to keep a record of why patches were introduced.

## How?

Add a readme note.

## Testing Instructions

None necessary.