### PR TITLE
Upgrade web-vitals package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51098,12 +51098,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/web-vitals": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.0.tgz",
-			"integrity": "sha512-f5YnCHVG9Y6uLCePD4tY8bO/Ge15NPEQWtvm3tPzDKygloiqtb4SVqRHBcrIAqo2ztqX5XueqDn97zHF0LdT6w==",
-			"dev": true
-		},
 		"node_modules/webdriver": {
 			"version": "8.16.20",
 			"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.16.20.tgz",
@@ -54149,7 +54143,7 @@
 				"get-port": "^5.1.1",
 				"lighthouse": "^10.4.0",
 				"mime": "^3.0.0",
-				"web-vitals": "^3.5.0"
+				"web-vitals": "^4.2.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -54158,6 +54152,13 @@
 			"peerDependencies": {
 				"@playwright/test": ">=1"
 			}
+		},
+		"packages/e2e-test-utils-playwright/node_modules/web-vitals": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.1.tgz",
+			"integrity": "sha512-U6bAxeudnhDqcXNl50JC4hLlqox9DZnngxfISZm3DMZnonW35xtJOVUc091L+DOY+6hVZVpKXoiCP0RiT6339Q==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"packages/e2e-tests": {
 			"name": "@wordpress/e2e-tests",
@@ -69305,7 +69306,15 @@
 				"get-port": "^5.1.1",
 				"lighthouse": "^10.4.0",
 				"mime": "^3.0.0",
-				"web-vitals": "^3.5.0"
+				"web-vitals": "^4.2.1"
+			},
+			"dependencies": {
+				"web-vitals": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.1.tgz",
+					"integrity": "sha512-U6bAxeudnhDqcXNl50JC4hLlqox9DZnngxfISZm3DMZnonW35xtJOVUc091L+DOY+6hVZVpKXoiCP0RiT6339Q==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/e2e-tests": {
@@ -95508,12 +95517,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
 			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-			"dev": true
-		},
-		"web-vitals": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.0.tgz",
-			"integrity": "sha512-f5YnCHVG9Y6uLCePD4tY8bO/Ge15NPEQWtvm3tPzDKygloiqtb4SVqRHBcrIAqo2ztqX5XueqDn97zHF0LdT6w==",
 			"dev": true
 		},
 		"webdriver": {

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -36,7 +36,7 @@
 		"get-port": "^5.1.1",
 		"lighthouse": "^10.4.0",
 		"mime": "^3.0.0",
-		"web-vitals": "^3.5.0"
+		"web-vitals": "^4.2.1"
 	},
 	"peerDependencies": {
 		"@playwright/test": ">=1"

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -332,17 +332,17 @@ export class Metrics {
 				window.__reportVitals__( JSON.stringify( measurement ) );
 
 			window.addEventListener( 'DOMContentLoaded', () => {
-				// @ts-ignore
+				// @ts-expect-error This is valid but web-vitals does not register the global types.
 				window.webVitals.onCLS( reportVitals );
-				// @ts-ignore
+				// @ts-expect-error This is valid but web-vitals does not register the global types.
 				window.webVitals.onFCP( reportVitals );
-				// @ts-ignore
+				// @ts-expect-error This is valid but web-vitals does not register the global types.
 				window.webVitals.onFID( reportVitals );
-				// @ts-ignore
+				// @ts-expect-error This is valid but web-vitals does not register the global types.
 				window.webVitals.onINP( reportVitals );
-				// @ts-ignore
+				// @ts-expect-error This is valid but web-vitals does not register the global types.
 				window.webVitals.onLCP( reportVitals );
-				// @ts-ignore
+				// @ts-expect-error This is valid but web-vitals does not register the global types.
 				window.webVitals.onTTFB( reportVitals );
 			} );
 		} );
@@ -368,6 +368,7 @@ export class Metrics {
 		this.webVitals = {};
 
 		const hasScript = await this.page.evaluate(
+			// @ts-expect-error This is valid but web-vitals does not register the global types.
 			() => typeof window.webVitals !== 'undefined'
 		);
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Upgrade the web-vitals package.

## Why?

This is blocking the TypeScript 5.5 upgrade: https://github.com/WordPress/gutenberg/pull/63012

There's an issue with some incompatible types addressed in the most recent web-vitals version: https://github.com/GoogleChrome/web-vitals/issues/498

## How?

Upgrade the package and fix type errors.

## Testing Instructions

CI passes.
