### PR TITLE
Fix double check in `isTemplateRemovable`

### DIFF
--- a/packages/editor/src/dataviews/actions/utils.ts
+++ b/packages/editor/src/dataviews/actions/utils.ts
@@ -43,8 +43,6 @@ export function isTemplateRemovable( template: TemplateOrTemplatePart ) {
 	return (
 		[ template.source, template.source ].includes(
 			TEMPLATE_ORIGINS.custom
-		) &&
-		! template.has_theme_file &&
-		! template?.has_theme_file
+		) && ! template.has_theme_file
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Super small follow up of: https://github.com/WordPress/gutenberg/pull/62913/files#r1660974636