### PR TITLE
Docs: Interactivity API Docs - Include references to more examples from the docs

### DIFF
--- a/docs/reference-guides/interactivity-api/README.md
+++ b/docs/reference-guides/interactivity-api/README.md
@@ -101,9 +101,12 @@ Here you have some more resources to learn/read more about the Interactivity API
 - [WordPress 6.5 Dev Note](https://make.wordpress.org/core/2024/03/04/interactivity-api-dev-note/)
 - [Merge announcement](https://make.wordpress.org/core/2024/02/19/merge-announcement-interactivity-api/)
 - [Proposal: The Interactivity API – A better developer experience in building interactive blocks](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/)
-- [Interactivity API Discussions](https://github.com/WordPress/gutenberg/discussions/52882)
-- Developer Hours sessions ([Americas](https://www.youtube.com/watch?v=RXNoyP2ZiS8&t=664s) & [APAC/EMEA](https://www.youtube.com/watch?v=6ghbrhyAcvA))
+- [Interactivity API Discussions](https://github.com/WordPress/gutenberg/discussions/52882), especially the [showcase](https://github.com/WordPress/gutenberg/discussions/55642#discussioncomment-9667164) discussions.   
 - [wpmovies.dev](http://wpmovies.dev/) demo and its [wp-movies-demo](https://github.com/WordPress/wp-movies-demo) repo
+- Examples using the Interactivity API at [block-development-examples](https://github.com/WordPress/block-development-examples):
+  - [`interactivity-api-block-833d15`](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/833d15)
+  - [`interactivity-api-countdown-3cd73e`](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/interactivity-api-countdown-3cd73e)
+  - [`interactivity-api-quiz-1835fa`](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/interactivity-api-quiz-1835fa)
 
 <div class="callout">
     There's a Tracking Issue opened to ease the coordination of the work related to the Interactivity API Docs: <a href="https://github.com/WordPress/gutenberg/issues/53296">Documentation for the Interactivity API - Tracking Issue #53296</a>

--- a/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md
+++ b/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md
@@ -39,3 +39,6 @@ npx @wp-now/wp-now start
 ```
 
 You should be able to insert the "My First Interactive Block" block into any post and see how it behaves in the front end when published.
+
+## Next Steps
+

--- a/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md
+++ b/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md
@@ -40,5 +40,14 @@ npx @wp-now/wp-now start
 
 You should be able to insert the "My First Interactive Block" block into any post and see how it behaves in the front end when published.
 
-## Next Steps
+<div class="callout callout-info">
+    <p>To get more advanced examples of using the Interactivity API you can check the following resources:</p>
+    <ul>
+      <li><a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/#docs-examples">Docs & Examples</a></li>
+      <li><a href="https://github.com/WordPress/gutenberg/discussions/52894">Getting Started - and other learning resources</a></li>
+      <li><a href="https://github.com/WordPress/gutenberg/discussions/55642#">Interactivity API showcase</a></li>
+    </ul>
+</div>
+
+
 


### PR DESCRIPTION
## What?
Adds more references to more advanced examples.

## Why?
Feedback from the community states that more advanced references (besides the Quick Start Guide project reference) would help the community better understand the Interactivity API.