### PR TITLE
Docgen: Fix function param for const function expression

### DIFF
--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix getting param annotations for exported variables assigned to function expressions ([#tbd](https://github.com/WordPress/gutenberg/pull/tbd)).
+
 ## 2.2.0 (2024-06-26)
 
 ## 2.1.0 (2024-06-15)
@@ -98,7 +102,7 @@
 
 ### Bug Fixes
 
--   Fix getting param annotations for default exported functions. ([#31603](https://github.com/WordPress/gutenberg/pull/31603))
+-   Fix getting param annotations for default exported functions ([#31603](https://github.com/WordPress/gutenberg/pull/31603)).
 
 ## 1.17.0 (2021-04-29)
 

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -405,6 +405,10 @@ function unwrapWrappedSelectors( token ) {
 		return token;
 	}
 
+	if ( babelTypes.isFunctionExpression( token ) ) {
+		return token;
+	}
+
 	if ( babelTypes.isArrowFunctionExpression( token ) ) {
 		return token;
 	}
@@ -433,7 +437,7 @@ function unwrapWrappedSelectors( token ) {
 
 /**
  * @param {ASTNode} token
- * @return {babelTypes.ArrowFunctionExpression | babelTypes.FunctionDeclaration} The function token.
+ * @return {babelTypes.ArrowFunctionExpression | babelTypes.FunctionDeclaration | babelTypes.FunctionExpression} The function token.
  */
 function getFunctionToken( token ) {
 	let resolvedToken = token;
@@ -517,8 +521,7 @@ function getQualifiedObjectPatternTypeAnnotation( tag, paramType ) {
 function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 	const functionToken = getFunctionToken( declarationToken );
 
-	// Otherwise find the corresponding parameter token for the documented parameter.
-	let paramToken = functionToken.params[ paramIndex ];
+	let paramToken = functionToken?.params[ paramIndex ];
 
 	// This shouldn't happen due to our ESLint enforcing correctly documented parameter names but just in case
 	// we'll give a descriptive error so that it's easy to diagnose the issue.

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -31,12 +31,12 @@ describe( 'Type annotations', () => {
 		expect( result ).toBeFalsy();
 	} );
 
-	const paramTag = {
+	const paramTag = /** @type {const} */ ( {
 		tag: 'param',
 		type: '',
 		name: 'foo',
 		description: 'A foo parameter',
-	};
+	} );
 
 	describe( 'simple types', () => {
 		const keywordTypes = [
@@ -462,5 +462,23 @@ describe( 'Type annotations', () => {
 			 `;
 			expect( getStateArgType( code ) ).toBe( 'number' );
 		} );
+	} );
+
+	it( 'should find types in a constant function expression assignment', () => {
+		const node = parse( `
+				export const __unstableAwaitPromise = function < T >( promise: Promise< T > ): {
+					type: 'AWAIT_PROMISE';
+					promise: Promise< T >;
+				} {
+					return {
+						type: 'AWAIT_PROMISE',
+						promise,
+					};
+				};
+			 ` );
+
+		expect(
+			getTypeAnnotation( { tag: 'param', name: 'promise' }, node, 0 )
+		).toBe( 'Promise< T >' );
 	} );
 } );


### PR DESCRIPTION

## What?

Fix an issue where docgen does not get the parameter types of a function expression.
Add test for the issue.

## Why?

It failed with named exports like this:

```ts
/** @param p */
const func = function ( p: string ): string { return p; }
```

This was an issue in #63012 where docgen failed on data-controls types.

Normally this would either be an exported function or a variable assigned to an arrow expression. Apparently this case was uncovered.

## How?

Fix docgen to correctly handle this.

## Testing Instructions
CI passes.
