### PR TITLE
FontSizePicker: add pickerMode

### DIFF
--- a/packages/block-editor/src/components/font-sizes/README.md
+++ b/packages/block-editor/src/components/font-sizes/README.md
@@ -2,7 +2,7 @@
 
 FontSizePicker is a React component that renders a UI that allows users to select a font size.
 The component renders a user interface that allows the user to select predefined (common) font sizes and contains an option that allows users to select custom font sizes (by choosing the value) if that functionality is enabled.
-There is an equivalent component exposed under @wordpress/components. The difference between this component and the @wordpress components one is that this component does not require the `fontSizes` and `disableCustomFontSizes` properties. The editor settings are used to compute the value of these props.
+There is an equivalent component exposed under @wordpress/components. The difference between this component and the @wordpress components one is that this component does not require the `fontSizes` and `pickerMode` properties. The editor settings are used to compute the value of these props.
 
 ## Usage
 

--- a/packages/block-editor/src/components/font-sizes/font-size-picker.js
+++ b/packages/block-editor/src/components/font-sizes/font-size-picker.js
@@ -18,7 +18,7 @@ function FontSizePicker( props ) {
 		<BaseFontSizePicker
 			{ ...props }
 			fontSizes={ fontSizes }
-			disableCustomFontSizes={ ! customFontSize }
+			pickerMode={ customFontSize ? 'both' : 'predefined' }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -209,7 +209,9 @@ export default function TypographyPanel( {
 
 	// Font Size
 	const hasFontSizeEnabled = useHasFontSizeControl( settings );
-	const disableCustomFontSizes = ! settings?.typography?.customFontSize;
+	const fontSizePickerMode = ! settings?.typography?.customFontSize
+		? 'predefined'
+		: 'both';
 	const mergedFontSizes = getMergedFontSizes( settings );
 
 	const fontSize = decodeValue( inheritedValue?.typography?.fontSize );
@@ -443,7 +445,7 @@ export default function TypographyPanel( {
 						value={ fontSize }
 						onChange={ setFontSize }
 						fontSizes={ mergedFontSizes }
-						disableCustomFontSizes={ disableCustomFontSizes }
+						pickerMode={ fontSizePickerMode }
 						withReset={ false }
 						withSlider
 						size="__unstable-large"

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -48,13 +48,6 @@ const MyFontSizePicker = () => {
 
 The component accepts the following props:
 
-### `disableCustomFontSizes`: `boolean`
-
-If `true`, it will not be possible to choose a custom fontSize. The user will be forced to pick one of the pre-defined sizes passed in fontSizes.
-
--   Required: no
--   Default: `false`
-
 ### `fallbackFontSize`: `number`
 
 If no value exists, this prop defines the starting position for the font size picker slider. Only relevant if `withSlider` is `true`.
@@ -80,6 +73,13 @@ If onChange is called without any parameter, it should reset the value, attendin
 
 -   Required: Yes
 
+### `pickerMode`: `'predefined' | 'custom' | 'both`
+
+When set to `predefined`, the user will be only able to pick a font size from the predefined list passed via the `fontSizes` prop. When set to `custom`, the user will be only able to choose a custom font size. When set to `both`, the user will be able to access both UIs through a toggle.
+
+-   Required: No
+-   Default: `'both'`
+
 ### `size`: `'default' | '__unstable-large'`
 
 Size of the control.
@@ -102,14 +102,23 @@ The current font size value.
 
 ### `withReset`: `boolean`
 
-If `true`, a reset button will be displayed alongside the input field when a custom font size is active. Has no effect when `disableCustomFontSizes` is `true`.
+If `true`, a reset button will be displayed alongside the input field when a custom font size is active. Has no effect when `pickerMode` is `'predefined'` or `withSlider` is `true`.
 
 -   Required: no
 -   Default: `true`
 
 ### `withSlider`: `boolean`
 
-If `true`, a slider will be displayed alongside the input field when a custom font size is active. Has no effect when `disableCustomFontSizes` is `true`.
+If `true`, a slider will be displayed alongside the input field when a custom font size is active. Has no effect when `pickerMode` is `predefined`.
+
+-   Required: no
+-   Default: `false`
+
+### `disableCustomFontSizes`: `boolean`
+
+_Note: this prop is deprecated. Please use the `pickerMode` prop instead._
+
+If `true`, it will not be possible to choose a custom font size. The user will be forced to pick one of the pre-defined sizes passed via the `fontSizes` prop.
 
 -   Required: no
 -   Default: `false`

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -73,12 +73,12 @@ If onChange is called without any parameter, it should reset the value, attendin
 
 -   Required: Yes
 
-### `pickerMode`: `'predefined' | 'custom' | 'both`
+### `pickerMode`: `'predefined' | 'custom' | 'all`
 
-When set to `predefined`, the user will be only able to pick a font size from the predefined list passed via the `fontSizes` prop. When set to `custom`, the user will be only able to choose a custom font size. When set to `both`, the user will be able to access both UIs through a toggle.
+When set to `predefined`, the user will be only able to pick a font size from the predefined list passed via the `fontSizes` prop. When set to `custom`, the user will be only able to choose a custom font size. When set to `all`, the user will be able to access all UIs through a toggle.
 
 -   Required: No
--   Default: `'both'`
+-   Default: `'all'`
 
 ### `size`: `'default' | '__unstable-large'`
 

--- a/packages/components/src/font-size-picker/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-select.tsx
@@ -30,7 +30,7 @@ const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
 		__next40pxDefaultSize,
 		fontSizes,
 		value,
-		disableCustomFontSizes,
+		pickerMode,
 		size,
 		onChange,
 		onSelectCustom,
@@ -59,7 +59,7 @@ const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
 				__experimentalHint: hint,
 			};
 		} ),
-		...( disableCustomFontSizes ? [] : [ CUSTOM_OPTION ] ),
+		...( pickerMode === 'both' ? [ CUSTOM_OPTION ] : [] ),
 	];
 
 	const selectedOption = value

--- a/packages/components/src/font-size-picker/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-select.tsx
@@ -59,7 +59,7 @@ const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
 				__experimentalHint: hint,
 			};
 		} ),
-		...( pickerMode === 'both' ? [ CUSTOM_OPTION ] : [] ),
+		...( pickerMode === 'all' ? [ CUSTOM_OPTION ] : [] ),
 	];
 
 	const selectedOption = value

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -23,6 +23,7 @@ const DEFAULT_FONT_SIZE = 16;
 
 function FontSizePicker( {
 	fontSizes = [],
+	// Can this be kept as-is?
 	disableCustomFontSizes = false,
 	onChange,
 	value: selectedValue,

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -8,7 +8,7 @@ import type { ForwardedRef } from 'react';
  */
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
-import { useState, forwardRef } from '@wordpress/element';
+import { useState, forwardRef, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -131,6 +131,12 @@ const UnforwardedFontSizePicker = (
 	const [ currentPickerType, setCurrentPickerType ] = useState<
 		'select' | 'togglegroup' | 'custom'
 	>( getPickerType( computedPickerMode, isCustomValue, fontSizes ) );
+
+	useEffect( () => {
+		setCurrentPickerType(
+			getPickerType( computedPickerMode, isCustomValue, fontSizes )
+		);
+	}, [ computedPickerMode, isCustomValue, fontSizes ] );
 
 	const units = useCustomUnits( {
 		availableUnits: unitsProp,

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -207,9 +207,7 @@ const UnforwardedFontSizePicker = (
 						__next40pxDefaultSize={ __next40pxDefaultSize }
 						fontSizes={ fontSizes }
 						value={ value }
-						disableCustomFontSizes={
-							preferredPickerMode === 'predefined'
-						}
+						pickerMode={ computedPickerMode }
 						size={ size }
 						onChange={ ( newValue ) => {
 							if ( newValue === undefined ) {
@@ -224,8 +222,6 @@ const UnforwardedFontSizePicker = (
 								);
 							}
 						} }
-						// TODO: "Custom" shouldn't be shown if
-						// computedPickerMode is "predefined-only"
 						onSelectCustom={ () =>
 							setCurrentPickerType( 'custom' )
 						}

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -9,6 +9,7 @@ import type { ForwardedRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 import { useState, forwardRef, useEffect } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -23,7 +24,6 @@ import {
 } from '../unit-control';
 import { VisuallyHidden } from '../visually-hidden';
 import { getCommonSizeUnit } from './utils';
-import type { FontSize, FontSizePickerProps } from './types';
 import {
 	Container,
 	Header,
@@ -35,21 +35,23 @@ import { Spacer } from '../spacer';
 import FontSizePickerSelect from './font-size-picker-select';
 import FontSizePickerToggleGroup from './font-size-picker-toggle-group';
 import { T_SHIRT_NAMES } from './constants';
-import deprecated from '@wordpress/deprecated';
+import type {
+	FontSize,
+	FontSizePickerProps,
+	FontSizePickerMode,
+	FontSizePickerType,
+} from './types';
 
 const DEFAULT_UNITS = [ 'px', 'em', 'rem', 'vw', 'vh' ];
-
-type PickerMode = 'predefined' | 'custom' | 'both';
-type PickerType = 'select' | 'togglegroup' | 'custom';
 
 const shouldUseSelectOverToggle = ( howManyfontSizes: number ) =>
 	howManyfontSizes > 5;
 
 const getPickerType = (
-	pickerMode: PickerMode,
+	pickerMode: FontSizePickerMode,
 	isCustomValue: boolean,
 	fontSizes: FontSize[]
-): PickerType => {
+): FontSizePickerType => {
 	if (
 		pickerMode === 'custom' ||
 		( pickerMode !== 'predefined' && isCustomValue )
@@ -63,7 +65,7 @@ const getPickerType = (
 };
 
 const getHeaderHint = (
-	currentPickerType: PickerType,
+	currentPickerType: FontSizePickerType,
 	selectedFontSize: FontSize | undefined,
 	fontSizes: FontSize[]
 ) => {
@@ -128,9 +130,9 @@ const UnforwardedFontSizePicker = (
 	);
 	const isCustomValue = !! value && ! selectedFontSize;
 
-	const [ currentPickerType, setCurrentPickerType ] = useState<
-		'select' | 'togglegroup' | 'custom'
-	>( getPickerType( computedPickerMode, isCustomValue, fontSizes ) );
+	const [ currentPickerType, setCurrentPickerType ] = useState(
+		getPickerType( computedPickerMode, isCustomValue, fontSizes )
+	);
 
 	useEffect( () => {
 		setCurrentPickerType(

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -9,7 +9,6 @@ import type { ForwardedRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 import { useState, forwardRef, useEffect } from '@wordpress/element';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -113,15 +112,6 @@ const UnforwardedFontSizePicker = (
 
 	let computedPickerMode = pickerMode;
 	if ( disableCustomFontSizes !== undefined ) {
-		deprecated(
-			'`disableCustomFontSizes` prop in wp.components.FontSizePicker',
-			{
-				since: '6.7',
-				version: '6.9',
-				alternative: '`pickerMode` prop',
-			}
-		);
-
 		computedPickerMode = disableCustomFontSizes ? 'predefined' : 'both';
 	}
 

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -99,7 +99,7 @@ const UnforwardedFontSizePicker = (
 		fallbackFontSize,
 		fontSizes = [],
 		onChange,
-		pickerMode = 'both',
+		pickerMode = 'all',
 		size = 'default',
 		units: unitsProp = DEFAULT_UNITS,
 		value,
@@ -112,7 +112,7 @@ const UnforwardedFontSizePicker = (
 
 	let computedPickerMode = pickerMode;
 	if ( disableCustomFontSizes !== undefined ) {
-		computedPickerMode = disableCustomFontSizes ? 'predefined' : 'both';
+		computedPickerMode = disableCustomFontSizes ? 'predefined' : 'all';
 	}
 
 	const selectedFontSize = fontSizes.find(
@@ -173,8 +173,8 @@ const UnforwardedFontSizePicker = (
 							</HeaderHint>
 						) }
 					</HeaderLabel>
-					{ /* Show toggle button only when both picker modes are enabled */ }
-					{ computedPickerMode === 'both' && (
+					{ /* Show toggle button only when all picker modes are enabled */ }
+					{ computedPickerMode === 'all' && (
 						<HeaderToggle
 							label={
 								currentPickerType === 'custom'

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -57,7 +57,7 @@ const getPickerType = (
 		return 'custom';
 	}
 
-	return shouldUseSelectOverToggle( fontSizes.length ) || isCustomValue
+	return shouldUseSelectOverToggle( fontSizes.length )
 		? 'select'
 		: 'togglegroup';
 };

--- a/packages/components/src/font-size-picker/stories/index.story.tsx
+++ b/packages/components/src/font-size-picker/stories/index.story.tsx
@@ -66,7 +66,6 @@ const TwoFontSizePickersWithState: StoryFn< typeof FontSizePicker > = ( {
 export const Default: StoryFn< typeof FontSizePicker > =
 	FontSizePickerWithState.bind( {} );
 Default.args = {
-	disableCustomFontSizes: false,
 	fontSizes: [
 		{
 			name: 'Small',
@@ -98,14 +97,14 @@ WithSlider.args = {
 };
 
 /**
- * With custom font sizes disabled via the `disableCustomFontSizes` prop, the user will
+ * With the `pickerMode` set to `'predefined'`, the user will
  * only be able to pick one of the predefined sizes passed in `fontSizes`.
  */
 export const WithCustomSizesDisabled: StoryFn< typeof FontSizePicker > =
 	FontSizePickerWithState.bind( {} );
 WithCustomSizesDisabled.args = {
 	...Default.args,
-	disableCustomFontSizes: true,
+	pickerMode: 'predefined',
 };
 
 /**

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -640,4 +640,10 @@ describe( 'FontSizePicker', () => {
 			expect( units[ 2 ] ).toHaveAccessibleName( 'ex' );
 		} );
 	}
+
+	describe( 'pickerModes', () => {
+		it( 'should pass', async () => {
+			expect( 5 ).toBeGreaterThan( 4 );
+		} );
+	} );
 } );

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -539,7 +539,7 @@ describe( 'FontSizePicker', () => {
 			expect( onChange ).toHaveBeenCalledWith( '80px' );
 		} );
 
-		it( 'does not allow custom values when the pickerMode mode is not "both"', () => {
+		it( 'does not allow custom values when the pickerMode mode is not "all"', () => {
 			const { rerender } = render(
 				<FontSizePicker
 					fontSizes={ fontSizes }
@@ -558,7 +558,7 @@ describe( 'FontSizePicker', () => {
 			).not.toBeInTheDocument();
 
 			rerender(
-				<FontSizePicker fontSizes={ fontSizes } pickerMode="both" />
+				<FontSizePicker fontSizes={ fontSizes } pickerMode="all" />
 			);
 			expect(
 				screen.getByRole( 'button', { name: 'Set custom size' } )

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -539,16 +539,30 @@ describe( 'FontSizePicker', () => {
 			expect( onChange ).toHaveBeenCalledWith( '80px' );
 		} );
 
-		it( 'does not allow custom values when disableCustomFontSizes is set', () => {
-			render(
+		it( 'does not allow custom values when the pickerMode mode is not "both"', () => {
+			const { rerender } = render(
 				<FontSizePicker
 					fontSizes={ fontSizes }
-					disableCustomFontSizes
+					pickerMode="predefined"
 				/>
 			);
 			expect(
 				screen.queryByRole( 'button', { name: 'Set custom size' } )
 			).not.toBeInTheDocument();
+
+			rerender(
+				<FontSizePicker fontSizes={ fontSizes } pickerMode="custom" />
+			);
+			expect(
+				screen.queryByRole( 'button', { name: 'Set custom size' } )
+			).not.toBeInTheDocument();
+
+			rerender(
+				<FontSizePicker fontSizes={ fontSizes } pickerMode="both" />
+			);
+			expect(
+				screen.getByRole( 'button', { name: 'Set custom size' } )
+			).toBeVisible();
 		} );
 
 		it( 'does not display a slider by default', async () => {

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -107,9 +107,7 @@ export type FontSizePickerSelectProps = Pick<
 	'value' | 'size'
 > & {
 	fontSizes: NonNullable< FontSizePickerProps[ 'fontSizes' ] >;
-	disableCustomFontSizes: NonNullable<
-		FontSizePickerProps[ 'disableCustomFontSizes' ]
-	>;
+	pickerMode: NonNullable< FontSizePickerProps[ 'pickerMode' ] >;
 	onChange: NonNullable< FontSizePickerProps[ 'onChange' ] >;
 	onSelectCustom: () => void;
 	__next40pxDefaultSize: boolean;

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -1,3 +1,7 @@
+export type FontSizePickerMode = 'predefined' | 'custom' | 'both';
+
+export type FontSizePickerType = 'select' | 'togglegroup' | 'custom';
+
 export type FontSizePickerProps = {
 	/**
 	 * When set to `predefined`, the user will be only able to pick a font size
@@ -7,7 +11,7 @@ export type FontSizePickerProps = {
 	 *
 	 * @default 'both'
 	 */
-	pickerMode?: 'custom' | 'predefined' | 'both';
+	pickerMode?: FontSizePickerMode;
 	/**
 	 * _Note: this prop is deprecated. Please use the `pickerMode` prop instead._
 	 *

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -1,4 +1,4 @@
-export type FontSizePickerMode = 'predefined' | 'custom' | 'both';
+export type FontSizePickerMode = 'predefined' | 'custom' | 'all';
 
 export type FontSizePickerType = 'select' | 'togglegroup' | 'custom';
 
@@ -7,9 +7,9 @@ export type FontSizePickerProps = {
 	 * When set to `predefined`, the user will be only able to pick a font size
 	 * from the predefined list passed via the `fontSizes` prop. When set to
 	 * `custom`, the user will be only able to choose a custom font size. When
-	 * set to `both`, the user will be able to access both UIs through a toggle.
+	 * set to `all`, the user will be able to access all UIs through a toggle.
 	 *
-	 * @default 'both'
+	 * @default 'all'
 	 */
 	pickerMode?: FontSizePickerMode;
 	/**

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -1,6 +1,9 @@
 export type FontSizePickerProps = {
 	/**
-	 * TBD description
+	 * When set to `predefined`, the user will be only able to pick a font size
+	 * from the predefined list passed via the `fontSizes` prop. When set to
+	 * `custom`, the user will be only able to choose a custom font size. When
+	 * set to `both`, the user will be able to access both UIs through a toggle.
 	 *
 	 * @default 'both'
 	 */
@@ -8,8 +11,9 @@ export type FontSizePickerProps = {
 	/**
 	 * _Note: this prop is deprecated. Please use the `pickerMode` prop instead._
 	 *
-	 * If `true`, it will not be possible to choose a custom fontSize. The user
-	 * will be forced to pick one of the pre-defined sizes passed in fontSizes.
+	 * If `true`, it will not be possible to choose a custom font size. The user
+	 * will be forced to pick one of the pre-defined sizes passed via the
+	 * `fontSizes` prop.
 	 *
 	 * @default false
 	 * @deprecated
@@ -38,7 +42,7 @@ export type FontSizePickerProps = {
 	/**
 	 * Available units for custom font size selection.
 	 *
-	 * @default `[ 'px', 'em', 'rem' ]`
+	 * @default [ 'px', 'em', 'rem' ]
 	 */
 	units?: string[];
 	/**
@@ -46,8 +50,8 @@ export type FontSizePickerProps = {
 	 */
 	value?: number | string;
 	/**
-	 * If `true`, the UI will contain a slider, instead of a numeric text input
-	 * field. If `false`, no slider will be present.
+	 * If `true`, a slider will be displayed alongside the input field when a
+	 * custom font size is active. Has no effect when `pickerMode` is `predefined`.
 	 *
 	 * @default false
 	 */
@@ -55,7 +59,7 @@ export type FontSizePickerProps = {
 	/**
 	 * If `true`, a reset button will be displayed alongside the input field
 	 * when a custom font size is active. Has no effect when
-	 * `disableCustomFontSizes` or `withSlider` is `true`.
+	 * `pickerMode` is `'predefined'` or `withSlider` is `true`.
 	 *
 	 * @default true
 	 */

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -1,9 +1,18 @@
 export type FontSizePickerProps = {
 	/**
+	 * TBD description
+	 *
+	 * @default 'both'
+	 */
+	pickerMode?: 'custom' | 'predefined' | 'both';
+	/**
+	 * _Note: this prop is deprecated. Please use the `pickerMode` prop instead._
+	 *
 	 * If `true`, it will not be possible to choose a custom fontSize. The user
 	 * will be forced to pick one of the pre-defined sizes passed in fontSizes.
 	 *
 	 * @default false
+	 * @deprecated
 	 */
 	disableCustomFontSizes?: boolean;
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following [this conversation](https://github.com/WordPress/gutenberg/pull/62328#discussion_r1659012795), this PR introduces a new `pickerMode` prop that is meant to supersede the existing `disableCustomFontSizes` prop (which gets marked as deprecated).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the `disableCustomFontSizes` prop, consumers of the component can choose to prevent users to enter custom font size values, forcing them to pick from the list of predefined font sizes.

But there isn't a way to achieve the opposite — ie. allow users to only pick from a list of custom values, without being able to choose from a list of predef options.

The `pickerMode` prop is a enum of different modes:

- `both` maps to `disableCustomFontSizes = false`
- `predefined` maps to `disableCustomFontSizes = true`
- `custom` introduces the missing mode discussed above.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I refactored the code and extracted some logic away from the render function, to bring more clarity to it.

Together with the `pickerMode` prop, I also introduced the idea of `pickerType` (see [this comment](https://github.com/WordPress/gutenberg/pull/63040#discussion_r1662016329)).

I also refactored tests and usages in Gutenberg to already use the new `pickerMode` prop.

TODO: 
- unit tests
- add documentation about the consumer being responsible for any validation to prevent weird UI states when custom values are used with `pickerMode="predefined"`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

_Note: I recommend enabling the "Hide whitespace changes" options when reviewing the code changes in this PR._

TBD

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
