### PR TITLE
Performance tests: restore 6.5-compatible locator

### DIFF
--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -295,22 +295,54 @@ test.describe( 'Site Editor Performance', () => {
 				} );
 				await editor.openDocumentSettingsSidebar();
 
+				/*
+				 * https://github.com/WordPress/gutenberg/pull/55091 updated the HTML by
+				 * removing the replace template button in sidebar-edit-mode/template-panel/replace-template-button.js
+				 * with a "transform into" list. https://github.com/WordPress/gutenberg/pull/59259 made these tests
+				 * compatible with the new UI, however, the performance tests compare previous versions of the UI.
+				 *
+				 * The following code is a workaround to test the performance of the new UI.
+				 * `actionsButtonElement` is used to check if the old UI is present.
+				 * If there is a Replace template button (old UI), click it, otherwise, click the "transform into" button.
+				 * Once the performance tests are updated to compare compatible versions this code can be removed.
+				 */
+				// eslint-disable-next-line no-restricted-syntax
+				const isActionsButtonVisible = await page
+					.locator(
+						'.edit-site-template-card__actions button[aria-label="Actions"]'
+					)
+					.isVisible();
+
+				if ( isActionsButtonVisible ) {
+					await page
+						.getByRole( 'button', {
+							name: 'Actions',
+						} )
+						.click();
+				}
+
 				// Wait for the browser to be idle before starting the monitoring.
 				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
 
 				const startTime = performance.now();
 
-				await page
-					.getByRole( 'button', { name: 'Design' } )
-					.or(
-						// Locator for backward compatibility with the old UI.
-						// The label was updated in https://github.com/WordPress/gutenberg/pull/62161.
-						page.getByRole( 'button', {
-							name: 'Transform into:',
-						} )
-					)
-					.click();
+				if ( isActionsButtonVisible ) {
+					await page
+						.getByRole( 'menuitem', { name: 'Replace template' } )
+						.click();
+				} else {
+					await page
+						.getByRole( 'button', { name: 'Design' } )
+						.or(
+							// Locator for backward compatibility with the old UI.
+							// The label was updated in https://github.com/WordPress/gutenberg/pull/62161.
+							page.getByRole( 'button', {
+								name: 'Transform into:',
+							} )
+						)
+						.click();
+				}
 
 				const patterns = [
 					'Blogging home template',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This was removed in #62362, probably [mistaken for 6.4 compatibility](https://github.com/WordPress/gutenberg/pull/62362/files#r1629137386).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The performance tests are failing when comparing 6.5 to 6.6: https://github.com/WordPress/gutenberg/actions/runs/9756328362/job/26926429203

This was the screenshot on failure:

![test-failed-1](https://github.com/WordPress/gutenberg/assets/4710635/0faf22e6-f430-492f-b11a-ef8d7470334d)


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Partial revert.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
