### PR TITLE
File block: Use native feature detection for pdf support

### DIFF
--- a/packages/block-library/src/file/utils/index.js
+++ b/packages/block-library/src/file/utils/index.js
@@ -5,6 +5,11 @@
  * @return {boolean} Whether or not the browser supports inline PDFs.
  */
 export const browserSupportsPdfs = () => {
+	// Use native feature detection if available.
+	if ( window.navigator.pdfViewerEnabled ) {
+		return true;
+	}
+
 	// Most mobile devices include "Mobi" in their UA.
 	if ( window.navigator.userAgent.indexOf( 'Mobi' ) > -1 ) {
 		return false;


### PR DESCRIPTION
Fixes #58891

Relies on https://developer.mozilla.org/en-US/docs/Web/API/Navigator/pdfViewerEnabled


## What?
This PR adds a reliable way to detect pdf viewer support.

## Why?
It fixes #58891 and deterministically looks for pdf viewer support.

## How?
We check whether the browser signals that pdf viewer is available and if so, immediately assumes that the browser supports pdf viewing (without relying on user agent detection). It falls back to the old behavior if this pdfViewerEnabled property is not available in navigator.

## Testing Instructions
1. Open a post or page
2. Insert a file block and choose a PDF
3. Save the post.
4. View from a mobile device

### Testing Instructions for Keyboard
Same as above.
