### PR TITLE
Components: Split stories and test files into separate projects

### DIFF
--- a/packages/components/src/clipboard-button/index.tsx
+++ b/packages/components/src/clipboard-button/index.tsx
@@ -32,7 +32,7 @@ export default function ClipboardButton( {
 		alternative: 'wp.compose.useCopyToClipboard',
 	} );
 
-	const timeoutId = useRef< NodeJS.Timeout >();
+	const timeoutId = useRef< number >();
 	const ref = useCopyToClipboard( text, () => {
 		onCopy();
 		if ( timeoutId.current ) {

--- a/packages/components/src/color-palette/stories/index.story.tsx
+++ b/packages/components/src/color-palette/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import type { CSSProperties } from 'react';
 
 /**
  * WordPress dependencies
@@ -91,11 +92,13 @@ MultipleOrigins.args = {
 export const CSSVariables: StoryFn< typeof ColorPalette > = ( args ) => {
 	return (
 		<div
-			style={ {
-				'--red': '#f00',
-				'--yellow': '#ff0',
-				'--blue': '#00f',
-			} }
+			style={
+				{
+					'--red': '#f00',
+					'--yellow': '#ff0',
+					'--blue': '#00f',
+				} as CSSProperties
+			}
 		>
 			<Template { ...args } />
 		</div>

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -33,7 +33,7 @@
 		"src/**/*.native.js",
 		"src/**/react-native-*",
 
-		// Stories and tests are included in another project dedicated project.
+		// Stories and tests are included in another project.
 		"src/**/stories",
 		"src/**/test"
 	]

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -4,12 +4,7 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"declarationDir": "build-types",
-		"types": [
-			"gutenberg-env",
-			"gutenberg-test-env",
-			"jest",
-			"@testing-library/jest-dom"
-		]
+		"types": [ "gutenberg-env" ]
 	},
 	"references": [
 		{ "path": "../a11y" },
@@ -31,13 +26,15 @@
 		{ "path": "../rich-text" },
 		{ "path": "../warning" }
 	],
-	"include": [ "src/**/*" ],
+	"include": [ "src" ],
 	"exclude": [
 		"src/**/*.android.js",
 		"src/**/*.ios.js",
 		"src/**/*.native.js",
 		"src/**/react-native-*",
-		"src/**/stories/**/*.js", // only exclude js files, tsx files should be checked
-		"src/**/test/**/*.js" // only exclude js files, ts{x} files should be checked
+
+		// Stories and tests are included in another project dedicated project.
+		"src/**/stories",
+		"src/**/test"
 	]
 }

--- a/packages/components/tsconfig.stories-tests.json
+++ b/packages/components/tsconfig.stories-tests.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"allowJs": false,
+		"allowJs": true,
 		"checkJs": false,
 		"noEmit": true,
 		"emitDeclarationOnly": false,
@@ -18,5 +18,10 @@
 	},
 	"references": [ { "path": "./tsconfig.json" } ],
 	"include": [ "src/**/stories", "src/**/test" ],
-	"exclude": []
+	"exclude": [
+		"**/*.android.js",
+		"**/*.ios.js",
+		"**/*.native.js",
+		"packages/**/react-native-*/**"
+	]
 }

--- a/packages/components/tsconfig.stories-tests.json
+++ b/packages/components/tsconfig.stories-tests.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"allowJs": false,
+		"checkJs": false,
+		"noEmit": true,
+		"emitDeclarationOnly": false,
+
+		"rootDir": "src",
+		"declarationDir": "build-types",
+		"types": [
+			"gutenberg-env",
+			"gutenberg-test-env",
+			"jest",
+			"@testing-library/jest-dom"
+		]
+	},
+	"references": [ { "path": "./tsconfig.json" } ],
+	"include": [ "src/**/stories", "src/**/test" ]
+}

--- a/packages/components/tsconfig.stories-tests.json
+++ b/packages/components/tsconfig.stories-tests.json
@@ -2,6 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"allowJs": false,
+		"checkJs": false,
 		"noEmit": true,
 		"emitDeclarationOnly": false,
 
@@ -15,11 +17,6 @@
 		]
 	},
 	"references": [ { "path": "./tsconfig.json" } ],
-	"include": [
-		// Only check TypeScript files
-		"src/**/stories/**/*.ts",
-		"src/**/stories/**/*.tsx",
-		"src/**/test/**/*.ts",
-		"src/**/test/**/*.tsx"
-	]
+	"include": [ "src/**/stories", "src/**/test" ],
+	"exclude": []
 }

--- a/packages/components/tsconfig.stories-tests.json
+++ b/packages/components/tsconfig.stories-tests.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"allowJs": false,
-		"checkJs": false,
 		"noEmit": true,
 		"emitDeclarationOnly": false,
 
@@ -17,5 +15,11 @@
 		]
 	},
 	"references": [ { "path": "./tsconfig.json" } ],
-	"include": [ "src/**/stories", "src/**/test" ]
+	"include": [
+		// Only check TypeScript files
+		"src/**/stories/**/*.ts",
+		"src/**/stories/**/*.tsx",
+		"src/**/test/**/*.ts",
+		"src/**/test/**/*.tsx"
+	]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,8 @@
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
 
+		"skipDefaultLibCheck": true,
+
 		/* Strict Type-Checking Options */
 		"strict": true,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 		{ "path": "packages/block-library" },
 		{ "path": "packages/block-serialization-default-parser" },
 		{ "path": "packages/components" },
+		{ "path": "packages/components/tsconfig.stories-tests.json" },
 		{ "path": "packages/compose" },
 		{ "path": "packages/core-data" },
 		{ "path": "packages/data" },


### PR DESCRIPTION


## What?

I did some TypeScript analysis and found that most TypeScript compilation time is spent on the components package. Some very costly compilation was in stories.

## Why?

I wanted to try to split out stories (and tests) for a few reasons:
- The use an environment that is not suitable for application code with jest, node, and other globals.
- There's no reason to emit anything (including declarations) for stories and tests. We can typecheck them, but nothing consumes the types so we can save the emit.


## How?

Split into a separate project.

## Testing Instructions
CI passes.
Look at some stories in an editor with TypeScript integration. Does everything seem OK?
