### PR TITLE
DataViews: Register the export pattern action like any third-party action

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -31,7 +31,6 @@ import {
 } from '../../store/constants';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { exportPatternAsJSONAction } from './export-pattern-action';
 import { CreateTemplatePartModalContents } from '../create-template-part-modal';
 import { getItemTitle } from '../../dataviews/actions/utils';
 
@@ -914,7 +913,6 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 				duplicateTemplatePartAction,
 			isPattern && userCanCreatePostType && duplicatePatternAction,
 			supportsTitle && renamePostActionForPostType,
-			isPattern && exportPatternAsJSONAction,
 			! isTemplateOrTemplatePart && restorePostActionForPostType,
 			! isTemplateOrTemplatePart &&
 				! isPattern &&

--- a/packages/editor/src/components/post-actions/export-pattern-action.native.js
+++ b/packages/editor/src/components/post-actions/export-pattern-action.native.js
@@ -1,4 +1,0 @@
-// Client-zip is meant to be used in a browser and is therefore released as an ES6 module only,
-// in order for the native build to succeed we are importing a null action and avoiding importing
-// the non working in native context client-zip module.
-export const exportPatternAsJSONAction = null;

--- a/packages/editor/src/dataviews/actions/export-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/export-pattern.tsx
@@ -34,12 +34,6 @@ const exportPattern: Action< Pattern > = {
 	id: 'export-pattern',
 	label: __( 'Export as JSON' ),
 	supportsBulk: true,
-	isEligible: ( item ) => {
-		if ( ! item.type ) {
-			return false;
-		}
-		return item.type === 'wp_block';
-	},
 	callback: async ( items ) => {
 		if ( items.length === 1 ) {
 			return downloadBlob(

--- a/packages/editor/src/dataviews/actions/export-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/export-pattern.tsx
@@ -9,18 +9,15 @@ import { downloadZip } from 'client-zip';
  */
 import { downloadBlob } from '@wordpress/blob';
 import { __ } from '@wordpress/i18n';
-import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
+import type { Action } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
  */
-import { unlock } from '../../lock-unlock';
-import { getItemTitle } from '../../dataviews/actions/utils';
+import type { Pattern } from '../types';
+import { getItemTitle } from './utils';
 
-// Patterns.
-const { PATTERN_TYPES } = unlock( patternsPrivateApis );
-
-function getJsonFromItem( item ) {
+function getJsonFromItem( item: Pattern ) {
 	return JSON.stringify(
 		{
 			__file: item.type,
@@ -33,7 +30,7 @@ function getJsonFromItem( item ) {
 	);
 }
 
-export const exportPatternAsJSONAction = {
+const exportPattern: Action< Pattern > = {
 	id: 'export-pattern',
 	label: __( 'Export as JSON' ),
 	supportsBulk: true,
@@ -41,7 +38,7 @@ export const exportPatternAsJSONAction = {
 		if ( ! item.type ) {
 			return false;
 		}
-		return item.type === PATTERN_TYPES.user;
+		return item.type === 'wp_block';
 	},
 	callback: async ( items ) => {
 		if ( items.length === 1 ) {
@@ -53,7 +50,7 @@ export const exportPatternAsJSONAction = {
 				'application/json'
 			);
 		}
-		const nameCount = {};
+		const nameCount: Record< string, number > = {};
 		const filesToZip = items.map( ( item ) => {
 			const name = kebabCase( getItemTitle( item ) || item.slug );
 			nameCount[ name ] = ( nameCount[ name ] || 0 ) + 1;
@@ -75,3 +72,5 @@ export const exportPatternAsJSONAction = {
 		);
 	},
 };
+
+export default exportPattern;

--- a/packages/editor/src/dataviews/actions/index.ts
+++ b/packages/editor/src/dataviews/actions/index.ts
@@ -7,6 +7,7 @@ import { type StoreDescriptor, dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import deletePost from './delete-post';
+import exportPattern from './export-pattern';
 import resetPost from './reset-post';
 
 // @ts-ignore
@@ -18,6 +19,7 @@ export default function registerDefaultActions() {
 		dispatch( editorStore as StoreDescriptor )
 	);
 
+	registerEntityAction( 'postType', 'wp_block', exportPattern );
 	registerEntityAction( 'postType', '*', resetPost );
 	registerEntityAction( 'postType', '*', deletePost );
 }

--- a/packages/editor/src/dataviews/store/reducer.ts
+++ b/packages/editor/src/dataviews/store/reducer.ts
@@ -19,8 +19,13 @@ function actions( state: ActionState = {}, action: ReduxAction ) {
 			return {
 				...state,
 				[ action.kind ]: {
+					...state[ action.kind ],
 					[ action.name ]: [
-						...( state[ action.kind ]?.[ action.name ] ?? [] ),
+						...(
+							state[ action.kind ]?.[ action.name ] ?? []
+						).filter(
+							( _action ) => _action.id !== action.config.id
+						),
 						action.config,
 					],
 				},
@@ -28,9 +33,12 @@ function actions( state: ActionState = {}, action: ReduxAction ) {
 		case 'UNREGISTER_ENTITY_ACTION': {
 			return {
 				...state,
-				[ action.kind ]: (
-					state[ action.kind ]?.[ action.name ] ?? []
-				).filter( ( _action ) => _action.id !== action.actionId ),
+				[ action.kind ]: {
+					...state[ action.kind ],
+					[ action.name ]: (
+						state[ action.kind ]?.[ action.name ] ?? []
+					).filter( ( _action ) => _action.id !== action.actionId ),
+				},
 			};
 		}
 	}

--- a/packages/editor/src/dataviews/types.ts
+++ b/packages/editor/src/dataviews/types.ts
@@ -20,7 +20,16 @@ export interface TemplateOrTemplatePart extends BasePost {
 	id: string;
 }
 
-export type Post = TemplateOrTemplatePart | BasePost;
+export interface Pattern extends BasePost {
+	slug: string;
+	title: { raw: string };
+	content: {
+		raw: string;
+	};
+	wp_pattern_sync_status: string;
+}
+
+export type Post = TemplateOrTemplatePart | Pattern | BasePost;
 
 // Will be unnecessary after typescript 5.0 upgrade.
 export type CoreDataError = { message?: string; code?: string };


### PR DESCRIPTION
Related #61084 
Similar to #62913 

## What?

In #62052 an API to register and unregister dataviews actions has been implemented. But in order to allow third-party developers to be able to unregister these actions, we need to be using the same actions in Core to register the core actions.

The current PR explore the possibility to use the API to register one action: "export pattern". 

## Testing Instructions

1- Open the patterns dataviews
2- Click "My patterns"
3- On the actions menu per pattern, click "Export as JSON"