### PR TITLE
Data Views: be more clear with the copy of the "hide" action

### DIFF
--- a/packages/dataviews/src/layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/layouts/table/column-header-menu.tsx
@@ -249,7 +249,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							} }
 						>
 							<DropdownMenuItemLabel>
-								{ __( 'Hide' ) }
+								{ __( 'Hide column' ) }
 							</DropdownMenuItemLabel>
 						</DropdownMenuItem>
 					) }


### PR DESCRIPTION
Small copy tweak to clarify what "hide" refers to.

<img width="326" alt="image" src="https://github.com/WordPress/gutenberg/assets/548849/3612bdd8-8c28-4edd-8391-2e3f4eed681f">
