### PR TITLE
Reduce specifity of social link icon specific colors

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -107,7 +107,7 @@
 }
 
 // Provide colors for a range of icons.
-.wp-block-social-links:not(.is-style-logos-only) {
+:where(.wp-block-social-links:not(.is-style-logos-only)) {
 	// Generic items such as mail, feed, etc.
 	@import "../social-link/socials-with-bg.scss";
 }
@@ -116,7 +116,7 @@
 // The specificity for this selector has not been reduced to 0-1-0 as per
 // global styles variation selectors as the lack of background should be
 // enforced for this block style.
-.wp-block-social-links.is-style-logos-only {
+:where(.wp-block-social-links.is-style-logos-only) {
 	.wp-social-link {
 		background: none;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reduces the specificity of the social links block background and foreground colors to 0,1,0.

## Why?
This allows colors defined in the theme.json block `css` property to override the default block css.

## How?
Wraps the selector in `:where` which results in the generated css having selectors like `:where(.wp-block-social-links:not(.is-style-logos-only)) .wp-social-link-behance` compared to the previous output of `.wp-block-social-links:not(.is-style-logos-only) .wp-social-link-behance`.

## Testing Instructions
1. Add something like the following snippet to your theme.json in the `styles.blocks` object:
```json
"core/social-links": {
	"css": " .wp-block-social-link {background-color: silver; color: red;}"
},
```
2. Add a social links block and some individual icons, check that the background is silver and the color is red.
3. Remove that code from the theme.json and check that the social links block works normally with no changes.

## Screenshots or screencast <!-- if applicable -->
In trunk (no silver background or red icon):
![Screenshot 2024-07-02 at 6 36 04 pm](https://github.com/WordPress/gutenberg/assets/677833/3fd0ac23-6e8b-45ad-a7d2-4ccaaae8680c)

In this PR (silver background and red icon):
![Screenshot 2024-07-02 at 6 35 39 pm](https://github.com/WordPress/gutenberg/assets/677833/0845d3eb-cfb6-49c0-81d7-794daf80a725)