### PR TITLE
Fix Incorrect URL basename logic in EmbedPreview

### DIFF
--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -73,14 +73,11 @@ class EmbedPreview extends Component {
 		const { interactive } = this.state;
 
 		const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
-		const parsedHost = new URL( url ).host.split( '.' );
-		const parsedHostBaseUrl = parsedHost
-			.splice( parsedHost.length - 2, parsedHost.length - 1 )
-			.join( '.' );
+		const embedSourceUrl = new URL( url ).hostname;
 		const iframeTitle = sprintf(
 			// translators: %s: host providing embed content e.g: www.youtube.com
 			__( 'Embedded content from %s' ),
-			parsedHostBaseUrl
+			embedSourceUrl
 		);
 		const sandboxClassnames = clsx(
 			type,
@@ -136,7 +133,7 @@ class EmbedPreview extends Component {
 								__(
 									"Embedded content from %s can't be previewed in the editor."
 								),
-								parsedHostBaseUrl
+								embedSourceUrl
 							) }
 						</p>
 					</Placeholder>

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { getAuthority } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -73,7 +74,7 @@ class EmbedPreview extends Component {
 		const { interactive } = this.state;
 
 		const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
-		const embedSourceUrl = new URL( url ).hostname;
+		const embedSourceUrl = getAuthority( url );
 		const iframeTitle = sprintf(
 			// translators: %s: host providing embed content e.g: www.youtube.com
 			__( 'Embedded content from %s' ),

--- a/packages/block-library/src/embed/embed-preview.native.js
+++ b/packages/block-library/src/embed/embed-preview.native.js
@@ -77,11 +77,14 @@ const EmbedPreview = ( {
 
 	const { provider_url: providerUrl } = preview;
 	const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
-	const embedSourceUrl = new URL( url ).host.split( '.' );
+	const parsedHost = new URL( url ).host.split( '.' );
+	const parsedHostBaseUrl = parsedHost
+		.splice( parsedHost.length - 2, parsedHost.length - 1 )
+		.join( '.' );
 	const iframeTitle = sprintf(
 		// translators: %s: host providing embed content e.g: www.youtube.com
 		__( 'Embedded content from %s' ),
-		embedSourceUrl
+		parsedHostBaseUrl
 	);
 	const sandboxClassnames = clsx(
 		type,

--- a/packages/block-library/src/embed/embed-preview.native.js
+++ b/packages/block-library/src/embed/embed-preview.native.js
@@ -77,14 +77,11 @@ const EmbedPreview = ( {
 
 	const { provider_url: providerUrl } = preview;
 	const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
-	const parsedHost = new URL( url ).host.split( '.' );
-	const parsedHostBaseUrl = parsedHost
-		.splice( parsedHost.length - 2, parsedHost.length - 1 )
-		.join( '.' );
+	const embedSourceUrl = new URL( url ).host.split( '.' );
 	const iframeTitle = sprintf(
 		// translators: %s: host providing embed content e.g: www.youtube.com
 		__( 'Embedded content from %s' ),
-		parsedHostBaseUrl
+		embedSourceUrl
 	);
 	const sandboxClassnames = clsx(
 		type,

--- a/test/e2e/specs/editor/various/embedding.spec.js
+++ b/test/e2e/specs/editor/various/embedding.spec.js
@@ -106,7 +106,7 @@ test.describe( 'Embedding content', () => {
 		await expect(
 			currenEmbedBlock.locator( 'iframe' ),
 			'Valid embed. Should render valid element.'
-		).toHaveAttribute( 'title', 'Embedded content from twitter' );
+		).toHaveAttribute( 'title', 'Embedded content from twitter.com' );
 
 		await embedUtils.insertEmbed(
 			'https://twitter.com/wooyaygutenberg123454312'
@@ -150,7 +150,7 @@ test.describe( 'Embedding content', () => {
 		await expect(
 			currenEmbedBlock.locator( 'iframe' ),
 			'Photo content. Should render valid iframe element.'
-		).toHaveAttribute( 'title', 'Embedded content from cloudup' );
+		).toHaveAttribute( 'title', 'Embedded content from cloudup.com' );
 	} );
 
 	test( 'should allow the user to convert unembeddable URLs to a paragraph with a link in it', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes #60248

## What?
This PR improves the URL parsing in the EmbedPreview component to display a more consistent and user-friendly source for embedded content.

## Why?
The current implementation of the EmbedPreview component displays inconsistent messages about the source of embedded content. This PR addresses this issue by providing a more reliable method to extract the hostname from URLs.

## How?
1. We replaced the complex URL parsing logic with a simpler approach using the URL API:
```const embedSourceUrl = new URL(url).hostname;```
2. This new embedSourceUrl is used in  iframe title and error message

## Testing Instructions
1. Open a post or page.
2. Insert embed block(s) for various providers
3. Set previewable attribute to false
4. See the consistent message

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="614" alt="Screenshot 2024-07-02 at 2 46 33 PM" src="https://github.com/WordPress/gutenberg/assets/64325240/a13297af-7b99-476c-b5e0-8c549cb17d40">

#### After
<img width="608" alt="Screenshot 2024-07-02 at 4 17 12 PM" src="https://github.com/WordPress/gutenberg/assets/64325240/ea437598-887a-4a77-a8a0-a91e532a36c6">


