### PR TITLE
Build: Enable TypeScript skipDefaultLibCheck

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,8 @@
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
 
+		"skipDefaultLibCheck": true,
+
 		/* Strict Type-Checking Options */
 		"strict": true,
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Enabling this configuration should improve TypeScript build performance with few or no downsides.

## Why?

This skips _checking_ types that are bundled with TypeScript. We should
be able to trust these types, so they can be used without checking them.

Many packages use the DOM types and this appeared as a hot spot when
analyzing the TypeScript build.

Adding this configuration should improve TypeScript build performance.

### Benchmark

Run `./node_modules/.bin/tsc --build --force`, which is a build without caches:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `branch` | 80.844 ± 2.019 | 78.665 | 83.717 | 1.00 |
| `trunk` | 91.972 ± 1.819 | 88.670 | 94.230 | 1.14 ± 0.04 |

That's a ~10s build improvement on my machine.

## Testing Instructions
CI passes.