### PR TITLE
Inserter: Remove the dialog behaviour

### DIFF
--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -6,10 +6,7 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import {
-	useViewportMatch,
-	__experimentalUseDialog as useDialog,
-} from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import { useCallback, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -63,10 +60,6 @@ export default function InserterSidebar() {
 	const { disableComplementaryArea } = useDispatch( interfaceStore );
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: () => setIsInserterOpened( false ),
-		focusOnMount: true,
-	} );
 	const libraryRef = useRef();
 
 	// When closing the inserter, focus should return to the toggle button.
@@ -120,13 +113,5 @@ export default function InserterSidebar() {
 			</div>
 		);
 	}
-	return (
-		<div
-			ref={ inserterDialogRef }
-			{ ...inserterDialogProps }
-			className="editor-inserter-sidebar"
-		>
-			{ inserterContents }
-		</div>
-	);
+	return <div className="editor-inserter-sidebar">{ inserterContents }</div>;
 }

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -102,16 +102,10 @@ export default function InserterSidebar() {
 		</div>
 	);
 
-	if ( window.__experimentalEnableZoomedOutPatternsTab ) {
-		return (
-			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-			<div
-				onKeyDown={ closeOnEscape }
-				className="editor-inserter-sidebar"
-			>
-				{ inserterContents }
-			</div>
-		);
-	}
-	return <div className="editor-inserter-sidebar">{ inserterContents }</div>;
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div onKeyDown={ closeOnEscape } className="editor-inserter-sidebar">
+			{ inserterContents }
+		</div>
+	);
 }

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -636,7 +636,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			page.getByRole( 'region', {
 				name: 'Block Library',
 			} )
-		).toBeHidden();
+		).toBeVisible();
 	} );
 
 	test( 'shows block preview when hovering over block in inserter', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes the dialog behaviour from the inserter sidebar panel. This was originally proposed in #61051 but was removed so that it didn't go into WordPress 6.6.

## Why?
Consistency. All of the other panels behave like this.

## How?
Remove the useDialog hook.

## Testing Instructions
0. Open the Site Editor
1. Open the inserter
2. Click on the canvas
3. Check that the inserter remains open.