### PR TITLE
Make SiteHub available in mobile viewports

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -174,10 +174,12 @@ export default function Layout( { route } ) {
 
 					{ isMobileViewport && areas.mobile && (
 						<div className="edit-site-layout__mobile">
-							<SiteHub
-								ref={ toggleRef }
-								isTransparent={ isResizableFrameOversized }
-							/>
+							{ canvasMode !== 'edit' && (
+								<SiteHub
+									ref={ toggleRef }
+									isTransparent={ isResizableFrameOversized }
+								/>
+							) }
 							{ areas.mobile }
 						</div>
 					) }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -175,10 +175,14 @@ export default function Layout( { route } ) {
 					{ isMobileViewport && areas.mobile && (
 						<div className="edit-site-layout__mobile">
 							{ canvasMode !== 'edit' && (
-								<SiteHub
-									ref={ toggleRef }
-									isTransparent={ isResizableFrameOversized }
-								/>
+								<SidebarContent routeKey={ routeKey }>
+									<SiteHub
+										ref={ toggleRef }
+										isTransparent={
+											isResizableFrameOversized
+										}
+									/>
+								</SidebarContent>
 							) }
 							{ areas.mobile }
 						</div>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -174,6 +174,10 @@ export default function Layout( { route } ) {
 
 					{ isMobileViewport && areas.mobile && (
 						<div className="edit-site-layout__mobile">
+							<SiteHub
+								ref={ toggleRef }
+								isTransparent={ isResizableFrameOversized }
+							/>
 							{ areas.mobile }
 						</div>
 					) }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -153,13 +153,13 @@ export default function Layout( { route } ) {
 										} }
 										className="edit-site-layout__sidebar"
 									>
-										<SiteHub
-											ref={ toggleRef }
-											isTransparent={
-												isResizableFrameOversized
-											}
-										/>
 										<SidebarContent routeKey={ routeKey }>
+											<SiteHub
+												ref={ toggleRef }
+												isTransparent={
+													isResizableFrameOversized
+												}
+											/>
 											{ areas.sidebar }
 										</SidebarContent>
 										<SaveHub />

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -25,7 +25,12 @@ function focusSidebarElement( el, direction, focusSelector ) {
 		elementToFocus = el.querySelector( focusSelector );
 	}
 	if ( direction !== null && ! elementToFocus ) {
-		const [ firstTabbable ] = focus.tabbable.find( el );
+		// When looking for the first tabbable element, we need to skip the
+		// site hub if present, where we do not want to place focus.
+		const siblingOfSiteHub = el.querySelector(
+			'.edit-site-site-hub'
+		)?.nextElementSibling;
+		const [ firstTabbable ] = focus.tabbable.find( siblingOfSiteHub || el );
 		elementToFocus = firstTabbable ?? el;
 	}
 	elementToFocus?.focus();

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -8,14 +8,16 @@ import clsx from 'clsx';
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { memo, forwardRef } from '@wordpress/element';
+import { memo, forwardRef, useContext } from '@wordpress/element';
 import { search } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 import { filterURLForDisplay } from '@wordpress/url';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
@@ -23,9 +25,15 @@ import { filterURLForDisplay } from '@wordpress/url';
 import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
+const { useHistory } = unlock( routerPrivateApis );
+import { SidebarNavigationContext } from '../sidebar';
 
 const SiteHub = memo(
 	forwardRef( ( { isTransparent }, ref ) => {
+		const isMobileViewport = useViewportMatch( 'medium', '<' );
+		const history = useHistory();
+		const { navigate } = useContext( SidebarNavigationContext );
+
 		const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
 			const { getSettings } = unlock( select( editSiteStore ) );
 
@@ -57,18 +65,37 @@ const SiteHub = memo(
 							}
 						) }
 					>
-						<Button
-							ref={ ref }
-							href={ dashboardLink }
-							label={ __( 'Go to the Dashboard' ) }
-							className="edit-site-layout__view-mode-toggle"
-							style={ {
-								transform: 'scale(0.5)',
-								borderRadius: 4,
-							} }
-						>
-							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-						</Button>
+						{ ! isMobileViewport && (
+							<Button
+								ref={ ref }
+								href={ dashboardLink }
+								label={ __( 'Go to the Dashboard' ) }
+								className="edit-site-layout__view-mode-toggle"
+								style={ {
+									transform: 'scale(0.5)',
+									borderRadius: 4,
+								} }
+							>
+								<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+							</Button>
+						) }
+						{ isMobileViewport && (
+							<Button
+								ref={ ref }
+								label={ __( 'Go to Site Editor' ) }
+								className="edit-site-layout__view-mode-toggle"
+								style={ {
+									transform: 'scale(0.5)',
+									borderRadius: 4,
+								} }
+								onClick={ () => {
+									history.push( {} );
+									navigate( 'back' );
+								} }
+							>
+								<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+							</Button>
+						) }
 					</div>
 
 					<HStack>

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -33,6 +33,9 @@ const SiteHub = memo(
 		const isMobileViewport = useViewportMatch( 'medium', '<' );
 		const history = useHistory();
 		const { navigate } = useContext( SidebarNavigationContext );
+		const isRoot =
+			history.location.pathname === '/wp-admin/site-editor.php' &&
+			history.location.search === '';
 
 		const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
 			const { getSettings } = unlock( select( editSiteStore ) );
@@ -65,7 +68,7 @@ const SiteHub = memo(
 							}
 						) }
 					>
-						{ ! isMobileViewport && (
+						{ ( isRoot || ! isMobileViewport ) && (
 							<Button
 								ref={ ref }
 								href={ dashboardLink }


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/60847 and https://github.com/WordPress/gutenberg/issues/62878

## What?

This makes the SiteHub always available for mobile viewports, for the Pages, Patterns, and Templates pages. It mimics what we had in 6.5.

| In `trunk` | This PR |
| --- | --- |
| <img width="383" alt="Captura de ecrã 2024-07-02, às 17 03 35" src="https://github.com/WordPress/gutenberg/assets/583546/013a8d31-b102-4bec-9954-a96d04805520"> | <img width="383" alt="Captura de ecrã 2024-07-02, às 17 02 53" src="https://github.com/WordPress/gutenberg/assets/583546/9f2e9b93-a921-4513-9bf3-6485b56d8b14"> |

## Why?

This brings back what we had in 6.5 for the Patterns page. While the overall direction is https://github.com/WordPress/gutenberg/issues/60847 we can me this quick change for improved navigation.

## How?

Render the `SiteHub` component on mobile viewports.

## Testing Instructions

Navigate to Pages, Patterns, and Templates and verify the SiteHub is present.
