### PR TITLE
Fix button wrapping in the document Inspector.

### DIFF
--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -25,6 +25,7 @@
 	.components-button {
 		max-width: 100%;
 		text-align: left;
+		white-space: normal;
 		text-wrap: balance; // Fallback for Safari.
 		text-wrap: pretty;
 		height: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix button wrapping in the document inspector:

<img width="280" alt="Screenshot 2024-07-02 at 15 44 32" src="https://github.com/WordPress/gutenberg/assets/846565/2f790862-ed69-4571-a9b0-21a60d4ab513">


## Why?
So that button labels are readable, and horizontal scrolling is avoided:

<img width="278" alt="Screenshot 2024-07-02 at 15 48 03" src="https://github.com/WordPress/gutenberg/assets/846565/2e103a63-2a94-4feb-a614-17ca645c2900">


## How?
Apply `white-space: normal` as a fallback since `text-wrap` is only supported in the latest Safari versions.

## Testing Instructions
1. In Safari, edit a page in the Site Editor
2. Set a long slug, or a publish date with a long label, or choose a template with a long label
3. Ensure the button label wraps
