### PR TITLE
Fix Pinterest URLs not embedding when not .com

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -8,6 +8,7 @@ import {
 	fallback,
 	getEmbedInfoByProvider,
 	getMergedAttributesWithPreview,
+	replaceDomain,
 } from './util';
 import EmbedControls from './embed-controls';
 import { embedContentIcon } from './icons';
@@ -220,8 +221,20 @@ const EmbedEdit = ( props ) => {
 							attributes.className
 						);
 
+						let modifiedUrl;
+						// If the provider is Pinterest, replace the domain in the URL and update local state.
+						if ( title === 'Pinterest' ) {
+							modifiedUrl = replaceDomain( url );
+							setURL( modifiedUrl );
+						} else {
+							modifiedUrl = url;
+						}
+
 						setIsEditingURL( false );
-						setAttributes( { url, className: blockClass } );
+						setAttributes( {
+							url: modifiedUrl,
+							className: blockClass,
+						} );
 					} }
 					value={ url }
 					cannotEmbed={ cannotEmbed }

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -347,3 +347,17 @@ export const getMergedAttributesWithPreview = (
 		),
 	};
 };
+
+/**
+ * Replaces any domain extension with 'com' in a given URL.
+ *
+ * @param {string} url - The URL string to be modified.
+ * @return {string} - The modified URL string with the domain extension replaced by 'com'.
+ */
+export function replaceDomain( url ) {
+	// Create a URL object to easily manipulate the URL parts
+	const urlObj = new URL( url );
+	// Replace any domain extension with 'com'
+	urlObj.hostname = urlObj.hostname.replace( /\.[a-z]{2,}$/, '.com' );
+	return urlObj.href;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes [#59400](https://github.com/WordPress/gutenberg/issues/59400)

## What?
Fixes an issue where Pinterest URLs from non-.com domains weren't embedding correctly.

## Why?
Pinterest uses different country-specific domains, causing embed failures. This PR ensures all Pinterest URLs embed correctly by converting non-.com domains to .com.

## How?
Introduced replaceDomain function to convert any domain extension to '.com' in URLs. Updated Embed block to use this function for Pinterest URLs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page in the Gutenberg editor.
2. Insert an Embed block with a Pinterest URL from a non-.com domain (e.g., .es, .it).
3. Ensure the URL converts to .com and the embed preview displays correctly.

## Screenshots or screencast <!-- if applicable --> 
<img width="644" alt="Screenshot 2024-07-02 at 10 52 35 PM" src="https://github.com/WordPress/gutenberg/assets/64325240/0ab78f3e-8ad0-45f2-a7a6-2baef4a52560">
<img width="555" alt="Screenshot 2024-07-02 at 10 52 46 PM" src="https://github.com/WordPress/gutenberg/assets/64325240/30e3878b-30ee-4ccd-bcc4-2dc90bb4828d">
