### PR TITLE
Block API: Introduce "local" attributes and use it for the image block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -388,7 +388,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 -	**Name:** core/image
 -	**Category:** media
 -	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow ()
--	**Attributes:** alt, aspectRatio, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
+-	**Attributes:** alt, aspectRatio, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, temporaryUrl, title, url, width
 
 ## Latest Comments
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -388,7 +388,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 -	**Name:** core/image
 -	**Category:** media
 -	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow ()
--	**Attributes:** alt, aspectRatio, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, temporaryUrl, title, url, width
+-	**Attributes:** alt, aspectRatio, blob, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -249,9 +249,9 @@ function GalleryEdit( props ) {
 		const imageArray = newFileUploads
 			? Array.from( selectedImages ).map( ( file ) => {
 					if ( ! file.url ) {
-						return pickRelevantMediaFiles( {
-							url: createBlobURL( file ),
-						} );
+						return {
+							temporaryUrl: createBlobURL( file ),
+						};
 					}
 
 					return file;
@@ -271,9 +271,9 @@ function GalleryEdit( props ) {
 			.filter( ( file ) => file.url || isValidFileType( file ) )
 			.map( ( file ) => {
 				if ( ! file.url ) {
-					return pickRelevantMediaFiles( {
-						url: createBlobURL( file ),
-					} );
+					return {
+						temporaryUrl: createBlobURL( file ),
+					};
 				}
 
 				return file;
@@ -307,6 +307,7 @@ function GalleryEdit( props ) {
 		const newBlocks = newImageList.map( ( image ) => {
 			return createBlock( 'core/image', {
 				id: image.id,
+				temporaryUrl: image.temporaryUrl,
 				url: image.url,
 				caption: image.caption,
 				alt: image.alt,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -237,7 +237,7 @@ function GalleryEdit( props ) {
 		return (
 			ALLOWED_MEDIA_TYPES.some(
 				( mediaType ) => mediaTypeSelector?.indexOf( mediaType ) === 0
-			) || file.url?.indexOf( 'blob:' ) === 0
+			) || file.blob
 		);
 	}
 
@@ -272,7 +272,7 @@ function GalleryEdit( props ) {
 			.map( ( file ) => {
 				if ( ! file.url ) {
 					return {
-						blob: createBlobURL( file ),
+						blob: file.blob || createBlobURL( file ),
 					};
 				}
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -250,7 +250,7 @@ function GalleryEdit( props ) {
 			? Array.from( selectedImages ).map( ( file ) => {
 					if ( ! file.url ) {
 						return {
-							temporaryUrl: createBlobURL( file ),
+							blob: createBlobURL( file ),
 						};
 					}
 
@@ -272,7 +272,7 @@ function GalleryEdit( props ) {
 			.map( ( file ) => {
 				if ( ! file.url ) {
 					return {
-						temporaryUrl: createBlobURL( file ),
+						blob: createBlobURL( file ),
 					};
 				}
 
@@ -307,7 +307,7 @@ function GalleryEdit( props ) {
 		const newBlocks = newImageList.map( ( image ) => {
 			return createBlock( 'core/image', {
 				id: image.id,
-				temporaryUrl: image.temporaryUrl,
+				blob: image.blob,
 				url: image.url,
 				caption: image.caption,
 				alt: image.alt,

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -223,7 +223,7 @@ const transforms = {
 				if ( isGalleryV2Enabled() ) {
 					const innerBlocks = files.map( ( file ) =>
 						createBlock( 'core/image', {
-							temporaryUrl: createBlobURL( file ),
+							blob: createBlobURL( file ),
 						} )
 					);
 

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -223,7 +223,7 @@ const transforms = {
 				if ( isGalleryV2Enabled() ) {
 					const innerBlocks = files.map( ( file ) =>
 						createBlock( 'core/image', {
-							url: createBlobURL( file ),
+							temporaryUrl: createBlobURL( file ),
 						} )
 					);
 

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -9,7 +9,7 @@
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",
 	"attributes": {
-		"temporaryUrl": {
+		"blob": {
 			"type": "string",
 			"isTemporary": true
 		},

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -11,7 +11,7 @@
 	"attributes": {
 		"blob": {
 			"type": "string",
-			"isTemporary": true
+			"__experimentalRole": "local"
 		},
 		"url": {
 			"type": "string",

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -9,6 +9,10 @@
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",
 	"attributes": {
+		"temporaryUrl": {
+			"type": "string",
+			"isTemporary": true
+		},
 		"url": {
 			"type": "string",
 			"source": "attribute",

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -19,7 +19,7 @@ import {
 	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { image as icon, plugins as pluginsIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -95,7 +95,6 @@ export function ImageEdit( {
 	__unstableParentLayout: parentLayout,
 } ) {
 	const {
-		temporaryUrl,
 		url = '',
 		alt,
 		caption,
@@ -108,6 +107,9 @@ export function ImageEdit( {
 		align,
 		metadata,
 	} = attributes;
+	const [ temporaryURL, setTemporaryURL ] = useState(
+		attributes.temporaryUrl
+	);
 
 	const altRef = useRef();
 	useEffect( () => {
@@ -158,15 +160,13 @@ export function ImageEdit( {
 				caption: undefined,
 				temporaryUrl: undefined,
 			} );
+			setTemporaryURL();
 
 			return;
 		}
 
 		if ( isBlobURL( media.url ) ) {
-			setAttributes( {
-				temporaryUrl: media.url,
-				url: undefined,
-			} );
+			setTemporaryURL( media.url );
 			return;
 		}
 
@@ -248,6 +248,7 @@ export function ImageEdit( {
 			...additionalAttributes,
 			linkDestination,
 		} );
+		setTemporaryURL();
 	}
 
 	function onSelectURL( newURL ) {
@@ -258,11 +259,12 @@ export function ImageEdit( {
 				id: undefined,
 				sizeSlug: getSettings().imageDefaultSize,
 			} );
+			setTemporaryURL();
 		}
 	}
 
 	useUploadMediaFromBlobURL( {
-		temporaryUrl,
+		url: temporaryURL,
 		allowedTypes: ALLOWED_MEDIA_TYPES,
 		onChange: onSelectImage,
 		onError: onUploadError,
@@ -283,7 +285,7 @@ export function ImageEdit( {
 	const shadowProps = getShadowClassesAndStyles( attributes );
 
 	const classes = clsx( className, {
-		'is-transient': !! temporaryUrl,
+		'is-transient': !! temporaryURL,
 		'is-resized': !! width || !! height,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 		'has-custom-border':
@@ -366,7 +368,7 @@ export function ImageEdit( {
 	return (
 		<figure { ...blockProps }>
 			<Image
-				temporaryURL={ temporaryUrl }
+				temporaryURL={ temporaryURL }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				isSingleSelected={ isSingleSelected }
@@ -390,7 +392,7 @@ export function ImageEdit( {
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				value={ { id, src } }
 				mediaPreview={ mediaPreview }
-				disableMediaButtons={ temporaryUrl || url }
+				disableMediaButtons={ temporaryURL || url }
 			/>
 		</figure>
 	);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -107,9 +107,7 @@ export function ImageEdit( {
 		align,
 		metadata,
 	} = attributes;
-	const [ temporaryURL, setTemporaryURL ] = useState(
-		attributes.temporaryUrl
-	);
+	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 
 	const altRef = useRef();
 	useEffect( () => {
@@ -146,7 +144,7 @@ export function ImageEdit( {
 			src: undefined,
 			id: undefined,
 			url: undefined,
-			temporaryUrl: undefined,
+			blob: undefined,
 		} );
 	}
 
@@ -158,7 +156,7 @@ export function ImageEdit( {
 				id: undefined,
 				title: undefined,
 				caption: undefined,
-				temporaryUrl: undefined,
+				blob: undefined,
 			} );
 			setTemporaryURL();
 
@@ -243,7 +241,7 @@ export function ImageEdit( {
 		mediaAttributes.href = href;
 
 		setAttributes( {
-			temporaryUrl: undefined,
+			blob: undefined,
 			...mediaAttributes,
 			...additionalAttributes,
 			linkDestination,
@@ -254,7 +252,7 @@ export function ImageEdit( {
 	function onSelectURL( newURL ) {
 		if ( newURL !== url ) {
 			setAttributes( {
-				temporaryUrl: undefined,
+				blob: undefined,
 				url: newURL,
 				id: undefined,
 				sizeSlug: getSettings().imageDefaultSize,

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -159,7 +159,7 @@ const transforms = {
 			transform( files ) {
 				const blocks = files.map( ( file ) => {
 					return createBlock( 'core/image', {
-						url: createBlobURL( file ),
+						temporaryUrl: createBlobURL( file ),
 					} );
 				} );
 				return blocks;

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -159,7 +159,7 @@ const transforms = {
 			transform( files ) {
 				const blocks = files.map( ( file ) => {
 					return createBlock( 'core/image', {
-						temporaryUrl: createBlobURL( file ),
+						blob: createBlobURL( file ),
 					} );
 				} );
 				return blocks;

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -48,17 +48,16 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 			return;
 		}
 
-		if ( ! latestArgs.current.temporaryUrl ) {
+		if ( ! latestArgs.current.url ) {
 			return;
 		}
 
-		const file = getBlobByURL( latestArgs.current.temporaryUrl );
+		const file = getBlobByURL( latestArgs.current.url );
 		if ( ! file ) {
 			return;
 		}
 
-		const { temporaryUrl, allowedTypes, onChange, onError } =
-			latestArgs.current;
+		const { url, allowedTypes, onChange, onError } = latestArgs.current;
 		const { mediaUpload } = getSettings();
 
 		hasUploadStarted.current = true;
@@ -71,12 +70,12 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 					return;
 				}
 
-				revokeBlobURL( temporaryUrl );
+				revokeBlobURL( url );
 				onChange( media );
 				hasUploadStarted.current = false;
 			},
 			onError: ( message ) => {
-				revokeBlobURL( temporaryUrl );
+				revokeBlobURL( url );
 				onError( message );
 				hasUploadStarted.current = false;
 			},

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -47,8 +47,10 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 		if ( hasUploadStarted.current ) {
 			return;
 		}
-
-		if ( ! latestArgs.current.url ) {
+		if (
+			! latestArgs.current.url ||
+			! isBlobURL( latestArgs.current.url )
+		) {
 			return;
 		}
 

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -48,19 +48,17 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 			return;
 		}
 
-		if (
-			! latestArgs.current.url ||
-			! isBlobURL( latestArgs.current.url )
-		) {
+		if ( ! latestArgs.current.temporaryUrl ) {
 			return;
 		}
 
-		const file = getBlobByURL( latestArgs.current.url );
+		const file = getBlobByURL( latestArgs.current.temporaryUrl );
 		if ( ! file ) {
 			return;
 		}
 
-		const { url, allowedTypes, onChange, onError } = latestArgs.current;
+		const { temporaryUrl, allowedTypes, onChange, onError } =
+			latestArgs.current;
 		const { mediaUpload } = getSettings();
 
 		hasUploadStarted.current = true;
@@ -73,12 +71,12 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 					return;
 				}
 
-				revokeBlobURL( url );
+				revokeBlobURL( temporaryUrl );
 				onChange( media );
 				hasUploadStarted.current = false;
 			},
 			onError: ( message ) => {
-				revokeBlobURL( url );
+				revokeBlobURL( temporaryUrl );
 				onError( message );
 				hasUploadStarted.current = false;
 			},

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -237,8 +237,8 @@ export function getCommentAttributes( blockType, attributes ) {
 				return accumulator;
 			}
 
-			// Ignore all temporary attributes
-			if ( attributeSchema.isTemporary ) {
+			// Ignore all local attributes
+			if ( attributeSchema.__experimentalRole === 'local' ) {
 				return accumulator;
 			}
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -237,6 +237,11 @@ export function getCommentAttributes( blockType, attributes ) {
 				return accumulator;
 			}
 
+			// Ignore all temporary attributes
+			if ( attributeSchema.isTemporary ) {
+				return accumulator;
+			}
+
 			// Ignore default value.
 			if (
 				'default' in attributeSchema &&

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -148,6 +148,30 @@ describe( 'block serializer', () => {
 
 			expect( attributes ).toEqual( { fruit: 'bananas' } );
 		} );
+
+		it( 'should ingore local attributes', () => {
+			const attributes = getCommentAttributes(
+				{
+					attributes: {
+						blob: {
+							type: 'string',
+							__experimentalRole: 'local',
+						},
+						url: {
+							type: 'string',
+						},
+					},
+				},
+				{
+					blob: 'blob://false-url.com',
+					url: 'http://real-url.com',
+				}
+			);
+
+			expect( attributes ).toEqual( {
+				url: 'http://real-url.com',
+			} );
+		} );
 	} );
 
 	describe( 'serializeAttributes()', () => {


### PR DESCRIPTION
Related #39223 
Related discussion #49466.

## What?

For some blocks (mostly media blocks), we need a way to create the blocks from transforms using temporary files. After the temporary image is inserted, we upload the image to the media library and upon success update the block with the Right URL.

So far, we were doing this using "blob urls" (local urls) in the URL attribute for images. The problem with this approach is that if you're fast enough and save your post while the image is still being uploaded, you might end up with "temporary urls" in the saved post. This should never be the case.

One potential solution that has been considered is to block "saving" when an upload is in progress. I think that's not ideal and doesn't address the root cause where anyone can actually trigger the saving programmatically.

The root cause is that we're actually putting local state (temporary urls) in the block attributes that are meant to be saved because we need immediate feedback (block insertion) when drag and dropping blocks. So a solution I'm proposing in this PR is to introduce the concept of "temporary block attributes":

 - These are attributes that don't get saved into the database. When you call `serialize` for a block, they are actually ignored and do not persist in the HTML. 
 - In this PR, I've updated the image block to use this attribute instead of the previous blob urls.


**Note:** There's probably some undo/related logic that need updating but I'm thinking that most of the time, when we actually set this attribute, we'll also be setting another non temporary attribute, so in most cases, there's no impact on undo/redo.

**Note 2:** I know that this idea has been discussed previously on multiple occasions, feel free to update the PR descriptions and link into any relevant issue or discussion.

## Testing Instructions

1- Throttle your network speed (that way uploading images will take a long time)
2- Drag and drop an image file into the post editor.
3- Save the post immediately.
4- Open the post in a new tab and notice that the inserted image is actually empty.
5- Go back to the old tab, and wait until the upload completes.
6- Notice that the image block has been updated properly with the right URL.