### PR TITLE
DataViews: Remove Table Cells animation

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -106,15 +106,6 @@
 			gap: $grid-unit-05;
 		}
 
-		th,
-		td {
-			&:first-child,
-			&:last-child {
-				transition: padding ease-out 0.1s;
-				@include reduce-motion("transition");
-			}
-		}
-
 		td:first-child,
 		th:first-child {
 			padding-left: $grid-unit-60;


### PR DESCRIPTION
Related #55083 
Initially raised by @mtias 

## What?

In the Table View for DataViews, if the content of the cells change, the size of each column can vary. The change in column size is now animated.

The problem though, is that the animation doesn't always feel great. I'm proposing removing this animation for now.

## Testing Instructions

1- Open the page dataviews
2- Switch to table view
3- Click on a column and apply a "sort"
4- In trunk, you can notice some weird animation when you sort (due to the animation and to the table emptying and filling its content back).

In addition to the removal of the animation, I think we should consider keeping stale data visible + some loading indicator but this can be explored separately. 