### PR TITLE
Button Block: Add back compat for WP6.4 regarding HTML Tag Processor

### DIFF
--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -19,18 +19,13 @@
 function render_block_core_button( $attributes, $content ) {
 	/*
 	 * The current Gutenberg plugin supports WordPress 6.4, but the next_token()
-	 *  method does not exist in WordPress 6.4. Therefore, if Gutenberg is used
-	 * as a plugin, use the Gutenberg class that has the `next_token()` method.
+	 * method does not exist in WordPress 6.4. Therefore, use the Gutenberg
+	 * class that has the `next_token()` method.
 	 *
 	 * TODO: After the Gutenberg plugin drops support for WordPress 6.4, this
-	 * conditional statement will be removed and the core class `WP_HTML_Tag_Processor`
-	 * should be used.
+	 * class should be replaced with `WP_HTML_Tag_Processor`.
 	 */
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && class_exists( 'Gutenberg_HTML_Tag_Processor_6_5' ) ) {
-		$p = new Gutenberg_HTML_Tag_Processor_6_5( $content );
-	} else {
-		$p = new WP_HTML_Tag_Processor( $content );
-	}
+	$p = new Gutenberg_HTML_Tag_Processor_6_5( $content ); // phpcs:ignore Gutenberg.CodeAnalysis.ForbiddenFunctionsAndClasses.ForbiddenClassUsage
 
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -19,17 +19,18 @@
 function render_block_core_button( $attributes, $content ) {
 	/*
 	 * The current Gutenberg plugin supports WordPress 6.4, but the next_token()
-	 * method does not exist in WordPress 6.4. Therefore, use the Gutenberg
-	 * class that has the `next_token()` method.
+	 *  method does not exist in WordPress 6.4. Therefore, if Gutenberg is used
+	 * as a plugin, use the Gutenberg class that has the `next_token()` method.
 	 *
 	 * TODO: After the Gutenberg plugin drops support for WordPress 6.4, this
-	 * class should be replaced with `WP_HTML_Tag_Processor`.
+	 * conditional statement will be removed and the core class `WP_HTML_Tag_Processor`
+	 * should be used.
 	 */
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && class_exists( 'Gutenberg_HTML_Tag_Processor_6_5' ) ) {
-	$p = new Gutenberg_HTML_Tag_Processor_6_5( $content );
-} else {
-	$p = new WP_HTML_Tag_Processor( $content );
-}
+		$p = new Gutenberg_HTML_Tag_Processor_6_5( $content );
+	} else {
+		$p = new WP_HTML_Tag_Processor( $content );
+	}
 
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -17,7 +17,20 @@
  * @return string The block content.
  */
 function render_block_core_button( $attributes, $content ) {
-	$p = new WP_HTML_Tag_Processor( $content );
+	/*
+	 * The current Gutenberg plugin supports WordPress 6.4, but the next_token()
+	 *  method does not exist in WordPress 6.4. Therefore, if Gutenberg is used
+	 * as a plugin, use the Gutenberg class that has the `next_token()` method.
+	 *
+	 * TODO: After the Gutenberg plugin drops support for WordPress 6.4, this
+	 * conditional statement will be removed and the core class `WP_HTML_Tag_Processor`
+	 * should be used.
+	 */
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && class_exists( 'Gutenberg_HTML_Tag_Processor_6_5' ) ) {
+		$p = new Gutenberg_HTML_Tag_Processor_6_5( $content );
+	} else {
+		$p = new WP_HTML_Tag_Processor( $content );
+	}
 
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -19,7 +19,7 @@
 function render_block_core_button( $attributes, $content ) {
 	/*
 	 * The current Gutenberg plugin supports WordPress 6.4, but the next_token()
-	 *  method does not exist in WordPress 6.4. Therefore, if Gutenberg is used
+	 * method does not exist in WordPress 6.4. Therefore, if Gutenberg is used
 	 * as a plugin, use the Gutenberg class that has the `next_token()` method.
 	 *
 	 * TODO: After the Gutenberg plugin drops support for WordPress 6.4, this

--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -25,7 +25,11 @@ function render_block_core_button( $attributes, $content ) {
 	 * TODO: After the Gutenberg plugin drops support for WordPress 6.4, this
 	 * class should be replaced with `WP_HTML_Tag_Processor`.
 	 */
-	$p = new Gutenberg_HTML_Tag_Processor_6_5( $content ); // phpcs:ignore Gutenberg.CodeAnalysis.ForbiddenFunctionsAndClasses.ForbiddenClassUsage
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && class_exists( 'Gutenberg_HTML_Tag_Processor_6_5' ) ) {
+	$p = new Gutenberg_HTML_Tag_Processor_6_5( $content );
+} else {
+	$p = new WP_HTML_Tag_Processor( $content );
+}
 
 	/*
 	 * The button block can render an `<a>` or `<button>` and also has a


### PR DESCRIPTION
Fixes #62986

## What?
This PR fixes a fatal error in the Button block, caused by the `WP_HTML_Tag_Processor` class in WP6.4 not yet having the `next_token()` method.

```
Fatal error: Uncaught Error: Call to undefined method WP_HTML_Tag_Processor::next_token() in /var/www/html/wp-content/plugins/gutenberg/build/block-library/blocks/button.php:44
```

## How?

A class with the next_token method exists in the Gutenberg plugin as `Gutenberg_HTML_Tag_Processor_6_5`. I set it up so that this class is used if the `IS_GUTENBERG_PLUGIN` variable is `true`. This prevents a critical error that occurs when the Gutenberg plugin is used in WP6.4.

In my opinion, the following flow would allow us to maintain full backward compatibility:

1. July 3rd (today): Gutenberg 18.7 was released.
2. Merge this PR.
3. July 16th: WordPress 6.6 will be officially released.
4. July 17th: Gutenberg 18.8 will be shipped with this PR included, which will fix the issue with WP6.4.
5. The Gutenberg plugin will drop support for WP6.4.
6. (TODO) Remove the fallback approach made in this PR.


## Testing Instructions

- Deactivate the Gutenberg plugin and downgrade to WP 6.4.
- Insert a Button block into a post and publish it.
- Activate the Gutenberg plugin and visit the post.
  - trunk: You will get a critical error.
  - This PR: You should not get a critical error and the Button block should render.