### PR TITLE
Global Styles: Don't display browse styles unless the theme has full styles available

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -25,6 +25,7 @@ import { IconWithCurrentColor } from './icon-with-current-color';
 import { NavigationButtonAsItem } from './navigation-button';
 import RootMenu from './root-menu';
 import PreviewStyles from './preview-styles';
+import { useThemeStyles } from '../../hooks';
 import { unlock } from '../../lock-unlock';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
@@ -32,12 +33,9 @@ const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 function ScreenRoot() {
 	const [ customCSS ] = useGlobalStyle( 'css' );
 
-	const { hasVariations, canEditCSS } = useSelect( ( select ) => {
-		const {
-			getEntityRecord,
-			__experimentalGetCurrentGlobalStylesId,
-			__experimentalGetCurrentThemeGlobalStylesVariations,
-		} = select( coreStore );
+	const { canEditCSS } = useSelect( ( select ) => {
+		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+			select( coreStore );
 
 		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
 		const globalStyles = globalStylesId
@@ -45,12 +43,11 @@ function ScreenRoot() {
 			: undefined;
 
 		return {
-			hasVariations:
-				!! __experimentalGetCurrentThemeGlobalStylesVariations()
-					?.length,
 			canEditCSS: !! globalStyles?._links?.[ 'wp:action-edit-css' ],
 		};
 	}, [] );
+
+	const themeStyles = useThemeStyles();
 
 	return (
 		<Card size="small" className="edit-site-global-styles-screen-root">
@@ -61,7 +58,7 @@ function ScreenRoot() {
 							<PreviewStyles />
 						</CardMedia>
 					</Card>
-					{ hasVariations && (
+					{ themeStyles?.length && (
 						<ItemGroup>
 							<NavigationButtonAsItem
 								path="/variations"

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -1,8 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
 import { useContext, useEffect, useMemo, useState } from '@wordpress/element';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -13,7 +11,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import PreviewStyles from './preview-styles';
 import Variation from './variations/variation';
-import { isVariationWithProperties } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import { useThemeStyles } from '../../hooks/';
 import { unlock } from '../../lock-unlock';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
@@ -27,23 +25,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		setCurrentUserStyles( user );
 	}, [ user ] );
 
-	const variations = useSelect( ( select ) => {
-		return select(
-			coreStore
-		).__experimentalGetCurrentThemeGlobalStylesVariations();
-	}, [] );
-
-	// Filter out variations that are color or typography variations.
-	const fullStyleVariations = variations?.filter( ( variation ) => {
-		return (
-			! isVariationWithProperties( variation, [ 'color' ] ) &&
-			! isVariationWithProperties( variation, [
-				'typography',
-				'spacing',
-			] )
-		);
-	} );
-
+	const themeStyles = useThemeStyles();
 	const themeVariations = useMemo( () => {
 		const withEmptyVariation = [
 			{
@@ -51,8 +33,9 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				settings: {},
 				styles: {},
 			},
-			...( fullStyleVariations ?? [] ),
+			...( themeStyles ?? [] ),
 		];
+
 		return [
 			...withEmptyVariation.map( ( variation ) => {
 				const blockStyles = { ...variation?.styles?.blocks } || {};
@@ -108,7 +91,7 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 				};
 			} ),
 		];
-	}, [ fullStyleVariations, userStyles?.blocks, userStyles?.css ] );
+	}, [ themeStyles, userStyles?.blocks, userStyles?.css ] );
 
 	return (
 		<Grid

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -93,6 +93,10 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		];
 	}, [ themeStyles, userStyles?.blocks, userStyles?.css ] );
 
+	if ( themeVariations.length <= 1 ) {
+		return null;
+	}
+
 	return (
 		<Grid
 			columns={ 2 }

--- a/packages/edit-site/src/hooks/index.js
+++ b/packages/edit-site/src/hooks/index.js
@@ -1,4 +1,27 @@
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
  * Internal dependencies
  */
 import './push-changes-to-global-styles';
+import { isVariationWithProperties } from './use-theme-style-variations/use-theme-style-variations-by-property';
+
+export function useThemeStyles() {
+	const variations = useSelect( ( select ) => {
+		return select(
+			coreStore
+		).__experimentalGetCurrentThemeGlobalStylesVariations();
+	}, [] );
+
+	// Filter out variations that are of single property type, i.e. color or typography variations.
+	return variations?.filter( ( variation ) => {
+		return (
+			! isVariationWithProperties( variation, [ 'color' ] ) &&
+			! isVariationWithProperties( variation, [ 'typography' ] )
+		);
+	} );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes the "Browse Styles" option from Global Styles when there are no full theme styles available.

## Why?
Without this bug fix the browse styles area still appears but is empty.

## How?
Create a new hook that gets all of the theme variations and then filters out the color and typography only variations.

## Testing Instructions
0. Remove all full style variations from your theme (for example in TT4 remove everything except Onyx)
1. Open the Site Editor
2. Open Global Styles
3. Check that the "Browse Styles" option isn't visible.

## Screenshots or screencast <!-- if applicable -->
<img width="305" alt="Screenshot 2024-07-03 at 12 23 57" src="https://github.com/WordPress/gutenberg/assets/275961/0f4f9a2f-2b1a-497d-886d-44eddd56286a">

