### PR TITLE
DataViews: rename `onSelectionChange` to `onChangeSelection`

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
-## 3.0.0 (2024-07-10)
+### Breaking Changes
 
+- `onSelectionChange` has been renamed to `onChangeSelection`.
+
+## 3.0.0 (2024-07-10)
 
 ### Breaking Changes
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -278,7 +278,7 @@ Whether the data is loading. `false` by default.
 
 Default layouts. By default, uses empty layouts: `table`, `grid`, `list`.
 
-### `onSelectionChange`: `function`
+### `onChangeSelection`: `function`
 
 Callback that signals the user selected one of more items, and takes them as parameter. So far, only the `list` view implements it.
 

--- a/packages/dataviews/src/bulk-actions-toolbar.tsx
+++ b/packages/dataviews/src/bulk-actions-toolbar.tsx
@@ -33,14 +33,14 @@ interface ToolbarContentProps< Item > {
 	selection: string[];
 	actionsToShow: Action< Item >[];
 	selectedItems: Item[];
-	onSelectionChange: SetSelection;
+	onChangeSelection: SetSelection;
 }
 
 interface BulkActionsToolbarProps< Item > {
 	data: Item[];
 	selection: string[];
 	actions: Action< Item >[];
-	onSelectionChange: SetSelection;
+	onChangeSelection: SetSelection;
 	getItemId: ( item: Item ) => string;
 }
 
@@ -131,7 +131,7 @@ function renderToolbarContent< Item >(
 	selectedItems: Item[],
 	actionInProgress: string | null,
 	setActionInProgress: ( actionId: string | null ) => void,
-	onSelectionChange: SetSelection
+	onChangeSelection: SetSelection
 ) {
 	return (
 		<>
@@ -171,7 +171,7 @@ function renderToolbarContent< Item >(
 					label={ __( 'Cancel' ) }
 					disabled={ !! actionInProgress }
 					onClick={ () => {
-						onSelectionChange( EMPTY_ARRAY );
+						onChangeSelection( EMPTY_ARRAY );
 					} }
 				/>
 			</ToolbarGroup>
@@ -183,7 +183,7 @@ function ToolbarContent< Item >( {
 	selection,
 	actionsToShow,
 	selectedItems,
-	onSelectionChange,
+	onChangeSelection,
 }: ToolbarContentProps< Item > ) {
 	const [ actionInProgress, setActionInProgress ] = useState< string | null >(
 		null
@@ -199,7 +199,7 @@ function ToolbarContent< Item >( {
 			selectedItems,
 			actionInProgress,
 			setActionInProgress,
-			onSelectionChange
+			onChangeSelection
 		);
 	} else if ( ! buttons.current ) {
 		buttons.current = renderToolbarContent(
@@ -208,7 +208,7 @@ function ToolbarContent< Item >( {
 			selectedItems,
 			actionInProgress,
 			setActionInProgress,
-			onSelectionChange
+			onChangeSelection
 		);
 	}
 	return buttons.current;
@@ -218,7 +218,7 @@ export default function BulkActionsToolbar< Item >( {
 	data,
 	selection,
 	actions = EMPTY_ARRAY,
-	onSelectionChange,
+	onChangeSelection,
 	getItemId,
 }: BulkActionsToolbarProps< Item > ) {
 	const isReducedMotion = useReducedMotion();
@@ -266,7 +266,7 @@ export default function BulkActionsToolbar< Item >( {
 							selection={ selection }
 							actionsToShow={ actionsToShow }
 							selectedItems={ selectedItems }
-							onSelectionChange={ onSelectionChange }
+							onChangeSelection={ onChangeSelection }
 						/>
 					</div>
 				</Toolbar>

--- a/packages/dataviews/src/bulk-actions.tsx
+++ b/packages/dataviews/src/bulk-actions.tsx
@@ -47,7 +47,7 @@ interface BulkActionsProps< Item > {
 	data: Item[];
 	actions: Action< Item >[];
 	selection: string[];
-	onSelectionChange: SetSelection;
+	onChangeSelection: SetSelection;
 	getItemId: ( item: Item ) => string;
 }
 
@@ -184,7 +184,7 @@ export default function BulkActions< Item >( {
 	data,
 	actions,
 	selection,
-	onSelectionChange,
+	onChangeSelection,
 	getItemId,
 }: BulkActionsProps< Item > ) {
 	const bulkActions = useMemo(
@@ -256,7 +256,7 @@ export default function BulkActions< Item >( {
 						disabled={ areAllSelected }
 						hideOnClick={ false }
 						onClick={ () => {
-							onSelectionChange(
+							onChangeSelection(
 								selectableItems.map( ( item ) =>
 									getItemId( item )
 								)
@@ -270,7 +270,7 @@ export default function BulkActions< Item >( {
 						disabled={ selection.length === 0 }
 						hideOnClick={ false }
 						onClick={ () => {
-							onSelectionChange( [] );
+							onChangeSelection( [] );
 						} }
 					>
 						{ __( 'Deselect' ) }

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -51,14 +51,14 @@ type DataViewsProps< Item > = {
 	defaultLayouts: SupportedLayouts;
 	selection?: string[];
 	setSelection?: SetSelection;
-	onSelectionChange?: ( items: Item[] ) => void;
+	onChangeSelection?: ( items: Item[] ) => void;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
 
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
 
-const defaultOnSelectionChange = () => {};
+const defaultOnChangeSelection = () => {};
 
 export default function DataViews< Item >( {
 	view,
@@ -74,7 +74,7 @@ export default function DataViews< Item >( {
 	defaultLayouts,
 	selection: selectionProperty,
 	setSelection: setSelectionProperty,
-	onSelectionChange = defaultOnSelectionChange,
+	onChangeSelection = defaultOnChangeSelection,
 }: DataViewsProps< Item > ) {
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const isUncontrolled =
@@ -88,7 +88,7 @@ export default function DataViews< Item >( {
 	function setSelectionWithChange( value: SelectionOrUpdater ) {
 		const newValue =
 			typeof value === 'function' ? value( selection ) : value;
-		onSelectionChange(
+		onChangeSelection(
 			data.filter( ( item ) => newValue.includes( getItemId( item ) ) )
 		);
 		return setSelection( value );
@@ -139,7 +139,7 @@ export default function DataViews< Item >( {
 						<BulkActions
 							actions={ actions }
 							data={ data }
-							onSelectionChange={ setSelectionWithChange }
+							onChangeSelection={ setSelectionWithChange }
 							selection={ _selection }
 							getItemId={ getItemId }
 						/>
@@ -158,7 +158,7 @@ export default function DataViews< Item >( {
 				getItemId={ getItemId }
 				isLoading={ isLoading }
 				onChangeView={ onChangeView }
-				onSelectionChange={ setSelectionWithChange }
+				onChangeSelection={ setSelectionWithChange }
 				selection={ _selection }
 				setOpenedFilter={ setOpenedFilter }
 				view={ view }
@@ -174,7 +174,7 @@ export default function DataViews< Item >( {
 						data={ data }
 						actions={ actions }
 						selection={ _selection }
-						onSelectionChange={ setSelectionWithChange }
+						onChangeSelection={ setSelectionWithChange }
 						getItemId={ getItemId }
 					/>
 				) }

--- a/packages/dataviews/src/layouts/grid/index.tsx
+++ b/packages/dataviews/src/layouts/grid/index.tsx
@@ -27,7 +27,7 @@ import type { SetSelection } from '../../private-types';
 
 interface GridItemProps< Item > {
 	selection: string[];
-	onSelectionChange: SetSelection;
+	onChangeSelection: SetSelection;
 	getItemId: ( item: Item ) => string;
 	item: Item;
 	actions: Action< Item >[];
@@ -40,7 +40,7 @@ interface GridItemProps< Item > {
 
 function GridItem< Item >( {
 	selection,
-	onSelectionChange,
+	onChangeSelection,
 	getItemId,
 	item,
 	actions,
@@ -73,7 +73,7 @@ function GridItem< Item >( {
 					if ( ! hasBulkAction ) {
 						return;
 					}
-					onSelectionChange(
+					onChangeSelection(
 						selection.includes( id )
 							? selection.filter( ( itemId ) => id !== itemId )
 							: [ ...selection, id ]
@@ -91,7 +91,7 @@ function GridItem< Item >( {
 				<SingleSelectionCheckbox
 					item={ item }
 					selection={ selection }
-					onSelectionChange={ onSelectionChange }
+					onChangeSelection={ onChangeSelection }
 					getItemId={ getItemId }
 					primaryField={ primaryField }
 					disabled={ ! hasBulkAction }
@@ -169,7 +169,7 @@ export default function ViewGrid< Item >( {
 	fields,
 	getItemId,
 	isLoading,
-	onSelectionChange,
+	onChangeSelection,
 	selection,
 	view,
 }: ViewGridProps< Item > ) {
@@ -217,7 +217,7 @@ export default function ViewGrid< Item >( {
 							<GridItem
 								key={ getItemId( item ) }
 								selection={ selection }
-								onSelectionChange={ onSelectionChange }
+								onChangeSelection={ onChangeSelection }
 								getItemId={ getItemId }
 								item={ item }
 								actions={ actions }

--- a/packages/dataviews/src/layouts/list/index.tsx
+++ b/packages/dataviews/src/layouts/list/index.tsx
@@ -320,7 +320,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		fields,
 		getItemId,
 		isLoading,
-		onSelectionChange,
+		onChangeSelection,
 		selection,
 		view,
 	} = props;
@@ -345,7 +345,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	);
 
 	const onSelect = ( item: Item ) =>
-		onSelectionChange( [ getItemId( item ) ] );
+		onChangeSelection( [ getItemId( item ) ] );
 
 	const getItemDomId = useCallback(
 		( item?: Item ) =>

--- a/packages/dataviews/src/layouts/table/index.tsx
+++ b/packages/dataviews/src/layouts/table/index.tsx
@@ -43,7 +43,7 @@ import ColumnHeaderMenu from './column-header-menu';
 
 interface BulkSelectionCheckboxProps< Item > {
 	selection: string[];
-	onSelectionChange: SetSelection;
+	onChangeSelection: SetSelection;
 	data: Item[];
 	actions: Action< Item >[];
 	getItemId: ( item: Item ) => string;
@@ -81,12 +81,12 @@ interface TableRowProps< Item > {
 	primaryField?: NormalizedField< Item >;
 	selection: string[];
 	getItemId: ( item: Item ) => string;
-	onSelectionChange: SetSelection;
+	onChangeSelection: SetSelection;
 }
 
 function BulkSelectionCheckbox< Item >( {
 	selection,
-	onSelectionChange,
+	onChangeSelection,
 	data,
 	actions,
 	getItemId,
@@ -114,9 +114,9 @@ function BulkSelectionCheckbox< Item >( {
 			indeterminate={ ! areAllSelected && !! selectedItems.length }
 			onChange={ () => {
 				if ( areAllSelected ) {
-					onSelectionChange( [] );
+					onChangeSelection( [] );
 				} else {
-					onSelectionChange(
+					onChangeSelection(
 						selectableItems.map( ( item ) => getItemId( item ) )
 					);
 				}
@@ -196,7 +196,7 @@ function TableRow< Item >( {
 	primaryField,
 	selection,
 	getItemId,
-	onSelectionChange,
+	onChangeSelection,
 }: TableRowProps< Item > ) {
 	const hasPossibleBulkAction = useHasAPossibleBulkAction( actions, item );
 	const isSelected = hasPossibleBulkAction && selection.includes( id );
@@ -235,7 +235,7 @@ function TableRow< Item >( {
 					! isTouchDevice.current &&
 					document.getSelection()?.type !== 'Range'
 				) {
-					onSelectionChange(
+					onChangeSelection(
 						selection.includes( id )
 							? selection.filter( ( itemId ) => id !== itemId )
 							: [ ...selection, id ]
@@ -254,7 +254,7 @@ function TableRow< Item >( {
 						<SingleSelectionCheckbox
 							item={ item }
 							selection={ selection }
-							onSelectionChange={ onSelectionChange }
+							onChangeSelection={ onChangeSelection }
 							getItemId={ getItemId }
 							primaryField={ primaryField }
 							disabled={ ! hasPossibleBulkAction }
@@ -306,7 +306,7 @@ function ViewTable< Item >( {
 	getItemId,
 	isLoading = false,
 	onChangeView,
-	onSelectionChange,
+	onChangeSelection,
 	selection,
 	setOpenedFilter,
 	view,
@@ -372,7 +372,7 @@ function ViewTable< Item >( {
 							>
 								<BulkSelectionCheckbox
 									selection={ selection }
-									onSelectionChange={ onSelectionChange }
+									onChangeSelection={ onChangeSelection }
 									data={ data }
 									actions={ actions }
 									getItemId={ getItemId }
@@ -448,7 +448,7 @@ function ViewTable< Item >( {
 								primaryField={ primaryField }
 								selection={ selection }
 								getItemId={ getItemId }
-								onSelectionChange={ onSelectionChange }
+								onChangeSelection={ onChangeSelection }
 							/>
 						) ) }
 				</tbody>

--- a/packages/dataviews/src/single-selection-checkbox.tsx
+++ b/packages/dataviews/src/single-selection-checkbox.tsx
@@ -12,7 +12,7 @@ import type { SetSelection } from './private-types';
 
 interface SingleSelectionCheckboxProps< Item > {
 	selection: string[];
-	onSelectionChange: SetSelection;
+	onChangeSelection: SetSelection;
 	item: Item;
 	getItemId: ( item: Item ) => string;
 	primaryField?: Field< Item >;
@@ -21,7 +21,7 @@ interface SingleSelectionCheckboxProps< Item > {
 
 export default function SingleSelectionCheckbox< Item >( {
 	selection,
-	onSelectionChange,
+	onChangeSelection,
 	item,
 	getItemId,
 	primaryField,
@@ -54,7 +54,7 @@ export default function SingleSelectionCheckbox< Item >( {
 					return;
 				}
 
-				onSelectionChange(
+				onChangeSelection(
 					selection.includes( id )
 						? selection.filter( ( itemId ) => id !== itemId )
 						: [ ...selection, id ]

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -430,7 +430,7 @@ export interface ViewBaseProps< Item > {
 	getItemId: ( item: Item ) => string;
 	isLoading?: boolean;
 	onChangeView: ( view: View ) => void;
-	onSelectionChange: SetSelection;
+	onChangeSelection: SetSelection;
 	selection: string[];
 	setOpenedFilter: ( fieldId: string ) => void;
 	view: View;

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -256,7 +256,7 @@ export default function PageTemplates() {
 		}
 	);
 	const history = useHistory();
-	const onSelectionChange = useCallback(
+	const onChangeSelection = useCallback(
 		( items ) => {
 			if ( view?.type === LAYOUT_LIST ) {
 				history.push( {
@@ -372,7 +372,7 @@ export default function PageTemplates() {
 				isLoading={ isLoadingData }
 				view={ view }
 				onChangeView={ onChangeView }
-				onSelectionChange={ onSelectionChange }
+				onChangeSelection={ onChangeSelection }
 				selection={ selection }
 				setSelection={ setSelection }
 				defaultLayouts={ defaultLayouts }

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -282,7 +282,7 @@ export default function PostList( { postType } ) {
 		params: { postId },
 	} = useLocation();
 	const [ selection, setSelection ] = useState( [ postId ] );
-	const onSelectionChange = useCallback(
+	const onChangeSelection = useCallback(
 		( items ) => {
 			const { params } = history.getLocationWithParams();
 			if (
@@ -612,7 +612,7 @@ export default function PostList( { postType } ) {
 				onChangeView={ setView }
 				selection={ selection }
 				setSelection={ setSelection }
-				onSelectionChange={ onSelectionChange }
+				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
 			/>


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Renames `onSelectionChange` to `onChangeSelection`.

## Why?

For API coherence. We are using `onChange*` in a few properties: `onChangeView` for DataViews, `onChange` for the upcoming `DataForm` at https://github.com/WordPress/gutenberg/pull/63032.

See conversation at https://github.com/WordPress/gutenberg/pull/63032#discussion_r1663883147

## How?

- Renames the property internally across the dataviews package.
- Updates the consumers that were using it: page templates, page pages, and the experimental post list.

## Testing Instructions

Verify those pages still work as expected. Examples:

- Bulk selection.
- Selection is used in list view to update the preview.

