### PR TITLE
Focal Point Picker: Set grid overlay state when dragging

### DIFF
--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -27,15 +27,12 @@ import {
 	MediaContainer,
 } from './styles/focal-point-picker-style';
 import { INITIAL_BOUNDS } from './utils';
-import { useUpdateEffect } from '../utils/hooks';
 import type { WordPressComponentProps } from '../context/wordpress-component';
 import type {
 	FocalPoint as FocalPointType,
 	FocalPointPickerProps,
 } from './types';
 import type { KeyboardEventHandler } from 'react';
-
-const GRID_OVERLAY_TIMEOUT = 600;
 
 /**
  * Focal Point Picker is a component which creates a UI for identifying the most important visual point of an image.
@@ -116,6 +113,7 @@ export function FocalPointPicker( {
 			}
 
 			onDragStart?.( value, event );
+			setShowGridOverlay( true );
 			setPoint( value );
 		},
 		onDragMove: ( event ) => {
@@ -129,6 +127,7 @@ export function FocalPointPicker( {
 			setPoint( value );
 		},
 		onDragEnd: () => {
+			setShowGridOverlay( false );
 			onDragEnd?.();
 			onChange?.( point );
 		},
@@ -236,15 +235,6 @@ export function FocalPointPicker( {
 
 	const instanceId = useInstanceId( FocalPointPicker );
 	const id = `inspector-focal-point-picker-control-${ instanceId }`;
-
-	useUpdateEffect( () => {
-		setShowGridOverlay( true );
-		const timeout = window.setTimeout( () => {
-			setShowGridOverlay( false );
-		}, GRID_OVERLAY_TIMEOUT );
-
-		return () => window.clearTimeout( timeout );
-	}, [ x, y ] );
 
 	return (
 		<BaseControl


### PR DESCRIPTION
## What?
PR updates the `FocalPointPicker` to set the `showGridOverlay` state via `onDragStart` and `onDragEnd` callbacks.

## Why?
The component has clear events that trigger point updates; we can set related states during these events and avoid effect synchronization.

## Testing Instructions
1. Open a post or page.
2. Insert a Cover block and set an image.
3. Try updating the image focal point.
4. The grid overlay should be displayed as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/8a3c5c05-06f3-44cc-bd00-8ea44d078001

