### PR TITLE
Dependency extraction: Map to `regenerator-runtime` instead of `wp-polyfill`

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -117,7 +117,7 @@ function defaultRequestToExternalModule( request ) {
 function defaultRequestToHandle( request ) {
 	switch ( request ) {
 		case '@babel/runtime/regenerator':
-			return 'wp-polyfill';
+			return 'regenerator-runtime';
 
 		case 'lodash-es':
 			return 'lodash';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a follow-up to https://core.trac.wordpress.org/ticket/60962 in WP 6.6, where `regenerator-runtime` was removed as a dependency from `wp-polyfill`. Now it needs to be added explicitly if still needed.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Via #63009 I realized that `@WordPress/dependency-extraction-webpack-plugin` still points to `wp-polyfill` though when using regenerator (which shouldn't happen when targeting newer browsers anyway).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Externalizes regenerator to `regenerator-runtime` directly instead of `wp-polyfill`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

If using generators in a script and targeting older browsers such as IE 11, `regenerator-runtime` would be added as a dependency instead of `wpo-polyfill`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A