### PR TITLE
Fix: Removed shuffle button when only 1 pattern is present

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -66,7 +66,8 @@ export default function Shuffle( { clientId, as = Container } ) {
 			);
 		} );
 	}, [ categories, patterns ] );
-	if ( sameCategoryPatternsWithSingleWrapper.length === 0 ) {
+
+	if ( sameCategoryPatternsWithSingleWrapper.length < 2 ) {
 		return null;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/63069

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the shuffle button when only 1 pattern is present in the same category

## Why?
Currently, if we have a single pattern having a single category then we are seeing the shuffle button in the toolbar which shouldn't be there as there is no other pattern to go to.

## How?
I have updated the condition to display the shuffle button only if we have 2 or more unsynced patterns of the same category.

## Testing Instructions

1. Create a simple unsynced pattern with a unique category, make sure the contents of the group are wrapped in a single group block.
2. Using the + menu in the top left, insert the pattern.
3. The shuffle button would not appear.