### PR TITLE
Group block: Simplify variations' isActive fields

### DIFF
--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -53,11 +53,6 @@ const variations = [
 		attributes: { layout: { type: 'constrained' } },
 		isDefault: true,
 		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) =>
-			! blockAttributes.layout ||
-			! blockAttributes.layout?.type ||
-			blockAttributes.layout?.type === 'default' ||
-			blockAttributes.layout?.type === 'constrained',
 		icon: group,
 	},
 	{
@@ -66,10 +61,7 @@ const variations = [
 		description: __( 'Arrange blocks horizontally.' ),
 		attributes: { layout: { type: 'flex', flexWrap: 'nowrap' } },
 		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) =>
-			blockAttributes.layout?.type === 'flex' &&
-			( ! blockAttributes.layout?.orientation ||
-				blockAttributes.layout?.orientation === 'horizontal' ),
+		isActive: [ 'layout.type' ],
 		icon: row,
 		example,
 	},
@@ -79,9 +71,7 @@ const variations = [
 		description: __( 'Arrange blocks vertically.' ),
 		attributes: { layout: { type: 'flex', orientation: 'vertical' } },
 		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) =>
-			blockAttributes.layout?.type === 'flex' &&
-			blockAttributes.layout?.orientation === 'vertical',
+		isActive: [ 'layout.type', 'layout.orientation' ],
 		icon: stack,
 		example,
 	},
@@ -91,8 +81,7 @@ const variations = [
 		description: __( 'Arrange blocks in a grid.' ),
 		attributes: { layout: { type: 'grid' } },
 		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) =>
-			blockAttributes.layout?.type === 'grid',
+		isActive: [ 'layout.type' ],
 		icon: grid,
 		example,
 	},


### PR DESCRIPTION
## What?
Simplify active variation detection for the Group block.

## Why?
To simplify code and showcase recent enhancements to active block variation detection.
It _might_ also help with fixing https://github.com/WordPress/gutenberg/issues/41303.

## How?
By leveraging changes to active variation detection from https://github.com/WordPress/gutenberg/pull/62088 and https://github.com/WordPress/gutenberg/pull/62031, which allow dot notation for nested attributes (e.g. `layout.type`), and picks the variation with the highest specificity if multiple variations match the given `isActive` criteria.

## Testing Instructions
Insert multiple Group blocks, choosing a different variation each time. Save your post and reload the editor. Verify that the block inspector reflects the correct variation for each block.

<img width="263" alt="unnamed" src="https://github.com/WordPress/gutenberg/assets/96308/ea034214-bfe3-442a-b682-99edd7ceaa57">
