### PR TITLE
ToolbarButton: Always keep focusable when disabled

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Enhancements
 
 -   `ToolbarButton`: Deprecate `isDisabled` prop and merge with `disabled` ([#63101](https://github.com/WordPress/gutenberg/pull/63101)).
+-   `ToolbarButton`: Always keep focusable when disabled ([#63102](https://github.com/WordPress/gutenberg/pull/63102)).
 
 ### Internal
 

--- a/packages/components/src/toolbar/toolbar-button/index.tsx
+++ b/packages/components/src/toolbar/toolbar-button/index.tsx
@@ -115,7 +115,6 @@ function UnforwardedToolbarButton(
  * ```jsx
  * import { Toolbar, ToolbarButton } from '@wordpress/components';
  * import { edit } from '@wordpress/icons';
-  import { __ } from '../../../../i18n/build-types/create-i18n';
  *
  * function MyToolbar() {
  *   return (

--- a/packages/components/src/toolbar/toolbar-button/index.tsx
+++ b/packages/components/src/toolbar/toolbar-button/index.tsx
@@ -32,7 +32,7 @@ function useDeprecatedProps( {
 function UnforwardedToolbarButton(
 	props: Omit<
 		WordPressComponentProps< ToolbarButtonProps, typeof Button, false >,
-		'__experimentalIsFocusable' // ToolbarButton will always be focusable.
+		'__experimentalIsFocusable' // ToolbarButton will always be focusable even when disabled.
 	> &
 		ToolbarButtonDeprecatedProps,
 	ref: ForwardedRef< any >

--- a/packages/components/src/toolbar/toolbar-button/index.tsx
+++ b/packages/components/src/toolbar/toolbar-button/index.tsx
@@ -16,7 +16,7 @@ import Button from '../../button';
 import ToolbarItem from '../toolbar-item';
 import ToolbarContext from '../toolbar-context';
 import ToolbarButtonContainer from './toolbar-button-container';
-import type { ToolbarButtonProps } from './types';
+import type { ToolbarButtonDeprecatedProps, ToolbarButtonProps } from './types';
 import type { WordPressComponentProps } from '../../context';
 
 function useDeprecatedProps( {
@@ -30,7 +30,11 @@ function useDeprecatedProps( {
 }
 
 function UnforwardedToolbarButton(
-	props: WordPressComponentProps< ToolbarButtonProps, typeof Button, false >,
+	props: Omit<
+		WordPressComponentProps< ToolbarButtonProps, typeof Button, false >,
+		'__experimentalIsFocusable' // ToolbarButton will always be focusable.
+	> &
+		ToolbarButtonDeprecatedProps,
 	ref: ForwardedRef< any >
 ) {
 	const {
@@ -111,6 +115,7 @@ function UnforwardedToolbarButton(
  * ```jsx
  * import { Toolbar, ToolbarButton } from '@wordpress/components';
  * import { edit } from '@wordpress/icons';
+  import { __ } from '../../../../i18n/build-types/create-i18n';
  *
  * function MyToolbar() {
  *   return (

--- a/packages/components/src/toolbar/toolbar-button/types.ts
+++ b/packages/components/src/toolbar/toolbar-button/types.ts
@@ -41,7 +41,7 @@ export type ToolbarButtonDeprecatedProps = {
 	/**
 	 * Whether to keep the button focusable when disabled.
 	 *
-	 * @deprecated ToolbarButton will always be focusable.
+	 * @deprecated ToolbarButton will always be focusable even when disabled.
 	 * @ignore
 	 */
 	__experimentalIsFocusable?: boolean;

--- a/packages/components/src/toolbar/toolbar-button/types.ts
+++ b/packages/components/src/toolbar/toolbar-button/types.ts
@@ -37,6 +37,16 @@ export type ToolbarButtonProps = {
 	title?: string;
 };
 
+export type ToolbarButtonDeprecatedProps = {
+	/**
+	 * Whether to keep the button focusable when disabled.
+	 *
+	 * @deprecated ToolbarButton will always be focusable.
+	 * @ignore
+	 */
+	__experimentalIsFocusable?: boolean;
+};
+
 export type ToolbarButtonContainerProps = {
 	/**
 	 * Children to be rendered inside the button container.

--- a/packages/components/src/toolbar/toolbar-item/index.tsx
+++ b/packages/components/src/toolbar/toolbar-item/index.tsx
@@ -50,6 +50,7 @@ function ToolbarItem(
 
 	return (
 		<Ariakit.ToolbarItem
+			accessibleWhenDisabled
 			{ ...allProps }
 			store={ accessibleToolbarStore }
 			render={ render }


### PR DESCRIPTION
Fixes #57701

## What?

Keeps disabled `ToolbarButton`s focusable in all instances.

## Why?

Toolbar/menu items are one of the UI elements that are [generally recommended](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols) to keep focusable when disabled.

## Testing Instructions

Play around with the [Storybook code](https://github.com/WordPress/gutenberg/blob/566b82a13633cb72006d1900931ca46a8e0d7937/packages/components/src/toolbar/stories/index.story.tsx#L118-L121) for the `ToolbarButton`s in the `Toolbar` story. Passing `disabled` should keep the button focusable.