### PR TITLE
Implement a content panel on the Template Part block inspector.

### DIFF
--- a/packages/block-library/src/template-part/edit/content-panel.js
+++ b/packages/block-library/src/template-part/edit/content-panel.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as blocksStore } from '@wordpress/blocks';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { BlockQuickNavigation } = unlock( blockEditorPrivateApis );
+
+export default function TemplatePartContentPanel( { clientId } ) {
+	const { descendentBlockIds, descendentBlockNames, blockTypes } = useSelect(
+		( select ) => {
+			const { getClientIdsOfDescendants, getBlockNamesByClientId } =
+				select( blockEditorStore );
+			const { getBlockTypes } = select( blocksStore );
+			const _descendentBlockIds = getClientIdsOfDescendants( clientId );
+			return {
+				descendentBlockIds: _descendentBlockIds,
+				descendentBlockNames:
+					getBlockNamesByClientId( _descendentBlockIds ),
+				blockTypes: getBlockTypes(),
+			};
+		},
+		[ clientId ]
+	);
+	const themeBlocks = useMemo( () => {
+		const themeBlockNames = blockTypes
+			.filter( ( blockType ) => {
+				return blockType.category === 'theme';
+			} )
+			.map( ( { name } ) => name );
+		return descendentBlockIds.filter( ( _, index ) => {
+			return themeBlockNames.includes( descendentBlockNames[ index ] );
+		} );
+	}, [ descendentBlockIds, descendentBlockNames, blockTypes ] );
+	if ( themeBlocks.length === 0 ) {
+		return null;
+	}
+	return (
+		<PanelBody title={ __( 'Content' ) }>
+			<BlockQuickNavigation clientIds={ themeBlocks } />
+		</PanelBody>
+	);
+}

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -40,6 +40,7 @@ import {
 	useAlternativeTemplateParts,
 	useTemplatePartArea,
 } from './utils/hooks';
+import ContentPanel from './content-panel';
 
 function ReplaceButton( {
 	isEntityAvailable,
@@ -301,6 +302,7 @@ export default function TemplatePartEdit( {
 				</BlockSettingsMenuControls>
 
 				<InspectorControls>
+					<ContentPanel clientId={ clientId } />
 					<TemplatesList
 						area={ area }
 						clientId={ clientId }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -39,6 +39,7 @@ import {
 	useAlternativeTemplateParts,
 	useTemplatePartArea,
 } from './utils/hooks';
+import ContentPanel from './content-panel';
 
 const SUPPORTED_AREAS = [ 'header', 'footer', 'navigation-overlay' ];
 
@@ -312,6 +313,7 @@ export default function TemplatePartEdit( {
 				</BlockSettingsMenuControls>
 
 				<InspectorControls group="settings">
+					<ContentPanel clientId={ clientId } />
 					<TemplatesList
 						area={ area }
 						clientId={ clientId }


### PR DESCRIPTION
Follow up to a comment by @jasmussen at https://github.com/WordPress/gutenberg/pull/62034#pullrequestreview-2125177005. It implements a Content Panel on the template part block inspector similar to the one on the document tab.

cc: @jasmussen, @jameskoster 

## Screenshot
<img width="350" alt="Screenshot 2024-07-03 at 18 47 26" src="https://github.com/WordPress/gutenberg/assets/11271197/7282a501-c572-4ca2-b70a-9281f2391ec5">


## Testing Instructions
- Open a template like "All archives" on the site editor.
- Using the list view, select the header block.
- Go to the block inspector and verify a content panel is rendered there.
