### PR TITLE
Make SiteHub available in mobile viewports: Try moving sidebar navigation context up higher

### DIFF
--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -31,30 +31,6 @@ function focusSidebarElement( el, direction, focusSelector ) {
 	elementToFocus?.focus();
 }
 
-// Navigation state that is updated when navigating back or forward. Helps us
-// manage the animations and also focus.
-function createNavState() {
-	let state = {
-		direction: null,
-		focusSelector: null,
-	};
-
-	return {
-		get() {
-			return state;
-		},
-		navigate( direction, focusSelector = null ) {
-			state = {
-				direction,
-				focusSelector:
-					direction === 'forward' && focusSelector
-						? focusSelector
-						: state.focusSelector,
-			};
-		},
-	};
-}
-
 function SidebarContentWrapper( { children } ) {
 	const navState = useContext( SidebarNavigationContext );
 	const wrapperRef = useRef();
@@ -79,15 +55,11 @@ function SidebarContentWrapper( { children } ) {
 }
 
 export default function SidebarContent( { routeKey, children } ) {
-	const [ navState ] = useState( createNavState );
-
 	return (
-		<SidebarNavigationContext.Provider value={ navState }>
-			<div className="edit-site-sidebar__content">
-				<SidebarContentWrapper key={ routeKey }>
-					{ children }
-				</SidebarContentWrapper>
-			</div>
-		</SidebarNavigationContext.Provider>
+		<div className="edit-site-sidebar__content">
+			<SidebarContentWrapper key={ routeKey }>
+				{ children }
+			</SidebarContentWrapper>
+		</div>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Split out from #63060, this PR attempts to move the `SidebarNavigationContext` provider up to the layout in the site editor.

Note: this PR targets `try/sitehub-mobile` instead of `trunk` to (hopefully) make it easier to see what's going on.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

So that we don't need to wrap the site hub in the `SidebarContent` component which was causing issues with which buttons are focused, and added unnecessary padding.

I've created this as a separate PR just to see if the idea works, and to make it easier to throw away than committing to #63060.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove no longer needed `<SidebarContent>` wrapping for the site hub
* Move the `SidebarNavigationContext` provider up to the layout so that the context can be shared with the site hub, without requiring extra wrapping

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Same as for #63060

Note: when looking at this PR, you might want to look at it with whitespace removed so that the diff is easier to read: https://github.com/WordPress/gutenberg/pull/63109/files?diff=unified&w=1

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
