### PR TITLE
Merge #63071 into wp/6.6 - Section Styles: Prevent flash of variation styles in post editor

### DIFF
--- a/backport-changelog/6.6/6959.md
+++ b/backport-changelog/6.6/6959.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/6959
+
+* https://github.com/WordPress/gutenberg/pull/63071
+

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -87,3 +87,20 @@ function gutenberg_register_global_styles_revisions_endpoints() {
 }
 
 add_action( 'rest_api_init', 'gutenberg_register_global_styles_revisions_endpoints' );
+
+/**
+ * Preload theme and global styles paths to avoid flash of variation styles in post editor.
+ *
+ * @param array                   $paths REST API paths to preload.
+ * @param WP_Block_Editor_Context $context Current block editor context.
+ * @return array Filtered preload paths.
+ */
+function gutenberg_block_editor_preload_paths_6_6( $paths, $context ) {
+	if ( 'core/edit-post' === $context->name ) {
+		$paths[] = '/wp/v2/global-styles/themes/' . get_stylesheet();
+		$paths[] = '/wp/v2/themes?context=edit&status=active';
+		$paths[] = '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=edit';
+	}
+	return $paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_6', 10, 2 );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -543,13 +543,17 @@ export const __experimentalGetCurrentGlobalStylesId =
 		const globalStylesURL =
 			activeThemes?.[ 0 ]?._links?.[ 'wp:user-global-styles' ]?.[ 0 ]
 				?.href;
-		if ( globalStylesURL ) {
-			const globalStylesObject = await apiFetch( {
-				url: globalStylesURL,
-			} );
-			dispatch.__experimentalReceiveCurrentGlobalStylesId(
-				globalStylesObject.id
-			);
+		if ( ! globalStylesURL ) {
+			return;
+		}
+
+		// Regex matches the ID at the end of a URL or immediately before
+		// the query string.
+		const matches = globalStylesURL.match( /\/(\d+)(?:\?|$)/ );
+		const id = matches ? Number( matches[ 1 ] ) : null;
+
+		if ( id ) {
+			dispatch.__experimentalReceiveCurrentGlobalStylesId( id );
 		}
 	};
 


### PR DESCRIPTION
## What?

Merges #63071 into `wp/6.6`

#63071 fixed an issue in the post editor where there would be a delayed flash of variation styling as the global styles data was loaded.

## Why?

There were merge conflicts when #63071 attempting to cherry pick #63071.


## Testing Instructions

Taken from #63071:

1. Active a theme that defines styles for the button outline block style variation e.g. TT4
2. In the post editor add a button, select the Outline style, and save.
3. Reload the post editor and ensure there is no flash of styling (i.e. from a solid color to the outline variant)
4. In the site editor navigate to Styles > Blocks > Button > Outline
5. Apply custom styles for the Outline block style variation e.g. change the border color, background etc.
6. Save the Global Styles changes
7. Switch back to the post editor, loading your earlier post with the button outline block
8. When the editor loads there should be no flash of styling from the default theme outline styles to the custom styles assigned via Global Styles


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/9fb45b16-2544-4c51-9797-36ae7d3bdaa1" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/36d94b27-47fe-4132-b19e-ef4a76c416e4" /> |
