### PR TITLE
Group: Update block example

### DIFF
--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -22,53 +22,49 @@ export { metadata, name };
 export const settings = {
 	icon,
 	example: {
+		attributes: {
+			layout: {
+				type: 'constrained',
+				justifyContent: 'center',
+			},
+			style: {
+				spacing: {
+					padding: {
+						top: '1em',
+						right: '1em',
+						bottom: '1em',
+						left: '1em',
+					},
+				},
+			},
+		},
 		innerBlocks: [
 			{
-				name: 'core/paragraph',
+				name: 'core/heading',
 				attributes: {
-					customTextColor: '#cf2e2e',
-					fontSize: 'large',
-					content: __( 'One.' ),
+					content: __( 'La Mancha' ),
+					textAlign: 'center',
+				},
+			},
+			{
+				name: 'core/image',
+				attributes: {
+					url: 'https://s.w.org/images/core/5.3/Glacial_lakes%2C_Bhutan.jpg',
 				},
 			},
 			{
 				name: 'core/paragraph',
 				attributes: {
-					customTextColor: '#ff6900',
-					fontSize: 'large',
-					content: __( 'Two.' ),
+					align: 'center',
+					content: __(
+						'In a village of La Mancha, the name of which I have no desire to call to mind, there lived not long since one of those gentlemen that keep a lance in the lance-rack, an old buckler, a lean hack, and a greyhound for coursing.'
+					),
 				},
 			},
 			{
-				name: 'core/paragraph',
+				name: 'core/button',
 				attributes: {
-					customTextColor: '#fcb900',
-					fontSize: 'large',
-					content: __( 'Three.' ),
-				},
-			},
-			{
-				name: 'core/paragraph',
-				attributes: {
-					customTextColor: '#00d084',
-					fontSize: 'large',
-					content: __( 'Four.' ),
-				},
-			},
-			{
-				name: 'core/paragraph',
-				attributes: {
-					customTextColor: '#0693e3',
-					fontSize: 'large',
-					content: __( 'Five.' ),
-				},
-			},
-			{
-				name: 'core/paragraph',
-				attributes: {
-					customTextColor: '#9b51e0',
-					fontSize: 'large',
-					content: __( 'Six.' ),
+					text: __( 'Read more' ),
 				},
 			},
 		],

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -30,10 +30,10 @@ export const settings = {
 			style: {
 				spacing: {
 					padding: {
-						top: '1em',
-						right: '1em',
-						bottom: '1em',
-						left: '1em',
+						top: '4em',
+						right: '3em',
+						bottom: '4em',
+						left: '3em',
 					},
 				},
 			},
@@ -47,12 +47,6 @@ export const settings = {
 				},
 			},
 			{
-				name: 'core/image',
-				attributes: {
-					url: 'https://s.w.org/images/core/5.3/Glacial_lakes%2C_Bhutan.jpg',
-				},
-			},
-			{
 				name: 'core/paragraph',
 				attributes: {
 					align: 'center',
@@ -62,12 +56,19 @@ export const settings = {
 				},
 			},
 			{
+				name: 'core/spacer',
+				attributes: {
+					height: '10px',
+				},
+			},
+			{
 				name: 'core/button',
 				attributes: {
 					text: __( 'Read more' ),
 				},
 			},
 		],
+		viewportWidth: 600,
 	},
 	transforms,
 	edit,

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -4,6 +4,59 @@
 import { __, _x } from '@wordpress/i18n';
 import { group, row, stack, grid } from '@wordpress/icons';
 
+const example = {
+	innerBlocks: [
+		{
+			name: 'core/paragraph',
+			attributes: {
+				customTextColor: '#cf2e2e',
+				fontSize: 'large',
+				content: __( 'One.' ),
+			},
+		},
+		{
+			name: 'core/paragraph',
+			attributes: {
+				customTextColor: '#ff6900',
+				fontSize: 'large',
+				content: __( 'Two.' ),
+			},
+		},
+		{
+			name: 'core/paragraph',
+			attributes: {
+				customTextColor: '#fcb900',
+				fontSize: 'large',
+				content: __( 'Three.' ),
+			},
+		},
+		{
+			name: 'core/paragraph',
+			attributes: {
+				customTextColor: '#00d084',
+				fontSize: 'large',
+				content: __( 'Four.' ),
+			},
+		},
+		{
+			name: 'core/paragraph',
+			attributes: {
+				customTextColor: '#0693e3',
+				fontSize: 'large',
+				content: __( 'Five.' ),
+			},
+		},
+		{
+			name: 'core/paragraph',
+			attributes: {
+				customTextColor: '#9b51e0',
+				fontSize: 'large',
+				content: __( 'Six.' ),
+			},
+		},
+	],
+};
+
 const variations = [
 	{
 		name: 'group',
@@ -30,6 +83,7 @@ const variations = [
 			( ! blockAttributes.layout?.orientation ||
 				blockAttributes.layout?.orientation === 'horizontal' ),
 		icon: row,
+		example,
 	},
 	{
 		name: 'group-stack',
@@ -41,6 +95,7 @@ const variations = [
 			blockAttributes.layout?.type === 'flex' &&
 			blockAttributes.layout?.orientation === 'vertical',
 		icon: stack,
+		example,
 	},
 	{
 		name: 'group-grid',
@@ -51,6 +106,7 @@ const variations = [
 		isActive: ( blockAttributes ) =>
 			blockAttributes.layout?.type === 'grid',
 		icon: grid,
+		example,
 	},
 ];
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63035

## What?

Updates the inner blocks for the default Group example block while keeping the existing example for the Row, Stack, and Grid block variations.

Alternative to https://github.com/WordPress/gutenberg/pull/63039.

## Why?

The current example doesn't add a lot of value, especially when a user is attempting to preview block style variations. See #63035

## How?

- Move existing example to the block variation definitions
- Update the default block example

## Testing Instructions
1. Activate a theme that defines block style variations for group blocks such as Assembler
2. In the site editor, select a group block and open the Styles tab in the selector.
3. Hover over the Block Styles buttons to trigger the previews using the example block
4. Ensure these previews show the new example
5. Open the main block inserter via the plus icon in the top left
6. Filter the blocks by "Group"
7. Confirm the standard Group block displays the new example
8. Check that each Group block variation (Row, Stack, and Grid) all show the original example.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/099edc24-1182-4044-a038-b74694ccfc92


## Possible Follow-ups

- Update the block inspector's preview to reflect the current block variation's example

