### PR TITLE
Make SiteHub available for Pages, Patterns, and Templates in mobile viewports

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -34,7 +34,7 @@ import { privateApis as coreCommandsPrivateApis } from '@wordpress/core-commands
  */
 import ErrorBoundary from '../error-boundary';
 import { store as editSiteStore } from '../../store';
-import SiteHub from '../site-hub';
+import { default as SiteHub, SiteHubMobile } from '../site-hub';
 import ResizableFrame from '../resizable-frame';
 import { unlock } from '../../lock-unlock';
 import KeyboardShortcutsRegister from '../keyboard-shortcuts/register';
@@ -174,6 +174,16 @@ export default function Layout( { route } ) {
 
 					{ isMobileViewport && areas.mobile && (
 						<div className="edit-site-layout__mobile">
+							{ canvasMode !== 'edit' && (
+								<SidebarContent routeKey={ routeKey }>
+									<SiteHubMobile
+										ref={ toggleRef }
+										isTransparent={
+											isResizableFrameOversized
+										}
+									/>
+								</SidebarContent>
+							) }
 							{ areas.mobile }
 						</div>
 					) }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -56,6 +56,18 @@
 	position: relative;
 	width: 100%;
 	z-index: z-index(".edit-site-layout__canvas-container");
+
+	/*
+	 * The SiteHubMobile component is displayed
+	 * for pages that do not have a sidebar,
+	 * yet it needs the Sidebar component for the React context.
+	 *
+	 * This removes the padding in this scenario.
+	 * See https://github.com/WordPress/gutenberg/pull/63118
+	 */
+	.edit-site-sidebar__screen-wrapper {
+		padding: 0;
+	}
 }
 
 .edit-site-layout__canvas-container {

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -11,11 +11,12 @@ import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { memo, forwardRef } from '@wordpress/element';
+import { memo, forwardRef, useContext } from '@wordpress/element';
 import { search } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 import { filterURLForDisplay } from '@wordpress/url';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
@@ -23,6 +24,8 @@ import { filterURLForDisplay } from '@wordpress/url';
 import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
+const { useHistory } = unlock( routerPrivateApis );
+import { SidebarNavigationContext } from '../sidebar';
 
 const SiteHub = memo(
 	forwardRef( ( { isTransparent }, ref ) => {
@@ -103,3 +106,83 @@ const SiteHub = memo(
 );
 
 export default SiteHub;
+
+export const SiteHubMobile = memo(
+	forwardRef( ( { isTransparent }, ref ) => {
+		const history = useHistory();
+		const { navigate } = useContext( SidebarNavigationContext );
+
+		const { homeUrl, siteTitle } = useSelect( ( select ) => {
+			const {
+				getSite,
+				getUnstableBase, // Site index.
+			} = select( coreStore );
+			const _site = getSite();
+			return {
+				homeUrl: getUnstableBase()?.home,
+				siteTitle:
+					! _site?.title && !! _site?.url
+						? filterURLForDisplay( _site?.url )
+						: _site?.title,
+			};
+		}, [] );
+		const { open: openCommandCenter } = useDispatch( commandsStore );
+
+		return (
+			<div className="edit-site-site-hub">
+				<HStack justify="flex-start" spacing="0">
+					<div
+						className={ clsx(
+							'edit-site-site-hub__view-mode-toggle-container',
+							{
+								'has-transparent-background': isTransparent,
+							}
+						) }
+					>
+						<Button
+							ref={ ref }
+							label={ __( 'Go to Site Editor' ) }
+							className="edit-site-layout__view-mode-toggle"
+							style={ {
+								transform: 'scale(0.5)',
+								borderRadius: 4,
+							} }
+							onClick={ () => {
+								history.push( {} );
+								navigate( 'back' );
+							} }
+						>
+							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+						</Button>
+					</div>
+
+					<HStack>
+						<div className="edit-site-site-hub__title">
+							<Button
+								variant="link"
+								href={ homeUrl }
+								target="_blank"
+								label={ __( 'View site (opens in a new tab)' ) }
+							>
+								{ decodeEntities( siteTitle ) }
+							</Button>
+						</div>
+						<HStack
+							spacing={ 0 }
+							expanded={ false }
+							className="edit-site-site-hub__actions"
+						>
+							<Button
+								className="edit-site-site-hub_toggle-command-center"
+								icon={ search }
+								onClick={ () => openCommandCenter() }
+								label={ __( 'Open command palette' ) }
+								shortcut={ displayShortcut.primary( 'k' ) }
+							/>
+						</HStack>
+					</HStack>
+				</HStack>
+			</div>
+		);
+	} )
+);


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/63060
Related to https://github.com/WordPress/gutenberg/issues/60847 and https://github.com/WordPress/gutenberg/issues/62878

## What?

This makes the SiteHub always available for mobile viewports for the Pages, Patterns, and Templates pages. Upon clicking the site icon, it takes you back to the root (instead of going back to wp-admin).

| In `trunk` | This PR |
| --- | --- |
| <img width="383" alt="Captura de ecrã 2024-07-02, às 17 03 35" src="https://github.com/WordPress/gutenberg/assets/583546/013a8d31-b102-4bec-9954-a96d04805520"> | <img width="383" alt="Captura de ecrã 2024-07-02, às 17 02 53" src="https://github.com/WordPress/gutenberg/assets/583546/9f2e9b93-a921-4513-9bf3-6485b56d8b14"> |

Here's how it works:

https://github.com/WordPress/gutenberg/assets/583546/69053ae1-ad39-4c27-b388-0e09586b8b38


## Why?

The overall direction for mobile navigation is https://github.com/WordPress/gutenberg/issues/60847 but we can me this quick change in 6.6 for improved navigation.

## How?

On mobile viewports, ender a specific `SiteHub` component that navigates back to root for Pages, Patterns, and Templates.

## Technical differences between this and 63060

This is an alternative to https://github.com/WordPress/gutenberg/pull/63060 that implements all requirements:

- At site editor root level it would take you to the Dashboard.
- At the Styles and Navigation it would take you to the Dashboard.
- At the Pages, Patterns, and Template levels it works like the 'back' button.

What I appreciate about this approach is that 1) it's self-contained, so it's less prone to affect any other thing — an important consideration this late in the cycle. And 2) it's more future-proof because it doesn't require us to leak route/component information elsewhere — everything is done in the `SiteHubMobile` component that can be updated/removed as we make progress on https://github.com/WordPress/gutenberg/issues/60847.

Compare this approach to https://github.com/WordPress/gutenberg/pull/63060 where we had to:

- detect the root level, aka route information leaked to the SiteHub component ([see](https://github.com/WordPress/gutenberg/pull/63060#discussion_r1664024756))
- modify the focus mechanism, aka component information leaked to the Sidebar component ([see](https://github.com/WordPress/gutenberg/pull/63060#discussion_r1665084191))

## Testing Instructions

Navigate to Pages, Patterns, and Templates and verify the SiteHub is present and that it navigates back. The SiteHub in the other pages (root, Styles, Navigation) takes you to the wp-admin instead.
