### PR TITLE
Fix: Crash when onActionPerformed is used with callback actions.

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1066,12 +1066,18 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 					const existingCallback = actions[ i ].callback;
 					actions[ i ] = {
 						...actions[ i ],
-						callback: ( items, { _onActionPerformed } ) => {
-							existingCallback( items, ( _items ) => {
-								if ( _onActionPerformed ) {
-									_onActionPerformed( _items );
-								}
-								onActionPerformed( actions[ i ].id, _items );
+						callback: ( items, argsObject ) => {
+							existingCallback( items, {
+								...argsObject,
+								onActionPerformed: ( _items ) => {
+									if ( argsObject.onActionPerformed ) {
+										argsObject.onActionPerformed( _items );
+									}
+									onActionPerformed(
+										actions[ i ].id,
+										_items
+									);
+								},
 							} );
 						},
 					};


### PR DESCRIPTION
Currently if we pass onActionPerformed to the usePostActions hook and a callback actions is executed there is a crash. This PR fixes the issue.


## Testing Instructions
Temporarily apply the following diff:
```
diff --git a/packages/edit-site/src/components/posts-app/posts-list.js b/packages/edit-site/src/components/posts-app/posts-list.js
index cf9b6f43ef..f9f2b16c53 100644
--- a/packages/edit-site/src/components/posts-app/posts-list.js
+++ b/packages/edit-site/src/components/posts-app/posts-list.js
@@ -490,6 +490,7 @@ export default function PostsList( { postType } ) {
        const postTypeActions = usePostActions( {
                postType,
                context: 'list',
+               onActionPerformed: console.log,
        } );
        const editAction = useEditPostAction();
        const actions = useMemo(
```
Execute a restore post action, verify the restore happens successfully and the action is logged on the console.
On trunk we get the following error:
```
actions.js:382 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'dispatch')
    at callback (actions.js:382:13)
    at Object.callback (actions.js:1070:8)
    at onClick (view-list.tsx:241:28)
    at props.<computed> (XM66DUTO.js:50:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:4164:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:16)
    at invokeGuardedCallback (react-dom.development.js:4277:31)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:4291:25)
    at executeDispatch (react-dom.development.js:9041:3)
    at processDispatchQueueItemsInOrder (react-dom.development.js:9073:7)
```