### PR TITLE
Fix: Permanently delete post action does not calls onActionPerformed.

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -276,7 +276,7 @@ const permanentlyDeletePostAction = {
 	isEligible( { status } ) {
 		return status === 'trash';
 	},
-	async callback( posts, { registry } ) {
+	async callback( posts, { registry, onActionPerformed } ) {
 		const { createSuccessNotice, createErrorNotice } =
 			registry.dispatch( noticesStore );
 		const { deleteEntityRecord } = registry.dispatch( coreStore );
@@ -307,6 +307,7 @@ const permanentlyDeletePostAction = {
 				type: 'snackbar',
 				id: 'permanently-delete-post-action',
 			} );
+			onActionPerformed?.( posts );
 		} else {
 			// If there was at lease one failure.
 			let errorMessage;


### PR DESCRIPTION
Currently, if we pass onActionPerformed to the usePostActions hook the permanently delete post action does not invoke it. This PR fixes the issue.


## Testing Instructions
Temporarily apply the following diff:
```
diff --git a/packages/edit-site/src/components/posts-app/posts-list.js b/packages/edit-site/src/components/posts-app/posts-list.js
index cf9b6f43ef..f9f2b16c53 100644
--- a/packages/edit-site/src/components/posts-app/posts-list.js
+++ b/packages/edit-site/src/components/posts-app/posts-list.js
@@ -490,6 +490,7 @@ export default function PostsList( { postType } ) {
        const postTypeActions = usePostActions( {
                postType,
                context: 'list',
+               onActionPerformed: console.log,
        } );
        const editAction = useEditPostAction();
        const actions = useMemo(
```
Execute a permanently delete post action, and verify the action is logged in the console as expected, on the trunk it is not.
