### PR TITLE
Interactivity API: add tests for the getElement() attributes

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/get-element/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-element/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test/get-element",
+	"title": "E2E Interactivity tests - getElement",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/get-element/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-element/render.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * HTML for testing the `store` function.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+?>
+
+<div data-wp-interactive="test/get-element">
+	<div
+		data-testid="read from attributes"
+		data-some-value="Initial value"
+		data-wp-bind--data-some-value="state.dataSomeValue"
+		data-wp-text="state.someValue"
+	></div>
+	<button
+		data-testid="mutate DOM"
+ 		data-wp-on-async--click="actions.mutateDOM"
+	>
+		Mutate via DOM manipulation
+	</button>
+	<button
+		data-testid="mutate prop"
+ 		data-wp-on-async--click="actions.mutateProp"
+	>
+		Mutate via data-wp-bind
+	</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/get-element/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-element/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/get-element/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-element/view.js
@@ -16,7 +16,7 @@ const { state } = store( 'test/get-element', {
 		mutateDOM() {
 			state.prefix = '++';
 			const el = document.querySelector(
-				'[data-testid="read from attributes]'
+				'[data-testid="read from attributes"]'
 			);
 			el.setAttribute( 'data-some-value', 'New DOM value' );
 		},

--- a/packages/e2e-tests/plugins/interactive-blocks/get-element/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-element/view.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getElement } from '@wordpress/interactivity';
+
+const { state } = store( 'test/get-element', {
+	state: {
+		prefix: '+',
+		dataSomeValue: 'Initial value',
+		get someValue() {
+			const { attributes } = getElement();
+			return attributes[ 'data-some-value' ]; // Should this be reactive?
+		},
+	},
+	actions: {
+		mutateDOM() {
+			state.prefix = '++';
+			const el = document.querySelector(
+				'[data-testid="read from attributes]'
+			);
+			el.setAttribute( 'data-some-value', 'New DOM value' );
+		},
+		mutateProp() {
+			const { attributes } = getElement();
+
+			attributes[ 'data-some-value' ] = state.dataSomeValue; // Does this make sense?
+
+			state.dataSomeValue = 'New prop value';
+		},
+	},
+} );

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -101,30 +101,6 @@ interface DirectivesProps {
 // Main context.
 const context = createContext< any >( {} );
 
-// Wrap the element props to prevent modifications.
-const immutableMap = new WeakMap();
-const immutableError = () => {
-	throw new Error(
-		'Please use `data-wp-bind` to modify the attributes of an element.'
-	);
-};
-const immutableHandlers: ProxyHandler< object > = {
-	get( target, key, receiver ) {
-		const value = Reflect.get( target, key, receiver );
-		return !! value && typeof value === 'object'
-			? deepImmutable( value )
-			: value;
-	},
-	set: immutableError,
-	deleteProperty: immutableError,
-};
-const deepImmutable = < T extends object = {} >( target: T ): T => {
-	if ( ! immutableMap.has( target ) ) {
-		immutableMap.set( target, new Proxy( target, immutableHandlers ) );
-	}
-	return immutableMap.get( target );
-};
-
 // Store stacks for the current scope and the default namespaces and export APIs
 // to interact with them.
 const scopeStack: Scope[] = [];
@@ -158,7 +134,7 @@ export const getElement = () => {
 	const { ref, attributes } = getScope();
 	return Object.freeze( {
 		ref: ref.current,
-		attributes: deepImmutable( attributes ),
+		attributes: Object.freeze( { ...attributes } ),
 	} );
 };
 

--- a/test/e2e/specs/interactivity/get-element.spec.ts
+++ b/test/e2e/specs/interactivity/get-element.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'store', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/get-element' );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/get-element' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'initial attributes can be accessed', async ( { page } ) => {
+		const el = page.getByTestId( 'read from attributes' );
+		await expect( el ).toHaveText( '+Initial value' );
+	} );
+
+	test( 'mutated attributes via DOM manipulation can be accessed', async ( {
+		page,
+	} ) => {
+		const button = page.getByTestId( 'mutate DOM' );
+		await button.click();
+		const el = page.getByTestId( 'read from attributes' );
+		await expect( el ).toHaveText( '++New DOM value' );
+	} );
+
+	test( 'mutated attributes via data-wp-bind can be accessed', async ( {
+		page,
+	} ) => {
+		const button = page.getByTestId( 'mutate prop' );
+		await button.click();
+		const el = page.getByTestId( 'read from attributes' );
+		await expect( el ).toHaveText( 'New prop value' );
+	} );
+} );

--- a/test/e2e/specs/interactivity/get-element.spec.ts
+++ b/test/e2e/specs/interactivity/get-element.spec.ts
@@ -20,7 +20,7 @@ test.describe( 'store', () => {
 
 	test( 'initial attributes can be accessed', async ( { page } ) => {
 		const el = page.getByTestId( 'read from attributes' );
-		await expect( el ).toHaveText( '+Initial value' );
+		await expect( el ).toHaveText( 'Initial value' );
 	} );
 
 	test( 'mutated attributes via DOM manipulation can be accessed', async ( {
@@ -29,7 +29,7 @@ test.describe( 'store', () => {
 		const button = page.getByTestId( 'mutate DOM' );
 		await button.click();
 		const el = page.getByTestId( 'read from attributes' );
-		await expect( el ).toHaveText( '++New DOM value' );
+		await expect( el ).toHaveText( 'New DOM value' );
 	} );
 
 	test( 'mutated attributes via data-wp-bind can be accessed', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It is still unclear how the attribute object returned by `getElement()` works. We should reconsider how it functions:
- Does it return the props of the virtual DOM or the attributes of the DOM?
- Can the attributes be modified?
- Are attributes reactive?
- If so, what happens when they are modified in the DOM (as opposed to via `data-wp-bind`)?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We've only considered the main use case (read `data` attributes on getters) so far, and it'd be good to think about all its implications to finalize this API.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've only added a couple of e2e tests so far. We can add more and change the implementation as we decide how to move forward.