### PR TITLE
Normalize focusable disabled ToolbarButton usage

### DIFF
--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -47,7 +47,6 @@ export default function BlockLockToolbar( { clientId } ) {
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
-					accessibleWhenDisabled
 					disabled={ ! canLock }
 					icon={ isLocked ? lock : unlock }
 					label={ label }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -268,7 +268,6 @@ function ReusableBlockEdit( {
 						<ToolbarButton
 							onClick={ resetContent }
 							disabled={ ! content }
-							__experimentalIsFocusable
 						>
 							{ __( 'Reset' ) }
 						</ToolbarButton>

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -57,10 +57,7 @@ function Header( {
 						/* translators: button label text should, if possible, be under 16 characters. */
 						label={ __( 'Undo' ) }
 						shortcut={ displayShortcut.primary( 'z' ) }
-						// If there are no undo levels we don't want to actually disable this
-						// button, because it will remove focus for keyboard users.
-						// See: https://github.com/WordPress/gutenberg/issues/3486
-						aria-disabled={ ! hasUndo }
+						disabled={ ! hasUndo }
 						onClick={ sidebar.undo }
 						className="customize-widgets-editor-history-button undo-button"
 					/>
@@ -69,10 +66,7 @@ function Header( {
 						/* translators: button label text should, if possible, be under 16 characters. */
 						label={ __( 'Redo' ) }
 						shortcut={ shortcut }
-						// If there are no undo levels we don't want to actually disable this
-						// button, because it will remove focus for keyboard users.
-						// See: https://github.com/WordPress/gutenberg/issues/3486
-						aria-disabled={ ! hasRedo }
+						disabled={ ! hasRedo }
 						onClick={ sidebar.redo }
 						className="customize-widgets-editor-history-button redo-button"
 					/>

--- a/packages/dataviews/src/bulk-actions-toolbar.tsx
+++ b/packages/dataviews/src/bulk-actions-toolbar.tsx
@@ -80,7 +80,6 @@ function ActionTrigger< Item >( {
 			size="compact"
 			onClick={ onClick }
 			isBusy={ isBusy }
-			__experimentalIsFocusable
 			tooltipPosition="top"
 		/>
 	);

--- a/packages/patterns/src/components/reset-overrides-control.js
+++ b/packages/patterns/src/components/reset-overrides-control.js
@@ -81,11 +81,7 @@ export default function ResetOverridesControl( props ) {
 	return (
 		<BlockControls group="other">
 			<ToolbarGroup>
-				<ToolbarButton
-					onClick={ onClick }
-					disabled={ ! isOverriden }
-					__experimentalIsFocusable
-				>
+				<ToolbarButton onClick={ onClick } disabled={ ! isOverriden }>
 					{ __( 'Reset' ) }
 				</ToolbarButton>
 			</ToolbarGroup>


### PR DESCRIPTION
Follow-up to #63102

## What?

Cleans up the code that was previously used to keep disabled `ToolbarButton`s focusable.

## Why?

ToolbarButtons will now always remain focusable when disabled (#63102).

## Testing Instructions

Only the change in `packages/customize-widgets/src/components/header/index.js` is somewhat unpredictable. To test this, activate the Twenty Twenty-One theme and go to the [Widgets editor](http://localhost:8888/wp-admin/widgets.php). The disabled undo/redo buttons in the toolbar should behave as expected.