### PR TITLE
CustomSelectControl V2 legacy adapter: fix trigger button font size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,7 @@
 -   `CustomSelectControlV2`: allow wrapping item hint to new line ([#62848](https://github.com/WordPress/gutenberg/pull/62848)).
 -   `CustomSelectControlV2`: fix select popover content overflow. ([#62844](https://github.com/WordPress/gutenberg/pull/62844))
 -   `CustomSelectControlV2`: keep legacy arrow down behavior only for legacy wrapper. ([#62919](https://github.com/WordPress/gutenberg/pull/62919))
+-   `CustomSelectControlV2`: fix trigger button font size. ([#63131](https://github.com/WordPress/gutenberg/pull/63131))
 -   Extract `TimeInput` component from `TimePicker` ([#60613](https://github.com/WordPress/gutenberg/pull/60613)).
 -   `TimeInput`: Add `label` prop ([#63106](https://github.com/WordPress/gutenberg/pull/63106)).
 

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
 import { COLORS, CONFIG } from '../utils';
 import { space } from '../utils/space';
 import { chevronIconSize } from '../select-control/styles/select-control-styles';
+import { fontSizeStyles } from '../input-control/styles/input-control-styles';
 import type { CustomSelectButtonSize } from './types';
 
 const INLINE_PADDING = {
@@ -91,7 +92,6 @@ export const Select = styled( Ariakit.Select, {
 		color: ${ COLORS.theme.foreground };
 		cursor: pointer;
 		font-family: inherit;
-		font-size: ${ CONFIG.fontSize };
 		text-align: start;
 		user-select: none;
 		width: 100%;
@@ -102,6 +102,7 @@ export const Select = styled( Ariakit.Select, {
 
 		${ getSelectSize( size, hasCustomRenderProp ? 'minHeight' : 'height' ) }
 		${ ! hasCustomRenderProp && truncateStyles }
+		${ fontSizeStyles( { inputSize: size } ) }
 	`
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Update the font size of the `CustomSelectControl` V2 legacy adapter to use the same underlying logic as V1

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

V2 legacy adapter should match V1 styles

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The [V1 implementation](https://github.com/WordPress/gutenberg/blob/b76de86ffe89b437808a7a56c48021838fcb2d8a/packages/components/src/custom-select-control/index.js#L163-L178) re-uses some [`SelectControl` styles](https://github.com/WordPress/gutenberg/blob/0221522f253e094b277a1485b7a2d186cb172632/packages/components/src/select-control/styles/select-control-styles.ts#L142), which in turn use a [utility from `InputControl` ](https://github.com/WordPress/gutenberg/blob/1ec58db138ca5febf4c54de83a8dde32f45b77de/packages/components/src/input-control/styles/input-control-styles.tsx) to determine the font size.

I've updated `CustomSelectControlV2` to use the same utility.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In Storybook, open `CustomSelectControlV2` legacy adapter examples:

- Make sure that the font size is `16px` regardless of the `size` prop for screens narrower than `600px`
- Make sure that, for screens wider than `600px`, the font size is `11px` when the `size` is `small`, and `13px` otherwise
- In general, make sure that the behavior is aligned with the V1 version of the component

> [!NOTE]  
> During my testing, I realised that `CustomSelectControl` V1 has a bug for which the font size doesn't change as it should according to the size for screens wider than `600px` — for some reason, the `size` doesn't get correctly passed to the `fontSizeStyles` utility, and as a consequence the default font size is always applied (`13px`). You can verify the buggy behaviour by setting `size="small"` on `CustomSelectControl` V1 and observe how the font size is still `13px` instead of `11px`.
> I don't think we should spend time fixing it, since the V1 implementation is soon going away.
