### PR TITLE
Storybook: fix links for block editor examples

### DIFF
--- a/storybook/stories/playground/index.story.js
+++ b/storybook/stories/playground/index.story.js
@@ -16,10 +16,22 @@ export const _default = () => {
 	return <EditorFullPage />;
 };
 
+_default.parameters = {
+	sourceLink: 'storybook/stories/playground/fullpage/index.js',
+};
+
 export const Box = () => {
 	return <EditorBox />;
 };
 
+Box.parameters = {
+	sourceLink: 'storybook/stories/playground/box/index.js',
+};
+
 export const UndoRedo = () => {
 	return <EditorWithUndoRedo />;
+};
+
+UndoRedo.parameters = {
+	sourceLink: 'storybook/stories/playground/with-undo-redo/index.js',
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the source links to the individual examples.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current links point to the whole folder:

<img width="463" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/f7c151a7-0954-4c97-8e69-31400f5d4637">

After:

<img width="300" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/48c106d8-58be-40fa-8461-718082a83b2f">



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
