### PR TITLE
Fix accessibility of the hooked blocks toggles

### DIFF
--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -3,18 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment, useMemo } from '@wordpress/element';
-import {
-	__experimentalHStack as HStack,
-	PanelBody,
-	ToggleControl,
-} from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { BlockIcon, InspectorControls } from '../components';
+import { InspectorControls } from '../components';
 import { store as blockEditorStore } from '../store';
 
 const EMPTY_OBJECT = {};
@@ -204,14 +200,7 @@ function BlockHooksControlPure( {
 										__nextHasNoMarginBottom
 										checked={ checked }
 										key={ block.title }
-										label={
-											<HStack justify="flex-start">
-												<BlockIcon
-													icon={ block.icon }
-												/>
-												<span>{ block.title }</span>
-											</HStack>
-										}
+										label={ block.title }
 										onChange={ () => {
 											if ( ! checked ) {
 												// Create and insert block.

--- a/packages/block-editor/src/hooks/block-hooks.scss
+++ b/packages/block-editor/src/hooks/block-hooks.scss
@@ -1,14 +1,5 @@
 .block-editor-hooks__block-hooks {
 	/**
-	 * Since we're displaying the block icon alongside the block name,
-	 * we need to right-align the toggle.
-	 */
-	.components-toggle-control .components-h-stack {
-		/* stylelint-disable-next-line declaration-property-value-allowed-list -- This should be refactored to not use the row-reverse value. */
-		flex-direction: row-reverse;
-	}
-
-	/**
 	 * Un-reverse the flex direction for the toggle's label.
 	 */
 	.components-toggle-control .components-h-stack .components-h-stack {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/63094

## What?
<!-- In a few words, what is the PR actually doing? -->
The hooked block toggles aren't accessible, as the visual order and DOM order mismatch.
Additionally, base component should not be overridden with local, ad-hoc custom implementations.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
VIsual order and DOM order must match, when the order affects meaning, oerability and interaction.
Base component should not be overridden: they are designed and tested to provide as much aaccessibility as possible and consistent design.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Changes the toggles to use a plain string for their labels instead of an icon plus a string;.
- Removes the `flex-direction: row-reverse` CSS property that was used to swap the toggle and label position.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Follow the instructios in the issue to add as much hooked blocks you like.
- Select the anchor block (ie. the block the hocked blocks are hooked to, in our examplee it's the post content in the Single Posts Template).
- Observe the 'Plugins' section in the INspector.
- Observe the toggles and their lables have now the standard layout with the toggle on the left and the lable immediately on the right.
- Observe the toggle do not use icons any longer.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before and after:

![before and after](https://github.com/WordPress/gutenberg/assets/1682452/c9c66b2a-7ebf-4c90-9a7f-a1f46d13117e)

