### PR TITLE
Pages: Trash view should default to table layout.

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -29,7 +29,7 @@ export default function DataViewItem( {
 	suffix,
 } ) {
 	const {
-		params: { postType, layout },
+		params: { postType, layout, activeView: previousView },
 	} = useLocation();
 
 	const iconToUse =
@@ -41,7 +41,7 @@ export default function DataViewItem( {
 	}
 	const linkInfo = useLink( {
 		postType,
-		layout,
+		layout: type !== 'list' || previousView === 'trash' ? type : layout,
 		activeView,
 		isCustom: isCustom ? 'true' : undefined,
 	} );

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -156,6 +156,7 @@ export function useDefaultViews( { postType } ) {
 					icon: trash,
 					view: {
 						...DEFAULT_POST_BASE,
+						type: LAYOUT_TABLE,
 						filters: [
 							{
 								field: 'status',


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/63128.
Makes the page trash view default to the table view.

cc: @jameskoster 


## Testing Instructions
I opened the pages list at wp-admin/site-editor.php?postType=page.
I switched to the trash view, and I verified the default view type of that view was table, while for the other the default list was kept.
