### PR TITLE
ToolbarButton: Fix docs for `accessibleWhenDisabled`

### DIFF
--- a/packages/components/src/toolbar/toolbar-button/index.tsx
+++ b/packages/components/src/toolbar/toolbar-button/index.tsx
@@ -16,7 +16,7 @@ import Button from '../../button';
 import ToolbarItem from '../toolbar-item';
 import ToolbarContext from '../toolbar-context';
 import ToolbarButtonContainer from './toolbar-button-container';
-import type { ToolbarButtonDeprecatedProps, ToolbarButtonProps } from './types';
+import type { ToolbarButtonOverriddenProps, ToolbarButtonProps } from './types';
 import type { WordPressComponentProps } from '../../context';
 
 function useDeprecatedProps( {
@@ -32,9 +32,9 @@ function useDeprecatedProps( {
 function UnforwardedToolbarButton(
 	props: Omit<
 		WordPressComponentProps< ToolbarButtonProps, typeof Button, false >,
-		'__experimentalIsFocusable' // ToolbarButton will always be focusable even when disabled.
+		'accessibleWhenDisabled' // By default, ToolbarButton will be focusable when disabled.
 	> &
-		ToolbarButtonDeprecatedProps,
+		ToolbarButtonOverriddenProps,
 	ref: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/toolbar/toolbar-button/types.ts
+++ b/packages/components/src/toolbar/toolbar-button/types.ts
@@ -37,14 +37,20 @@ export type ToolbarButtonProps = {
 	title?: string;
 };
 
-export type ToolbarButtonDeprecatedProps = {
+export type ToolbarButtonOverriddenProps = {
 	/**
 	 * Whether to keep the button focusable when disabled.
 	 *
-	 * @deprecated ToolbarButton will always be focusable even when disabled.
-	 * @ignore
+	 * In most cases, it is recommended to set this to `true`. Disabling a control without maintaining focusability
+	 * can cause accessibility issues, by hiding their presence from screen reader users,
+	 * or by preventing focus from returning to a trigger element.
+	 *
+	 * Learn more about the [focusability of disabled controls](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols)
+	 * in the WAI-ARIA Authoring Practices Guide.
+	 *
+	 * @default true
 	 */
-	__experimentalIsFocusable?: boolean;
+	accessibleWhenDisabled?: boolean;
 };
 
 export type ToolbarButtonContainerProps = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix the Storybook props table for `ToolbarButton` so it shows the correct default for the `accessibleWhenDisabled` prop.

## Why?

The `__experimentalIsFocusable` prop was stabilized and renamed to `accessibleWhenDisabled` (#62282) in the `Button` component where this component inherits its props from. The default for the prop in Button is `false`, whereas here it is functionally equivalent to `true`.

## Testing Instructions

The Storybook props table for the `ToolbarButton` component (subcomponent of `Toolbar`) should show the correct default for `accessibleWhenDisabled`.

## Screenshots or screencast <!-- if applicable -->

![Storybook props table showing the correct default](https://github.com/WordPress/gutenberg/assets/555336/206046b0-0b7c-4389-92df-143573870741)
