### PR TITLE
Zoom Out: Replace deprecated selector

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -21,9 +21,10 @@ function ZoomOutModeInserters() {
 		sectionRootClientId,
 		insertionPoint,
 		setInserterIsOpened,
-		selectedSection,
+		hasSelection,
 	} = useSelect( ( select ) => {
-		const { getSettings, getBlockOrder } = select( blockEditorStore );
+		const { getSettings, getBlockOrder, getSelectionStart } =
+			select( blockEditorStore );
 		const { sectionRootClientId: root } = unlock( getSettings() );
 		// To do: move ZoomOutModeInserters to core/editor.
 		// Or we perhaps we should move the insertion point state to the
@@ -33,7 +34,7 @@ function ZoomOutModeInserters() {
 		// eslint-disable-next-line @wordpress/data-no-store-string-literals
 		const editor = select( 'core/editor' );
 		return {
-			selectedSection: editor.getSelectedBlock(),
+			hasSelection: !! getSelectionStart().clientId,
 			blockOrder: getBlockOrder( root ),
 			insertionPoint: unlock( editor ).getInsertionPoint(),
 			sectionRootClientId: root,
@@ -63,7 +64,7 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
-	if ( ! isReady || ! selectedSection ) {
+	if ( ! isReady || ! hasSelection ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
PR replaces the deprecated `editor.getSelectedBlock` selector in the `ZoomOutModeInserters` component.

## Why?
The core shouldn't use deprecated selectors.

## How?
The component just needs a boolean if there's a block selection; we can use `getSelectionStart().clientId` for it.

## Testing Instructions
1. Enabled "zoomed out view when selecting a pattern category in the main inserter"  from Gutenberg > Experiments.
2. Go to Site Editor > any template.
3. Open the Inserter
4. Select a Pattern category.
5. Zoom out mode shouldn't enabled.
6. Select a section.
7. In-between inserters should be visible as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-04 at 22 22 20](https://github.com/WordPress/gutenberg/assets/240569/e6955b49-0454-497e-9425-0323e0b1cc1f)

![CleanShot 2024-07-04 at 22 45 06](https://github.com/WordPress/gutenberg/assets/240569/1f97fd45-22e0-44b2-9807-6820df77b0d8)
