### PR TITLE
DataViews: Update view fields rendering config

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Breaking Changes
 
 - Replace the `hiddenFields` property in the view prop of `DataViews` with a `fields` property that accepts an array of visible fields instead.
+- Remove the `layout` property in the view prop of `DataViews`. The format is now determined by the `view.fields` property. Each field can be a string or an object with a `format` property.
 
 ### New features
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -166,7 +166,7 @@ Properties:
 -   `sort`:
     -   `field`: the field used for sorting the dataset.
     -   `direction`: the direction to use for sorting, one of `asc` or `desc`.
--   `fields`: the `id` of the fields that are visible in the UI. Can also be an object to define the render type of the field example: `{ field: 'author', render: 'media' }`.
+-   `fields`: the `id` of the fields that are visible in the UI. Can also be an object to define the render type of the field example: `{ field: 'author', format: 'media' }`.
 
 ### `onChangeView`: `function`
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -150,7 +150,6 @@ const view = {
 		direction: 'desc',
 	},
 	fields: [ 'author', 'status' ],
-	layout: {},
 };
 ```
 
@@ -167,10 +166,7 @@ Properties:
 -   `sort`:
     -   `field`: the field used for sorting the dataset.
     -   `direction`: the direction to use for sorting, one of `asc` or `desc`.
--   `fields`: the `id` of the fields that are visible in the UI.
--   `layout`: config that is specific to a particular layout type.
-    -   `mediaField`: used by the `grid` and `list` layouts. The `id` of the field to be used for rendering each card's media.
-    -   `primaryField`: used by the `table`, `grid` and `list` layouts. The `id` of the field to be highlighted in each row/card/item.
+-   `fields`: the `id` of the fields that are visible in the UI. Can also be an object to define the render type of the field example: `{ field: 'author', render: 'media' }`.
 
 ### `onChangeView`: `function`
 
@@ -200,7 +196,6 @@ function MyCustomPageTable() {
 			},
 		],
 		fields: [ 'author', 'status' ],
-		layout: {},
 	} );
 
 	const queryArgs = useMemo( () => {

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -24,7 +24,13 @@ import {
 } from './bulk-actions';
 import { normalizeFields } from './normalize-fields';
 import BulkActionsToolbar from './bulk-actions-toolbar';
-import type { Action, Field, View, ViewBaseProps } from './types';
+import type {
+	Action,
+	Field,
+	FieldRenderConfig,
+	View,
+	ViewProps,
+} from './types';
 import type { SetSelection, SelectionOrUpdater } from './private-types';
 
 type ItemWithId = { id: string };
@@ -46,6 +52,7 @@ type DataViewsProps< Item > = {
 	selection?: string[];
 	setSelection?: SetSelection;
 	onSelectionChange?: ( items: Item[] ) => void;
+	defaultFields?: Record< string, FieldRenderConfig[] >;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
@@ -69,6 +76,7 @@ export default function DataViews< Item >( {
 	selection: selectionProperty,
 	setSelection: setSelectionProperty,
 	onSelectionChange = defaultOnSelectionChange,
+	defaultFields,
 }: DataViewsProps< Item > ) {
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const isUncontrolled =
@@ -89,7 +97,7 @@ export default function DataViews< Item >( {
 	}
 
 	const ViewComponent = VIEW_LAYOUTS.find( ( v ) => v.type === view.type )
-		?.component as ComponentType< ViewBaseProps< Item > >;
+		?.component as ComponentType< ViewProps< Item > >;
 	const _fields = useMemo( () => normalizeFields( fields ), [ fields ] );
 
 	const hasPossibleBulkAction = useSomeItemHasAPossibleBulkAction(
@@ -143,6 +151,7 @@ export default function DataViews< Item >( {
 					view={ view }
 					onChangeView={ onChangeView }
 					supportedLayouts={ supportedLayouts }
+					defaultFields={ defaultFields }
 				/>
 			</HStack>
 			<ViewComponent

--- a/packages/dataviews/src/field-format-primary.tsx
+++ b/packages/dataviews/src/field-format-primary.tsx
@@ -3,19 +3,19 @@
  */
 import type { NormalizedField } from './types';
 
-interface FieldRenderPrimaryProps< Item > {
+interface FieldFormatPrimaryProps< Item > {
 	field: NormalizedField< Item >;
 	item: Item;
 	id?: string;
 }
 
-export default function FieldRenderPrimary< Item >( {
+export default function FieldFormatPrimary< Item >( {
 	field,
 	item,
 	id,
-}: FieldRenderPrimaryProps< Item > ) {
+}: FieldFormatPrimaryProps< Item > ) {
 	return (
-		<div className="dataviews-field-render-primary" id={ id }>
+		<div className="dataviews-field-format-primary" id={ id }>
 			{ field.render( { item } ) }
 		</div>
 	);

--- a/packages/dataviews/src/field-render-primary.tsx
+++ b/packages/dataviews/src/field-render-primary.tsx
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import type { NormalizedField } from './types';
+
+interface FieldRenderPrimaryProps< Item > {
+	field: NormalizedField< Item >;
+	item: Item;
+	id?: string;
+}
+
+export default function FieldRenderPrimary< Item >( {
+	field,
+	item,
+	id,
+}: FieldRenderPrimaryProps< Item > ) {
+	return (
+		<div className="dataviews-field-render-primary" id={ id }>
+			{ field.render( { item } ) }
+		</div>
+	);
+}

--- a/packages/dataviews/src/normalize-field-render-configs.tsx
+++ b/packages/dataviews/src/normalize-field-render-configs.tsx
@@ -22,10 +22,10 @@ export function normalizeFieldRenderConfigs(
 	return configs
 		? configs.map( ( config ) => {
 				if ( typeof config === 'string' ) {
-					return { render: 'default', field: config };
+					return { format: 'default', field: config };
 				}
 
 				return config;
 		  } )
-		: fields.map( ( f ) => ( { render: 'default', field: f.id } ) );
+		: fields.map( ( f ) => ( { format: 'default', field: f.id } ) );
 }

--- a/packages/dataviews/src/normalize-field-render-configs.tsx
+++ b/packages/dataviews/src/normalize-field-render-configs.tsx
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import type {
+	FieldRenderConfig,
+	NormalizedField,
+	NormalizedFieldRenderConfig,
+} from './types';
+
+/**
+ * Normalizes all the default field render configs
+ * To simplify its usage in the code base.
+ *
+ * @param configs Field Render Configs.
+ * @param fields  Fields config.
+ * @return Normalized field render configs.
+ */
+export function normalizeFieldRenderConfigs(
+	configs: FieldRenderConfig[] | undefined,
+	fields: NormalizedField< any >[]
+): NormalizedFieldRenderConfig[] {
+	return configs
+		? configs.map( ( config ) => {
+				if ( typeof config === 'string' ) {
+					return { render: 'default', field: config };
+				}
+
+				return config;
+		  } )
+		: fields.map( ( f ) => ( { render: 'default', field: f.id } ) );
+}

--- a/packages/dataviews/src/stories/index.story.js
+++ b/packages/dataviews/src/stories/index.story.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo, useCallback } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,14 +17,18 @@ const meta = {
 };
 export default meta;
 
-const defaultConfigPerViewType = {
-	[ LAYOUT_TABLE ]: {
-		primaryField: 'title',
-	},
-	[ LAYOUT_GRID ]: {
-		mediaField: 'image',
-		primaryField: 'title',
-	},
+const defaultFields = {
+	[ LAYOUT_TABLE ]: [
+		{ render: 'primary', field: 'title' },
+		'description',
+		'categories',
+	],
+	[ LAYOUT_GRID ]: [
+		{ render: 'media', field: 'image' },
+		{ render: 'primary', field: 'title' },
+		'description',
+		'categories',
+	],
 };
 
 export const Default = ( props ) => {
@@ -32,21 +36,6 @@ export const Default = ( props ) => {
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );
 	}, [ view ] );
-	const onChangeView = useCallback(
-		( newView ) => {
-			if ( newView.type !== view.type ) {
-				newView = {
-					...newView,
-					layout: {
-						...defaultConfigPerViewType[ newView.type ],
-					},
-				};
-			}
-
-			setView( newView );
-		},
-		[ view.type, setView ]
-	);
 	return (
 		<DataViews
 			{ ...props }
@@ -54,7 +43,8 @@ export const Default = ( props ) => {
 			data={ shownData }
 			view={ view }
 			fields={ fields }
-			onChangeView={ onChangeView }
+			onChangeView={ setView }
+			defaultFields={ defaultFields }
 		/>
 	);
 };

--- a/packages/dataviews/src/stories/index.story.js
+++ b/packages/dataviews/src/stories/index.story.js
@@ -19,13 +19,13 @@ export default meta;
 
 const defaultFields = {
 	[ LAYOUT_TABLE ]: [
-		{ render: 'primary', field: 'title' },
+		{ format: 'primary', field: 'title' },
 		'description',
 		'categories',
 	],
 	[ LAYOUT_GRID ]: [
-		{ render: 'media', field: 'image' },
-		{ render: 'primary', field: 'title' },
+		{ format: 'media', field: 'image' },
+		{ format: 'primary', field: 'title' },
 		'description',
 		'categories',
 	],

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -205,7 +205,7 @@
 				flex-grow: 1;
 			}
 
-			.dataviews-field-render-primary {
+			.dataviews-field-format-primary {
 				a {
 					flex-grow: 0;
 				}
@@ -246,7 +246,7 @@
 	}
 }
 
-.dataviews-field-render-primary {
+.dataviews-field-format-primary {
 	font-size: $default-font-size;
 	font-weight: 500;
 	color: $gray-700;
@@ -442,7 +442,7 @@
 		}
 
 		&:not(.is-selected) {
-			.dataviews-field-render-primary {
+			.dataviews-field-format-primary {
 				color: $gray-900;
 			}
 			&:hover,
@@ -450,7 +450,7 @@
 				color: var(--wp-admin-theme-color);
 				background-color: #f8f8f8;
 
-				.dataviews-field-render-primary,
+				.dataviews-field-format-primary,
 				.dataviews-view-list__fields {
 					color: var(--wp-admin-theme-color);
 				}
@@ -465,7 +465,7 @@
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			color: $gray-900;
 
-			.dataviews-field-render-primary,
+			.dataviews-field-format-primary,
 			.dataviews-view-list__fields {
 				color: var(--wp-admin-theme-color);
 			}
@@ -489,7 +489,7 @@
 				border-radius: $radius-block-ui;
 			}
 		}
-		.dataviews-field-render-primary {
+		.dataviews-field-format-primary {
 			min-height: $grid-unit-05 * 5;
 			line-height: $grid-unit-05 * 5;
 			overflow: hidden;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -205,7 +205,7 @@
 				flex-grow: 1;
 			}
 
-			&.dataviews-view-table__primary-field {
+			.dataviews-field-render-primary {
 				a {
 					flex-grow: 0;
 				}
@@ -246,9 +246,7 @@
 	}
 }
 
-.dataviews-view-list__primary-field,
-.dataviews-view-grid__primary-field,
-.dataviews-view-table__primary-field {
+.dataviews-field-render-primary {
 	font-size: $default-font-size;
 	font-weight: 500;
 	color: $gray-700;
@@ -312,10 +310,8 @@
 
 		.dataviews-view-grid__title-actions {
 			padding: $grid-unit-10 0 $grid-unit-05;
-		}
-
-		.dataviews-view-grid__primary-field {
-			min-height: $grid-unit-40; // Preserve layout when there is no ellipsis button
+			// Preserve layout when there is no ellipsis button
+			min-height: $grid-unit-40;
 		}
 
 		&.is-selected {
@@ -446,7 +442,7 @@
 		}
 
 		&:not(.is-selected) {
-			.dataviews-view-list__primary-field {
+			.dataviews-field-render-primary {
 				color: $gray-900;
 			}
 			&:hover,
@@ -454,7 +450,7 @@
 				color: var(--wp-admin-theme-color);
 				background-color: #f8f8f8;
 
-				.dataviews-view-list__primary-field,
+				.dataviews-field-render-primary,
 				.dataviews-view-list__fields {
 					color: var(--wp-admin-theme-color);
 				}
@@ -469,7 +465,7 @@
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			color: $gray-900;
 
-			.dataviews-view-list__primary-field,
+			.dataviews-field-render-primary,
 			.dataviews-view-list__fields {
 				color: var(--wp-admin-theme-color);
 			}
@@ -493,7 +489,7 @@
 				border-radius: $radius-block-ui;
 			}
 		}
-		.dataviews-view-list__primary-field {
+		.dataviews-field-render-primary {
 			min-height: $grid-unit-05 * 5;
 			line-height: $grid-unit-05 * 5;
 			overflow: hidden;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -208,14 +208,14 @@ export interface NormalizedFilter {
 }
 
 export interface NormalizedFieldRenderConfig {
-	render: 'primary' | 'badge' | 'media' | 'column' | 'default';
+	format: 'primary' | 'badge' | 'media' | 'column' | 'default';
 	field: string;
 }
 
 export type FieldRenderConfig =
 	| string
 	| {
-			render: 'primary' | 'badge' | 'media' | 'column' | 'default';
+			format: 'primary' | 'badge' | 'media' | 'column' | 'default';
 			field: string;
 	  };
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -207,11 +207,23 @@ export interface NormalizedFilter {
 	isPrimary: boolean;
 }
 
-interface ViewBase {
+export interface NormalizedFieldRenderConfig {
+	render: 'primary' | 'badge' | 'media' | 'default';
+	field: string;
+}
+
+export type FieldRenderConfig =
+	| string
+	| {
+			render: 'primary' | 'badge' | 'media' | 'default';
+			field: string;
+	  };
+
+export interface View {
 	/**
 	 * The layout of the view.
 	 */
-	type: string;
+	type: 'table' | 'grid' | 'list';
 
 	/**
 	 * The global search term.
@@ -251,68 +263,8 @@ interface ViewBase {
 	/**
 	 * The hidden fields.
 	 */
-	fields?: string[];
+	fields?: FieldRenderConfig[];
 }
-
-export interface ViewTable extends ViewBase {
-	type: 'table';
-
-	layout: {
-		/**
-		 * The field to use as the primary field.
-		 */
-		primaryField?: string;
-
-		/**
-		 * The field to use as the media field.
-		 */
-		mediaField?: string;
-	};
-}
-
-export interface ViewList extends ViewBase {
-	type: 'list';
-
-	layout: {
-		/**
-		 * The field to use as the primary field.
-		 */
-		primaryField?: string;
-
-		/**
-		 * The field to use as the media field.
-		 */
-		mediaField?: string;
-	};
-}
-
-export interface ViewGrid extends ViewBase {
-	type: 'grid';
-
-	layout: {
-		/**
-		 * The field to use as the primary field.
-		 */
-		primaryField?: string;
-
-		/**
-		 * The field to use as the media field.
-		 */
-		mediaField?: string;
-
-		/**
-		 * The fields to use as columns.
-		 */
-		columnFields?: string[];
-
-		/**
-		 * The fields to use as badge fields.
-		 */
-		badgeFields?: string[];
-	};
-}
-
-export type View = ViewList | ViewGrid | ViewTable;
 
 interface ActionBase< Item > {
 	/**
@@ -400,7 +352,7 @@ export interface ActionButton< Item > extends ActionBase< Item > {
 
 export type Action< Item > = ActionModal< Item > | ActionButton< Item >;
 
-export interface ViewBaseProps< Item > {
+export interface ViewProps< Item > {
 	actions: Action< Item >[];
 	data: Item[];
 	fields: NormalizedField< Item >[];
@@ -412,20 +364,3 @@ export interface ViewBaseProps< Item > {
 	setOpenedFilter: ( fieldId: string ) => void;
 	view: View;
 }
-
-export interface ViewTableProps< Item > extends ViewBaseProps< Item > {
-	view: ViewTable;
-}
-
-export interface ViewListProps< Item > extends ViewBaseProps< Item > {
-	view: ViewList;
-}
-
-export interface ViewGridProps< Item > extends ViewBaseProps< Item > {
-	view: ViewGrid;
-}
-
-export type ViewProps< Item > =
-	| ViewTableProps< Item >
-	| ViewGridProps< Item >
-	| ViewListProps< Item >;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -208,14 +208,14 @@ export interface NormalizedFilter {
 }
 
 export interface NormalizedFieldRenderConfig {
-	render: 'primary' | 'badge' | 'media' | 'default';
+	render: 'primary' | 'badge' | 'media' | 'column' | 'default';
 	field: string;
 }
 
 export type FieldRenderConfig =
 	| string
 	| {
-			render: 'primary' | 'badge' | 'media' | 'default';
+			render: 'primary' | 'badge' | 'media' | 'column' | 'default';
 			field: string;
 	  };
 

--- a/packages/dataviews/src/view-actions.tsx
+++ b/packages/dataviews/src/view-actions.tsx
@@ -177,7 +177,7 @@ function FieldsVisibilityMenu< Item >( {
 		fields
 	);
 	const mediaFieldId = fieldRenderConfigs.find(
-		( fieldRender ) => fieldRender.render === 'media'
+		( fieldRender ) => fieldRender.format === 'media'
 	)?.field;
 	const hidableFields = fields.filter(
 		( field ) => field.enableHiding !== false && field.id !== mediaFieldId

--- a/packages/dataviews/src/view-actions.tsx
+++ b/packages/dataviews/src/view-actions.tsx
@@ -48,6 +48,7 @@ interface FieldsVisibilityMenuProps< Item > {
 	view: View;
 	onChangeView: ( view: View ) => void;
 	fields: NormalizedField< Item >[];
+	defaultFields?: Record< string, FieldRenderConfig[] >;
 }
 
 interface SortMenuProps< Item > {
@@ -171,6 +172,7 @@ function FieldsVisibilityMenu< Item >( {
 	view,
 	onChangeView,
 	fields,
+	defaultFields,
 }: FieldsVisibilityMenuProps< Item > ) {
 	const fieldRenderConfigs = normalizeFieldRenderConfigs(
 		view.fields,
@@ -185,6 +187,10 @@ function FieldsVisibilityMenu< Item >( {
 	if ( ! hidableFields?.length ) {
 		return null;
 	}
+	const normalizedDefaultFields = normalizeFieldRenderConfigs(
+		defaultFields?.[ view.type ],
+		[]
+	);
 	return (
 		<DropdownMenu
 			trigger={
@@ -205,6 +211,9 @@ function FieldsVisibilityMenu< Item >( {
 						value={ field.id }
 						checked={ isVisible }
 						onChange={ () => {
+							const fieldFormat = normalizedDefaultFields.find(
+								( f ) => f.field === field.id
+							);
 							onChangeView( {
 								...view,
 								fields: isVisible
@@ -212,7 +221,10 @@ function FieldsVisibilityMenu< Item >( {
 											( fieldRender ) =>
 												fieldRender.field !== field.id
 									  )
-									: [ ...fieldRenderConfigs, field.id ],
+									: [
+											...fieldRenderConfigs,
+											fieldFormat ?? field.id,
+									  ],
 							} );
 						} }
 					>
@@ -347,6 +359,7 @@ function _ViewActions< Item >( {
 					fields={ fields }
 					view={ view }
 					onChangeView={ onChangeView }
+					defaultFields={ defaultFields }
 				/>
 				<PageSizeMenu view={ view } onChangeView={ onChangeView } />
 			</DropdownMenuGroup>

--- a/packages/dataviews/src/view-grid.tsx
+++ b/packages/dataviews/src/view-grid.tsx
@@ -59,7 +59,7 @@ function GridItem< Item >( {
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
 	const badgeFields = groupedRenderFields.badge;
-	const otherFields = groupedRenderFields.default;
+	const otherFields = groupedRenderFields.other;
 	return (
 		<VStack
 			spacing={ 0 }
@@ -138,10 +138,10 @@ function GridItem< Item >( {
 			{ !! otherFields?.length && (
 				<VStack className="dataviews-view-grid__fields" spacing={ 3 }>
 					{ fields.map( ( field ) => {
-						const isVisible = !! otherFields.find(
+						const fieldRenderConfig = otherFields.find(
 							( fr ) => field.id === fr.field
 						);
-						if ( ! isVisible ) {
+						if ( ! fieldRenderConfig ) {
 							return null;
 						}
 						const renderedValue = field.render( {
@@ -152,12 +152,22 @@ function GridItem< Item >( {
 						}
 						return (
 							<Flex
-								className="dataviews-view-grid__field"
+								className={ clsx(
+									'dataviews-view-grid__field',
+									fieldRenderConfig.render === 'column'
+										? 'is-column'
+										: 'is-row'
+								) }
 								key={ field.id }
 								gap={ 1 }
 								justify="flex-start"
 								expanded
 								style={ { height: 'auto' } }
+								direction={
+									fieldRenderConfig.render === 'column'
+										? 'column'
+										: 'row'
+								}
 							>
 								<>
 									<FlexItem className="dataviews-view-grid__field-name">
@@ -211,10 +221,11 @@ export default function ViewGrid< Item >( {
 			) {
 				return accumulator;
 			}
-			accumulator[ fieldRender.render ].push( fieldRender );
+			const key = fieldRender.render === 'badge' ? 'badge' : 'other';
+			accumulator[ key ].push( fieldRender );
 			return accumulator;
 		},
-		{ default: [], badge: [], column: [] }
+		{ other: [], badge: [] }
 	);
 	const hasData = !! data?.length;
 	return (

--- a/packages/dataviews/src/view-grid.tsx
+++ b/packages/dataviews/src/view-grid.tsx
@@ -59,7 +59,7 @@ function GridItem< Item >( {
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
 	const badgeFields = groupedRenderFields.badge;
-	const defaultFields = groupedRenderFields.default;
+	const otherFields = groupedRenderFields.default;
 	return (
 		<VStack
 			spacing={ 0 }
@@ -135,10 +135,10 @@ function GridItem< Item >( {
 					} ) }
 				</HStack>
 			) }
-			{ !! defaultFields?.length && (
+			{ !! otherFields?.length && (
 				<VStack className="dataviews-view-grid__fields" spacing={ 3 }>
 					{ fields.map( ( field ) => {
-						const isVisible = !! defaultFields.find(
+						const isVisible = !! otherFields.find(
 							( fr ) => field.id === fr.field
 						);
 						if ( ! isVisible ) {

--- a/packages/dataviews/src/view-grid.tsx
+++ b/packages/dataviews/src/view-grid.tsx
@@ -30,7 +30,7 @@ import type {
 } from './types';
 import type { SetSelection } from './private-types';
 import { normalizeFieldRenderConfigs } from './normalize-field-render-configs';
-import FieldRenderPrimary from './field-render-primary';
+import FieldFormatPrimary from './field-format-primary';
 
 interface GridItemProps< Item > {
 	selection: string[];
@@ -99,7 +99,7 @@ function GridItem< Item >( {
 					disabled={ ! hasBulkAction }
 				/>
 				{ !! primaryField && (
-					<FieldRenderPrimary item={ item } field={ primaryField } />
+					<FieldFormatPrimary item={ item } field={ primaryField } />
 				) }
 				<ItemActions item={ item } actions={ actions } isCompact />
 			</HStack>
@@ -154,7 +154,7 @@ function GridItem< Item >( {
 							<Flex
 								className={ clsx(
 									'dataviews-view-grid__field',
-									fieldRenderConfig.render === 'column'
+									fieldRenderConfig.format === 'column'
 										? 'is-column'
 										: 'is-row'
 								) }
@@ -164,7 +164,7 @@ function GridItem< Item >( {
 								expanded
 								style={ { height: 'auto' } }
 								direction={
-									fieldRenderConfig.render === 'column'
+									fieldRenderConfig.format === 'column'
 										? 'column'
 										: 'row'
 								}
@@ -204,10 +204,10 @@ export default function ViewGrid< Item >( {
 		fields
 	);
 	const mediaFieldId = fieldRenderConfigs.find(
-		( fieldRender ) => fieldRender.render === 'media'
+		( fieldRender ) => fieldRender.format === 'media'
 	)?.field;
 	const primaryFieldId = fieldRenderConfigs.find(
-		( fieldRender ) => fieldRender.render === 'primary'
+		( fieldRender ) => fieldRender.format === 'primary'
 	)?.field;
 	const mediaField = fields.find( ( f ) => f.id === mediaFieldId );
 	const primaryField = fields.find( ( f ) => f.id === primaryFieldId );
@@ -221,7 +221,7 @@ export default function ViewGrid< Item >( {
 			) {
 				return accumulator;
 			}
-			const key = fieldRender.render === 'badge' ? 'badge' : 'other';
+			const key = fieldRender.format === 'badge' ? 'badge' : 'other';
 			accumulator[ key ].push( fieldRender );
 			return accumulator;
 		},

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -54,7 +54,7 @@ interface ListViewItemProps< Item > {
 	onSelect: ( item: Item ) => void;
 	primaryField?: NormalizedField< Item >;
 	store: CompositeStore;
-	defaultFields: NormalizedFieldRenderConfig[];
+	otherFields: NormalizedFieldRenderConfig[];
 }
 
 const {
@@ -75,7 +75,7 @@ function ListItem< Item >( {
 	onSelect,
 	primaryField,
 	store,
-	defaultFields,
+	otherFields,
 }: ListViewItemProps< Item > ) {
 	const registry = useRegistry();
 	const itemRef = useRef< HTMLElement >( null );
@@ -174,7 +174,7 @@ function ListItem< Item >( {
 									id={ descriptionId }
 								>
 									{ fields.map( ( field ) => {
-										const isVisible = !! defaultFields.find(
+										const isVisible = !! otherFields.find(
 											( fr ) => field.id === fr.field
 										);
 										if ( ! isVisible ) {
@@ -348,7 +348,7 @@ export default function ViewList< Item >( props: ViewProps< Item > ) {
 	)?.field;
 	const mediaField = fields.find( ( f ) => f.id === mediaFieldId );
 	const primaryField = fields.find( ( f ) => f.id === primaryFieldId );
-	const defaultFields = fieldRenderConfigs.filter(
+	const otherFields = fieldRenderConfigs.filter(
 		( fieldRender ) =>
 			! [ mediaFieldId, primaryFieldId ].includes( fieldRender.field )
 	);
@@ -422,7 +422,7 @@ export default function ViewList< Item >( props: ViewProps< Item > ) {
 						mediaField={ mediaField }
 						primaryField={ primaryField }
 						store={ store }
-						defaultFields={ defaultFields }
+						otherFields={ otherFields }
 					/>
 				);
 			} ) }

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -42,7 +42,7 @@ import type {
 
 import { ActionsDropdownMenuGroup, ActionModal } from './item-actions';
 import { normalizeFieldRenderConfigs } from './normalize-field-render-configs';
-import FieldRenderPrimary from './field-render-primary';
+import FieldFormatPrimary from './field-format-primary';
 
 interface ListViewItemProps< Item > {
 	actions: Action< Item >[];
@@ -163,7 +163,7 @@ function ListItem< Item >( {
 							</div>
 							<VStack spacing={ 0 }>
 								{ !! primaryField && (
-									<FieldRenderPrimary
+									<FieldFormatPrimary
 										item={ item }
 										field={ primaryField }
 										id={ labelId }
@@ -341,10 +341,10 @@ export default function ViewList< Item >( props: ViewProps< Item > ) {
 		fields
 	);
 	const mediaFieldId = fieldRenderConfigs.find(
-		( fieldRender ) => fieldRender.render === 'media'
+		( fieldRender ) => fieldRender.format === 'media'
 	)?.field;
 	const primaryFieldId = fieldRenderConfigs.find(
-		( fieldRender ) => fieldRender.render === 'primary'
+		( fieldRender ) => fieldRender.format === 'primary'
 	)?.field;
 	const mediaField = fields.find( ( f ) => f.id === mediaFieldId );
 	const primaryField = fields.find( ( f ) => f.id === primaryFieldId );

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -53,7 +53,7 @@ import type {
 	NormalizedFieldRenderConfig,
 } from './types';
 import type { SetSelection } from './private-types';
-import FieldRenderPrimary from './field-render-primary';
+import FieldFormatPrimary from './field-format-primary';
 import { normalizeFieldRenderConfigs } from './normalize-field-render-configs';
 
 const {
@@ -321,7 +321,7 @@ function TableRow< Item >( {
 	// behaviours.
 	const isTouchDevice = useRef( false );
 	const primaryFieldId = fieldRenderConfigs.find(
-		( fieldRenderConfig ) => fieldRenderConfig.render === 'primary'
+		( fieldRenderConfig ) => fieldRenderConfig.format === 'primary'
 	)?.field;
 	const primaryField = fields.find( ( f ) => f.id === primaryFieldId );
 
@@ -380,8 +380,8 @@ function TableRow< Item >( {
 					return null;
 				}
 				const fieldOutput =
-					fieldRender.render === 'primary' ? (
-						<FieldRenderPrimary field={ field } item={ item } />
+					fieldRender.format === 'primary' ? (
+						<FieldFormatPrimary field={ field } item={ item } />
 					) : (
 						field.render( { item } )
 					);

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -61,14 +61,14 @@ const EMPTY_ARRAY = [];
 const defaultFields = {
 	[ LAYOUT_TABLE ]: [
 		'preview',
-		{ render: 'primary', field: 'title' },
+		{ format: 'primary', field: 'title' },
 		'sync-status',
 		'author',
 	],
 	[ LAYOUT_GRID ]: [
-		{ render: 'media', field: 'preview' },
-		{ render: 'primary', field: 'title' },
-		{ render: 'badge', field: 'sync-status' },
+		{ format: 'media', field: 'preview' },
+		{ format: 'primary', field: 'title' },
+		{ format: 'badge', field: 'sync-status' },
 		'author',
 	],
 };

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -13,13 +13,7 @@ import {
 	Flex,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import {
-	useState,
-	useMemo,
-	useCallback,
-	useId,
-	useEffect,
-} from '@wordpress/element';
+import { useState, useMemo, useId, useEffect } from '@wordpress/element';
 import {
 	BlockPreview,
 	privateApis as blockEditorPrivateApis,
@@ -64,25 +58,27 @@ const { usePostActions } = unlock( editorPrivateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
-const defaultConfigPerViewType = {
-	[ LAYOUT_TABLE ]: {
-		primaryField: 'title',
-	},
-	[ LAYOUT_GRID ]: {
-		mediaField: 'preview',
-		primaryField: 'title',
-		badgeFields: [ 'sync-status' ],
-	},
+const defaultFields = {
+	[ LAYOUT_TABLE ]: [
+		'preview',
+		{ render: 'primary', field: 'title' },
+		'sync-status',
+		'author',
+	],
+	[ LAYOUT_GRID ]: [
+		{ render: 'media', field: 'preview' },
+		{ render: 'primary', field: 'title' },
+		{ render: 'badge', field: 'sync-status' },
+		'author',
+	],
 };
 const DEFAULT_VIEW = {
 	type: LAYOUT_GRID,
 	search: '',
 	page: 1,
 	perPage: 20,
-	layout: {
-		...defaultConfigPerViewType[ LAYOUT_GRID ],
-	},
 	filters: [],
+	fields: defaultFields[ LAYOUT_GRID ],
 };
 
 const SYNC_FILTERS = [
@@ -381,20 +377,6 @@ export default function DataviewsPatterns() {
 		}
 		return [ editAction, ...patternActions ].filter( Boolean );
 	}, [ editAction, type, templatePartActions, patternActions ] );
-	const onChangeView = useCallback(
-		( newView ) => {
-			if ( newView.type !== view.type ) {
-				newView = {
-					...newView,
-					layout: {
-						...defaultConfigPerViewType[ newView.type ],
-					},
-				};
-			}
-			setView( newView );
-		},
-		[ view.type, setView ]
-	);
 	const id = useId();
 	const settings = usePatternSettings();
 	// Wrap everything in a block editor provider.
@@ -421,8 +403,9 @@ export default function DataviewsPatterns() {
 					getItemId={ ( item ) => item.name ?? item.id }
 					isLoading={ isResolving }
 					view={ view }
-					onChangeView={ onChangeView }
+					onChangeView={ setView }
 					supportedLayouts={ [ LAYOUT_GRID, LAYOUT_TABLE ] }
+					defaultFields={ defaultFields }
 				/>
 			</Page>
 		</ExperimentalBlockEditorProvider>

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -63,6 +63,7 @@ const defaultFields = {
 	[ LAYOUT_GRID ]: [
 		{ render: 'media', field: 'preview' },
 		{ render: 'primary', field: 'title' },
+		{ render: 'column', field: 'description' },
 	],
 	[ LAYOUT_LIST ]: [
 		{ render: 'media', field: 'preview' },

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -54,19 +54,21 @@ const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
 
-const defaultConfigPerViewType = {
-	[ LAYOUT_TABLE ]: {
-		primaryField: 'title',
-	},
-	[ LAYOUT_GRID ]: {
-		mediaField: 'preview',
-		primaryField: 'title',
-		columnFields: [ 'description' ],
-	},
-	[ LAYOUT_LIST ]: {
-		primaryField: 'title',
-		mediaField: 'preview',
-	},
+const defaultFields = {
+	[ LAYOUT_TABLE ]: [
+		{ render: 'primary', field: 'title' },
+		'description',
+		'author',
+	],
+	[ LAYOUT_GRID ]: [
+		{ render: 'media', field: 'preview' },
+		{ render: 'primary', field: 'title' },
+	],
+	[ LAYOUT_LIST ]: [
+		{ render: 'media', field: 'preview' },
+		{ render: 'primary', field: 'title' },
+		'author',
+	],
 };
 
 const DEFAULT_VIEW = {
@@ -78,8 +80,7 @@ const DEFAULT_VIEW = {
 		field: 'title',
 		direction: 'asc',
 	},
-	fields: [ 'title', 'description', 'author' ],
-	layout: defaultConfigPerViewType[ LAYOUT_GRID ],
+	fields: defaultFields[ LAYOUT_GRID ],
 	filters: [],
 };
 
@@ -192,7 +193,7 @@ export default function PageTemplates() {
 		return {
 			...DEFAULT_VIEW,
 			type: usedType,
-			layout: defaultConfigPerViewType[ usedType ],
+			fields: defaultFields[ usedType ],
 			filters:
 				activeView !== 'all'
 					? [
@@ -336,13 +337,6 @@ export default function PageTemplates() {
 	const onChangeView = useCallback(
 		( newView ) => {
 			if ( newView.type !== view.type ) {
-				newView = {
-					...newView,
-					layout: {
-						...defaultConfigPerViewType[ newView.type ],
-					},
-				};
-
 				history.push( {
 					...params,
 					layout: newView.type,
@@ -371,6 +365,7 @@ export default function PageTemplates() {
 				onSelectionChange={ onSelectionChange }
 				selection={ selection }
 				setSelection={ setSelection }
+				defaultFields={ defaultFields }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -56,18 +56,18 @@ const EMPTY_ARRAY = [];
 
 const defaultFields = {
 	[ LAYOUT_TABLE ]: [
-		{ render: 'primary', field: 'title' },
+		{ format: 'primary', field: 'title' },
 		'description',
 		'author',
 	],
 	[ LAYOUT_GRID ]: [
-		{ render: 'media', field: 'preview' },
-		{ render: 'primary', field: 'title' },
-		{ render: 'column', field: 'description' },
+		{ format: 'media', field: 'preview' },
+		{ format: 'primary', field: 'title' },
+		{ format: 'column', field: 'description' },
 	],
 	[ LAYOUT_LIST ]: [
-		{ render: 'media', field: 'preview' },
-		{ render: 'primary', field: 'title' },
+		{ format: 'media', field: 'preview' },
+		{ format: 'primary', field: 'title' },
 		'author',
 	],
 };

--- a/packages/edit-site/src/components/posts-app/posts-list.js
+++ b/packages/edit-site/src/components/posts-app/posts-list.js
@@ -25,7 +25,7 @@ import Page from '../page';
 import { default as Link, useLink } from '../routes/link';
 import {
 	useDefaultViews,
-	DEFAULT_CONFIG_PER_VIEW_TYPE,
+	defaultFields,
 } from '../sidebar-dataviews/default-views';
 import {
 	LAYOUT_GRID,
@@ -67,9 +67,6 @@ function useView( postType ) {
 			return {
 				...defaultView,
 				type: layout,
-				layout: {
-					...( DEFAULT_CONFIG_PER_VIEW_TYPE[ layout ] || {} ),
-				},
 			};
 		}
 		return defaultView;
@@ -102,16 +99,7 @@ function useView( postType ) {
 		const storedView =
 			editedViewRecord?.content &&
 			JSON.parse( editedViewRecord?.content );
-		if ( ! storedView ) {
-			return storedView;
-		}
-
-		return {
-			...storedView,
-			layout: {
-				...( DEFAULT_CONFIG_PER_VIEW_TYPE[ storedView?.type ] || {} ),
-			},
-		};
+		return storedView;
 	}, [ editedViewRecord?.content ] );
 
 	const setCustomView = useCallback(
@@ -496,23 +484,6 @@ export default function PostsList( { postType } ) {
 		() => [ editAction, ...postTypeActions ],
 		[ postTypeActions, editAction ]
 	);
-
-	const onChangeView = useCallback(
-		( newView ) => {
-			if ( newView.type !== view.type ) {
-				newView = {
-					...newView,
-					layout: {
-						...DEFAULT_CONFIG_PER_VIEW_TYPE[ newView.type ],
-					},
-				};
-			}
-
-			setView( newView );
-		},
-		[ view.type, setView ]
-	);
-
 	const [ showAddPostModal, setShowAddPostModal ] = useState( false );
 
 	const openModal = () => setShowAddPostModal( true );
@@ -558,11 +529,12 @@ export default function PostsList( { postType } ) {
 				data={ records || EMPTY_ARRAY }
 				isLoading={ isLoadingMainEntities || isLoadingAuthors }
 				view={ view }
-				onChangeView={ onChangeView }
+				onChangeView={ setView }
 				selection={ selection }
 				setSelection={ setSelection }
 				onSelectionChange={ onSelectionChange }
 				getItemId={ getItemId }
+				defaultFields={ defaultFields }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -28,19 +28,19 @@ import {
 
 export const defaultFields = {
 	[ LAYOUT_TABLE ]: [
-		{ render: 'primary', field: 'title' },
+		{ format: 'primary', field: 'title' },
 		'author',
 		'status',
 	],
 	[ LAYOUT_GRID ]: [
-		{ render: 'media', field: 'featured-image' },
-		{ render: 'primary', field: 'title' },
+		{ format: 'media', field: 'featured-image' },
+		{ format: 'primary', field: 'title' },
 		'author',
 		'status',
 	],
 	[ LAYOUT_LIST ]: [
-		{ render: 'media', field: 'featured-image' },
-		{ render: 'primary', field: 'title' },
+		{ format: 'media', field: 'featured-image' },
+		{ format: 'primary', field: 'title' },
 		'author',
 		'status',
 	],

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -26,18 +26,24 @@ import {
 	OPERATOR_IS_ANY,
 } from '../../utils/constants';
 
-export const DEFAULT_CONFIG_PER_VIEW_TYPE = {
-	[ LAYOUT_TABLE ]: {
-		primaryField: 'title',
-	},
-	[ LAYOUT_GRID ]: {
-		mediaField: 'featured-image',
-		primaryField: 'title',
-	},
-	[ LAYOUT_LIST ]: {
-		primaryField: 'title',
-		mediaField: 'featured-image',
-	},
+export const defaultFields = {
+	[ LAYOUT_TABLE ]: [
+		{ render: 'primary', field: 'title' },
+		'author',
+		'status',
+	],
+	[ LAYOUT_GRID ]: [
+		{ render: 'media', field: 'featured-image' },
+		{ render: 'primary', field: 'title' },
+		'author',
+		'status',
+	],
+	[ LAYOUT_LIST ]: [
+		{ render: 'media', field: 'featured-image' },
+		{ render: 'primary', field: 'title' },
+		'author',
+		'status',
+	],
 };
 
 const DEFAULT_POST_BASE = {
@@ -50,10 +56,7 @@ const DEFAULT_POST_BASE = {
 		field: 'date',
 		direction: 'desc',
 	},
-	fields: [ 'title', 'author', 'status' ],
-	layout: {
-		...DEFAULT_CONFIG_PER_VIEW_TYPE[ LAYOUT_LIST ],
-	},
+	fields: defaultFields[ LAYOUT_LIST ],
 };
 
 export function useDefaultViews( { postType } ) {


### PR DESCRIPTION
Related to #55083 
Follow-up to #63127 

## What?

This PR does two things:

 - Removes the `layout` property from the `view` object. In favor of a `defaultFields` prop that can be passed optionally to the DataViews component. The defaultFields will tell which fields are visible by default on each layout (when switching layouts) 
 - Moves all the "badge", "media", "primary" configs into the `view.fields` config instead of being separate. So the view fields are defined like `[{ render: 'media', field: 'preview' }, "author", "description" ]`. The idea is that we'll be using this later to combine fields as well.

It's a significant change to the API, so it's a good idea to test most dataviews:

**Note** One known regression here is that I removed the "column/row" distinction in the grid layout. Personally, I think it was wrong to have this in the first place. I'd argue that we could potentially hide the "field labels" in this layout like we do for "list". 

**Note2** I believe badge fields are only supported in grid views right now, I think this can be easily extended to all layouts if we want.

## Testing Instructions

1- Test all layouts.
2- Test toggling field visibility for all layouts.
3- Test custom views.