### PR TITLE
Remove third party domain

### DIFF
--- a/docs/how-to-guides/metabox.md
+++ b/docs/how-to-guides/metabox.md
@@ -243,7 +243,7 @@ When the meta box area is saving, we display an updating overlay, to prevent use
 
 An example save url would look like:
 
-`mysite.com/wp-admin/post.php?post=1&action=edit&meta-box-loader=1`
+`example.com/wp-admin/post.php?post=1&action=edit&meta-box-loader=1`
 
 This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
 

--- a/docs/how-to-guides/metabox.md
+++ b/docs/how-to-guides/metabox.md
@@ -243,7 +243,7 @@ When the meta box area is saving, we display an updating overlay, to prevent use
 
 An example save url would look like:
 
-`example.com/wp-admin/post.php?post=1&action=edit&meta-box-loader=1`
+`example.org/wp-admin/post.php?post=1&action=edit&meta-box-loader=1`
 
 This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
 

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -261,7 +261,9 @@ export function ParentRow() {
 								__(
 									"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services,' its URL would be %1$s/services/web-design."
 								),
-								homeUrl.replace( /^https?:\/\//, '' )
+								homeUrl
+									.replace( /^https?:\/\//, '' )
+									.replace( /\/$/, '' )
 							) }
 							<p>
 								{ __(

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -250,7 +250,8 @@ export function ParentRow() {
 						/>
 						<div>
 							{ __(
-								"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services,' its URL would be mysite.com/services/web-design."
+								/* translators: To avoid the potential for linking to live sites, the example URL should be either wordpress.org, a sub-domain of wordpress.org, example.com or example.org */
+								"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services,' its URL would be example.com/services/web-design."
 							) }
 							<p>
 								{ __(

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -217,13 +217,6 @@ function PostParentToggle( { isOpen, onClick } ) {
 }
 
 export function ParentRow() {
-	const { homeUrl } = useSelect( ( select ) => {
-		const { getUnstableBase } = select( coreStore );
-		return {
-			homeUrl: getUnstableBase()?.home,
-		};
-	}, [] );
-
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -256,15 +249,12 @@ export function ParentRow() {
 							onClose={ onClose }
 						/>
 						<div>
-							{ sprintf(
-								/* translators: %1$s The home URL of the WordPress installation without the scheme. */
+							{
+								/* translators: The domain name should be a reserved domain name to prevent linking to third party sites outside the WordPress projects control. You may also wish to use wordpress.org or a wordpress.org sub-domain. */
 								__(
-									"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services', its URL would be %1$s/services/web-design."
-								),
-								homeUrl
-									.replace( /^https?:\/\//, '' )
-									.replace( /\/$/, '' )
-							) }
+									"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services', its URL would be example.org/services/web-design."
+								)
+							}
 							<p>
 								{ __(
 									'They also show up as sub-items in the default navigation menu. '

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -217,6 +217,13 @@ function PostParentToggle( { isOpen, onClick } ) {
 }
 
 export function ParentRow() {
+	const { homeUrl } = useSelect( ( select ) => {
+		const { getUnstableBase } = select( coreStore );
+		return {
+			homeUrl: getUnstableBase()?.home,
+		};
+	}, [] );
+
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -249,9 +256,12 @@ export function ParentRow() {
 							onClose={ onClose }
 						/>
 						<div>
-							{ __(
-								/* translators: To avoid the potential for linking to live sites, the example URL should be either wordpress.org, a sub-domain of wordpress.org, example.com or example.org */
-								"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services,' its URL would be example.com/services/web-design."
+							{ sprintf(
+								/* translators: %1$s The home URL of the WordPress installation without the scheme. */
+								__(
+									"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services,' its URL would be %1$s/services/web-design."
+								),
+								homeUrl.replace( /^https?:\/\//, '' )
 							) }
 							<p>
 								{ __(

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -259,7 +259,7 @@ export function ParentRow() {
 							{ sprintf(
 								/* translators: %1$s The home URL of the WordPress installation without the scheme. */
 								__(
-									"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services,' its URL would be %1$s/services/web-design."
+									"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services', its URL would be %1$s/services/web-design."
 								),
 								homeUrl
 									.replace( /^https?:\/\//, '' )

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -250,7 +250,7 @@ export function ParentRow() {
 						/>
 						<div>
 							{
-								/* translators: The domain name should be a reserved domain name to prevent linking to third party sites outside the WordPress projects control. You may also wish to use wordpress.org or a wordpress.org sub-domain. */
+								/* translators: The domain name should be a reserved domain name to prevent linking to third party sites outside the WordPress project's control. You may also wish to use wordpress.org or a wordpress.org sub-domain. */
 								__(
 									"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services', its URL would be example.org/services/web-design."
 								)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Replaces references to `mysite.com` with `example.com`

Fixes https://core.trac.wordpress.org/ticket/61570

## Why?
This comes out of discussion in the polyglots slack channel to avoid references to potentially live third party sites.

As WordPress has no control over the sites, this could be problematic if the content of the demonstration URL was either malware or content unsuitable for people of all ages.

## How?

`mysite.com` is replaced with `example.org`

Initially I used the homeURL of the site but @ramonjd and I were worried it could become too long for the copy space so we went with the reserved domain instead. If needs be, it can be switched to home URL later.

## Testing Instructions
1. Create a new page
2. Wait for the templates to load, close it immediately 
3. Click the Parent: None link
4. The inline documentation should show the example.org rather than mysite.com

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-07-05 at 9 41 44 AM](https://github.com/WordPress/gutenberg/assets/519727/347978b8-0202-4b50-b5cf-9d721115b5d4)

