### PR TITLE
Tooltip Component: Add custom class name support

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-
 ### Enhancements
 
 -   `Tooltip`: Add support for `className` prop ([#63157](https://github.com/WordPress/gutenberg/pull/63157)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,10 +1,11 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
--   `Tooltip`: Add support for `className` prop ([#63157](https://github.com/WordPress/gutenberg/pull/63157)).
+
 
 ### Enhancements
 
+-   `Tooltip`: Add support for `className` prop ([#63157](https://github.com/WordPress/gutenberg/pull/63157)).
 -   `Toolbar`: Add support for `vertical` orientation ([#60123](https://github.com/WordPress/gutenberg/pull/60123)).
 
 ### Bug Fixes

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+-   `Tooltip`: Add support for `className` prop ([#63157](https://github.com/WordPress/gutenberg/pull/63157)).
 
 ### Enhancements
 

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -50,6 +50,7 @@ function UnforwardedTooltip(
 		position,
 		shortcut,
 		text,
+		className,
 
 		...restProps
 	} = props;
@@ -112,7 +113,7 @@ function UnforwardedTooltip(
 			{ isOnlyChild && ( text || shortcut ) && (
 				<Ariakit.Tooltip
 					{ ...restProps }
-					className="components-tooltip"
+					className={ className === undefined ? "components-tooltip" : "components-tooltip " + className }
 					unmountOnHide
 					gutter={ 4 }
 					id={ describedById }

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as Ariakit from '@ariakit/react';
+import clsx from 'clsx';
 
 /**
  * WordPress dependencies

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -113,7 +113,7 @@ function UnforwardedTooltip(
 			{ isOnlyChild && ( text || shortcut ) && (
 				<Ariakit.Tooltip
 					{ ...restProps }
-					className={ className === undefined ? "components-tooltip" : "components-tooltip " + className }
+					className={ clsx( 'components-tooltip', className ) }
 					unmountOnHide
 					gutter={ 4 }
 					id={ describedById }

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -45,13 +45,13 @@ function UnforwardedTooltip(
 ) {
 	const {
 		children,
+		className,
 		delay = TOOLTIP_DELAY,
 		hideOnClick = true,
 		placement,
 		position,
 		shortcut,
 		text,
-		className,
 
 		...restProps
 	} = props;

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -114,22 +114,13 @@ describe( 'Tooltip', () => {
 				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
 			);
 
-			// Check core class
+			// Check default and custom classnames
 			await waitFor( () =>
 				expect(
 					screen.getByRole( 'tooltip', {
 						name: 'tooltip text',
 					} )
-				).toHaveClass('components-tooltip')
-			);
-
-			// Check custom class
-			await waitFor( () =>
-				expect(
-					screen.getByRole( 'tooltip', {
-						name: 'tooltip text',
-					} )
-				).toHaveClass('foo')
+				).toHaveClass( 'components-tooltip', 'foo' )
 			);
 		} );
 	} );

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -106,7 +106,7 @@ describe( 'Tooltip', () => {
 			).not.toHaveAttribute( 'data-foo' );
 		} );
 
-		it( 'should add custom class to the tooltip', async () => {
+		it( 'should add default and custom class names to the tooltip', async () => {
 			render( <Tooltip { ...props } className="foo" /> );
 
 			// Hover over the anchor, tooltip should show

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -105,6 +105,33 @@ describe( 'Tooltip', () => {
 				screen.getByRole( 'button', { name: 'Anchor' } )
 			).not.toHaveAttribute( 'data-foo' );
 		} );
+
+		it( 'should add custom class to the tooltip', async () => {
+			render( <Tooltip { ...props } className='foo' /> );
+
+			// Hover over the anchor, tooltip should show
+			await hover(
+				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+			);
+
+			// Check core class
+			await waitFor( () =>
+				expect(
+					screen.getByRole( 'tooltip', {
+						name: 'tooltip text',
+					} )
+				).toHaveClass('components-tooltip')
+			);
+
+			// Check custom class
+			await waitFor( () =>
+				expect(
+					screen.getByRole( 'tooltip', {
+						name: 'tooltip text',
+					} )
+				).toHaveClass('foo')
+			);
+		} );
 	} );
 
 	describe( 'keyboard focus', () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -107,7 +107,7 @@ describe( 'Tooltip', () => {
 		} );
 
 		it( 'should add custom class to the tooltip', async () => {
-			render( <Tooltip { ...props } className='foo' /> );
+			render( <Tooltip { ...props } className="foo" /> );
 
 			// Hover over the anchor, tooltip should show
 			await hover(

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -61,6 +61,7 @@ export type TooltipProps = {
 	/**
 	 * The custom class name for the tooltip.
 	 * The default class for tooltip is `components-tooltip` and always will be added.
+	 * The custom class name will be appended to the default class.
 	 */
 	className?: string;
 };

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -17,6 +17,10 @@ export type TooltipProps = {
 	 */
 	children: React.ReactElement;
 	/**
+	 * Custom class name for the tooltip, in addition to the default `components-tooltip`.
+	 */
+	className?: string;
+	/**
 	 * Option to hide the tooltip when the anchor is clicked.
 	 *
 	 * @default true
@@ -58,10 +62,6 @@ export type TooltipProps = {
 	 * The text shown in the tooltip when anchor element is focused or hovered.
 	 */
 	text?: string;
-	/**
-	 * Custom class name for the tooltip, in addition to the default `components-tooltip`.
-	 */
-	className?: string;
 };
 
 export type TooltipInternalContext = {

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -58,6 +58,11 @@ export type TooltipProps = {
 	 * The text shown in the tooltip when anchor element is focused or hovered.
 	 */
 	text?: string;
+	/**
+	 * The custom class name for the tooltip.
+	 * The default class for tooltip is `components-tooltip` and always will be added.
+	 */
+	className?: string;
 };
 
 export type TooltipInternalContext = {

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -17,7 +17,7 @@ export type TooltipProps = {
 	 */
 	children: React.ReactElement;
 	/**
-	 * Custom class name for the tooltip, in addition to the default `components-tooltip`.
+	 * Custom class name for the tooltip.
 	 */
 	className?: string;
 	/**

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -59,9 +59,7 @@ export type TooltipProps = {
 	 */
 	text?: string;
 	/**
-	 * The custom class name for the tooltip.
-	 * The default class for tooltip is `components-tooltip` and always will be added.
-	 * The custom class name will be appended to the default class.
+	 * Custom class name for the tooltip, in addition to the default `components-tooltip`.
 	 */
 	className?: string;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The Tooltip component does not supports custom css class name.

## Why?
I added the custom class name support that that for many reasons can be used for design customization of tooltip.

## How?
I added the `className` prop and also added test to make sure it works properly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Unlinked contributors: aliaghdam.

