### PR TITLE
Resizing in Auto mode shouldn't add `columnStart` and `rowStart` values

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -62,7 +62,7 @@ function BlockMover( {
 				orientation: getBlockListSettings( _rootClientId )?.orientation,
 				isManualGrid:
 					layout.type === 'grid' &&
-					!! layout.columnCount &&
+					layout.isManualPlacement &&
 					window.__experimentalEnableGridInteractivity,
 			};
 		},

--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -19,7 +19,7 @@ export function GridItemResizer( {
 } ) {
 	const blockElement = useBlockElement( clientId );
 	const rootBlockElement = blockElement?.parentElement;
-	const { columnCount } = parentLayout;
+	const { isManualPlacement } = parentLayout;
 
 	if ( ! blockElement || ! rootBlockElement ) {
 		return null;
@@ -33,7 +33,8 @@ export function GridItemResizer( {
 			rootBlockElement={ rootBlockElement }
 			onChange={ onChange }
 			isManualGrid={
-				!! columnCount && window.__experimentalEnableGridInteractivity
+				isManualPlacement &&
+				window.__experimentalEnableGridInteractivity
 			}
 		/>
 	);

--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -32,7 +32,7 @@ export function GridVisualizer( { clientId, contentRef, parentLayout } ) {
 	}
 
 	const isManualGrid =
-		parentLayout?.columnCount &&
+		parentLayout?.isManualPlacement &&
 		window.__experimentalEnableGridInteractivity;
 	return (
 		<GridVisualizerGrid

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -31,9 +31,8 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 		const updates = {};
 
 		const { columnCount, rowCount, isManualPlacement } = gridLayout;
-		const isManualGrid = !! isManualPlacement;
 
-		if ( isManualGrid ) {
+		if ( isManualPlacement ) {
 			const rects = [];
 
 			// Respect the position of blocks that already have a columnStart and rowStart value.

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -152,7 +152,7 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 	const {
 		type: parentLayoutType = 'default',
 		allowSizingOnChildren = false,
-		columnCount,
+		isManualPlacement,
 	} = parentLayout;
 
 	const rootClientId = useSelect(
@@ -168,8 +168,6 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 	if ( parentLayoutType !== 'grid' ) {
 		return null;
 	}
-
-	const isManualGrid = !! columnCount;
 
 	function updateLayout( layout ) {
 		setAttributes( {
@@ -199,15 +197,16 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 					parentLayout={ parentLayout }
 				/>
 			) }
-			{ isManualGrid && window.__experimentalEnableGridInteractivity && (
-				<GridItemMovers
-					layout={ style?.layout }
-					parentLayout={ parentLayout }
-					onChange={ updateLayout }
-					gridClientId={ rootClientId }
-					blockClientId={ clientId }
-				/>
-			) }
+			{ isManualPlacement &&
+				window.__experimentalEnableGridInteractivity && (
+					<GridItemMovers
+						layout={ style?.layout }
+						parentLayout={ parentLayout }
+						onChange={ updateLayout }
+						gridClientId={ rootClientId }
+						blockClientId={ clientId }
+					/>
+				) }
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a regression introduced in #62777.

When the grid interactivity experiment is enabled, it's possible to add a maximum number of columns to a Grid block in Auto mode. This should not cause grid children to get `columnStart` and `rowStart` values when they're resized with the resizing handles. `columnStart` and `rowStart` should only be set when the grid is in Manual mode.

Update: also removes dropzones from Auto grids with `columnCount` set.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In Gutenberg > Experiments enable the Grid experiment;
2. Add a Grid block to a post or template and add some blocks inside it;
3. In Auto mode, set a non-zero number of "Columns" in the sidebar;
4. Resize one of the grid children with the resize handles and check that in its sidebar, under "Dimensions", the "Column" and "Row" fields aren't visible.


Before:

<img width="276" alt="Screenshot 2024-07-05 at 11 24 13 AM" src="https://github.com/WordPress/gutenberg/assets/8096000/443f282d-8303-462d-9e12-5437dee36a1e">


After:

<img width="272" alt="Screenshot 2024-07-05 at 11 24 28 AM" src="https://github.com/WordPress/gutenberg/assets/8096000/289e069e-ecdf-4c56-918e-9b2b238d7971">

