### PR TITLE
Remove dotted border from grid dropzone

### DIFF
--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -27,7 +27,6 @@
 
 .block-editor-grid-visualizer__drop-zone {
 	background: rgba($gray-400, 0.1);
-	border: $border-width dotted $gray-300;
 	width: 100%;
 	height: 100%;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes regression introduced in #61025 as per [this comment](https://github.com/WordPress/gutenberg/pull/62777#issuecomment-2194002144).

Removes dotted border from grid cell dropzones.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1.In Gutenberg > Experiments enable the Grid experiment;
2. Add a Grid block to a post or template and add some blocks inside it;
3. Switch the Grid to Manual mode in the block sidebar under "Layout";
4. Select one of the child blocks of the Grid;
5. Check that grid cells are highlighted with a solid line and not a dotted one.


Before:

<img width="895" alt="Screenshot 2024-07-05 at 1 32 59 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/c5056343-27df-4542-a4fc-81870a7c0877">

After:

<img width="900" alt="Screenshot 2024-07-05 at 1 33 54 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/64415550-ad91-4e70-a1c4-2906836ebc20">

