### PR TITLE
Constrain `is-fullscreen-mode` admin body class to posts list

### DIFF
--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -7,13 +7,15 @@
 
 add_action( 'admin_menu', 'gutenberg_replace_posts_dashboard' );
 
-// Default to is-fullscreen-mode to avoid jumps in the UI.
-add_filter(
-	'admin_body_class',
-	static function ( $classes ) {
-		return "$classes is-fullscreen-mode";
-	}
-);
+if ( isset( $_GET['page'] ) && 'gutenberg-posts-dashboard' === $_GET['page'] ) {
+	// Default to is-fullscreen-mode to avoid jumps in the UI.
+	add_filter(
+		'admin_body_class',
+		static function ( $classes ) {
+			return "$classes is-fullscreen-mode";
+		}
+	);
+}
 
 /**
  * Renders the new posts dashboard page.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a bug introduced here: https://github.com/WordPress/gutenberg/pull/62705


This PR constrains the `is-fullscreen-mode` admin body class to posts list.

