### PR TITLE
DataViews: add performance test for pages

### DIFF
--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -34,6 +34,7 @@ export interface WPRawPerformanceResults {
 	inserterSearch: number[];
 	inserterHover: number[];
 	loadPatterns: number[];
+	loadPages: number[];
 	listViewOpen: number[];
 	navigate: number[];
 	wpBeforeTemplate: number[];
@@ -69,6 +70,7 @@ export interface WPPerformanceResults {
 	inserterSearch?: PerformanceStats;
 	inserterHover?: PerformanceStats;
 	loadPatterns?: PerformanceStats;
+	loadPages?: PerformanceStats;
 	listViewOpen?: PerformanceStats;
 	navigate?: PerformanceStats;
 	wpBeforeTemplate?: PerformanceStats;
@@ -106,6 +108,7 @@ export function curateResults(
 		inserterSearch: stats( results.inserterSearch ),
 		inserterHover: stats( results.inserterHover ),
 		loadPatterns: stats( results.loadPatterns ),
+		loadPages: stats( results.loadPages ),
 		listViewOpen: stats( results.listViewOpen ),
 		navigate: stats( results.navigate ),
 		wpBeforeTemplate: stats( results.wpBeforeTemplate ),

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -418,18 +418,23 @@ test.describe( 'Site Editor Performance', () => {
 
 			const samples = 10;
 			for ( let i = 1; i <= samples; i++ ) {
-				// We want to start from a fresh state each time, without
-				// queries or patterns already cached.
-				await admin.visitSiteEditor();
+				// Start from the trash view, then navigate to all pages, so we
+				// test item loading rather than site editor load as a whole.
+				// For some reason `visiSiteEditor` does not work with these
+				// parameters.
+				await admin.visitAdminPage(
+					'site-editor.php?postType=page&layout=table&activeView=trash'
+				);
 
 				const startTime = performance.now();
 
-				await page.getByRole( 'button', { name: 'Pages' } ).click();
+				await page.getByRole( 'button', { name: 'All Pages' } ).click();
 
+				// Wait for all pages to be rendered.
 				await Promise.all(
 					Array.from( { length: perPage }, async ( el, index ) => {
 						return await page
-							.getByRole( 'button', {
+							.getByRole( 'link', {
 								name: `Page (${ index })`,
 							} )
 							.waitFor( { state: 'attached' } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

See #63151.

Adds a performance test for the pages data view (per page = 20, the default). These are just simple pages. Maybe at some point we can add featured images.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's easier to get a sense of progress when we're measuring.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See the test's code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

There should be an extra entry for `loadPages` is the performance test.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
