### PR TITLE
DateFormatPicker: use CustomSelectControl V2 legacy adapter

### DIFF
--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -8,10 +8,19 @@ import {
 	TextControl,
 	ExternalLink,
 	VisuallyHidden,
-	CustomSelectControl,
 	ToggleControl,
 	__experimentalVStack as VStack,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { CustomSelectControlV2Legacy: CustomSelectControl } = unlock(
+	componentsPrivateApis
+);
 
 // So that we illustrate the different formats in the dropdown properly, show a date that is
 // somwhat recent, has a day greater than 12, and a month with more than three letters.

--- a/packages/block-editor/src/components/date-format-picker/style.scss
+++ b/packages/block-editor/src/components/date-format-picker/style.scss
@@ -4,13 +4,4 @@
 
 .block-editor-date-format-picker__custom-format-select-control__custom-option {
 	border-top: 1px solid $gray-300;
-
-	&.has-hint {
-		grid-template-columns: auto 30px;
-	}
-
-	.components-custom-select-control__item-hint {
-		grid-row: 2;
-		text-align: left;
-	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Replace the V1 `CustomSelectControl` with the V2 legacy adapter in the date format picker control

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The goal is to ultimately replace the legacy V1 implementation entirely with the V2 legacy adapter. We're performing the migration gradually, and fixing any bugs / gaps as we go.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

 - Import the V2 legacy adapter instead of the V1 implementation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert query loop and pick the standard template
2. Select the post date in the newly added block
3. In the block sidebar, turn off the "Default format" toggle
4. Play with the "Choose a format" dropdown, make sure it looks and behaves like on `trunk`

_Note: on trunk, each option item in the dropdown has a an extra `6px` bottom margin that is the result of a style leak (see the second set of screenshots below). I assume that's not intended. The leak does not apply when using the new version of the component since its option items are not rendered using the `li` HTML element._

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/01e62d62-cc04-4f37-9d56-fcdeeb1ec3d2" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/2f19a0fc-728c-4876-a525-454877a1d3b6" /> |
| ![Screenshot 2024-07-05 at 10 46 55](https://github.com/WordPress/gutenberg/assets/1083581/1d36d1ac-7e7b-40e2-beb4-cd51d8e7e713) | ![Screenshot 2024-07-05 at 10 47 09](https://github.com/WordPress/gutenberg/assets/1083581/ca484d05-281c-4f1e-869a-ac3012d74fe9) |
