### PR TITLE
Section Styles: Resolve ref values in variations data

### DIFF
--- a/backport-changelog/6.6/6989.md
+++ b/backport-changelog/6.6/6989.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/6989
+
+* https://github.com/WordPress/gutenberg/pull/63172

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -81,7 +81,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 
 	// Recursively resolve any ref values with the appropriate value within the
 	// theme_json data.
-	$replace_refs = function ( &$variation_data ) use( &$replace_refs, $theme_json ) {
+	$replace_refs = function ( &$variation_data ) use ( &$replace_refs, $theme_json ) {
 		foreach ( $variation_data as $key => &$value ) {
 			// Only need to potentially process arrays.
 			if ( is_array( $value ) ) {

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -51,7 +51,7 @@ function gutenberg_resolve_block_style_variation_ref_values( &$variation_data, $
 		// Only need to potentially process arrays.
 		if ( is_array( $value ) ) {
 			// If ref value is set, attempt to find its matching value and update it.
-			if ( isset( $value['ref'] ) ) {
+			if ( array_key_exists( 'ref', $value ) ) {
 				// Clean up any invalid ref value.
 				if ( empty( $value['ref'] ) || ! is_string( $value['ref'] ) ) {
 					unset( $variation_data[ $key ] );

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -60,12 +60,11 @@ function gutenberg_resolve_block_style_variation_ref_values( &$variation_data, $
 				$value_path = explode( '.', $value['ref'] ?? '' );
 				$ref_value  = _wp_array_get( $theme_json, $value_path );
 
-				// Only update this value if the referenced path matched a value.
-				if ( $ref_value ) {
-					$value = $ref_value;
-				} else {
-					// Otherwise, remove the ref node.
+				// Only update the current value if the referenced path matched a value.
+				if ( null === $ref_value ) {
 					unset( $variation_data[ $key ] );
+				} else {
+					$value = $ref_value;
 				}
 			} else {
 				// Recursively look for ref instances.

--- a/packages/block-editor/src/hooks/block-style-variation.js
+++ b/packages/block-editor/src/hooks/block-style-variation.js
@@ -14,6 +14,7 @@ import {
 	getBlockSelectors,
 } from '../components/global-styles';
 import { useStyleOverride } from './utils';
+import { getValueFromObjectPath } from '../utils/object';
 import { store as blockEditorStore } from '../store';
 import { globalStylesDataKey } from '../store/private-keys';
 import { unlock } from '../lock-unlock';
@@ -180,6 +181,67 @@ export function __unstableBlockStyleVariationOverridesWithConfig( { config } ) {
 	);
 }
 
+/**
+ * Retrieves any variation styles data and resolves any referenced values.
+ *
+ * @param {Object}    globalStyles A complete global styles object, containing settings and styles.
+ * @param {string}    name         The name of the desired block type.
+ * @param {variation} variation    The of the block style variation to retrieve data for.
+ *
+ * @return {Object|undefined} The global styles data for the specified variation.
+ */
+function getVariationStylesWithRefValues( globalStyles, name, variation ) {
+	if ( ! globalStyles?.styles?.blocks?.[ name ]?.variations?.[ variation ] ) {
+		return;
+	}
+
+	// Helper to recursively look for `ref` values to resolve.
+	const replaceRefs = ( variationStyles ) => {
+		Object.keys( variationStyles ).forEach( ( key ) => {
+			const value = variationStyles[ key ];
+
+			// Only process objects.
+			if ( typeof value === 'object' && value !== null ) {
+				// Process `ref` value if present.
+				if ( value.ref !== undefined ) {
+					if (
+						typeof value.ref !== 'string' ||
+						value.ref.trim() === ''
+					) {
+						// Remove invalid ref.
+						delete variationStyles[ key ];
+					} else {
+						// Resolve `ref` value.
+						const refValue = getValueFromObjectPath(
+							globalStyles,
+							value.ref
+						);
+
+						if ( refValue ) {
+							variationStyles[ key ] = refValue;
+						} else {
+							delete variationStyles[ key ];
+						}
+					}
+				} else {
+					// Recursively resolve `ref` values in nested objects.
+					replaceRefs( value );
+				}
+			}
+		} );
+	};
+
+	// Deep clone variation node to avoid mutating it within global styles and losing refs.
+	const styles = JSON.parse(
+		JSON.stringify(
+			globalStyles.styles.blocks[ name ].variations[ variation ]
+		)
+	);
+	replaceRefs( styles );
+
+	return styles;
+}
+
 function useBlockStyleVariation( name, variation, clientId ) {
 	// Prefer global styles data in GlobalStylesContext, which are available
 	// if in the site editor. Otherwise fall back to whatever is in the
@@ -194,9 +256,14 @@ function useBlockStyleVariation( name, variation, clientId ) {
 	}, [] );
 
 	return useMemo( () => {
-		const styles = mergedConfig?.styles ?? globalStyles;
-		const variationStyles =
-			styles?.blocks?.[ name ]?.variations?.[ variation ];
+		const variationStyles = getVariationStylesWithRefValues(
+			{
+				settings: mergedConfig?.settings ?? globalSettings,
+				styles: mergedConfig?.styles ?? globalStyles,
+			},
+			name,
+			variation
+		);
 
 		return {
 			settings: mergedConfig?.settings ?? globalSettings,

--- a/packages/block-editor/src/hooks/block-style-variation.js
+++ b/packages/block-editor/src/hooks/block-style-variation.js
@@ -190,7 +190,11 @@ export function __unstableBlockStyleVariationOverridesWithConfig( { config } ) {
  *
  * @return {Object|undefined} The global styles data for the specified variation.
  */
-function getVariationStylesWithRefValues( globalStyles, name, variation ) {
+export function getVariationStylesWithRefValues(
+	globalStyles,
+	name,
+	variation
+) {
 	if ( ! globalStyles?.styles?.blocks?.[ name ]?.variations?.[ variation ] ) {
 		return;
 	}
@@ -226,6 +230,12 @@ function getVariationStylesWithRefValues( globalStyles, name, variation ) {
 				} else {
 					// Recursively resolve `ref` values in nested objects.
 					replaceRefs( value );
+
+					// After recursion, if value is empty due to explicitly
+					// `undefined` ref value, remove it.
+					if ( Object.keys( value ).length === 0 ) {
+						delete variationStyles[ key ];
+					}
 				}
 			}
 		} );

--- a/packages/block-editor/src/hooks/test/get-variation-styles-with-ref-values.js
+++ b/packages/block-editor/src/hooks/test/get-variation-styles-with-ref-values.js
@@ -1,0 +1,91 @@
+/**
+ * Internal dependencies
+ */
+import { getVariationStylesWithRefValues } from '../block-style-variation';
+
+describe( 'getVariationStylesWithRefValues', () => {
+	it( 'should resolve ref values correctly', () => {
+		const globalStyles = {
+			styles: {
+				color: { background: 'red' },
+				blocks: {
+					'core/heading': {
+						color: { text: 'blue' },
+					},
+					'core/group': {
+						variations: {
+							custom: {
+								color: {
+									text: { ref: 'styles.does-not-exist' },
+									background: {
+										ref: 'styles.color.background',
+									},
+								},
+								blocks: {
+									'core/heading': {
+										color: {
+											text: {
+												ref: 'styles.blocks.core/heading.color.text',
+											},
+											background: { ref: '' },
+										},
+									},
+								},
+								elements: {
+									link: {
+										color: {
+											text: {
+												ref: 'styles.elements.link.color.text',
+											},
+											background: { ref: undefined },
+										},
+										':hover': {
+											color: {
+												text: {
+													ref: 'styles.elements.link.:hover.color.text',
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				elements: {
+					link: {
+						color: { text: 'green' },
+						':hover': {
+							color: { text: 'yellow' },
+						},
+					},
+				},
+			},
+		};
+
+		expect(
+			getVariationStylesWithRefValues(
+				globalStyles,
+				'core/group',
+				'custom'
+			)
+		).toEqual( {
+			color: { background: 'red' },
+			blocks: {
+				'core/heading': {
+					color: { text: 'blue' },
+				},
+			},
+			elements: {
+				link: {
+					color: {
+						text: 'green',
+					},
+					':hover': {
+						color: { text: 'yellow' },
+					},
+				},
+			},
+		} );
+	} );
+} );

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -189,4 +189,76 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 
 		$this->assertSameSetsWithIndex( $expected, $group_styles, 'Variation data does not match' );
 	}
+
+	/**
+	 * Tests that block style variations resolve any `ref` values when generating styles.
+	 */
+	public function test_block_style_variation_ref_values() {
+		switch_theme( 'block-theme' );
+
+		$variation_data = array(
+			'color'    => array(
+				'text'       => array(
+					'ref' => 'styles.does-not-exist',
+				),
+				'background' => array(
+					'ref' => 'styles.blocks.core/group.variations.block-style-variation-a.color.text',
+				),
+			),
+			'blocks'   => array(
+				'core/heading' => array(
+					'color' => array(
+						'text'       => array(
+							'ref' => 'styles.blocks.core/group.variations.block-style-variation-a.color.background',
+						),
+						'background' => array(
+							'ref' => '',
+						),
+					),
+				),
+			),
+			'elements' => array(
+				'link' => array(
+					'color'  => array(
+						'text'       => array(
+							'ref' => 'styles.blocks.core/group.variations.block-style-variation-b.color.text',
+						),
+						'background' => array(
+							'ref' => null,
+						),
+					),
+					':hover' => array(
+						'color' => array(
+							'text' => array(
+								'ref' => 'styles.blocks.core/group.variations.block-style-variation-b.color.background',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_raw_data();
+
+		gutenberg_resolve_block_style_variation_ref_values( $variation_data, $theme_json );
+
+		$expected = array(
+			'color'    => array( 'background' => 'plum' ),
+			'blocks'   => array(
+				'core/heading' => array(
+					'color' => array( 'text' => 'indigo' ),
+				),
+			),
+			'elements' => array(
+				'link' => array(
+					'color'  => array( 'text' => 'lightblue' ),
+					':hover' => array(
+						'color' => array( 'text' => 'midnightblue' ),
+					),
+				),
+			),
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $variation_data, 'Variation data with resolved ref values does not match' );
+	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63159

## What?

Retrieve reference values when generating styles for block style variations.

## Why?

Without resolving `ref` values some styles may not be generated.

## How?

When retrieving variation data, to generate styles from, also retrieve any referenced values.

## Testing Instructions

1. Add some ref values for block style variations to your theme.json e.g. update TT4 with the sections from the theme.json snippet below
2. Load the site editor and edit the default home page
3. Confirm that outline buttons are displayed and have the correct referenced style values
4. Save and ensure the same on the frontend

<details>
<summary>Example theme.json snippet</summary>

```json
{
    "styles": {
        "elements": {
            "button": {
                "border": {
                    "color": "transparent",
                    "radius": "0.25em",
                    "style": "solid",
                    "width": "1px"
                },
                "color": {
                    "background": "var(--wp--preset--color--accent)",
                    "text": "var(--wp--preset--color--base)"
                },
                "spacing": {
                    "padding": {
                        "bottom": "0.5em",
                        "left": "1.25em",
                        "right": "1.25em",
                        "top": "0.5em"
                    }
                }
            }
        },
        "blocks": {
            "core/button": {
                "border": {
                    "color": { "ref": "styles.elements.button.border.color" },
                    "radius": { "ref": "styles.elements.button.border.radius" },
                    "style": { "ref": "styles.elements.button.border.style" },
                    "width": { "ref": "styles.elements.button.border.width" }
                },
                "color": {
                    "background": { "ref": "styles.elements.button.color.background" },
                    "text": { "ref": "styles.elements.button.color.text" }
                },
                "spacing": {
                    "padding": {
                        "bottom": { "ref": "styles.elements.button.spacing.padding.bottom" },
                        "left": { "ref": "styles.elements.button.spacing.padding.left" },
                        "right": { "ref": "styles.elements.button.spacing.padding.right" },
                        "top": { "ref": "styles.elements.button.spacing.padding.top" }
                    }
                },
                "variations": {
                    "outline": {
                        "border": {
                            "color": "currentColor",
                            "width": { "ref": "styles.elements.button.border.width" }
                        },
                        "color": {
                            "text": { "ref": "styles.elements.button.color.background" }
                        },
                        "spacing": {
                            "padding": {
                                "bottom": { "ref": "styles.elements.button.spacing.padding.bottom" },
                                "left": { "ref": "styles.elements.button.spacing.padding.left" },
                                "right": { "ref": "styles.elements.button.spacing.padding.right" },
                                "top": { "ref": "styles.elements.button.spacing.padding.top" },
                            }
                        }
                    }
                }
            }
        }
    }
}
```

</details>


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="640" alt="Screenshot 2024-07-05 at 6 21 01 PM" src="https://github.com/WordPress/gutenberg/assets/60436221/6922522c-4c16-47aa-bc73-6beedec62c2c"> | <img width="652" alt="Screenshot 2024-07-05 at 6 20 41 PM" src="https://github.com/WordPress/gutenberg/assets/60436221/fe342573-29d5-4cc0-8a61-fb3cb8170a3c"> |



