### PR TITLE
DataViews: Performance: check isEligible on dropdown open

### DIFF
--- a/packages/dataviews/src/bulk-actions.tsx
+++ b/packages/dataviews/src/bulk-actions.tsx
@@ -66,19 +66,13 @@ export function useHasAPossibleBulkAction< Item >(
 }
 
 export function useSomeItemHasAPossibleBulkAction< Item >(
-	actions: Action< Item >[],
-	data: Item[]
+	actions: Action< Item >[]
 ) {
 	return useMemo( () => {
-		return data.some( ( item ) => {
-			return actions.some( ( action ) => {
-				return (
-					action.supportsBulk &&
-					( ! action.isEligible || action.isEligible( item ) )
-				);
-			} );
+		return actions.some( ( action ) => {
+			return action.supportsBulk;
 		} );
-	}, [ actions, data ] );
+	}, [ actions ] );
 }
 
 function ActionWithModal< Item >( {

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -92,10 +92,7 @@ export default function DataViews< Item >( {
 		?.component as ComponentType< ViewBaseProps< Item > >;
 	const _fields = useMemo( () => normalizeFields( fields ), [ fields ] );
 
-	const hasPossibleBulkAction = useSomeItemHasAPossibleBulkAction(
-		actions,
-		data
-	);
+	const hasPossibleBulkAction = useSomeItemHasAPossibleBulkAction( actions );
 	const _selection = useMemo( () => {
 		return selection.filter( ( id ) =>
 			data.some( ( item ) => getItemId( item ) === id )

--- a/packages/dataviews/src/item-actions.tsx
+++ b/packages/dataviews/src/item-actions.tsx
@@ -157,9 +157,12 @@ export function ActionsDropdownMenuGroup< Item >( {
 	item,
 }: ActionsDropdownMenuGroupProps< Item > ) {
 	const registry = useRegistry();
+	const eligibleActions = actions.filter(
+		( action ) => ! action.isEligible || action.isEligible( item )
+	);
 	return (
 		<DropdownMenuGroup>
-			{ actions.map( ( action ) => {
+			{ eligibleActions.map( ( action ) => {
 				if ( 'RenderModal' in action ) {
 					return (
 						<ActionWithModal
@@ -181,6 +184,11 @@ export function ActionsDropdownMenuGroup< Item >( {
 					/>
 				);
 			} ) }
+			{ ! eligibleActions.length && (
+				<DropdownMenuItem disabled>
+					{ __( 'No actions available' ) }
+				</DropdownMenuItem>
+			) }
 		</DropdownMenuGroup>
 	);
 }

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -18,13 +18,7 @@ import {
 	Spinner,
 	VisuallyHidden,
 } from '@wordpress/components';
-import {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
@@ -91,20 +85,9 @@ function ListItem< Item >( {
 		}
 	}, [ isSelected ] );
 
-	const { primaryAction, eligibleActions } = useMemo( () => {
-		// If an action is eligible for all items, doesn't need
-		// to provide the `isEligible` function.
-		const _eligibleActions = actions.filter(
-			( action ) => ! action.isEligible || action.isEligible( item )
-		);
-		const _primaryActions = _eligibleActions.filter(
-			( action ) => action.isPrimary && !! action.icon
-		);
-		return {
-			primaryAction: _primaryActions?.[ 0 ],
-			eligibleActions: _eligibleActions,
-		};
-	}, [ actions, item ] );
+	const primaryAction = actions.filter(
+		( action ) => action.isPrimary && !! action.icon
+	)?.[ 0 ];
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const primaryActionLabel =
@@ -184,7 +167,7 @@ function ListItem< Item >( {
 						</HStack>
 					</CompositeItem>
 				</div>
-				{ eligibleActions?.length > 0 && (
+				{ actions?.length > 0 && (
 					<HStack
 						spacing={ 1 }
 						justify="flex-end"
@@ -291,7 +274,7 @@ function ListItem< Item >( {
 								placement="bottom-end"
 							>
 								<ActionsDropdownMenuGroup
-									actions={ eligibleActions }
+									actions={ actions }
 									item={ item }
 								/>
 							</DropdownMenu>

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -426,7 +426,7 @@ function ViewTable< Item >( {
 	const headerMenuToFocusRef = useRef< HTMLButtonElement >();
 	const [ nextHeaderMenuToFocus, setNextHeaderMenuToFocus ] =
 		useState< HTMLButtonElement >();
-	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
+	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions );
 
 	useEffect( () => {
 		if ( headerMenuToFocusRef.current ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently we check `isEligible` for  the trash, restore, and rename actions, even though these are not even rendered on load (the action buttons appear in a dropdown). This PR moves the checks to the place where the buttons are rendered.

One catch is that we cannot disable the button when no actions are available. Instead, I added a message in the dropdown that no actions are available. I believe that's ok, and it should be rarer anyway?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It initiates an OPTION request for EACH item on load.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
