### PR TITLE
Apply same styles to block previews on inserter and Global Styles

### DIFF
--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -57,6 +57,7 @@ function InserterPreviewPanel( { item } ) {
 											min-height:${ Math.round( minHeight ) }px;
 											display:flex;align-items:center;justify-content:center; 
 										}
+										.is-root-container { width: 100%; }
 									`,
 								},
 							] }

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -32,6 +32,13 @@ function InserterPreviewPanel( { item } ) {
 	}, [ name, example, initialAttributes ] );
 	// Same as height of BlockPreviewPanel.
 	const previewHeight = 144;
+	const sidebarWidth = 280;
+	const viewportWidth = example?.viewportWidth ?? 500;
+	const scale = sidebarWidth / viewportWidth;
+	const minHeight =
+		scale !== 0 && scale < 1 && previewHeight
+			? previewHeight / scale
+			: previewHeight;
 
 	return (
 		<div className="block-editor-inserter__preview-container">
@@ -40,13 +47,14 @@ function InserterPreviewPanel( { item } ) {
 					<div className="block-editor-inserter__preview-content">
 						<BlockPreview
 							blocks={ blocks }
-							viewportWidth={ example?.viewportWidth ?? 500 }
+							viewportWidth={ viewportWidth }
 							minHeight={ previewHeight }
 							additionalStyles={ [
 								{
 									css: `
 										body { 
 											padding: 24px;
+											min-height:${ Math.round( minHeight ) }px;
 											display:flex;align-items:center;justify-content:center; 
 										}
 									`,

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -55,7 +55,7 @@ function InserterPreviewPanel( { item } ) {
 										body { 
 											padding: 24px;
 											min-height:${ Math.round( minHeight ) }px;
-											display:flex;align-items:center;justify-content:center; 
+											display:flex;align-items:center;
 										}
 										.is-root-container { width: 100%; }
 									`,

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -49,9 +49,11 @@ function InserterPreviewPanel( { item } ) {
 							blocks={ blocks }
 							viewportWidth={ viewportWidth }
 							minHeight={ previewHeight }
-							additionalStyles={ [
-								{
-									css: `
+							additionalStyles={
+								//We want this CSS to be in sync with the one in BlockPreviewPanel.
+								[
+									{
+										css: `
 										body { 
 											padding: 24px;
 											min-height:${ Math.round( minHeight ) }px;
@@ -60,8 +62,9 @@ function InserterPreviewPanel( { item } ) {
 										}
 										.is-root-container { width: 100%; }
 									`,
-								},
-							] }
+									},
+								]
+							}
 						/>
 					</div>
 				) : (

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -55,7 +55,8 @@ function InserterPreviewPanel( { item } ) {
 										body { 
 											padding: 24px;
 											min-height:${ Math.round( minHeight ) }px;
-											display:flex;align-items:center;
+											display:flex;
+											align-items:center;
 										}
 										.is-root-container { width: 100%; }
 									`,

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -40,7 +40,7 @@ function InserterPreviewPanel( { item } ) {
 					<div className="block-editor-inserter__preview-content">
 						<BlockPreview
 							blocks={ blocks }
-							viewportWidth={ example?.viewportWidth ?? 350 }
+							viewportWidth={ example?.viewportWidth ?? 500 }
 							minHeight={ previewHeight }
 							additionalStyles={ [
 								{

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -30,6 +30,8 @@ function InserterPreviewPanel( { item } ) {
 			innerBlocks: example.innerBlocks,
 		} );
 	}, [ name, example, initialAttributes ] );
+	// Same as height of BlockPreviewPanel.
+	const previewHeight = 144;
 
 	return (
 		<div className="block-editor-inserter__preview-container">
@@ -39,8 +41,14 @@ function InserterPreviewPanel( { item } ) {
 						<BlockPreview
 							blocks={ blocks }
 							viewportWidth={ example?.viewportWidth ?? 500 }
+							minHeight={ previewHeight }
 							additionalStyles={ [
-								{ css: 'body { padding: 24px; }' },
+								{
+									css: `body { 
+									padding: 24px;
+									min-height:100%;
+									display:flex;align-items:center;justify-content:center; }`,
+								},
 							] }
 						/>
 					</div>

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -40,7 +40,7 @@ function InserterPreviewPanel( { item } ) {
 					<div className="block-editor-inserter__preview-content">
 						<BlockPreview
 							blocks={ blocks }
-							viewportWidth={ example?.viewportWidth ?? 500 }
+							viewportWidth={ example?.viewportWidth ?? 350 }
 							minHeight={ previewHeight }
 							additionalStyles={ [
 								{

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -44,10 +44,12 @@ function InserterPreviewPanel( { item } ) {
 							minHeight={ previewHeight }
 							additionalStyles={ [
 								{
-									css: `body { 
-									padding: 24px;
-									min-height:100%;
-									display:flex;align-items:center;justify-content:center; }`,
+									css: `
+										body { 
+											padding: 24px;
+											display:flex;align-items:center;justify-content:center; 
+										}
+									`,
 								},
 							] }
 						/>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -326,7 +326,6 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__preview-content {
-	min-height: $grid-unit-60 * 3;
 	background: $gray-100;
 	display: grid;
 	flex-grow: 1;

--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -21,6 +21,12 @@ export { metadata, name };
 export const settings = {
 	icon,
 	example: {
+		attributes: {
+			layout: {
+				type: 'flex',
+				justifyContent: 'center',
+			},
+		},
 		innerBlocks: [
 			{
 				name: 'core/button',

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -24,6 +24,7 @@ export const settings = {
 		attributes: {
 			content: __( 'Code is Poetry' ),
 			level: 2,
+			textAlign: 'center',
 		},
 	},
 	__experimentalLabel( attributes, { context } ) {

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -16,7 +16,12 @@
 			"default": 0
 		}
 	},
-	"example": {},
+	"example": {
+		"viewportWidth": 350,
+		"attributes": {
+			"textAlign": "center"
+		}
+	},
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -17,7 +17,12 @@ export { metadata, name };
 
 export const settings = {
 	icon,
-	example: {},
+	example: {
+		viewportWidth: 350,
+		attributes: {
+			textAlign: 'center',
+		},
+	},
 	edit,
 	transforms,
 	deprecated,

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -33,7 +33,8 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 	}, [ name, blockExample, variation ] );
 
 	const viewportWidth = blockExample?.viewportWidth ?? null;
-	const previewHeight = 150;
+	// Same as height of InserterPreviewPanel.
+	const previewHeight = 144;
 
 	if ( ! blockExample ) {
 		return null;
@@ -47,13 +48,14 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 			>
 				<BlockPreview
 					blocks={ blocks }
-					viewportWidth={ viewportWidth }
+					viewportWidth={ viewportWidth ?? 500 }
 					minHeight={ previewHeight }
 					additionalStyles={ [
 						{
 							css: `
 								body{
-									min-height:${ previewHeight }px;
+									padding: 24px;
+									min-height:100%;
 									display:flex;align-items:center;justify-content:center;
 								}
 							`,

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -56,7 +56,8 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 								body{
 									padding: 24px;
 									min-height:100%;
-									display:flex;align-items:center;
+									display:flex;
+									align-items:center;
 								}
 								.is-root-container { width: 100%; }
 							`,

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -48,7 +48,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 			>
 				<BlockPreview
 					blocks={ blocks }
-					viewportWidth={ viewportWidth ?? 500 }
+					viewportWidth={ viewportWidth ?? 350 }
 					minHeight={ previewHeight }
 					additionalStyles={ [
 						{

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -50,9 +50,11 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 					blocks={ blocks }
 					viewportWidth={ viewportWidth }
 					minHeight={ previewHeight }
-					additionalStyles={ [
-						{
-							css: `
+					additionalStyles={
+						//We want this CSS to be in sync with the one in InserterPreviewPanel.
+						[
+							{
+								css: `
 								body{
 									padding: 24px;
 									min-height:100%;
@@ -61,8 +63,9 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 								}
 								.is-root-container { width: 100%; }
 							`,
-						},
-					] }
+							},
+						]
+					}
 				/>
 			</div>
 		</Spacer>

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -48,7 +48,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 			>
 				<BlockPreview
 					blocks={ blocks }
-					viewportWidth={ viewportWidth ?? 350 }
+					viewportWidth={ viewportWidth ?? 500 }
 					minHeight={ previewHeight }
 					additionalStyles={ [
 						{

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -56,7 +56,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 								body{
 									padding: 24px;
 									min-height:100%;
-									display:flex;align-items:center;justify-content:center;
+									display:flex;align-items:center;
 								}
 								.is-root-container { width: 100%; }
 							`,

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -58,6 +58,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 									min-height:100%;
 									display:flex;align-items:center;justify-content:center;
 								}
+								.is-root-container { width: 100%; }
 							`,
 						},
 					] }

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -32,7 +32,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 		return getBlockFromExample( name, example );
 	}, [ name, blockExample, variation ] );
 
-	const viewportWidth = blockExample?.viewportWidth ?? null;
+	const viewportWidth = blockExample?.viewportWidth ?? 500;
 	// Same as height of InserterPreviewPanel.
 	const previewHeight = 144;
 
@@ -48,7 +48,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 			>
 				<BlockPreview
 					blocks={ blocks }
-					viewportWidth={ viewportWidth ?? 500 }
+					viewportWidth={ viewportWidth }
 					minHeight={ previewHeight }
 					additionalStyles={ [
 						{

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -108,7 +108,7 @@
 }
 
 .edit-site-global-styles__shadow-preview-panel {
-	height: 150px;
+	height: 144px;
 	border: $gray-200 $border-width solid;
 	border-radius: $radius-block-ui;
 	overflow: auto;

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -108,7 +108,7 @@
 }
 
 .edit-site-global-styles__shadow-preview-panel {
-	height: 144px;
+	height: $grid-unit-60 * 3;
 	border: $gray-200 $border-width solid;
 	border-radius: $radius-block-ui;
 	overflow: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->


This tries to apply the same styles to the Block Preview that lives in Global Styles to the one in the inserter, and tries to fix [some minor visual issues](https://github.com/WordPress/gutenberg/issues/30029#issuecomment-2209382539) for both in the meantime.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The previews for block look very different in the GS sidebar and the inserter. Different CSS is applied to both and GS wasn't even scaling with the viewport width selected on the blocks settings. This aims to align the two together for a more consistent experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This tries to bring the changes from https://github.com/WordPress/gutenberg/pull/46727 to the inserter previews and polish any issues that arise for certain blocks because of it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- On a post or the site editor (the two experiences are different because the post editor has context for some of the blocks) open the block inserter.
- Scroll and hover over the blocks to see their previews. They shouldn't look broken. They should look centered.
- Go to Global Styles and select Blocks. Open them to check their previews. They should look like the inserter ones, with the caveat that the height of the preview here is fixed and some blocks will require scrolling. Nothing should look broken here either

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

**Before:**

Inserter |  GS
--- | --- 
<img width="673" alt="Screenshot 2024-07-08 at 16 50 54" src="https://github.com/WordPress/gutenberg/assets/3593343/2f5f340b-1067-4cdd-8b6c-ed2ff0d8fe0a"> | <img width="267" alt="Screenshot 2024-07-08 at 16 50 35" src="https://github.com/WordPress/gutenberg/assets/3593343/9d2aa842-1881-4636-8bb0-37b0eacde241">
<img width="701" alt="Screenshot 2024-07-08 at 16 51 00" src="https://github.com/WordPress/gutenberg/assets/3593343/494a94aa-a163-41fe-b857-5f0cc598139e"> | <img width="271" alt="Screenshot 2024-07-08 at 16 50 45" src="https://github.com/WordPress/gutenberg/assets/3593343/7092cfaf-d8cd-4393-a729-7a11ab2e96f8">


**After:**

Inserter |  GS
--- | --- 
<img width="668" alt="Screenshot 2024-07-08 at 16 43 03" src="https://github.com/WordPress/gutenberg/assets/3593343/f9422827-bfdd-4e59-afc4-b40c0470af0e"> |  <img width="268" alt="Screenshot 2024-07-08 at 16 44 04" src="https://github.com/WordPress/gutenberg/assets/3593343/bb297b9e-520c-4884-82c1-3504435aedbd">
<img width="659" alt="Screenshot 2024-07-08 at 16 43 37" src="https://github.com/WordPress/gutenberg/assets/3593343/a16d275f-096a-4cf0-b8cc-7b1fed11277d"> | <img width="263" alt="Screenshot 2024-07-08 at 16 43 50" src="https://github.com/WordPress/gutenberg/assets/3593343/d50b9a6f-d465-42fb-8e7c-7a8c59b39ebb">

