### PR TITLE
FontAppearanceControl: use CustomSelectControl V2 legacy adapter

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { CustomSelectControl } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -9,7 +9,11 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights';
+import { unlock } from '../../lock-unlock';
 
+const { CustomSelectControlV2Legacy: CustomSelectControl } = unlock(
+	componentsPrivateApis
+);
 /**
  * Adjusts font appearance field label in case either font styles or weights
  * are disabled.

--- a/packages/block-editor/src/components/font-appearance-control/style.scss
+++ b/packages/block-editor/src/components/font-appearance-control/style.scss
@@ -1,8 +1,6 @@
 .components-font-appearance-control {
-	ul {
-		li {
-			color: $gray-900;
-			text-transform: capitalize;
-		}
+	[role="option"] {
+		color: $gray-900;
+		text-transform: capitalize;
 	}
 }

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -469,7 +469,6 @@ export default function TypographyPanel( {
 						hasFontWeights={ hasFontWeights }
 						fontFamilyFaces={ fontFamilyFaces }
 						size="__unstable-large"
-						__nextHasNoMarginBottom
 					/>
 				</ToolsPanelItem>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Replace the V1 `CustomSelectControl` with the V2 legacy adapter in the font appearance control

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The goal is to ultimately replace the legacy V1 implementation entirely with the V2 legacy adapter. We're performing the migration gradually, and fixing any bugs / gaps as we go.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

 - Import the V2 legacy adapter instead of the V1 implementation
 - Tweak style overrides so that they continue to target the option items in a more semantic way

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Insert a paragraph block and type some text
- Select the newly inserted block, and in the block inspector controls, add the "Appearance" control under the "Typography" section (it can be done by clicking on the "..." menu in top right of the Typography panel)
- Play with the dropdown and make sure that styles and behavior are as on `trunk`

> [!NOTE]
> There are few known differences between trunk and this PR:
> - On short screens, the select dropdown may "flip" its position and render above the sidebar's sticky header (https://github.com/WordPress/gutenberg/issues/63180)
> - The new version of the component adds more inline (left/right) padding to its items in order to match the padding of the trigger button. Its items also reserve empty space for the tick, even when they're not selected. These two differences combined cause the available space for option item text to shrink. This can be observed particularly in the case of the font appearance control (see screenshots below)


## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/6210ce9e-d023-4dd3-81f9-41d4487b6dbb" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/b484c40a-a8d3-41e5-8121-dbaefd364fba" /> |
| <img src="https://github.com/WordPress/gutenberg/assets/1083581/fd5e0351-0e82-490a-ab7c-b7e0c7def560" width="180" /> <img src="https://github.com/WordPress/gutenberg/assets/1083581/12c2dba7-1e08-4bfe-801e-59c4c7564eb0" width="180" /> | <img src="https://github.com/WordPress/gutenberg/assets/1083581/adeb07db-fec8-4b49-859b-43cf04c439e7" width="180" /> <img src="https://github.com/WordPress/gutenberg/assets/1083581/2c05073a-cdb4-4857-9d54-0c63813c88f7" width="180" /> |
