### PR TITLE
Introduce new filter "render_block_core_navigation_link_allowed_post_status"

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -183,10 +183,14 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		 * @since 6.7.0
 		 *
 		 * @param array $post_status
+		 * @param array $attributes
+		 * @param WP_Block $block
 		 */
 		$allowed_post_status = (array) apply_filters(
 			'render_block_core_navigation_link_allowed_post_status',
-			array( 'publish' )
+			array( 'publish' ),
+			$attributes,
+			$block
 		);
 		if ( ! $post || ! in_array( $post->post_status, $allowed_post_status, true ) ) {
 			return '';

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -177,7 +177,18 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Don't render the block's subtree if it is a draft or if the ID does not exist.
 	if ( $is_post_type && $navigation_link_has_id ) {
 		$post = get_post( $attributes['id'] );
-		if ( ! $post || 'publish' !== $post->post_status ) {
+		/**
+		 * Filter allowed post_status for navigation link block to render.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $post_status
+		 */
+		$allowed_post_status = (array) apply_filters(
+			'render_block_core_navigation_link_allowed_post_status',
+			array( 'publish' )
+		);
+		if ( ! $post || ! in_array( $post->post_status, $allowed_post_status, true ) ) {
 			return '';
 		}
 	}

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -180,7 +180,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		/**
 		 * Filter allowed post_status for navigation link block to render.
 		 *
-		 * @since 6.7.0
+		 * @since 6.8.0
 		 *
 		 * @param array $post_status
 		 * @param array $attributes


### PR DESCRIPTION
This PR introduces a new Filter for rendering the "Navigation Link"-Block to whitelist post_status to not restrict the output to only "public" post_status.

See more information in: https://github.com/WordPress/gutenberg/issues/33215

## Why?

Since Gutenberg 9.8.0 (see commit: https://github.com/WordPress/gutenberg/commit/1936a04bc5ff31eb5c29fddaf4f304759d35a7ed | issue: https://github.com/WordPress/gutenberg/pull/27207) the "Navigation Link"-Block limits the output to only "public" post_status.

While it is possible to hook into `WP_Query` and the `WP_REST_Post_Search_Handler` via `rest_post_search_query` to extend the `$query_args` with custom `post_status` in the REST Response, the rendering part will still limit to `post_status = "publish`. 

With this new filter `render_block_core_navigation_link_allowed_post_status` it is now possible to also whitelist multiple post_status for rendering in frontend.

## Testing Instructions

0. You need to have at least 1 Post which is `post_status = "private"`.
1. Add a new mu-plugin which hooks into following:

```php
add_filter( 
    'render_block_core_navigation_link_allowed_post_status', 
    static function(array $postStatus): array {
        $postStatus[] = 'private';

        return $postStatus;
} );

add_filter( 
    'rest_post_search_query', 
    static function( array $queryArgs): array {
        $postStatus = $queryArgs['post_status'] ?? [];
        $postStatus[] = 'private';

        $queryArgs['post_status'] = $postStatus;

        return $queryArgs;
} );
```

2. Create a new Page with "Navigation Block" and search for 0. the Post with `post_status = "private"` and insert
3. Save Page and go to frontend -> "private Post"-link is rendered.