### PR TITLE
[Mobile] - Remove `themes` from supported endpoints

### DIFF
--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -15,6 +15,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] Prevent hiding the keyboard when creating new list items [#62446]
 -   [*] Fix issue when pasting HTML content [#62588]
 -   [**] Add support prefix transforms [#62576]
+-   [*] Remove themes from supported endpoints [#63183]
 
 ## 1.120.1
 

--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -7,9 +7,13 @@ import { applyFilters } from '@wordpress/hooks';
 
 const SUPPORTED_METHODS = [ 'GET', 'POST' ];
 // Please add only wp.org API paths here!
-// Don't add /themes endpoint due to an issue on Android
-// with the wp.org API implementation for React Native.
 const SUPPORTED_ENDPOINTS = {
+	// Temporarily disabling themes endpoint calls within the editor.
+	// Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/21034
+	// The editor's GET requests to the themes endpoint are not functioning as expected.
+	// This is likely due to the method used for performing GET requests within the host Android app.
+	// TODO: Investigate and resolve the issue with GET requests from the editor.
+	// Until then, themes endpoint calls are disabled to prevent unexpected behavior.
 	GET: [
 		/wp\/v2\/(media|categories|blocks)\/?\d*?.*/i,
 		/wp\/v2\/search\?.*/i,

--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -7,9 +7,11 @@ import { applyFilters } from '@wordpress/hooks';
 
 const SUPPORTED_METHODS = [ 'GET', 'POST' ];
 // Please add only wp.org API paths here!
+// Don't add /themes endpoint due to an issue on Android
+// with the wp.org API implementation for React Native.
 const SUPPORTED_ENDPOINTS = {
 	GET: [
-		/wp\/v2\/(media|categories|blocks|themes)\/?\d*?.*/i,
+		/wp\/v2\/(media|categories|blocks)\/?\d*?.*/i,
 		/wp\/v2\/search\?.*/i,
 		/oembed\/1\.0\/proxy\?.*/i,
 	],


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6967

## What?
Due to recent changes, the editor now fetches the `/themes` endpoint when it opens, this is causing an issue on Android devices.

**Note:** The theme endpoint was added in https://github.com/WordPress/gutenberg/pull/33654 to be able to show the `Resize for smaller devices` block option for the Embed block but I haven't been able to see this option with a testing site I have, same on the Web editor.

## Why?
This is currently affecting self-hosted sites preventing them from using the editor which freezes after attempting to call this endpoint.

The native host apps already fetch the themes data and sends the information the editor needs. It appears there are some issues with how the native editor makes the GET request through the bridge and the host app.

## How?
By removing `themes` from the `SUPPORTED_ENDPOINTS` list for now.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

> [!NOTE]  
> Use the following build to test:
> - [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/21032#issuecomment-2210636299)

- Install the app (fresh installation)
- Log in using a self-hosted site without Jetpack and Gutenberg plugin enabled
- Open the editor
- **Expect** to be able to edit/create content
- **Expect** to see the default theme colors in the Color palettes (Text/Background color)

## Screenshots or screencast <!-- if applicable -->

Before|After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/0065fabf-ed4c-4c62-8e4e-1002935a6587" width=250 />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/655d083c-035a-4917-a838-8bb7b82aa919" width=250 />