### PR TITLE
Block Bindings: Unify `getValue`/`getValues` and `setValue`/`setValues` APIs

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -121,7 +121,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 			const attributes = {};
 
-			const bindingsBySource = new Map();
+			const blockBindingsBySource = new Map();
 
 			for ( const [ attributeName, binding ] of Object.entries(
 				blockBindings
@@ -135,16 +135,16 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					continue;
 				}
 
-				bindingsBySource.set( source, {
-					...bindingsBySource.get( source ),
+				blockBindingsBySource.set( source, {
+					...blockBindingsBySource.get( source ),
 					[ attributeName ]: {
 						args: sourceArgs,
 					},
 				} );
 			}
 
-			if ( bindingsBySource.size ) {
-				for ( const [ source, bindings ] of bindingsBySource ) {
+			if ( blockBindingsBySource.size ) {
+				for ( const [ source, bindings ] of blockBindingsBySource ) {
 					// Get values in batch if the source supports it.
 					const values = source.getValues( {
 						registry,
@@ -190,7 +190,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					}
 
 					const keptAttributes = { ...nextAttributes };
-					const bindingsBySource = new Map();
+					const blockBindingsBySource = new Map();
 
 					// Loop only over the updated attributes to avoid modifying the bound ones that haven't changed.
 					for ( const [ attributeName, newValue ] of Object.entries(
@@ -208,8 +208,8 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						if ( ! source?.setValues ) {
 							continue;
 						}
-						bindingsBySource.set( source, {
-							...bindingsBySource.get( source ),
+						blockBindingsBySource.set( source, {
+							...blockBindingsBySource.get( source ),
 							[ attributeName ]: {
 								args: binding.args,
 								newValue,
@@ -218,8 +218,11 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						delete keptAttributes[ attributeName ];
 					}
 
-					if ( bindingsBySource.size ) {
-						for ( const [ source, bindings ] of bindingsBySource ) {
+					if ( blockBindingsBySource.size ) {
+						for ( const [
+							source,
+							bindings,
+						] of blockBindingsBySource ) {
 							source.setValues( {
 								registry,
 								context,

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -101,7 +101,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 		const hasPatternOverridesDefaultBinding =
 			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ]
 				?.source === 'core/pattern-overrides';
-		const bindings = useMemo(
+		const blockBindings = useMemo(
 			() =>
 				replacePatternOverrideDefaultBindings(
 					name,
@@ -115,7 +115,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 		// there are attribute updates.
 		// `source.getValues` may also call a selector via `registry.select`.
 		const boundAttributes = useSelect( () => {
-			if ( ! bindings ) {
+			if ( ! blockBindings ) {
 				return;
 			}
 
@@ -124,7 +124,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			const bindingsBySource = new Map();
 
 			for ( const [ attributeName, binding ] of Object.entries(
-				bindings
+				blockBindings
 			) ) {
 				const { source: sourceName, args: sourceArgs } = binding;
 				const source = sources[ sourceName ];
@@ -144,13 +144,13 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			}
 
 			if ( bindingsBySource.size ) {
-				for ( const [ source, sourceBindings ] of bindingsBySource ) {
+				for ( const [ source, bindings ] of bindingsBySource ) {
 					// Get values in batch if the source supports it.
 					const values = source.getValues( {
 						registry,
 						context,
 						clientId,
-						sourceBindings,
+						bindings,
 					} );
 					for ( const [ attributeName, value ] of Object.entries(
 						values
@@ -166,8 +166,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 										context,
 										clientId,
 										attributeName,
-										args: sourceBindings[ attributeName ]
-											.args,
+										args: bindings[ attributeName ].args,
 									} );
 							}
 						} else {
@@ -178,14 +177,14 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			}
 
 			return attributes;
-		}, [ bindings, name, clientId, context, registry, sources ] );
+		}, [ blockBindings, name, clientId, context, registry, sources ] );
 
 		const { setAttributes } = props;
 
 		const _setAttributes = useCallback(
 			( nextAttributes ) => {
 				registry.batch( () => {
-					if ( ! bindings ) {
+					if ( ! blockBindings ) {
 						setAttributes( nextAttributes );
 						return;
 					}
@@ -198,13 +197,13 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						keptAttributes
 					) ) {
 						if (
-							! bindings[ attributeName ] ||
+							! blockBindings[ attributeName ] ||
 							! canBindAttribute( name, attributeName )
 						) {
 							continue;
 						}
 
-						const binding = bindings[ attributeName ];
+						const binding = blockBindings[ attributeName ];
 						const source = sources[ binding?.source ];
 						if ( ! source?.setValues ) {
 							continue;
@@ -220,15 +219,12 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					}
 
 					if ( bindingsBySource.size ) {
-						for ( const [
-							source,
-							sourceBindings,
-						] of bindingsBySource ) {
+						for ( const [ source, bindings ] of bindingsBySource ) {
 							source.setValues( {
 								registry,
 								context,
 								clientId,
-								sourceBindings,
+								bindings,
 							} );
 						}
 					}
@@ -253,7 +249,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			},
 			[
 				registry,
-				bindings,
+				blockBindings,
 				name,
 				clientId,
 				context,

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -181,7 +181,10 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 						const binding = bindings[ attributeName ];
 						const source = sources[ binding?.source ];
-						if ( ! source?.setValue && ! source?.setValues ) {
+						if (
+							! source?.setValue &&
+							! source?.setValuesInBatch
+						) {
 							continue;
 						}
 						updatesBySource.set( source, {
@@ -196,8 +199,8 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 							source,
 							attributes,
 						] of updatesBySource ) {
-							if ( source.setValues ) {
-								source.setValues( {
+							if ( source.setValuesInBatch ) {
+								source.setValuesInBatch( {
 									registry,
 									context,
 									clientId,

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -166,7 +166,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					}
 
 					const keptAttributes = { ...nextAttributes };
-					const updatesBySource = new Map();
+					const bindingsBySource = new Map();
 
 					// Loop only over the updated attributes to avoid modifying the bound ones that haven't changed.
 					for ( const [ attributeName, newValue ] of Object.entries(
@@ -187,37 +187,39 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						) {
 							continue;
 						}
-						updatesBySource.set( source, {
-							...updatesBySource.get( source ),
-							[ attributeName ]: newValue,
+						bindingsBySource.set( source, {
+							...bindingsBySource.get( source ),
+							[ attributeName ]: {
+								args: binding.args,
+								newValue,
+							},
 						} );
 						delete keptAttributes[ attributeName ];
 					}
 
-					if ( updatesBySource.size ) {
+					if ( bindingsBySource.size ) {
 						for ( const [
 							source,
-							attributes,
-						] of updatesBySource ) {
+							sourceBindings,
+						] of bindingsBySource ) {
 							if ( source.setValuesInBatch ) {
 								source.setValuesInBatch( {
 									registry,
 									context,
 									clientId,
-									attributes,
+									sourceBindings,
 								} );
 							} else {
 								for ( const [
 									attributeName,
-									value,
-								] of Object.entries( attributes ) ) {
-									const binding = bindings[ attributeName ];
+									{ args, newValue: value },
+								] of Object.entries( sourceBindings ) ) {
 									source.setValue( {
 										registry,
 										context,
 										clientId,
 										attributeName,
-										args: binding.args,
+										args,
 										value,
 									} );
 								}

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -770,8 +770,7 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  * @param {Object}   source                    Properties of the source to be registered.
  * @param {string}   source.name               The unique and machine-readable name.
  * @param {string}   source.label              Human-readable label.
- * @param {Function} [source.getValue]         Function to get the value of the source.
- * @param {Function} [source.setValue]         Function to update the value of the source.
+ * @param {Function} [source.getValues]        Function to get the values from the source.
  * @param {Function} [source.setValues]        Function to update multiple values connected to the source.
  * @param {Function} [source.getPlaceholder]   Function to get the placeholder when the value is undefined.
  * @param {Function} [source.canUserEditValue] Function to determine if the user can edit the value.
@@ -784,8 +783,7 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  * registerBlockBindingsSource( {
  *     name: 'plugin/my-custom-source',
  *     label: _x( 'My Custom Source', 'block bindings source' ),
- *     getValue: () => 'Value to place in the block attribute',
- *     setValue: () => updateMyCustomValue(),
+ *     getValues: () => getSourceValues(),
  *     setValues: () => updateMyCustomValuesInBatch(),
  *     getPlaceholder: () => 'Placeholder text when the value is undefined',
  *     canUserEditValue: () => true,
@@ -796,8 +794,7 @@ export const registerBlockBindingsSource = ( source ) => {
 	const {
 		name,
 		label,
-		getValue,
-		setValue,
+		getValues,
 		setValues,
 		getPlaceholder,
 		canUserEditValue,
@@ -857,15 +854,9 @@ export const registerBlockBindingsSource = ( source ) => {
 		return;
 	}
 
-	// Check the `getValue` property is correct.
-	if ( getValue && typeof getValue !== 'function' ) {
-		warning( 'Block bindings source getValue must be a function.' );
-		return;
-	}
-
-	// Check the `setValue` property is correct.
-	if ( setValue && typeof setValue !== 'function' ) {
-		warning( 'Block bindings source setValue must be a function.' );
+	// Check the `getValues` property is correct.
+	if ( getValues && typeof getValues !== 'function' ) {
+		warning( 'Block bindings source getValues must be a function.' );
 		return;
 	}
 

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1512,28 +1512,15 @@ describe( 'blocks', () => {
 			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
 		} );
 
-		// Check the `getValue` callback is correct.
-		it( 'should reject invalid getValue callback', () => {
+		// Check the `getValues` callback is correct.
+		it( 'should reject invalid getValues callback', () => {
 			registerBlockBindingsSource( {
 				name: 'core/testing',
 				label: 'testing',
-				getValue: 'should be a function',
+				getValues: 'should be a function',
 			} );
 			expect( console ).toHaveWarnedWith(
-				'Block bindings source getValue must be a function.'
-			);
-			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
-		} );
-
-		// Check the `setValue` callback is correct.
-		it( 'should reject invalid setValue callback', () => {
-			registerBlockBindingsSource( {
-				name: 'core/testing',
-				label: 'testing',
-				setValue: 'should be a function',
-			} );
-			expect( console ).toHaveWarnedWith(
-				'Block bindings source setValue must be a function.'
+				'Block bindings source getValues must be a function.'
 			);
 			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
 		} );
@@ -1581,8 +1568,7 @@ describe( 'blocks', () => {
 		it( 'should register a valid source', () => {
 			const sourceProperties = {
 				label: 'Valid Source',
-				getValue: () => 'value',
-				setValue: () => 'new value',
+				getValues: () => 'value',
 				setValues: () => 'new values',
 				getPlaceholder: () => 'placeholder',
 				canUserEditValue: () => true,
@@ -1603,8 +1589,7 @@ describe( 'blocks', () => {
 				label: 'Valid Source',
 			} );
 			const source = getBlockBindingsSource( 'core/valid-source' );
-			expect( source.getValue ).toBeUndefined();
-			expect( source.setValue ).toBeUndefined();
+			expect( source.getValues ).toBeUndefined();
 			expect( source.setValues ).toBeUndefined();
 			expect( source.getPlaceholder ).toBeUndefined();
 			expect( source.canUserEditValue ).toBeUndefined();

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -52,6 +52,7 @@ export function addBlockBindingsSource( source ) {
 		name: source.name,
 		label: source.label,
 		getValue: source.getValue,
+		getValuesInBatch: source.getValuesInBatch,
 		setValue: source.setValue,
 		setValuesInBatch: source.setValuesInBatch,
 		getPlaceholder: source.getPlaceholder,

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -51,10 +51,8 @@ export function addBlockBindingsSource( source ) {
 		type: 'ADD_BLOCK_BINDINGS_SOURCE',
 		name: source.name,
 		label: source.label,
-		getValue: source.getValue,
-		getValuesInBatch: source.getValuesInBatch,
-		setValue: source.setValue,
-		setValuesInBatch: source.setValuesInBatch,
+		getValues: source.getValues,
+		setValues: source.setValues,
 		getPlaceholder: source.getPlaceholder,
 		canUserEditValue: source.canUserEditValue,
 	};

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -53,7 +53,7 @@ export function addBlockBindingsSource( source ) {
 		label: source.label,
 		getValue: source.getValue,
 		setValue: source.setValue,
-		setValues: source.setValues,
+		setValuesInBatch: source.setValuesInBatch,
 		getPlaceholder: source.getPlaceholder,
 		canUserEditValue: source.canUserEditValue,
 	};

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -380,7 +380,7 @@ export function blockBindingsSources( state = {}, action ) {
 					label: action.label,
 					getValue: action.getValue,
 					setValue: action.setValue,
-					setValues: action.setValues,
+					setValuesInBatch: action.setValuesInBatch,
 					getPlaceholder: action.getPlaceholder,
 					canUserEditValue: action.canUserEditValue,
 				},

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -378,10 +378,8 @@ export function blockBindingsSources( state = {}, action ) {
 				...state,
 				[ action.name ]: {
 					label: action.label,
-					getValue: action.getValue,
-					getValuesInBatch: action.getValuesInBatch,
-					setValue: action.setValue,
-					setValuesInBatch: action.setValuesInBatch,
+					getValues: action.getValuesInBatch,
+					setValues: action.setValuesInBatch,
 					getPlaceholder: action.getPlaceholder,
 					canUserEditValue: action.canUserEditValue,
 				},

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -378,8 +378,8 @@ export function blockBindingsSources( state = {}, action ) {
 				...state,
 				[ action.name ]: {
 					label: action.label,
-					getValues: action.getValuesInBatch,
-					setValues: action.setValuesInBatch,
+					getValues: action.getValues,
+					setValues: action.setValues,
 					getPlaceholder: action.getPlaceholder,
 					canUserEditValue: action.canUserEditValue,
 				},

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -379,6 +379,7 @@ export function blockBindingsSources( state = {}, action ) {
 				[ action.name ]: {
 					label: action.label,
 					getValue: action.getValue,
+					getValuesInBatch: action.getValuesInBatch,
 					setValue: action.setValue,
 					setValuesInBatch: action.setValuesInBatch,
 					getPlaceholder: action.getPlaceholder,

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -22,7 +22,8 @@ export default {
 				]?.[ attributeName ];
 
 			// If it has not been overriden, return the original value.
-			if ( ! overridableValue ) {
+			// Check undefined because empty string is a valid value.
+			if ( overridableValue === undefined ) {
 				overridesValues[ attributeName ] =
 					currentBlockAttributes[ attributeName ];
 				continue;

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -11,10 +11,6 @@ export default {
 	label: _x( 'Pattern Overrides', 'block bindings source' ),
 	getValues( { registry, clientId, context, sourceBindings } ) {
 		const patternOverridesContent = context[ 'pattern/overrides' ];
-		if ( ! patternOverridesContent ) {
-			return {};
-		}
-
 		const { getBlockAttributes } = registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
 
@@ -24,8 +20,16 @@ export default {
 				patternOverridesContent?.[
 					currentBlockAttributes?.metadata?.name
 				]?.[ attributeName ];
-			overridesValues[ attributeName ] =
-				overridableValue === '' ? undefined : overridableValue;
+
+			// If it has not been overriden, return the original value.
+			if ( ! overridableValue ) {
+				overridesValues[ attributeName ] =
+					currentBlockAttributes[ attributeName ];
+				continue;
+			} else {
+				overridesValues[ attributeName ] =
+					overridableValue === '' ? undefined : overridableValue;
+			}
 		}
 		return overridesValues;
 	},

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -9,30 +9,7 @@ const CONTENT = 'content';
 export default {
 	name: 'core/pattern-overrides',
 	label: _x( 'Pattern Overrides', 'block bindings source' ),
-	getValue( { registry, clientId, context, attributeName } ) {
-		const patternOverridesContent = context[ 'pattern/overrides' ];
-		const { getBlockAttributes } = registry.select( blockEditorStore );
-		const currentBlockAttributes = getBlockAttributes( clientId );
-
-		if ( ! patternOverridesContent ) {
-			return currentBlockAttributes[ attributeName ];
-		}
-
-		const overridableValue =
-			patternOverridesContent?.[
-				currentBlockAttributes?.metadata?.name
-			]?.[ attributeName ];
-
-		// If there is no pattern client ID, or it is not overwritten, return the default value.
-		if ( overridableValue === undefined ) {
-			return currentBlockAttributes[ attributeName ];
-		}
-
-		return overridableValue === '' ? undefined : overridableValue;
-	},
-	// When `getValuesInBatch` is defined, this is not running.
-	// Keeping it here to show the different possibilities.
-	getValuesInBatch( { registry, clientId, context, sourceBindings } ) {
+	getValues( { registry, clientId, context, sourceBindings } ) {
 		const patternOverridesContent = context[ 'pattern/overrides' ];
 		if ( ! patternOverridesContent ) {
 			return {};
@@ -52,7 +29,7 @@ export default {
 		}
 		return overridesValues;
 	},
-	setValuesInBatch( { registry, clientId, sourceBindings } ) {
+	setValues( { registry, clientId, sourceBindings } ) {
 		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
 			registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -30,7 +30,7 @@ export default {
 
 		return overridableValue === '' ? undefined : overridableValue;
 	},
-	setValues( { registry, clientId, attributes } ) {
+	setValuesInBatch( { registry, clientId, attributes } ) {
 		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
 			registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -30,7 +30,7 @@ export default {
 
 		return overridableValue === '' ? undefined : overridableValue;
 	},
-	setValuesInBatch( { registry, clientId, attributes } ) {
+	setValuesInBatch( { registry, clientId, sourceBindings } ) {
 		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
 			registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
@@ -43,6 +43,15 @@ export default {
 			clientId,
 			'core/block',
 			true
+		);
+
+		// Extract the updated attributes from the source bindings.
+		const attributes = Object.entries( sourceBindings ).reduce(
+			( attrs, [ key, { newValue } ] ) => {
+				attrs[ key ] = newValue;
+				return attrs;
+			},
+			{}
 		);
 
 		// If there is no pattern client ID, sync blocks with the same name and same attributes.

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -30,6 +30,28 @@ export default {
 
 		return overridableValue === '' ? undefined : overridableValue;
 	},
+	// When `getValuesInBatch` is defined, this is not running.
+	// Keeping it here to show the different possibilities.
+	getValuesInBatch( { registry, clientId, context, sourceBindings } ) {
+		const patternOverridesContent = context[ 'pattern/overrides' ];
+		if ( ! patternOverridesContent ) {
+			return {};
+		}
+
+		const { getBlockAttributes } = registry.select( blockEditorStore );
+		const currentBlockAttributes = getBlockAttributes( clientId );
+
+		const overridesValues = {};
+		for ( const attributeName of Object.keys( sourceBindings ) ) {
+			const overridableValue =
+				patternOverridesContent?.[
+					currentBlockAttributes?.metadata?.name
+				]?.[ attributeName ];
+			overridesValues[ attributeName ] =
+				overridableValue === '' ? undefined : overridableValue;
+		}
+		return overridesValues;
+	},
 	setValuesInBatch( { registry, clientId, sourceBindings } ) {
 		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
 			registry.select( blockEditorStore );

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -9,13 +9,13 @@ const CONTENT = 'content';
 export default {
 	name: 'core/pattern-overrides',
 	label: _x( 'Pattern Overrides', 'block bindings source' ),
-	getValues( { registry, clientId, context, sourceBindings } ) {
+	getValues( { registry, clientId, context, bindings } ) {
 		const patternOverridesContent = context[ 'pattern/overrides' ];
 		const { getBlockAttributes } = registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
 
 		const overridesValues = {};
-		for ( const attributeName of Object.keys( sourceBindings ) ) {
+		for ( const attributeName of Object.keys( bindings ) ) {
 			const overridableValue =
 				patternOverridesContent?.[
 					currentBlockAttributes?.metadata?.name
@@ -34,7 +34,7 @@ export default {
 		}
 		return overridesValues;
 	},
-	setValues( { registry, clientId, sourceBindings } ) {
+	setValues( { registry, clientId, bindings } ) {
 		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
 			registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
@@ -50,7 +50,7 @@ export default {
 		);
 
 		// Extract the updated attributes from the source bindings.
-		const attributes = Object.entries( sourceBindings ).reduce(
+		const attributes = Object.entries( bindings ).reduce(
 			( attrs, [ key, { newValue } ] ) => {
 				attrs[ key ] = newValue;
 				return attrs;

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -15,18 +15,7 @@ export default {
 	getPlaceholder( { args } ) {
 		return args.key;
 	},
-	// When `getValuesInBatch` is defined, this is not running.
-	// Keeping it here to show the different possibilities.
-	getValue( { registry, context, args } ) {
-		return registry
-			.select( coreDataStore )
-			.getEditedEntityRecord(
-				'postType',
-				context?.postType,
-				context?.postId
-			).meta?.[ args.key ];
-	},
-	getValuesInBatch( { registry, context, sourceBindings } ) {
+	getValues( { registry, context, sourceBindings } ) {
 		const meta = registry
 			.select( coreDataStore )
 			.getEditedEntityRecord(
@@ -42,18 +31,7 @@ export default {
 		}
 		return newValues;
 	},
-	// When `setValuesInBatch` is defined, this is not running.
-	// Keeping it here to show the different possibilities.
-	setValue( { registry, context, args, value } ) {
-		registry
-			.dispatch( coreDataStore )
-			.editEntityRecord( 'postType', context?.postType, context?.postId, {
-				meta: {
-					[ args.key ]: value,
-				},
-			} );
-	},
-	setValuesInBatch( { registry, context, sourceBindings } ) {
+	setValues( { registry, context, sourceBindings } ) {
 		const newMeta = {};
 		Object.values( sourceBindings ).forEach( ( { args, newValue } ) => {
 			newMeta[ args.key ] = newValue;

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -15,7 +15,7 @@ export default {
 	getPlaceholder( { args } ) {
 		return args.key;
 	},
-	getValues( { registry, context, sourceBindings } ) {
+	getValues( { registry, context, bindings } ) {
 		const meta = registry
 			.select( coreDataStore )
 			.getEditedEntityRecord(
@@ -24,16 +24,14 @@ export default {
 				context?.postId
 			)?.meta;
 		const newValues = {};
-		for ( const [ attributeName, source ] of Object.entries(
-			sourceBindings
-		) ) {
+		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
 			newValues[ attributeName ] = meta?.[ source.args.key ];
 		}
 		return newValues;
 	},
-	setValues( { registry, context, sourceBindings } ) {
+	setValues( { registry, context, bindings } ) {
 		const newMeta = {};
-		Object.values( sourceBindings ).forEach( ( { args, newValue } ) => {
+		Object.values( bindings ).forEach( ( { args, newValue } ) => {
 			newMeta[ args.key ] = newValue;
 		} );
 		registry

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -24,6 +24,8 @@ export default {
 				context?.postId
 			).meta?.[ args.key ];
 	},
+	// When `setValuesInBatch` is defined, this is not running.
+	// Keeping it here to show the different possibilities.
 	setValue( { registry, context, args, value } ) {
 		registry
 			.dispatch( coreDataStore )
@@ -31,6 +33,17 @@ export default {
 				meta: {
 					[ args.key ]: value,
 				},
+			} );
+	},
+	setValuesInBatch( { registry, context, sourceBindings } ) {
+		const newMeta = {};
+		Object.values( sourceBindings ).forEach( ( { args, newValue } ) => {
+			newMeta[ args.key ] = newValue;
+		} );
+		registry
+			.dispatch( coreDataStore )
+			.editEntityRecord( 'postType', context?.postType, context?.postId, {
+				meta: newMeta,
 			} );
 	},
 	canUserEditValue( { select, context, args } ) {

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -15,6 +15,8 @@ export default {
 	getPlaceholder( { args } ) {
 		return args.key;
 	},
+	// When `getValuesInBatch` is defined, this is not running.
+	// Keeping it here to show the different possibilities.
 	getValue( { registry, context, args } ) {
 		return registry
 			.select( coreDataStore )
@@ -23,6 +25,22 @@ export default {
 				context?.postType,
 				context?.postId
 			).meta?.[ args.key ];
+	},
+	getValuesInBatch( { registry, context, sourceBindings } ) {
+		const meta = registry
+			.select( coreDataStore )
+			.getEditedEntityRecord(
+				'postType',
+				context?.postType,
+				context?.postId
+			)?.meta;
+		const newValues = {};
+		for ( const [ attributeName, source ] of Object.entries(
+			sourceBindings
+		) ) {
+			newValues[ attributeName ] = meta?.[ source.args.key ];
+		}
+		return newValues;
 	},
 	// When `setValuesInBatch` is defined, this is not running.
 	// Keeping it here to show the different possibilities.


### PR DESCRIPTION
## What?
Initially discussed [here](https://github.com/WordPress/gutenberg/pull/60721#issuecomment-2111810386).

I'm opening this pull request to discuss some of the editor APIs that should be exposed by block bindings and how to make them more coherent. Right now, we have:

* `getValue`: To get the value of each connected attribute one by one. 
* `setValue`: To update the value of each connected attribute one by one.
* `setValues`: To update the values of all the attributes connected to a specific source in batch.

In [the pull request to use block bindings in pattern overrides](https://github.com/WordPress/gutenberg/pull/60721), `setValues` function was introduced because updating in batch was needed for this particular use case.

This is a valid use case not only for pattern overrides, but also for other sources that might want to call an API only once to update all the attributes connected to it. And this not only happens for updating the attributes (`setValues`), but to get the value as well (`getValues`). For example, in post meta we are using `getValue` and `setValue`, which means we are calling the REST API for each attribute connected to post meta.

I can think of two main options:

### ✅ (Selected option) Option 1: Have ONLY `getValues` and `setValues`.
_Covered in this pull request._

Basically, this would require source developers to update the values in batch. They will receive an object with all of the block attributes that are bound to that specific source, and it's up to them to decide what to do.

The developer experience might be slightly more complicated, and maybe it is a bit harder conceptually.

You can see how each source would use the different possibilities in the alternative pull request:
* Post meta `getValue` vs `getValues`: [link](https://github.com/WordPress/gutenberg/blob/5c3221f46bfaed90bd79c5c050a8d8870a0a6bf8/packages/editor/src/bindings/post-meta.js#L20-L44).
* Post meta `setValue` vs `setValues`: [link](https://github.com/WordPress/gutenberg/blob/5c3221f46bfaed90bd79c5c050a8d8870a0a6bf8/packages/editor/src/bindings/post-meta.js#L47-L66).
* Pattern overrides `getValue` vs`getValues`: [link](https://github.com/WordPress/gutenberg/blob/5c3221f46bfaed90bd79c5c050a8d8870a0a6bf8/packages/editor/src/bindings/pattern-overrides.js#L12-L54).

You can check the differences in [pattern overrides](https://github.com/WordPress/gutenberg/compare/try/block-bindings-unify-get-set-calls-apis?expand=1#diff-deffea7af4722e1274cca18247b89c007e041054cc2fa315c68a0bb1425d9eb8R12-R30) and [post meta](https://github.com/WordPress/gutenberg/compare/try/block-bindings-unify-get-set-calls-apis?expand=1#diff-cf4447b4134dbf24fa2819703999f0131449fb79a0611bd544c5e05fd80aa36bL18-R32) functions.

### 🔴 (Discarded option) Option 2: Have `getValue`, `getValuesInBatch`, `setValue`, and `setValuesInBatch`.
_Covered in [this other pull request](https://github.com/WordPress/gutenberg/pull/63186)_

Another option would be to allow both options and let developers decide which one to use. This will give more flexibility, but at the same time, it implies having two functions for a really similar purpose, which could also be confusing. Additionally, it complicates the core logic, and it will probably require more maintenance.

---

**I would love to know more opinions on which approach you would take or other alternatives I didn't consider.**


## Why?
As an effort to polish the existing block bindings APIs in order to make them public, I believe it makes sense to revisit the this part and make it coherent.

## Testing Instructions

Automated tests should pass. Block bindings and pattern overrides should keep working the same way.
