### PR TITLE
Block Bindings experiment: Alternative to unifying the editor APIs to get and update values

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -181,7 +181,10 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 						const binding = bindings[ attributeName ];
 						const source = sources[ binding?.source ];
-						if ( ! source?.setValue && ! source?.setValues ) {
+						if (
+							! source?.setValue &&
+							! source?.setValuesInBatch
+						) {
 							continue;
 						}
 						updatesBySource.set( source, {
@@ -196,8 +199,8 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 							source,
 							attributes,
 						] of updatesBySource ) {
-							if ( source.setValues ) {
-								source.setValues( {
+							if ( source.setValuesInBatch ) {
+								source.setValuesInBatch( {
 									registry,
 									context,
 									clientId,

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -166,7 +166,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					}
 
 					const keptAttributes = { ...nextAttributes };
-					const updatesBySource = new Map();
+					const bindingsBySource = new Map();
 
 					// Loop only over the updated attributes to avoid modifying the bound ones that haven't changed.
 					for ( const [ attributeName, newValue ] of Object.entries(
@@ -187,37 +187,39 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						) {
 							continue;
 						}
-						updatesBySource.set( source, {
-							...updatesBySource.get( source ),
-							[ attributeName ]: newValue,
+						bindingsBySource.set( source, {
+							...bindingsBySource.get( source ),
+							[ attributeName ]: {
+								args: binding.args,
+								newValue,
+							},
 						} );
 						delete keptAttributes[ attributeName ];
 					}
 
-					if ( updatesBySource.size ) {
+					if ( bindingsBySource.size ) {
 						for ( const [
 							source,
-							attributes,
-						] of updatesBySource ) {
+							sourceBindings,
+						] of bindingsBySource ) {
 							if ( source.setValuesInBatch ) {
 								source.setValuesInBatch( {
 									registry,
 									context,
 									clientId,
-									attributes,
+									sourceBindings,
 								} );
 							} else {
 								for ( const [
 									attributeName,
-									value,
-								] of Object.entries( attributes ) ) {
-									const binding = bindings[ attributeName ];
+									{ args, newValue: value },
+								] of Object.entries( sourceBindings ) ) {
 									source.setValue( {
 										registry,
 										context,
 										clientId,
 										attributeName,
-										args: binding.args,
+										args,
 										value,
 									} );
 								}

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -52,6 +52,7 @@ export function registerBlockBindingsSource( source ) {
 		sourceName: source.name,
 		sourceLabel: source.label,
 		getValue: source.getValue,
+		getValuesInBatch: source.getValuesInBatch,
 		setValue: source.setValue,
 		setValuesInBatch: source.setValuesInBatch,
 		getPlaceholder: source.getPlaceholder,

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -53,7 +53,7 @@ export function registerBlockBindingsSource( source ) {
 		sourceLabel: source.label,
 		getValue: source.getValue,
 		setValue: source.setValue,
-		setValues: source.setValues,
+		setValuesInBatch: source.setValuesInBatch,
 		getPlaceholder: source.getPlaceholder,
 		canUserEditValue: source.canUserEditValue,
 	};

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -379,7 +379,7 @@ export function blockBindingsSources( state = {}, action ) {
 				label: action.sourceLabel,
 				getValue: action.getValue,
 				setValue: action.setValue,
-				setValues: action.setValues,
+				setValuesInBatch: action.setValuesInBatch,
 				getPlaceholder: action.getPlaceholder,
 				canUserEditValue: action.canUserEditValue || ( () => false ),
 			},

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -378,6 +378,7 @@ export function blockBindingsSources( state = {}, action ) {
 			[ action.sourceName ]: {
 				label: action.sourceLabel,
 				getValue: action.getValue,
+				getValuesInBatch: action.getValuesInBatch,
 				setValue: action.setValue,
 				setValuesInBatch: action.setValuesInBatch,
 				getPlaceholder: action.getPlaceholder,

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -30,7 +30,7 @@ export default {
 
 		return overridableValue === '' ? undefined : overridableValue;
 	},
-	setValues( { registry, clientId, attributes } ) {
+	setValuesInBatch( { registry, clientId, attributes } ) {
 		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
 			registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -30,7 +30,7 @@ export default {
 
 		return overridableValue === '' ? undefined : overridableValue;
 	},
-	setValuesInBatch( { registry, clientId, attributes } ) {
+	setValuesInBatch( { registry, clientId, sourceBindings } ) {
 		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
 			registry.select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
@@ -43,6 +43,15 @@ export default {
 			clientId,
 			'core/block',
 			true
+		);
+
+		// Extract the updated attributes from the source bindings.
+		const attributes = Object.entries( sourceBindings ).reduce(
+			( attrs, [ key, { newValue } ] ) => {
+				attrs[ key ] = newValue;
+				return attrs;
+			},
+			{}
 		);
 
 		// If there is no pattern client ID, sync blocks with the same name and same attributes.

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -30,6 +30,28 @@ export default {
 
 		return overridableValue === '' ? undefined : overridableValue;
 	},
+	// When `getValuesInBatch` is defined, this is not running.
+	// Keeping it here to show the different possibilities.
+	getValuesInBatch( { registry, clientId, context, sourceBindings } ) {
+		const patternOverridesContent = context[ 'pattern/overrides' ];
+		if ( ! patternOverridesContent ) {
+			return {};
+		}
+
+		const { getBlockAttributes } = registry.select( blockEditorStore );
+		const currentBlockAttributes = getBlockAttributes( clientId );
+
+		const overridesValues = {};
+		for ( const attributeName of Object.keys( sourceBindings ) ) {
+			const overridableValue =
+				patternOverridesContent?.[
+					currentBlockAttributes?.metadata?.name
+				]?.[ attributeName ];
+			overridesValues[ attributeName ] =
+				overridableValue === '' ? undefined : overridableValue;
+		}
+		return overridesValues;
+	},
 	setValuesInBatch( { registry, clientId, sourceBindings } ) {
 		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
 			registry.select( blockEditorStore );

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -24,6 +24,8 @@ export default {
 				context?.postId
 			).meta?.[ args.key ];
 	},
+	// When `setValuesInBatch` is defined, this is not running.
+	// Keeping it here to show the different possibilities.
 	setValue( { registry, context, args, value } ) {
 		registry
 			.dispatch( coreDataStore )
@@ -31,6 +33,17 @@ export default {
 				meta: {
 					[ args.key ]: value,
 				},
+			} );
+	},
+	setValuesInBatch( { registry, context, sourceBindings } ) {
+		const newMeta = {};
+		Object.values( sourceBindings ).forEach( ( { args, newValue } ) => {
+			newMeta[ args.key ] = newValue;
+		} );
+		registry
+			.dispatch( coreDataStore )
+			.editEntityRecord( 'postType', context?.postType, context?.postId, {
+				meta: newMeta,
 			} );
 	},
 	canUserEditValue( { select, context, args } ) {

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -15,6 +15,8 @@ export default {
 	getPlaceholder( { args } ) {
 		return args.key;
 	},
+	// When `getValuesInBatch` is defined, this is not running.
+	// Keeping it here to show the different possibilities.
 	getValue( { registry, context, args } ) {
 		return registry
 			.select( coreDataStore )
@@ -23,6 +25,22 @@ export default {
 				context?.postType,
 				context?.postId
 			).meta?.[ args.key ];
+	},
+	getValuesInBatch( { registry, context, sourceBindings } ) {
+		const meta = registry
+			.select( coreDataStore )
+			.getEditedEntityRecord(
+				'postType',
+				context?.postType,
+				context?.postId
+			)?.meta;
+		const newValues = {};
+		for ( const [ attributeName, source ] of Object.entries(
+			sourceBindings
+		) ) {
+			newValues[ attributeName ] = meta?.[ source.args.key ];
+		}
+		return newValues;
 	},
 	// When `setValuesInBatch` is defined, this is not running.
 	// Keeping it here to show the different possibilities.


### PR DESCRIPTION
I'm opening this pull request as an alternative for https://github.com/WordPress/gutenberg/pull/63185 in order to easily see the code. Let's keep the discussion there.
