### PR TITLE
SpacingInputControl: use CustomSelectControl V2 legacy adapter

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -3,13 +3,13 @@
  */
 import {
 	Button,
-	CustomSelectControl,
 	Icon,
 	RangeControl,
 	__experimentalHStack as HStack,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
@@ -31,6 +31,11 @@ import {
 	getPresetValueFromCustomValue,
 	isValueSpacingPreset,
 } from '../utils';
+import { unlock } from '../../../lock-unlock';
+
+const { CustomSelectControlV2Legacy: CustomSelectControl } = unlock(
+	componentsPrivateApis
+);
 
 const CUSTOM_VALUE_SETTINGS = {
 	px: { max: 300, steps: 1 },


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Replace the V1 `CustomSelectControl` with the V2 legacy adapter in the spacing input control component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The goal is to ultimately replace the legacy V1 implementation entirely with the V2 legacy adapter. We're performing the migration gradually, and fixing any bugs / gaps as we go.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

 - Import the V2 legacy adapter instead of the V1 implementation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

_Note: during my testing I experiences some unexpected behavior (also on `trunk`), which I've logged in https://github.com/WordPress/gutenberg/issues/63191_

1. Increase the number of spacing presets in the theme.json to 9 or more. Alternatively, apply the following diff:

```diff
diff --git a/packages/block-editor/src/components/spacing-sizes-control/utils.js b/packages/block-editor/src/components/spacing-sizes-control/utils.js
index 91c5a91934..4c8c85bf6d 100644
--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -12,7 +12,7 @@ import {
 	sidesVertical,
 } from '@wordpress/icons';
 
-export const RANGE_CONTROL_MAX_SIZE = 8;
+export const RANGE_CONTROL_MAX_SIZE = 2;
 
 export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
 

```

2. Select a paragraph block
3. In the block inspector controls, click on the "..." button in the top right of the "Dimensions" panel, and add both margin and padding spacing controls
4. Play around with the dropdown, and make sure it looks and behaves as expected

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/88a365e1-e500-46c0-a91e-852d5aa18093" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/ba9ad8c1-a9ad-4468-b5ae-dae462034f94" /> |

