### PR TITLE
Site Editor Sidebar: Hide horizontal scrollbar when navigating

### DIFF
--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -1,7 +1,12 @@
 .edit-site-sidebar__content {
 	flex-grow: 1;
-	overflow-x: hidden;
 	overflow-y: auto;
+	// Prevents horizontal overflow while animating screen transitions
+	overflow-x: hidden;
+	// Mark this section of the DOM as isolated, providing performance benefits
+	// by limiting calculations of layout, style and paint to a DOM subtree rather
+	// than the entire page.
+	contain: content;
 }
 
 @keyframes local--slide-from-right {

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -1,5 +1,6 @@
 .edit-site-sidebar__content {
 	flex-grow: 1;
+	overflow-x: hidden;
 	overflow-y: auto;
 }
 


### PR DESCRIPTION
Fixes #63192

## What?
This PR hides the horizontal scrollbar that appears when navigating in the site editor sidebar.

![scroll-bar](https://github.com/WordPress/gutenberg/assets/54422211/dc13cf82-581a-4e9d-8ab6-b4dacdbadb6a)


## How?
To be honest, I didn't know the root cause. Maybe it's related to animations when navigating.

The only solution I found was to apply `overflow-x: hidden;` to the sidebar content.

## Testing Instructions

- If you're using MacOS, make sure the scrollbar is always visible.
- Navigate to any screen in the site editor.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/54422211/ab46d7c2-c3d3-4e23-b558-5117d00c42ab

### After

https://github.com/WordPress/gutenberg/assets/54422211/371044ac-3974-4d24-a170-14386c28e1e6


