### PR TITLE
Fix unlabeled Remove shadow buttons.

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -371,8 +371,7 @@ function ShadowItem( { shadow, onChange, canRemove, onRemove } ) {
 						'edit-site-global-styles__shadow-editor__remove-button',
 						{ 'is-open': isOpen }
 					),
-					ariaLabel: __( 'Remove shadow' ),
-					tooltip: __( 'Remove shadow' ),
+					label: __( 'Remove shadow' ),
 				};
 
 				return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
FIxes https://github.com/WordPress/gutenberg/issues/63196

## What?
<!-- In a few words, what is the PR actually doing? -->
The 'Remove shadow' buttons are unlabeled.
They don't show a tooltip as well.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All interactive controls _must_ be labeled.
Icon buttons _must_ visually expose their accessible name via a tooltiip.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Fixes the `label` prop. 
Removes incorrect `tooltip` prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the test instructions from https://github.com/WordPress/gutenberg/issues/63196
- Hover or focus the Remove shadow button and observe it does show a tooltip.
- Inspect the source and observe the button markup does not have an `arialabel` or `tooltip` HTML attributes.
- Instead, observe the button markup does have an `aria-label` attribute.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
