### PR TITLE
RangeControl: Fix RTL support for custom marks

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `Button`: Stabilize `__experimentalIsFocusable` prop as `accessibleWhenDisabled` ([#62282](https://github.com/WordPress/gutenberg/pull/62282)).
 -   `ToolbarButton`: Always keep focusable when disabled ([#63102](https://github.com/WordPress/gutenberg/pull/63102)).
 -   `ProgressBar`: Fix indeterminate RTL support. ([#63129](https://github.com/WordPress/gutenberg/pull/63129)).
+-   `RangeControl`: Fix RTL support for custom marks ([#63198](https://github.com/WordPress/gutenberg/pull/63198)).
 
 ### Internal
 

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -168,12 +168,16 @@ const markLabelFill = ( { isFilled }: RangeMarkProps ) => {
 
 export const MarkLabel = styled.span`
 	color: ${ COLORS.gray[ 300 ] };
-	left: 0;
 	font-size: 11px;
 	position: absolute;
 	top: 12px;
-	transform: translateX( -50% );
 	white-space: nowrap;
+
+	${ rtl( { left: 0 } ) };
+	${ rtl(
+		{ transform: 'translateX( -50% )' },
+		{ transform: 'translateX( 50% )' }
+	) };
 
 	${ markLabelFill };
 `;


### PR DESCRIPTION
## What?
Fix the RTL support for `RangeControl` with custom marks.

Spotted as I was playing with RTL in Storybook while working on #63129.

## Why?
Currently on RTL, the custom marks are off for RTL browsers.

## How?
We're essentially applying some RTL considerations to the custom mark styles 

## Testing Instructions
* Open the `RangeControl` component in storybook
* Try all stories with marks and verify they work well on both LTR and RTL.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
The "With Decimal Step And Marks" story on RTL:

Before:

![Screenshot 2024-07-05 at 17 38 11](https://github.com/WordPress/gutenberg/assets/8436925/fd4a93a1-43b2-43c2-938e-8c1925a75cc3)


After:

![Screenshot 2024-07-05 at 17 37 55](https://github.com/WordPress/gutenberg/assets/8436925/f6293c24-432b-4b4b-8a15-8dab9c11b2f0)

