### PR TITLE
Split layout / view options. Use active layout icon for the layout button

### DIFF
--- a/packages/dataviews/src/view-actions.tsx
+++ b/packages/dataviews/src/view-actions.tsx
@@ -9,6 +9,7 @@ import type { ChangeEvent } from 'react';
 import {
 	Button,
 	privateApis as componentsPrivateApis,
+	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { memo } from '@wordpress/element';
@@ -291,44 +292,56 @@ function _ViewActions< Item >( {
 	const activeView = VIEW_LAYOUTS.find( ( v ) => view.type === v.type );
 	return (
 		<>
-			<DropdownMenu
-				trigger={
-					<Button
-						size="compact"
-						icon={ activeView?.icon }
-						label={ __( 'Layout' ) }
-					/>
-				}
+			<HStack
+				spacing={ 1 }
+				expanded={ false }
+				style={ { flexShrink: 0 } }
 			>
-				<ViewTypeMenu
-					view={ view }
-					onChangeView={ onChangeView }
-					supportedLayouts={ supportedLayouts }
-				/>
-			</DropdownMenu>
-			<DropdownMenu
-				trigger={
-					<Button
-						size="compact"
-						icon={ cog }
-						label={ _x( 'View options', 'View is used as a noun' ) }
-					/>
-				}
-			>
-				<DropdownMenuGroup>
-					<SortMenu
-						fields={ fields }
+				<DropdownMenu
+					trigger={
+						<Button
+							size="compact"
+							icon={ activeView?.icon }
+							label={ __( 'Layout' ) }
+						/>
+					}
+				>
+					<ViewTypeMenu
 						view={ view }
 						onChangeView={ onChangeView }
+						supportedLayouts={ supportedLayouts }
 					/>
-					<FieldsVisibilityMenu
-						fields={ fields }
-						view={ view }
-						onChangeView={ onChangeView }
-					/>
-					<PageSizeMenu view={ view } onChangeView={ onChangeView } />
-				</DropdownMenuGroup>
-			</DropdownMenu>
+				</DropdownMenu>
+				<DropdownMenu
+					trigger={
+						<Button
+							size="compact"
+							icon={ cog }
+							label={ _x(
+								'View options',
+								'View is used as a noun'
+							) }
+						/>
+					}
+				>
+					<DropdownMenuGroup>
+						<SortMenu
+							fields={ fields }
+							view={ view }
+							onChangeView={ onChangeView }
+						/>
+						<FieldsVisibilityMenu
+							fields={ fields }
+							view={ view }
+							onChangeView={ onChangeView }
+						/>
+						<PageSizeMenu
+							view={ view }
+							onChangeView={ onChangeView }
+						/>
+					</DropdownMenuGroup>
+				</DropdownMenu>
+			</HStack>
 		</>
 	);
 }

--- a/packages/dataviews/src/view-actions.tsx
+++ b/packages/dataviews/src/view-actions.tsx
@@ -75,51 +75,34 @@ function ViewTypeMenu( {
 	if ( _availableViews.length === 1 ) {
 		return null;
 	}
-	const activeView = _availableViews.find( ( v ) => view.type === v.type );
-	return (
-		<DropdownMenu
-			trigger={
-				<DropdownMenuItem
-					suffix={
-						<span aria-hidden="true">{ activeView?.label }</span>
+	return _availableViews.map( ( availableView ) => {
+		return (
+			<DropdownMenuRadioItem
+				key={ availableView.type }
+				value={ availableView.type }
+				name="view-actions-available-view"
+				checked={ availableView.type === view.type }
+				hideOnClick
+				onChange={ ( e: ChangeEvent< HTMLInputElement > ) => {
+					switch ( e.target.value ) {
+						case 'list':
+						case 'grid':
+						case 'table':
+							return onChangeView( {
+								...view,
+								type: e.target.value,
+								layout: {},
+							} );
 					}
-				>
-					<DropdownMenuItemLabel>
-						{ __( 'Layout' ) }
-					</DropdownMenuItemLabel>
-				</DropdownMenuItem>
-			}
-		>
-			{ _availableViews.map( ( availableView ) => {
-				return (
-					<DropdownMenuRadioItem
-						key={ availableView.type }
-						value={ availableView.type }
-						name="view-actions-available-view"
-						checked={ availableView.type === view.type }
-						hideOnClick
-						onChange={ ( e: ChangeEvent< HTMLInputElement > ) => {
-							switch ( e.target.value ) {
-								case 'list':
-								case 'grid':
-								case 'table':
-									return onChangeView( {
-										...view,
-										type: e.target.value,
-										layout: {},
-									} );
-							}
-							throw new Error( 'Invalid dataview' );
-						} }
-					>
-						<DropdownMenuItemLabel>
-							{ availableView.label }
-						</DropdownMenuItemLabel>
-					</DropdownMenuRadioItem>
-				);
-			} ) }
-		</DropdownMenu>
-	);
+					throw new Error( 'Invalid dataview' );
+				} }
+			>
+				<DropdownMenuItemLabel>
+					{ availableView.label }
+				</DropdownMenuItemLabel>
+			</DropdownMenuRadioItem>
+		);
+	} );
 }
 
 const PAGE_SIZE_VALUES = [ 10, 20, 50, 100 ];
@@ -305,35 +288,48 @@ function _ViewActions< Item >( {
 	onChangeView,
 	supportedLayouts,
 }: ViewActionsProps< Item > ) {
+	const activeView = VIEW_LAYOUTS.find( ( v ) => view.type === v.type );
 	return (
-		<DropdownMenu
-			trigger={
-				<Button
-					size="compact"
-					icon={ cog }
-					label={ _x( 'View options', 'View is used as a noun' ) }
-				/>
-			}
-		>
-			<DropdownMenuGroup>
+		<>
+			<DropdownMenu
+				trigger={
+					<Button
+						size="compact"
+						icon={ activeView?.icon }
+						label={ __( 'Layout' ) }
+					/>
+				}
+			>
 				<ViewTypeMenu
 					view={ view }
 					onChangeView={ onChangeView }
 					supportedLayouts={ supportedLayouts }
 				/>
-				<SortMenu
-					fields={ fields }
-					view={ view }
-					onChangeView={ onChangeView }
-				/>
-				<FieldsVisibilityMenu
-					fields={ fields }
-					view={ view }
-					onChangeView={ onChangeView }
-				/>
-				<PageSizeMenu view={ view } onChangeView={ onChangeView } />
-			</DropdownMenuGroup>
-		</DropdownMenu>
+			</DropdownMenu>
+			<DropdownMenu
+				trigger={
+					<Button
+						size="compact"
+						icon={ cog }
+						label={ _x( 'View options', 'View is used as a noun' ) }
+					/>
+				}
+			>
+				<DropdownMenuGroup>
+					<SortMenu
+						fields={ fields }
+						view={ view }
+						onChangeView={ onChangeView }
+					/>
+					<FieldsVisibilityMenu
+						fields={ fields }
+						view={ view }
+						onChangeView={ onChangeView }
+					/>
+					<PageSizeMenu view={ view } onChangeView={ onChangeView } />
+				</DropdownMenuGroup>
+			</DropdownMenu>
+		</>
 	);
 }
 

--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -48,6 +48,11 @@ test.describe( 'Dataviews List Layout', () => {
 
 		await page.keyboard.press( 'Tab' );
 		await expect(
+			page.getByRole( 'button', { name: 'Layout' } )
+		).toBeFocused();
+
+		await page.keyboard.press( 'Tab' );
+		await expect(
 			page.getByRole( 'button', { name: 'View options' } )
 		).toBeFocused();
 
@@ -66,6 +71,7 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 
 		// Tab until reaching the items list.
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
@@ -98,6 +104,7 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
 
 		// Make sure the items have loaded before reaching for the 1st item in the list.
 		await expect( page.getByRole( 'grid' ) ).toBeVisible();
@@ -118,6 +125,7 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 
 		// Tab until reaching the items list.
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
@@ -159,6 +167,7 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 
 		// Tab until reaching the items list.
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -86,8 +86,7 @@ test.describe( 'Templates', () => {
 	test( 'Field visibility', async ( { admin, page } ) => {
 		await admin.visitSiteEditor( { postType: 'wp_template' } );
 
-		await page.getByRole( 'button', { name: 'View options' } ).click();
-		await page.getByRole( 'menuitem', { name: 'Layout' } ).click();
+		await page.getByRole( 'button', { name: 'Layout' } ).click();
 		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
 
 		await page.getByRole( 'button', { name: 'Description' } ).click();

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -222,15 +222,11 @@ test.describe( 'Site Editor Performance', () => {
 				// If it's there, switch to the list layout before running the test.
 				// See https://github.com/WordPress/gutenberg/pull/59792
 				const isDataViewsUI = await page
-					.getByRole( 'button', { name: 'View options' } )
+					.getByRole( 'button', { name: 'Layout' } )
 					.isVisible();
 				if ( isDataViewsUI ) {
 					await page
-						.getByRole( 'button', { name: 'View options' } )
-						.click();
-					await page
-						.getByRole( 'menuitem' )
-						.filter( { has: page.getByText( 'Layout' ) } )
+						.getByRole( 'button', { name: 'Layout' } )
 						.click();
 					await page
 						.getByRole( 'menuitemradio' )


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63195

Extracting the layout toggle from the main view options menu makes it quicker to switch. This will be a useful affordance for data views where layout switching is more common such as the Media Libary (https://github.com/WordPress/gutenberg/issues/55238).

cc: @jameskoster 

## Screenshots


<img width="1411" alt="Screenshot 2024-07-05 at 18 30 44" src="https://github.com/WordPress/gutenberg/assets/11271197/2a86e364-fc46-4336-9501-2ae6b5e69a55">
<img width="1394" alt="Screenshot 2024-07-05 at 18 30 36" src="https://github.com/WordPress/gutenberg/assets/11271197/fa07daae-ef1f-4e76-9e9c-dc63c9aa27b8">

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## Testing Instructions
I verified the layout switcher worked as expected.