### PR TITLE
TimePicker: Fix time zone overflow

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `useUpdateEffect`: Correctly track mounted state in strict mode. ([#62974](https://github.com/WordPress/gutenberg/pull/62974))
 -   `UnitControl`: Fix an issue where keyboard shortcuts unintentionally shift focus on Windows OS. ([#62988](https://github.com/WordPress/gutenberg/pull/62988))
 -   Fix inaccessibly disabled `Button`s ([#62306](https://github.com/WordPress/gutenberg/pull/62306)).
+-   `TimePicker`: Fix time zone overflow ([#63209](https://github.com/WordPress/gutenberg/pull/63209)).
 
 ### Enhancements
 

--- a/packages/components/src/date-time/time-input/index.tsx
+++ b/packages/components/src/date-time/time-input/index.tsx
@@ -103,7 +103,7 @@ export function TimeInput( {
 				</BaseControl.VisualLabel>
 			) }
 
-			<HStack alignment="left">
+			<HStack alignment="left" expanded={ false }>
 				<TimeWrapper
 					className="components-datetime__time-field components-datetime__time-field-time" // Unused, for backwards compatibility.
 				>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes a style regression introduced in #60613 where the time zone in the `TimePicker` was overflowing a bit.

This was especially noticeable in the "Date" block:

<img width="200" alt="Time zone overflowing in popover" src="https://github.com/WordPress/gutenberg/assets/555336/0cc8a950-41c0-4afe-a6d1-2312c65bf20b">

## How?

Remove the `width: 100%` style in the container element, by adding a `expanded={ false }` prop to `HStack`.

## Testing Instructions

Compare the result in the Storybook for `TimePicker`. Or, in the editor, the post publish popover or the "Date" block.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/WordPress/gutenberg/assets/555336/a494c674-8999-4190-8447-d2f5099ac840" alt="Time zone is overflowing" width="400">|<img src="https://github.com/WordPress/gutenberg/assets/555336/299bfdc1-00d8-4e62-9621-67f2fceb9326" alt="Time zone is in correct position" width="400">|