### PR TITLE
Font Library Modal: enhance pagination appearance

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -28,7 +28,13 @@ import {
 } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
 import { sprintf, __, _x } from '@wordpress/i18n';
-import { moreVertical, chevronLeft } from '@wordpress/icons';
+import {
+	moreVertical,
+	chevronLeft,
+	chevronRight,
+	previous,
+	next,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -429,7 +435,7 @@ function FontCollection( { slug } ) {
 					{ selectedFont && (
 						<Flex
 							justify="flex-end"
-							className="font-library-modal__tabpanel-layout__footer"
+							className="font-library-modal__footer"
 						>
 							<Button
 								variant="primary"
@@ -446,32 +452,38 @@ function FontCollection( { slug } ) {
 					) }
 
 					{ ! selectedFont && (
-						<Flex
+						<HStack
+							spacing={ 4 }
 							justify="center"
-							className="font-library-modal__tabpanel-layout__footer"
+							className="font-library-modal__footer"
 						>
-							<Button
-								label={ __( 'First page' ) }
-								size="compact"
-								onClick={ () => setPage( 1 ) }
-								disabled={ page === 1 }
-								accessibleWhenDisabled
-							>
-								<span>«</span>
-							</Button>
-							<Button
-								label={ __( 'Previous page' ) }
-								size="compact"
-								onClick={ () => setPage( page - 1 ) }
-								disabled={ page === 1 }
-								accessibleWhenDisabled
-							>
-								<span>‹</span>
-							</Button>
+							<HStack expanded={ false } spacing={ 1 }>
+								<Button
+									label={ __( 'First page' ) }
+									size="compact"
+									onClick={ () => setPage( 1 ) }
+									disabled={ page === 1 }
+									showTooltip
+									accessibleWhenDisabled
+									icon={ previous }
+									tooltipPosition="top"
+								/>
+								<Button
+									label={ __( 'Previous page' ) }
+									size="compact"
+									onClick={ () => setPage( page - 1 ) }
+									disabled={ page === 1 }
+									showTooltip
+									accessibleWhenDisabled
+									icon={ chevronLeft }
+									tooltipPosition="top"
+								/>
+							</HStack>
 							<HStack
 								justify="flex-start"
 								expanded={ false }
 								spacing={ 2 }
+								className="font-library-modal__page-selection"
 							>
 								{ createInterpolateElement(
 									sprintf(
@@ -509,25 +521,27 @@ function FontCollection( { slug } ) {
 									}
 								) }
 							</HStack>
-							<Button
-								label={ __( 'Next page' ) }
-								size="compact"
-								onClick={ () => setPage( page + 1 ) }
-								disabled={ page === totalPages }
-								accessibleWhenDisabled
-							>
-								<span>›</span>
-							</Button>
-							<Button
-								label={ __( 'Last page' ) }
-								size="compact"
-								onClick={ () => setPage( totalPages ) }
-								disabled={ page === totalPages }
-								accessibleWhenDisabled
-							>
-								<span>»</span>
-							</Button>
-						</Flex>
+							<HStack expanded={ false } spacing={ 1 }>
+								<Button
+									label={ __( 'Next page' ) }
+									size="compact"
+									onClick={ () => setPage( page + 1 ) }
+									disabled={ page === totalPages }
+									accessibleWhenDisabled
+									icon={ chevronRight }
+									tooltipPosition="top"
+								/>
+								<Button
+									label={ __( 'Last page' ) }
+									size="compact"
+									onClick={ () => setPage( totalPages ) }
+									disabled={ page === totalPages }
+									accessibleWhenDisabled
+									icon={ next }
+									tooltipPosition="top"
+								/>
+							</HStack>
+						</HStack>
 					) }
 				</>
 			) }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -28,13 +28,7 @@ import {
 } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
 import { sprintf, __, _x } from '@wordpress/i18n';
-import {
-	moreVertical,
-	chevronLeft,
-	chevronRight,
-	previous,
-	next,
-} from '@wordpress/icons';
+import { moreVertical, chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -457,28 +451,16 @@ function FontCollection( { slug } ) {
 							justify="center"
 							className="font-library-modal__footer"
 						>
-							<HStack expanded={ false } spacing={ 1 }>
-								<Button
-									label={ __( 'First page' ) }
-									size="compact"
-									onClick={ () => setPage( 1 ) }
-									disabled={ page === 1 }
-									showTooltip
-									accessibleWhenDisabled
-									icon={ previous }
-									tooltipPosition="top"
-								/>
-								<Button
-									label={ __( 'Previous page' ) }
-									size="compact"
-									onClick={ () => setPage( page - 1 ) }
-									disabled={ page === 1 }
-									showTooltip
-									accessibleWhenDisabled
-									icon={ chevronLeft }
-									tooltipPosition="top"
-								/>
-							</HStack>
+							<Button
+								label={ __( 'Previous page' ) }
+								size="compact"
+								onClick={ () => setPage( page - 1 ) }
+								disabled={ page === 1 }
+								showTooltip
+								accessibleWhenDisabled
+								icon={ chevronLeft }
+								tooltipPosition="top"
+							/>
 							<HStack
 								justify="flex-start"
 								expanded={ false }
@@ -521,26 +503,15 @@ function FontCollection( { slug } ) {
 									}
 								) }
 							</HStack>
-							<HStack expanded={ false } spacing={ 1 }>
-								<Button
-									label={ __( 'Next page' ) }
-									size="compact"
-									onClick={ () => setPage( page + 1 ) }
-									disabled={ page === totalPages }
-									accessibleWhenDisabled
-									icon={ chevronRight }
-									tooltipPosition="top"
-								/>
-								<Button
-									label={ __( 'Last page' ) }
-									size="compact"
-									onClick={ () => setPage( totalPages ) }
-									disabled={ page === totalPages }
-									accessibleWhenDisabled
-									icon={ next }
-									tooltipPosition="top"
-								/>
-							</HStack>
+							<Button
+								label={ __( 'Next page' ) }
+								size="compact"
+								onClick={ () => setPage( page + 1 ) }
+								disabled={ page === totalPages }
+								accessibleWhenDisabled
+								icon={ chevronRight }
+								tooltipPosition="top"
+							/>
 						</HStack>
 					) }
 				</>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -311,7 +311,7 @@ function InstalledFonts() {
 
 					<HStack
 						justify="flex-end"
-						className="font-library-modal__tabpanel-layout__footer"
+						className="font-library-modal__footer"
 					>
 						{ isInstalling && <ProgressBar /> }
 						{ shouldDisplayDeleteButton && (

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -49,17 +49,24 @@ $footer-height: 70px;
 		// It should be 120px (72px modal header height + 48px tab height)
 		padding-top: $header-height + $grid-unit-15 + $grid-unit-60;
 	}
+}
 
-	.font-library-modal__tabpanel-layout__footer {
-		border-top: 1px solid $gray-300;
-		margin: 0 #{$grid-unit-40 * -1} #{$grid-unit-40 * -1};
-		padding: $grid-unit-20 $grid-unit-40;
-		position: absolute;
-		bottom: $grid-unit-40;
-		width: 100%;
-		height: $footer-height;
-		background-color: $white;
-	}
+.font-library-modal__footer {
+	border-top: 1px solid $gray-300;
+	margin: 0 #{$grid-unit-40 * -1} #{$grid-unit-40 * -1};
+	padding: $grid-unit-20 $grid-unit-40;
+	position: absolute;
+	bottom: $grid-unit-40;
+	width: 100%;
+	height: $footer-height;
+	background-color: $white;
+}
+
+.font-library-modal__page-selection {
+	font-size: 11px;
+	text-transform: uppercase;
+	font-weight: 500;
+	color: $gray-900;
 }
 
 .font-library-modal__tabpanel-layout .components-base-control__field {


### PR DESCRIPTION
Fixes #59408
Part of #60528

## What?

This PR improves the appearance of pagination in the Font Library modal, making it more consistent with the pagination UI in the Data View and Revisions panel.


## How?

- The layout is constructed in much the same way as other similar pagination.
- Changed the display position of the tooltip from bottom to top.
- Also includes minor CSS class name refactoring.

## Testing Instructions

In the font library, make sure pagination still works as before.

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/6b248e5a-2a7f-44f6-b948-6288061a105d)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/26ff733f-9eb9-4eaf-a688-2c1dcab6763b)