### PR TITLE
Data Views: Add padding around selected values in author filter

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -745,7 +745,7 @@
 		border: 1px solid transparent;
 		cursor: pointer;
 		padding: $grid-unit-05 $grid-unit-15;
-		height: auto;
+		min-height: $grid-unit-40;
 		background: $gray-100;
 		color: $gray-800;
 		position: relative;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -744,8 +744,8 @@
 		border-radius: $grid-unit-20;
 		border: 1px solid transparent;
 		cursor: pointer;
-		padding: 0 $grid-unit-15;
-		height: $grid-unit-40;
+		padding: $grid-unit-05 $grid-unit-15;
+		height: auto;
 		background: $gray-100;
 		color: $gray-800;
 		position: relative;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/63152

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Missing space around selected values in dataview filter due to fixed height of 32px, This PR resolve that issue by setting auto height and adding top-bottom padding.

## Screenshots or screencast <!-- if applicable -->
<img width="1395" alt="image" src="https://github.com/WordPress/gutenberg/assets/61308756/9d2e5de0-4ec4-4296-a752-819f939005d6">

