### PR TITLE
Patterns Page: Hide preview column by default

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -82,6 +82,7 @@ const DEFAULT_VIEW = {
 	layout: {
 		...defaultConfigPerViewType[ LAYOUT_GRID ],
 	},
+	fields: [ 'title', 'sync-status' ],
 	filters: [],
 };
 
@@ -285,7 +286,6 @@ export default function DataviewsPatterns() {
 					<Preview item={ item } viewType={ view.type } />
 				),
 				enableSorting: false,
-				enableHiding: false,
 				width: '1%',
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/60704

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Pattern preview is displayed by default on patterns list page for table view, where it should be hidden by default as we have implemented for templates page.
 
## Screenshots or screencast <!-- if applicable -->
[Blog-Home-‹-Template-‹-gutenberg-‹-Editor-—-WordPress.webm](https://github.com/WordPress/gutenberg/assets/61308756/af4d08ab-f0e4-4417-b345-5bb9f2878500)
