### PR TITLE
Raw handling: Remove IE11 fallback code

### DIFF
--- a/packages/block-editor/src/utils/pasting.js
+++ b/packages/block-editor/src/utils/pasting.js
@@ -52,21 +52,14 @@ export function getPasteEventData( { clipboardData } ) {
 	let plainText = '';
 	let html = '';
 
-	// IE11 only supports `Text` as an argument for `getData` and will
-	// otherwise throw an invalid argument error, so we try the standard
-	// arguments first, then fallback to `Text` if they fail.
 	try {
 		plainText = clipboardData.getData( 'text/plain' );
 		html = clipboardData.getData( 'text/html' );
-	} catch ( error1 ) {
-		try {
-			html = clipboardData.getData( 'Text' );
-		} catch ( error2 ) {
-			// Some browsers like UC Browser paste plain text by default and
-			// don't support clipboardData at all, so allow default
-			// behaviour.
-			return;
-		}
+	} catch ( error ) {
+		// Some browsers like UC Browser paste plain text by default and
+		// don't support clipboardData at all, so allow default
+		// behaviour.
+		return;
 	}
 
 	// Remove Windows-specific metadata appended within copied HTML text.

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -111,7 +111,6 @@ export function pasteHandler( {
 	}
 
 	// Normalize unicode to use composed characters.
-	// This is unsupported in IE 11 but it's a nice-to-have feature, not mandatory.
 	// Not normalizing the content will only affect older browsers and won't
 	// entirely break the app.
 	// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -85,21 +85,14 @@ function PostTitle( _, forwardedRef ) {
 		let plainText = '';
 		let html = '';
 
-		// IE11 only supports `Text` as an argument for `getData` and will
-		// otherwise throw an invalid argument error, so we try the standard
-		// arguments first, then fallback to `Text` if they fail.
 		try {
 			plainText = clipboardData.getData( 'text/plain' );
 			html = clipboardData.getData( 'text/html' );
-		} catch ( error1 ) {
-			try {
-				html = clipboardData.getData( 'Text' );
-			} catch ( error2 ) {
-				// Some browsers like UC Browser paste plain text by default and
-				// don't support clipboardData at all, so allow default
-				// behaviour.
-				return;
-			}
+		} catch ( error ) {
+			// Some browsers like UC Browser paste plain text by default and
+			// don't support clipboardData at all, so allow default
+			// behaviour.
+			return;
 		}
 
 		// Allows us to ask for this information when we get a report.


### PR DESCRIPTION
Part of #58034

## What?
This PR removes the fallback code for IE11 in row handling.

## Why?

Support for IE11 has been [officially removed in WordPress 5.8](https://make.wordpress.org/core/2021/04/22/ie-11-support-phase-out-plan/). And since the Gutenberg plugin no longer supports WordPress 5.8, we can remove the fallback code for IE11.

## Testing Instructions

All CIs should pass.

