### PR TITLE
Block Editor: Remove CSS hack for Internet Explorer 11

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -24,8 +24,6 @@
 	.components-toolbar-group,
 	.components-toolbar {
 		background: none;
-		// IE11 has thick paddings without this.
-		line-height: 0;
 
 		// These margins make the buttons themselves overlap the chrome of the toolbar.
 		// This helps make them square, and maximize the hit area.
@@ -151,15 +149,7 @@
 }
 
 .block-editor-block-toolbar__slot {
-	// Required for IE11.
-	display: inline-block;
-	// Fix for toolbar button misalignment on IE11
-	line-height: 0;
-
-	// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
-	@supports (position: sticky) {
-		display: inline-flex;
-	}
+	display: inline-flex;
 }
 
 .show-icon-labels {


### PR DESCRIPTION
Part of #58034

This PR is the final one to remove fallback styles for IE11 for stylesheets.

## What?
Remove the CSS code for IE11 that exists in the `block-editor` package. The styles that will be removed are all related to the block toolbar.

## Why?
Support for IE11 has been [officially removed in WordPress 5.8](https://make.wordpress.org/core/2021/04/22/ie-11-support-phase-out-plan/). And since the Gutenberg plugin no longer supports WordPress 5.8, we can remove the fallback code for IE11.

## Testing Instructions

The layout of the block toolbar should remain the same.
