### PR TITLE
Fix background height and padding in non-iframe editor canvas

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,4 +1,4 @@
-.edit-post-layout.has-metaboxes .edit-post-visual-editor {
+.edit-post-visual-editor:not(.is-iframed) {
 	flex: 1 0 auto;
 	height: auto;
 }


### PR DESCRIPTION
Fixes #63110
Related to #62940

## What?

This PR fixes two issues with the background when **the post editor is not an iframe but does not have a meta box**:

### There is not enough space at the bottom of the content

![issue_1](https://github.com/WordPress/gutenberg/assets/54422211/7bd286ee-22c1-46c8-a40d-31555b39989f)


### The background color disappears halfway through

![issue_2](https://github.com/WordPress/gutenberg/assets/54422211/9e9d7dea-2bde-4e18-9a20-5b125ed89c27)

## Why?

In #62940, the post editor was styled as follows to fix the triple scroll issue:

```css
// From
.editor-visual-editor {
	flex: 1 0 auto;
	height: auto;
}

// To
.edit-post-layout.has-metaboxes .edit-post-visual-editor {
	flex: 1 0 auto;
	height: auto;
}
```

This style works in the non-iframe editor where meta boxes (custom fields) are enabled. However, the post editor will not become an iframe if there is a v2 or lower block present, even if it does not have a meta box. In this case, the `.has-metaboxes` class does not exist, so the editor defaults to `height:100%`, which seems to cause the issue mentioned above.

## How?

I used `.is-iframed` instead of `.has-metaboxes` class to accurately determine if the editor is an iframe or not.

## Testing Instructions

- Enable the TT1 theme, which has a more visible background color.
- Activate the Jetpack plugin. This plugin won't add a meta box to the post editor, but because the plugin includes version 1 blocks, the post editor will no longer be an iframe.
- Access the post editor and enter more content.
- Scroll to the very bottom of the content.
- The background color should extend to the bottom of the canvas and have sufficient bottom padding.

Also, there have been some scrollbar fixes in this area in the past, so please make sure we have not run into regressions or unwanted scrollbars in the following cases:

- Iframe editor
- Mobile or tablet preview
- Pattern editor
- Add lots of notices (`wp.data.dispatch( 'core/notices' ).createInfoNotice( 'Notice' );`)

**Note:** However, there is one issue that this PR doesn't solve: when you open the Pattern Editor in a non-iframe editor, the background gets cut off.

![pattern-editor](https://github.com/WordPress/gutenberg/assets/54422211/e922ed19-37a0-4330-9dbe-a8be20800554)

I believe the root cause of this issue is based on the fact that when the post editor is not an iframe, the pattern editor is not an iframe either. I believe the pattern editor should be an iframe regardless of whether the post editor is an iframe or not, just like the tablet and mobile views. However, since this change is impactful, I thought it should be addressed in a follow-up.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/cb45b418-eb85-4f45-aca3-38b94bbff88f

