### PR TITLE
Block Bindings: Remove "Site Updated" notification for post entity changes

### DIFF
--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -153,6 +153,7 @@ export const saveDirtyEntities =
 		close?.( entitiesToSave );
 		const siteItemsToSave = [];
 		const pendingSavedRecords = [];
+		let showPostUpdatedMessage = false;
 		let showSiteUpdatedMessage = false;
 		entitiesToSave.forEach( ( { kind, name, key, property } ) => {
 			if ( 'root' === kind && 'site' === name ) {
@@ -182,7 +183,9 @@ export const saveDirtyEntities =
 				// This flag allows us to avoid showing the 'site updated' message
 				// in scenarios related to entity changes when the message shouldn't be
 				// triggered, like when modifying post meta via block bindings.
-				if ( kind !== 'postType' ) {
+				if ( kind === 'postType' ) {
+					showPostUpdatedMessage = true;
+				} else {
 					showSiteUpdatedMessage = true;
 				}
 			}
@@ -213,19 +216,30 @@ export const saveDirtyEntities =
 					registry
 						.dispatch( noticesStore )
 						.createErrorNotice( __( 'Saving failed.' ) );
-				} else if ( showSiteUpdatedMessage ) {
-					registry
-						.dispatch( noticesStore )
-						.createSuccessNotice( __( 'Site updated.' ), {
-							type: 'snackbar',
-							id: saveNoticeId,
-							actions: [
-								{
-									label: __( 'View site' ),
-									url: homeUrl,
-								},
-							],
-						} );
+				} else {
+					if ( showSiteUpdatedMessage ) {
+						registry
+							.dispatch( noticesStore )
+							.createSuccessNotice( __( 'Site updated.' ), {
+								type: 'snackbar',
+								id: saveNoticeId,
+								actions: [
+									{
+										label: __( 'View site' ),
+										url: homeUrl,
+									},
+								],
+							} );
+					}
+
+					if ( showPostUpdatedMessage ) {
+						registry
+							.dispatch( noticesStore )
+							.createSuccessNotice( __( 'Post updated.' ), {
+								type: 'snackbar',
+								id: saveNoticeId,
+							} );
+					}
 				}
 			} )
 			.catch( ( error ) =>

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -153,9 +153,11 @@ export const saveDirtyEntities =
 		close?.( entitiesToSave );
 		const siteItemsToSave = [];
 		const pendingSavedRecords = [];
+		let showSiteUpdatedMessage = false;
 		entitiesToSave.forEach( ( { kind, name, key, property } ) => {
 			if ( 'root' === kind && 'site' === name ) {
 				siteItemsToSave.push( property );
+				showSiteUpdatedMessage = true;
 			} else {
 				if (
 					PUBLISH_ON_SAVE_ENTITIES.some(
@@ -176,6 +178,13 @@ export const saveDirtyEntities =
 						.dispatch( coreStore )
 						.saveEditedEntityRecord( kind, name, key )
 				);
+
+				// This flag allows us to avoid showing the 'site updated' message
+				// in scenarios related to entity changes when the message shouldn't be
+				// triggered, like when modifying post meta via block bindings.
+				if ( kind !== 'postType' ) {
+					showSiteUpdatedMessage = true;
+				}
 			}
 		} );
 		if ( siteItemsToSave.length ) {
@@ -204,7 +213,7 @@ export const saveDirtyEntities =
 					registry
 						.dispatch( noticesStore )
 						.createErrorNotice( __( 'Saving failed.' ) );
-				} else {
+				} else if ( showSiteUpdatedMessage ) {
 					registry
 						.dispatch( noticesStore )
 						.createSuccessNotice( __( 'Site updated.' ), {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Currently, the block editor erroneously shows a `Site Updated` notification when modifying a block connected to post metadata via block bindings as reported in https://github.com/WordPress/gutenberg/issues/62236. This PR fixes that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We don't want to show users misleading or incorrect information.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It introduces a check to see if the current entity changes are of the kind `postType`, and it only displays the `Site Updated` message if they are not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
<details>
<summary>1. Register post meta by adding this snippet to your theme's functions.php</summary>

```php
add_action( 'init', 'test_block_bindings' );

function test_block_bindings() {
	register_meta(
		'post',
		'text_field',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'default'           => 'default text value',
		)
	);
}
```

</details>


<details>

<summary>2. In the post editor, add a paragraph block bound to the custom field using the Code Editor</summary>

```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field"}}}}} -->
<p>Paragraph content</p>
<!-- /wp:paragraph -->
```

</details>
 
3. Press the Save button.
4. See that the `Site Updated` message _does not_ appear, as expected.

Please also test other scenarios in the site editor to ensure the `Site Updated` message continues to show as normal when expected.


<!-- ### Testing Instructions for Keyboard How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

 ## Screenshots or screencast

### Before

<img width="1238" alt="site-updated-bug" src="https://github.com/WordPress/gutenberg/assets/5360536/2aac3dce-23df-4a6e-817c-f95d45cd15e2">

### After

<img width="968" alt="Screenshot 2024-07-07 at 6 42 55 PM" src="https://github.com/WordPress/gutenberg/assets/5360536/e52d1d69-4826-44d0-8e95-5a0342837546">
