### PR TITLE
Quality: Remove postcss-local-keyframes from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,8 +80,7 @@
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/widgets": "file:packages/widgets",
 				"@wordpress/wordcount": "file:packages/wordcount",
-				"es-module-shims": "^1.8.2",
-				"postcss-local-keyframes": "^0.0.2"
+				"es-module-shims": "^1.8.2"
 			},
 			"devDependencies": {
 				"@actions/core": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
 		"@wordpress/warning": "file:packages/warning",
 		"@wordpress/widgets": "file:packages/widgets",
 		"@wordpress/wordcount": "file:packages/wordcount",
-		"es-module-shims": "^1.8.2",
-		"postcss-local-keyframes": "^0.0.2"
+		"es-module-shims": "^1.8.2"
 	},
 	"devDependencies": {
 		"@actions/core": "1.9.1",


### PR DESCRIPTION
Related to #62673

## What?

I found out that `postcss-local-keyframes` exists in both `dependencies` and `devDependencies`, so I deleted the one that exists in `dependencies`.


## How?

- Manually delete `postcss-local-keyframes` entry that exists in `dependencies` group
- Run `npm install`

## Testing Instructions

All CIs should pass.