### PR TITLE
Global styles: tweak block background position preview height

### DIFF
--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -195,6 +195,8 @@
 	.components-focal-point-picker-wrapper {
 		background-color: $gray-100;
 		width: 100%;
+		border-radius: $radius-block-ui;
+		border: $border-width solid $gray-300;
 	}
 	.components-focal-point-picker__media--image {
 		max-height: 180px;

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -192,8 +192,12 @@
 	.components-toggle-control {
 		margin-bottom: 0;
 	}
+	.components-focal-point-picker-wrapper {
+		background-color: $gray-100;
+		width: 100%;
+	}
 	.components-focal-point-picker__media--image {
-		max-height: clamp(120px, 9vh, 280px);
+		max-height: 180px;
 	}
 }
 


### PR DESCRIPTION



## What? How?
This PR adds a gray background for the focal picker image preview, with a max-height of 180px.

Props to @jasmussen 

See: https://github.com/WordPress/gutenberg/pull/60100#issuecomment-2210377368

## Why?
Trying to come up with a compromise in relation to varying image dimensions. 



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Desktop screens

<img width="592" alt="Screenshot 2024-07-08 at 1 52 08 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/81110e8e-1e59-4b08-aec9-5dec5ff31c38">


https://github.com/WordPress/gutenberg/assets/6458278/bc25fc72-4c0e-450c-8919-a0cf68fed85d

| Narrow image | Wide image |
|--------|--------|
| <img width="279" alt="Screenshot 2024-07-08 at 1 58 16 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/02413907-45b6-4bb0-88b5-68006ed3b95e"> | <img width="264" alt="Screenshot 2024-07-08 at 1 57 26 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/bb05586f-e5c0-41cf-87c4-6d290ce17559"> | 




### Mobile screens

<img width="445" alt="Screenshot 2024-07-08 at 1 53 31 PM" src="https://github.com/WordPress/gutenberg/assets/6458278/9f3e0fd8-6670-4b4c-a95d-b3644cf94536">

https://github.com/WordPress/gutenberg/assets/6458278/f5708c58-4412-4eaa-b156-5b4f947f790d



