### PR TITLE
Patterns: check for edited entity content property when exporting

### DIFF
--- a/packages/editor/src/dataviews/actions/export-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/export-pattern.tsx
@@ -22,7 +22,7 @@ function getJsonFromItem( item: Pattern ) {
 		{
 			__file: item.type,
 			title: getItemTitle( item ),
-			content: item.content.raw,
+			content: item.content?.raw || item.content,
 			syncStatus: item.wp_pattern_sync_status,
 		},
 		null,

--- a/packages/editor/src/dataviews/actions/export-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/export-pattern.tsx
@@ -22,7 +22,10 @@ function getJsonFromItem( item: Pattern ) {
 		{
 			__file: item.type,
 			title: getItemTitle( item ),
-			content: item.content?.raw || item.content,
+			content:
+				typeof item.content === 'string'
+					? item.content
+					: item.content?.raw,
 			syncStatus: item.wp_pattern_sync_status,
 		},
 		null,

--- a/packages/editor/src/dataviews/types.ts
+++ b/packages/editor/src/dataviews/types.ts
@@ -23,9 +23,7 @@ export interface TemplateOrTemplatePart extends BasePost {
 export interface Pattern extends BasePost {
 	slug: string;
 	title: { raw: string };
-	content: {
-		raw: string;
-	};
+	content: { raw: string } | string;
 	wp_pattern_sync_status: string;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How?

(Maybe) fixes https://github.com/WordPress/gutenberg/issues/63217

Ensures that content is exported when exporting custom patterns from the editor pattern side bar.

Check for `item.content.raw` and `item.content` when exporting item JSON, e.g., for a custom pattern.

This bug was reported in WordPress slack by @jeflopodev. Thank you!

## Why?

The "item" passed to [getJsonFromItem](https://github.com/WordPress/gutenberg/blob/6d3282e0ba3fb56bb4e55cb797eb5f0d5dae8795/packages/editor/src/dataviews/actions/export-pattern.tsx#L20-L20) is fetched using [getEditedEntityRecord](https://github.com/WordPress/gutenberg/blob/6d3282e0ba3fb56bb4e55cb797eb5f0d5dae8795/packages/editor/src/components/post-actions/index.js#L37-L37).

`getEditedEntityRecord` calls [getRawEntityRecord](https://github.com/WordPress/gutenberg/blob/6d3282e0ba3fb56bb4e55cb797eb5f0d5dae8795/packages/core-data/src/selectors.ts#L442-L442). 

`getRawEntityRecord` maps properties to their raw values, so `content.raw` will be mapped to `content`.

Because an item can either be an entity record fetched via `getEntityRecord` or `getEditedEntityRecord`, I think we should support both formats.

## Testing Instructions

1. Head over to the site editor and duplicate a theme pattern to create a "custom pattern". Or you can create your own in the editor if you wish!
2. Edit the custom pattern.
3. In the pattern sidebar, click on the actions ellipsis menu and export your pattern as JSON.
4. Check that the JSON contains your pattern's content.
5. Also check that exporting patterns from the patterns library (for theme and custom patterns) works as expected.

Example:

```json
{
  "__file": "wp_block",
  "title": "Test Custom Pattern",
  "content": "<!-- wp:paragraph -->\n<p>A synced pattern</p>\n<!-- /wp:paragraph -->",
  "syncStatus": ""
}
```



https://github.com/WordPress/gutenberg/assets/6458278/597bf3a1-58ab-4744-b54f-aedfa882c700




