### PR TITLE
Fix: Restrict export pattern action to user patterns

### DIFF
--- a/packages/editor/src/dataviews/actions/export-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/export-pattern.tsx
@@ -34,9 +34,7 @@ const exportPattern: Action< Pattern > = {
 	id: 'export-pattern',
 	label: __( 'Export as JSON' ),
 	supportsBulk: true,
-	isEligible: ( item ) => {
-		return item.type === 'wp_block';
-	},
+	isEligible: ( item ) => item.type === 'wp_block',
 	callback: async ( items ) => {
 		if ( items.length === 1 ) {
 			return downloadBlob(

--- a/packages/editor/src/dataviews/actions/export-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/export-pattern.tsx
@@ -34,6 +34,9 @@ const exportPattern: Action< Pattern > = {
 	id: 'export-pattern',
 	label: __( 'Export as JSON' ),
 	supportsBulk: true,
+	isEligible: ( item ) => {
+		return item.type === 'wp_block';
+	},
 	callback: async ( items ) => {
 		if ( items.length === 1 ) {
 			return downloadBlob(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
According to this issue: https://github.com/WordPress/gutenberg/issues/61787 the `export pattern` action is not meant to be for theme patterns. With a recent refactoring of that action this regressed and we ended up with showing this action in theme patterns, which also caused other issues of not exporting properly(#63217). 

I think the solution is to add back the check about the `wp_block` (theme patterns have `type===pattern`). This makes it a bit confusing though with our API for registering actions, which right now is `registerEntityAction( 'postType', 'wp_block', exportPattern );`.

We should look into the `type===pattern` and where/why is needed.. 

## Testing Instructions
1. Exporting/importing patterns should work properly in patterns list (there is [an open issue](https://github.com/WordPress/gutenberg/issues/63217) for the post summary actions)
2. Export action should not be available for theme patterns

