### PR TITLE
CustomSelectControlV2: collapse checkmark space when unchecked

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   `CustomSelectControlV2`: keep legacy arrow down behavior only for legacy wrapper. ([#62919](https://github.com/WordPress/gutenberg/pull/62919))
 -   `CustomSelectControlV2`: fix trigger button font size. ([#63131](https://github.com/WordPress/gutenberg/pull/63131))
 -   `CustomSelectControlV2`: fix labelling with a visually hidden label. ([#63137](https://github.com/WordPress/gutenberg/pull/63137))
+-   `CustomSelectControlV2`: allow checkmark wrapper to collapse when not shown. ([#63229](https://github.com/WordPress/gutenberg/pull/63229))
 -   Extract `TimeInput` component from `TimePicker` ([#60613](https://github.com/WordPress/gutenberg/pull/60613)).
 -   `TimeInput`: Add `label` prop ([#63106](https://github.com/WordPress/gutenberg/pull/63106)).
 -   Method style type signatures have been changed to function style ([#62718](https://github.com/WordPress/gutenberg/pull/62718)).

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -150,13 +150,6 @@ export const SelectItem = styled( Ariakit.SelectItem )(
 	`
 );
 
-export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
-	display: flex;
-	align-items: center;
-	margin-inline-start: ${ space( 2 ) };
-	font-size: 24px; // Size of checkmark icon
-`;
-
 const truncateStyles = css`
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -187,4 +180,19 @@ export const WithHintItemHint = styled.span`
 	line-height: ${ CONFIG.fontLineHeightBase };
 	padding-inline-end: ${ space( 1 ) };
 	margin-block: ${ space( 1 ) };
+`;
+
+export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
+	display: flex;
+	align-items: center;
+	margin-inline-start: ${ space( 2 ) };
+
+	// Since the checkmark's dimensions are applied with 'em' units, setting a
+	// font size of 0 allows the space reserved for the checkmark to collapse for
+	// items that are not selected or that don't have an associated item hint.
+	font-size: 0;
+	${ WithHintItemWrapper } ~ &,
+	&:not(:empty) {
+		font-size: 24px; // Size of checkmark icon
+	}
 `;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Extracted from #63179

Allow checkmark wrapper to collapse when not shown

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

So that the item's content can go full width in most scenarios, like it does already in the legacy V1 implementation

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By setting the `font-size` to `0` when necessary.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In Storybook, visit the `CustomSelectControlV2` legacy "with long labels" example
- Open the select popover, and resize the page until the text needs to wrap on two or more lines.
- Notice how the text goes all the way to the end of the popover (since the checkmark is collapsed)
- Select that item, and notice how the checkmark appears, causing the text to take less space
- Make sure this is the same behavior of V1
- Visit the "With Hints" example, and make sure that the checkmark wrapper never collapses, even for items that are not checked

## Screenshots or screencast <!-- if applicable -->

| Legacy V1 | V2 adapter - before (trunk) | V2 adapted - after (this PR) |
|---|---|---|
| ![Screenshot 2024-07-08 at 10 16 03](https://github.com/WordPress/gutenberg/assets/1083581/0f435c2a-0bde-4135-af25-b71b159daaf4) | ![Screenshot 2024-07-08 at 10 15 39](https://github.com/WordPress/gutenberg/assets/1083581/78cc9874-bd5e-4492-bc62-e443716c9c83) | ![Screenshot 2024-07-08 at 10 19 59](https://github.com/WordPress/gutenberg/assets/1083581/6629f1e6-017e-499d-a9d3-2ee3edcb91a8) |
| ![Screenshot 2024-07-08 at 10 16 13](https://github.com/WordPress/gutenberg/assets/1083581/a567eb42-4d34-4b42-92cd-0cca543fc9e3) | ![Screenshot 2024-07-08 at 10 15 28](https://github.com/WordPress/gutenberg/assets/1083581/8014a59f-54c3-4bc0-9bc8-714a8fa83f8c) | ![Screenshot 2024-07-08 at 10 20 15](https://github.com/WordPress/gutenberg/assets/1083581/97b8be46-4fd7-4919-b60f-eda3655bf708) |
