### PR TITLE
CustomSelectControlV2: keep item checkmark top aligned

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -34,6 +34,7 @@
 -   `CustomSelectControlV2`: fix trigger text alignment in RTL languages ([#62869](https://github.com/WordPress/gutenberg/pull/62869)).
 -   `CustomSelectControlV2`: allow wrapping item hint to new line ([#62848](https://github.com/WordPress/gutenberg/pull/62848)).
 -   `CustomSelectControlV2`: fix select popover content overflow. ([#62844](https://github.com/WordPress/gutenberg/pull/62844))
+-   `CustomSelectControlV2`: keep item checkmark top aligned. ([#63230](https://github.com/WordPress/gutenberg/pull/63230))
 -   `CustomSelectControlV2`: keep legacy arrow down behavior only for legacy wrapper. ([#62919](https://github.com/WordPress/gutenberg/pull/62919))
 -   `CustomSelectControlV2`: fix trigger button font size. ([#63131](https://github.com/WordPress/gutenberg/pull/63131))
 -   `CustomSelectControlV2`: fix labelling with a visually hidden label. ([#63137](https://github.com/WordPress/gutenberg/pull/63137))

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -187,6 +187,12 @@ export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
 	align-items: center;
 	margin-inline-start: ${ space( 2 ) };
 
+	// Keep the checkmark vertically aligned at the top. Since the item text has a
+	// 28px line height and the checkmark is 24px tall, a (28-24)/2 = 2px margin
+	// is applied to keep the correct alignment between the text and the checkmark.
+	align-self: start;
+	margin-block-start: 2px;
+
 	// Since the checkmark's dimensions are applied with 'em' units, setting a
 	// font size of 0 allows the space reserved for the checkmark to collapse for
 	// items that are not selected or that don't have an associated item hint.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023
Extracted from #63139 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Design feedback

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By using flexbox's alignment options + adding a small margin to preserve the correct vertical alignment with the first line of item text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Apply the following diff

```diff
diff --git a/packages/components/src/custom-select-control/stories/index.story.tsx b/packages/components/src/custom-select-control/stories/index.story.tsx
index 8ff9a023c5..9ebf38ab3d 100644
--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -111,7 +111,8 @@ WithHints.args = {
 		{
 			key: 'medium',
 			name: 'Medium',
-			__experimentalHint: '250x250',
+			__experimentalHint:
+				'A very long hint just to test the checkmark alignment (250x250)',
 		},
 		{
 			key: 'large',

```

2. Open the `CustomSelectControlV2` Legacy "With Hints" example
3. Select the "Medium" item
4. Open the select popover, make sure that the checkmark is correctly top aligned
5. Select other items on this and other examples, make sure that the checkmark is center aligned with the item text when the option item fits on one row

## Screenshots or screencast <!-- if applicable -->


| Scenario | Before (trunk) | After (this PR) |
|---|---|---|
| Selected item on one line | ![Screenshot 2024-07-08 at 10 40 17](https://github.com/WordPress/gutenberg/assets/1083581/439fdffa-188e-455f-b514-13f6d296686b) | ![Screenshot 2024-07-08 at 10 43 28](https://github.com/WordPress/gutenberg/assets/1083581/0ca8b3f2-2783-4382-a4ec-cb62ccffc935) |
| Selected item on multiple lines | ![Screenshot 2024-07-08 at 12 51 26](https://github.com/WordPress/gutenberg/assets/1083581/ad07ae27-46b8-495b-b32d-daacc1cd608d) | ![Screenshot 2024-07-08 at 10 40 22](https://github.com/WordPress/gutenberg/assets/1083581/782f2e5d-e4f2-4840-b7bc-18dad39c736b) |

