### PR TITLE
Fix: block selection mode in block lists with disabled blocks

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -138,12 +138,6 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 
 		const selectedBlockClientId = getSelectedBlockClientId();
 		const selectionEndClientId = getMultiSelectedBlocksEndClientId();
-		const selectionBeforeEndClientId = getPreviousBlockClientId(
-			selectionEndClientId || selectedBlockClientId
-		);
-		const selectionAfterEndClientId = getNextBlockClientId(
-			selectionEndClientId || selectedBlockClientId
-		);
 
 		const navigateUp = ( isTab && isShift ) || isUp;
 		const navigateDown = ( isTab && ! isShift ) || isDown;
@@ -154,9 +148,13 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 
 		let focusedBlockUid;
 		if ( navigateUp ) {
-			focusedBlockUid = selectionBeforeEndClientId;
+			focusedBlockUid = getPreviousBlockClientId(
+				selectionEndClientId || selectedBlockClientId
+			);
 		} else if ( navigateDown ) {
-			focusedBlockUid = selectionAfterEndClientId;
+			focusedBlockUid = getNextBlockClientId(
+				selectionEndClientId || selectedBlockClientId
+			);
 		} else if ( navigateOut ) {
 			focusedBlockUid =
 				getBlockRootClientId( selectedBlockClientId ) ??

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -235,6 +235,10 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 			if ( focusedBlockUid ) {
 				event.preventDefault();
 				selectBlock( focusedBlockUid );
+			} else if ( ! isTab ) {
+				// Prevent screenreaders from moving beyond the bounds of
+				// the block list when using arrow key navigation.
+				event.preventDefault();
 			} else if ( isTab && selectedBlockClientId ) {
 				let nextTabbable;
 

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -100,7 +100,6 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 			const {
 				getBlock,
 				hasBlockMovingClientId,
-				getBlockListSettings,
 				__unstableGetEditorMode,
 				getNextBlockClientId,
 				getPreviousBlockClientId,
@@ -113,13 +112,10 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 				select( blocksStore );
 			const { name, attributes } = getBlock( clientId );
 			const blockType = getBlockType( name );
-			const orientation =
-				getBlockListSettings( rootClientId )?.orientation;
 			const match = getActiveBlockVariation( name, attributes );
 
 			return {
 				blockType,
-				orientation,
 				attributes,
 				blockMovingMode: hasBlockMovingClientId(),
 				editorMode: __unstableGetEditorMode(),
@@ -135,30 +131,51 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 	const {
 		blockType,
 		attributes,
-		orientation,
 		icon,
 		blockMovingMode,
 		editorMode,
 		canMove,
 		enabledClientIdsTree,
 	} = selected;
-	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
+	const {
+		setNavigationMode,
+		removeBlock,
+		selectBlock,
+		clearSelectedBlock,
+		setBlockMovingClientId,
+		moveBlockToPosition,
+	} = useDispatch( blockEditorStore );
+
+	const {
+		hasBlockMovingClientId,
+		getBlockIndex,
+		getBlockRootClientId,
+		getSelectedBlockClientId,
+		getBlockListSettings,
+	} = useSelect( blockEditorStore );
 
 	const { parent, firstChild, previous, next, blockIndex } = useMemo(
 		() => findBlockNeighbors( enabledClientIdsTree, clientId ),
 		[ enabledClientIdsTree, clientId ]
 	);
 
-	const label = useMemo(
-		() =>
-			getAccessibleBlockLabel(
-				blockType,
-				attributes,
-				blockIndex,
-				orientation
-			),
-		[ attributes, blockIndex, blockType, orientation ]
-	);
+	const label = useMemo( () => {
+		const orientation = getBlockListSettings(
+			parent?.clientId ?? ''
+		)?.orientation;
+		return getAccessibleBlockLabel(
+			blockType,
+			attributes,
+			blockIndex,
+			orientation
+		);
+	}, [
+		attributes,
+		blockIndex,
+		blockType,
+		getBlockListSettings,
+		parent?.clientId,
+	] );
 
 	// Focus the block selection button in navigation mode.
 	// Only one block selection button renders at a time (for the individual selected block),
@@ -177,19 +194,6 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 		}
 	}, [ clientId, editorMode, label, ref ] );
 	const blockElement = useBlockElement( clientId );
-
-	const {
-		hasBlockMovingClientId,
-		getBlockIndex,
-		getBlockRootClientId,
-		getSelectedBlockClientId,
-	} = useSelect( blockEditorStore );
-	const {
-		selectBlock,
-		clearSelectedBlock,
-		setBlockMovingClientId,
-		moveBlockToPosition,
-	} = useDispatch( blockEditorStore );
 
 	function onKeyDown( event ) {
 		const { keyCode } = event;

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -162,7 +162,7 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 
 	// Focus the block selection button in navigation mode.
 	// Only one block selection button renders at a time (for the individual selected block),
-	// so the instance should be focused once on mount, and then never again.
+	// so the instance should only be focused on change of client id.
 	const focusedClientId = useRef();
 	useEffect( () => {
 		const canFocus =


### PR DESCRIPTION
## What?
Fixes #62935

For a few releases, the block editor has had the concept of blocks that cannot be edited or even selected via the block editing mode feature (`blockEditingMode === 'disabled').

Generally these blocks can only be edited by editing a different document (e.g. for example when editing a page, the blocks that are part of the template need to be edited by opening the template, they can't be edited from the page). The idea is that this simplifies editing, as users are only interacting with one document at a time.

There's a bug in trunk that the editor's select mode still allows selecting and editing blocks from other documents. They should be bypassed via select mode. This is confusing because the edits made are not something that can be saved.

## How?
Refactors select mode navigation to navigate the block hierarchy returned by `getEnabledClientIdsTree`. This existing memoized selector returns the same block hierarchy as shown by list view, and ignores disabled blocks.

This completely changes the way the navigation worked, so has required some refactoring. There were also some code quality issues in the file, so I've attempted to solve them, but it might be worth moving them into a separate PR to make the diff easier to understand.

### Testing Instructions for Keyboard
TBC - I'm thinking of a good way to explain how this can be tested 🤔 

## Screenshots or screencast <!-- if applicable -->
