### PR TITLE
Remove michalczaplinski as block-library/src/image owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /packages/block-library/src/comment-template    @michalczaplinski
 /packages/block-library/src/comments            @michalczaplinski
 /packages/block-library/src/table-of-contents   @ZebulanStanphill
-/packages/block-library/src/image               @artemiomorales @michalczaplinski
+/packages/block-library/src/image               @artemiomorales
 
 # Duotone
 /lib/block-supports/duotone.php


### PR DESCRIPTION
## What?


I remove myself from CODEOWNERS for the `Image` block for the time being. 


## Why?

I added myself originally due to having worked on the Image Lightbox feature. The vast majority of pings I receive are nowadays unrelated to that work.