### PR TITLE
Core Commands: fix Pages command link

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -315,7 +315,7 @@ function useSiteEditorBasicNavigationCommands() {
 				icon: page,
 				callback: ( { close } ) => {
 					const args = {
-						post_type: 'page',
+						postType: 'page',
 					};
 					const targetUrl = addQueryArgs( 'site-editor.php', args );
 					if ( isSiteEditor ) {


### PR DESCRIPTION
Related to #61741

## What?

I noticed that the core command "Pages" wasn't linking to the correct pages, so I fixed that.

## Why?

The parameter was changed [here](https://github.com/WordPress/gutenberg/pull/61741/files#diff-ebd9886af023e11457166051cbc482c19a82e428a3db1797da2e3ba8eb846afeR317), but it looks like a typo to me.

## Testing Instructions

- Launch the command palette in the site editor.
- Select "Pages"
- You should see the Page screen.
- It should work the same way when you run the command palette in the post editor.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/54422211/4118ebfa-382e-4362-be93-36d242b90b47

