### PR TITLE
DataViews: Support combined fields

### DIFF
--- a/packages/dataviews/src/layouts.ts
+++ b/packages/dataviews/src/layouts.ts
@@ -16,6 +16,7 @@ import ViewTable from './view-table';
 import ViewGrid from './view-grid';
 import ViewList from './view-list';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from './constants';
+import type { View } from './types';
 
 export const VIEW_LAYOUTS = [
 	{
@@ -37,3 +38,29 @@ export const VIEW_LAYOUTS = [
 		icon: isRTL() ? formatListBulletsRTL : formatListBullets,
 	},
 ];
+
+export function getMandatoryFields( view: View ): string[] {
+	if ( view.type === 'table' ) {
+		return [ view.layout?.primaryField ]
+			.concat(
+				view.layout?.combinedFields?.flatMap(
+					( field ) => field.children
+				) ?? []
+			)
+			.filter( ( item ): item is string => !! item );
+	}
+
+	if ( view.type === 'grid' ) {
+		return [ view.layout?.primaryField, view.layout?.mediaField ].filter(
+			( item ): item is string => !! item
+		);
+	}
+
+	if ( view.type === 'list' ) {
+		return [ view.layout?.primaryField, view.layout?.mediaField ].filter(
+			( item ): item is string => !! item
+		);
+	}
+
+	return [];
+}

--- a/packages/dataviews/src/stories/fixtures.js
+++ b/packages/dataviews/src/stories/fixtures.js
@@ -167,20 +167,17 @@ export const fields = [
 				<img src={ item.image } alt="" style={ { width: '100%' } } />
 			);
 		},
-		width: 50,
 		enableSorting: false,
 	},
 	{
 		header: 'Title',
 		id: 'title',
-		maxWidth: 400,
 		enableHiding: false,
 		enableGlobalSearch: true,
 	},
 	{
 		header: 'Type',
 		id: 'type',
-		maxWidth: 400,
 		enableHiding: false,
 		elements: [
 			{ value: 'Not a planet', label: 'Not a planet' },
@@ -197,7 +194,6 @@ export const fields = [
 	{
 		header: 'Description',
 		id: 'description',
-		maxWidth: 200,
 		enableSorting: false,
 		enableGlobalSearch: true,
 	},

--- a/packages/dataviews/src/stories/index.story.js
+++ b/packages/dataviews/src/stories/index.story.js
@@ -39,6 +39,20 @@ Default.args = {
 		[ LAYOUT_TABLE ]: {
 			layout: {
 				primaryField: 'title',
+				styles: {
+					image: {
+						width: 50,
+					},
+					title: {
+						maxWidth: 400,
+					},
+					type: {
+						maxWidth: 400,
+					},
+					description: {
+						maxWidth: 200,
+					},
+				},
 			},
 		},
 		[ LAYOUT_GRID ]: {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -211,6 +211,10 @@
 				}
 			}
 		}
+
+		.components-v-stack > .dataviews-view-table__cell-content-wrapper:not(:first-child) {
+			min-height: 0;
+		}
 	}
 	.dataviews-view-table-header-button {
 		padding: $grid-unit-05 $grid-unit-10;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -91,7 +91,7 @@
 		padding: $grid-unit-15;
 		white-space: nowrap;
 
-		&[data-field-id="actions"] {
+		&.dataviews-view-table__actions-column {
 			text-align: right;
 		}
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -280,11 +280,6 @@ export interface ViewTable extends ViewBase {
 		primaryField?: string;
 
 		/**
-		 * The field to use as the media field.
-		 */
-		mediaField?: string;
-
-		/**
 		 * The fields to use as columns.
 		 */
 		combinedFields?: CombinedField[];

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -76,21 +76,6 @@ export type Field< Item > = {
 	render?: ( args: { item: Item } ) => ReactNode;
 
 	/**
-	 * The width of the field column.
-	 */
-	width?: string | number;
-
-	/**
-	 * The minimum width of the field column.
-	 */
-	maxWidth?: string | number;
-
-	/**
-	 * The maximum width of the field column.
-	 */
-	minWidth?: string | number;
-
-	/**
 	 * Whether the field is sortable.
 	 */
 	enableSorting?: boolean;
@@ -270,6 +255,23 @@ export interface CombinedField {
 	direction: 'horizontal' | 'vertical';
 }
 
+export interface ColumnStyle {
+	/**
+	 * The width of the field column.
+	 */
+	width?: string | number;
+
+	/**
+	 * The minimum width of the field column.
+	 */
+	maxWidth?: string | number;
+
+	/**
+	 * The maximum width of the field column.
+	 */
+	minWidth?: string | number;
+}
+
 export interface ViewTable extends ViewBase {
 	type: 'table';
 
@@ -283,6 +285,11 @@ export interface ViewTable extends ViewBase {
 		 * The fields to use as columns.
 		 */
 		combinedFields?: CombinedField[];
+
+		/**
+		 * The styles for the columns.
+		 */
+		styles?: Record< string, ColumnStyle >;
 	};
 }
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -249,9 +249,25 @@ interface ViewBase {
 	perPage?: number;
 
 	/**
-	 * The hidden fields.
+	 * The fields to render
 	 */
 	fields?: string[];
+}
+
+export interface CombinedField {
+	id: string;
+
+	header: string;
+
+	/**
+	 * The fields to use as columns.
+	 */
+	children: string[];
+
+	/**
+	 * The direction of the stack.
+	 */
+	direction: 'horizontal' | 'vertical';
 }
 
 export interface ViewTable extends ViewBase {
@@ -267,6 +283,11 @@ export interface ViewTable extends ViewBase {
 		 * The field to use as the media field.
 		 */
 		mediaField?: string;
+
+		/**
+		 * The fields to use as columns.
+		 */
+		combinedFields?: CombinedField[];
 	};
 }
 

--- a/packages/dataviews/src/view-actions.tsx
+++ b/packages/dataviews/src/view-actions.tsx
@@ -20,7 +20,7 @@ import { cog } from '@wordpress/icons';
  */
 import { unlock } from './lock-unlock';
 import { SORTING_DIRECTIONS, sortLabels } from './constants';
-import { VIEW_LAYOUTS } from './layouts';
+import { VIEW_LAYOUTS, getMandatoryFields } from './layouts';
 import type { NormalizedField, View, SupportedLayouts } from './types';
 
 const {
@@ -147,10 +147,11 @@ function FieldsVisibilityMenu< Item >( {
 	onChangeView,
 	fields,
 }: FieldsVisibilityMenuProps< Item > ) {
+	const mandatoryFields = getMandatoryFields( view );
 	const hidableFields = fields.filter(
 		( field ) =>
 			field.enableHiding !== false &&
-			field.id !== view?.layout?.mediaField
+			! mandatoryFields.includes( field.id )
 	);
 	const viewFields = view.fields || fields.map( ( field ) => field.id );
 	if ( ! hidableFields?.length ) {

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -470,24 +470,23 @@ function TableRow< Item >( {
 					</div>
 				</td>
 			) }
-			{ columns.map( ( column ) => (
-				<td
-					key={ column }
-					/*style={ {
-						width: field.width || undefined,
-						minWidth: field.minWidth || undefined,
-						maxWidth: field.maxWidth || undefined,
-					} }*/
-				>
-					<TableColumn
-						primaryField={ primaryField }
-						fields={ fields }
-						item={ item }
-						column={ column }
-						view={ view }
-					/>
-				</td>
-			) ) }
+			{ columns.map( ( column: string ) => {
+				// Explicits picks the supported styles.
+				const { width, maxWidth, minWidth } =
+					view.layout?.styles?.[ column ] ?? {};
+
+				return (
+					<td key={ column } style={ { width, maxWidth, minWidth } }>
+						<TableColumn
+							primaryField={ primaryField }
+							fields={ fields }
+							item={ item }
+							column={ column }
+							view={ view }
+						/>
+					</td>
+				);
+			} ) }
 			{ !! actions?.length && (
 				// Disable reason: we are not making the element interactive,
 				// but preventing any click events from bubbling up to the
@@ -588,51 +587,52 @@ function ViewTable< Item >( {
 								/>
 							</th>
 						) }
-						{ columns.map( ( column, index ) => (
-							<th
-								key={ column }
-								/*style={ {
-									width: field.width || undefined,
-									minWidth: field.minWidth || undefined,
-									maxWidth: field.maxWidth || undefined,
-								} }*/
-								aria-sort={
-									view.sort?.field === column
-										? sortValues[ view.sort.direction ]
-										: undefined
-								}
-								scope="col"
-							>
-								<HeaderMenu
-									ref={ ( node ) => {
-										if ( node ) {
-											headerMenuRefs.current.set(
-												column,
-												{
-													node,
-													fallback:
-														columns[
-															index > 0
-																? index - 1
-																: 1
-														],
-												}
-											);
-										} else {
-											headerMenuRefs.current.delete(
-												column
-											);
-										}
-									} }
-									fieldId={ column }
-									view={ view }
-									fields={ fields }
-									onChangeView={ onChangeView }
-									onHide={ onHide }
-									setOpenedFilter={ setOpenedFilter }
-								/>
-							</th>
-						) ) }
+						{ columns.map( ( column, index ) => {
+							// Explicits picks the supported styles.
+							const { width, maxWidth, minWidth } =
+								view.layout?.styles?.[ column ] ?? {};
+							return (
+								<th
+									key={ column }
+									style={ { width, maxWidth, minWidth } }
+									aria-sort={
+										view.sort?.field === column
+											? sortValues[ view.sort.direction ]
+											: undefined
+									}
+									scope="col"
+								>
+									<HeaderMenu
+										ref={ ( node ) => {
+											if ( node ) {
+												headerMenuRefs.current.set(
+													column,
+													{
+														node,
+														fallback:
+															columns[
+																index > 0
+																	? index - 1
+																	: 1
+															],
+													}
+												);
+											} else {
+												headerMenuRefs.current.delete(
+													column
+												);
+											}
+										} }
+										fieldId={ column }
+										view={ view }
+										fields={ fields }
+										onChangeView={ onChangeView }
+										onHide={ onHide }
+										setOpenedFilter={ setOpenedFilter }
+									/>
+								</th>
+							);
+						} ) }
 						{ !! actions?.length && (
 							<th className="dataviews-view-table__actions-column">
 								<span className="dataviews-view-table-header">

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -360,17 +360,23 @@ function TableColumnField< Item >( {
 	item,
 	field,
 }: TableColumnFieldProps< Item > ) {
+	const value = field.render( {
+		item,
+	} );
 	return (
-		<div
-			className={ clsx( 'dataviews-view-table__cell-content-wrapper', {
-				'dataviews-view-table__primary-field':
-					primaryField?.id === field.id,
-			} ) }
-		>
-			{ field.render( {
-				item,
-			} ) }
-		</div>
+		!! value && (
+			<div
+				className={ clsx(
+					'dataviews-view-table__cell-content-wrapper',
+					{
+						'dataviews-view-table__primary-field':
+							primaryField?.id === field.id,
+					}
+				) }
+			>
+				{ value }
+			</div>
+		)
 	);
 }
 

--- a/packages/dataviews/src/view-table.tsx
+++ b/packages/dataviews/src/view-table.tsx
@@ -384,15 +384,14 @@ function TableColumnCombined< Item >( {
 	field,
 	...props
 }: TableColumnCombinedProps< Item > ) {
-	const Stack = field.direction === 'horizontal' ? HStack : VStack;
+	const children = field.children.map( ( child ) => (
+		<TableColumn key={ child } { ...props } column={ child } />
+	) );
 
-	return (
-		<Stack>
-			{ field.children.map( ( child ) => (
-				<TableColumn key={ child } { ...props } column={ child } />
-			) ) }
-		</Stack>
-	);
+	if ( field.direction === 'horizontal' ) {
+		return <HStack spacing={ 3 }>{ children }</HStack>;
+	}
+	return <VStack spacing={ 0 }>{ children }</VStack>;
 }
 
 function TableRow< Item >( {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -62,6 +62,14 @@ const defaultLayouts = {
 	[ LAYOUT_TABLE ]: {
 		layout: {
 			primaryField: 'title',
+			styles: {
+				preview: {
+					width: '1%',
+				},
+				author: {
+					width: '1%',
+				},
+			},
 		},
 	},
 	[ LAYOUT_GRID ]: {
@@ -282,7 +290,6 @@ export default function DataviewsPatterns() {
 					<Preview item={ item } viewType={ view.type } />
 				),
 				enableSorting: false,
-				width: '1%',
 			},
 			{
 				header: __( 'Title' ),
@@ -335,7 +342,6 @@ export default function DataviewsPatterns() {
 				filterBy: {
 					isPrimary: true,
 				},
-				width: '1%',
 			} );
 		}
 

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -62,6 +62,19 @@ const defaultLayouts = {
 					direction: 'vertical',
 				},
 			],
+			styles: {
+				template: {
+					maxWidth: 400,
+					minWidth: 320,
+				},
+				preview: {
+					minWidth: 120,
+					maxWidth: 120,
+				},
+				author: {
+					width: '1%',
+				},
+			},
 		},
 	},
 	[ LAYOUT_GRID ]: {
@@ -277,8 +290,6 @@ export default function PageTemplates() {
 				render: ( { item } ) => {
 					return <Preview item={ item } viewType={ view.type } />;
 				},
-				minWidth: 120,
-				maxWidth: 120,
 				enableSorting: false,
 			},
 			{
@@ -288,7 +299,6 @@ export default function PageTemplates() {
 				render: ( { item } ) => (
 					<Title item={ item } viewType={ view.type } />
 				),
-				maxWidth: 400,
 				enableHiding: false,
 				enableGlobalSearch: true,
 			},
@@ -304,8 +314,6 @@ export default function PageTemplates() {
 						)
 					);
 				},
-				maxWidth: 400,
-				minWidth: 320,
 				enableSorting: false,
 				enableGlobalSearch: true,
 			},
@@ -317,7 +325,6 @@ export default function PageTemplates() {
 					return <AuthorField viewType={ view.type } item={ item } />;
 				},
 				elements: authors,
-				width: '1%',
 			},
 		],
 		[ authors, view.type ]

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -56,11 +56,21 @@ const EMPTY_ARRAY = [];
 
 const defaultLayouts = {
 	[ LAYOUT_TABLE ]: {
+		fields: [ 'template', 'author' ],
 		layout: {
 			primaryField: 'title',
+			combinedFields: [
+				{
+					id: 'template',
+					header: __( 'Template' ),
+					children: [ 'title', 'description' ],
+					direction: 'vertical',
+				},
+			],
 		},
 	},
 	[ LAYOUT_GRID ]: {
+		fields: [ 'title', 'description', 'author' ],
 		layout: {
 			mediaField: 'preview',
 			primaryField: 'title',
@@ -68,6 +78,7 @@ const defaultLayouts = {
 		},
 	},
 	[ LAYOUT_LIST ]: {
+		fields: [ 'title', 'description', 'author' ],
 		layout: {
 			primaryField: 'title',
 			mediaField: 'preview',
@@ -84,7 +95,7 @@ const DEFAULT_VIEW = {
 		field: 'title',
 		direction: 'asc',
 	},
-	fields: [ 'title', 'description', 'author' ],
+	fields: defaultLayouts[ LAYOUT_GRID ].fields,
 	layout: defaultLayouts[ LAYOUT_GRID ].layout,
 	filters: [],
 };
@@ -199,6 +210,7 @@ export default function PageTemplates() {
 			...DEFAULT_VIEW,
 			type: usedType,
 			layout: defaultLayouts[ usedType ].layout,
+			fields: defaultLayouts[ usedType ].fields,
 			filters:
 				activeView !== 'all'
 					? [

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -6,12 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	Icon,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-	VisuallyHidden,
-} from '@wordpress/components';
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -301,20 +296,11 @@ export default function PageTemplates() {
 				header: __( 'Description' ),
 				id: 'description',
 				render: ( { item } ) => {
-					return item.description ? (
-						<span className="page-templates-description">
-							{ decodeEntities( item.description ) }
-						</span>
-					) : (
-						view.type === LAYOUT_TABLE && (
-							<>
-								<Text variant="muted" aria-hidden="true">
-									&#8212;
-								</Text>
-								<VisuallyHidden>
-									{ __( 'No description.' ) }
-								</VisuallyHidden>
-							</>
+					return (
+						item.description && (
+							<span className="page-templates-description">
+								{ decodeEntities( item.description ) }
+							</span>
 						)
 					);
 				},

--- a/packages/edit-site/src/components/posts-app/posts-list.js
+++ b/packages/edit-site/src/components/posts-app/posts-list.js
@@ -62,6 +62,24 @@ import { usePrevious } from '@wordpress/compose';
 const { usePostActions } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 const EMPTY_ARRAY = [];
+const defaultLayouts = {
+	[ LAYOUT_TABLE ]: {
+		layout: {
+			'featured-image': {
+				width: '1%',
+			},
+			title: {
+				maxWidth: 300,
+			},
+		},
+	},
+	[ LAYOUT_GRID ]: {
+		layout: {},
+	},
+	[ LAYOUT_LIST ]: {
+		layout: {},
+	},
+};
 
 const getFormattedDate = ( dateToDisplay ) =>
 	dateI18n(
@@ -405,7 +423,6 @@ export default function PostsList( { postType } ) {
 					<FeaturedImage item={ item } viewType={ view.type } />
 				),
 				enableSorting: false,
-				width: '1%',
 			},
 			{
 				header: __( 'Title' ),
@@ -459,7 +476,6 @@ export default function PostsList( { postType } ) {
 						</HStack>
 					);
 				},
-				maxWidth: 300,
 				enableHiding: false,
 			},
 			{
@@ -645,6 +661,7 @@ export default function PostsList( { postType } ) {
 				setSelection={ setSelection }
 				onSelectionChange={ onSelectionChange }
 				getItemId={ getItemId }
+				defaultLayouts={ defaultLayouts }
 			/>
 		</Page>
 	);

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -89,11 +89,11 @@ test.describe( 'Templates', () => {
 		await page.getByRole( 'button', { name: 'Layout' } ).click();
 		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
 
-		await page.getByRole( 'button', { name: 'Description' } ).click();
+		await page.getByRole( 'button', { name: 'Author' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Hide' } ).click();
 
 		await expect(
-			page.getByRole( 'button', { name: 'Description' } )
+			page.getByRole( 'button', { name: 'Author' } )
 		).toBeHidden();
 	} );
 } );


### PR DESCRIPTION
Related to #55083 
Follow-up to #63127 

## What?

This PR implements combining fields in table views. It allows combining one or more fields horizontally or vertically in table views. To do so, you have to define a "combinedField" in `view.layout.combinedFields` For instance:

```
{
	id: 'template',
	header: __( 'Template' ),
	children: [ 'title', 'description' ],
	direction: 'vertical',
}
```

and then you can update the `fields` property to include the `template` field. 

This doesn't work entirely well in the fields visibility menu.

I was considering an alternative approach that was way bigger (See #63148) but now I'm thinking the refactoring is not worth doing yet as there's still a lot of unknowns. So this PR implements the combination with the minimal changes.

**Testing instructions**

 - You can check the "table" layout in the templates dataviews.