### PR TITLE
Block Bindings: Disable post meta editing in blocks inside a Query Loop

### DIFF
--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -34,6 +34,11 @@ export default {
 			} );
 	},
 	canUserEditValue( { select, context, args } ) {
+		// Lock editing in query loop.
+		if ( context?.query || context?.queryId ) {
+			return false;
+		}
+
 		const postType =
 			context?.postType || select( editorStore ).getCurrentPostType();
 


### PR DESCRIPTION
## What?
Right now, when you connect a paragraph (or other block) to "Post Meta", it is possible to edit it even when it is inside a query loop block. This pull requests locks the editing in that context.

## Why?
It was first reported in [this Twitter thread](https://twitter.com/briancoords/status/1808546178054902061) and, after checking how Post Title or Post Featured Image work, it seems they aren't editable either.

## How?
Check that the context provided by the query loop is available.

## Testing Instructions
1. Add a query loop in a page.
2. Add a paragraph in the Post Template and connect it to a custom field with something like this:
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"my_custom_field"}}}}} -->
<p>Default</p>
<!-- /wp:paragraph -->
```
3. Ensure the custom field has been registered and it has values for the different posts.
4. Check that the field is not editable inside the query loop. Before, it should be editable.