### PR TITLE
Fix Global styles panel header buttons text overlap for 'Show button text labels'

### DIFF
--- a/packages/edit-site/src/components/global-styles-sidebar/index.js
+++ b/packages/edit-site/src/components/global-styles-sidebar/index.js
@@ -137,6 +137,7 @@ export default function GlobalStylesSidebar() {
 					</FlexItem>
 					<Flex
 						justify="flex-end"
+						gap={ 1 }
 						className="edit-site-global-styles-sidebar__header-actions"
 					>
 						<FlexItem>

--- a/packages/edit-site/src/components/global-styles-sidebar/index.js
+++ b/packages/edit-site/src/components/global-styles-sidebar/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { FlexItem, FlexBlock, Flex, Button } from '@wordpress/components';
+import { FlexItem, Flex, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { styles, seen, backup } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -130,38 +130,45 @@ export default function GlobalStylesSidebar() {
 					className="edit-site-global-styles-sidebar__header"
 					gap={ 1 }
 				>
-					<FlexBlock style={ { minWidth: 'min-content' } }>
+					<FlexItem>
 						<h2 className="edit-site-global-styles-sidebar__header-title">
 							{ __( 'Styles' ) }
 						</h2>
-					</FlexBlock>
-					<FlexItem>
-						<Button
-							icon={ seen }
-							label={ __( 'Style Book' ) }
-							isPressed={
-								isStyleBookOpened || isRevisionsStyleBookOpened
-							}
-							accessibleWhenDisabled
-							disabled={ shouldClearCanvasContainerView }
-							onClick={ toggleStyleBook }
-							size="compact"
-						/>
 					</FlexItem>
-					<FlexItem>
-						<Button
-							label={ __( 'Revisions' ) }
-							icon={ backup }
-							onClick={ toggleRevisions }
-							accessibleWhenDisabled
-							disabled={ ! hasRevisions }
-							isPressed={
-								isRevisionsOpened || isRevisionsStyleBookOpened
-							}
-							size="compact"
-						/>
-					</FlexItem>
-					<GlobalStylesMenuSlot />
+					<Flex
+						justify="flex-end"
+						className="edit-site-global-styles-sidebar__header-actions"
+					>
+						<FlexItem>
+							<Button
+								icon={ seen }
+								label={ __( 'Style Book' ) }
+								isPressed={
+									isStyleBookOpened ||
+									isRevisionsStyleBookOpened
+								}
+								accessibleWhenDisabled
+								disabled={ shouldClearCanvasContainerView }
+								onClick={ toggleStyleBook }
+								size="compact"
+							/>
+						</FlexItem>
+						<FlexItem>
+							<Button
+								label={ __( 'Revisions' ) }
+								icon={ backup }
+								onClick={ toggleRevisions }
+								accessibleWhenDisabled
+								disabled={ ! hasRevisions }
+								isPressed={
+									isRevisionsOpened ||
+									isRevisionsStyleBookOpened
+								}
+								size="compact"
+							/>
+						</FlexItem>
+						<GlobalStylesMenuSlot />
+					</Flex>
 				</Flex>
 			}
 		>

--- a/packages/edit-site/src/components/global-styles-sidebar/style.scss
+++ b/packages/edit-site/src/components/global-styles-sidebar/style.scss
@@ -31,6 +31,10 @@
 	margin: 0;
 }
 
+.edit-site-global-styles-sidebar .edit-site-global-styles-sidebar__header-actions {
+	flex: 1;
+}
+
 .edit-site-global-styles-sidebar .components-navigation__menu-title-heading {
 	font-size: $default-font-size * 1.2;
 	font-weight: 500;

--- a/packages/edit-site/src/components/global-styles-sidebar/style.scss
+++ b/packages/edit-site/src/components/global-styles-sidebar/style.scss
@@ -75,6 +75,8 @@
 .show-icon-labels {
 	.edit-site-global-styles-sidebar__header {
 		.components-button.has-icon {
+			width: auto;
+
 			// Hide the button icons when labels are set to display...
 			svg {
 				display: none;

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -26,11 +26,6 @@
 
 	.components-button.has-icon {
 		display: none;
-		margin-left: auto;
-
-		~ .components-button {
-			margin-left: 0;
-		}
 
 		@include break-medium() {
 			display: flex;

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -303,7 +303,7 @@ function ComplementaryArea( {
 					smallScreenTitle={ smallScreenTitle }
 					toggleButtonProps={ {
 						label: closeLabel,
-						size: 'compact',
+						size: 'small',
 						shortcut: toggleShortcut,
 						scope,
 						identifier,

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -303,7 +303,7 @@ function ComplementaryArea( {
 					smallScreenTitle={ smallScreenTitle }
 					toggleButtonProps={ {
 						label: closeLabel,
-						size: 'small',
+						size: 'compact',
 						shortcut: toggleShortcut,
 						scope,
 						identifier,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Temporary fix for https://github.com/WordPress/gutenberg/issues/61761

A more solid solution should be implemented by changing the design and not placing buttons in the panels header in the first place. This PR overrides the Button component CSS, which isn't ideal but it is worth noting the 'Show button text labels' feature itself overrides the base component CSS. An alternative solution is being explored in https://github.com/WordPress/gutenberg/issues/61763

Additionally, makes the size of the Close button consistent with the size of the other buttons.

## What?
<!-- In a few words, what is the PR actually doing? -->
The buttons text overlaps.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Overlapping text isn't readable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Makes the button width be `auto` when 'Show button text labels' is enabled.
Makes the Close button use the `compact` size so that it is consistent with the other buttons.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site Editor > Styles
- In Options > Preferences > Accessibility, enable the 'Show button text labels' preference.
- Alternatively, issue this command in your browser dev tools console: `window.wp.data.dispatch( 'core/preferences' ).set( 'core', 'showIconLabels', true )`
- Observe the text of the buttons in the Styles panel header don't overlap any longer.
- Test with the admin language set to languages that may provide longer strings e.g. German, Spanish, Italian.
- Disable 'Show button text labels' from the preferences modal or alternatively issue this command in the console: `window.wp.data.dispatch( 'core/preferences' ).set( 'core', 'showIconLabels', false )`
- Observe the size of the X close button is 32 by 32 pixels.
- Install a plugin that adds its own settings panel e.g. Yoast SEO.
- Go to the Post Editor.
- Open the Plugin sidbar from the Options dropdown menu.
- Observe the Plugin panel Close button size is 32 by 32 pixels.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Overlapping text - Before: English and italian

![Screenshot 2024-07-08 at 15 06 08](https://github.com/WordPress/gutenberg/assets/1682452/319035bd-3a2c-4086-9173-4b4c2ce81ee2)

After:

![english](https://github.com/WordPress/gutenberg/assets/1682452/71221851-965d-4b59-8c84-68aa11a31f7b)

Close button size before (all buttons focused to better illustrate):

![inconsistent size](https://github.com/WordPress/gutenberg/assets/1682452/89dde00a-d2f0-4b0e-85c3-6bbf5cf0760f)

After:

![Screenshot 2024-07-08 at 14 46 46](https://github.com/WordPress/gutenberg/assets/1682452/9c6c641c-850f-4048-b82f-dea56c29cea5)

