### PR TITLE
Try: Inspector inner shadow border fix.

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -132,7 +132,7 @@ html.interface-interface-skeleton__html-container {
 	right: 0;
 
 	@include break-medium() {
-		box-shadow: $border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+		box-shadow: $border-width 0 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 		outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 	}
 }

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -122,7 +122,7 @@ html.interface-interface-skeleton__html-container {
 	overflow: hidden;
 
 	@include break-medium() {
-		box-shadow: -$border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+		box-shadow: -$border-width 0 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 		outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 	}
 }


### PR DESCRIPTION
## What?

There's a double-border at the footer of the inspector:

![double border](https://github.com/WordPress/gutenberg/assets/1204802/4ca2079e-f4bc-4d11-98b1-f5a259360325)

Perhaps not double, but stacked, at least. This is related to changing some of the borders to be shadow based. This PR changes the direction of the shadow, so this stacked shadow disappears:

![single border](https://github.com/WordPress/gutenberg/assets/1204802/87612c8e-1737-4dc5-ad97-1d3d9c26e720)

**Note:** From reading the code, the 1px `y` position value seemed like it was intentionally added. So I'd love a good look at what side-effects zeroing that out might have. I couldn't find any, but I could be missing a beat.

## Testing Instructions

Test the site and post editors at various breakpoints, with and without the inspector. 