### PR TITLE
Duplicate modal: move to 40px components.

### DIFF
--- a/packages/dataviews/src/dataform.tsx
+++ b/packages/dataviews/src/dataform.tsx
@@ -51,6 +51,7 @@ function DataFormTextControl< Item >( {
 			placeholder={ placeholder }
 			value={ value }
 			onChange={ onChangeControl }
+			__next40pxDefaultSize
 		/>
 	);
 }

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -770,6 +770,7 @@ const useDuplicatePostAction = ( postType ) => {
 									<Button
 										variant="tertiary"
 										onClick={ closeModal }
+										__next40pxDefaultSize
 									>
 										{ __( 'Cancel' ) }
 									</Button>
@@ -778,6 +779,7 @@ const useDuplicatePostAction = ( postType ) => {
 										type="submit"
 										isBusy={ isCreatingPage }
 										aria-disabled={ isCreatingPage }
+										__next40pxDefaultSize
 									>
 										{ _x( 'Duplicate', 'action label' ) }
 									</Button>


### PR DESCRIPTION
## What?

Components should be 40px by default with 32 in some contexts (#46734). This PR makes progress on that for the Duplicate modal. Before, a mix of sizes in the duplicate modal:

![before](https://github.com/WordPress/gutenberg/assets/1204802/c60faf95-8996-4c23-a9d1-8d452240bdd4)

After: uniform 40px:

![after](https://github.com/WordPress/gutenberg/assets/1204802/aaafe455-cb9c-4775-84fc-1ad0cd4b3bd9)

## Testing Instructions

* Go to the site editor.
* Go to Pages. 
* Click the ellipsis on a page item, choose "Duplicate". 

Observe the input field and button heights in the modal.