### PR TITLE
CustomSelectControl V2 legacy adapter: stabilize experimental props

### DIFF
--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -126,7 +126,7 @@ function NonDefaultControls( { format, onChange } ) {
 		name: __( 'Custom' ),
 		className:
 			'block-editor-date-format-picker__custom-format-select-control__custom-option',
-		__experimentalHint: __( 'Enter your own date format' ),
+		hint: __( 'Enter your own date format' ),
 	};
 
 	const [ isCustom, setIsCustom ] = useState(

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -42,7 +42,7 @@ const STICKY_OPTION = {
 	key: 'sticky',
 	value: 'sticky',
 	name: _x( 'Sticky', 'Name for the value of the CSS position property' ),
-	__experimentalHint: __(
+	hint: __(
 		'The block will stick to the top of the window instead of scrolling.'
 	),
 };
@@ -51,9 +51,7 @@ const FIXED_OPTION = {
 	key: 'fixed',
 	value: 'fixed',
 	name: _x( 'Fixed', 'Name for the value of the CSS position property' ),
-	__experimentalHint: __(
-		'The block will not move when the page is scrolled.'
-	),
+	hint: __( 'The block will not move when the page is scrolled.' ),
 };
 
 const POSITION_SIDES = [ 'top', 'right', 'bottom', 'left' ];

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   `ToolbarButton`: Always keep focusable when disabled ([#63102](https://github.com/WordPress/gutenberg/pull/63102)).
 -   `ProgressBar`: Fix indeterminate RTL support. ([#63129](https://github.com/WordPress/gutenberg/pull/63129)).
 -   `RangeControl`: Fix RTL support for custom marks ([#63198](https://github.com/WordPress/gutenberg/pull/63198)).
+-   `CustomSelectControl`: Stabilize `__experimentalShowSelectedHint` and `options[]. __experimentalHint` props ([#63248](https://github.com/WordPress/gutenberg/pull/63248)).
 -   `TimePicker`: Add `dateOrder` prop ([#62481](https://github.com/WordPress/gutenberg/pull/62481)).
 
 ### Bug Fixes

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
 
+### Enhancements
+
+-   `CustomSelectControl`: Stabilize `__experimentalShowSelectedHint` and `options[]. __experimentalHint` props ([#63248](https://github.com/WordPress/gutenberg/pull/63248)).
+
 ## 28.3.0 (2024-07-10)
 
 ### Enhancements
@@ -19,7 +23,6 @@
 -   `ToolbarButton`: Always keep focusable when disabled ([#63102](https://github.com/WordPress/gutenberg/pull/63102)).
 -   `ProgressBar`: Fix indeterminate RTL support. ([#63129](https://github.com/WordPress/gutenberg/pull/63129)).
 -   `RangeControl`: Fix RTL support for custom marks ([#63198](https://github.com/WordPress/gutenberg/pull/63198)).
--   `CustomSelectControl`: Stabilize `__experimentalShowSelectedHint` and `options[]. __experimentalHint` props ([#63248](https://github.com/WordPress/gutenberg/pull/63248)).
 -   `TimePicker`: Add `dateOrder` prop ([#62481](https://github.com/WordPress/gutenberg/pull/62481)).
 
 ### Bug Fixes

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -9,7 +9,7 @@ import clsx from 'clsx';
  */
 import _CustomSelect from '../custom-select';
 import CustomSelectItem from '../item';
-import type { LegacyCustomSelectProps } from '../types';
+import type { LegacyCustomSelectProps, LegacyOption } from '../types';
 import * as Styled from '../styles';
 
 function useDeprecatedProps( {
@@ -26,6 +26,14 @@ function useDeprecatedProps( {
 				: showSelectedHint,
 	};
 }
+const computeOptionDeprecatedProps = ( {
+	__experimentalHint,
+	hint,
+	...rest
+}: LegacyOption ) => ( {
+	...rest,
+	hint: typeof __experimentalHint !== 'undefined' ? __experimentalHint : hint,
+} );
 
 function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	const {
@@ -75,56 +83,59 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 		defaultValue: options[ 0 ]?.name,
 	} );
 
-	const children = options.map(
-		( { name, key, __experimentalHint, style, className } ) => {
-			const withHint = (
-				<Styled.WithHintItemWrapper>
-					<span>{ name }</span>
-					<Styled.WithHintItemHint
-					// TODO: Legacy classname. Add V1 styles are removed from the codebase
-					// className="components-custom-select-control__item-hint"
-					>
-						{ __experimentalHint }
-					</Styled.WithHintItemHint>
-				</Styled.WithHintItemWrapper>
-			);
+	const children = options.map( ( option ) => {
+		const { name, key, hint, style, className } =
+			computeOptionDeprecatedProps( option );
 
-			return (
-				<CustomSelectItem
-					key={ key }
-					value={ name }
-					children={ __experimentalHint ? withHint : name }
-					style={ style }
-					className={ clsx(
-						// TODO: Legacy classname. Add V1 styles are removed from the codebase
-						// 'components-custom-select-control__item',
-						className
-						// TODO: Legacy classname. Add V1 styles are removed from the codebase
-						// {
-						// 	'has-hint': __experimentalHint,
-						// }
-					) }
-				/>
-			);
-		}
-	);
+		const withHint = (
+			<Styled.WithHintItemWrapper>
+				<span>{ name }</span>
+				<Styled.WithHintItemHint
+				// TODO: Legacy classname. Add V1 styles are removed from the codebase
+				// className="components-custom-select-control__item-hint"
+				>
+					{ hint }
+				</Styled.WithHintItemHint>
+			</Styled.WithHintItemWrapper>
+		);
+
+		return (
+			<CustomSelectItem
+				key={ key }
+				value={ name }
+				children={ hint ? withHint : name }
+				style={ style }
+				className={ clsx(
+					// TODO: Legacy classname. Add V1 styles are removed from the codebase
+					// 'components-custom-select-control__item',
+					className
+					// TODO: Legacy classname. Add V1 styles are removed from the codebase
+					// {
+					// 	'has-hint': hint,
+					// }
+				) }
+			/>
+		);
+	} );
 
 	const renderSelectedValueHint = () => {
 		const { value: currentValue } = store.getState();
 
-		const currentHint = options?.find(
+		const selectedOption = options?.find(
 			( { name } ) => currentValue === name
 		);
 
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
 				{ currentValue }
-				<Styled.SelectedExperimentalHintItem
-				// TODO: Legacy classname. Add V1 styles are removed from the codebase
-				// className="components-custom-select-control__hint"
-				>
-					{ currentHint?.__experimentalHint }
-				</Styled.SelectedExperimentalHintItem>
+				{ selectedOption && (
+					<Styled.SelectedExperimentalHintItem
+					// TODO: Legacy classname. Add V1 styles are removed from the codebase
+					// className="components-custom-select-control__hint"
+					>
+						{ computeOptionDeprecatedProps( selectedOption )?.hint }
+					</Styled.SelectedExperimentalHintItem>
+				) }
 			</Styled.SelectedExperimentalHintWrapper>
 		);
 	};

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -21,15 +21,20 @@ function useDeprecatedProps( {
 }: LegacyCustomSelectProps ) {
 	return {
 		...otherProps,
-		options: options.map(
-			( { __experimentalHint, hint, ...restOption } ) => ( {
-				...restOption,
-				hint:
-					typeof __experimentalHint !== 'undefined'
-						? __experimentalHint
-						: hint,
-			} )
-		),
+		options: options.map( ( o ) => {
+			const toReturn = o;
+
+			const hint =
+				typeof o.__experimentalHint !== 'undefined'
+					? o.__experimentalHint
+					: o.hint;
+
+			if ( hint ) {
+				toReturn.hint = hint;
+			}
+
+			return toReturn;
+		} ),
 		showSelectedHint:
 			typeof __experimentalShowSelectedHint !== 'undefined'
 				? __experimentalShowSelectedHint

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -24,7 +24,7 @@ function useDeprecatedProps( {
 
 // The removal of `__experimentalHint` in favour of `hint` doesn't happen in
 // the `useDeprecatedProps` hook in order not to break consumers that rely
-// on object identity (see https://github.com/WordPress/gutenberg/pull/63248/files/175907e16310fcd3ef13fcb2964e138a69134760#r1668842238)
+// on object identity (see https://github.com/WordPress/gutenberg/pull/63248#discussion_r1672213131)
 function applyOptionDeprecations( {
 	__experimentalHint,
 	...rest

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -12,9 +12,23 @@ import CustomSelectItem from '../item';
 import type { LegacyCustomSelectProps } from '../types';
 import * as Styled from '../styles';
 
+function useDeprecatedProps( {
+	showSelectedHint = false,
+	// Deprecated
+	__experimentalShowSelectedHint,
+	...otherProps
+}: LegacyCustomSelectProps ) {
+	return {
+		...otherProps,
+		showSelectedHint:
+			typeof __experimentalShowSelectedHint !== 'undefined'
+				? __experimentalShowSelectedHint
+				: showSelectedHint,
+	};
+}
+
 function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	const {
-		__experimentalShowSelectedHint = false,
 		__next40pxDefaultSize = false,
 		describedBy,
 		options,
@@ -22,8 +36,9 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 		size = 'default',
 		value,
 		className: classNameProp,
+		showSelectedHint,
 		...restProps
-	} = props;
+	} = useDeprecatedProps( props );
 
 	// Forward props + store from v2 implementation
 	const store = Ariakit.useSelectStore( {
@@ -131,9 +146,7 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 		<_CustomSelect
 			aria-describedby={ describedBy }
 			renderSelectedValue={
-				__experimentalShowSelectedHint
-					? renderSelectedValueHint
-					: undefined
+				showSelectedHint ? renderSelectedValueHint : undefined
 			}
 			size={ translatedSize }
 			store={ store }

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -13,13 +13,13 @@ import type { LegacyCustomSelectProps } from '../types';
 import * as Styled from '../styles';
 
 function useDeprecatedProps( {
-	showSelectedHint = false,
 	options,
 	// Deprecated
 	__experimentalShowSelectedHint,
 	...otherProps
 }: LegacyCustomSelectProps ) {
 	return {
+		showSelectedHint: __experimentalShowSelectedHint,
 		...otherProps,
 		options: options.map( ( o ) => {
 			const toReturn = o;
@@ -35,10 +35,6 @@ function useDeprecatedProps( {
 
 			return toReturn;
 		} ),
-		showSelectedHint:
-			typeof __experimentalShowSelectedHint !== 'undefined'
-				? __experimentalShowSelectedHint
-				: showSelectedHint,
 	};
 }
 
@@ -51,7 +47,7 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 		size = 'default',
 		value,
 		className: classNameProp,
-		showSelectedHint,
+		showSelectedHint = false,
 		...restProps
 	} = useDeprecatedProps( props );
 

--- a/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/index.tsx
@@ -9,31 +9,33 @@ import clsx from 'clsx';
  */
 import _CustomSelect from '../custom-select';
 import CustomSelectItem from '../item';
-import type { LegacyCustomSelectProps, LegacyOption } from '../types';
+import type { LegacyCustomSelectProps } from '../types';
 import * as Styled from '../styles';
 
 function useDeprecatedProps( {
 	showSelectedHint = false,
+	options,
 	// Deprecated
 	__experimentalShowSelectedHint,
 	...otherProps
 }: LegacyCustomSelectProps ) {
 	return {
 		...otherProps,
+		options: options.map(
+			( { __experimentalHint, hint, ...restOption } ) => ( {
+				...restOption,
+				hint:
+					typeof __experimentalHint !== 'undefined'
+						? __experimentalHint
+						: hint,
+			} )
+		),
 		showSelectedHint:
 			typeof __experimentalShowSelectedHint !== 'undefined'
 				? __experimentalShowSelectedHint
 				: showSelectedHint,
 	};
 }
-const computeOptionDeprecatedProps = ( {
-	__experimentalHint,
-	hint,
-	...rest
-}: LegacyOption ) => ( {
-	...rest,
-	hint: typeof __experimentalHint !== 'undefined' ? __experimentalHint : hint,
-} );
 
 function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	const {
@@ -83,10 +85,7 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 		defaultValue: options[ 0 ]?.name,
 	} );
 
-	const children = options.map( ( option ) => {
-		const { name, key, hint, style, className } =
-			computeOptionDeprecatedProps( option );
-
+	const children = options.map( ( { name, key, hint, style, className } ) => {
 		const withHint = (
 			<Styled.WithHintItemWrapper>
 				<span>{ name }</span>
@@ -121,19 +120,19 @@ function CustomSelectControl( props: LegacyCustomSelectProps ) {
 	const renderSelectedValueHint = () => {
 		const { value: currentValue } = store.getState();
 
-		const selectedOption = options?.find(
+		const selectedOptionHint = options?.find(
 			( { name } ) => currentValue === name
-		);
+		)?.hint;
 
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
 				{ currentValue }
-				{ selectedOption && (
+				{ selectedOptionHint && (
 					<Styled.SelectedExperimentalHintItem
 					// TODO: Legacy classname. Add V1 styles are removed from the codebase
 					// className="components-custom-select-control__hint"
 					>
-						{ computeOptionDeprecatedProps( selectedOption )?.hint }
+						{ selectedOptionHint }
 					</Styled.SelectedExperimentalHintItem>
 				) }
 			</Styled.SelectedExperimentalHintWrapper>

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -297,7 +297,7 @@ describe.each( [
 					{
 						key: 'one',
 						name: 'One',
-						__experimentalHint: 'Hint',
+						hint: 'Hint',
 					},
 				] }
 			/>
@@ -318,7 +318,7 @@ describe.each( [
 					{
 						key: 'one',
 						name: 'One',
-						__experimentalHint: 'Hint',
+						hint: 'Hint',
 					},
 				] }
 				showSelectedHint
@@ -343,7 +343,7 @@ describe.each( [
 					{
 						key: 'one',
 						name: 'One',
-						__experimentalHint: 'Hint',
+						hint: 'Hint',
 					},
 				] }
 			/>

--- a/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/legacy-component/test/index.tsx
@@ -309,7 +309,7 @@ describe.each( [
 		);
 	} );
 
-	it( 'shows selected hint when __experimentalShowSelectedHint is set', async () => {
+	it( 'shows selected hint when showSelectedHint is set', async () => {
 		render(
 			<Component
 				{ ...legacyProps }
@@ -321,7 +321,7 @@ describe.each( [
 						__experimentalHint: 'Hint',
 					},
 				] }
-				__experimentalShowSelectedHint
+				showSelectedHint
 			/>
 		);
 
@@ -334,7 +334,7 @@ describe.each( [
 		);
 	} );
 
-	it( 'shows selected hint in list of options when added, regardless of __experimentalShowSelectedHint prop', async () => {
+	it( 'shows selected hint in list of options when added, regardless of showSelectedHint prop', async () => {
 		render(
 			<Component
 				{ ...legacyProps }

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -169,11 +169,17 @@ export type LegacyCustomSelectProps = {
 	 */
 	value?: LegacyOption;
 	/**
-	 * Legacy way to add additional text to the right of each option.
+	 * Use the `showSelectedHint` property instead.
+	 * @deprecated
+	 * @ignore
+	 */
+	__experimentalShowSelectedHint?: boolean;
+	/**
+	 * Show the hint of the selected item in the trigger button.
 	 *
 	 * @default false
 	 */
-	__experimentalShowSelectedHint?: boolean;
+	showSelectedHint?: boolean;
 	/**
 	 * Opt-in prop for an unconstrained width style which became the default in
 	 * WordPress 6.5. The prop is no longer needed and can be safely removed.

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -85,7 +85,7 @@ export type CustomSelectProps = _CustomSelectProps & CustomSelectSize;
 /**
  * The legacy object structure for the options array.
  */
-export type LegacyOption = {
+type LegacyOption = {
 	key: string;
 	name: string;
 	style?: React.CSSProperties;

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -85,11 +85,17 @@ export type CustomSelectProps = _CustomSelectProps & CustomSelectSize;
 /**
  * The legacy object structure for the options array.
  */
-type LegacyOption = {
+export type LegacyOption = {
 	key: string;
 	name: string;
 	style?: React.CSSProperties;
 	className?: string;
+	hint?: string;
+	/**
+	 * Use the `hint` property instead
+	 * @deprecated
+	 * @ignore
+	 */
 	__experimentalHint?: string;
 	[ key: string ]: any;
 };

--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -106,22 +106,22 @@ WithHints.args = {
 		{
 			key: 'thumbnail',
 			name: 'Thumbnail',
-			hint: '150x150',
+			__experimentalHint: '150x150',
 		},
 		{
 			key: 'medium',
 			name: 'Medium',
-			hint: '250x250',
+			__experimentalHint: '250x250',
 		},
 		{
 			key: 'large',
 			name: 'Large',
-			hint: '1024x1024',
+			__experimentalHint: '1024x1024',
 		},
 		{
 			key: 'full',
 			name: 'Full Size',
-			hint: '1600x1600',
+			__experimentalHint: '1600x1600',
 		},
 	],
 };

--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -106,22 +106,22 @@ WithHints.args = {
 		{
 			key: 'thumbnail',
 			name: 'Thumbnail',
-			__experimentalHint: '150x150',
+			hint: '150x150',
 		},
 		{
 			key: 'medium',
 			name: 'Medium',
-			__experimentalHint: '250x250',
+			hint: '250x250',
 		},
 		{
 			key: 'large',
 			name: 'Large',
-			__experimentalHint: '1024x1024',
+			hint: '1024x1024',
 		},
 		{
 			key: 'full',
 			name: 'Full Size',
-			__experimentalHint: '1600x1600',
+			hint: '1600x1600',
 		},
 	],
 };

--- a/packages/components/src/font-size-picker/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-select.tsx
@@ -79,7 +79,7 @@ const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
 			) }
 			options={ options }
 			value={ selectedOption }
-			__experimentalShowSelectedHint
+			showSelectedHint
 			onChange={ ( {
 				selectedItem,
 			}: {

--- a/packages/components/src/font-size-picker/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-select.tsx
@@ -56,7 +56,7 @@ const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
 				key: fontSize.slug,
 				name: fontSize.name || fontSize.slug,
 				value: fontSize.size,
-				__experimentalHint: hint,
+				hint,
 			};
 		} ),
 		...( disableCustomFontSizes ? [] : [ CUSTOM_OPTION ] ),

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -110,7 +110,7 @@ export type FontSizePickerSelectOption = {
 	key: string;
 	name: string;
 	value?: FontSize[ 'size' ];
-	__experimentalHint?: string;
+	hint?: string;
 };
 
 export type FontSizePickerToggleGroupProps = Pick<


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Stabilize the `__experimentalShowSelectedHint`  and `options[]. __experimentalHint` props of `CustomSelectControl` V2 legacy adapter by providing an equivalent, un-prefixed version: `showSelectedHint` and `options[].hint`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As we're about to swap the current V1 implementation with a new implementation based on `ariakit` (ie. the V2 legacy adapter), it's also a good time to stabilize those props in preparation for the swap.

Once the swap happens, we will also be able to remove [the private `CustomSelectControl` export](https://github.com/WordPress/gutenberg/blob/938a51387ff6c1b7f8c7a4ad4deb745afeff84d5/packages/components/src/private-apis.ts#L39).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By soft-deprecating those props. Existing consumers using those props won't experience any breakages or warnings, but the deprecated props will show as such in the docs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Code-review the code snippet in charge of the soft deprecation
- Smoke test V1 and V2 legacy adapter Storybook examples — especially the "with hint" one. Make sure that the individual option hints show as expected, and play around with the `showSelectedHint` prop.
- Make sure that, in the V2 legacy adapter Storybook controls, the `__experimentalShowSelectedHint` is not shows anymore
- Smoke test component's usages in the editor, especially in the font picker

## ✍️ Dev note

See dev note in https://github.com/WordPress/gutenberg/pull/63258
