### PR TITLE
Section Styles: Fix error when blocks are deregistered

### DIFF
--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -671,7 +671,7 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 						}
 						const variationSelector =
 							blockSelectors[ blockName ]
-								.styleVariationSelectors?.[ variationName ];
+								?.styleVariationSelectors?.[ variationName ];
 
 						// Process the variation's inner element styles.
 						// This comes before the inner block styles so the
@@ -700,18 +700,18 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 								const variationBlockSelector = scopeSelector(
 									variationSelector,
 									blockSelectors[ variationBlockName ]
-										.selector
+										?.selector
 								);
 								const variationDuotoneSelector = scopeSelector(
 									variationSelector,
 									blockSelectors[ variationBlockName ]
-										.duotoneSelector
+										?.duotoneSelector
 								);
 								const variationFeatureSelectors =
 									scopeFeatureSelectors(
 										variationSelector,
 										blockSelectors[ variationBlockName ]
-											.featureSelectors
+											?.featureSelectors
 									);
 
 								const variationBlockStyleNodes =
@@ -728,10 +728,10 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 									featureSelectors: variationFeatureSelectors,
 									fallbackGapValue:
 										blockSelectors[ variationBlockName ]
-											.fallbackGapValue,
+											?.fallbackGapValue,
 									hasLayoutSupport:
 										blockSelectors[ variationBlockName ]
-											.hasLayoutSupport,
+											?.hasLayoutSupport,
 									styles: variationBlockStyleNodes,
 								} );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63208

## What?

Adds optional chaining to retrieval of variation selectors to prevent an error and editor crash when a block has been deregistered via JS.

A better long-term fix will be to refactor the block style variations hook so that the block types and selectors retrieved there can't be stale. This PR is the quickest fix that addresses the issue in time for the final 6.6 RC. It will also make any future refactor more robust as well.

Props to @t-hamano for isolating the cause of the error 🙇 

## Why?

<img width="652" alt="Screenshot 2024-07-09 at 12 40 42 AM" src="https://github.com/WordPress/gutenberg/assets/60436221/2ab659ed-8eb4-4615-a9e7-06c5707f0af7">

## How?

`.` --> `?.`


## Testing Instructions

1. Checkout `trunk`
2. Navigate to Appearance > Editor > Patterns
3. In console deregister a block type that has a core block style variation e.g. `core/site-logo`, `core/image` etc.
    - `wp.blocks.unregisterBlockType( 'core/image' );`
4. Select a pattern to edit and editor will crash with the above error in console.
5. Checkout this PR
6. Repeat the process and ensure there are no errors.

#### Bonus Points

1. Define a block style variation for a group block that styles inner image blocks (e.g. Add example snippet below to functions.php)
2. Repeat the steps above and deregister the `core/image` block
3. Confirm there are still no errors

<details>
<summary>PHP group block style variation snippet</summary>

```php
register_block_style(
	array( 'core/group' ),
	array(
		'name'       => 'section-a',
		'label'      => __( 'Section A' ),
		'style_data' => array(
			'blocks' => array(
				'core/image' => array(
					'border' => array(
						'color' => 'pink',
						'width' => '1em',
						'style' => 'solid',
					),
				),
			),
		),
	)
);

```

</details>

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/a0bbd0ec-9643-42d7-9f22-3807921950d3" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/eb49158e-03c9-4395-ba18-3a2d381d7378" /> |

