### PR TITLE
Add local version of wp-env schema to .wp-env.json

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "./schemas/json/wp-env.json",
 	"core": "WordPress/WordPress",
 	"plugins": [ "." ],
 	"themes": [ "./test/emptytheme" ],


### PR DESCRIPTION
Similar to #61312

## What?

This PR adds a reference to the local schema in the wp-env config file used by the Gutenberg project.

## Why?

- This will prevent incorrect fields from being defined in future updates to `.wp-env.json`.
- As mentioned in [this comment](https://github.com/WordPress/gutenberg/pull/36276#issuecomment-2214222158), there are some fields missing in the current schema. When fixing these, it will be easier to test using the `.wp-env.json` in the Gutenberg project.

## Testing Instructions

- Check out this PR.
- Open the `.wp-env.json` file in a code editor.
- The code editor should help you auto-complete fields and warn you about invalid fields and values.