### PR TITLE
Fix Calendar Block Color options are not working properly

### DIFF
--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -34,7 +34,17 @@ const getYearMonth = memoize( ( date ) => {
 } );
 
 export default function CalendarEdit( { attributes } ) {
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: [
+			attributes.backgroundColor
+				? `has-${ attributes.backgroundColor }-background-color`
+				: '',
+			attributes.textColor ? `has-${ attributes.textColor }-color` : '',
+		]
+			.filter( Boolean )
+			.join( ' ' ),
+	} );
+
 	const { date, hasPosts, hasPostsResolved } = useSelect( ( select ) => {
 		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
 

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -37,9 +37,26 @@
 			color: inherit;
 		}
 	}
+
+	&.has-background {
+		table#wp-calendar th {
+			background: inherit;
+		}
+	}
 }
 
 // Keep the hard-coded header background color for backward compatibility.
 :where(.wp-block-calendar table:not(.has-background) th) {
 	background: $gray-300;
+}
+
+// Update editor color.
+.wp-block-calendar.has-link-color table#wp-calendar th,
+.wp-block-calendar.has-link-color table#wp-calendar {
+	color: inherit;
+	border-color: inherit;
+}
+
+.wp-block-calendar.has-link-color table#wp-calendar td {
+	border-color: inherit;
 }


### PR DESCRIPTION
Fixes [#61346](https://github.com/WordPress/gutenberg/issues/61346)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes an issue with the Calendar Block where color changes (text and background) were not immediately reflected in the editor view.

## Why?
Previously, when users changed the text or background color of the Calendar Block, the changes were only visible after a page refresh or in the front-end preview. This inconsistency created a poor user experience and made it difficult for users to visualize their changes in real-time.

## How?
1. Restructuring CSS to ensure color changes are applied consistently in the editor
2. Improving the handling of text and background color classes

## Testing Instructions
1. Open the block editor and add a Calendar Block
2. Open the block settings in the sidebar
3. Change the text color of the Calendar Block
4. Verify that the text color change is immediately visible in the editor
5. Change the background color of the Calendar Block
6. Verify that the background color change is immediately visible in the editor
7. Save the post and view it on the front-end to ensure changes are applied correctly there as well

## Screenshots or screencast <!-- if applicable -->
https://www.loom.com/share/055937c227674e46902d4abbe4ba3ac0?sid=cea7abb7-83e7-44ae-9bb8-4f6e42b28853
