### PR TITLE
In-between inserter: allow scrolling over indicator

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -161,7 +161,7 @@ export function useInBetweenInserter() {
 
 				if ( event.type === 'click' ) {
 					hideInsertionPoint();
-					selectBlock( clientId );
+					selectBlock( clientId, -1 );
 					return;
 				}
 

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -30,7 +30,7 @@ export function useInBetweenInserter() {
 		getBlockEditingMode,
 		getBlockName,
 	} = useSelect( blockEditorStore );
-	const { showInsertionPoint, hideInsertionPoint } =
+	const { showInsertionPoint, hideInsertionPoint, selectBlock } =
 		useDispatch( blockEditorStore );
 
 	return useRefEffect(
@@ -159,15 +159,23 @@ export function useInBetweenInserter() {
 					return;
 				}
 
+				if ( event.type === 'click' ) {
+					hideInsertionPoint();
+					selectBlock( clientId );
+					return;
+				}
+
 				showInsertionPoint( rootClientId, index, {
 					__unstableWithInserter: true,
 				} );
 			}
 
 			node.addEventListener( 'mousemove', onMouseMove );
+			node.addEventListener( 'click', onMouseMove );
 
 			return () => {
 				node.removeEventListener( 'mousemove', onMouseMove );
+				node.removeEventListener( 'click', onMouseMove );
 			};
 		},
 		[

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -30,18 +30,10 @@
 	// drop zone.
 	pointer-events: none;
 
-	* {
-		pointer-events: none;
-	}
-
 	// Re-enable pointer events when the inbetween inserter has a '+' button.
 	// Needs specificity, do not simplify.
-	.is-with-inserter {
+	.block-editor-block-list__insertion-point-inserter {
 		pointer-events: all;
-
-		* {
-			pointer-events: all;
-		}
 	}
 }
 

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -6,8 +6,8 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useRef, createContext, useContext } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { createContext, useContext } from '@wordpress/element';
 import { __unstableMotion as motion } from '@wordpress/components';
 import { useReducedMotion } from '@wordpress/compose';
 
@@ -27,9 +27,7 @@ function InbetweenInsertionPointPopover( {
 	operation = 'insert',
 	nearestSide = 'right',
 } ) {
-	const { selectBlock, hideInsertionPoint } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
-	const ref = useRef();
 	const {
 		orientation,
 		previousClientId,
@@ -81,35 +79,8 @@ function InbetweenInsertionPointPopover( {
 			isInserterShown: insertionPoint?.__unstableWithInserter,
 		};
 	}, [] );
-	const { getBlockEditingMode } = useSelect( blockEditorStore );
 
 	const disableMotion = useReducedMotion();
-
-	function onClick( event ) {
-		if (
-			event.target === ref.current &&
-			nextClientId &&
-			getBlockEditingMode( nextClientId ) !== 'disabled'
-		) {
-			selectBlock( nextClientId, -1 );
-		}
-	}
-
-	function maybeHideInserterPoint( event ) {
-		// Only hide the inserter if it's triggered on the wrapper,
-		// and the inserter is not open.
-		if ( event.target === ref.current && ! openRef.current ) {
-			hideInsertionPoint();
-		}
-	}
-
-	function onFocus( event ) {
-		// Only handle click on the wrapper specifically, and not an event
-		// bubbled from the inserter itself.
-		if ( event.target !== ref.current ) {
-			openRef.current = true;
-		}
-	}
 
 	const lineVariants = {
 		// Initial position starts from the center and invisible.
@@ -171,12 +142,7 @@ function InbetweenInsertionPointPopover( {
 				whileHover="hover"
 				whileTap="pressed"
 				exit="start"
-				ref={ ref }
-				tabIndex={ -1 }
-				onClick={ onClick }
-				onFocus={ onFocus }
 				className={ className }
-				onHoverEnd={ maybeHideInserterPoint }
 			>
 				<motion.div
 					variants={ lineVariants }

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -175,9 +175,7 @@ function InbetweenInsertionPointPopover( {
 				tabIndex={ -1 }
 				onClick={ onClick }
 				onFocus={ onFocus }
-				className={ clsx( className, {
-					'is-with-inserter': isInserterShown,
-				} ) }
+				className={ className }
 				onHoverEnd={ maybeHideInserterPoint }
 			>
 				<motion.div


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/63260.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's super annoying. :) 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Looks like pointer-events: all was re-applied to early on the entire indicator instead of just on the button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Hover over the space in between blocks and scroll.

Make sure that #45420 does not regress.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
