### PR TITLE
Tabs: Fix text-align when text wraps in vertical mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   `UnitControl`: Fix an issue where keyboard shortcuts unintentionally shift focus on Windows OS. ([#62988](https://github.com/WordPress/gutenberg/pull/62988))
 -   Fix inaccessibly disabled `Button`s ([#62306](https://github.com/WordPress/gutenberg/pull/62306)).
 -   `TimePicker`: Fix time zone overflow ([#63209](https://github.com/WordPress/gutenberg/pull/63209)).
+-   `Tabs`: Fix text-align when text wraps in vertical mode ([#63272](https://github.com/WordPress/gutenberg/pull/63272)).
 
 ### Internal
 

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -15,9 +15,13 @@ export const TabListWrapper = styled.div`
 	display: flex;
 	align-items: stretch;
 	flex-direction: row;
+	text-align: center;
+
 	&[aria-orientation='vertical'] {
 		flex-direction: column;
+		text-align: start;
 	}
+
 	@media not ( prefers-reduced-motion: reduce ) {
 		&.is-animation-enabled::after {
 			transition-property: left, top, width, height;
@@ -66,6 +70,7 @@ export const Tab = styled( Ariakit.Tab )`
 		padding: 3px ${ space( 4 ) }; // Use padding to offset the [aria-selected="true"] border, this benefits Windows High Contrast mode
 		margin-left: 0;
 		font-weight: 500;
+		text-align: inherit;
 
 		&[aria-disabled='true'] {
 			cursor: default;


### PR DESCRIPTION
## What?

Fixes the text alignment in `Tabs` when the tab names wrap and `orientation="vertical"`.

## Why?

The tab names look misaligned if centered in vertical mode.

## Testing Instructions

See Storybook for `Tabs`.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/WordPress/gutenberg/assets/555336/5c5162fb-ead4-46cd-90cc-4d50121b91cd" alt="Text aligned to center" width="400">|<img src="https://github.com/WordPress/gutenberg/assets/555336/bb22e2e8-c061-4433-b84e-ead26edc92da" alt="Text aligned to start" width="400">|

