### PR TITLE
WP 6.6 merge - Patterns: check for edited entity content property when exporting

### DIFF
--- a/packages/editor/src/components/post-actions/export-pattern-action.js
+++ b/packages/editor/src/components/post-actions/export-pattern-action.js
@@ -24,8 +24,10 @@ function getJsonFromItem( item ) {
 		{
 			__file: item.type,
 			title: item.title || item.name,
-			content: item.patternPost.content.raw,
-			syncStatus: item.patternPost.wp_pattern_sync_status,
+			content: item?.patternPost?.content?.raw || item.content,
+			syncStatus:
+				item?.patternPost?.wp_pattern_sync_status ||
+				item.wp_pattern_sync_status,
 		},
 		null,
 		2


### PR DESCRIPTION


## What?

This PR merges https://github.com/WordPress/gutenberg/pull/63227 into wp/6.6

It ensures that `content` and `syncStatus` is exported when exporting custom patterns from the editor pattern side bar.




## Why?

The "item" passed to [getJsonFromItem](https://github.com/WordPress/gutenberg/blob/6d3282e0ba3fb56bb4e55cb797eb5f0d5dae8795/packages/editor/src/dataviews/actions/export-pattern.tsx#L20-L20) is fetched using [getEditedEntityRecord](https://github.com/WordPress/gutenberg/blob/6d3282e0ba3fb56bb4e55cb797eb5f0d5dae8795/packages/editor/src/components/post-actions/index.js#L37-L37).

`getEditedEntityRecord` calls [getRawEntityRecord](https://github.com/WordPress/gutenberg/blob/6d3282e0ba3fb56bb4e55cb797eb5f0d5dae8795/packages/core-data/src/selectors.ts#L442-L442). 

`getRawEntityRecord` maps properties to their raw values, so `content.raw` will be mapped to `content`.

Because an item can either be an entity record fetched via `getEntityRecord` or `getEditedEntityRecord`, I think we should support both formats.

## How?

Checks for `content.raw` and `content` when exporting item JSON, e.g., for a custom pattern.



## Testing Instructions

1. Head over to the site editor and duplicate a theme pattern to create a "custom pattern". Or you can create your own in the editor if you wish!
2. Edit the custom pattern.
3. In the pattern sidebar, click on the actions ellipsis menu and export your pattern as JSON.
4. Check that the JSON contains your pattern's content and other properties, including `syncStatus`, `title`.
5. Also check that exporting patterns from the patterns library (for theme and custom patterns) works as expected, and contain the correct properties.

Example:

```json
{
  "__file": "wp_block",
  "title": "Test Custom Pattern (Copy)",
  "content": "<!-- wp:paragraph -->\n<p>A synced pattern</p>\n<!-- /wp:paragraph -->",
  "syncStatus": "unsynced"
}
```



https://github.com/WordPress/gutenberg/assets/6458278/597bf3a1-58ab-4744-b54f-aedfa882c700