### PR TITLE
Add example for query block and posts list

### DIFF
--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -19,6 +19,46 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {
+		viewportWidth: 650,
+		attributes: {
+			namespace: 'core/posts-list',
+			query: {
+				perPage: 4,
+				pages: 1,
+				offset: 0,
+				postType: 'post',
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				sticky: 'exclude',
+				inherit: false,
+			},
+		},
+		innerBlocks: [
+			{
+				name: 'core/post-template',
+				attributes: {
+					layout: {
+						type: 'grid',
+						columnCount: 2,
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'core/post-title',
+					},
+					{
+						name: 'core/post-date',
+					},
+					{
+						name: 'core/post-excerpt',
+					},
+				],
+			},
+		],
+	},
 	save,
 	variations,
 	deprecated,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This adds an example for `core/query` and the variation posts list in the inserter

Part of https://github.com/WordPress/gutenberg/issues/30029

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it was showing empty before

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By including the example attributes and settings in the block's index.js

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the block inserter and search for the query or posts list block, hover over it and you'll see the example. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="673" alt="Screenshot 2024-07-09 at 10 27 51" src="https://github.com/WordPress/gutenberg/assets/3593343/5f583777-98f1-4aba-a650-773b176943ca">
