### PR TITLE
Post editor: increase specificity bottom padding

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -138,7 +138,9 @@ function useEditorStyles() {
 			return [
 				...baseStyles,
 				{
-					css: 'body{padding-bottom: 40vh}',
+					// Should override global styles padding, so ensure 0-1-0
+					// specificity.
+					css: ':root :where(body){padding-bottom: 40vh}',
 				},
 			];
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Increases the specificity of the body bottom padding to override any padding set by global styles.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #63278.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Set to 0-1-0. Alternatively we could use `!important`, but I guess we better avoid that if we know the specificity needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See #63278.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
