### PR TITLE
Image block: Remove unnecessary variables on expand on click implementation

### DIFF
--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -19,20 +19,6 @@ let isTouching = false;
  */
 let lastTouchTime = 0;
 
-/**
- * Stores the image reference of the currently opened lightbox.
- *
- * @type {HTMLElement}
- */
-let imageRef;
-
-/**
- * Stores the button reference of the currently opened lightbox.
- *
- * @type {HTMLElement}
- */
-let buttonRef;
-
 const { state, actions, callbacks } = store(
 	'core/image',
 	{
@@ -79,8 +65,6 @@ const { state, actions, callbacks } = store(
 
 				// Moves the information of the expaned image to the state.
 				ctx.currentSrc = ctx.imageRef.currentSrc;
-				imageRef = ctx.imageRef;
-				buttonRef = ctx.buttonRef;
 				state.currentImage = ctx;
 				state.overlayEnabled = true;
 
@@ -98,14 +82,12 @@ const { state, actions, callbacks } = store(
 						// Delays before changing the focus. Otherwise the focus ring will
 						// appear on Firefox before the image has finished animating, which
 						// looks broken.
-						buttonRef.focus( {
+						state.currentImage.buttonRef.focus( {
 							preventScroll: true,
 						} );
 
 						// Resets the current image to mark the overlay as closed.
 						state.currentImage = {};
-						imageRef = null;
-						buttonRef = null;
 					}, 450 );
 
 					// Starts the overlay closing animation. The showClosingAnimation
@@ -174,7 +156,7 @@ const { state, actions, callbacks } = store(
 		},
 		callbacks: {
 			setOverlayStyles() {
-				if ( ! imageRef ) {
+				if ( ! state.currentImage.imageRef ) {
 					return;
 				}
 
@@ -183,9 +165,9 @@ const { state, actions, callbacks } = store(
 					naturalHeight,
 					offsetWidth: originalWidth,
 					offsetHeight: originalHeight,
-				} = imageRef;
+				} = state.currentImage.imageRef;
 				let { x: screenPosX, y: screenPosY } =
-					imageRef.getBoundingClientRect();
+					state.currentImage.imageRef.getBoundingClientRect();
 
 				// Natural ratio of the image clicked to open the lightbox.
 				const naturalRatio = naturalWidth / naturalHeight;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I have deleted some unnecessary variables from the implementation of the expand-on-click feature of the image block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because at the time this implementation was done, there was a bug in the Interactivity API: when an element was added to the context or the state, the internal variables of that element tried to become reactive and failed.

That bug was fixed in [this pull request](https://github.com/WordPress/gutenberg/pull/59039), so the variables in this implementation that stored the reference of the button and the reference of the image are no longer needed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Simply deleting those variables and letting everything be in the context/state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add an image to a post.
2. Enable the "Expand on click" option.
3. Open the post on the frontend and check that everything works correctly.
