### PR TITLE
Pattern overrides: Ensure "Reset" button always shows as last item and with border

### DIFF
--- a/packages/patterns/src/components/reset-overrides-control.js
+++ b/packages/patterns/src/components/reset-overrides-control.js
@@ -3,7 +3,7 @@
  */
 import {
 	store as blockEditorStore,
-	BlockControls,
+	__unstableBlockToolbarLastItem as BlockToolbarLastItem,
 } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useRegistry, useSelect } from '@wordpress/data';
@@ -79,12 +79,12 @@ export default function ResetOverridesControl( props ) {
 	}
 
 	return (
-		<BlockControls group="other">
+		<BlockToolbarLastItem>
 			<ToolbarGroup>
 				<ToolbarButton onClick={ onClick } disabled={ ! isOverriden }>
 					{ __( 'Reset' ) }
 				</ToolbarButton>
 			</ToolbarGroup>
-		</BlockControls>
+		</BlockToolbarLastItem>
 	);
 }


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/62310

It ensures that the "Reset" button added by pattern overrides always shows as the last item and with the appropriate borders.

## Why?
To keep consistency across the different blocks.

## How?
Using the `__unstableBlockToolbarLastItem` component. Is it okay to use this component?

## Testing Instructions
1. Create a synced pattern with an image block inside.
2. Edit the original pattern, select the image, open the Advanced panel in the settings sidebar and enable overrides. Save,
3. Go back to where you had placed the pattern.
4. Select the image and view the toolbar.

**Before: The "Reset" button was in the same group as "Replace, Alt, Title".**

![Screenshot 2024-07-09 at 12 42 34](https://github.com/WordPress/gutenberg/assets/34552881/231569fd-9aff-4882-97d2-9c9c01f875f5)

**After: The "Reset" button has its own group.**

![Screenshot 2024-07-09 at 12 37 03](https://github.com/WordPress/gutenberg/assets/34552881/dd4b202a-2da3-419a-80a8-06917c241c3b)

