### PR TITLE
Core Data: Introduce entity-aware permission selector

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -550,6 +550,26 @@ _Returns_
 
 -   `boolean`: True if the REST request was completed. False otherwise.
 
+### hasPermission
+
+Returns whether the current user can perform the given action on the entity record.
+
+Calling this may trigger an OPTIONS request to the REST API via the `hasPermission()` resolver.
+
+<https://developer.wordpress.org/rest-api/reference/>
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+-   _action_ `string`: Action to check. One of: 'create', 'read', 'update', 'delete'.
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name
+-   _key_ `EntityRecordKey`: Optional record's key.
+
+_Returns_
+
+-   `boolean | undefined`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
+
 ### hasRedo
 
 Returns true if there is a next edit from the current undo offset for the entity records edits history, and false otherwise.

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -42,7 +42,8 @@ export default function PostTitleEdit( {
 			if ( isDescendentOfQueryLoop ) {
 				return false;
 			}
-			return select( coreStore ).canUserEditEntityRecord(
+			return select( coreStore ).hasPermission(
+				'update',
 				'postType',
 				postType,
 				postId

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -18,7 +18,7 @@ import { useViewportMatch } from '@wordpress/compose';
 export function useCanEditEntity( kind, name, recordId ) {
 	return useSelect(
 		( select ) =>
-			select( coreStore ).canUserEditEntityRecord( kind, name, recordId ),
+			select( coreStore ).hasPermission( 'update', kind, name, recordId ),
 		[ kind, name, recordId ]
 	);
 }

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -871,6 +871,26 @@ _Returns_
 
 -   `boolean`: True if the REST request was completed. False otherwise.
 
+### hasPermission
+
+Returns whether the current user can perform the given action on the entity record.
+
+Calling this may trigger an OPTIONS request to the REST API via the `hasPermission()` resolver.
+
+<https://developer.wordpress.org/rest-api/reference/>
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+-   _action_ `string`: Action to check. One of: 'create', 'read', 'update', 'delete'.
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name
+-   _key_ `EntityRecordKey`: Optional record's key.
+
+_Returns_
+
+-   `boolean | undefined`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
+
 ### hasRedo
 
 Returns true if there is a next edit from the current undo offset for the entity records edits history, and false otherwise.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -519,16 +519,7 @@ export const hasPermission =
 export const canUserEditEntityRecord =
 	( kind, name, recordId ) =>
 	async ( { dispatch } ) => {
-		const configs = await dispatch( getOrLoadEntitiesConfig( kind, name ) );
-		const entityConfig = configs.find(
-			( config ) => config.name === name && config.kind === kind
-		);
-		if ( ! entityConfig ) {
-			return;
-		}
-
-		const resource = entityConfig.__unstable_rest_base;
-		await dispatch( canUser( 'update', resource, recordId ) );
+		await dispatch( hasPermission( 'update', kind, name, recordId ) );
 	};
 
 /**

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1183,6 +1183,34 @@ export function canUserEditEntityRecord(
 }
 
 /**
+ * Returns whether the current user can perform the given action on the entity record.
+ *
+ * Calling this may trigger an OPTIONS request to the REST API via the
+ * `hasPermission()` resolver.
+ *
+ * https://developer.wordpress.org/rest-api/reference/
+ *
+ * @param state  Data state.
+ * @param action Action to check. One of: 'create', 'read', 'update', 'delete'.
+ * @param kind   Entity kind.
+ * @param name   Entity name
+ * @param key    Optional record's key.
+ *
+ * @return Whether or not the user can perform the action,
+ *         or `undefined` if the OPTIONS request is still being made.
+ */
+export function hasPermission(
+	state: State,
+	action: string,
+	kind: string,
+	name: string,
+	key?: EntityRecordKey
+): boolean | undefined {
+	const cacheKey = [ action, kind, name, key ].filter( Boolean ).join( '/' );
+	return state.userPermissions[ cacheKey ];
+}
+
+/**
  * Returns the latest autosaves for the post.
  *
  * May return multiple autosaves since the backend stores one autosave per

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1173,13 +1173,7 @@ export function canUserEditEntityRecord(
 	name: string,
 	recordId: EntityRecordKey
 ): boolean | undefined {
-	const entityConfig = getEntityConfig( state, kind, name );
-	if ( ! entityConfig ) {
-		return false;
-	}
-	const resource = entityConfig.__unstable_rest_base;
-
-	return canUser( state, 'update', resource, recordId );
+	return hasPermission( state, 'update', kind, name, recordId );
 }
 
 /**

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -284,7 +284,7 @@ describe( 'getEmbedPreview', () => {
 } );
 
 describe( 'canUser', () => {
-	let registry;
+	let dispatch, registry;
 	beforeEach( async () => {
 		registry = {
 			select: jest.fn( () => ( {
@@ -292,14 +292,13 @@ describe( 'canUser', () => {
 			} ) ),
 			batch: ( callback ) => callback(),
 		};
+		dispatch = Object.assign( jest.fn(), {
+			receiveUserPermission: jest.fn(),
+		} );
 		triggerFetch.mockReset();
 	} );
 
 	it( 'does nothing when there is an API error', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		triggerFetch.mockImplementation( () =>
 			Promise.reject( { status: 404 } )
 		);
@@ -316,10 +315,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'receives false when the user is not allowed to perform an action', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		triggerFetch.mockImplementation( () => ( {
 			headers: new Map( [ [ 'allow', 'GET' ] ] ),
 		} ) );
@@ -339,10 +334,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'receives true when the user is allowed to perform an action', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		triggerFetch.mockImplementation( () => ( {
 			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
@@ -362,10 +353,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'receives true when the user is allowed to perform an action on a specific resource', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		triggerFetch.mockImplementation( () => ( {
 			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
@@ -385,10 +372,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'runs apiFetch only once per resource', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		registry = {
 			...registry,
 			select: () => ( {
@@ -416,10 +399,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'retrieves all permissions even when ID is not given', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		registry = {
 			...registry,
 			select: () => ( {
@@ -455,10 +434,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'runs apiFetch only once per resource ID', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		registry = {
 			...registry,
 			select: () => ( {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -24,6 +24,7 @@ import {
 	getCurrentUser,
 	getRevisions,
 	getRevision,
+	hasPermission,
 } from '../selectors';
 // getEntityRecord and __experimentalGetEntityRecordNoResolver selectors share the same tests.
 describe.each( [
@@ -763,6 +764,39 @@ describe( 'canUserEditEntityRecord', () => {
 		expect(
 			canUserEditEntityRecord( state, 'postType', 'post', '1' )
 		).toBe( true );
+	} );
+} );
+
+describe( 'hasPermission', () => {
+	it( 'returns undefined by default', () => {
+		const state = deepFreeze( {
+			userPermissions: {},
+		} );
+		expect( hasPermission( state, 'create', 'root', 'media' ) ).toBe(
+			undefined
+		);
+	} );
+
+	it( 'returns whether an action can be performed', () => {
+		const state = deepFreeze( {
+			userPermissions: {
+				'create/root/media': false,
+			},
+		} );
+		expect( hasPermission( state, 'create', 'root', 'media' ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'returns whether an action can be performed for a given resource', () => {
+		const state = deepFreeze( {
+			userPermissions: {
+				'update/root/media/123': true,
+			},
+		} );
+		expect( hasPermission( state, 'update', 'root', 'media', 123 ) ).toBe(
+			true
+		);
 	} );
 } );
 

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -18,7 +18,6 @@ import {
 	getEmbedPreview,
 	isPreviewEmbedFallback,
 	canUser,
-	canUserEditEntityRecord,
 	getAutosave,
 	getAutosaves,
 	getCurrentUser,
@@ -709,61 +708,6 @@ describe( 'canUser', () => {
 			},
 		} );
 		expect( canUser( state, 'create', 'media', 123 ) ).toBe( false );
-	} );
-} );
-
-describe( 'canUserEditEntityRecord', () => {
-	it( 'returns false by default', () => {
-		const state = deepFreeze( {
-			userPermissions: {},
-			entities: { records: {} },
-		} );
-		expect( canUserEditEntityRecord( state, 'postType', 'post' ) ).toBe(
-			false
-		);
-	} );
-
-	it( 'returns whether the user can edit', () => {
-		const state = deepFreeze( {
-			userPermissions: {
-				'create/posts': false,
-				'update/posts/1': true,
-			},
-			entities: {
-				config: [
-					{
-						kind: 'postType',
-						name: 'post',
-						__unstable_rest_base: 'posts',
-					},
-				],
-				records: {
-					root: {
-						postType: {
-							queriedData: {
-								items: {
-									default: {
-										post: {
-											slug: 'post',
-											__unstable: 'posts',
-										},
-									},
-								},
-								itemIsComplete: {
-									default: {
-										post: true,
-									},
-								},
-								queries: {},
-							},
-						},
-					},
-				},
-			},
-		} );
-		expect(
-			canUserEditEntityRecord( state, 'postType', 'post', '1' )
-		).toBe( true );
 	} );
 } );
 

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -59,7 +59,8 @@ export default {
 		}
 
 		// Check that the user has the capability to edit post meta.
-		const canUserEdit = select( coreDataStore ).canUserEditEntityRecord(
+		const canUserEdit = select( coreDataStore ).hasPermission(
+			'update',
 			'postType',
 			context?.postType,
 			context?.postId


### PR DESCRIPTION
## What?
Resolves #43751.

PR introduces a new entity-aware user permission selector for the `core-data` store. I've also replaced the usage of `canUserEditEntityRecord` in the code base.

## Why?
* `canUser` - only supports resources in the `wp/v2` namespace. Additionally, you must know the final REST API path. Typically, however, only an entity's kind and name are known.
* `canUserEntityRecord` - is limited to only the edit action check. It was a wrapper for `canUser` and only supported the `wp/v2` namespace, which hasn't been required since WP 5.9.

The new selector also opens up the possibility to leverage ["target hints"](https://github.com/WordPress/gutenberg/pull/61644#discussion_r1600465798) and bulk fetch permissions data for DataViews.

## Notes
* I'll make the selector private. It is only public for testing fast testing purposes.
* The name isn't final, and I'm open to suggestions.
* The selector is very similar to `canUser`.
* The state uses the same storage as `canUser` - `cacheKey = isAllowed`.

## Testing Instructions

### Basic Testing
```
wp.data.select( 'core' ).hasPermission( 'update', 'root', 'site' );
wp.data.select( 'core' ).hasPermission( 'delete', 'root', 'site' );
```

### Testing canUserEntityRecord changes
1. Open a post.
2. Add Title and Excerpt blocks.
3. Confirm you can edit them as before.

### Testing Instructions for Keyboard
Same.
