### PR TITLE
Enable `save draft` button for posts with custom post status

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -21,6 +21,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 /**
  * Internal dependencies
  */
+import { STATUS_OPTIONS } from '../../components/post-status';
 import { store as editorStore } from '../../store';
 
 /**
@@ -104,10 +105,19 @@ export default function PostSavedState( { forceIsDirty } ) {
 		return null;
 	}
 
+	// We shouldn't render the button if the post has not one of the following statuses: pending, draft, auto-draft.
+	// The reason for this is that this button handles the `save as pending` and `save draft` actions.
+	// An exception for this is when the post has a custom status and there should be a way to save changes without
+	// having to publish. This should be handled better in the future when custom statuses have better support.
+	// @see https://github.com/WordPress/gutenberg/issues/3144.
+	const isIneligibleStatus =
+		! [ 'pending', 'draft', 'auto-draft' ].includes( postStatus ) &&
+		STATUS_OPTIONS.map( ( { value } ) => value ).includes( postStatus );
+
 	if (
 		isPublished ||
 		isScheduled ||
-		! [ 'pending', 'draft', 'auto-draft' ].includes( postStatus ) ||
+		isIneligibleStatus ||
 		( postStatusHasChanged &&
 			[ 'pending', 'draft' ].includes( postStatus ) )
 	) {

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -40,7 +40,7 @@ const labels = {
 	publish: __( 'Published' ),
 };
 
-const STATUS_OPTIONS = [
+export const STATUS_OPTIONS = [
 	{
 		label: (
 			<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/63161

Before the update of the publishing flow, we would render the `save draft` button for a post with custom post type, even if it wasn't really a post with `draft` status. This enabled use cases to make changes in such posts without having to publish first.

This PR adds an extra check when to show this button, to see if the post status is a custom one.

## Testing Instructions
From the issue: 

1.  In PHP, register a custom post status and insert a sample post with that status: 
```php
function sample_post_for_save_as_issue() {
  register_post_status('testing', ['label' => 'Testing', 'internal' => false, 'protected' => true]); 
  
  if (!is_user_logged_in()) {return;}
    
  $query = new WP_Query(['name' => 'status_test_345234']);
  
  if (!$query->have_posts()) {
    wp_insert_post(['post_name' => 'status_test_345234', 'post_title' => 'Status Test', 'post_status' => 'testing']);
  }
}

add_action('init', 'sample_post_for_save_as_issue');
```
2. Open the sample post "Status Test" in Gutenberg.
3. Make and save changes using the `save draft` button.
4. Check existing flows for posts without custom statuses that there is no regression.

### Notes
Custom post statuses are not handled well right now and this is tracked in [this issue](https://github.com/WordPress/gutenberg/issues/3144).
