### PR TITLE
Add: Permission checks to avoid 403 errors on non admin roles.

### DIFF
--- a/packages/edit-post/src/store/private-selectors.js
+++ b/packages/edit-post/src/store/private-selectors.js
@@ -12,8 +12,10 @@ export const getEditedPostTemplateId = createRegistrySelector(
 			type: postType,
 			slug,
 		} = select( editorStore ).getCurrentPost();
-		const { getSite, getEntityRecords } = select( coreStore );
-		const siteSettings = getSite();
+		const { getSite, getEntityRecords, canUser } = select( coreStore );
+		const siteSettings = canUser( 'read', 'settings' )
+			? getSite()
+			: undefined;
 		// First check if the current page is set as the posts page.
 		const isPostsPage = +postId === siteSettings?.page_for_posts;
 		if ( isPostsPage ) {

--- a/packages/edit-post/src/store/private-selectors.js
+++ b/packages/edit-post/src/store/private-selectors.js
@@ -13,7 +13,10 @@ export const getEditedPostTemplateId = createRegistrySelector(
 			slug,
 		} = select( editorStore ).getCurrentPost();
 		const { getSite, getEntityRecords, canUser } = select( coreStore );
-		const siteSettings = canUser( 'read', 'settings' )
+		const siteSettings = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
 			? getSite()
 			: undefined;
 		// First check if the current page is set as the posts page.

--- a/packages/editor/src/components/blog-title/index.js
+++ b/packages/editor/src/components/blog-title/index.js
@@ -27,9 +27,11 @@ export default function BlogTitle() {
 	const { editEntityRecord } = useDispatch( coreStore );
 	const { postsPageTitle, postsPageId, isTemplate, postSlug } = useSelect(
 		( select ) => {
-			const { getEntityRecord, getEditedEntityRecord } =
+			const { getEntityRecord, getEditedEntityRecord, canUser } =
 				select( coreStore );
-			const siteSettings = getEntityRecord( 'root', 'site' );
+			const siteSettings = canUser( 'read', 'settings' )
+				? getEntityRecord( 'root', 'site' )
+				: undefined;
 			const _postsPageRecord = siteSettings?.page_for_posts
 				? getEditedEntityRecord(
 						'postType',

--- a/packages/editor/src/components/blog-title/index.js
+++ b/packages/editor/src/components/blog-title/index.js
@@ -29,7 +29,10 @@ export default function BlogTitle() {
 		( select ) => {
 			const { getEntityRecord, getEditedEntityRecord, canUser } =
 				select( coreStore );
-			const siteSettings = canUser( 'read', 'settings' )
+			const siteSettings = canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} )
 				? getEntityRecord( 'root', 'site' )
 				: undefined;
 			const _postsPageRecord = siteSettings?.page_for_posts

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -41,9 +41,14 @@ function useGlobalStylesUserConfig() {
 			} = select( coreStore );
 			const _globalStylesId =
 				select( coreStore ).__experimentalGetCurrentGlobalStylesId();
+
+			// Doing canUser( 'read', 'global_styles' ) returns false even for users with the capability.
+			// See: https://github.com/WordPress/gutenberg/issues/63438
+			// So we need to check the user capabilities directly.
 			const userId = getCurrentUser()?.id;
 			const canEditThemeOptions =
 				userId && getUser( userId )?.capabilities?.edit_theme_options;
+
 			const record =
 				_globalStylesId && canEditThemeOptions
 					? getEditedEntityRecord(
@@ -139,6 +144,10 @@ function useGlobalStylesBaseConfig() {
 			getUser,
 			__experimentalGetCurrentThemeBaseGlobalStyles,
 		} = select( coreStore );
+
+		// Doing canUser( 'read', 'global_styles' ) returns false even for users with the capability.
+		// See: https://github.com/WordPress/gutenberg/issues/63438
+		// So we need to check the user capabilities directly.
 		const userId = getCurrentUser()?.id;
 		const canEditThemeOptions =
 			userId && getUser( userId )?.capabilities?.edit_theme_options;

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -33,17 +33,25 @@ export function mergeBaseAndUserConfigs( base, user ) {
 function useGlobalStylesUserConfig() {
 	const { globalStylesId, isReady, settings, styles, _links } = useSelect(
 		( select ) => {
-			const { getEditedEntityRecord, hasFinishedResolution } =
-				select( coreStore );
+			const {
+				getEditedEntityRecord,
+				hasFinishedResolution,
+				getUser,
+				getCurrentUser,
+			} = select( coreStore );
 			const _globalStylesId =
 				select( coreStore ).__experimentalGetCurrentGlobalStylesId();
-			const record = _globalStylesId
-				? getEditedEntityRecord(
-						'root',
-						'globalStyles',
-						_globalStylesId
-				  )
-				: undefined;
+			const userId = getCurrentUser()?.id;
+			const canEditThemeOptions =
+				userId && getUser( userId )?.capabilities?.edit_theme_options;
+			const record =
+				_globalStylesId && canEditThemeOptions
+					? getEditedEntityRecord(
+							'root',
+							'globalStyles',
+							_globalStylesId
+					  )
+					: undefined;
 
 			let hasResolved = false;
 			if (
@@ -126,9 +134,19 @@ function useGlobalStylesUserConfig() {
 
 function useGlobalStylesBaseConfig() {
 	const baseConfig = useSelect( ( select ) => {
-		return select(
-			coreStore
-		).__experimentalGetCurrentThemeBaseGlobalStyles();
+		const {
+			getCurrentUser,
+			getUser,
+			__experimentalGetCurrentThemeBaseGlobalStyles,
+		} = select( coreStore );
+		const userId = getCurrentUser()?.id;
+		const canEditThemeOptions =
+			userId && getUser( userId )?.capabilities?.edit_theme_options;
+
+		return (
+			canEditThemeOptions &&
+			__experimentalGetCurrentThemeBaseGlobalStyles()
+		);
 	}, [] );
 
 	return [ !! baseConfig, baseConfig ];

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -36,8 +36,11 @@ export default function PostCardPanel( { actions } ) {
 				getCurrentPostId,
 				__experimentalGetTemplateInfo,
 			} = select( editorStore );
+			const { canUser } = select( coreStore );
 			const { getEditedEntityRecord } = select( coreStore );
-			const siteSettings = getEditedEntityRecord( 'root', 'site' );
+			const siteSettings = canUser( 'read', 'settings' )
+				? getEditedEntityRecord( 'root', 'site' )
+				: undefined;
 			const _type = getCurrentPostType();
 			const _id = getCurrentPostId();
 			const _record = getEditedEntityRecord( 'postType', _type, _id );

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -38,7 +38,10 @@ export default function PostCardPanel( { actions } ) {
 			} = select( editorStore );
 			const { canUser } = select( coreStore );
 			const { getEditedEntityRecord } = select( coreStore );
-			const siteSettings = canUser( 'read', 'settings' )
+			const siteSettings = canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} )
 				? getEditedEntityRecord( 'root', 'site' )
 				: undefined;
 			const _type = getCurrentPostType();

--- a/packages/editor/src/components/post-content-information/index.js
+++ b/packages/editor/src/components/post-content-information/index.js
@@ -25,8 +25,11 @@ export default function PostContentInformation() {
 	const { postContent } = useSelect( ( select ) => {
 		const { getEditedPostAttribute, getCurrentPostType, getCurrentPostId } =
 			select( editorStore );
+		const { canUser } = select( coreStore );
 		const { getEntityRecord } = select( coreStore );
-		const siteSettings = getEntityRecord( 'root', 'site' );
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEntityRecord( 'root', 'site' )
+			: undefined;
 		const postType = getCurrentPostType();
 		const _id = getCurrentPostId();
 		const isPostsPage = +_id === siteSettings?.page_for_posts;

--- a/packages/editor/src/components/post-content-information/index.js
+++ b/packages/editor/src/components/post-content-information/index.js
@@ -27,7 +27,10 @@ export default function PostContentInformation() {
 			select( editorStore );
 		const { canUser } = select( coreStore );
 		const { getEntityRecord } = select( coreStore );
-		const siteSettings = canUser( 'read', 'settings' )
+		const siteSettings = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
 			? getEntityRecord( 'root', 'site' )
 			: undefined;
 		const postType = getCurrentPostType();

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -23,8 +23,14 @@ export function useAllowSwitchingTemplates() {
 	const { postType, postId } = useEditedPostContext();
 	return useSelect(
 		( select ) => {
-			const { getEntityRecord, getEntityRecords } = select( coreStore );
-			const siteSettings = getEntityRecord( 'root', 'site' );
+			const { canUser, getEntityRecord, getEntityRecords } =
+				select( coreStore );
+			const siteSettings = canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} )
+				? getEntityRecord( 'root', 'site' )
+				: undefined;
 			const templates = getEntityRecords( 'postType', 'wp_template', {
 				per_page: -1,
 			} );

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -61,8 +61,10 @@ export default function PostURLPanel() {
 function PostURLToggle( { isOpen, onClick } ) {
 	const { slug, isFrontPage, postLink } = useSelect( ( select ) => {
 		const { getCurrentPostId, getCurrentPost } = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
-		const siteSettings = getEditedEntityRecord( 'root', 'site' );
+		const { getEditedEntityRecord, canUser } = select( coreStore );
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEditedEntityRecord( 'root', 'site' )
+			: undefined;
 		const _id = getCurrentPostId();
 		return {
 			slug: select( editorStore ).getEditedPostSlug(),

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -62,7 +62,10 @@ function PostURLToggle( { isOpen, onClick } ) {
 	const { slug, isFrontPage, postLink } = useSelect( ( select ) => {
 		const { getCurrentPostId, getCurrentPost } = select( editorStore );
 		const { getEditedEntityRecord, canUser } = select( coreStore );
-		const siteSettings = canUser( 'read', 'settings' )
+		const siteSettings = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
 			? getEditedEntityRecord( 'root', 'site' )
 			: undefined;
 		const _id = getCurrentPostId();

--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -24,8 +24,10 @@ export default function PostsPerPage() {
 	const { postsPerPage, isTemplate, postSlug } = useSelect( ( select ) => {
 		const { getEditedPostAttribute, getCurrentPostType } =
 			select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
-		const siteSettings = getEditedEntityRecord( 'root', 'site' );
+		const { getEditedEntityRecord, canUser } = select( coreStore );
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEditedEntityRecord( 'root', 'site' )
+			: undefined;
 		return {
 			isTemplate: getCurrentPostType() === TEMPLATE_POST_TYPE,
 			postSlug: getEditedPostAttribute( 'slug' ),

--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -25,7 +25,10 @@ export default function PostsPerPage() {
 		const { getEditedPostAttribute, getCurrentPostType } =
 			select( editorStore );
 		const { getEditedEntityRecord, canUser } = select( coreStore );
-		const siteSettings = canUser( 'read', 'settings' )
+		const siteSettings = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
 			? getEditedEntityRecord( 'root', 'site' )
 			: undefined;
 		return {

--- a/packages/editor/src/components/site-discussion/index.js
+++ b/packages/editor/src/components/site-discussion/index.js
@@ -55,8 +55,10 @@ export default function SiteDiscussion() {
 		( select ) => {
 			const { getEditedPostAttribute, getCurrentPostType } =
 				select( editorStore );
-			const { getEditedEntityRecord } = select( coreStore );
-			const siteSettings = getEditedEntityRecord( 'root', 'site' );
+			const { getEditedEntityRecord, canUser } = select( coreStore );
+			const siteSettings = canUser( 'read', 'settings' )
+				? getEditedEntityRecord( 'root', 'site' )
+				: undefined;
 			return {
 				isTemplate: getCurrentPostType() === TEMPLATE_POST_TYPE,
 				postSlug: getEditedPostAttribute( 'slug' ),

--- a/packages/editor/src/components/site-discussion/index.js
+++ b/packages/editor/src/components/site-discussion/index.js
@@ -56,7 +56,10 @@ export default function SiteDiscussion() {
 			const { getEditedPostAttribute, getCurrentPostType } =
 				select( editorStore );
 			const { getEditedEntityRecord, canUser } = select( coreStore );
-			const siteSettings = canUser( 'read', 'settings' )
+			const siteSettings = canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} )
 				? getEditedEntityRecord( 'root', 'site' )
 				: undefined;
 			return {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/60987

Adds permission checks for site settings and global styles retrieval on the editor package to avoid 403 HTTP request errors currently happening when a non-admin role like an editor loads the post editor.


### Testing Instructions for Keyboard
With a user whose role is editor, I created a new page and verified on the browser console that there are no 403 HTTP requests (on trunk there are).
