### PR TITLE
Inserter: fix 'append-after' keyboard a11y in both modes

### DIFF
--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -47,10 +47,12 @@
 
 .block-editor-block-list__insertion-point {
 	opacity: 0;
+	pointer-events: none;
 
 	&:focus-within,
 	.is-visible {
 		opacity: 1;
+		pointer-events: all;
 	}
 }
 

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -45,6 +45,14 @@
 	}
 }
 
+.block-editor-block-list__insertion-point {
+	opacity: 0;
+
+	&:focus-within,
+	.is-visible {
+		opacity: 1;
+	}
+}
 
 .components-popover.block-editor-block-popover__drop-zone {
 	// Disable pointer events for dragging and dropping.

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -202,12 +202,6 @@ export default function BlockTools( {
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div { ...props } onKeyDown={ onKeyDown }>
 			<InsertionPointOpenRef.Provider value={ useRef( false ) }>
-				{ ! isTyping && (
-					<InsertionPoint
-						__unstableContentRef={ __unstableContentRef }
-					/>
-				) }
-
 				{ showEmptyBlockSideInserter && (
 					<EmptyBlockInserter
 						__unstableContentRef={ __unstableContentRef }
@@ -251,6 +245,11 @@ export default function BlockTools( {
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
 				/>
+				{ ! isTyping && (
+					<InsertionPoint
+						__unstableContentRef={ __unstableContentRef }
+					/>
+				) }
 				{ window.__experimentalEnableZoomedOutPatternsTab &&
 					isZoomOutMode && (
 						<ZoomOutModeInserters

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -26,6 +26,7 @@ function InbetweenInsertionPointPopover( {
 	__unstableContentRef,
 	operation = 'insert',
 	nearestSide = 'right',
+	isVisible,
 } ) {
 	const { selectBlock, hideInsertionPoint } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
@@ -78,7 +79,7 @@ function InbetweenInsertionPointPopover( {
 			rootClientId: insertionPoint.rootClientId,
 			isNavigationMode: _isNavigationMode(),
 			isDistractionFree: settings.isDistractionFree,
-			isInserterShown: insertionPoint?.__unstableWithInserter,
+			isInserterShown: insertionPoint?.__unstableWithInserter ?? true,
 		};
 	}, [] );
 	const { getBlockEditingMode } = useSelect( blockEditorStore );
@@ -177,6 +178,7 @@ function InbetweenInsertionPointPopover( {
 				onFocus={ onFocus }
 				className={ clsx( className, {
 					'is-with-inserter': isInserterShown,
+					'is-visible': isVisible,
 				} ) }
 				onHoverEnd={ maybeHideInserterPoint }
 			>
@@ -231,7 +233,6 @@ export default function InsertionPoint( props ) {
 	);
 
 	if (
-		! isVisible ||
 		// Don't render the insertion point if the block list is empty.
 		// The insertion point will be represented by the appender instead.
 		isBlockListEmpty
@@ -243,7 +244,7 @@ export default function InsertionPoint( props ) {
 	 * Render a popover that overlays the block when the desired operation is to replace it.
 	 * Otherwise, render a popover in between blocks for the indication of inserting between them.
 	 */
-	return insertionPoint.operation === 'replace' ? (
+	return isVisible && insertionPoint.operation === 'replace' ? (
 		<BlockDropZonePopover
 			// Force remount to trigger the animation.
 			key={ `${ insertionPoint.rootClientId }-${ insertionPoint.index }` }
@@ -253,6 +254,7 @@ export default function InsertionPoint( props ) {
 		<InbetweenInsertionPointPopover
 			operation={ insertionPoint.operation }
 			nearestSide={ insertionPoint.nearestSide }
+			isVisible={ isVisible }
 			{ ...props }
 		/>
 	);

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -79,7 +79,7 @@ function InbetweenInsertionPointPopover( {
 			rootClientId: insertionPoint.rootClientId,
 			isNavigationMode: _isNavigationMode(),
 			isDistractionFree: settings.isDistractionFree,
-			isInserterShown: insertionPoint?.__unstableWithInserter ?? true,
+			isInserterShown: insertionPoint?.__unstableWithInserter,
 		};
 	}, [] );
 	const { getBlockEditingMode } = useSelect( blockEditorStore );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1476,7 +1476,7 @@ export const getBlockInsertionPoint = createSelector(
 			index = getBlockOrder( state ).length;
 		}
 
-		return { rootClientId, index };
+		return { rootClientId, index, __unstableWithInserter: true };
 	},
 	( state ) => [
 		state.insertionPoint,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #61391.

Adds a tabbable inserter:

* In edit mode, after the selected block.
* In navigation/select mode, at the end of the canvas.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make it easier to add a block after the selected block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The approach here is to leverage the "in-between" inserter. Instead of being accessible with pointer devices only, make it also keyboard accessible.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* In edit mode, select a block, then press tab. Focus should mode the inserter. Press tab again and it should move to the sidebar. Reverse tab should also work correctly.
* In navigation/select mode (press Esc), Tab to the last block. The next tab should focus the inserter, the next the sidebar. Reverse tab should also work correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

See above, this is a keyboard only fix.

## Screenshots or screencast <!-- if applicable -->

![insert-after](https://github.com/WordPress/gutenberg/assets/4710635/67e1038a-b182-431c-96da-88635967a5f4)

