### PR TITLE
Core Data: Remove entity config '__experimentalNoFetch' flag checks

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -292,7 +292,7 @@ export const deleteEntityRecord =
 		);
 		let error;
 		let deletedRecord = false;
-		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
+		if ( ! entityConfig ) {
 			return;
 		}
 
@@ -507,7 +507,7 @@ export const saveEntityRecord =
 		const entityConfig = configs.find(
 			( config ) => config.kind === kind && config.name === name
 		);
-		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
+		if ( ! entityConfig ) {
 			return;
 		}
 		const entityIdKey = entityConfig.key || DEFAULT_ENTITY_KEY;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -63,7 +63,7 @@ export const getEntityRecord =
 		const entityConfig = configs.find(
 			( config ) => config.name === name && config.kind === kind
 		);
-		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
+		if ( ! entityConfig ) {
 			return;
 		}
 
@@ -198,7 +198,7 @@ export const getEntityRecords =
 		const entityConfig = configs.find(
 			( config ) => config.name === name && config.kind === kind
 		);
-		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
+		if ( ! entityConfig ) {
 			return;
 		}
 
@@ -742,7 +742,7 @@ export const getRevisions =
 			( config ) => config.name === name && config.kind === kind
 		);
 
-		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
+		if ( ! entityConfig ) {
 			return;
 		}
 
@@ -867,7 +867,7 @@ export const getRevision =
 			( config ) => config.name === name && config.kind === kind
 		);
 
-		if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
+		if ( ! entityConfig ) {
 			return;
 		}
 


### PR DESCRIPTION
## What?
PR removes `entityConfig.__experimentalNoFetch` checks from resolvers and selectors.

## Why?
It was introduced initially to handle a particular case in the now-removed Navigation editor (#34839). I don't see a reason for core entities to use this flag.

## Testing Instructions
All CI checks should be green.
