### PR TITLE
Update: Include avatars on list view.

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -173,7 +173,7 @@ function Author( { item, viewType } ) {
 	const withIcon = viewType !== LAYOUT_LIST;
 
 	return (
-		<HStack alignment="left" spacing={ 1 }>
+		<HStack alignment="left" spacing={ 0 }>
 			{ withIcon && imageUrl && (
 				<div
 					className={ clsx( 'page-templates-author-field__avatar', {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -106,7 +106,7 @@ function AuthorField( { item } ) {
 	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
 
 	return (
-		<HStack alignment="left" spacing={ 1 }>
+		<HStack alignment="left" spacing={ 0 }>
 			{ imageUrl && (
 				<div
 					className={ clsx( 'page-templates-author-field__avatar', {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -101,14 +101,13 @@ function Title( { item, viewType } ) {
 	);
 }
 
-function AuthorField( { item, viewType } ) {
+function AuthorField( { item } ) {
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
-	const withIcon = viewType !== LAYOUT_LIST;
 
 	return (
 		<HStack alignment="left" spacing={ 1 }>
-			{ withIcon && imageUrl && (
+			{ imageUrl && (
 				<div
 					className={ clsx( 'page-templates-author-field__avatar', {
 						'is-loaded': isImageLoaded,
@@ -121,7 +120,7 @@ function AuthorField( { item, viewType } ) {
 					/>
 				</div>
 			) }
-			{ withIcon && ! imageUrl && (
+			{ ! imageUrl && (
 				<div className="page-templates-author-field__icon">
 					<Icon icon={ icon } />
 				</div>

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -71,6 +71,7 @@
 	display: flex;
 
 	img {
+		margin-left: -$grid-unit-05;
 		width: 20px;
 		height: 20px;
 		object-fit: cover;
@@ -94,6 +95,7 @@
 	height: $grid-unit-30;
 
 	svg {
+		margin-left: -$grid-unit-05;
 		fill: currentColor;
 	}
 }

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -67,13 +67,12 @@
 	width: $grid-unit-30;
 	height: $grid-unit-30;
 	align-items: center;
-	justify-content: center;
+	justify-content: left;
 	display: flex;
 
 	img {
-		margin-left: -$grid-unit-05;
-		width: 20px;
-		height: 20px;
+		width: $grid-unit-20;
+		height: $grid-unit-20;
 		object-fit: cover;
 		opacity: 0;
 		transition: opacity 0.1s linear;

--- a/packages/edit-site/src/components/posts-app/posts-list.js
+++ b/packages/edit-site/src/components/posts-app/posts-list.js
@@ -241,26 +241,22 @@ function PostStatusField( { item } ) {
 	);
 }
 
-function PostAuthorField( { item, viewType } ) {
-	const { text, icon, imageUrl } = useSelect(
+function PostAuthorField( { item } ) {
+	const { text, imageUrl } = useSelect(
 		( select ) => {
 			const { getUser } = select( coreStore );
 			const user = getUser( item.author );
 			return {
-				icon: authorIcon,
 				imageUrl: user?.avatar_urls?.[ 48 ],
 				text: user?.name,
 			};
 		},
 		[ item ]
 	);
-
-	const withAuthorImage = viewType !== LAYOUT_LIST && imageUrl;
-	const withAuthorIcon = viewType !== LAYOUT_LIST && ! imageUrl;
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 	return (
 		<HStack alignment="left" spacing={ 1 }>
-			{ withAuthorImage && (
+			{ !! imageUrl && (
 				<div
 					className={ clsx( 'page-templates-author-field__avatar', {
 						'is-loaded': isImageLoaded,
@@ -273,9 +269,9 @@ function PostAuthorField( { item, viewType } ) {
 					/>
 				</div>
 			) }
-			{ withAuthorIcon && (
+			{ ! imageUrl && (
 				<div className="page-templates-author-field__icon">
-					<Icon icon={ icon } />
+					<Icon icon={ authorIcon } />
 				</div>
 			) }
 			<span className="page-templates-author-field__name">{ text }</span>
@@ -471,11 +467,7 @@ export default function PostsList( { postType } ) {
 						value: id,
 						label: name,
 					} ) ) || [],
-				render: ( { item } ) => {
-					return (
-						<PostAuthorField viewType={ view.type } item={ item } />
-					);
-				},
+				render: PostAuthorField,
 			},
 			{
 				header: __( 'Status' ),

--- a/packages/edit-site/src/components/posts-app/posts-list.js
+++ b/packages/edit-site/src/components/posts-app/posts-list.js
@@ -230,7 +230,7 @@ function PostStatusField( { item } ) {
 	const label = status?.label || item.status;
 	const icon = status?.icon;
 	return (
-		<HStack alignment="left" spacing={ 1 }>
+		<HStack alignment="left" spacing={ 0 }>
 			{ icon && (
 				<div className="posts-list-page-post-author-field__icon-container">
 					<Icon icon={ icon } />
@@ -255,7 +255,7 @@ function PostAuthorField( { item } ) {
 	);
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 	return (
-		<HStack alignment="left" spacing={ 1 }>
+		<HStack alignment="left" spacing={ 0 }>
 			{ !! imageUrl && (
 				<div
 					className={ clsx( 'page-templates-author-field__avatar', {

--- a/packages/edit-site/src/components/posts-app/style.scss
+++ b/packages/edit-site/src/components/posts-app/style.scss
@@ -76,7 +76,9 @@
 
 .posts-list-page-post-author-field__icon-container {
 	height: $grid-unit-30;
+	width: $grid-unit-30;
 	svg {
 		fill: currentColor;
+		margin-left: -$grid-unit-05;
 	}
 }


### PR DESCRIPTION
Adds avatars to the list layout as suggested by @jameskoster.

## Screenshots

<img width="1055" alt="Screenshot 2024-07-09 at 15 28 53" src="https://github.com/WordPress/gutenberg/assets/11271197/42c86798-61ee-41f7-a900-bc492db6f722">
<img width="1052" alt="Screenshot 2024-07-09 at 15 28 43" src="https://github.com/WordPress/gutenberg/assets/11271197/39b5b1a8-a307-469c-9a89-2e13dc20d3ca">


## Testing Instructions
Verified the avatars appear on the list layout view and other views.