### PR TITLE
Build: Include Core blocks' `render` and `variations` files

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Enhancements
 
-- Inlines CSS files imported from other CSS files before optimization in the `build` command ([#61121](https://github.com/WordPress/gutenberg/pull/61121)).
+-   Inlines CSS files imported from other CSS files before optimization in the `build` command ([#61121](https://github.com/WordPress/gutenberg/pull/61121)).
+-   Add automatic support for handling `variations` field from `block.json` in the `build` and `start` scripts ([#63311](https://github.com/WordPress/gutenberg/pull/63311)).
 
 ### Bug Fixes
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -10,8 +10,7 @@
 
 ### Enhancements
 
--   Inlines CSS files imported from other CSS files before optimization in the `build` command ([#61121](https://github.com/WordPress/gutenberg/pull/61121)).
--   Add automatic support for handling `variations` field from `block.json` in the `build` and `start` scripts ([#63311](https://github.com/WordPress/gutenberg/pull/63311)).
+- Inlines CSS files imported from other CSS files before optimization in the `build` command ([#61121](https://github.com/WordPress/gutenberg/pull/61121)).
 
 ### Bug Fixes
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Enhancements
 
 -   Inlines CSS files imported from other CSS files before optimization in the `build` command ([#61121](https://github.com/WordPress/gutenberg/pull/61121)).
--   Adds automatic support for handling `variations` field from `block.json` in the `build` and `start` scripts ([#63311](https://github.com/WordPress/gutenberg/pull/63311)).
+-   Add automatic support for handling `variations` field from `block.json` in the `build` and `start` scripts ([#63311](https://github.com/WordPress/gutenberg/pull/63311)).
 
 ### Bug Fixes
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Enhancements
 
 -   Inlines CSS files imported from other CSS files before optimization in the `build` command ([#61121](https://github.com/WordPress/gutenberg/pull/61121)).
--   Add automatic support for handling `variations` field from `block.json` in the `build` and `start` scripts ([#63311](https://github.com/WordPress/gutenberg/pull/63311)).
+-   Adds automatic support for handling `variations` field from `block.json` in the `build` and `start` scripts ([#63311](https://github.com/WordPress/gutenberg/pull/63311)).
 
 ### Bug Fixes
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -13,7 +13,6 @@ const RtlCssPlugin = require( 'rtlcss-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const { realpathSync } = require( 'fs' );
 const { sync: glob } = require( 'fast-glob' );
-const { validate } = require( 'schema-utils' );
 
 /**
  * WordPress dependencies
@@ -32,11 +31,11 @@ const {
 	hasPostCSSConfig,
 	getWordPressSrcDirectory,
 	getWebpackEntryPoints,
-	getPhpFilePaths,
 	getAsBooleanFromENV,
 	getBlockJsonModuleFields,
 	getBlockJsonScriptFields,
 	fromProjectRoot,
+	PhpFilePathsPlugin,
 } = require( '../utils' );
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -49,49 +48,6 @@ const hasReactFastRefresh = hasArgInCLI( '--hot' ) && ! isProduction;
 const hasExperimentalModulesFlag = getAsBooleanFromENV(
 	'WP_EXPERIMENTAL_MODULES'
 );
-
-const phpFilePathsPluginSchema = {
-	type: 'object',
-	properties: {
-		props: {
-			type: 'array',
-			items: {
-				type: 'string',
-			},
-		},
-	},
-};
-
-/**
- * The plugin recomputes PHP file paths once on each compilation. It is necessary to avoid repeating processing
- * when filtering every discovered PHP file in the source folder. This is the most performant way to ensure that
- * changes in `block.json` files are picked up in watch mode.
- */
-class PhpFilePathsPlugin {
-	/**
-	 * PHP file paths from `render` and `variations` props found in `block.json` files.
-	 *
-	 * @type {string[]}
-	 */
-	static paths;
-
-	constructor( options = {} ) {
-		validate( phpFilePathsPluginSchema, options, {
-			name: 'PHP File Paths Plugin',
-			baseDataPath: 'options',
-		} );
-
-		this.options = options;
-	}
-
-	apply( compiler ) {
-		const pluginName = this.constructor.name;
-
-		compiler.hooks.thisCompilation.tap( pluginName, () => {
-			this.constructor.paths = getPhpFilePaths( this.options.props );
-		} );
-	}
-}
 
 const cssLoaders = [
 	{

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -301,7 +301,10 @@ const scriptConfig = {
 				cleanStaleWebpackAssets: false,
 			} ),
 
-		new PhpFilePathsPlugin( { props: [ 'render', 'variations' ] } ),
+		new PhpFilePathsPlugin( {
+			context: getWordPressSrcDirectory(),
+			props: [ 'render', 'variations' ],
+		} ),
 		new CopyWebpackPlugin( {
 			patterns: [
 				{

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -351,22 +351,23 @@ function getWebpackEntryPoints( buildType ) {
 /**
  * Returns the list of PHP file paths found in `block.json` files for the given props.
  *
- * @param {string[]} props The props to search for in the `block.json` files.
+ * @param {string}   context The path to search for `block.json` files.
+ * @param {string[]} props   The props to search for in the `block.json` files.
  * @return {string[]} The list of PHP file paths.
  */
-function getPhpFilePaths( props ) {
+function getPhpFilePaths( context, props ) {
 	// Continue only if the source directory exists.
-	if ( ! hasProjectFile( getWordPressSrcDirectory() ) ) {
+	if ( ! hasProjectFile( context ) ) {
 		return [];
 	}
 
 	// Checks whether any block metadata files can be detected in the defined source directory.
 	const blockMetadataFiles = glob( '**/block.json', {
 		absolute: true,
-		cwd: fromProjectRoot( getWordPressSrcDirectory() ),
+		cwd: fromProjectRoot( context ),
 	} );
 
-	const srcDirectory = fromProjectRoot( getWordPressSrcDirectory() + sep );
+	const srcDirectory = fromProjectRoot( context + sep );
 
 	return blockMetadataFiles.flatMap( ( blockMetadataFile ) => {
 		const blockJson = JSON.parse( readFileSync( blockMetadataFile ) );
@@ -396,7 +397,7 @@ function getPhpFilePaths( props ) {
 						) }" listed in "${ blockMetadataFile.replace(
 							fromProjectRoot( sep ),
 							''
-						) }". File is located outside of the "${ getWordPressSrcDirectory() }" directory.`
+						) }". File is located outside of the "${ context }" directory.`
 					)
 				);
 				continue;

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -29,6 +29,7 @@ const {
 	getBlockJsonModuleFields,
 	getBlockJsonScriptFields,
 } = require( './block-json' );
+const { PhpFilePathsPlugin } = require( './php-file-paths-plugin' );
 
 module.exports = {
 	fromProjectRoot,
@@ -55,5 +56,6 @@ module.exports = {
 	hasPostCSSConfig,
 	hasPrettierConfig,
 	hasProjectFile,
+	PhpFilePathsPlugin,
 	spawnScript,
 };

--- a/packages/scripts/utils/php-file-paths-plugin.js
+++ b/packages/scripts/utils/php-file-paths-plugin.js
@@ -6,7 +6,7 @@ const { validate } = require( 'schema-utils' );
 /**
  * Internal dependencies
  */
-const { getPhpFilePaths } = require( '../utils' );
+const { getPhpFilePaths } = require( './config' );
 
 const phpFilePathsPluginSchema = {
 	type: 'object',

--- a/packages/scripts/utils/php-file-paths-plugin.js
+++ b/packages/scripts/utils/php-file-paths-plugin.js
@@ -11,6 +11,9 @@ const { getPhpFilePaths } = require( '../utils' );
 const phpFilePathsPluginSchema = {
 	type: 'object',
 	properties: {
+		context: {
+			type: 'string',
+		},
 		props: {
 			type: 'array',
 			items: {
@@ -46,7 +49,10 @@ class PhpFilePathsPlugin {
 		const pluginName = this.constructor.name;
 
 		compiler.hooks.thisCompilation.tap( pluginName, () => {
-			this.constructor.paths = getPhpFilePaths( this.options.props );
+			this.constructor.paths = getPhpFilePaths(
+				this.options.context,
+				this.options.props
+			);
 		} );
 	}
 }

--- a/packages/scripts/utils/php-file-paths-plugin.js
+++ b/packages/scripts/utils/php-file-paths-plugin.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+const { validate } = require( 'schema-utils' );
+
+/**
+ * Internal dependencies
+ */
+const { getPhpFilePaths } = require( '../utils' );
+
+const phpFilePathsPluginSchema = {
+	type: 'object',
+	properties: {
+		props: {
+			type: 'array',
+			items: {
+				type: 'string',
+			},
+		},
+	},
+};
+
+/**
+ * The plugin recomputes PHP file paths once on each compilation. It is necessary to avoid repeating processing
+ * when filtering every discovered PHP file in the source folder. This is the most performant way to ensure that
+ * changes in `block.json` files are picked up in watch mode.
+ */
+class PhpFilePathsPlugin {
+	/**
+	 * PHP file paths from `render` and `variations` props found in `block.json` files.
+	 *
+	 * @type {string[]}
+	 */
+	static paths;
+
+	constructor( options = {} ) {
+		validate( phpFilePathsPluginSchema, options, {
+			name: 'PHP File Paths Plugin',
+			baseDataPath: 'options',
+		} );
+
+		this.options = options;
+	}
+
+	apply( compiler ) {
+		const pluginName = this.constructor.name;
+
+		compiler.hooks.thisCompilation.tap( pluginName, () => {
+			this.constructor.paths = getPhpFilePaths( this.options.props );
+		} );
+	}
+}
+
+module.exports = { PhpFilePathsPlugin };

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -152,7 +152,7 @@ module.exports = [
 							filter: ( filepath ) => {
 								return (
 									filepath.endsWith( sep + 'index.php' ) ||
-									PhpFilePathsPlugin.renderPaths.includes(
+									PhpFilePathsPlugin.paths.includes(
 										realpathSync( filepath ).replace(
 											/\\/g,
 											'/'

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -94,7 +94,7 @@ module.exports = [
 			new DependencyExtractionWebpackPlugin( { injectPolyfill: false } ),
 			new PhpFilePathsPlugin( {
 				context: './packages/block-library/src/',
-				props: [ 'render' ],
+				props: [ 'render', 'variations' ],
 			} ),
 			new CopyWebpackPlugin( {
 				patterns: [].concat(

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -92,7 +92,10 @@ module.exports = [
 		plugins: [
 			...plugins,
 			new DependencyExtractionWebpackPlugin( { injectPolyfill: false } ),
-			new PhpFilePathsPlugin( { props: [ 'render' ] } ),
+			new PhpFilePathsPlugin( {
+				context: './packages/block-library/src/',
+				props: [ 'render' ],
+			} ),
 			new CopyWebpackPlugin( {
 				patterns: [].concat(
 					[


### PR DESCRIPTION
## What?
If a Core block's `block.json` contains a `render` and/or `variations` field that points to a PHP file name, copy those files to the build directory.

## Why?
It's an attempt at fixing https://github.com/WordPress/gutenberg/issues/63077.

## How?
By reusing logic from the `@wordpress/scripts` package.

## Testing Instructions

- On this branch, apply the patch below. (It will move the Template Part block's `render` method from `index.php` to a newly created `render.php`, and add a `render` field to `block.json` that points to that `render.php` file.)
- Run `npm run start`.
- Verify that `packages/block-library/src/template-part/render.php` has been copied to `build/block-library/blocks/template-part/render.php`.
- Make sure you're using a block theme such as TT4.
- In your web browser, verify that all instances of the Template Part block -- e.g. the header and footer -- render correctly.

<details>
<summary>
Patch
</summary>

```diff
diff --git a/packages/block-library/src/template-part/block.json b/packages/block-library/src/template-part/block.json
index 9710bdeee2e..7c3e28f52c0 100644
--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -29,5 +29,6 @@
 			"clientNavigation": true
 		}
 	},
-	"editorStyle": "wp-block-template-part-editor"
+	"editorStyle": "wp-block-template-part-editor",
+	"render": "file:./render.php"
 }
diff --git a/packages/block-library/src/template-part/index.php b/packages/block-library/src/template-part/index.php
index be867c4ced1..a9aef23f3da 100644
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -5,176 +5,6 @@
  * @package WordPress
  */
 
-/**
- * Renders the `core/template-part` block on the server.
- *
- * @since 5.9.0
- *
- * @global WP_Embed $wp_embed WordPress Embed object.
- *
- * @param array $attributes The block attributes.
- *
- * @return string The render.
- */
-function render_block_core_template_part( $attributes ) {
-	static $seen_ids = array();
-
-	$template_part_id = null;
-	$content          = null;
-	$area             = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
-	$theme            = isset( $attributes['theme'] ) ? $attributes['theme'] : get_stylesheet();
-
-	if ( isset( $attributes['slug'] ) && get_stylesheet() === $theme ) {
-		$template_part_id    = $theme . '//' . $attributes['slug'];
-		$template_part_query = new WP_Query(
-			array(
-				'post_type'           => 'wp_template_part',
-				'post_status'         => 'publish',
-				'post_name__in'       => array( $attributes['slug'] ),
-				'tax_query'           => array(
-					array(
-						'taxonomy' => 'wp_theme',
-						'field'    => 'name',
-						'terms'    => $theme,
-					),
-				),
-				'posts_per_page'      => 1,
-				'no_found_rows'       => true,
-				'lazy_load_term_meta' => false, // Do not lazy load term meta, as template parts only have one term.
-			)
-		);
-		$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
-		if ( $template_part_post ) {
-			// A published post might already exist if this template part was customized elsewhere
-			// or if it's part of a customized template.
-			$block_template = _build_block_template_result_from_post( $template_part_post );
-			$content        = $block_template->content;
-			if ( isset( $block_template->area ) ) {
-				$area = $block_template->area;
-			}
-			/**
-			 * Fires when a block template part is loaded from a template post stored in the database.
-			 *
-			 * @since 5.9.0
-			 *
-			 * @param string  $template_part_id   The requested template part namespaced to the theme.
-			 * @param array   $attributes         The block attributes.
-			 * @param WP_Post $template_part_post The template part post object.
-			 * @param string  $content            The template part content.
-			 */
-			do_action( 'render_block_core_template_part_post', $template_part_id, $attributes, $template_part_post, $content );
-		} else {
-			$template_part_file_path = '';
-			// Else, if the template part was provided by the active theme,
-			// render the corresponding file content.
-			if ( 0 === validate_file( $attributes['slug'] ) ) {
-				$block_template = get_block_file_template( $template_part_id, 'wp_template_part' );
-
-				$content = $block_template->content;
-				if ( isset( $block_template->area ) ) {
-					$area = $block_template->area;
-				}
-
-				// Needed for the `render_block_core_template_part_file` and `render_block_core_template_part_none` actions below.
-				$block_template_file = _get_block_template_file( 'wp_template_part', $attributes['slug'] );
-				if ( $block_template_file ) {
-					$template_part_file_path = $block_template_file['path'];
-				}
-			}
-
-			if ( '' !== $content && null !== $content ) {
-				/**
-				 * Fires when a block template part is loaded from a template part in the theme.
-				 *
-				 * @since 5.9.0
-				 *
-				 * @param string $template_part_id        The requested template part namespaced to the theme.
-				 * @param array  $attributes              The block attributes.
-				 * @param string $template_part_file_path Absolute path to the template path.
-				 * @param string $content                 The template part content.
-				 */
-				do_action( 'render_block_core_template_part_file', $template_part_id, $attributes, $template_part_file_path, $content );
-			} else {
-				/**
-				 * Fires when a requested block template part does not exist in the database nor in the theme.
-				 *
-				 * @since 5.9.0
-				 *
-				 * @param string $template_part_id        The requested template part namespaced to the theme.
-				 * @param array  $attributes              The block attributes.
-				 * @param string $template_part_file_path Absolute path to the not found template path.
-				 */
-				do_action( 'render_block_core_template_part_none', $template_part_id, $attributes, $template_part_file_path );
-			}
-		}
-	}
-
-	// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
-	// is set in `wp_debug_mode()`.
-	$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
-
-	if ( is_null( $content ) ) {
-		if ( $is_debug && isset( $attributes['slug'] ) ) {
-			return sprintf(
-				/* translators: %s: Template part slug. */
-				__( 'Template part has been deleted or is unavailable: %s' ),
-				$attributes['slug']
-			);
-		}
-
-		return '';
-	}
-
-	if ( isset( $seen_ids[ $template_part_id ] ) ) {
-		return $is_debug ?
-			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			__( '[block rendering halted]' ) :
-			'';
-	}
-
-	// Look up area definition.
-	$area_definition = null;
-	$defined_areas   = get_allowed_block_template_part_areas();
-	foreach ( $defined_areas as $defined_area ) {
-		if ( $defined_area['area'] === $area ) {
-			$area_definition = $defined_area;
-			break;
-		}
-	}
-
-	// If $area is not allowed, set it back to the uncategorized default.
-	if ( ! $area_definition ) {
-		$area = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
-	}
-
-	// Run through the actions that are typically taken on the_content.
-	$content                       = shortcode_unautop( $content );
-	$content                       = do_shortcode( $content );
-	$seen_ids[ $template_part_id ] = true;
-	$content                       = do_blocks( $content );
-	unset( $seen_ids[ $template_part_id ] );
-	$content = wptexturize( $content );
-	$content = convert_smilies( $content );
-	$content = wp_filter_content_tags( $content, "template_part_{$area}" );
-
-	// Handle embeds for block template parts.
-	global $wp_embed;
-	$content = $wp_embed->autoembed( $content );
-
-	if ( empty( $attributes['tagName'] ) || tag_escape( $attributes['tagName'] ) !== $attributes['tagName'] ) {
-		$area_tag = 'div';
-		if ( $area_definition && isset( $area_definition['area_tag'] ) ) {
-			$area_tag = $area_definition['area_tag'];
-		}
-		$html_tag = $area_tag;
-	} else {
-		$html_tag = esc_attr( $attributes['tagName'] );
-	}
-	$wrapper_attributes = get_block_wrapper_attributes();
-
-	return "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
-}
-
 /**
  * Returns an array of area variation objects for the template part block.
  *
@@ -293,7 +123,7 @@ function register_block_core_template_part() {
 	register_block_type_from_metadata(
 		__DIR__ . '/template-part',
 		array(
-			'render_callback'    => 'render_block_core_template_part',
+			//'render_callback'    => 'render_block_core_template_part',
 			'variation_callback' => 'build_template_part_block_variations',
 		)
 	);
diff --git a/packages/block-library/src/template-part/render.php b/packages/block-library/src/template-part/render.php
new file mode 100644
index 00000000000..f22a06d954c
--- /dev/null
+++ b/packages/block-library/src/template-part/render.php
@@ -0,0 +1,171 @@
+<?php
+
+/**
+ * Renders the `core/template-part` block on the server.
+ *
+ * @since 5.9.0
+ *
+ * @global WP_Embed $wp_embed WordPress Embed object.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string The render.
+ */
+//function render_block_core_template_part( $attributes ) {
+	static $seen_ids = array();
+
+	$template_part_id = null;
+	$content          = null;
+	$area             = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
+	$theme            = isset( $attributes['theme'] ) ? $attributes['theme'] : get_stylesheet();
+
+	if ( isset( $attributes['slug'] ) && get_stylesheet() === $theme ) {
+		$template_part_id    = $theme . '//' . $attributes['slug'];
+		$template_part_query = new WP_Query(
+			array(
+				'post_type'           => 'wp_template_part',
+				'post_status'         => 'publish',
+				'post_name__in'       => array( $attributes['slug'] ),
+				'tax_query'           => array(
+					array(
+						'taxonomy' => 'wp_theme',
+						'field'    => 'name',
+						'terms'    => $theme,
+					),
+				),
+				'posts_per_page'      => 1,
+				'no_found_rows'       => true,
+				'lazy_load_term_meta' => false, // Do not lazy load term meta, as template parts only have one term.
+			)
+		);
+		$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
+		if ( $template_part_post ) {
+			// A published post might already exist if this template part was customized elsewhere
+			// or if it's part of a customized template.
+			$block_template = _build_block_template_result_from_post( $template_part_post );
+			$content        = $block_template->content;
+			if ( isset( $block_template->area ) ) {
+				$area = $block_template->area;
+			}
+			/**
+			 * Fires when a block template part is loaded from a template post stored in the database.
+			 *
+			 * @since 5.9.0
+			 *
+			 * @param string  $template_part_id   The requested template part namespaced to the theme.
+			 * @param array   $attributes         The block attributes.
+			 * @param WP_Post $template_part_post The template part post object.
+			 * @param string  $content            The template part content.
+			 */
+			do_action( 'render_block_core_template_part_post', $template_part_id, $attributes, $template_part_post, $content );
+		} else {
+			$template_part_file_path = '';
+			// Else, if the template part was provided by the active theme,
+			// render the corresponding file content.
+			if ( 0 === validate_file( $attributes['slug'] ) ) {
+				$block_template = get_block_file_template( $template_part_id, 'wp_template_part' );
+
+				$content = $block_template->content;
+				if ( isset( $block_template->area ) ) {
+					$area = $block_template->area;
+				}
+
+				// Needed for the `render_block_core_template_part_file` and `render_block_core_template_part_none` actions below.
+				$block_template_file = _get_block_template_file( 'wp_template_part', $attributes['slug'] );
+				if ( $block_template_file ) {
+					$template_part_file_path = $block_template_file['path'];
+				}
+			}
+
+			if ( '' !== $content && null !== $content ) {
+				/**
+				 * Fires when a block template part is loaded from a template part in the theme.
+				 *
+				 * @since 5.9.0
+				 *
+				 * @param string $template_part_id        The requested template part namespaced to the theme.
+				 * @param array  $attributes              The block attributes.
+				 * @param string $template_part_file_path Absolute path to the template path.
+				 * @param string $content                 The template part content.
+				 */
+				do_action( 'render_block_core_template_part_file', $template_part_id, $attributes, $template_part_file_path, $content );
+			} else {
+				/**
+				 * Fires when a requested block template part does not exist in the database nor in the theme.
+				 *
+				 * @since 5.9.0
+				 *
+				 * @param string $template_part_id        The requested template part namespaced to the theme.
+				 * @param array  $attributes              The block attributes.
+				 * @param string $template_part_file_path Absolute path to the not found template path.
+				 */
+				do_action( 'render_block_core_template_part_none', $template_part_id, $attributes, $template_part_file_path );
+			}
+		}
+	}
+
+	// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
+	// is set in `wp_debug_mode()`.
+	$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
+
+	if ( is_null( $content ) ) {
+		if ( $is_debug && isset( $attributes['slug'] ) ) {
+			return sprintf(
+				/* translators: %s: Template part slug. */
+				__( 'Template part has been deleted or is unavailable: %s' ),
+				$attributes['slug']
+			);
+		}
+
+		return '';
+	}
+
+	if ( isset( $seen_ids[ $template_part_id ] ) ) {
+		return $is_debug ?
+			// translators: Visible only in the front end, this warning takes the place of a faulty block.
+			__( '[block rendering halted]' ) :
+			'';
+	}
+
+	// Look up area definition.
+	$area_definition = null;
+	$defined_areas   = get_allowed_block_template_part_areas();
+	foreach ( $defined_areas as $defined_area ) {
+		if ( $defined_area['area'] === $area ) {
+			$area_definition = $defined_area;
+			break;
+		}
+	}
+
+	// If $area is not allowed, set it back to the uncategorized default.
+	if ( ! $area_definition ) {
+		$area = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
+	}
+
+	// Run through the actions that are typically taken on the_content.
+	$content                       = shortcode_unautop( $content );
+	$content                       = do_shortcode( $content );
+	$seen_ids[ $template_part_id ] = true;
+	$content                       = do_blocks( $content );
+	unset( $seen_ids[ $template_part_id ] );
+	$content = wptexturize( $content );
+	$content = convert_smilies( $content );
+	$content = wp_filter_content_tags( $content, "template_part_{$area}" );
+
+	// Handle embeds for block template parts.
+	global $wp_embed;
+	$content = $wp_embed->autoembed( $content );
+
+	if ( empty( $attributes['tagName'] ) || tag_escape( $attributes['tagName'] ) !== $attributes['tagName'] ) {
+		$area_tag = 'div';
+		if ( $area_definition && isset( $area_definition['area_tag'] ) ) {
+			$area_tag = $area_definition['area_tag'];
+		}
+		$html_tag = $area_tag;
+	} else {
+		$html_tag = esc_attr( $attributes['tagName'] );
+	}
+	$wrapper_attributes = get_block_wrapper_attributes();
+
+	echo "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
+//}
```
</details>

