### PR TITLE
Update: List / Table layout – selected item stroke should be tinted blue

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -100,7 +100,7 @@
 		}
 	}
 	tr {
-		border-bottom: 1px solid $gray-100;
+		border-top: 1px solid $gray-100;
 
 		.dataviews-view-table-header-button {
 			gap: $grid-unit-05;
@@ -164,6 +164,10 @@
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			color: $gray-700;
 
+			&, & + tr {
+				border-top: 1px solid var(--wp-admin-theme-color);
+			}
+
 			&:hover {
 				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 			}
@@ -179,7 +183,6 @@
 		}
 		th {
 			background-color: $white;
-			box-shadow: inset 0 -#{$border-width} 0 $gray-100;
 			padding-top: $grid-unit-10;
 			padding-bottom: $grid-unit-10;
 			padding-left: $grid-unit-15;
@@ -462,6 +465,10 @@
 			.dataviews-view-list__item-actions {
 				background-color: rgb(247 248 255);
 				box-shadow: -12px 0 8px 0 rgb(247 248 255);
+			}
+			border-top: 1px solid var(--wp-admin-theme-color);
+			& + li {
+				border-top: 1px solid var(--wp-admin-theme-color);
 			}
 		}
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -469,7 +469,7 @@
 			}
 		}
 
-		&.is-selected {
+		&.is-selected.is-selected {
 			border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
 
 			& + li {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -164,8 +164,9 @@
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			color: $gray-700;
 
-			&, & + tr {
-				border-top: 1px solid var(--wp-admin-theme-color);
+			&,
+			& + tr {
+				border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
 			}
 
 			&:hover {
@@ -466,9 +467,13 @@
 				background-color: rgb(247 248 255);
 				box-shadow: -12px 0 8px 0 rgb(247 248 255);
 			}
-			border-top: 1px solid var(--wp-admin-theme-color);
+		}
+
+		&.is-selected {
+			border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
+
 			& + li {
-				border-top: 1px solid var(--wp-admin-theme-color);
+				border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
 			}
 		}
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/63128.

Adds blue border marks to the selected item.

cc: @jameskoster 

## Screenshot

<img width="1026" alt="Screenshot 2024-07-09 at 15 54 03" src="https://github.com/WordPress/gutenberg/assets/11271197/1642e8d4-886c-406d-a354-d90f2bb8d3ff">
<img width="1162" alt="Screenshot 2024-07-09 at 15 53 41" src="https://github.com/WordPress/gutenberg/assets/11271197/4ffff9b4-84a7-4599-a2a0-1592f4c1c3bc">

## Testing Instructions
I opened the list layout and the table layout selected items and verified the borders of the items were blue.
