### PR TITLE
Editor: Do not truncate post excerpt if not editable

### DIFF
--- a/packages/editor/src/components/post-excerpt/panel.js
+++ b/packages/editor/src/components/post-excerpt/panel.js
@@ -173,7 +173,7 @@ function PrivateExcerpt() {
 		return false;
 	}
 	const excerptText = !! excerpt && (
-		<Text align="left" numberOfLines={ 4 } truncate>
+		<Text align="left" numberOfLines={ 4 } truncate={ allowEditing }>
 			{ decodeEntities( excerpt ) }
 		</Text>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/63313

From the issue:
>Excerpts are elided so that really verbose ones do not dominate the Inspector. This is okay because you can click it to open the edit UI and view the full excerpt.

>Template descriptions use the same functionality, but since not all template descriptions can be edited the result is incomplete descriptions in some cases, like the screenshot above.

>Ideally only editable excerpts should be elided this way.



## Testing Instructions
1. Visit templates where the excerpt/description cannot be edited like `Archive` template.
2. The full description is shown 


## Screenshots
<img width="538" alt="Screenshot 2024-07-09 at 6 22 48 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/206f0bfe-506b-4c33-b957-32abfb78f483">


