### PR TITLE
Zoom Out: Move the hook to the inserter component

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-preview-panel.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-preview-panel.js
@@ -2,9 +2,8 @@
  * Internal dependencies
  */
 import { PatternCategoryPreviews } from './pattern-category-previews';
-import { useZoomOut } from '../../../hooks/use-zoom-out';
 
-function PatternCategoryPreviewPanelInner( {
+export function PatternCategoryPreviewPanel( {
 	rootClientId,
 	onInsert,
 	onHover,
@@ -23,18 +22,4 @@ function PatternCategoryPreviewPanelInner( {
 			patternFilter={ patternFilter }
 		/>
 	);
-}
-
-function PatternCategoryPreviewPanelWithZoomOut( props ) {
-	useZoomOut();
-	return <PatternCategoryPreviewPanelInner { ...props } />;
-}
-
-export function PatternCategoryPreviewPanel( props ) {
-	// When the pattern panel is showing, we want to use zoom out mode
-	if ( window.__experimentalEnableZoomedOutPatternsTab ) {
-		return <PatternCategoryPreviewPanelWithZoomOut { ...props } />;
-	}
-
-	return <PatternCategoryPreviewPanelInner { ...props } />;
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -32,6 +32,7 @@ import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import { store as blockEditorStore } from '../../store';
 import TabbedSidebar from '../tabbed-sidebar';
+import { useZoomOut } from '../../hooks/use-zoom-out';
 
 const NOOP = () => {};
 function InserterMenu(
@@ -144,6 +145,11 @@ function InserterMenu(
 		!! selectedPatternCategory;
 
 	const showMediaPanel = selectedTab === 'media' && !! selectedMediaCategory;
+
+	const showZoomOut =
+		showPatternPanel && window.__experimentalEnableZoomedOutPatternsTab;
+
+	useZoomOut( showZoomOut );
 
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/62707.

Runs the hook in the inserter component so it doesn't keep running on each mount of the pattern category preview panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This prevents the continual running of the hook when mounting and unmounting the pattern preview component.

## How?
Moves the hook back to the inserter component.

## Testing Instructions
1. Open the Site Editor
2. Open the Inserter
3. Open the Patterns tab
4. Select a category
5. Check that zoom out mode is invoked
6. Switch to a different category
7. Check that zoom out mode is still active
8. Switch to the block tab
9. Check that zoom out mode is disabled.

Do the same in the post editor.

## Screenshots or screencast 
https://github.com/WordPress/gutenberg/assets/275961/81cb7c86-cfbf-45ea-943a-80ee70230ebd



