### PR TITLE
Improves vertical alignment of the Apply and Link settings buttons in…

### DIFF
--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -10,6 +10,7 @@
 .block-editor-url-popover__row {
 	display: flex;
 	gap: $grid-unit-05;
+	align-items: center;
 }
 
 // Any children of the popover-row that are not the settings-toggle

--- a/packages/format-library/src/link/style.scss
+++ b/packages/format-library/src/link/style.scss
@@ -1,5 +1,6 @@
 .block-editor-format-toolbar__link-container-content {
 	display: flex;
+	align-items: center;
 }
 
 .block-editor-format-toolbar__link-container-value {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: #63294 

## Why?
See this [comment](https://github.com/WordPress/gutenberg/issues/63294#issue-2398028242)

## How?
Fixed vertical alignment of `Apply` and `Link settings`
