### PR TITLE
Global Styles: Create new public function to make it easier to expose style variations from other themes

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -764,8 +764,18 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array
 	 */
 	public static function get_style_variations( $scope = 'theme' ) {
+		return static::get_style_variations_from_directory( get_stylesheet_directory() );
+	}
+
+	/**
+	 * Returns the style variation files defined by the theme (parent and child).
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return array An array of style variation files.
+	 */
+	protected static function get_style_variation_files_from_current_theme() {
 		$variation_files    = array();
-		$variations         = array();
 		$base_directory     = get_stylesheet_directory() . '/styles';
 		$template_directory = get_template_directory() . '/styles';
 		if ( is_dir( $base_directory ) ) {
@@ -782,6 +792,29 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				}
 			}
 			$variation_files = array_merge( $variation_files, $variation_files_parent );
+		}
+
+		return $variation_files;
+	}
+
+	/**
+	 * Returns the style variations in the given directory.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param string $directory The directory to get the style variations from.
+	 * @param string $scope     The scope or type of style variation to retrieve e.g. theme, block etc.
+	 * @return array
+	 */
+	public static function get_style_variations_from_directory( $directory, $scope = 'theme' ) {
+		$variation_files    = array();
+		$variations         = array();
+		if ( is_dir( $directory ) ) {
+			if ( $directory === get_stylesheet_directory() ) {
+				$variation_files = static::get_style_variation_files_from_current_theme();
+			} else {
+				$variation_files = static::recursively_iterate_json( $base_directory );
+			}
 		}
 		ksort( $variation_files );
 		foreach ( $variation_files as $path => $file ) {

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -764,7 +764,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array
 	 */
 	public static function get_style_variations( $scope = 'theme' ) {
-		return static::get_style_variations_from_directory( get_stylesheet_directory() );
+		return static::get_style_variations_from_directory( get_stylesheet_directory(), $scope );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -807,13 +807,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array
 	 */
 	public static function get_style_variations_from_directory( $directory, $scope = 'theme' ) {
-		$variation_files    = array();
-		$variations         = array();
+		$variation_files = array();
+		$variations      = array();
 		if ( is_dir( $directory ) ) {
-			if ( $directory === get_stylesheet_directory() ) {
+			if ( get_stylesheet_directory() === $directory ) {
 				$variation_files = static::get_style_variation_files_from_current_theme();
 			} else {
-				$variation_files = static::recursively_iterate_json( $base_directory );
+				$variation_files = static::recursively_iterate_json( $directory );
 			}
 		}
 		ksort( $variation_files );

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -7,13 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useMergeRefs } from '@wordpress/compose';
-import {
-	forwardRef,
-	useMemo,
-	memo,
-	useState,
-	useEffect,
-} from '@wordpress/element';
+import { forwardRef, useMemo, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	getBlockSupport,
@@ -192,7 +186,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		__unstableDisableDropZone,
 		dropZoneElement,
 	} = options;
-
 	const {
 		clientId,
 		layout = null,
@@ -269,28 +262,15 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		defaultLayout,
 	} = selected;
 
-	const [ isReady, setIsReady ] = useState( false );
-	// Defer the initial rendering to avoid the jumps due to the animation.
-	useEffect( () => {
-		const timeout = setTimeout( () => {
-			setIsReady( true );
-		}, 5000 );
-		return () => {
-			clearTimeout( timeout );
-		};
-	}, [] );
-
 	const blockDropZoneRef = useBlockDropZone( {
 		dropZoneElement,
 		rootClientId: clientId,
 		parentClientId,
-		isDropZoneDisabled,
 	} );
 
 	const ref = useMergeRefs( [
 		props.ref,
 		__unstableDisableDropZone ||
-		! isReady ||
 		isDropZoneDisabled ||
 		( layout?.isManualPlacement &&
 			window.__experimentalEnableGridInteractivity )

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -7,7 +7,13 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useMergeRefs } from '@wordpress/compose';
-import { forwardRef, useMemo, memo } from '@wordpress/element';
+import {
+	forwardRef,
+	useMemo,
+	memo,
+	useState,
+	useEffect,
+} from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	getBlockSupport,
@@ -186,6 +192,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		__unstableDisableDropZone,
 		dropZoneElement,
 	} = options;
+
 	const {
 		clientId,
 		layout = null,
@@ -262,15 +269,28 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		defaultLayout,
 	} = selected;
 
+	const [ isReady, setIsReady ] = useState( false );
+	// Defer the initial rendering to avoid the jumps due to the animation.
+	useEffect( () => {
+		const timeout = setTimeout( () => {
+			setIsReady( true );
+		}, 5000 );
+		return () => {
+			clearTimeout( timeout );
+		};
+	}, [] );
+
 	const blockDropZoneRef = useBlockDropZone( {
 		dropZoneElement,
 		rootClientId: clientId,
 		parentClientId,
+		isDropZoneDisabled,
 	} );
 
 	const ref = useMergeRefs( [
 		props.ref,
 		__unstableDisableDropZone ||
+		! isReady ||
 		isDropZoneDisabled ||
 		( layout?.isManualPlacement &&
 			window.__experimentalEnableGridInteractivity )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In https://github.com/WordPress/gutenberg/issues/45371 we want to expose style variations from other themes. This makes that possible by creating a new function in `WP_Theme_JSON_Resolver_Gutenberg` called `get_style_variations_from_directory`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This gives us freedom to load style variations from sources outside the currently active theme.

## How?
1. Create a new function `get_style_variations_from_directory`
2. Call this function in `get_style_variations` and pass the theme directory (`get_stylesheet_directory()`)
3. Also create a new function `get_style_variation_files_from_current_theme` which specifically gets the variation files from the currently active theme. This is used inside `get_style_variations_from_directory` to get the variation files from the active theme.

## Testing Instructions

###Testing for no regressions
0. Open the Site Editor
1. Open Global Styles > Browse Styles
2. Check that the style variations load as before

### Testing the new functionality
0. Add this patch to your repo:
```
diff --git a/lib/class-wp-theme-json-resolver-gutenberg.php b/lib/class-wp-theme-json-resolver-gutenberg.php
index 28b3808861..4bc7bb2f08 100644
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -764,7 +764,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array
 	 */
 	public static function get_style_variations( $scope = 'theme' ) {
-		return static::get_style_variations_from_directory( get_stylesheet_directory() );
+		$stylesheet     = get_stylesheet();
+		$theme_root     = get_theme_root( $stylesheet );
+		return static::get_style_variations_from_directory( $theme_root );
 	}
 
 	/**
 ```
1. Now open Global Styles > Browse Styles
2. Check that you now see the style variations from all your themes

## Notes
The main concern I can see with this approach is that it exposes a new public function, which increases the area that we need to maintain going forward.