### PR TITLE
Core Data: Support entities in the 'canUser' selector

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -18,7 +18,7 @@ _Parameters_
 
 -   _state_ `State`: Data state.
 -   _action_ `string`: Action to check. One of: 'create', 'read', 'update', 'delete'.
--   _resource_ `string | Record< string, any >`: REST resource to check, e.g. 'media' or 'posts'.
+-   _resource_ `string | EntityResource`: Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }` or REST base as a string - `media`.
 -   _id_ `EntityRecordKey`: Optional ID of the rest resource to check.
 
 _Returns_

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -23,7 +23,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean | undefined | null`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
+-   `boolean | undefined`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
 
 ### canUserEditEntityRecord
 
@@ -42,7 +42,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean | undefined | null`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
+-   `boolean | undefined`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
 
 ### getAuthors
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -23,7 +23,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean | undefined`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
+-   `boolean | undefined | null`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
 
 ### canUserEditEntityRecord
 
@@ -42,7 +42,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean | undefined`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
+-   `boolean | undefined | null`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
 
 ### getAuthors
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -18,7 +18,7 @@ _Parameters_
 
 -   _state_ `State`: Data state.
 -   _action_ `string`: Action to check. One of: 'create', 'read', 'update', 'delete'.
--   _resource_ `string`: REST resource to check, e.g. 'media' or 'posts'.
+-   _resource_ `string | Record< string, any >`: REST resource to check, e.g. 'media' or 'posts'.
 -   _id_ `EntityRecordKey`: Optional ID of the rest resource to check.
 
 _Returns_

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -42,11 +42,11 @@ export default function PostTitleEdit( {
 			if ( isDescendentOfQueryLoop ) {
 				return false;
 			}
-			return select( coreStore ).canUserEditEntityRecord(
-				'postType',
-				postType,
-				postId
-			);
+			return select( coreStore ).canUser( 'update', {
+				kind: 'postType',
+				name: postType,
+				id: postId,
+			} );
 		},
 		[ isDescendentOfQueryLoop, postType, postId ]
 	);

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -18,7 +18,11 @@ import { useViewportMatch } from '@wordpress/compose';
 export function useCanEditEntity( kind, name, recordId ) {
 	return useSelect(
 		( select ) =>
-			select( coreStore ).canUserEditEntityRecord( kind, name, recordId ),
+			select( coreStore ).canUser( 'update', {
+				kind,
+				name,
+				id: recordId,
+			} ),
 		[ kind, name, recordId ]
 	);
 }

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -344,7 +344,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean | undefined | null`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
+-   `boolean | undefined`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
 
 ### canUserEditEntityRecord
 
@@ -363,7 +363,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean | undefined | null`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
+-   `boolean | undefined`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
 
 ### getAuthors
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -344,7 +344,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean | undefined`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
+-   `boolean | undefined | null`: Whether or not the user can perform the action, or `undefined` if the OPTIONS request is still being made.
 
 ### canUserEditEntityRecord
 
@@ -363,7 +363,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean | undefined`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
+-   `boolean | undefined | null`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
 
 ### getAuthors
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -339,7 +339,7 @@ _Parameters_
 
 -   _state_ `State`: Data state.
 -   _action_ `string`: Action to check. One of: 'create', 'read', 'update', 'delete'.
--   _resource_ `string | Record< string, any >`: REST resource to check, e.g. 'media' or 'posts'.
+-   _resource_ `string | EntityResource`: Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }` or REST base as a string - `media`.
 -   _id_ `EntityRecordKey`: Optional ID of the rest resource to check.
 
 _Returns_

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -339,7 +339,7 @@ _Parameters_
 
 -   _state_ `State`: Data state.
 -   _action_ `string`: Action to check. One of: 'create', 'read', 'update', 'delete'.
--   _resource_ `string`: REST resource to check, e.g. 'media' or 'posts'.
+-   _resource_ `string | Record< string, any >`: REST resource to check, e.g. 'media' or 'posts'.
 -   _id_ `EntityRecordKey`: Optional ID of the rest resource to check.
 
 _Returns_

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -352,10 +352,11 @@ export const getEmbedPreview =
  * Checks whether the current user can perform the given action on the given
  * REST resource.
  *
- * @param {string}  requestedAction Action to check. One of: 'create', 'read', 'update',
- *                                  'delete'.
- * @param {string}  resource        REST resource to check, e.g. 'media' or 'posts'.
- * @param {?string} id              ID of the rest resource to check.
+ * @param {string}        requestedAction Action to check. One of: 'create', 'read', 'update',
+ *                                        'delete'.
+ * @param {string|Object} resource        Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }`
+ *                                        or REST base as a string - `media`.
+ * @param {?string}       id              ID of the rest resource to check.
  */
 export const canUser =
 	( requestedAction, resource, id ) =>

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -370,7 +370,7 @@ export const canUser =
 		let resourcePath = null;
 		if ( typeof resource === 'object' ) {
 			if ( ! resource.kind || ! resource.name ) {
-				return;
+				throw new Error( 'The entity resource object is not valid.' );
 			}
 
 			const configs = await dispatch(

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -374,7 +374,7 @@ export const canUser =
 			const entityConfig = configs.find(
 				( config ) =>
 					config.name === resource.name &&
-					config.kind === resource.name
+					config.kind === resource.kind
 			);
 			if ( ! entityConfig ) {
 				return;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -368,6 +368,10 @@ export const canUser =
 
 		let resourcePath = null;
 		if ( typeof resource === 'object' ) {
+			if ( ! resource.kind || ! resource.name ) {
+				return;
+			}
+
 			const configs = await dispatch(
 				getOrLoadEntitiesConfig( resource.kind, resource.name )
 			);

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -460,16 +460,7 @@ export const canUser =
 export const canUserEditEntityRecord =
 	( kind, name, recordId ) =>
 	async ( { dispatch } ) => {
-		const configs = await dispatch( getOrLoadEntitiesConfig( kind, name ) );
-		const entityConfig = configs.find(
-			( config ) => config.name === name && config.kind === kind
-		);
-		if ( ! entityConfig ) {
-			return;
-		}
-
-		const resource = entityConfig.__unstable_rest_base;
-		await dispatch( canUser( 'update', resource, recordId ) );
+		await dispatch( canUser( 'update', { kind, name, id: recordId } ) );
 	};
 
 /**

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -120,6 +120,8 @@ type EntityRecordArgs =
 	| [ string, string, EntityRecordKey ]
 	| [ string, string, EntityRecordKey, GetRecordsHttpQuery ];
 
+type EntityResource = { kind: string; name: string; id?: EntityRecordKey };
+
 /**
  * Shared reference to an empty object for cases where it is important to avoid
  * returning a new object reference on every invocation, as in a connected or
@@ -1136,7 +1138,8 @@ export function isPreviewEmbedFallback( state: State, url: string ): boolean {
  *
  * @param state    Data state.
  * @param action   Action to check. One of: 'create', 'read', 'update', 'delete'.
- * @param resource REST resource to check, e.g. 'media' or 'posts'.
+ * @param resource Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }`
+ *                 or REST base as a string - `media`.
  * @param id       Optional ID of the rest resource to check.
  *
  * @return Whether or not the user can perform the action,
@@ -1145,7 +1148,7 @@ export function isPreviewEmbedFallback( state: State, url: string ): boolean {
 export function canUser(
 	state: State,
 	action: string,
-	resource: string | Record< string, any >,
+	resource: string | EntityResource,
 	id?: EntityRecordKey
 ): boolean | undefined {
 	const isEntity = typeof resource === 'object';

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1180,13 +1180,7 @@ export function canUserEditEntityRecord(
 	name: string,
 	recordId: EntityRecordKey
 ): boolean | undefined {
-	const entityConfig = getEntityConfig( state, kind, name );
-	if ( ! entityConfig ) {
-		return false;
-	}
-	const resource = entityConfig.__unstable_rest_base;
-
-	return canUser( state, 'update', resource, recordId );
+	return canUser( state, 'update', { kind, name, id: recordId } );
 }
 
 /**

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1145,10 +1145,17 @@ export function isPreviewEmbedFallback( state: State, url: string ): boolean {
 export function canUser(
 	state: State,
 	action: string,
-	resource: string,
+	resource: string | Record< string, any >,
 	id?: EntityRecordKey
 ): boolean | undefined {
-	const key = [ action, resource, id ].filter( Boolean ).join( '/' );
+	const key = (
+		typeof resource === 'object'
+			? [ action, resource.kind, resource.name, resource.id ]
+			: [ action, resource, id ]
+	)
+		.filter( Boolean )
+		.join( '/' );
+
 	return state.userPermissions[ key ];
 }
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1188,6 +1188,11 @@ export function canUserEditEntityRecord(
 	name: string,
 	recordId: EntityRecordKey
 ): boolean | undefined {
+	deprecated( `wp.data.select( 'core' ).canUserEditEntityRecord()`, {
+		since: '6.7',
+		alternative: `wp.data.select( 'core' ).canUser( 'update', { kind, name, id } )`,
+	} );
+
 	return canUser( state, 'update', { kind, name, id: recordId } );
 }
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1147,9 +1147,14 @@ export function canUser(
 	action: string,
 	resource: string | Record< string, any >,
 	id?: EntityRecordKey
-): boolean | undefined {
+): boolean | undefined | null {
+	const isEntity = typeof resource === 'object';
+	if ( isEntity && ( ! resource.kind || ! resource.name ) ) {
+		return null;
+	}
+
 	const key = (
-		typeof resource === 'object'
+		isEntity
 			? [ action, resource.kind, resource.name, resource.id ]
 			: [ action, resource, id ]
 	)
@@ -1179,7 +1184,7 @@ export function canUserEditEntityRecord(
 	kind: string,
 	name: string,
 	recordId: EntityRecordKey
-): boolean | undefined {
+): boolean | undefined | null {
 	return canUser( state, 'update', { kind, name, id: recordId } );
 }
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1147,10 +1147,10 @@ export function canUser(
 	action: string,
 	resource: string | Record< string, any >,
 	id?: EntityRecordKey
-): boolean | undefined | null {
+): boolean | undefined {
 	const isEntity = typeof resource === 'object';
 	if ( isEntity && ( ! resource.kind || ! resource.name ) ) {
-		return null;
+		return false;
 	}
 
 	const key = (
@@ -1184,7 +1184,7 @@ export function canUserEditEntityRecord(
 	kind: string,
 	name: string,
 	recordId: EntityRecordKey
-): boolean | undefined | null {
+): boolean | undefined {
 	return canUser( state, 'update', { kind, name, id: recordId } );
 }
 

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -333,6 +333,25 @@ describe( 'canUser', () => {
 		expect( dispatch.receiveUserPermission ).not.toHaveBeenCalled();
 	} );
 
+	it( 'does nothing when entity kind or name is missing', async () => {
+		triggerFetch.mockImplementation( () =>
+			Promise.reject( { status: 404 } )
+		);
+
+		await canUser( 'create', { kind: 'root', name: 'media' } )( {
+			dispatch,
+			registry,
+		} );
+		await canUser( 'create', { name: 'wp_block' } )( {
+			dispatch,
+			registry,
+		} );
+
+		expect( triggerFetch ).not.toHaveBeenCalledWith();
+
+		expect( dispatch.receiveUserPermission ).not.toHaveBeenCalled();
+	} );
+
 	it( 'receives false when the user is not allowed to perform an action', async () => {
 		triggerFetch.mockImplementation( () => ( {
 			headers: new Map( [ [ 'allow', 'GET' ] ] ),

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -283,7 +283,7 @@ describe( 'getEmbedPreview', () => {
 } );
 
 describe( 'canUser', () => {
-	let registry;
+	let dispatch, registry;
 	beforeEach( async () => {
 		registry = {
 			select: jest.fn( () => ( {
@@ -291,14 +291,13 @@ describe( 'canUser', () => {
 			} ) ),
 			batch: ( callback ) => callback(),
 		};
+		dispatch = Object.assign( jest.fn(), {
+			receiveUserPermission: jest.fn(),
+		} );
 		triggerFetch.mockReset();
 	} );
 
 	it( 'does nothing when there is an API error', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		triggerFetch.mockImplementation( () =>
 			Promise.reject( { status: 404 } )
 		);
@@ -315,10 +314,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'receives false when the user is not allowed to perform an action', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		triggerFetch.mockImplementation( () => ( {
 			headers: new Map( [ [ 'allow', 'GET' ] ] ),
 		} ) );
@@ -338,10 +333,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'receives true when the user is allowed to perform an action', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		triggerFetch.mockImplementation( () => ( {
 			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
@@ -361,10 +352,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'receives true when the user is allowed to perform an action on a specific resource', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		triggerFetch.mockImplementation( () => ( {
 			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
@@ -384,10 +371,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'runs apiFetch only once per resource', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		registry = {
 			...registry,
 			select: () => ( {
@@ -415,10 +398,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'retrieves all permissions even when ID is not given', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		registry = {
 			...registry,
 			select: () => ( {
@@ -454,10 +433,6 @@ describe( 'canUser', () => {
 	} );
 
 	it( 'runs apiFetch only once per resource ID', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveUserPermission: jest.fn(),
-		} );
-
 		registry = {
 			...registry,
 			select: () => ( {

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -333,23 +333,13 @@ describe( 'canUser', () => {
 		expect( dispatch.receiveUserPermission ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does nothing when entity kind or name is missing', async () => {
-		triggerFetch.mockImplementation( () =>
-			Promise.reject( { status: 404 } )
-		);
-
-		await canUser( 'create', { kind: 'root', name: 'media' } )( {
-			dispatch,
-			registry,
-		} );
-		await canUser( 'create', { name: 'wp_block' } )( {
-			dispatch,
-			registry,
-		} );
-
-		expect( triggerFetch ).not.toHaveBeenCalledWith();
-
-		expect( dispatch.receiveUserPermission ).not.toHaveBeenCalled();
+	it( 'throws an error when an entity resource object is malformed', async () => {
+		await expect(
+			canUser( 'create', { name: 'wp_block' } )( {
+				dispatch,
+				registry,
+			} )
+		).rejects.toThrow( 'The entity resource object is not valid.' );
 	} );
 
 	it( 'receives false when the user is not allowed to perform an action', async () => {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -18,7 +18,6 @@ import {
 	getEmbedPreview,
 	isPreviewEmbedFallback,
 	canUser,
-	canUserEditEntityRecord,
 	getAutosave,
 	getAutosaves,
 	getCurrentUser,
@@ -719,61 +718,6 @@ describe( 'canUser', () => {
 		expect(
 			canUser( state, 'create', { kind: 'root', name: 'media', id: 123 } )
 		).toBe( false );
-	} );
-} );
-
-describe( 'canUserEditEntityRecord', () => {
-	it( 'returns false by default', () => {
-		const state = deepFreeze( {
-			userPermissions: {},
-			entities: { records: {} },
-		} );
-		expect( canUserEditEntityRecord( state, 'postType', 'post' ) ).toBe(
-			false
-		);
-	} );
-
-	it( 'returns whether the user can edit', () => {
-		const state = deepFreeze( {
-			userPermissions: {
-				'create/posts': false,
-				'update/posts/1': true,
-			},
-			entities: {
-				config: [
-					{
-						kind: 'postType',
-						name: 'post',
-						__unstable_rest_base: 'posts',
-					},
-				],
-				records: {
-					root: {
-						postType: {
-							queriedData: {
-								items: {
-									default: {
-										post: {
-											slug: 'post',
-											__unstable: 'posts',
-										},
-									},
-								},
-								itemIsComplete: {
-									default: {
-										post: true,
-									},
-								},
-								queries: {},
-							},
-						},
-					},
-				},
-			},
-		} );
-		expect(
-			canUserEditEntityRecord( state, 'postType', 'post', '1' )
-		).toBe( true );
 	} );
 } );
 

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -694,6 +694,14 @@ describe( 'canUser', () => {
 		).toBe( undefined );
 	} );
 
+	it( 'returns null when entity kind or name is missing', () => {
+		const state = deepFreeze( {
+			userPermissions: {},
+		} );
+		expect( canUser( state, 'create', { name: 'media' } ) ).toBe( null );
+		expect( canUser( state, 'create', { kind: 'root' } ) ).toBe( null );
+	} );
+
 	it( 'returns whether an action can be performed', () => {
 		const state = deepFreeze( {
 			userPermissions: {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -698,8 +698,8 @@ describe( 'canUser', () => {
 		const state = deepFreeze( {
 			userPermissions: {},
 		} );
-		expect( canUser( state, 'create', { name: 'media' } ) ).toBe( null );
-		expect( canUser( state, 'create', { kind: 'root' } ) ).toBe( null );
+		expect( canUser( state, 'create', { name: 'media' } ) ).toBe( false );
+		expect( canUser( state, 'create', { kind: 'root' } ) ).toBe( false );
 	} );
 
 	it( 'returns whether an action can be performed', () => {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -690,24 +690,35 @@ describe( 'canUser', () => {
 			userPermissions: {},
 		} );
 		expect( canUser( state, 'create', 'media' ) ).toBe( undefined );
+		expect(
+			canUser( state, 'create', { kind: 'root', name: 'media' } )
+		).toBe( undefined );
 	} );
 
 	it( 'returns whether an action can be performed', () => {
 		const state = deepFreeze( {
 			userPermissions: {
 				'create/media': false,
+				'create/root/media': false,
 			},
 		} );
 		expect( canUser( state, 'create', 'media' ) ).toBe( false );
+		expect(
+			canUser( state, 'create', { kind: 'root', name: 'media' } )
+		).toBe( false );
 	} );
 
 	it( 'returns whether an action can be performed for a given resource', () => {
 		const state = deepFreeze( {
 			userPermissions: {
 				'create/media/123': false,
+				'create/root/media/123': false,
 			},
 		} );
 		expect( canUser( state, 'create', 'media', 123 ) ).toBe( false );
+		expect(
+			canUser( state, 'create', { kind: 'root', name: 'media', id: 123 } )
+		).toBe( false );
 	} );
 } );
 

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -59,11 +59,11 @@ export default {
 		}
 
 		// Check that the user has the capability to edit post meta.
-		const canUserEdit = select( coreDataStore ).canUserEditEntityRecord(
-			'postType',
-			context?.postType,
-			context?.postId
-		);
+		const canUserEdit = select( coreDataStore ).canUser( 'update', {
+			kind: 'postType',
+			name: context?.postType,
+			id: context?.postId,
+		} );
 		if ( ! canUserEdit ) {
 			return false;
 		}


### PR DESCRIPTION
## What?
Resolves #43751.
Alternative to #63292.

PR updates the `canUser` selector to support core data entities. The new supported and recommended syntax:

```js
canUser( action, { kind, name, id } );
```

## Why?
* `canUser` - currently only supports resources in the `wp/v2` namespace. Additionally, you must know the final REST API path. Typically, however, only an entity's kind and name are known.
* `canUserEntityRecord` - is limited to only the edit action check. It was a wrapper for `canUser` and only supported the `wp/v2` namespace, which hasn't been required since WP 5.9.

The update also opens up the possibility of leveraging ["target hints"](https://github.com/WordPress/gutenberg/pull/61644#discussion_r1600465798) and bulk fetch permissions data for DataViews.

## Todo
- [x] Update the selector DocBlock and maybe types.
- [x] Deprecate `canUserEditEntityRecord` selector.

## Testing Instructions

### Basic Testing
```js
wp.data.select( 'core' ).canUser( 'update', { kind: 'root', name: 'media', id: 1342 } );
wp.data.select( 'core' ).canUser( 'create', { kind: 'root', name: 'site' } );
wp.data.select( 'core' ).canUser( 'delete', { kind: 'root', name: 'site' } );

// Running this should log deprecation warning.
wp.data.select( 'core' ).canUserEditEntityRecord( 'root', 'site' );
```

### Testing canUserEntityRecord changes
1. Open a post.
2. Add Title and Excerpt blocks.
3. Confirm you can edit them as before.

### Testing Instructions for Keyboard
Same.

## Screenshot
![CleanShot 2024-07-10 at 21 38 47](https://github.com/WordPress/gutenberg/assets/240569/b3c039bc-1dc4-432e-9e7e-86218747d49f)
