### PR TITLE
Only add customizer additional CSS to global styles in block themes

### DIFF
--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -44,17 +44,19 @@ function gutenberg_enqueue_global_styles() {
 
 	$stylesheet = gutenberg_get_global_stylesheet();
 
-	/*
-	 * Dequeue the Customizer's custom CSS
-	 * and add it before the global styles custom CSS.
-	 */
-	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
-	// Get the custom CSS from the Customizer and add it to the global stylesheet.
-	$custom_css  = wp_get_custom_css();
-	$stylesheet .= $custom_css;
+	if ( $is_block_theme ) {
+			/*
+		* Dequeue the Customizer's custom CSS
+		* and add it before the global styles custom CSS.
+		*/
+		remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
+		// Get the custom CSS from the Customizer and add it to the global stylesheet.
+		$custom_css  = wp_get_custom_css();
+		$stylesheet .= $custom_css;
 
-	// Add the global styles custom CSS at the end.
-	$stylesheet .= gutenberg_get_global_stylesheet( array( 'custom-css' ) );
+		// Add the global styles custom CSS at the end.
+		$stylesheet .= gutenberg_get_global_stylesheet( array( 'custom-css' ) );
+	}
 
 	if ( empty( $stylesheet ) ) {
 		return;

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -45,10 +45,10 @@ function gutenberg_enqueue_global_styles() {
 	$stylesheet = gutenberg_get_global_stylesheet();
 
 	if ( $is_block_theme ) {
-			/*
-		* Dequeue the Customizer's custom CSS
-		* and add it before the global styles custom CSS.
-		*/
+		/*
+		 * Dequeue the Customizer's custom CSS
+		 * and add it before the global styles custom CSS.
+		 */
 		remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
 		// Get the custom CSS from the Customizer and add it to the global stylesheet.
 		$custom_css  = wp_get_custom_css();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes bug spotted [in the core sync PR](https://github.com/WordPress/wordpress-develop/pull/6750#pullrequestreview-2167805588) for #62357.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Activate a classic theme.
2. In the customizer, add some additional CSS that causes immediate visual change such as body background-color.
3. In this PR branch, the change should be reflected in the preview straightaway. (In trunk, the preview doesn't update as it should.)

## Screenshots or screencast <!-- if applicable -->


<img width="1284" alt="Screenshot 2024-07-10 at 2 47 19 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/77763bc4-f3be-4bf8-a0a8-6c0a443dab45">
