### PR TITLE
Grid: Place new block after currently selected block when using slash inserter and splitting text

### DIFF
--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -133,12 +133,13 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 			}
 		}
 
-		// TODO: We should be able to replace this with a single call to updateBlockAttributes(),
-		// but there seems to be a bug where getBlocks() selectors don't always update when
-		// updating attributes this way.
-		for ( const [ clientId, attributes ] of Object.entries( updates ) ) {
+		if ( Object.keys( updates ).length ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			updateBlockAttributes( clientId, attributes );
+			updateBlockAttributes(
+				Object.keys( updates ),
+				updates,
+				/* uniqueByBlock: */ true
+			);
 		}
 	}, [
 		// Actual deps to sync:

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -133,13 +133,12 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 			}
 		}
 
-		if ( Object.keys( updates ).length ) {
+		// TODO: We should be able to replace this with a single call to updateBlockAttributes(),
+		// but there seems to be a bug where getBlocks() selectors don't always update when
+		// updating attributes this way.
+		for ( const [ clientId, attributes ] of Object.entries( updates ) ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			updateBlockAttributes(
-				Object.keys( updates ),
-				updates,
-				/* uniqueByBlock: */ true
-			);
+			updateBlockAttributes( clientId, attributes );
 		}
 	}, [
 		// Actual deps to sync:

--- a/packages/block-editor/src/hooks/grid-visualizer.js
+++ b/packages/block-editor/src/hooks/grid-visualizer.js
@@ -26,14 +26,12 @@ function GridTools( { clientId, layout } ) {
 		};
 	} );
 
-	if ( ! isSelected && ! isDragging ) {
-		return null;
-	}
-
 	return (
 		<>
-			<GridVisualizer clientId={ clientId } parentLayout={ layout } />
 			<GridLayoutSync clientId={ clientId } />
+			{ ( isSelected || isDragging ) && (
+				<GridVisualizer clientId={ clientId } parentLayout={ layout } />
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/57478.

Currently in `trunk` if you use the slash inserter in a manual grid, or split a block (press <kbd>Enter</kbd> while typing text in a paragraph), the newly created block is inserted into the top-left-most empty cell.

This PR changes that so that the newly created block is positioned after the previously selected block. Specifically, it begins at the bottom right cell of the previously selected block and scans left→right and top→bottom for the first empty cell. It will auto create rows if needed.

To test, you'll need to disable the `useEffect` in `packages/block-editor/src/components/global-styles/typography-panel.js`. See https://github.com/WordPress/gutenberg/pull/63333#issuecomment-2222134002. Here's a patch that does that:

```diff
diff --git a/packages/block-editor/src/components/global-styles/typography-panel.js b/packages/block-editor/src/components/global-styles/typography-panel.js
index c497ea46833..52473538963 100644
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -257,6 +257,7 @@ export default function TypographyPanel( {
 
 	// Check if previous font style and weight values are available in the new font family
 	useEffect( () => {
+		return;
 		const { fontStyles, fontWeights, isSystemFont } =
 			getFontStylesAndWeights( fontFamilyFaces );
 		const hasFontStyle = fontStyles?.some(
```