### PR TITLE
Tabs: hyphenate tab labels

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `Tabs`: hyphenate tab labels ([#63337](https://github.com/WordPress/gutenberg/pull/63337)).
 -   `Tooltip`: Add support for `className` prop ([#63157](https://github.com/WordPress/gutenberg/pull/63157)).
 -   `Toolbar`: Add support for `vertical` orientation ([#60123](https://github.com/WordPress/gutenberg/pull/60123)).
 -   `BaseControl`: forward ref on `VisualLabel` ([#63169](https://github.com/WordPress/gutenberg/pull/63169)).

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -75,6 +75,7 @@ export const Tab = styled( Ariakit.Tab )`
 		margin-left: 0;
 		font-weight: 500;
 		text-align: inherit;
+		hyphens: auto;
 
 		&[aria-disabled='true'] {
 			cursor: default;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #62020

Add automatic hyphenation for tab labels in the `Tabs` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To prevent long tab labels from pushing the width of the tab list and causing unexpected scrolling behavior.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By using the [`hyphens`](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens) CSS property as [suggested](https://github.com/WordPress/gutenberg/issues/62020#issuecomment-2218248821) by @jameskoster 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open Storybook
- Change the tab labels to become more verbose, including very long single words
- Observe how the labels are broken (hyphenated) into multiple lines, preventing the tablist from overflowing and causing horizontal scroll in the document

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2024-07-10 at 08 53 49](https://github.com/WordPress/gutenberg/assets/1083581/02c2a798-4f76-4843-a591-337209ba57d2) | ![Screenshot 2024-07-10 at 08 53 38](https://github.com/WordPress/gutenberg/assets/1083581/578c9dde-7461-4a9a-b96a-7eab17f07e80) |
