### PR TITLE
Widgets: Memoize 'getWidgets' store selector

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -30,6 +30,8 @@ const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
 
+const EMPTY_ARRAY = [];
+
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,
 	children,
@@ -54,7 +56,7 @@ export default function WidgetAreasBlockEditorProvider( {
 			widgets: select( editWidgetsStore ).getWidgets(),
 			reusableBlocks: ALLOW_REUSABLE_BLOCKS
 				? getEntityRecords( 'postType', 'wp_block' )
-				: [],
+				: EMPTY_ARRAY,
 			isFixedToolbarActive: !! select( preferencesStore ).get(
 				'core/edit-widgets',
 				'fixedToolbar'

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 import { getWidgetIdFromBlock } from '@wordpress/widgets';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -29,24 +29,35 @@ const EMPTY_INSERTION_POINT = {
  *
  * @return {Object[]} API List of widgets.
  */
-export const getWidgets = createRegistrySelector( ( select ) => () => {
-	const widgets = select( coreStore ).getEntityRecords(
-		'root',
-		'widget',
-		buildWidgetsQuery()
-	);
+export const getWidgets = createRegistrySelector( ( select ) =>
+	createSelector(
+		() => {
+			const widgets = select( coreStore ).getEntityRecords(
+				'root',
+				'widget',
+				buildWidgetsQuery()
+			);
 
-	return (
-		// Key widgets by their ID.
-		widgets?.reduce(
-			( allWidgets, widget ) => ( {
-				...allWidgets,
-				[ widget.id ]: widget,
-			} ),
-			{}
-		) || {}
-	);
-} );
+			return (
+				// Key widgets by their ID.
+				widgets?.reduce(
+					( allWidgets, widget ) => ( {
+						...allWidgets,
+						[ widget.id ]: widget,
+					} ),
+					{}
+				) || {}
+			);
+		},
+		() => [
+			select( coreStore ).getEntityRecords(
+				'root',
+				'widget',
+				buildWidgetsQuery()
+			),
+		]
+	)
+);
 
 /**
  * Returns API widget data for a particular widget ID.

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -46,7 +46,7 @@ export const getWidgets = createRegistrySelector( ( select ) =>
 						[ widget.id ]: widget,
 					} ),
 					{}
-				) || {}
+				) ?? {}
 			);
 		},
 		() => [


### PR DESCRIPTION
## What?
PR memoizes the `getWidgets` selector and prevents it from returning different values when called with the same state.

## How?
It's now possible to memoize registry selectors - #57888.

## Testing Instructions
1. Enabled TT1 theme.
2. Navigate to Appearance -> Widgets.
3. Confirm it loads correctly.
4. Confirm you can update widgets as before.

_The screen also has e2e tests._

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-10 at 11 09 44](https://github.com/WordPress/gutenberg/assets/240569/c222fe81-f151-449b-914d-1c29db345552)
