### PR TITLE
Fix Comment pagination should use a nav and an accessible name

### DIFF
--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -83,7 +83,12 @@ export default function QueryPaginationEdit( {
 					</PanelBody>
 				</InspectorControls>
 			) }
-			<div { ...innerBlocksProps } />
+			<nav { ...innerBlocksProps } aria-label={ __( 'Comments' ) }>
+				<span className="screen-reader-text">
+					{ __( 'Comments navigation' ) }
+				</span>
+				{ innerBlocksProps.children }
+			</nav>
 		</>
 	);
 }

--- a/packages/block-library/src/comments-pagination/index.php
+++ b/packages/block-library/src/comments-pagination/index.php
@@ -28,8 +28,10 @@ function render_block_core_comments_pagination( $attributes, $content ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
 	return sprintf(
-		'<div %1$s>%2$s</div>',
+		'<nav %1$s aria-label="%2$s"><span class="screen-reader-text">%3$s</span>%4$s</nav>',
 		$wrapper_attributes,
+		__( 'Comments' ),
+		__( 'Comments navigation' ),
 		$content
 	);
 }


### PR DESCRIPTION
Fixes [#63328](https://github.com/WordPress/gutenberg/issues/63328)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR improves the accessibility of the Comments Pagination block by using a semantic `<nav>` element with an `aria-label` and screen reader text.

## Why?
The current implementation uses a `<div>` which lacks semantic meaning for navigation. This change aligns the block with accessibility best practices and matches the behavior of classic theme pagination functions.

## How?
- Updated `edit.js` to render a `<nav>` instead of a `<div>`
- Modified `index.php` to use `<nav>` in the server-side render function
- Added `aria-label="Comments"` to the navigation element
- Included visually hidden text for screen readers
- Ensured the 'comments-pagination' class is consistently applied

## Testing Instructions
1. Add a Comments block to a post or page
2. Enable comment pagination in the Discussion Settings if not already enabled
3. Add the Comments Pagination block inside the Comments block
4. Check the rendered output in both the editor and the front-end

## Screenshots or screencast <!-- if applicable -->
<img width="583" alt="Screenshot 2024-07-10 at 12 53 25 PM" src="https://github.com/WordPress/gutenberg/assets/64325240/2029c596-8539-4fa3-94a5-a4dce213ec4f">
