### PR TITLE
CustomSelectControlV2: animate select popover appearance

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -44,6 +44,7 @@
 -   `CustomSelectControlV2`: keep item checkmark top aligned. ([#63230](https://github.com/WordPress/gutenberg/pull/63230))
 -   `CustomSelectControlV2`: keep legacy arrow down behavior only for legacy wrapper. ([#62919](https://github.com/WordPress/gutenberg/pull/62919))
 -   `CustomSelectControlV2`: fix trigger button font size. ([#63131](https://github.com/WordPress/gutenberg/pull/63131))
+-   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
 -   `CustomSelectControlV2`: fix labelling with a visually hidden label. ([#63137](https://github.com/WordPress/gutenberg/pull/63137))
 -   `CustomSelectControlV2`: allow checkmark wrapper to collapse when not shown. ([#63229](https://github.com/WordPress/gutenberg/pull/63229))
 -   Extract `TimeInput` component from `TimePicker` ([#60613](https://github.com/WordPress/gutenberg/pull/60613)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
+
 ## 28.3.0 (2024-07-10)
 
 ### Enhancements
@@ -44,7 +48,6 @@
 -   `CustomSelectControlV2`: keep item checkmark top aligned. ([#63230](https://github.com/WordPress/gutenberg/pull/63230))
 -   `CustomSelectControlV2`: keep legacy arrow down behavior only for legacy wrapper. ([#62919](https://github.com/WordPress/gutenberg/pull/62919))
 -   `CustomSelectControlV2`: fix trigger button font size. ([#63131](https://github.com/WordPress/gutenberg/pull/63131))
--   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
 -   `CustomSelectControlV2`: fix labelling with a visually hidden label. ([#63137](https://github.com/WordPress/gutenberg/pull/63137))
 -   `CustomSelectControlV2`: allow checkmark wrapper to collapse when not shown. ([#63229](https://github.com/WordPress/gutenberg/pull/63229))
 -   Extract `TimeInput` component from `TimePicker` ([#60613](https://github.com/WordPress/gutenberg/pull/60613)).

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -105,10 +105,10 @@ export const Select = styled( Ariakit.Select, {
 	`
 );
 
-const slideUpAndFade = keyframes( {
+const slideDownAndFade = keyframes( {
 	'0%': {
 		opacity: 0,
-		transform: `translateY(${ ANIMATION_PARAMS.SLIDE_AMOUNT })`,
+		transform: `translateY(-${ ANIMATION_PARAMS.SLIDE_AMOUNT })`,
 	},
 	'100%': { opacity: 1, transform: 'translateY(0)' },
 } );
@@ -134,7 +134,7 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	/* Animation */
 	animation-duration: ${ ANIMATION_PARAMS.DURATION };
 	animation-timing-function: ${ ANIMATION_PARAMS.EASING };
-	animation-name: ${ slideUpAndFade };
+	animation-name: ${ slideDownAndFade };
 	will-change: transform, opacity;
 	@media ( prefers-reduced-motion ) {
 		animation-duration: 0s;

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as Ariakit from '@ariakit/react';
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 /**
  * Internal dependencies
@@ -12,6 +12,13 @@ import { space } from '../utils/space';
 import { chevronIconSize } from '../select-control/styles/select-control-styles';
 import { fontSizeStyles } from '../input-control/styles/input-control-styles';
 import type { CustomSelectButtonSize } from './types';
+
+// TODO: extract to common utils and apply to relevant components
+const ANIMATION_PARAMS = {
+	SLIDE_AMOUNT: '2px',
+	DURATION: '400ms',
+	EASING: 'cubic-bezier( 0.16, 1, 0.3, 1 )',
+};
 
 const INLINE_PADDING = {
 	compact: 8, // space(2)
@@ -98,6 +105,14 @@ export const Select = styled( Ariakit.Select, {
 	`
 );
 
+const slideUpAndFade = keyframes( {
+	'0%': {
+		opacity: 0,
+		transform: `translateY(${ ANIMATION_PARAMS.SLIDE_AMOUNT })`,
+	},
+	'100%': { opacity: 1, transform: 'translateY(0)' },
+} );
+
 export const SelectPopover = styled( Ariakit.SelectPopover )`
 	display: flex;
 	flex-direction: column;
@@ -113,11 +128,21 @@ export const SelectPopover = styled( Ariakit.SelectPopover )`
 	overflow: auto;
 	overscroll-behavior: contain;
 
-	// The smallest size without overflowing the container.
+	/* The smallest size without overflowing the container. */
 	min-width: min-content;
 
+	/* Animation */
+	animation-duration: ${ ANIMATION_PARAMS.DURATION };
+	animation-timing-function: ${ ANIMATION_PARAMS.EASING };
+	animation-name: ${ slideUpAndFade };
+	will-change: transform, opacity;
+	@media ( prefers-reduced-motion ) {
+		animation-duration: 0s;
+	}
+
 	&[data-focus-visible] {
-		outline: none; // outline will be on the trigger, rather than the popover
+		/* The outline will be on the trigger, rather than the popover. */
+		outline: none;
 	}
 `;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Animate the select popover appearance in the new version of `CustomSelectControl`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make UI interactions feel more polished and to uniform the component with the direction taken in other components.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using CSS animations to add a fade + slide down animation when the select popover appears

> [!NOTE]
> For now, the slide direction in the animation will always be downwards. I tried to detect when `Ariakit` "flips" the popover from bottom to top for lack of space, so that I could apply a "slide down" animation instead, but I couldn't extract that information from the ariakit store (I tried the [same technique](https://github.com/WordPress/gutenberg/blob/039bd9081abeb7ce93d7a57e56ca0abfbc6b7937/packages/components/src/dropdown-menu-v2/index.tsx#L250-L253) used in the `DropdownMenuV2` component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the `CustomSelectControlV2` Storybook default or legacy examples
2. Open and close the select popover, make sure the animation works 
3. Using browser dev tools (or OS settings), enable the preference for `reduced motion`. Open and close the select popover again, and make sure that it doesn't animate.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/60801d78-125a-4340-ab21-7e0b98443fde" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/d986678c-d3a2-4510-b9ba-1d2de919e8fb" /> |



