### PR TITLE
Fix Featured Image label missing after image has been added to page

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -123,6 +123,9 @@ function PostFeaturedImage( {
 
 	return (
 		<PostFeaturedImageCheck>
+			{ featuredImageId !== 0 && (
+				<span>{ DEFAULT_FEATURE_IMAGE_LABEL }</span>
+			) }
 			{ noticeUI }
 			<div className="editor-post-featured-image">
 				{ media && (


### PR DESCRIPTION
Fixes [#63321](https://github.com/WordPress/gutenberg/issues/63321)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR improves the accessibility and labeling of the Featured Image component in the post editor.

## Why?
The current implementation lacks clear visual context for the Featured Image section, potentially confusing users unfamiliar with WordPress. It also has room for improvement in terms of accessibility for screen reader users.

## How?
- Added a visible label for the Featured Image section using an `<span>` element

## Testing Instructions
1. Open a new or existing post in the editor.
2. Locate the Featured Image section in the post settings sidebar.
3. Add Featured Image for post/ page.
4. Verify that there's a visible "Featured Image" label above the image area.
5. Remove the featured image and confirm that the interface reverts to the initial state with clear labeling.

## Screenshots or screencast <!-- if applicable -->
<img width="279" alt="Screenshot 2024-07-10 at 2 27 08 PM" src="https://github.com/WordPress/gutenberg/assets/64325240/21294f34-e52a-4ad8-a0cf-f208918a857d">
<img width="278" alt="Screenshot 2024-07-10 at 2 27 20 PM" src="https://github.com/WordPress/gutenberg/assets/64325240/22f6ed5e-002d-49d0-bff3-f015f65131aa">
