### PR TITLE
Block Directory: Memoize store selectors

### DIFF
--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createRegistrySelector } from '@wordpress/data';
+import { createSelector, createRegistrySelector } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -53,15 +53,21 @@ export function getInstalledBlockTypes( state ) {
  *
  * @return {Array} Block type items.
  */
-export const getNewBlockTypes = createRegistrySelector(
-	( select ) => ( state ) => {
-		const usedBlockTree = select( blockEditorStore ).getBlocks();
-		const installedBlockTypes = getInstalledBlockTypes( state );
+export const getNewBlockTypes = createRegistrySelector( ( select ) =>
+	createSelector(
+		( state ) => {
+			const usedBlockTree = select( blockEditorStore ).getBlocks();
+			const installedBlockTypes = getInstalledBlockTypes( state );
 
-		return installedBlockTypes.filter( ( blockType ) =>
-			hasBlockType( blockType, usedBlockTree )
-		);
-	}
+			return installedBlockTypes.filter( ( blockType ) =>
+				hasBlockType( blockType, usedBlockTree )
+			);
+		},
+		( state ) => [
+			getInstalledBlockTypes( state ),
+			select( blockEditorStore ).getBlocks(),
+		]
+	)
 );
 
 /**
@@ -72,15 +78,21 @@ export const getNewBlockTypes = createRegistrySelector(
  *
  * @return {Array} Block type items.
  */
-export const getUnusedBlockTypes = createRegistrySelector(
-	( select ) => ( state ) => {
-		const usedBlockTree = select( blockEditorStore ).getBlocks();
-		const installedBlockTypes = getInstalledBlockTypes( state );
+export const getUnusedBlockTypes = createRegistrySelector( ( select ) =>
+	createSelector(
+		( state ) => {
+			const usedBlockTree = select( blockEditorStore ).getBlocks();
+			const installedBlockTypes = getInstalledBlockTypes( state );
 
-		return installedBlockTypes.filter(
-			( blockType ) => ! hasBlockType( blockType, usedBlockTree )
-		);
-	}
+			return installedBlockTypes.filter(
+				( blockType ) => ! hasBlockType( blockType, usedBlockTree )
+			);
+		},
+		( state ) => [
+			getInstalledBlockTypes( state ),
+			select( blockEditorStore ).getBlocks(),
+		]
+	)
 );
 
 /**


### PR DESCRIPTION
## What?
PR adds memoization to the `getNewBlockTypes` and `getUnusedBlockTypes` block directory store selectors.

## Why?
This is a follow-up to #57888. It prevents selectors from returning different values when called with the same state.

There were no `useSelect` warnings in the editor because of how these selectors are called in components. The `mapSelect` directly returns values, which satisfies shallow equality.

https://github.com/WordPress/gutenberg/blob/4f706f1777d05566f66b80a82560dd7c498942dc/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js#L19-L22

## Testing Instructions
The feature has e2e test coverage.

1. Create a post.
2. Install a block plugin from the directory.
3. Try publishing a post.
4. Confirm that the newly installed block is listed in the pre-publish sidebar.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-10 at 13 29 24](https://github.com/WordPress/gutenberg/assets/240569/e12d58da-7148-4843-9776-c93cd5c7f1b9)
