### PR TITLE
[Mobile] Remove Quote and List block V2 flags

### DIFF
--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -370,8 +370,6 @@ extension GutenbergViewController: GutenbergWebDelegate {
 extension GutenbergViewController: GutenbergBridgeDataSource {
     class EditorSettings: GutenbergEditorSettings {
         var isFSETheme: Bool = true
-        var quoteBlockV2: Bool = true
-        var listBlockV2: Bool = true
         var rawStyles: String? = nil
         var rawFeatures: String? = nil
         var colors: [[String: String]]? = nil


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6973

## What?
Removes remaining variables for the experimental flags for List and Quote V2.

## Why?
These are not used anymore.

## How?
By removing it from the code.

## Testing Instructions
No testing is needed for this change.

### Testing Instructions for Keyboard
No testing is needed for this change.

## Screenshots or screencast <!-- if applicable -->
Since this is just a small code removal of unused variables, there a no screenshots for this PR.