### PR TITLE
Image lightbox: move image data from context to state

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -187,7 +187,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$figure_styles      = $p->get_attribute( 'style' );
 
 	// Create unique id and set the image metadata in the state.
-	$unique_image_id = substr( md5( $img_uploaded_src ), 0, 10 );
+	$unique_image_id = uniqid();
 
 	wp_interactivity_state(
 		'core/image',

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -187,7 +187,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$figure_styles      = $p->get_attribute( 'style' );
 
 	// Create unique id and set the image metadata in the state.
-	$unique_image_id = wp_unique_id( 'image-' );
+	$unique_image_id = substr( md5( $img_uploaded_src ), 0, 10 );
+
 	wp_interactivity_state(
 		'core/image',
 		array(

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -185,22 +185,36 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$p->seek( 'figure' );
 	$figure_class_names = $p->get_attribute( 'class' );
 	$figure_styles      = $p->get_attribute( 'style' );
+
+	// Create unique id and set the image metadata in the state.
+	$unique_image_id = wp_unique_id( 'image-' );
+	wp_interactivity_state(
+		'core/image',
+		array(
+			'metadata' => array(
+				$unique_image_id => array(
+					'uploadedSrc'      => $img_uploaded_src,
+					'figureClassNames' => $figure_class_names,
+					'figureStyles'     => $figure_styles,
+					'imgClassNames'    => $img_class_names,
+					'imgStyles'        => $img_styles,
+					'targetWidth'      => $img_width,
+					'targetHeight'     => $img_height,
+					'scaleAttr'        => $block['attrs']['scale'] ?? false,
+					'ariaLabel'        => $aria_label,
+					'alt'              => $alt,
+				),
+			),
+		)
+	);
+
 	$p->add_class( 'wp-lightbox-container' );
 	$p->set_attribute( 'data-wp-interactive', 'core/image' );
 	$p->set_attribute(
 		'data-wp-context',
 		wp_json_encode(
 			array(
-				'uploadedSrc'      => $img_uploaded_src,
-				'figureClassNames' => $figure_class_names,
-				'figureStyles'     => $figure_styles,
-				'imgClassNames'    => $img_class_names,
-				'imgStyles'        => $img_styles,
-				'targetWidth'      => $img_width,
-				'targetHeight'     => $img_height,
-				'scaleAttr'        => $block['attrs']['scale'] ?? false,
-				'ariaLabel'        => $aria_label,
-				'alt'              => $alt,
+				'imageId' => $unique_image_id,
 			),
 			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 		)

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -246,8 +246,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			aria-label="' . esc_attr( $aria_label ) . '"
 			data-wp-init="callbacks.initTriggerButton"
 			data-wp-on-async--click="actions.showLightbox"
-			data-wp-style--right="context.imageButtonRight"
-			data-wp-style--top="context.imageButtonTop"
+			data-wp-style--right="state.imageButtonRight"
+			data-wp-style--top="state.imageButtonTop"
 		>
 			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
 				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -324,13 +324,11 @@ const { state, actions, callbacks } = store(
 			`;
 			},
 			setButtonStyles() {
-				const ctx = getContext();
+				const { imageId } = getContext();
 				const { ref } = getElement();
-				state.metadata[ ctx.imageId ] = {
-					...state.metadata[ ctx.imageId ],
-					imageRef: ref,
-					currentSrc: ref.currentSrc,
-				};
+
+				state.metadata[ imageId ].imageRef = ref;
+				state.metadata[ imageId ].currentSrc = ref.currentSrc;
 
 				const {
 					naturalWidth,
@@ -406,11 +404,8 @@ const { state, actions, callbacks } = store(
 					}
 				}
 
-				state.metadata[ ctx.imageId ] = {
-					...state.metadata[ ctx.imageId ],
-					imageButtonTop,
-					imageButtonRight,
-				};
+				state.metadata[ imageId ].imageButtonTop = imageButtonTop;
+				state.metadata[ imageId ].imageButtonRight = imageButtonRight;
 			},
 			setOverlayFocus() {
 				if ( state.overlayEnabled ) {
@@ -420,12 +415,9 @@ const { state, actions, callbacks } = store(
 				}
 			},
 			initTriggerButton() {
-				const ctx = getContext();
+				const { imageId } = getContext();
 				const { ref } = getElement();
-				state.metadata[ ctx.imageId ] = {
-					...state.metadata[ ctx.imageId ],
-					buttonRef: ref,
-				};
+				state.metadata[ imageId ].buttonRef = ref;
 			},
 		},
 	},

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -23,6 +23,7 @@ const { state, actions, callbacks } = store(
 	'core/image',
 	{
 		state: {
+			metadata: {},
 			currentImage: {},
 			get overlayOpened() {
 				return state.currentImage.currentSrc;
@@ -58,14 +59,20 @@ const { state, actions, callbacks } = store(
 					return;
 				}
 
-				// Stores the positons of the scroll to fix it until the overlay is
+				// Stores the positions of the scroll to fix it until the overlay is
 				// closed.
 				state.scrollTopReset = document.documentElement.scrollTop;
 				state.scrollLeftReset = document.documentElement.scrollLeft;
 
-				// Moves the information of the expaned image to the state.
-				ctx.currentSrc = ctx.imageRef.currentSrc;
-				state.currentImage = ctx;
+				// Sets the information of the expanded image in the state.
+				state.currentImage = {
+					...state.metadata[ ctx.imageId ],
+					imageRef: ctx.imageRef,
+					buttonRef: ctx.buttonRef,
+					currentSrc: ctx.imageRef.currentSrc,
+					imageButtonTop: ctx.imageButtonTop,
+					imageButtonRight: ctx.imageButtonRight,
+				};
 				state.overlayEnabled = true;
 
 				// Computes the styles of the overlay for the animation.

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -51,6 +51,14 @@ const { state, actions, callbacks } = store(
 					) }; object-fit:cover;`
 				);
 			},
+			get imageButtonRight() {
+				const { imageId } = getContext();
+				return state.metadata[ imageId ].imageButtonRight;
+			},
+			get imageButtonTop() {
+				const { imageId } = getContext();
+				return state.metadata[ imageId ].imageButtonTop;
+			},
 		},
 		actions: {
 			showLightbox() {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -377,7 +377,7 @@ const { state, actions, callbacks } = store(
 				// In the case of an image with object-fit: contain, the size of the
 				// <img> element can be larger than the image itself, so it needs to
 				// calculate where to place the button.
-				if ( ctx.scaleAttr === 'contain' ) {
+				if ( state.metadata[ imageId ].scaleAttr === 'contain' ) {
 					// Natural ratio of the image.
 					const naturalRatio = naturalWidth / naturalHeight;
 					// Offset ratio of the image.

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -55,9 +55,11 @@ const { state, actions, callbacks } = store(
 				const ctx = getContext();
 
 				// Bails out if the image has not loaded yet.
-				if ( ! ctx.imageRef?.complete ) {
+				if ( ! state.metadata[ ctx.imageId ].imageRef?.complete ) {
 					return;
 				}
+
+				state.overlayEnabled = true;
 
 				// Stores the positions of the scroll to fix it until the overlay is
 				// closed.
@@ -65,15 +67,7 @@ const { state, actions, callbacks } = store(
 				state.scrollLeftReset = document.documentElement.scrollLeft;
 
 				// Sets the information of the expanded image in the state.
-				state.currentImage = {
-					...state.metadata[ ctx.imageId ],
-					imageRef: ctx.imageRef,
-					buttonRef: ctx.buttonRef,
-					currentSrc: ctx.imageRef.currentSrc,
-					imageButtonTop: ctx.imageButtonTop,
-					imageButtonRight: ctx.imageButtonRight,
-				};
-				state.overlayEnabled = true;
+				state.currentImage = state.metadata[ ctx.imageId ];
 
 				// Computes the styles of the overlay for the animation.
 				callbacks.setOverlayStyles();
@@ -332,7 +326,11 @@ const { state, actions, callbacks } = store(
 			setButtonStyles() {
 				const ctx = getContext();
 				const { ref } = getElement();
-				ctx.imageRef = ref;
+				state.metadata[ ctx.imageId ] = {
+					...state.metadata[ ctx.imageId ],
+					imageRef: ref,
+					currentSrc: ref.currentSrc,
+				};
 
 				const {
 					naturalWidth,
@@ -375,6 +373,9 @@ const { state, actions, callbacks } = store(
 				const buttonOffsetTop = figureHeight - offsetHeight;
 				const buttonOffsetRight = figureWidth - offsetWidth;
 
+				let imageButtonTop = buttonOffsetTop + 16;
+				let imageButtonRight = buttonOffsetRight + 16;
+
 				// In the case of an image with object-fit: contain, the size of the
 				// <img> element can be larger than the image itself, so it needs to
 				// calculate where to place the button.
@@ -388,25 +389,28 @@ const { state, actions, callbacks } = store(
 						// If it reaches the width first, it keeps the width and compute the
 						// height.
 						const referenceHeight = offsetWidth / naturalRatio;
-						ctx.imageButtonTop =
+						imageButtonTop =
 							( offsetHeight - referenceHeight ) / 2 +
 							buttonOffsetTop +
 							16;
-						ctx.imageButtonRight = buttonOffsetRight + 16;
+						imageButtonRight = buttonOffsetRight + 16;
 					} else {
 						// If it reaches the height first, it keeps the height and compute
 						// the width.
 						const referenceWidth = offsetHeight * naturalRatio;
-						ctx.imageButtonTop = buttonOffsetTop + 16;
-						ctx.imageButtonRight =
+						imageButtonTop = buttonOffsetTop + 16;
+						imageButtonRight =
 							( offsetWidth - referenceWidth ) / 2 +
 							buttonOffsetRight +
 							16;
 					}
-				} else {
-					ctx.imageButtonTop = buttonOffsetTop + 16;
-					ctx.imageButtonRight = buttonOffsetRight + 16;
 				}
+
+				state.metadata[ ctx.imageId ] = {
+					...state.metadata[ ctx.imageId ],
+					imageButtonTop,
+					imageButtonRight,
+				};
 			},
 			setOverlayFocus() {
 				if ( state.overlayEnabled ) {
@@ -418,7 +422,10 @@ const { state, actions, callbacks } = store(
 			initTriggerButton() {
 				const ctx = getContext();
 				const { ref } = getElement();
-				ctx.buttonRef = ref;
+				state.metadata[ ctx.imageId ] = {
+					...state.metadata[ ctx.imageId ],
+					buttonRef: ref,
+				};
 			},
 		},
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This change moves the image data from context to state.
The data is set in the set against a `unique_id` created for the image.

After this change, image data of all images can be accessed directly from the 'core/image` state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This helps to control the image lightbox from containing blocks such as `gallery`.
In a future change, gallery can will hold list of `image_ids` in its context, and sets the image block with current `image_id` to show lightbox as a carousel.

Gallery block cannot access context data of all images.
Alternatively, gallery could have an array and each image block may push its context data to gallery array `on image init`, but it make the same data to be present in two places.

Hence the image metadata is moved to its state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Enable lightbox for image (Click to expand in global styles)
* verify lightbox functionality in image and gallery blocks.
* It should work the same as before without any issues.
