### PR TITLE
InnerBlocks: Make sure blockType is set before trying to use it

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -132,7 +132,10 @@ function UncontrolledInnerBlocks( props ) {
 		/>
 	);
 
-	if ( Object.keys( blockType.providesContext ).length === 0 ) {
+	if (
+		! blockType?.providesContext ||
+		Object.keys( blockType.providesContext ).length === 0
+	) {
 		return items;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds a check that `blockType` is set before attempting to use it in `InnerBlocks`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR addresses an error that is thrown in the context of the WooCommerce new product editor when generating product variations. See https://github.com/woocommerce/woocommerce/pull/49216 for a try branch that triggers the error.

Without this fix, whenever variations are generated, the following error is logged in the browser dev console (note, we worked around the error in the UI in https://github.com/woocommerce/woocommerce/pull/49248, so it does not crash WooCommerce).

```
TypeError: undefined is not an object (evaluating 'w.providesContext')
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR adds a check that `blockType` is set before attempting to use it in `InnerBlocks`.

## Testing Instructions

With the Gutenberg plugin built from this PR and a WooCommerce env running the branch from https://github.com/woocommerce/woocommerce/pull/49216 with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. On the `Variations` tab, click `Add Options` and add some variation options.
3. Verify that the variations are added correctly and the selected tab remains `Variations`
4. Verify that no `TypeError: undefined is not an object (evaluating 'w.providesContext')` error was logged in the browser dev console.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

n/a

## Screenshots or screencast <!-- if applicable -->

n/a