### PR TITLE
Patterns inserter tabs: temporary disable animated indicator

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -228,6 +228,13 @@ $block-inserter-tabs-height: 44px;
 		margin-top: auto;
 	}
 
+	// Temporary disable the component's indicator animation. This override should
+	// removed in favour of using the native component's styles and behavior.
+	// See https://github.com/WordPress/gutenberg/pull/62879#issuecomment-2219720582
+	&[aria-orientation="vertical"]::after {
+		content: none;
+	}
+
 	.block-editor-inserter__category-tab {
 		// Account for the icon on the right so that it's visually balanced.
 		padding: $grid-unit-10 $grid-unit-05 $grid-unit-10 $grid-unit-15;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -228,9 +228,9 @@ $block-inserter-tabs-height: 44px;
 		margin-top: auto;
 	}
 
-	// Temporary disable the component's indicator animation. This override should
-	// removed in favour of using the native component's styles and behavior.
-	// See https://github.com/WordPress/gutenberg/pull/62879#issuecomment-2219720582
+	// Temporarily disable the component's indicator animation.
+	// TODO: remove in favor of using the native component's styles and behavior,
+	// see https://github.com/WordPress/gutenberg/pull/62879#issuecomment-2219720582
 	&[aria-orientation="vertical"]::after {
 		content: none;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

As discussed in https://github.com/WordPress/gutenberg/pull/62879#issuecomment-2219720582, this PR disables the animated indicator from the `Tabs` component in the patterns inserter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The new animation conflicts with the current custom indicator styles. This PR aims at putting a temporary stopgap until we come up with a better solution.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding a CSS override hiding the animated indicator.


## Next steps

To be carried out in separate PRs, cc @DaniGuardiola:

- agree on indicator looks & animation for the `Tabs` component, both in horizontal and vertical orientations, that can be used across the whole editor
- remove the style overrides (introduced by this PR) and the custom indicator styles on the pattern inserter
- improve UI jankiness, likely caused by the pattern previews being quite complex to render

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the block pattern inserter
- Select different categories (tabs)
- Make sure that the tabs indicator doesn't animate

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/92a967c4-501c-41a4-9fc2-59e8e663c9ec" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/c983569c-7ea8-4db2-9d2a-7bc019792ee8" /> |
