### PR TITLE
Query Loop: Change default query loop variations

### DIFF
--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -14,22 +14,6 @@ import {
 	imageDateTitle,
 } from './icons';
 
-const QUERY_DEFAULT_ATTRIBUTES = {
-	query: {
-		perPage: 3,
-		pages: 0,
-		offset: 0,
-		postType: 'post',
-		order: 'desc',
-		orderBy: 'date',
-		author: '',
-		search: '',
-		exclude: [],
-		sticky: '',
-		inherit: false,
-	},
-};
-
 const variations = [
 	{
 		name: 'posts-list',
@@ -60,7 +44,7 @@ const variations = [
 		name: 'title-date',
 		title: __( 'Title & Date' ),
 		icon: titleDate,
-		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
+		attributes: {},
 		innerBlocks: [
 			[
 				'core/post-template',
@@ -76,7 +60,7 @@ const variations = [
 		name: 'title-excerpt',
 		title: __( 'Title & Excerpt' ),
 		icon: titleExcerpt,
-		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
+		attributes: {},
 		innerBlocks: [
 			[
 				'core/post-template',
@@ -92,7 +76,7 @@ const variations = [
 		name: 'title-date-excerpt',
 		title: __( 'Title, Date, & Excerpt' ),
 		icon: titleDateExcerpt,
-		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
+		attributes: {},
 		innerBlocks: [
 			[
 				'core/post-template',
@@ -112,7 +96,7 @@ const variations = [
 		name: 'image-date-title',
 		title: __( 'Image, Date, & Title' ),
 		icon: imageDateTitle,
-		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
+		attributes: {},
 		innerBlocks: [
 			[
 				'core/post-template',


### PR DESCRIPTION
Related #30369 

## What?

A lot of people have raised that the default Query Loop is confusing because picking one of the initial variations results in a query loop that doesn't inherit the default WP query (permalinks, pagination, archive...)

The block itself has "inherit" set to true by default but for some reason (probably unintentional), inherit is set to false when "starting blank" and picking one of the variations.

**Note** There's another variation that I didn't not update, it's called "Posts List", I think it corresponds more to a "Latest Posts" variation. I believe the original purpose of this variation was to replace the "Latest Posts" widget/block which is also still selectable. I don't think we should update the "inherit" flag for this variation because it will change its purpose entirely but I think we have a few options there:
 
 - Remove that variation entirely
 - Rename it to "Latest Posts" or "Recent Posts" or something like that
 - Should we also hide the existing "Latests Posts" block?

(This can be addressed separately though)

## Testing Instructions

1- Insert Query Loop block
2- Click "Start blank"
3- Pick one of the proposed variations
4- Notice that the inserted query has the "inherit" toggle enabled.