### PR TITLE
CustomSelectControlV2: do not flip popover if legacy adapter

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Internal
 
 -   `CustomSelectControl`: switch to ariakit-based implementation ([#63258](https://github.com/WordPress/gutenberg/pull/63258)).
--   `CustomSelectControl`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
+-   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
+-   `CustomSelectControlV2`: do not flip popover if legacy adapter. ([#63357](https://github.com/WordPress/gutenberg/pull/63357)).
 
 ### Enhancements
 

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -145,6 +145,8 @@ function _CustomSelect(
 					sameWidth
 					slide={ false }
 					onKeyDown={ onSelectPopoverKeyDown }
+					// Match legacy behavior
+					flip={ ! isLegacy }
 				>
 					<CustomSelectContext.Provider value={ contextValue }>
 						{ children }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

Do not allow the select popover in the `CustomSelectControl` V2 legacy adapter to flip when there isn't much space to render below the trigger button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This matches more closely the behavior of the legacy, downshift-based component and prevents (avoids it without solving) the issue reported in https://github.com/WordPress/gutenberg/issues/63180

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By setting the `flip` property to `false` on the ariakit select popover

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Render `CustomSelectControlV2` legacy adapter and open the select popover
- Resize its window until there is not enough space for the popover
- Notice how the popover doesn't flip, but continues to render below the trigger button

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/2a448ca7-274e-4ca1-86b0-cea492832af6" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/6996c082-6142-4d37-bad9-7feb54a6943e" /> |

