### PR TITLE
Add missing aria-haspopup attribute to the buttons to set and replace the featured image

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -170,7 +170,9 @@ function PostFeaturedImage( {
 									aria-label={
 										! featuredImageId
 											? null
-											: __( 'Edit or replace the image' )
+											: __(
+													'Edit or replace the featured image'
+											  )
 									}
 									aria-describedby={
 										! featuredImageId

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -177,6 +177,7 @@ function PostFeaturedImage( {
 											? null
 											: `editor-post-featured-image-${ featuredImageId }-describedby`
 									}
+									aria-haspopup="dialog"
 								>
 									{ !! featuredImageId && media && (
 										<img
@@ -197,6 +198,7 @@ function PostFeaturedImage( {
 										<Button
 											className="editor-post-featured-image__action"
 											onClick={ open }
+											aria-haspopup="dialog"
 										>
 											{ __( 'Replace' ) }
 										</Button>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/63359

## What?
<!-- In a few words, what is the PR actually doing? -->
The buttons to set and replace the featured image do open a dialog but miss to inform screen reader users about it.

Additionally, when the featured image is set, the button aria label only says:
`Edit or replace the featured image`
There is no mention anywhere this is the _featured_ image. No heading, no other text. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
it is important to inform users a toggle button will open a dialog.
It is important to calrify this is the post _featured_ image.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add missing `aria-haspopup="dialog"` attribute.
When a featured image is set, changes the button aria-label from `Edit or replace the image` to `Edit or replace the featured image`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue https://github.com/WordPress/gutenberg/issues/63359
- Observe the buttons now provide information that they are going to open a dialog. 
- When an image is set, observe the button with the image preview has an aria label `Edit or replace the featured image`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/WordPress/gutenberg/assets/1682452/fed05d1c-9357-43fd-aece-1f02b7eaa999)


After:


![after](https://github.com/WordPress/gutenberg/assets/1682452/79da47e7-07d4-429d-8af5-cb9cce938543)
