### PR TITLE
Set query loop to have the inherit value by default

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -150,7 +150,7 @@ export default function QueryInspectorControls( props ) {
 							__nextHasNoMarginBottom
 							label={ __( 'Inherit query from template' ) }
 							help={ __(
-								'Toggle to use the global query context that is set with the current template, such as an archive or search. Disable to customize the settings independently.'
+								'Enable to use the global query context that is set with the current template, such as an archive or search. Disable to customize the settings independently.'
 							) }
 							checked={ !! inherit }
 							onChange={ ( value ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Simplify flow by defaulting query block loops to inherit which relies on the Reading Settings or Template settings posts per page value. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
