### PR TITLE
Composite: export new stable version, deprecate unstable version

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -6,7 +6,7 @@ import {
 	Button,
 	Spinner,
 	VisuallyHidden,
-	privateApis as componentsPrivateApis,
+	CompositeItem,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -20,9 +20,6 @@ import BlockRatings from '../block-ratings';
 import DownloadableBlockIcon from '../downloadable-block-icon';
 import DownloadableBlockNotice from '../downloadable-block-notice';
 import { store as blockDirectoryStore } from '../../store';
-import { unlock } from '../../lock-unlock';
-
-const { CompositeItemV2: CompositeItem } = unlock( componentsPrivateApis );
 
 // Return the appropriate block item label, given the block data and status.
 function getDownloadableBlockLabel(

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { Composite, useCompositeStore } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 
@@ -11,10 +11,7 @@ import { useDispatch } from '@wordpress/data';
  */
 import DownloadableBlockListItem from '../downloadable-block-list-item';
 import { store as blockDirectoryStore } from '../../store';
-import { unlock } from '../../lock-unlock';
 
-const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
-	unlock( componentsPrivateApis );
 const noop = () => {};
 
 function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {

--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -5,7 +5,9 @@ import { useDispatch } from '@wordpress/data';
 import { cloneBlock } from '@wordpress/blocks';
 import {
 	VisuallyHidden,
-	privateApis as componentsPrivateApis,
+	Composite,
+	CompositeItem,
+	useCompositeStore,
 } from '@wordpress/components';
 
 import { useState } from '@wordpress/element';
@@ -20,13 +22,6 @@ import BlockPreview from '../block-preview';
 import SetupToolbar from './setup-toolbar';
 import usePatternsSetup from './use-patterns-setup';
 import { VIEWMODES } from './constants';
-import { unlock } from '../../lock-unlock';
-
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
 
 const SetupContent = ( {
 	viewMode,

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -11,7 +11,9 @@ import { useEffect, useState, forwardRef, useMemo } from '@wordpress/element';
 import {
 	VisuallyHidden,
 	Tooltip,
-	privateApis as componentsPrivateApis,
+	Composite,
+	CompositeItem,
+	useCompositeStore,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
@@ -21,17 +23,10 @@ import { Icon, symbol } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { unlock } from '../../lock-unlock';
 import BlockPreview from '../block-preview';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 import BlockPatternsPaging from '../block-patterns-paging';
 import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
-
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
 
 const WithToolTip = ( { showTooltip, title, children } ) => {
 	if ( showTooltip ) {

--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -11,7 +11,9 @@ import {
 	MenuItem,
 	Popover,
 	VisuallyHidden,
-	privateApis as componentsPrivateApis,
+	Composite,
+	CompositeItem,
+	useCompositeStore,
 } from '@wordpress/components';
 
 /**
@@ -19,13 +21,6 @@ import {
  */
 import BlockPreview from '../block-preview';
 import useTransformedPatterns from './use-transformed-patterns';
-import { unlock } from '../../lock-unlock';
-
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
 
 function PatternTransformationsMenu( {
 	blocks,

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -10,7 +10,9 @@ import {
 	Button,
 	FlexItem,
 	Dropdown,
-	privateApis as componentsPrivateApis,
+	CompositeItem,
+	Composite,
+	useCompositeStore,
 } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
@@ -21,22 +23,12 @@ import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 
 /**
- * Internal dependencies
- */
-import { unlock } from '../../lock-unlock';
-
-/**
  * Shared reference to an empty array for cases where it is important to avoid
  * returning a new array reference on every invocation.
  *
  * @type {Array}
  */
 const EMPTY_ARRAY = [];
-const {
-	CompositeItemV2: CompositeItem,
-	CompositeV2: Composite,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
 
 export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
 	const shadows = useShadowPresets( settings );

--- a/packages/block-editor/src/components/inserter-listbox/index.js
+++ b/packages/block-editor/src/components/inserter-listbox/index.js
@@ -1,19 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../../lock-unlock';
+import { Composite, useCompositeStore } from '@wordpress/components';
 
 export { default as InserterListboxGroup } from './group';
 export { default as InserterListboxRow } from './row';
 export { default as InserterListboxItem } from './item';
-
-const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
-	unlock( componentsPrivateApis );
 
 function InserterListbox( { children } ) {
 	const store = useCompositeStore( {

--- a/packages/block-editor/src/components/inserter-listbox/item.js
+++ b/packages/block-editor/src/components/inserter-listbox/item.js
@@ -1,18 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { Button, CompositeItem } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../../lock-unlock';
-
-const { CompositeItemV2: CompositeItem } = unlock( componentsPrivateApis );
 
 function InserterListboxItem(
 	{ isFirst, as: Component, children, ...props },

--- a/packages/block-editor/src/components/inserter-listbox/row.js
+++ b/packages/block-editor/src/components/inserter-listbox/row.js
@@ -2,14 +2,7 @@
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../../lock-unlock';
-
-const { CompositeGroupV2: CompositeGroup } = unlock( componentsPrivateApis );
+import { CompositeGroup } from '@wordpress/components';
 
 function InserterListboxRow( props, ref ) {
 	return <CompositeGroup role="presentation" ref={ ref } { ...props } />;

--- a/packages/block-editor/src/components/inserter/media-tab/media-list.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-list.js
@@ -1,17 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { Composite, useCompositeStore } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { MediaPreview } from './media-preview';
-import { unlock } from '../../../lock-unlock';
-
-const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
-	unlock( componentsPrivateApis );
 
 function MediaList( {
 	mediaList,

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -16,7 +16,7 @@ import {
 	Flex,
 	FlexItem,
 	Button,
-	privateApis as componentsPrivateApis,
+	CompositeItem,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -33,7 +33,6 @@ import { isBlobURL } from '@wordpress/blob';
 import InserterDraggableBlocks from '../../inserter-draggable-blocks';
 import { getBlockAndPreviewFromMedia } from './utils';
 import { store as blockEditorStore } from '../../../store';
-import { unlock } from '../../../lock-unlock';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const MAXIMUM_TITLE_LENGTH = 25;
@@ -42,8 +41,6 @@ const MEDIA_OPTIONS_POPOVER_PROPS = {
 	className:
 		'block-editor-inserter__media-list__item-preview-options__popover',
 };
-
-const { CompositeItemV2: CompositeItem } = unlock( componentsPrivateApis );
 
 function MediaPreviewOptions( { category, media } ) {
 	if ( ! category.getReportUrl ) {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   `Composite`: export new stable version, deprecate unstable version. ([#63364](https://github.com/WordPress/gutenberg/pull/63364))
+
 ### Internal
 
 -   `CustomSelectControl`: switch to ariakit-based implementation ([#63258](https://github.com/WordPress/gutenberg/pull/63258)).

--- a/packages/components/src/alignment-matrix-control/cell.tsx
+++ b/packages/components/src/alignment-matrix-control/cell.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { CompositeItem } from '../composite/v2';
+import { CompositeItem } from '../composite';
 import Tooltip from '../tooltip';
 import { VisuallyHidden } from '../visually-hidden';
 

--- a/packages/components/src/alignment-matrix-control/index.tsx
+++ b/packages/components/src/alignment-matrix-control/index.tsx
@@ -13,7 +13,7 @@ import { useInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import Cell from './cell';
-import { Composite, CompositeRow, useCompositeStore } from '../composite/v2';
+import { Composite, CompositeRow, useCompositeStore } from '../composite';
 import { Root, Row } from './styles/alignment-matrix-control-styles';
 import AlignmentMatrixControlIcon from './icon';
 import { GRID, getItemId, getItemValue } from './utils';

--- a/packages/components/src/circular-option-picker/circular-option-picker-option.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker-option.tsx
@@ -16,7 +16,7 @@ import { Icon, check } from '@wordpress/icons';
  */
 import { CircularOptionPickerContext } from './circular-option-picker-context';
 import Button from '../button';
-import { CompositeItem } from '../composite/v2';
+import { CompositeItem } from '../composite';
 import Tooltip from '../tooltip';
 import type { OptionProps, CircularOptionPickerCompositeStore } from './types';
 

--- a/packages/components/src/circular-option-picker/circular-option-picker.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker.tsx
@@ -13,7 +13,7 @@ import { isRTL } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { CircularOptionPickerContext } from './circular-option-picker-context';
-import { Composite, useCompositeStore } from '../composite/v2';
+import { Composite, useCompositeStore } from '../composite';
 import type {
 	CircularOptionPickerProps,
 	ListboxCircularOptionPickerProps,

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -14,7 +14,7 @@ import type { Icon } from '@wordpress/icons';
 import type { ButtonAsButtonProps } from '../button/types';
 import type { DropdownProps } from '../dropdown/types';
 import type { WordPressComponentProps } from '../context';
-import type { CompositeStore } from '../composite/v2';
+import type { CompositeStore } from '../composite';
 
 type CommonCircularOptionPickerProps = {
 	/**

--- a/packages/components/src/composite/current/stories/index.story.tsx
+++ b/packages/components/src/composite/current/stories/index.story.tsx
@@ -21,7 +21,8 @@ import {
 import { UseCompositeStorePlaceholder, transform } from './utils';
 
 const meta: Meta< typeof UseCompositeStorePlaceholder > = {
-	title: 'Components/Composite (V2)',
+	// TODO: do we need a redirect from the previous path?
+	title: 'Components/Composite',
 	component: UseCompositeStorePlaceholder,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
@@ -33,7 +34,6 @@ const meta: Meta< typeof UseCompositeStorePlaceholder > = {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 		CompositeItem,
 	},
-	tags: [ 'status-private' ],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/packages/components/src/composite/index.ts
+++ b/packages/components/src/composite/index.ts
@@ -1,7 +1,1 @@
-// Originally this pointed at a Reakit implementation of
-// `Composite`, but we are removing Reakit entirely from the
-// codebase. We will continue to support the Reakit API
-// through the 'legacy' version, which uses Ariakit under
-// the hood.
-
-export * from './legacy';
+export * from './current';

--- a/packages/components/src/composite/legacy/index.tsx
+++ b/packages/components/src/composite/legacy/index.tsx
@@ -5,6 +5,11 @@
  * tab stop for the whole Composite element. This means that it can behave as
  * a roving tabindex or aria-activedescendant container.
  *
+ * This file aims at providing component that are as close as possible to the
+ * original `reakit`-based implementation (which was removed from the codebase),
+ * although it is recommended that consumers of the package switch to the stable,
+ * un-prefixed, ariakit-based version of `Composite`.
+ *
  * @see https://ariakit.org/components/composite
  */
 

--- a/packages/components/src/composite/legacy/index.tsx
+++ b/packages/components/src/composite/legacy/index.tsx
@@ -17,12 +17,13 @@
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
 import * as Current from '../current';
-import { useInstanceId } from '@wordpress/compose';
 
 type Orientation = 'horizontal' | 'vertical';
 
@@ -123,6 +124,12 @@ function proxyComposite< C extends Component >(
 	propMap: Record< string, string > = {}
 ): CompositeComponent< C > {
 	const displayName = ProxiedComponent.displayName;
+
+	deprecated( `__unstable${ displayName }`, {
+		since: '6.7',
+		alternative: `stable ${ displayName } component`,
+	} );
+
 	const Component = ( legacyProps: CompositeStateProps ) => {
 		const { store, ...rest } =
 			mapLegacyStatePropsToComponentProps( legacyProps );
@@ -160,15 +167,40 @@ const unproxiedCompositeGroup = forwardRef<
 } );
 unproxiedCompositeGroup.displayName = 'CompositeGroup';
 
+/**
+ * _Note: please use the stable `Composite` component instead._
+ *
+ * @deprecated
+ */
 export const Composite = proxyComposite( Current.Composite, { baseId: 'id' } );
+/**
+ * _Note: please use the stable `CompositeGroup` component instead._
+ *
+ * @deprecated
+ */
 export const CompositeGroup = proxyComposite( unproxiedCompositeGroup );
+/**
+ * _Note: please use the stable `CompositeItem` component instead._
+ *
+ * @deprecated
+ */
 export const CompositeItem = proxyComposite( Current.CompositeItem, {
 	focusable: 'accessibleWhenDisabled',
 } );
 
+/**
+ * _Note: please use the stable `useCompositeStore` hook instead._
+ *
+ * @deprecated
+ */
 export function useCompositeState(
 	legacyStateOptions: LegacyStateOptions = {}
 ): CompositeState {
+	deprecated( `__unstableUseCompositeState`, {
+		since: '6.7',
+		alternative: `useCompositeStore hook`,
+	} );
+
 	const {
 		baseId,
 		currentId: defaultActiveId,

--- a/packages/components/src/composite/legacy/index.tsx
+++ b/packages/components/src/composite/legacy/index.tsx
@@ -125,12 +125,12 @@ function proxyComposite< C extends Component >(
 ): CompositeComponent< C > {
 	const displayName = ProxiedComponent.displayName;
 
-	deprecated( `__unstable${ displayName }`, {
-		since: '6.7',
-		alternative: `stable ${ displayName } component`,
-	} );
-
 	const Component = ( legacyProps: CompositeStateProps ) => {
+		deprecated( `wp.components.__unstable${ displayName }`, {
+			since: '6.7',
+			alternative: `the unprefixed, stable version of the ${ displayName } component`,
+		} );
+
 		const { store, ...rest } =
 			mapLegacyStatePropsToComponentProps( legacyProps );
 		const props = rest as ComponentProps< C >;
@@ -196,9 +196,9 @@ export const CompositeItem = proxyComposite( Current.CompositeItem, {
 export function useCompositeState(
 	legacyStateOptions: LegacyStateOptions = {}
 ): CompositeState {
-	deprecated( `__unstableUseCompositeState`, {
+	deprecated( `wp.components.__unstableUseCompositeState`, {
 		since: '6.7',
-		alternative: `useCompositeStore hook`,
+		alternative: `the useCompositeStore hook`,
 	} );
 
 	const {

--- a/packages/components/src/composite/legacy/stories/index.story.tsx
+++ b/packages/components/src/composite/legacy/stories/index.story.tsx
@@ -15,7 +15,9 @@ import {
 import { UseCompositeStatePlaceholder, transform } from './utils';
 
 const meta: Meta< typeof UseCompositeStatePlaceholder > = {
-	title: 'Components/Composite',
+	// TODO: should we keep this story around? If so, how should we call it?
+	// Should we add a `status-deprecated` tag with associated badge?
+	title: 'Components/Composite/Legacy',
 	component: UseCompositeStatePlaceholder,
 	subcomponents: {
 		Composite,

--- a/packages/components/src/composite/legacy/test/index.tsx
+++ b/packages/components/src/composite/legacy/test/index.tsx
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { queryByAttribute, render, screen } from '@testing-library/react';
+import {
+	queryByAttribute,
+	render,
+	screen,
+	renderHook,
+} from '@testing-library/react';
 import { press, sleep, waitFor } from '@ariakit/test';
 
 /**
@@ -155,6 +160,57 @@ function getShiftTestItems() {
 		itemC2: screen.getByText( 'Item C2' ),
 	};
 }
+
+// Checking for deprecation warnings before other tests because the `deprecated`
+// utility only fires a console.warn the first time a component is rendered.
+describe( 'Shows a deprecation warning', () => {
+	it( 'useCompositeState', () => {
+		renderHook( () => useCompositeState() );
+		expect( console ).toHaveWarnedWith(
+			'wp.components.__unstableUseCompositeState is deprecated since version 6.7. Please use the useCompositeStore hook instead.'
+		);
+	} );
+	it( 'Composite', () => {
+		const Test = () => {
+			const props = useCompositeState();
+			return <Composite { ...props } />;
+		};
+		render( <Test /> );
+		expect( console ).toHaveWarnedWith(
+			'wp.components.__unstableComposite is deprecated since version 6.7. Please use the unprefixed, stable version of the Composite component instead.'
+		);
+	} );
+	it( 'CompositeItem', () => {
+		const Test = () => {
+			const props = useCompositeState();
+			return (
+				<Composite { ...props }>
+					<CompositeItem { ...props } />
+				</Composite>
+			);
+		};
+		render( <Test /> );
+		expect( console ).toHaveWarnedWith(
+			'wp.components.__unstableCompositeItem is deprecated since version 6.7. Please use the unprefixed, stable version of the CompositeItem component instead.'
+		);
+	} );
+	it( 'CompositeGroup', () => {
+		const Test = () => {
+			const props = useCompositeState();
+			return (
+				<Composite { ...props }>
+					<CompositeGroup { ...props }>
+						<CompositeItem { ...props } />
+					</CompositeGroup>
+				</Composite>
+			);
+		};
+		render( <Test /> );
+		expect( console ).toHaveWarnedWith(
+			'wp.components.__unstableCompositeGroup is deprecated since version 6.7. Please use the unprefixed, stable version of the CompositeGroup component instead.'
+		);
+	} );
+} );
 
 describe.each( [
 	[

--- a/packages/components/src/composite/v2.ts
+++ b/packages/components/src/composite/v2.ts
@@ -1,4 +1,0 @@
-// Although we have migrated away from Reakit, the 'current'
-// Ariakit implementation is still considered a v2.
-
-export * from './current';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -61,6 +61,14 @@ export {
 	CompositeGroup as __unstableCompositeGroup,
 	CompositeItem as __unstableCompositeItem,
 	useCompositeState as __unstableUseCompositeState,
+} from './composite/legacy';
+export {
+	Composite,
+	CompositeGroup,
+	CompositeGroupLabel,
+	CompositeItem,
+	CompositeRow,
+	useCompositeStore,
 } from './composite';
 export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
 export { default as CustomSelectControl } from './custom-select-control';

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -1,13 +1,6 @@
 /**
  * Internal dependencies
  */
-import {
-	Composite as CompositeV2,
-	CompositeGroup as CompositeGroupV2,
-	CompositeItem as CompositeItemV2,
-	CompositeRow as CompositeRowV2,
-	useCompositeStore as useCompositeStoreV2,
-} from './composite/v2';
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
 import { createPrivateSlotFill } from './slot-fill';
 import {
@@ -28,11 +21,6 @@ import { lock } from './lock-unlock';
 
 export const privateApis = {};
 lock( privateApis, {
-	CompositeV2,
-	CompositeGroupV2,
-	CompositeItemV2,
-	CompositeRowV2,
-	useCompositeStoreV2,
 	__experimentalPopoverLegacyPositionToPlacement,
 	createPrivateSlotFill,
 	ComponentsContext,

--- a/packages/dataviews/src/search-widget.tsx
+++ b/packages/dataviews/src/search-widget.tsx
@@ -13,7 +13,9 @@ import { useState, useMemo, useDeferredValue } from '@wordpress/element';
 import {
 	VisuallyHidden,
 	Icon,
-	privateApis as componentsPrivateApis,
+	Composite,
+	CompositeItem,
+	useCompositeStore,
 } from '@wordpress/components';
 import { search, check } from '@wordpress/icons';
 import { SVG, Circle } from '@wordpress/primitives';
@@ -21,14 +23,7 @@ import { SVG, Circle } from '@wordpress/primitives';
 /**
  * Internal dependencies
  */
-import { unlock } from './lock-unlock';
 import type { Filter, NormalizedFilter, View } from './types';
-
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
 
 interface SearchWidgetProps {
 	view: View;

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -14,6 +14,10 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
+	Composite,
+	CompositeItem,
+	CompositeRow,
+	useCompositeStore,
 	privateApis as componentsPrivateApis,
 	Spinner,
 	VisuallyHidden,
@@ -49,13 +53,7 @@ interface ListViewItemProps< Item > {
 	visibleFields: NormalizedField< Item >[];
 }
 
-const {
-	useCompositeStoreV2: useCompositeStore,
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	CompositeRowV2: CompositeRow,
-	DropdownMenuV2: DropdownMenu,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2: DropdownMenu } = unlock( componentsPrivateApis );
 
 function ListItem< Item >( {
 	actions,

--- a/packages/dataviews/src/view-list.tsx
+++ b/packages/dataviews/src/view-list.tsx
@@ -67,7 +67,7 @@ function ListItem< Item >( {
 	visibleFields,
 }: ListViewItemProps< Item > ) {
 	const registry = useRegistry();
-	const itemRef = useRef< HTMLElement >( null );
+	const itemRef = useRef< HTMLDivElement >( null );
 	const labelId = `${ id }-label`;
 	const descriptionId = `${ id }-description`;
 

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -9,7 +9,9 @@ import {
 	FlexItem,
 	SearchControl,
 	TextHighlight,
-	privateApis as componentsPrivateApis,
+	Composite,
+	CompositeItem,
+	useCompositeStore,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -20,14 +22,7 @@ import { useDebouncedInput } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { unlock } from '../../lock-unlock';
 import { mapToIHasNameAndId } from './utils';
-
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
 
 const EMPTY_ARRAY = [];
 

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -8,6 +8,9 @@ import clsx from 'clsx';
  */
 import {
 	Disabled,
+	Composite,
+	CompositeItem,
+	useCompositeStore,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -44,12 +47,7 @@ const {
 } = unlock( blockEditorPrivateApis );
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-	Tabs,
-} = unlock( componentsPrivateApis );
+const { Tabs } = unlock( componentsPrivateApis );
 
 // The content area of the Style Book is rendered within an iframe so that global styles
 // are applied to elements within the entire content area. To support elements that are


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #58850

This PR promotes the new private `CompositeV2` component family to stable, and marks the "unstable" (legacy) version of the component as deprecated.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The unstable version is using a sub-optimal API layer and is currently not 100% supported. Consumers of the component should migrate to using the new, unprefixed, stable version of `Composite`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Export the new, ariakit-based `Composite` component from the `@wordpress/components` package
- Mark the legacy `__unstable` components as deprecated, and update unit tests
- Remove the `CompositeV2` private APIs, and update imports across the package
- Update Storybook files

TODO:
- [ ] Add a README

> [!WARNING]  
> This PR shouldn't be merged until we reach consensus on [what naming strategy should be adopted for compounds components](https://github.com/WordPress/gutenberg/issues/63242).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Project builds
- Smoke test in Storybook and in the editor components using `Composite`