### PR TITLE
DataViews: Cleanup preview styles

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -200,16 +200,6 @@
 			min-height: $grid-unit-40;
 			display: flex;
 			align-items: center;
-
-			> * {
-				flex-grow: 1;
-			}
-
-			&.dataviews-view-table__primary-field {
-				a {
-					flex-grow: 0;
-				}
-			}
 		}
 	}
 	.dataviews-view-table-header-button {

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	width: 100%;
 
 	.page-templates-preview-field__button {
 		box-shadow: none;


### PR DESCRIPTION
Related #55083 

## What?

I found these styles in the dataviews table view and I was wondering what was their purpose and by reading the git history, it seems mostly needed to render the "previews" properly in the table view of the templates dataviews.

This PR clean up these styles in favor of a simple style that applies only to the preview field rather than impacting all the fields.

## Testing Instructions

1- Toggle preview field in the templates table o
2- Try the preview field in other layouts too.
