### PR TITLE
Post terms block: add an example

### DIFF
--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -27,6 +27,9 @@
 		}
 	},
 	"usesContext": [ "postId", "postType" ],
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"html": false,
 		"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a basic example to the `core/post-terms` block.

Part of https://github.com/WordPress/gutenberg/issues/30029

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it was showing empty before

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I define a viewport size for the example

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the block inserter and search for the post tags block, hover over it and you'll see the example. The Post categories block should show the same.
On Global Styles, go to blocks, and search for post terms: it should have a preview.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


<img width="646" alt="Screenshot 2024-07-10 at 18 10 40" src="https://github.com/WordPress/gutenberg/assets/3593343/b4c4e41d-a22b-4d6b-aba7-c18a52b2dfc0">
<img width="683" alt="Screenshot 2024-07-10 at 18 10 48" src="https://github.com/WordPress/gutenberg/assets/3593343/f7a94c95-bf3d-4d0f-bd9d-18d67ba8ff64">
