### PR TITLE
Fix Publish Date text

### DIFF
--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -33,7 +33,7 @@ export function PublishDateTimePicker(
 	return (
 		<div ref={ ref } className="block-editor-publish-date-time-picker">
 			<InspectorPopoverHeader
-				title={ __( 'Publish' ) }
+				title={ __( 'Published Date' ) }
 				actions={
 					showPopoverHeaderActions
 						? [

--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -61,7 +61,10 @@ export default function PostSchedulePanel() {
 
 	return (
 		<PostScheduleCheck>
-			<PostPanelRow label={ __( 'Publish' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow
+				label={ __( 'Published Date' ) }
+				ref={ setPopoverAnchor }
+			>
 				<Dropdown
 					popoverProps={ popoverProps }
 					focusOnMount


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR is fixing the left panel with text 'Publish' to 'Published Date' 

## Why?
Link to the Issue thread: https://github.com/WordPress/gutenberg/issues/63342

## Testing 
I was able to see the text to be 'Published Date' in Popover and Panel 

## Screenshots or screencast <!-- if applicable -->
<img width="564" alt="image" src="https://github.com/WordPress/gutenberg/assets/74411873/112665c5-e0d9-41eb-90de-5c3229f675e2">
