### PR TITLE
Query Loop block: Convert the post content type setting to a ToggleGroupControl if there are few items

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/author-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/author-control.js
@@ -76,6 +76,7 @@ function AuthorControl( { value, onChange } ) {
 			suggestions={ authorsInfo.names }
 			onChange={ onAuthorChange }
 			__experimentalShowHowTo={ false }
+			__next40pxDefaultSize
 		/>
 	);
 }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -5,6 +5,7 @@ import {
 	PanelBody,
 	TextControl,
 	SelectControl,
+	RadioControl,
 	RangeControl,
 	ToggleControl,
 	Notice,
@@ -101,6 +102,10 @@ export default function QueryInspectorControls( props ) {
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
+	const postTypeControlLabel = __( 'Post content' );
+	const postTypeControlHelp = __(
+		'WordPress contains different types of content and they are divided into collections called “Post types”. By default there are a few different ones such as blog posts and pages, but plugins could add more.'
+	);
 	const showColumnsControl = false;
 	const showOrderControl =
 		! inherit && isControlAllowed( allowedControls, 'order' );
@@ -152,18 +157,26 @@ export default function QueryInspectorControls( props ) {
 							}
 						/>
 					) }
-					{ showPostTypeControl && (
-						<SelectControl
-							__nextHasNoMarginBottom
-							options={ postTypesSelectOptions }
-							value={ postType }
-							label={ __( 'Post type' ) }
-							onChange={ onPostTypeChange }
-							help={ __(
-								'WordPress contains different types of content and they are divided into collections called “Post types”. By default there are a few different ones such as blog posts and pages, but plugins could add more.'
-							) }
-						/>
-					) }
+					{ showPostTypeControl &&
+						( ( postTypesSelectOptions.length > 2 && (
+							<SelectControl
+								__nextHasNoMarginBottom
+								options={ postTypesSelectOptions }
+								value={ postType }
+								label={ postTypeControlLabel }
+								onChange={ onPostTypeChange }
+								help={ postTypeControlHelp }
+							/>
+						) ) || (
+							<RadioControl
+								__nextHasNoMarginBottom
+								options={ postTypesSelectOptions }
+								selected={ postType }
+								label={ postTypeControlLabel }
+								onChange={ onPostTypeChange }
+								help={ postTypeControlHelp }
+							/>
+						) ) }
 					{ showColumnsControl && (
 						<>
 							<RangeControl

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -5,9 +5,10 @@ import {
 	PanelBody,
 	TextControl,
 	SelectControl,
-	RadioControl,
 	RangeControl,
 	ToggleControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	Notice,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -168,15 +169,23 @@ export default function QueryInspectorControls( props ) {
 								help={ postTypeControlHelp }
 							/>
 						) ) || (
-							<RadioControl
+							<ToggleGroupControl
 								__nextHasNoMarginBottom
-								options={ postTypesSelectOptions }
-								selected={ postType }
+								value={ postType }
 								label={ postTypeControlLabel }
 								onChange={ onPostTypeChange }
 								help={ postTypeControlHelp }
-							/>
+							>
+								{ postTypesSelectOptions.map( ( option ) => (
+									<ToggleGroupControlOption
+										key={ option.value }
+										value={ option.value }
+										label={ option.label }
+									/>
+								) ) }
+							</ToggleGroupControl>
 						) ) }
+
 					{ showColumnsControl && (
 						<>
 							<RangeControl

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -159,7 +159,7 @@ export default function QueryInspectorControls( props ) {
 						/>
 					) }
 					{ showPostTypeControl &&
-						( ( postTypesSelectOptions.length > 2 && (
+						( postTypesSelectOptions.length > 2 ? (
 							<SelectControl
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize
@@ -169,7 +169,7 @@ export default function QueryInspectorControls( props ) {
 								onChange={ onPostTypeChange }
 								help={ postTypeControlHelp }
 							/>
-						) ) || (
+						) : (
 							<ToggleGroupControl
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -171,6 +171,7 @@ export default function QueryInspectorControls( props ) {
 						) ) || (
 							<ToggleGroupControl
 								__nextHasNoMarginBottom
+								isBlock
 								value={ postType }
 								label={ postTypeControlLabel }
 								onChange={ onPostTypeChange }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -162,6 +162,7 @@ export default function QueryInspectorControls( props ) {
 						( ( postTypesSelectOptions.length > 2 && (
 							<SelectControl
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								options={ postTypesSelectOptions }
 								value={ postType }
 								label={ postTypeControlLabel }
@@ -171,6 +172,7 @@ export default function QueryInspectorControls( props ) {
 						) ) || (
 							<ToggleGroupControl
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								isBlock
 								value={ postType }
 								label={ postTypeControlLabel }
@@ -191,6 +193,7 @@ export default function QueryInspectorControls( props ) {
 						<>
 							<RangeControl
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								label={ __( 'Columns' ) }
 								value={ displayLayout.columns }
 								onChange={ ( value ) =>
@@ -285,6 +288,7 @@ export default function QueryInspectorControls( props ) {
 						>
 							<TextControl
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								label={ __( 'Keyword' ) }
 								value={ querySearch }
 								onChange={ setQuerySearch }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -102,9 +102,9 @@ export default function QueryInspectorControls( props ) {
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
-	const postTypeControlLabel = __( 'Post content' );
+	const postTypeControlLabel = __( 'Content type' );
 	const postTypeControlHelp = __(
-		'WordPress contains different types of content and they are divided into collections called “Post types”. By default there are a few different ones such as blog posts and pages, but plugins could add more.'
+		'WordPress contains different types of content you can filter by. Posts and pages are the default types, but plugins could add more.'
 	);
 	const showColumnsControl = false;
 	const showOrderControl =

--- a/packages/block-library/src/query/edit/inspector-controls/order-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/order-control.js
@@ -28,6 +28,7 @@ function OrderControl( { order, orderBy, onChange } ) {
 	return (
 		<SelectControl
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 			label={ __( 'Order by' ) }
 			value={ `${ orderBy }/${ order }` }
 			options={ orderOptions }

--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -14,6 +14,7 @@ export default function StickyControl( { value, onChange } ) {
 	return (
 		<SelectControl
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 			label={ __( 'Sticky posts' ) }
 			options={ stickyOptions }
 			value={ value }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -187,6 +187,7 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 				displayTransform={ decodeEntities }
 				onChange={ onTermsChange }
 				__experimentalShowHowTo={ false }
+				__next40pxDefaultSize
 			/>
 		</div>
 	);


### PR DESCRIPTION
Closes #63374.

## What?
When there are fewer than three items, this PR converts the Query Loop's post content type inspector control to a `ToggleGroupControl` instead of using the `SelectControl`.

It also changes the label copy from `Post type` to `Post content` for accuracy and applies `__next40pxDefaultSize` to this and other Query Loop inspector controls.

## Why?
Select controls are useful for avoiding visual clutter when there are many options to choose from. However, they require an extra click and do not offer visual improvements when there are few items. 

## How?
By using a `ToggleGroupControl` instead of a `SelectControl` when there are fewer than three items.

## Testing Instructions
1. In a vanilla site, add a Query Loop block or edit an existing one.
2. Disable the `Inherit query from template` setting.
3. The `Post content` option will appear using a ToggleGroupControl with `Post` and `Page` as options.
4. Add a custom post type or a plugin that adds more post types.
5. Edit the same Query Loop block as before, and notice there are now more options but showing as a SelectControl.


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/27339341/40f0503b-94bc-42bf-98c0-04b8c0ebd5fa

