### PR TITLE
Button: Never apply `aria-disabled` to anchor

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Button`: Never apply `aria-disabled` to anchor ([#63376](https://github.com/WordPress/gutenberg/pull/63376)).
+
 ### Internal
 
 -   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -162,7 +162,7 @@ export function UnforwardedButton(
 	} );
 
 	const trulyDisabled = disabled && ! accessibleWhenDisabled;
-	const Tag = href !== undefined && ! trulyDisabled ? 'a' : 'button';
+	const Tag = href !== undefined && ! disabled ? 'a' : 'button';
 	const buttonProps: ComponentPropsWithoutRef< 'button' > =
 		Tag === 'button'
 			? {

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -542,6 +542,19 @@ describe( 'Button', () => {
 
 			expect( screen.getByRole( 'button' ) ).toBeVisible();
 		} );
+
+		it( 'should become a button again when disabled is supplied, even with `accessibleWhenDisabled`', () => {
+			render(
+				<Button
+					// @ts-expect-error - a button should not have `href`
+					// eslint-disable-next-line no-restricted-syntax
+					href="https://wordpress.org/"
+					disabled
+					accessibleWhenDisabled
+				/>
+			);
+			expect( screen.getByRole( 'button' ) ).toBeVisible();
+		} );
 	} );
 
 	describe( 'ref forwarding', () => {
@@ -646,7 +659,7 @@ describe( 'Button', () => {
 			<Button type="image/png" />
 			{ /* @ts-expect-error */ }
 			<Button type="invalidtype" />
-			{ /* @ts-expect-error - although the runtime behavior will allow this to be an anchor, this is probably a mistake. */ }
+			{ /* @ts-expect-error */ }
 			<Button disabled accessibleWhenDisabled href="foo" />
 		</>;
 	} );


### PR DESCRIPTION
Fixes #62281

## What?

Prevents link (anchor) buttons from ever having an `aria-disabled` attribute.

## Why?

`<Button href="foo">` automatically renders an anchor element, whereas `<Button href="foo" disabled>` will remain a button element, because anchor elements cannot be disabled. Neither `disabled` nor `aria-disabled` are valid attributes on an anchor.

However, there was a bug where `<Button href="foo" disabled accessibleWhenDisabled>` rendered an anchor with an `aria-disabled` attribute.

## Testing Instructions

See the Storybook for `Button` and see what happens when you render `<Button href="foo" disabled accessibleWhenDisabled>`.

✅ New unit test should also pass.