### PR TITLE
Query Loop Block: add variations for each post type

### DIFF
--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -5,7 +5,6 @@
 	"title": "Query Loop",
 	"category": "theme",
 	"description": "An advanced block that allows displaying post types based on different query parameters and visual configurations.",
-	"keywords": [ "blog", "content" ],
 	"textdomain": "default",
 	"attributes": {
 		"queryId": {

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -5,6 +5,7 @@
 	"title": "Query Loop",
 	"category": "theme",
 	"description": "An advanced block that allows displaying post types based on different query parameters and visual configurations.",
+	"keywords": [ "blog", "content" ],
 	"textdomain": "default",
 	"attributes": {
 		"queryId": {

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -71,7 +71,7 @@ export const settings = {
 	deprecated,
 };
 
-const previousPostTypes = [];
+let previousPostTypes = [];
 let haltSubscribing = false;
 
 const keywords = {
@@ -112,11 +112,17 @@ subscribe( () => {
 						postType: postType.slug,
 					},
 				},
-				keywords: keywords[ postType.slug ] ?? [],
+				keywords: [
+					postType.labels.name,
+					postType.labels.menu_name,
+					...( keywords[ postType.slug ] ?? [] ),
+				],
 			} );
 			haltSubscribing = false;
 		}
 	}
+
+	previousPostTypes = filteredPostTypes;
 } );
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a query loop block variation for each post type so it shows up in the inserter when searching for "posts", "pages", "portfolio" (custom post types), etc.

Also adds the "blog" keyword for the post variation.

<img width="678" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/8c2aa4cc-f7f8-4a52-a2ae-0ea62c19ff74">


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It doesn't show up if you search for it with these words.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Search the inserter.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Another nice thing is that you get a preview for that particular post type. For example I had no posts a this site, but I did have pages.

![query-result](https://github.com/WordPress/gutenberg/assets/4710635/d2dcb88f-62fa-4bb5-8c5b-d12bdf79288f)
