### PR TITLE
Image lightbox: Remove duplicate image when lightbox is opened

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -220,8 +220,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 		)
 	);
-	$p->set_attribute( 'data-wp-class--hide-content', 'state.isContentHidden' );
-	$p->set_attribute( 'data-wp-class--show-content', 'state.isContentVisible' );
 
 	// Image.
 	$p->next_tag( 'img' );
@@ -232,6 +230,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.
 	$p->set_attribute( 'data-wp-on-async--click', 'actions.showLightbox' );
+	$p->set_attribute( 'data-wp-class--hide', 'state.isContentHidden' );
+	$p->set_attribute( 'data-wp-class--show', 'state.isContentVisible' );
 
 	$body_content = $p->get_updated_html();
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -230,6 +230,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.
 	$p->set_attribute( 'data-wp-on-async--click', 'actions.showLightbox' );
+	$p->set_attribute( 'data-wp-class--hide', 'state.overlayOpened' );
 
 	$body_content = $p->get_updated_html();
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -230,8 +230,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.
 	$p->set_attribute( 'data-wp-on-async--click', 'actions.showLightbox' );
-	$p->set_attribute( 'data-wp-class--hide', 'state.contentImageHide' );
-	$p->set_attribute( 'data-wp-class--show', 'state.contentImageShow' );
+	$p->set_attribute( 'data-wp-class--hide', 'state.isContentHidden' );
+	$p->set_attribute( 'data-wp-class--show', 'state.isContentVisible' );
 
 	$body_content = $p->get_updated_html();
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -230,7 +230,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.
 	$p->set_attribute( 'data-wp-on-async--click', 'actions.showLightbox' );
-	$p->set_attribute( 'data-wp-class--hide', 'state.overlayOpened' );
+	$p->set_attribute( 'data-wp-class--hide', 'state.contentImageHide' );
+	$p->set_attribute( 'data-wp-class--show', 'state.contentImageShow' );
 
 	$body_content = $p->get_updated_html();
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -220,6 +220,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 		)
 	);
+	$p->set_attribute( 'data-wp-class--hide-content', 'state.isContentHidden' );
+	$p->set_attribute( 'data-wp-class--show-content', 'state.isContentVisible' );
 
 	// Image.
 	$p->next_tag( 'img' );
@@ -230,8 +232,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.
 	$p->set_attribute( 'data-wp-on-async--click', 'actions.showLightbox' );
-	$p->set_attribute( 'data-wp-class--hide', 'state.isContentHidden' );
-	$p->set_attribute( 'data-wp-class--show', 'state.isContentVisible' );
 
 	$body_content = $p->get_updated_html();
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -9,6 +9,10 @@
 		max-width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;
+
+		&.hide {
+			opacity: 0;
+		}
 	}
 
 	// The following style maintains border radius application for deprecated

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -10,12 +10,14 @@
 		vertical-align: bottom;
 		box-sizing: border-box;
 
-		&.hide {
-			visibility: hidden;
-		}
+		@media (prefers-reduced-motion: no-preference) {
+			&.hide {
+				visibility: hidden;
+			}
 
-		&.show {
-			animation: show-content-image 0.4s;
+			&.show {
+				animation: show-content-image 0.4s;
+			}
 		}
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -9,28 +9,14 @@
 		max-width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;
-	}
 
-	@media (prefers-reduced-motion: no-preference) {
-		&.hide-content {
-			img {
+		@media (prefers-reduced-motion: no-preference) {
+			&.hide {
 				visibility: hidden;
 			}
-			figcaption {
-				.wp-block-gallery & {
-					visibility: hidden;
-				}
-			}
-		}
 
-		&.show-content {
-			img {
+			&.show {
 				animation: show-content-image 0.4s;
-			}
-			figcaption {
-				.wp-block-gallery & {
-					animation: show-content-image 0.4s;
-				}
 			}
 		}
 	}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -9,14 +9,28 @@
 		max-width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;
+	}
 
-		@media (prefers-reduced-motion: no-preference) {
-			&.hide {
+	@media (prefers-reduced-motion: no-preference) {
+		&.hide-content {
+			img {
 				visibility: hidden;
 			}
+			figcaption {
+				.wp-block-gallery & {
+					visibility: hidden;
+				}
+			}
+		}
 
-			&.show {
+		&.show-content {
+			img {
 				animation: show-content-image 0.4s;
+			}
+			figcaption {
+				.wp-block-gallery & {
+					animation: show-content-image 0.4s;
+				}
 			}
 		}
 	}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -11,7 +11,11 @@
 		box-sizing: border-box;
 
 		&.hide {
-			opacity: 0;
+			visibility: hidden;
+		}
+
+		&.show {
+			animation: show-content-image 0.4s;
 		}
 	}
 
@@ -320,6 +324,18 @@
 				}
 			}
 		}
+	}
+}
+
+@keyframes show-content-image {
+	0% {
+		visibility: hidden;
+	}
+	99% {
+		visibility: hidden;
+	}
+	100% {
+		visibility: visible;
 	}
 }
 

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -59,6 +59,19 @@ const { state, actions, callbacks } = store(
 				const { imageId } = getContext();
 				return state.metadata[ imageId ].imageButtonTop;
 			},
+			get contentImageHide() {
+				const ctx = getContext();
+				return (
+					state.overlayEnabled && state.currentImageId === ctx.imageId
+				);
+			},
+			get contentImageShow() {
+				const ctx = getContext();
+				return (
+					! state.overlayEnabled &&
+					state.currentImageId === ctx.imageId
+				);
+			},
 		},
 		actions: {
 			showLightbox() {
@@ -75,8 +88,8 @@ const { state, actions, callbacks } = store(
 				state.scrollLeftReset = document.documentElement.scrollLeft;
 
 				// Sets the current expanded image in the state and enables the overlay.
-				state.currentImageId = imageId;
 				state.overlayEnabled = true;
+				state.currentImageId = imageId;
 
 				// Computes the styles of the overlay for the animation.
 				callbacks.setOverlayStyles();

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -59,13 +59,13 @@ const { state, actions, callbacks } = store(
 				const { imageId } = getContext();
 				return state.metadata[ imageId ].imageButtonTop;
 			},
-			get contentImageHide() {
+			get isContentHidden() {
 				const ctx = getContext();
 				return (
 					state.overlayEnabled && state.currentImageId === ctx.imageId
 				);
 			},
-			get contentImageShow() {
+			get isContentVisible() {
 				const ctx = getContext();
 				return (
 					! state.overlayEnabled &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR hides the duplicate image that shows when the lightbox is opened, reported in https://github.com/WordPress/gutenberg/issues/55960

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's a better user experience if the image is not duplicated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It sets the visibility to `hidden` on the content image when the lightbox is opened, and uses CSS keyframes to set the visibility back to `visible` at the appropriate time when the lightbox is closed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add an image to a post. I recommend aligning the image to the right or left and setting it to a smaller size to better observe the content image.
2. Click on the image link settings and enable `Expand on Click`
3. Publish and view the post
4. Click on the image

Please also test on mobile and in different browsers.

<!--  ### Testing Instructions for Keyboard
How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/7dd46674-c34e-4918-9c50-2679285e0d3c

### After

https://github.com/user-attachments/assets/b64e31d4-747b-46d9-ba54-2e6dd92b2236


