### PR TITLE
Move visualizer popover to slot under the canvas

### DIFF
--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -89,7 +89,7 @@ const GridVisualizerGrid = forwardRef(
 					'is-dropping-allowed': isDroppingAllowed,
 				} ) }
 				clientId={ gridClientId }
-				__unstablePopoverSlot="block-toolbar"
+				__unstablePopoverSlot="__unstable-block-tools-after"
 			>
 				<div
 					ref={ ref }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In Manual mode, the Grid visualizer has appenders in the empty cells. This PR moves the visualizer to the slot under the canvas, so the appenders come between the block and the sidebar in the tabbing order, instead of between the toolbar and the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In Gutenberg > Experiments enable the Grid experiment;
2. Add a Grid block to a post or template and add some blocks inside it;
3. Set the Grid to Manual mode;
4. Select a child item and try tabbing between the block toolbar, the block itself and the sidebar. Check that tabbing order makes sense.

