### PR TITLE
Disable in-between inserter in Manual grids

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -29,6 +29,7 @@ export function useInBetweenInserter() {
 		__unstableIsWithinBlockOverlay,
 		getBlockEditingMode,
 		getBlockName,
+		getBlockAttributes,
 	} = useSelect( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } =
 		useDispatch( blockEditorStore );
@@ -79,7 +80,8 @@ export function useInBetweenInserter() {
 				if (
 					getTemplateLock( rootClientId ) ||
 					getBlockEditingMode( rootClientId ) === 'disabled' ||
-					getBlockName( rootClientId ) === 'core/block'
+					getBlockName( rootClientId ) === 'core/block' ||
+					getBlockAttributes( rootClientId ).layout?.isManualPlacement
 				) {
 					return;
 				}

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -81,7 +81,9 @@ export function useInBetweenInserter() {
 					getTemplateLock( rootClientId ) ||
 					getBlockEditingMode( rootClientId ) === 'disabled' ||
 					getBlockName( rootClientId ) === 'core/block' ||
-					getBlockAttributes( rootClientId ).layout?.isManualPlacement
+					( rootClientId &&
+						getBlockAttributes( rootClientId ).layout
+							?.isManualPlacement )
 				) {
 					return;
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the in-between inserter from Manual grids, because blocks in a Manual grid should be inserted directly into cells, not in between them. The appenders in the grid cells already exist for that effect.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Under Gutenberg > Experiments, enable "Grid interactivity";
2. Add a Grid block to a post or template and set it to Manual mode;
3. Add a block in the first cell and another in the third cell;
4. Hover over the empty second cell and verify the button appender appears instead of the in-between inserter.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="879" alt="Screenshot 2024-07-11 at 11 15 03 AM" src="https://github.com/WordPress/gutenberg/assets/8096000/9a9e00f4-6d6f-425a-9a37-6135b015b0dd">

After:
<img width="804" alt="Screenshot 2024-07-11 at 11 15 24 AM" src="https://github.com/WordPress/gutenberg/assets/8096000/961eb584-9ace-4778-bec7-787f3496da67">



