### PR TITLE
Polish "Delete" modal

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -53,10 +53,18 @@ export function BlockRemovalWarningModal( { rules } ) {
 		>
 			<p>{ message }</p>
 			<HStack justify="right">
-				<Button variant="tertiary" onClick={ clearBlockRemovalPrompt }>
+				<Button
+					variant="tertiary"
+					onClick={ clearBlockRemovalPrompt }
+					__next40pxDefaultSize
+				>
 					{ __( 'Cancel' ) }
 				</Button>
-				<Button variant="primary" onClick={ onConfirmRemoval }>
+				<Button
+					variant="primary"
+					onClick={ onConfirmRemoval }
+					__next40pxDefaultSize
+				>
 					{ __( 'Delete' ) }
 				</Button>
 			</HStack>

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -41,6 +41,7 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 						setIsConfirmDialogVisible( false );
 					} }
 					confirmButtonText={ __( 'Delete' ) }
+					size="medium"
 				>
 					{ __(
 						'Are you sure you want to delete this Navigation Menu?'

--- a/packages/editor/src/dataviews/actions/delete-post.tsx
+++ b/packages/editor/src/dataviews/actions/delete-post.tsx
@@ -78,6 +78,7 @@ const deletePostAction: Action< Post > = {
 						onClick={ closeModal }
 						disabled={ isBusy }
 						accessibleWhenDisabled
+						__next40pxDefaultSize
 					>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -95,6 +96,7 @@ const deletePostAction: Action< Post > = {
 						isBusy={ isBusy }
 						disabled={ isBusy }
 						accessibleWhenDisabled
+						__next40pxDefaultSize
 					>
 						{ __( 'Delete' ) }
 					</Button>


### PR DESCRIPTION
Related to #46741

## What?

This PR adjusts the size of the Delete modal and the button size.

## How?

### Delete pattern/template/tempate part modal

Change the button size to 40px.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/15a463f1-4ddb-4c9a-930e-2003c2e76d4a) | ![delete-post-after](https://github.com/WordPress/gutenberg/assets/54422211/43f7d2d8-de3d-46a0-9632-205116a76ca1) | 

### Delete a block containing a post content block

Change the button size to 40px.

| Before | After |
|--------|--------|
| ![delete-post-content-before](https://github.com/WordPress/gutenberg/assets/54422211/001dd2f4-20cc-4821-a2a3-738307d7cc51) | ![delete-post-content-after](https://github.com/WordPress/gutenberg/assets/54422211/5a260817-66ff-4c42-93b4-c69eb0306cd2) |


### Delete navigation menu from block sidebar advanced panel

Add `size="medium"` prop. At first glance, the size of the modal may seem a little large, but this size is used for almost all confirmation dialogs.

| Before | After |
|--------|--------|
| ![delete-navigation-menu-before](https://github.com/WordPress/gutenberg/assets/54422211/ecc2cd03-594b-47a8-a186-c8e31dc32480) | ![delete-navigation-menu-after](https://github.com/WordPress/gutenberg/assets/54422211/cd8f38fe-6d3b-4e1a-a363-833d80447501) |

