### PR TITLE
Grid: Better looking block movers

### DIFF
--- a/packages/block-editor/src/components/grid/grid-item-movers.js
+++ b/packages/block-editor/src/components/grid/grid-item-movers.js
@@ -7,7 +7,11 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, VisuallyHidden } from '@wordpress/components';
+import {
+	VisuallyHidden,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import {
 	chevronLeft,
 	chevronUp,
@@ -50,7 +54,7 @@ export function GridItemMovers( {
 
 	return (
 		<BlockControls group="parent">
-			<div className="block-editor-grid-item-mover__move-button-container">
+			<ToolbarGroup className="block-editor-grid-item-mover__move-button-container">
 				<GridItemMover
 					className="is-left-button"
 					icon={ chevronLeft }
@@ -141,7 +145,7 @@ export function GridItemMovers( {
 						);
 					} }
 				/>
-			</div>
+			</ToolbarGroup>
 		</BlockControls>
 	);
 }
@@ -158,7 +162,7 @@ function GridItemMover( {
 	const descriptionId = `block-editor-grid-item-mover-button__description-${ instanceId }`;
 	return (
 		<>
-			<Button
+			<ToolbarButton
 				className={ clsx(
 					'block-editor-grid-item-mover-button',
 					className

--- a/packages/block-editor/src/components/grid/grid-item-movers.js
+++ b/packages/block-editor/src/components/grid/grid-item-movers.js
@@ -1,10 +1,21 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToolbarButton } from '@wordpress/components';
-import { arrowLeft, arrowUp, arrowDown, arrowRight } from '@wordpress/icons';
+import { Button, VisuallyHidden } from '@wordpress/components';
+import {
+	chevronLeft,
+	chevronUp,
+	chevronDown,
+	chevronRight,
+} from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -39,44 +50,12 @@ export function GridItemMovers( {
 
 	return (
 		<BlockControls group="parent">
-			<ToolbarButton
-				icon={ arrowUp }
-				label={ __( 'Move block up' ) }
-				disabled={ rowStart <= 1 }
-				onClick={ () => {
-					onChange( {
-						rowStart: rowStart - 1,
-					} );
-					__unstableMarkNextChangeAsNotPersistent();
-					moveBlocksToPosition(
-						[ blockClientId ],
-						gridClientId,
-						gridClientId,
-						getNumberOfBlocksBeforeCell( columnStart, rowStart - 1 )
-					);
-				} }
-			/>
-			<ToolbarButton
-				icon={ arrowDown }
-				label={ __( 'Move block down' ) }
-				disabled={ rowCount && rowEnd >= rowCount }
-				onClick={ () => {
-					onChange( {
-						rowStart: rowStart + 1,
-					} );
-					__unstableMarkNextChangeAsNotPersistent();
-					moveBlocksToPosition(
-						[ blockClientId ],
-						gridClientId,
-						gridClientId,
-						getNumberOfBlocksBeforeCell( columnStart, rowStart + 1 )
-					);
-				} }
-			/>
-			<ToolbarButton
-				icon={ arrowLeft }
+			<GridItemMover
+				className="is-left-button"
+				icon={ chevronLeft }
 				label={ __( 'Move block left' ) }
-				disabled={ columnStart <= 1 }
+				description={ __( 'Move block left' ) }
+				isDisabled={ columnStart <= 1 }
 				onClick={ () => {
 					onChange( {
 						columnStart: columnStart - 1,
@@ -90,10 +69,58 @@ export function GridItemMovers( {
 					);
 				} }
 			/>
-			<ToolbarButton
-				icon={ arrowRight }
+			<div className="block-editor-block-mover__move-button-container">
+				<GridItemMover
+					className="is-up-button"
+					icon={ chevronUp }
+					label={ __( 'Move block up' ) }
+					description={ __( 'Move block up' ) }
+					isDisabled={ rowStart <= 1 }
+					onClick={ () => {
+						onChange( {
+							rowStart: rowStart - 1,
+						} );
+						__unstableMarkNextChangeAsNotPersistent();
+						moveBlocksToPosition(
+							[ blockClientId ],
+							gridClientId,
+							gridClientId,
+							getNumberOfBlocksBeforeCell(
+								columnStart,
+								rowStart - 1
+							)
+						);
+					} }
+				/>
+				<GridItemMover
+					className="is-down-button"
+					icon={ chevronDown }
+					label={ __( 'Move block down' ) }
+					description={ __( 'Move block down' ) }
+					isDisabled={ rowCount && rowEnd >= rowCount }
+					onClick={ () => {
+						onChange( {
+							rowStart: rowStart + 1,
+						} );
+						__unstableMarkNextChangeAsNotPersistent();
+						moveBlocksToPosition(
+							[ blockClientId ],
+							gridClientId,
+							gridClientId,
+							getNumberOfBlocksBeforeCell(
+								columnStart,
+								rowStart + 1
+							)
+						);
+					} }
+				/>
+			</div>
+			<GridItemMover
+				className="is-right-button"
+				icon={ chevronRight }
 				label={ __( 'Move block right' ) }
-				disabled={ columnCount && columnEnd >= columnCount }
+				description={ __( 'Move block right' ) }
+				isDisabled={ columnCount && columnEnd >= columnCount }
 				onClick={ () => {
 					onChange( {
 						columnStart: columnStart + 1,
@@ -108,5 +135,36 @@ export function GridItemMovers( {
 				} }
 			/>
 		</BlockControls>
+	);
+}
+
+function GridItemMover( {
+	className,
+	icon,
+	label,
+	isDisabled,
+	onClick,
+	description,
+} ) {
+	const instanceId = useInstanceId( GridItemMover );
+	const descriptionId = `block-editor-block-mover-button__description-${ instanceId }`;
+	return (
+		<>
+			<Button
+				className={ clsx(
+					'block-editor-block-mover-button',
+					className
+				) }
+				icon={ icon }
+				label={ label }
+				aria-describedby={ descriptionId }
+				onClick={ isDisabled ? null : onClick }
+				disabled={ isDisabled }
+				accessibleWhenDisabled
+			/>
+			<VisuallyHidden id={ descriptionId }>
+				{ description }
+			</VisuallyHidden>
+		</>
 	);
 }

--- a/packages/block-editor/src/components/grid/grid-item-movers.js
+++ b/packages/block-editor/src/components/grid/grid-item-movers.js
@@ -50,35 +50,16 @@ export function GridItemMovers( {
 
 	return (
 		<BlockControls group="parent">
-			<GridItemMover
-				className="is-left-button"
-				icon={ chevronLeft }
-				label={ __( 'Move block left' ) }
-				description={ __( 'Move block left' ) }
-				isDisabled={ columnStart <= 1 }
-				onClick={ () => {
-					onChange( {
-						columnStart: columnStart - 1,
-					} );
-					__unstableMarkNextChangeAsNotPersistent();
-					moveBlocksToPosition(
-						[ blockClientId ],
-						gridClientId,
-						gridClientId,
-						getNumberOfBlocksBeforeCell( columnStart - 1, rowStart )
-					);
-				} }
-			/>
-			<div className="block-editor-block-mover__move-button-container">
+			<div className="block-editor-grid-item-mover__move-button-container">
 				<GridItemMover
-					className="is-up-button"
-					icon={ chevronUp }
-					label={ __( 'Move block up' ) }
-					description={ __( 'Move block up' ) }
-					isDisabled={ rowStart <= 1 }
+					className="is-left-button"
+					icon={ chevronLeft }
+					label={ __( 'Move left' ) }
+					description={ __( 'Move left' ) }
+					isDisabled={ columnStart <= 1 }
 					onClick={ () => {
 						onChange( {
-							rowStart: rowStart - 1,
+							columnStart: columnStart - 1,
 						} );
 						__unstableMarkNextChangeAsNotPersistent();
 						moveBlocksToPosition(
@@ -86,21 +67,67 @@ export function GridItemMovers( {
 							gridClientId,
 							gridClientId,
 							getNumberOfBlocksBeforeCell(
-								columnStart,
-								rowStart - 1
+								columnStart - 1,
+								rowStart
 							)
 						);
 					} }
 				/>
+				<div className="block-editor-grid-item-mover__move-vertical-button-container">
+					<GridItemMover
+						className="is-up-button"
+						icon={ chevronUp }
+						label={ __( 'Move up' ) }
+						description={ __( 'Move up' ) }
+						isDisabled={ rowStart <= 1 }
+						onClick={ () => {
+							onChange( {
+								rowStart: rowStart - 1,
+							} );
+							__unstableMarkNextChangeAsNotPersistent();
+							moveBlocksToPosition(
+								[ blockClientId ],
+								gridClientId,
+								gridClientId,
+								getNumberOfBlocksBeforeCell(
+									columnStart,
+									rowStart - 1
+								)
+							);
+						} }
+					/>
+					<GridItemMover
+						className="is-down-button"
+						icon={ chevronDown }
+						label={ __( 'Move down' ) }
+						description={ __( 'Move down' ) }
+						isDisabled={ rowCount && rowEnd >= rowCount }
+						onClick={ () => {
+							onChange( {
+								rowStart: rowStart + 1,
+							} );
+							__unstableMarkNextChangeAsNotPersistent();
+							moveBlocksToPosition(
+								[ blockClientId ],
+								gridClientId,
+								gridClientId,
+								getNumberOfBlocksBeforeCell(
+									columnStart,
+									rowStart + 1
+								)
+							);
+						} }
+					/>
+				</div>
 				<GridItemMover
-					className="is-down-button"
-					icon={ chevronDown }
-					label={ __( 'Move block down' ) }
-					description={ __( 'Move block down' ) }
-					isDisabled={ rowCount && rowEnd >= rowCount }
+					className="is-right-button"
+					icon={ chevronRight }
+					label={ __( 'Move right' ) }
+					description={ __( 'Move right' ) }
+					isDisabled={ columnCount && columnEnd >= columnCount }
 					onClick={ () => {
 						onChange( {
-							rowStart: rowStart + 1,
+							columnStart: columnStart + 1,
 						} );
 						__unstableMarkNextChangeAsNotPersistent();
 						moveBlocksToPosition(
@@ -108,32 +135,13 @@ export function GridItemMovers( {
 							gridClientId,
 							gridClientId,
 							getNumberOfBlocksBeforeCell(
-								columnStart,
-								rowStart + 1
+								columnStart + 1,
+								rowStart
 							)
 						);
 					} }
 				/>
 			</div>
-			<GridItemMover
-				className="is-right-button"
-				icon={ chevronRight }
-				label={ __( 'Move block right' ) }
-				description={ __( 'Move block right' ) }
-				isDisabled={ columnCount && columnEnd >= columnCount }
-				onClick={ () => {
-					onChange( {
-						columnStart: columnStart + 1,
-					} );
-					__unstableMarkNextChangeAsNotPersistent();
-					moveBlocksToPosition(
-						[ blockClientId ],
-						gridClientId,
-						gridClientId,
-						getNumberOfBlocksBeforeCell( columnStart + 1, rowStart )
-					);
-				} }
-			/>
 		</BlockControls>
 	);
 }
@@ -147,12 +155,12 @@ function GridItemMover( {
 	description,
 } ) {
 	const instanceId = useInstanceId( GridItemMover );
-	const descriptionId = `block-editor-block-mover-button__description-${ instanceId }`;
+	const descriptionId = `block-editor-grid-item-mover-button__description-${ instanceId }`;
 	return (
 		<>
 			<Button
 				className={ clsx(
-					'block-editor-block-mover-button',
+					'block-editor-grid-item-mover-button',
 					className
 				) }
 				icon={ icon }

--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -152,6 +152,7 @@
 	position: relative;
 	@include break-small() {
 		flex-direction: column;
+		justify-content: space-around;
 
 		> .block-editor-grid-item-mover-button.block-editor-grid-item-mover-button {
 			height: $block-toolbar-height * 0.5 - $grid-unit-05;
@@ -166,20 +167,22 @@
 
 		.block-editor-grid-item-mover-button.is-up-button svg,
 		.block-editor-grid-item-mover-button.is-down-button svg {
-			top: 3px;
 			flex-shrink: 0;
+			height: $block-toolbar-height * 0.5 - $grid-unit-05;
 		}
 	}
 }
 
 .show-icon-labels {
 
-	.block-editor-grid-item-mover-button.is-left-button {
+	.block-editor-grid-item-mover-button.block-editor-grid-item-mover-button.is-left-button {
 		border-right: 1px solid $gray-700;
+		padding-right: 12px;
 	}
 
-	.block-editor-grid-item-mover-button.is-right-button {
+	.block-editor-grid-item-mover-button.block-editor-grid-item-mover-button.is-right-button {
 		border-left: 1px solid $gray-700;
+		padding-left: 12px;
 	}
 
 

--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -96,3 +96,116 @@
 	}
 }
 
+.block-editor-grid-item-mover__move-button-container {
+	display: flex;
+	padding: 0;
+	border: none;
+	justify-content: center;
+
+	.block-editor-grid-item-mover-button {
+		width: $block-toolbar-height * 0.5;
+		min-width: 0 !important; // overrides default button width.
+		overflow: hidden;
+		padding-left: 0;
+		padding-right: 0;
+
+		svg {
+			min-width: $grid-unit-30;
+		}
+
+		// Focus and toggle pseudo elements.
+		&::before {
+			content: "";
+			position: absolute;
+			display: block;
+			border-radius: $radius-block-ui;
+			height: $grid-unit-40;
+
+			// Position the focus rectangle.
+			left: $grid-unit-10;
+			right: $grid-unit-10;
+			z-index: -1;
+
+			// Animate in.
+			animation: components-button__appear-animation 0.1s ease;
+			animation-fill-mode: forwards;
+			@include reduce-motion("animation");
+		}
+
+		// Don't show the focus inherited by the Button component.
+		&:focus,
+		&:focus:enabled,
+		&:focus::before {
+			box-shadow: none;
+			outline: none;
+		}
+
+		&:focus-visible::before {
+			@include block-toolbar-button-style__focus();
+		}
+	}
+}
+
+
+.block-editor-grid-item-mover__move-vertical-button-container {
+	display: flex;
+	position: relative;
+	@include break-small() {
+		flex-direction: column;
+
+		> .block-editor-grid-item-mover-button.block-editor-grid-item-mover-button {
+			height: $block-toolbar-height * 0.5 - $grid-unit-05;
+			width: 100%;
+			min-width: 0 !important; // overrides default button width.
+
+			// Focus style.
+			&::before {
+				height: calc(100% - 4px);
+			}
+		}
+
+		.block-editor-grid-item-mover-button.is-up-button svg,
+		.block-editor-grid-item-mover-button.is-down-button svg {
+			top: 3px;
+			flex-shrink: 0;
+		}
+	}
+}
+
+.show-icon-labels {
+
+	.block-editor-grid-item-mover-button {
+		.block-editor-grid-item-mover-button.is-left-button {
+			border-right: 1px solid $gray-700;
+		}
+
+		.block-editor-grid-item-mover-button.is-right-button {
+			border-left: 1px solid $gray-700;
+		}
+
+	}
+
+	.block-editor-grid-item-mover__move-vertical-button-container {
+		&::before {
+			@include break-small() {
+				content: "";
+				height: $border-width;
+				width: 100%;
+				background: $gray-200;
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				// With Top toolbar enabled, this separator has a smaller width. Translating the
+				// X axis allows to make the separator always centered regardless of its width.
+				transform: translate(-50%, 0);
+				margin-top: -$border-width * 0.5;
+			}
+
+			@include break-medium {
+				background: $gray-900;
+			}
+		}
+	}
+
+}
+

--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -174,16 +174,14 @@
 
 .show-icon-labels {
 
-	.block-editor-grid-item-mover-button {
-		.block-editor-grid-item-mover-button.is-left-button {
-			border-right: 1px solid $gray-700;
-		}
-
-		.block-editor-grid-item-mover-button.is-right-button {
-			border-left: 1px solid $gray-700;
-		}
-
+	.block-editor-grid-item-mover-button.is-left-button {
+		border-right: 1px solid $gray-700;
 	}
+
+	.block-editor-grid-item-mover-button.is-right-button {
+		border-left: 1px solid $gray-700;
+	}
+
 
 	.block-editor-grid-item-mover__move-vertical-button-container {
 		&::before {


### PR DESCRIPTION
Update the design of the grid block movers.

Before:

<img width="571" alt="Screenshot 2024-07-11 at 13 50 43" src="https://github.com/WordPress/gutenberg/assets/612155/1c7e8b35-2020-4c32-a313-cab01a4f3b17">

After:
<img width="510" alt="Screenshot 2024-07-11 at 4 32 45 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/158c9c11-fe23-474b-9298-723438906430">

<img width="863" alt="Screenshot 2024-07-11 at 4 32 32 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/7685e106-f9dd-4eb8-9b3a-1fdce564d71e">


