### PR TITLE
Don't display default appender inside Manual grid.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -24,10 +24,14 @@ import { store as blockEditorStore } from '../../store';
 export const ZWNBSP = '\ufeff';
 
 export default function DefaultBlockAppender( { rootClientId } ) {
-	const { showPrompt, isLocked, placeholder } = useSelect(
+	const { showPrompt, isLocked, placeholder, isManualGrid } = useSelect(
 		( select ) => {
-			const { getBlockCount, getSettings, getTemplateLock } =
-				select( blockEditorStore );
+			const {
+				getBlockCount,
+				getSettings,
+				getTemplateLock,
+				getBlockAttributes,
+			} = select( blockEditorStore );
 
 			const isEmpty = ! getBlockCount( rootClientId );
 			const { bodyPlaceholder } = getSettings();
@@ -36,6 +40,9 @@ export default function DefaultBlockAppender( { rootClientId } ) {
 				showPrompt: isEmpty,
 				isLocked: !! getTemplateLock( rootClientId ),
 				placeholder: bodyPlaceholder,
+				isManualGrid:
+					getBlockAttributes( rootClientId )?.layout
+						?.isManualPlacement,
 			};
 		},
 		[ rootClientId ]
@@ -43,7 +50,7 @@ export default function DefaultBlockAppender( { rootClientId } ) {
 
 	const { insertDefaultBlock, startTyping } = useDispatch( blockEditorStore );
 
-	if ( isLocked ) {
+	if ( isLocked || isManualGrid ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Similarly to #63391, the default appender shouldn't display inside a Manual grid.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Under Gutenberg > Experiments, enable "Grid interactivity";
2. Add a Grid block to a post or template and set it to Manual mode;
3. Check that the default appender doesn't display when the Grid is selected;
4. Switch the Grid to Auto and check that default appender now appears.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="743" alt="Screenshot 2024-07-11 at 1 45 50 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/3864e367-d9a4-4786-9df8-cadd9df96746">

After:
<img width="680" alt="Screenshot 2024-07-11 at 1 46 23 PM" src="https://github.com/WordPress/gutenberg/assets/8096000/65fc9ee8-b070-4271-8359-ed6bae993307">



