### PR TITLE
Prevent empty void at the bottom of editor when block directory results are present

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -6,6 +6,12 @@
 	display: grid;
 	grid-template-columns: auto 1fr;
 
+	// The item contains absolutely positioned items.
+	// Set `position: relative` on the parent to prevent overflow issues
+	// in scroll containers.
+	// See: https://github.com/WordPress/gutenberg/issues/63384
+	position: relative;
+
 	&:hover {
 		@include button-style__focus();
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #63384

## Why?
The issue happens because of elements with `position: absolute` in the block directory results. When elements with this positioning are relative to an element that's outside of the scroll container (an ancestor of the scroll container), they can cause weird overflow issues. Applying `position: relative` to a parent within the scroll container fixes the issue.

## How?
Because the absolutely positioned elements are within the `block-directory-downloadable-block-list-item`, I decided to apply `position: relative` there, with the idea that this component should be reusable anywhere and not cause these weird overflow issues.

I guess the previous fix (in #60287) regressed because the tabs are now shown when there a search results, and the fix only applied to the no tabs view. It could also be an idea to apply another fix similar to that one in addition to this PR so that inserter search results can never cause overflow.

## Testing Instructions
1. Create a new post
2. Open the inserter
3. Search for 'blog'
4. Scroll down to the bottom
5. A blank 'void' area shouldn't be shown at the bottom of the editor

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screenshot 2024-07-11 at 12 35 04 PM](https://github.com/WordPress/gutenberg/assets/677833/b7037cbb-e7b1-4e9a-ada9-ad971e149eb1)

#### After
![Screenshot 2024-07-11 at 12 34 34 PM](https://github.com/WordPress/gutenberg/assets/677833/8c9477bd-a517-4536-b1fa-80ce8e124d73)

