### PR TITLE
Post Editor: Revert "Save" button to "Update"

### DIFF
--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -63,7 +63,7 @@ export default function PublishButtonLabel() {
 		! isAutosaving
 	) {
 		/* translators: button label text should, if possible, be under 16 characters. */
-		return __( 'Saving…' );
+		return __( 'Updating…' );
 	}
 	if ( ! hasPublishAction ) {
 		// TODO: this is because "Submit for review" string is too long in some languages.
@@ -79,7 +79,7 @@ export default function PublishButtonLabel() {
 			! [ 'future', 'publish' ].includes( postStatus ) ) ||
 		( ! postStatusHasChanged && postStatus === 'future' )
 	) {
-		return __( 'Save' );
+		return __( 'Update' );
 	}
 	if ( isBeingScheduled ) {
 		return __( 'Schedule' );


### PR DESCRIPTION
## What?
Revert "Save" button to "Update", and "Saving..." to "Updating..." in the post editor.
Issue: https://github.com/WordPress/gutenberg/issues/63387

## Why?
Save word is a little confusing to users when they are actually updating the post.

## How?
Replaced "Save" word with "Update" and, replaced "Saving..." with "Updating...".

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Go to the Post editor.
- Make changes in the post.
- We can see the button on top with the word "Update".

## Screenshots or screencast <!-- if applicable -->
<img width="1469" alt="gutenberg-post-editor-btn" src="https://github.com/WordPress/gutenberg/assets/62138457/fd329c2f-0c90-4d23-a818-a5589bb7a6ec">

