### PR TITLE
Query Loop: Fix passing of `namespace` when selecting from suggested patterns

### DIFF
--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -213,6 +213,7 @@ export const getTransformedBlocksFromPattern = (
 ) => {
 	const {
 		query: { postType, inherit },
+		namespace,
 	} = queryBlockAttributes;
 	const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
 	const queryClientIds = [];
@@ -225,6 +226,9 @@ export const getTransformedBlocksFromPattern = (
 				postType,
 				inherit,
 			};
+			if ( namespace ) {
+				block.attributes.namespace = namespace;
+			}
 			queryClientIds.push( block.clientId );
 		}
 		block.innerBlocks?.forEach( ( innerBlock ) => {


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/pull/58194

By testing another PR I noticed that when we insert a Query Loop variation that uses the `namespace` attribute to define whether is active, if we select one of the suggested patterns to start with, the namespace is not passed, making it inactive.

This PR fixes that.


## Testing Instructions
1. Insert `Posts List` variation and click `choose` to show the suggested patterns
2. Select one
3. Observe that the variation is still active.
4. Evertyhing else works as before regarding Query Loop
