### PR TITLE
Query Loop Block: remove Posts List variation

### DIFF
--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { postList } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -31,31 +30,6 @@ const QUERY_DEFAULT_ATTRIBUTES = {
 };
 
 const variations = [
-	{
-		name: 'posts-list',
-		title: __( 'Posts List' ),
-		description: __(
-			'Display a list of your most recent posts, excluding sticky posts.'
-		),
-		icon: postList,
-		attributes: {
-			namespace: 'core/posts-list',
-			query: {
-				perPage: 4,
-				pages: 1,
-				offset: 0,
-				postType: 'post',
-				order: 'desc',
-				orderBy: 'date',
-				author: '',
-				search: '',
-				sticky: 'exclude',
-				inherit: false,
-			},
-		},
-		scope: [ 'inserter' ],
-		isActive: [ 'namespace', 'query.postType' ],
-	},
 	{
 		name: 'title-date',
 		title: __( 'Title & Date' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As mentioned [here](https://github.com/WordPress/gutenberg/pull/63380#discussion_r1673097917), this is causing more harm than good because when you insert this block, the query won't inherit the main query by default.

This block variation is also not very useful for showing recent posts in the sidebar, because it has pagination etc. It's not designed for that. So it seems this variation does not have any good use cases, or it has bad defaults.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
