### PR TITLE
Navigation block: Allow themes to override block library text-decoration rule

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -76,14 +76,12 @@ $navigation-icon-size: 24px;
 		}
 	}
 
-	&:where(:not([class*="has-text-decoration"])) {
-		a {
-			text-decoration: none;
+	&:where(:not([class*="has-text-decoration"])) :where(a) {
+		text-decoration: none;
 
-			&:focus,
-			&:active {
-				text-decoration: none;
-			}
+		&:focus,
+		&:active {
+			text-decoration: none;
 		}
 	}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -76,12 +76,10 @@ $navigation-icon-size: 24px;
 		}
 	}
 
-	&:where(:not([class*="has-text-decoration"])) {
-		& :where(a),
-		& :where(a:focus),
-		& :where(a:active) {
-			text-decoration: none;
-		}
+	& :where(a),
+	& :where(a:focus),
+	& :where(a:active) {
+		text-decoration: none;
 	}
 
 	// Submenu indicator.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -76,11 +76,10 @@ $navigation-icon-size: 24px;
 		}
 	}
 
-	&:where(:not([class*="has-text-decoration"])) :where(a) {
-		text-decoration: none;
-
-		&:focus,
-		&:active {
+	&:where(:not([class*="has-text-decoration"])) {
+		& :where(a),
+		& :where(a:focus),
+		& :where(a:active) {
 			text-decoration: none;
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In a default install of WordPress 6.5, when hovering over a navigation link an underline is shown.

In 6.6 this doesn't happen. Theme developers are unable to override block library styles for text decoration.

## Why?
In 6.5, there's a CSS rule that sets the underline hover with the specificity of 0,2,1 ([it comes from the TT4's theme.json](https://github.com/WordPress/wordpress-develop/blob/349590c8135b003857b47ff1a4636dc283d8b71c/src/wp-content/themes/twentytwentyfour/theme.json#L525-L541)):
```css
.wp-block-navigation a:where(:not(.wp-element-button)):hover {
    text-decoration: underline;
}
```

It overrides some of the block library css (specificity 0,1,1):
```css
.wp-block-navigation:where(:not([class*=has-text-decoration])) a {
    text-decoration: none;
}
```

In 6.6, the first rule's specificity was reduced to 0,1,0, and now the block library css has a higher specificity it results in that taking precedence and no hover underline styles.

## How?
This reduces the specificity of the block library css to 0,1,0, following the general rule that theme.json/global styles should be able to override block css.

## Testing Instructions
#### Simple test of hover styles
1. View the frontend of a default WordPress install and hover over a navigation link

Expected: the link should be underlined

#### Active and Focus styles
1. Activate emptytheme
2. Add active/focus styles to link elements in the nav block within your theme.json using the snippet below
3. Add nav block to a page without customizing its styles
4. Load the page on the frontend

Expected: Navigation block links have line-through styles when focused or active

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/navigation": {
				"elements": {
					"link": {
						":focus": {
							"typography": {
								"textDecoration": "line-through"
							}
						},
						":active": {
							"typography": {
								"textDecoration": "line-through"
							}
						}
					}
				}
			}
		}
	}
}
```

## Screenshots or screencast <!-- if applicable -->
### Before
![Screenshot 2024-07-11 at 4 33 05 PM](https://github.com/WordPress/gutenberg/assets/677833/a58aca8a-b120-40d9-aca1-42fcffbbc85c)

### After
![Screenshot 2024-07-11 at 4 33 17 PM](https://github.com/WordPress/gutenberg/assets/677833/d931d57d-1840-458c-afc0-a396ca891c46)

