### PR TITLE
DataViews: Move the layouts into a dedicated folder

### DIFF
--- a/packages/dataviews/src/layouts/grid/index.tsx
+++ b/packages/dataviews/src/layouts/grid/index.tsx
@@ -19,11 +19,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import ItemActions from './item-actions';
-import SingleSelectionCheckbox from './single-selection-checkbox';
-import { useHasAPossibleBulkAction } from './bulk-actions';
-import type { Action, NormalizedField, ViewGridProps } from './types';
-import type { SetSelection } from './private-types';
+import ItemActions from '../../item-actions';
+import SingleSelectionCheckbox from '../../single-selection-checkbox';
+import { useHasAPossibleBulkAction } from '../../bulk-actions';
+import type { Action, NormalizedField, ViewGridProps } from '../../types';
+import type { SetSelection } from '../../private-types';
 
 interface GridItemProps< Item > {
 	selection: string[];

--- a/packages/dataviews/src/layouts/index.ts
+++ b/packages/dataviews/src/layouts/index.ts
@@ -12,11 +12,11 @@ import {
 /**
  * Internal dependencies
  */
-import ViewTable from './view-table';
-import ViewGrid from './view-grid';
-import ViewList from './view-list';
-import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from './constants';
-import type { View } from './types';
+import ViewTable from './table';
+import ViewGrid from './grid';
+import ViewList from './list';
+import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../constants';
+import type { View } from '../types';
 
 export const VIEW_LAYOUTS = [
 	{

--- a/packages/dataviews/src/layouts/list/index.tsx
+++ b/packages/dataviews/src/layouts/list/index.tsx
@@ -32,10 +32,9 @@ import { useRegistry } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { unlock } from './lock-unlock';
-import type { Action, NormalizedField, ViewListProps } from './types';
-
-import { ActionsDropdownMenuGroup, ActionModal } from './item-actions';
+import { unlock } from '../../lock-unlock';
+import { ActionsDropdownMenuGroup, ActionModal } from '../../item-actions';
+import type { Action, NormalizedField, ViewListProps } from '../../types';
 
 interface ListViewItemProps< Item > {
 	actions: Action< Item >[];

--- a/packages/dataviews/src/layouts/table/index.tsx
+++ b/packages/dataviews/src/layouts/table/index.tsx
@@ -32,20 +32,20 @@ import {
 /**
  * Internal dependencies
  */
-import SingleSelectionCheckbox from './single-selection-checkbox';
-import { unlock } from './lock-unlock';
-import ItemActions from './item-actions';
-import { sanitizeOperators } from './utils';
+import SingleSelectionCheckbox from '../../single-selection-checkbox';
+import { unlock } from '../../lock-unlock';
+import ItemActions from '../../item-actions';
+import { sanitizeOperators } from '../../utils';
 import {
 	SORTING_DIRECTIONS,
 	sortArrows,
 	sortLabels,
 	sortValues,
-} from './constants';
+} from '../../constants';
 import {
 	useSomeItemHasAPossibleBulkAction,
 	useHasAPossibleBulkAction,
-} from './bulk-actions';
+} from '../../bulk-actions';
 import type {
 	Action,
 	NormalizedField,
@@ -53,8 +53,8 @@ import type {
 	ViewTable as ViewTableType,
 	ViewTableProps,
 	CombinedField,
-} from './types';
-import type { SetSelection } from './private-types';
+} from '../../types';
+import type { SetSelection } from '../../private-types';
 
 const {
 	DropdownMenuV2: DropdownMenu,


### PR DESCRIPTION
Related to #55083 

I know @ntsekouras has been asking this for some time: reorganize the dataviews component into folders and I've come to terms with the idea. There are different ways to do the organization though.

So to start, I'm just putting the "layouts" into dedicated folders as I wanted to create more components that are specific to one particular layout.

This PR doesn't change any behavior, just moves files around.