### PR TITLE
Update getContext() usage examples with namespace argument

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1054,7 +1054,12 @@ Apart from the store function, there are also some methods that allows the devel
 
 #### getContext()
 
-Retrieves the context inherited by the element evaluating a function from the store. The returned value depends on the element and the namespace where the function calling `getContext()` exists.
+Retrieves the context inherited by the element evaluating a function from the store. The returned value depends on the element and the namespace where the function calling `getContext()` exists. It can also take an optional namespace argument to retrieve the context of a specific interactive region.
+
+```js
+const context = getContext(namespace);
+```
+- `namespace` (optional): A string that matches the namespace of an interactive region. If not provided, it retrieves the context of the current interactive region.
 
 ```php
 // render.php
@@ -1073,33 +1078,11 @@ store( "myPlugin", {
       const context = getContext();
 			 // Logs "false"
       console.log('context => ', context.isOpen)
-    },
-  },
-});
-```
 
-When `getContext()` called with a namespace argument, `getContext(namespace)` retrieves the context specific to that namespace within the current element's context.
-
-```php
-// render.php
-<div data-wp-interactive="myPlugin" data-wp-context='{ "isOpen": false, "region": { "name": "North" } }'>
-	<button data-wp-on--click="actions.log">Log</button>
-</div>
-```
-
-```js
-// store
-import { store, getContext } from '@wordpress/interactivity';
-
-store( "myPlugin", {
-  actions: {
-    log: () => {
-      // Retrieve the context for the 'region' namespace.
-      const regionContext = getContext('region');
-      // Logs "North"
-      console.log('regionContext => ', regionContext.name);
-      // Logs the entire 'region' context object.
-      console.log('regionContext => ', regionContext);
+      // With namespace argument.
+      const myPluginContext = getContext("myPlugin");
+      // Logs "false"
+      console.log('myPlugin isOpen => ', myPluginContext.isOpen);
     },
   },
 });

--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1057,7 +1057,7 @@ Apart from the store function, there are also some methods that allows the devel
 Retrieves the context inherited by the element evaluating a function from the store. The returned value depends on the element and the namespace where the function calling `getContext()` exists. It can also take an optional namespace argument to retrieve the context of a specific interactive region.
 
 ```js
-const context = getContext(namespace);
+const context = getContext('namespace');
 ```
 - `namespace` (optional): A string that matches the namespace of an interactive region. If not provided, it retrieves the context of the current interactive region.
 

--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1078,6 +1078,33 @@ store( "myPlugin", {
 });
 ```
 
+When `getContext()` called with a namespace argument, `getContext(namespace)` retrieves the context specific to that namespace within the current element's context.
+
+```php
+// render.php
+<div data-wp-interactive="myPlugin" data-wp-context='{ "isOpen": false, "region": { "name": "North" } }'>
+	<button data-wp-on--click="actions.log">Log</button>
+</div>
+```
+
+```js
+// store
+import { store, getContext } from '@wordpress/interactivity';
+
+store( "myPlugin", {
+  actions: {
+    log: () => {
+      // Retrieve the context for the 'region' namespace.
+      const regionContext = getContext('region');
+      // Logs "North"
+      console.log('regionContext => ', regionContext.name);
+      // Logs the entire 'region' context object.
+      console.log('regionContext => ', regionContext);
+    },
+  },
+});
+```
+
 #### getElement()
 
 Retrieves a representation of the element that the action is bound to or called from. Such representation is read-only, and contains a reference to the DOM element, its props and a local reactive state.


### PR DESCRIPTION
Fixes [#63366](https://github.com/WordPress/gutenberg/issues/63366)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR updates the documentation for the getContext() function to separate usage examples with and without namespace arguments. It provides clear, distinct examples and explanations for each case.

## Why?
This PR addresses the need for clearer documentation on how to use the getContext() function both with and without the optional namespace argument. It helps developers understand the different use cases and how to retrieve specific parts of the context, improving the overall usability and clarity of the documentation.

## How?
Adding a section for using getContext(namespace) with a namespace argument.
