### PR TITLE
Site Editor: Deprecate 'getCanUserCreateMedia' selector

### DIFF
--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -76,7 +76,7 @@ export const getCanUserCreateMedia = createRegistrySelector(
 			`wp.data.select( 'core/edit-site' ).getCanUserCreateMedia()`,
 			{
 				since: '6.7',
-				alternative: `wp.data.select( 'core' ).canUser()`,
+				alternative: `wp.data.select( 'core' ).canUser( 'create', { kind: 'root', type: 'media' } )`,
 			}
 		);
 

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -92,13 +92,11 @@ export const getCanUserCreateMedia = createRegistrySelector(
  * @return {Array} The available reusable blocks.
  */
 export const getReusableBlocks = createRegistrySelector( ( select ) => () => {
-	deprecated(
-		"select( 'core/core' ).getEntityRecords( 'postType', 'wp_block' )",
-		{
-			since: '6.5',
-			version: '6.8',
-		}
-	);
+	deprecated( `select( 'core/edit-site' ).getReusableBlocks()`, {
+		since: '6.5',
+		version: '6.8',
+		alternative: `select( 'core/core' ).getEntityRecords( 'postType', 'wp_block' )`,
+	} );
 	const isWeb = Platform.OS === 'web';
 	return isWeb
 		? select( coreDataStore ).getEntityRecords( 'postType', 'wp_block', {

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -71,7 +71,17 @@ export const __experimentalGetPreviewDeviceType = createRegistrySelector(
  * @return {Object} Whether the current user can create media or not.
  */
 export const getCanUserCreateMedia = createRegistrySelector(
-	( select ) => () => select( coreDataStore ).canUser( 'create', 'media' )
+	( select ) => () => {
+		deprecated(
+			`wp.data.select( 'core/edit-site' ).getCanUserCreateMedia()`,
+			{
+				since: '6.7',
+				alternative: `wp.data.select( 'core' ).canUser()`,
+			}
+		);
+
+		return select( coreDataStore ).canUser( 'create', 'media' );
+	}
 );
 
 /**

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -1,34 +1,9 @@
 /**
- * WordPress dependencies
- */
-import { store as coreDataStore } from '@wordpress/core-data';
-
-/**
  * Internal dependencies
  */
-import {
-	getCanUserCreateMedia,
-	getEditedPostType,
-	getEditedPostId,
-	isPage,
-} from '../selectors';
+import { getEditedPostType, getEditedPostId, isPage } from '../selectors';
 
 describe( 'selectors', () => {
-	const canUser = jest.fn( () => true );
-	getCanUserCreateMedia.registry = {
-		select: jest.fn( () => ( { canUser } ) ),
-	};
-
-	describe( 'getCanUserCreateMedia', () => {
-		it( "selects `canUser( 'create', 'media' )` from the core store", () => {
-			expect( getCanUserCreateMedia() ).toBe( true );
-			expect(
-				getCanUserCreateMedia.registry.select
-			).toHaveBeenCalledWith( coreDataStore );
-			expect( canUser ).toHaveBeenCalledWith( 'create', 'media' );
-		} );
-	} );
-
 	describe( 'getEditedPostId', () => {
 		it( 'returns the template ID', () => {
 			const state = { editedPost: { id: 10 } };


### PR DESCRIPTION
## What?
PR deprecates the `getCanUserCreateMedia` selector for the `edit-site` store. It's no longer used in the core, and there's a better selector for the same check.

Also, I've fixed the deprecation for `getReusableBlocks`. It was printing the incorrect selector name as deprecated.

## Testing Instructions
Running the following selector in the console should print the correct deprecation messages:

```
wp.data.select( 'core/edit-site' ).getCanUserCreateMedia()
wp.data.select( 'core/edit-site' ).getReusableBlocks()
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-11 at 13 23 05](https://github.com/WordPress/gutenberg/assets/240569/e1a29d1f-6932-4262-bc55-f46555d0fe1c)
![CleanShot 2024-07-11 at 13 25 56](https://github.com/WordPress/gutenberg/assets/240569/9372e713-e114-4f46-82ef-e5a0aac8e514)
