### PR TITLE
Use entity details when calling 'canUser' selectors

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -156,7 +156,11 @@ function ReusableBlockEdit( {
 				getBlockEditingMode: _getBlockEditingMode,
 			} = select( blockEditorStore );
 			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
-			const canEdit = canUser( 'update', 'blocks', ref );
+			const canEdit = canUser( 'update', {
+				kind: 'postType',
+				name: 'wp_block',
+				id: ref,
+			} );
 
 			// For editing link to the site editor if the theme and user permissions support it.
 			return {

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -21,10 +21,10 @@ import {
 
 function useFrontPageId() {
 	return useSelect( ( select ) => {
-		const canReadSettings = select( coreStore ).canUser(
-			'read',
-			'settings'
-		);
+		const canReadSettings = select( coreStore ).canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} );
 		if ( ! canReadSettings ) {
 			return undefined;
 		}

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -49,7 +49,10 @@ export default function QueryContent( {
 	const { postsPerPage } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { getEntityRecord, canUser } = select( coreStore );
-		const settingPerPage = canUser( 'read', 'settings' )
+		const settingPerPage = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
 			? +getEntityRecord( 'root', 'site' )?.posts_per_page
 			: +getSettings().postsPerPage;
 		return {

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -403,7 +403,10 @@ export default function LogoEdit( {
 	} = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
-		const _canUserEdit = canUser( 'update', 'settings' );
+		const _canUserEdit = canUser( 'update', {
+			kind: 'root',
+			name: 'site',
+		} );
 		const siteSettings = _canUserEdit
 			? getEditedEntityRecord( 'root', 'site' )
 			: undefined;

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -29,12 +29,15 @@ export default function SiteTaglineEdit( {
 	const { canUserEdit, tagline } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
-		const canEdit = canUser( 'update', 'settings' );
+		const canEdit = canUser( 'update', {
+			kind: 'root',
+			name: 'site',
+		} );
 		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
 		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
 
 		return {
-			canUserEdit: canUser( 'update', 'settings' ),
+			canUserEdit: canEdit,
 			tagline: canEdit
 				? settings?.description
 				: readOnlySettings?.description,

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -32,7 +32,10 @@ export default function SiteTitleEdit( {
 	const { canUserEdit, title } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
-		const canEdit = canUser( 'update', 'settings' );
+		const canEdit = canUser( 'update', {
+			kind: 'root',
+			name: 'site',
+		} );
 		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
 		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
 

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -151,8 +151,10 @@ export default function TemplatePartEdit( {
 				  )
 				: false;
 
-			const _canEditTemplate =
-				select( coreStore ).canUser( 'create', 'templates' ) ?? false;
+			const _canEditTemplate = select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template_part',
+			} );
 
 			return {
 				hasInnerBlocks: getBlockCount( clientId ) > 0,
@@ -165,7 +167,7 @@ export default function TemplatePartEdit( {
 				onNavigateToEntityRecord:
 					getSettings().onNavigateToEntityRecord,
 				title: entityRecord?.title,
-				canEditTemplate: _canEditTemplate,
+				canEditTemplate: !! _canEditTemplate,
 			};
 		},
 		[ templatePartId, attributes.area, clientId ]

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -127,11 +127,14 @@ export default function TemplatePartInnerBlocks( {
 	const { canViewTemplatePart, canEditTemplatePart } = useSelect(
 		( select ) => {
 			return {
-				canViewTemplatePart:
-					select( coreStore ).canUser( 'read', 'templates' ) ?? false,
-				canEditTemplatePart:
-					select( coreStore ).canUser( 'create', 'templates' ) ??
-					false,
+				canViewTemplatePart: !! select( coreStore ).canUser( 'read', {
+					kind: 'postType',
+					name: 'wp_template',
+				} ),
+				canEditTemplatePart: !! select( coreStore ).canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_template',
+				} ),
 			};
 		},
 		[]

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -266,7 +266,10 @@ function useSiteEditorBasicNavigationCommands() {
 		'site-editor.php'
 	);
 	const canCreateTemplate = useSelect( ( select ) => {
-		return select( coreStore ).canUser( 'create', 'templates' );
+		return select( coreStore ).canUser( 'create', {
+			kind: 'postType',
+			name: 'wp_template',
+		} );
 	}, [] );
 	const isBlockBasedTheme = useIsBlockBasedTheme();
 	const commands = useMemo( () => {

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -51,7 +51,10 @@ export default function SidebarBlockEditor( {
 		const { get } = select( preferencesStore );
 		return {
 			hasUploadPermissions:
-				select( coreStore ).canUser( 'create', 'media' ) ?? true,
+				select( coreStore ).canUser( 'create', {
+					kind: 'root',
+					name: 'media',
+				} ) ?? true,
 			isFixedToolbarActive: !! get(
 				'core/customize-widgets',
 				'fixedToolbar'

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -198,7 +198,10 @@ function Layout( {
 			const supportsTemplateMode = settings.supportsTemplateMode;
 			const isViewable =
 				getPostType( currentPost.postType )?.viewable ?? false;
-			const canViewTemplate = canUser( 'read', 'templates' );
+			const canViewTemplate = canUser( 'read', {
+				kind: 'postType',
+				name: 'wp_template',
+			} );
 
 			return {
 				mode: select( editorStore ).getEditorMode(),

--- a/packages/edit-post/src/components/more-menu/manage-patterns-menu-item.js
+++ b/packages/edit-post/src/components/more-menu/manage-patterns-menu-item.js
@@ -20,7 +20,12 @@ function ManagePatternsMenuItem() {
 		// The site editor and templates both check whether the user has
 		// edit_theme_options capabilities. We can leverage that here and not
 		// display the manage patterns link if the user can't access it.
-		return canUser( 'create', 'templates' ) ? patternsUrl : defaultUrl;
+		return canUser( 'create', {
+			kind: 'postType',
+			name: 'wp_template',
+		} )
+			? patternsUrl
+			: defaultUrl;
 	}, [] );
 
 	return (

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -56,8 +56,14 @@ export default function AddNewPattern() {
 			addNewTemplatePartLabel: getPostType( TEMPLATE_PART_POST_TYPE )
 				?.labels?.add_new_item,
 			// Blocks refers to the wp_block post type, this checks the ability to create a post of that type.
-			canCreatePattern: canUser( 'create', 'blocks' ),
-			canCreateTemplatePart: canUser( 'create', 'template-parts' ),
+			canCreatePattern: canUser( 'create', {
+				kind: 'postType',
+				name: PATTERN_TYPES.user,
+			} ),
+			canCreateTemplatePart: canUser( 'create', {
+				kind: 'postType',
+				name: TEMPLATE_PART_POST_TYPE,
+			} ),
 		};
 	}, [] );
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -46,8 +46,10 @@ function FontLibraryModal( {
 } ) {
 	const { collections, setNotice } = useContext( FontLibraryContext );
 	const canUserCreate = useSelect( ( select ) => {
-		const { canUser } = select( coreStore );
-		return canUser( 'create', 'font-families' );
+		return select( coreStore ).canUser( 'create', {
+			kind: 'postType',
+			name: 'wp_font_family',
+		} );
 	}, [] );
 
 	const tabs = [ DEFAULT_TAB ];

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -93,7 +93,11 @@ function InstalledFonts() {
 			const { canUser } = select( coreStore );
 			return (
 				customFontFamilyId &&
-				canUser( 'delete', 'font-families', customFontFamilyId )
+				canUser( 'delete', {
+					kind: 'postType',
+					name: 'wp_font_family',
+					id: customFontFamilyId,
+				} )
 			);
 		},
 		[ customFontFamilyId ]

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -372,15 +372,14 @@ export default function PostList( { postType } ) {
 			const { getEntityRecord, getPostType, canUser } =
 				select( coreStore );
 			const siteSettings = getEntityRecord( 'root', 'site' );
-			const postTypeObject = getPostType( postType );
 			return {
 				frontPageId: siteSettings?.page_on_front,
 				postsPageId: siteSettings?.page_for_posts,
 				labels: getPostType( postType )?.labels,
-				canCreateRecord: canUser(
-					'create',
-					postTypeObject?.rest_base || 'posts'
-				),
+				canCreateRecord: canUser( 'create', {
+					kind: 'postType',
+					name: postType,
+				} ),
 			};
 		},
 		[ postType ]

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -48,7 +48,10 @@ export default function WidgetAreasBlockEditorProvider( {
 	} = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEntityRecords } =
 			select( coreStore );
-		const siteSettings = canUser( 'read', 'settings' )
+		const siteSettings = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
 			? getEntityRecord( 'root', 'site' )
 			: undefined;
 		return {

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -59,10 +59,10 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 					);
 				}
 			}
-			const _canEditTemplates = select( coreStore ).canUser(
-				'create',
-				'templates'
-			);
+			const _canEditTemplates = select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} );
 			return {
 				canEditTemplates: _canEditTemplates,
 				entity: record,

--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -18,7 +18,10 @@ function MaybeCategoryPanel() {
 		const postType = select( editorStore ).getCurrentPostType();
 		const { canUser, getEntityRecord, getTaxonomy } = select( coreStore );
 		const categoriesTaxonomy = getTaxonomy( 'category' );
-		const defaultCategoryId = canUser( 'read', 'settings' )
+		const defaultCategoryId = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
 			? getEntityRecord( 'root', 'site' )?.default_category
 			: undefined;
 		const defaultCategory = defaultCategoryId

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -53,7 +53,11 @@ export default function BlockThemeControl( { id } ) {
 
 	const canCreateTemplate = useSelect(
 		( select ) =>
-			select( coreStore ).canUser( 'create', 'templates' ) ?? false
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ),
+		[]
 	);
 
 	if ( ! hasResolved ) {

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -53,7 +53,7 @@ export default function BlockThemeControl( { id } ) {
 
 	const canCreateTemplate = useSelect(
 		( select ) =>
-			select( coreStore ).canUser( 'create', {
+			!! select( coreStore ).canUser( 'create', {
 				kind: 'postType',
 				name: 'wp_template',
 			} ),

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -33,8 +33,10 @@ function PostTemplateToggle( { isOpen, onClick } ) {
 			return availableTemplates[ templateSlug ];
 		}
 		const template =
-			select( coreStore ).canUser( 'create', 'templates' ) &&
-			select( editorStore ).getCurrentTemplateId();
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ) && select( editorStore ).getCurrentTemplateId();
 		return (
 			template?.title ||
 			template?.slug ||
@@ -78,7 +80,10 @@ function PostTemplateDropdownContent( { onClose } ) {
 		( select ) => {
 			const { canUser, getEntityRecords } = select( coreStore );
 			const editorSettings = select( editorStore ).getEditorSettings();
-			const canCreateTemplates = canUser( 'create', 'templates' );
+			const canCreateTemplates = canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} );
 			const _currentTemplateId =
 				select( editorStore ).getCurrentTemplateId();
 			return {

--- a/packages/editor/src/components/post-template/create-new-template.js
+++ b/packages/editor/src/components/post-template/create-new-template.js
@@ -17,7 +17,10 @@ export default function CreateNewTemplate( { onClick } ) {
 	const { canCreateTemplates } = useSelect( ( select ) => {
 		const { canUser } = select( coreStore );
 		return {
-			canCreateTemplates: canUser( 'create', 'templates' ),
+			canCreateTemplates: canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ),
 		};
 	}, [] );
 	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );

--- a/packages/editor/src/components/post-template/panel.js
+++ b/packages/editor/src/components/post-template/panel.js
@@ -48,12 +48,20 @@ export default function PostTemplatePanel() {
 		}
 
 		const canCreateTemplates =
-			select( coreStore ).canUser( 'create', 'templates' ) ?? false;
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ) ?? false;
 		return canCreateTemplates;
 	}, [] );
 
 	const canViewTemplates = useSelect( ( select ) => {
-		return select( coreStore ).canUser( 'read', 'templates' ) ?? false;
+		return (
+			select( coreStore ).canUser( 'read', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ) ?? false
+		);
 	}, [] );
 
 	if ( ( ! isBlockTheme || ! canViewTemplates ) && isVisible ) {

--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -21,13 +21,17 @@ export default function PostTrashCheck( { children } ) {
 	const { canTrashPost } = useSelect( ( select ) => {
 		const { isEditedPostNew, getCurrentPostId, getCurrentPostType } =
 			select( editorStore );
-		const { getPostType, canUser } = select( coreStore );
-		const postType = getPostType( getCurrentPostType() );
+		const { canUser } = select( coreStore );
+		const postType = getCurrentPostType();
 		const postId = getCurrentPostId();
 		const isNew = isEditedPostNew();
-		const resource = postType?.rest_base || ''; // eslint-disable-line camelcase
-		const canUserDelete =
-			postId && resource ? canUser( 'delete', resource, postId ) : false;
+		const canUserDelete = !! postId
+			? canUser( 'delete', {
+					kind: 'postType',
+					name: postType,
+					id: postId,
+			  } )
+			: false;
 
 		return {
 			canTrashPost: ( ! isNew || postId ) && canUserDelete,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -133,7 +133,10 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			const { getBlockTypes } = select( blocksStore );
 			const { getBlocksByName, getBlockAttributes } =
 				select( blockEditorStore );
-			const siteSettings = canUser( 'read', 'settings' )
+			const siteSettings = canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} )
 				? getEntityRecord( 'root', 'site' )
 				: undefined;
 
@@ -167,8 +170,15 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				hiddenBlockTypes: get( 'core', 'hiddenBlockTypes' ),
 				isDistractionFree: get( 'core', 'distractionFree' ),
 				keepCaretInsideBlock: get( 'core', 'keepCaretInsideBlock' ),
-				hasUploadPermissions: canUser( 'create', 'media' ) ?? true,
-				userCanCreatePages: canUser( 'create', 'pages' ),
+				hasUploadPermissions:
+					canUser( 'create', {
+						kind: 'root',
+						name: 'media',
+					} ) ?? true,
+				userCanCreatePages: canUser( 'create', {
+					kind: 'postType',
+					name: 'page',
+				} ),
 				pageOnFront: siteSettings?.page_on_front,
 				pageForPosts: siteSettings?.page_for_posts,
 				userPatternCategories: getUserPatternCategories(),

--- a/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
@@ -40,7 +40,11 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 
 	const canEditTemplate = useSelect(
 		( select ) =>
-			select( coreStore ).canUser( 'create', 'templates' ) ?? false
+			!! select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ),
+		[]
 	);
 
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -142,7 +142,10 @@ function VisualEditor( {
 		const editorSettings = getEditorSettings();
 		const supportsTemplateMode = editorSettings.supportsTemplateMode;
 		const postTypeObject = getPostType( postTypeSlug );
-		const canEditTemplate = canUser( 'create', 'templates' );
+		const canEditTemplate = canUser( 'create', {
+			kind: 'postType',
+			name: 'wp_template',
+		} );
 		const currentTemplateId = getCurrentTemplateId();
 		const template = currentTemplateId
 			? getEditedEntityRecord(

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -86,7 +86,10 @@ export default function PatternConvertButton( {
 				) &&
 				// Hide when current doesn't have permission to do that.
 				// Blocks refers to the wp_block post type, this checks the ability to create a post of that type.
-				!! canUser( 'create', 'blocks' );
+				!! canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_block',
+				} );
 
 			return _canConvert;
 		},

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -28,16 +28,19 @@ function PatternsManageButton( { clientId } ) {
 				isVisible:
 					!! reusableBlock &&
 					isReusableBlock( reusableBlock ) &&
-					!! canUser(
-						'update',
-						'blocks',
-						reusableBlock.attributes.ref
-					),
+					!! canUser( 'update', {
+						kind: 'postType',
+						name: 'wp_block',
+						id: reusableBlock.attributes.ref,
+					} ),
 				innerBlockCount: getBlockCount( clientId ),
 				// The site editor and templates both check whether the user
 				// has edit_theme_options capabilities. We can leverage that here
 				// and omit the manage patterns link if the user can't access it.
-				managePatternsUrl: canUser( 'create', 'templates' )
+				managePatternsUrl: canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_template',
+				} )
 					? addQueryArgs( 'site-editor.php', {
 							path: '/patterns',
 					  } )

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -93,7 +93,10 @@ export default function ReusableBlockConvertButton( {
 				) &&
 				// Hide when current doesn't have permission to do that.
 				// Blocks refers to the wp_block post type, this checks the ability to create a post of that type.
-				!! canUser( 'create', 'blocks' );
+				!! canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_block',
+				} );
 
 			return _canConvert;
 		},

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -27,16 +27,19 @@ function ReusableBlocksManageButton( { clientId } ) {
 				isVisible:
 					!! reusableBlock &&
 					isReusableBlock( reusableBlock ) &&
-					!! canUser(
-						'update',
-						'blocks',
-						reusableBlock.attributes.ref
-					),
+					!! canUser( 'update', {
+						kind: 'postType',
+						name: 'wp_block',
+						id: reusableBlock.attributes.ref,
+					} ),
 				innerBlockCount: getBlockCount( clientId ),
 				// The site editor and templates both check whether the user
 				// has edit_theme_options capabilities. We can leverage that here
 				// and omit the manage patterns link if the user can't access it.
-				managePatternsUrl: canUser( 'create', 'templates' )
+				managePatternsUrl: canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_template',
+				} )
 					? addQueryArgs( 'site-editor.php', {
 							path: '/patterns',
 					  } )


### PR DESCRIPTION
## What?
This is a follow-up to #63322.

PR updates the codebase to use new entity-are syntax for the `canUser` selector.

## How?
I just switched the selector calls to the new syntax and tried to make as few changes as possible to the logic.

## Testing Instructions
I hope e2e tests have our back for these changes, but smoke testing the editor functionality will help.

### Testing Instructions for Keyboard
Same.
