### PR TITLE
Zoom Out: Ensure that we only enter zoom out mode if the experiment is enabled

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -147,7 +147,7 @@ function InserterMenu(
 	const showMediaPanel = selectedTab === 'media' && !! selectedMediaCategory;
 
 	const showZoomOut =
-		showPatternPanel && window.__experimentalEnableZoomedOutPatternsTab;
+		showPatternPanel && !! window.__experimentalEnableZoomedOutPatternsTab;
 
 	useZoomOut( showZoomOut );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Don't trigger zoom out unless you have the experiment enabled.

## Why?
If the experiment setting is unchecked then `window.__experimentalEnableZoomedOutPatternsTab` is `undefined` and therefore `showZoomOut` is `undefined` which means that `useZoomOut` triggers zoom out mode.

## How?
Add a double bang to `window.__experimentalEnableZoomedOutPatternsTab` so that `showZoomOut` evaluates to either true or false.

## Testing Instructions
1. Disable the zoom out experiment at `wp-admin/admin.php?page=gutenberg-experiments`
2. Open the Site Editor
3. Open the Patterns tab
4. Select a pattern category
5. Check that zoom out is not invoked
6. Take a break
1. Enable the zoom out experiment at `wp-admin/admin.php?page=gutenberg-experiments`
2. Open the Site Editor
3. Open the Patterns tab
4. Select a pattern category
5. Check that zoom out is invoked

