### PR TITLE
Details block: add transform from any block type

### DIFF
--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -11,6 +11,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
@@ -35,6 +36,7 @@ export const settings = {
 	},
 	save,
 	edit,
+	transforms,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/details/transforms.js
+++ b/packages/block-library/src/details/transforms.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock, cloneBlock } from '@wordpress/blocks';
+
+export default {
+	from: [
+		{
+			type: 'block',
+			isMultiBlock: true,
+			blocks: [ '*' ],
+			__experimentalConvert( blocks ) {
+				return createBlock(
+					'core/details',
+					{},
+					blocks.map( ( block ) => cloneBlock( block ) )
+				);
+			},
+		},
+	],
+};

--- a/packages/block-library/src/details/transforms.js
+++ b/packages/block-library/src/details/transforms.js
@@ -9,6 +9,11 @@ export default {
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ '*' ],
+			isMatch( {}, blocks ) {
+				return ! (
+					blocks.length === 1 && blocks[ 0 ].name === 'core/details'
+				);
+			},
 			__experimentalConvert( blocks ) {
 				return createBlock(
 					'core/details',

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -363,6 +363,7 @@ test.describe( 'Post-type locking', () => {
 				'Buttons',
 				'Code',
 				'Columns',
+				'Details',
 				'Group',
 				'Preformatted',
 				'Pullquote',

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -34,7 +34,14 @@ test.describe( 'Block Switcher', () => {
 		await blockSwitcher.click();
 		await expect(
 			page.getByRole( 'menu', { name: 'List' } ).getByRole( 'menuitem' )
-		).toHaveText( [ 'Paragraph', 'Heading', 'Quote', 'Columns', 'Group' ] );
+		).toHaveText( [
+			'Paragraph',
+			'Heading',
+			'Quote',
+			'Columns',
+			'Details',
+			'Group',
+		] );
 	} );
 
 	test( 'Should show the expected block transforms on the list block when the quote block is removed', async ( {
@@ -74,7 +81,13 @@ test.describe( 'Block Switcher', () => {
 		await blockSwitcher.click();
 		await expect(
 			page.getByRole( 'menu', { name: 'List' } ).getByRole( 'menuitem' )
-		).toHaveText( [ 'Paragraph', 'Heading', 'Columns', 'Group' ] );
+		).toHaveText( [
+			'Paragraph',
+			'Heading',
+			'Columns',
+			'Details',
+			'Group',
+		] );
 	} );
 
 	test( 'Should not show the block switcher if the block has no styles and cannot be removed', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ran into the problem of not being able to select blocks and moving them into a details blocks. This PR adds a transform for that. Fixes #55602. See also #51247.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's not currently possible to move content into a details block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create some block, then select them and click the block icon to transform them into the details block.
Also singular blocks can be transformed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
