### PR TITLE
DataViews: Fix featured image height regression

### DIFF
--- a/packages/edit-site/src/components/post-list/style.scss
+++ b/packages/edit-site/src/components/post-list/style.scss
@@ -4,7 +4,7 @@
 	width: 100%;
 }
 
-.posts-list-page__featured-image-wrapper {
+.edit-site-post-list__featured-image-wrapper {
 	height: 100%;
 	width: 100%;
 	border-radius: $grid-unit-05;


### PR DESCRIPTION
Fix a small regression that was introduced in https://github.com/WordPress/gutenberg/pull/63334

You can check by opening the "pages" in the site editor and check that the featured images appear properly in both list and grid views.