### PR TITLE
[Mobile] - Gallery block - Fix getMediaItems

### DIFF
--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -57,19 +57,23 @@ const fetchHandler = (
 	}
 
 	const parseResponse = ( response ) => {
+		const isStringResponse = typeof response === 'string';
+
 		// If the 'parse' parameter is false, return the response as a new Response object
 		// with the JSON string. This is necessary because one of the middlewares in the API
 		// fetch library expects the response to be a JavaScript Response object with JSON
 		// functionality. By doing this, we ensure that the response is handled correctly
 		// by fetch-all-middleware.
 		if ( parse === false ) {
-			const jsonData = JSON.stringify( response );
-			return new Response( jsonData, {
+			const body = isStringResponse
+				? response
+				: JSON.stringify( response );
+			return new Response( body, {
 				headers: { 'Content-Type': 'application/json' },
 			} );
 		}
 
-		if ( typeof response === 'string' ) {
+		if ( isStringResponse ) {
 			response = JSON.parse( response );
 		}
 		return response;

--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -57,10 +57,6 @@ const fetchHandler = (
 	}
 
 	const parseResponse = ( response ) => {
-		if ( typeof response === 'string' ) {
-			return ( response = JSON.parse( response ) );
-		}
-
 		// If the 'parse' parameter is false, return the response as a new Response object
 		// with the JSON string. This is necessary because one of the middlewares in the API
 		// fetch library expects the response to be a JavaScript Response object with JSON
@@ -71,6 +67,10 @@ const fetchHandler = (
 			return new Response( jsonData, {
 				headers: { 'Content-Type': 'application/json' },
 			} );
+		}
+
+		if ( typeof response === 'string' ) {
+			response = JSON.parse( response );
 		}
 		return response;
 	};

--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -32,7 +32,7 @@ const setTimeoutPromise = ( delay ) =>
 	new Promise( ( resolve ) => setTimeout( resolve, delay ) );
 
 const fetchHandler = (
-	{ path, method = 'GET', data },
+	{ path, method = 'GET', data, parse },
 	retries = 20,
 	retryCount = 1
 ) => {
@@ -58,7 +58,19 @@ const fetchHandler = (
 
 	const parseResponse = ( response ) => {
 		if ( typeof response === 'string' ) {
-			response = JSON.parse( response );
+			return ( response = JSON.parse( response ) );
+		}
+
+		// If the 'parse' parameter is false, return the response as a new Response object
+		// with the JSON string. This is necessary because one of the middlewares in the API
+		// fetch library expects the response to be a JavaScript Response object with JSON
+		// functionality. By doing this, we ensure that the response is handled correctly
+		// by fetch-all-middleware.
+		if ( parse === false ) {
+			const jsonData = JSON.stringify( response );
+			return new Response( jsonData, {
+				headers: { 'Content-Type': 'application/json' },
+			} );
 		}
 		return response;
 	};


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6978
- https://github.com/wordpress-mobile/WordPress-Android/pull/21053
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23417

## What?
This PR addresses a regression in the Gallery block that was causing error notices to appear in certain scenarios. Additionally, it prevents the images from randomly changing their position when new images are added.

## Why?
To provide a good user experience when adding new images by preventing random errors and unexpected behavior.

## How?
I didn’t find the culprit of this regression, but after some investigation, I confirmed that the data was being fetched correctly, yet it wasn’t being stored in the state.

This was causing the [useGetMedia](https://github.com/WordPress/gutenberg/blob/a4e042f1e2bb628ffcab3bb8dedb12cc61974f0d/packages/block-library/src/gallery/use-get-media.native.js) hook to not return the expected data of the images.

By looking more into the code, I realized the fetch promise was being intercepted [by a catch](https://github.com/WordPress/gutenberg/blob/a4e042f1e2bb628ffcab3bb8dedb12cc61974f0d/packages/core-data/src/resolvers.js#L298-L300), so no data was being stored.

The error was happening in [fetchAllMiddleware](https://github.com/WordPress/gutenberg/blob/a4e042f1e2bb628ffcab3bb8dedb12cc61974f0d/packages/api-fetch/src/middlewares/fetch-all-middleware.js#L30-L31), where [parseResponse](https://github.com/WordPress/gutenberg/blob/a4e042f1e2bb628ffcab3bb8dedb12cc61974f0d/packages/api-fetch/src/middlewares/fetch-all-middleware.js#L30-L31) is called and expects to have a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) parameter in JSON format.

After all this, I decided to update the native implementation of [fetchHandler](https://github.com/WordPress/gutenberg/blob/a4e042f1e2bb628ffcab3bb8dedb12cc61974f0d/packages/react-native-editor/src/api-fetch-setup.js) and update how it parses the response.

Now it will return a `Response` object if the `parse` parameter is set to `false`.

## Testing Instructions
> [!NOTE]  
> Please use the following builds to test:
> - [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/23417#issuecomment-2222997070)
> - [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/21053#issuecomment-2223010177)

Steps provided from [another PR review](https://github.com/wordpress-mobile/gutenberg-mobile/pull/6973#pullrequestreview-2167369822):

1. Insert a Gallery block.
2. Select media for the block.
3. Move block selection to the Gallery block.
4. Tap the inline appender.
5. Add media already within the Gallery block.
6. Note the error message and lack of new image.
7. Move block selection to an Image block within the Gallery block.
8. Tap the block inserter in the toolbar.
9. Add media already within the Gallery block.
10. Note the image is added.
11. Move block selection to the Gallery block.
12. Tap the inline appender.
13. Add media already within the Gallery block.
14. Note the error message, the lack of new image, and the existing images order is reshuffled.

### Testing Instructions for Keyboard
No testing is needed.

## Screenshots or screencast <!-- if applicable -->
Before|After
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/319fddfe-4d3f-46e5-b468-efd94991052b" width=250 />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/576b49a1-2189-4979-ba09-640afaac4dee" width=250 />