### PR TITLE
Gallery: Add border block support

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -112,6 +112,16 @@
 	"supports": {
 		"anchor": true,
 		"align": true,
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true
+			}
+		},
 		"html": false,
 		"units": [ "px", "em", "rem", "vh", "vw" ],
 		"spacing": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the gallery block.

Partial for https://github.com/WordPress/gutenberg/issues/43247

## Why?
The block is missing these options. Adding them improves the consistency and enables more design options.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json

## Testing Instructions
Create a new post and add a gallery block. Adjust the border settings and compare the result in the editor and front.
Next test the global styles options from the Styles sidebar in the Site Editor.

## Screenshots or screencast <!-- if applicable -->
Different border settings in combination with background and caption. The last gallery has extra padding. Using Twenty Twenty-Four:
![gallery-border](https://github.com/WordPress/gutenberg/assets/7422055/692a72a0-0b2d-4c9e-811f-ebbd517bd7d2)

