### PR TITLE
Core Data: Resolve user capabilities when fetching an entity

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -121,6 +121,51 @@ export default function ReusableBlockEditRecursionWrapper( props ) {
 	);
 }
 
+function ReusableBlockControl( {
+	recordId,
+	canOverrideBlocks,
+	hasContent,
+	handleEditOriginal,
+	resetContent,
+} ) {
+	const canUserEdit = useSelect(
+		( select ) =>
+			!! select( coreStore ).canUser( 'update', {
+				kind: 'postType',
+				name: 'wp_block',
+				id: recordId,
+			} ),
+		[ recordId ]
+	);
+
+	return (
+		<>
+			{ canUserEdit && !! handleEditOriginal && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton onClick={ handleEditOriginal }>
+							{ __( 'Edit original' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
+
+			{ canOverrideBlocks && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							onClick={ resetContent }
+							disabled={ ! hasContent }
+						>
+							{ __( 'Reset' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
+		</>
+	);
+}
+
 function ReusableBlockEdit( {
 	name,
 	attributes: { ref, content },
@@ -143,29 +188,20 @@ function ReusableBlockEdit( {
 
 	const {
 		innerBlocks,
-		userCanEdit,
 		onNavigateToEntityRecord,
 		editingMode,
 		hasPatternOverridesSource,
 	} = useSelect(
 		( select ) => {
-			const { canUser } = select( coreStore );
 			const {
 				getBlocks,
 				getSettings,
 				getBlockEditingMode: _getBlockEditingMode,
 			} = select( blockEditorStore );
 			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
-			const canEdit = canUser( 'update', {
-				kind: 'postType',
-				name: 'wp_block',
-				id: ref,
-			} );
-
 			// For editing link to the site editor if the theme and user permissions support it.
 			return {
 				innerBlocks: getBlocks( patternClientId ),
-				userCanEdit: canEdit,
 				getBlockEditingMode: _getBlockEditingMode,
 				onNavigateToEntityRecord:
 					getSettings().onNavigateToEntityRecord,
@@ -175,7 +211,7 @@ function ReusableBlockEdit( {
 				),
 			};
 		},
-		[ patternClientId, ref ]
+		[ patternClientId ]
 	);
 
 	// Sync the editing mode of the pattern block with the inner blocks.
@@ -256,27 +292,18 @@ function ReusableBlockEdit( {
 
 	return (
 		<>
-			{ userCanEdit && onNavigateToEntityRecord && (
-				<BlockControls>
-					<ToolbarGroup>
-						<ToolbarButton onClick={ handleEditOriginal }>
-							{ __( 'Edit original' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
-
-			{ canOverrideBlocks && (
-				<BlockControls>
-					<ToolbarGroup>
-						<ToolbarButton
-							onClick={ resetContent }
-							disabled={ ! content }
-						>
-							{ __( 'Reset' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
+			{ hasResolved && (
+				<ReusableBlockControl
+					recordId={ ref }
+					canOverrideBlocks={ canOverrideBlocks }
+					hasContent={ !! content }
+					handleEditOriginal={
+						onNavigateToEntityRecord
+							? handleEditOriginal
+							: undefined
+					}
+					resetContent={ resetContent }
+				/>
 			) }
 
 			{ children === null ? (

--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -158,7 +158,9 @@ describe( 'Synced patterns', () => {
 			if ( path.startsWith( endpoint ) ) {
 				response = getMockedReusableBlock( id );
 			}
-			return Promise.resolve( response );
+			return Promise.resolve( {
+				json: () => Promise.resolve( response ),
+			} );
 		} );
 
 		const screen = await initializeEditor( {
@@ -229,7 +231,9 @@ describe( 'Synced patterns', () => {
 			response.content.raw = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none"} -->
 <figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></figure>
 <!-- /wp:image -->`;
-			return Promise.resolve( response );
+			return Promise.resolve( {
+				json: () => Promise.resolve( response ),
+			} );
 		} );
 
 		const screen = await initializeEditor( {

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -48,6 +48,7 @@ function mockGetMedia( media ) {
 const FETCH_MEDIA = {
 	request: {
 		path: `/wp/v2/media/1?context=edit`,
+		parse: false,
 	},
 	response: {
 		source_url: 'https://cldup.com/cXyG__fTLN.jpg',

--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -27,10 +27,11 @@ describe( 'useEntityRecord', () => {
 	} );
 
 	const TEST_RECORD = { id: 1, hello: 'world' };
+	const TEST_RECORD_RESPONSE = { json: () => Promise.resolve( TEST_RECORD ) };
 
 	it( 'resolves the entity record when missing from the state', async () => {
 		// Provide response
-		triggerFetch.mockImplementation( () => TEST_RECORD );
+		triggerFetch.mockImplementation( () => TEST_RECORD_RESPONSE );
 
 		let data;
 		const TestComponent = () => {
@@ -60,6 +61,7 @@ describe( 'useEntityRecord', () => {
 		await waitFor( () =>
 			expect( triggerFetch ).toHaveBeenCalledWith( {
 				path: '/wp/v2/widgets/1?context=edit',
+				parse: false,
 			} )
 		);
 
@@ -79,7 +81,7 @@ describe( 'useEntityRecord', () => {
 
 	it( 'applies edits to the entity record', async () => {
 		// Provide response
-		triggerFetch.mockImplementation( () => TEST_RECORD );
+		triggerFetch.mockImplementation( () => TEST_RECORD_RESPONSE );
 
 		let widget;
 		const TestComponent = () => {
@@ -119,7 +121,7 @@ describe( 'useEntityRecord', () => {
 	} );
 
 	it( 'does not resolve entity record when disabled via options', async () => {
-		triggerFetch.mockImplementation( () => TEST_RECORD );
+		triggerFetch.mockImplementation( () => TEST_RECORD_RESPONSE );
 
 		let data;
 		const TestComponent = ( { enabled } ) => {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -201,6 +201,10 @@ export const getEntityRecord =
 							permissionKey,
 							permissions[ action ]
 						);
+						dispatch.finishResolution( 'canUser', [
+							action,
+							{ kind, name, id: key },
+						] );
 					}
 				} );
 			}

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -20,6 +20,7 @@ import {
 	isRawAttribute,
 	setNestedValue,
 	isNumericID,
+	getUserPermissionCacheKey,
 } from './utils';
 import type * as ET from './entity-types';
 import type { UndoManager } from '@wordpress/undo-manager';
@@ -1156,13 +1157,7 @@ export function canUser(
 		return false;
 	}
 
-	const key = (
-		isEntity
-			? [ action, resource.kind, resource.name, resource.id ]
-			: [ action, resource, id ]
-	)
-		.filter( Boolean )
-		.join( '/' );
+	const key = getUserPermissionCacheKey( action, resource, id );
 
 	return state.userPermissions[ key ];
 }

--- a/packages/core-data/src/utils/index.js
+++ b/packages/core-data/src/utils/index.js
@@ -9,3 +9,8 @@ export { default as isRawAttribute } from './is-raw-attribute';
 export { default as setNestedValue } from './set-nested-value';
 export { default as getNestedValue } from './get-nested-value';
 export { default as isNumericID } from './is-numeric-id';
+export {
+	getUserPermissionCacheKey,
+	getUserPermissionsFromResponse,
+	ALLOWED_RESOURCE_ACTIONS,
+} from './user-permissions';

--- a/packages/core-data/src/utils/user-permissions.js
+++ b/packages/core-data/src/utils/user-permissions.js
@@ -9,7 +9,7 @@ export function getUserPermissionsFromResponse( response ) {
 	const permissions = {};
 
 	// Optional chaining operator is used here because the API requests don't
-	// return the expected result in the native version. Instead, API requests
+	// return the expected result in the React native version. Instead, API requests
 	// only return the result, without including response properties like the headers.
 	const allowedMethods = response.headers?.get( 'allow' ) || '';
 

--- a/packages/core-data/src/utils/user-permissions.js
+++ b/packages/core-data/src/utils/user-permissions.js
@@ -1,0 +1,39 @@
+export const ALLOWED_RESOURCE_ACTIONS = [
+	'create',
+	'read',
+	'update',
+	'delete',
+];
+
+export function getUserPermissionsFromResponse( response ) {
+	const permissions = {};
+
+	// Optional chaining operator is used here because the API requests don't
+	// return the expected result in the native version. Instead, API requests
+	// only return the result, without including response properties like the headers.
+	const allowedMethods = response.headers?.get( 'allow' ) || '';
+
+	const methods = {
+		create: 'POST',
+		read: 'GET',
+		update: 'PUT',
+		delete: 'DELETE',
+	};
+	for ( const [ actionName, methodName ] of Object.entries( methods ) ) {
+		permissions[ actionName ] = allowedMethods.includes( methodName );
+	}
+
+	return permissions;
+}
+
+export function getUserPermissionCacheKey( action, resource, id ) {
+	const key = (
+		typeof resource === 'object'
+			? [ action, resource.kind, resource.name, resource.id ]
+			: [ action, resource, id ]
+	)
+		.filter( Boolean )
+		.join( '/' );
+
+	return key;
+}

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -90,7 +90,9 @@ describe( 'Post actions', () => {
 					method === 'GET' &&
 					path.startsWith( '/wp/v2/types/post' )
 				) {
-					return {};
+					return {
+						json: () => Promise.resolve( {} ),
+					};
 				}
 
 				throw {
@@ -178,7 +180,9 @@ describe( 'Post actions', () => {
 						path.startsWith( '/wp/v2/types/post' ) ||
 						path.startsWith( `/wp/v2/posts/${ postId }` )
 					) {
-						return {};
+						return {
+							json: () => Promise.resolve( {} ),
+						};
 					}
 				}
 
@@ -262,7 +266,9 @@ describe( 'Post actions', () => {
 					method === 'GET' &&
 					path.startsWith( '/wp/v2/types/post' )
 				) {
-					return {};
+					return {
+						json: () => Promise.resolve( {} ),
+					};
 				}
 
 				throw {


### PR DESCRIPTION
## What?
Inspired by https://github.com/WordPress/gutenberg/pull/43480#issuecomment-1231810231.
Hopefully, this will be more effective after merging #63415 and #63423.

PR updates the `getEntityRecord` to resolve entity-related user permission when fetching entity data.

## Why?
Most of the time, actions to interact with the entity are displayed after loading it. Resolving user capability selectors for the same entity can improve the UI (no more popcorning) and reduce the number of requests the app makes.

## Testing Instructions

### Manually run selectors
1. Open a post or page.
2. Run selectors below in order using DevTools Console.
3. Running the `canUser` selector for the same entity shouldn't trigger a REST API request.

```
// 1. Fetch media details.
wp.data.select( 'core' ).getEntityRecord( 'root', 'media', 1342 );

// 2. Fetch user permission related to the media. It shouldn't trigger a REST API request.
wp.data.select( 'core' ).canUser( 'update', { kind: 'root', name: 'media', id: 1342 } );
```

### Pattern blocks

1. Open a post or page.
2. Add multiple synced pattern blocks.
3. Save and reload the editor.
4. Confirm using Network tools that no `OPTIONS` requests are made for these patterns. You can use `v2/blocks` to filter the endpoint.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
**Requests before with four pattern blocks on canvas:**
![CleanShot 2024-07-15 at 16 52 13](https://github.com/user-attachments/assets/884e8fb7-6bff-4c5d-bfc6-ed5e46886433)


**Requests after:**
![CleanShot 2024-07-15 at 16 52 36](https://github.com/user-attachments/assets/29505301-9572-4dd0-bbdd-d405d3f80528)