### PR TITLE
Dataviews: dedupe Ariakit dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53958,41 +53958,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"packages/dataviews/node_modules/@ariakit/core": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.1.tgz",
-			"integrity": "sha512-Rdhw0/K0x+50gFvzuMW9wp+WJxpkrgiMgegRTOZSU92bv1K+6XfQWnlieIkLt2FC7pZGrDpGlS4C7ztEVF+JRg=="
-		},
-		"packages/dataviews/node_modules/@ariakit/react": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.1.tgz",
-			"integrity": "sha512-hKfCYjc3MFW20kn2dcvejB5zbYt/uU33Teq82c414/utf5sEoeRF+bxjNku8x1baJby9/SDP6zj2IgWPuedFNA==",
-			"dependencies": {
-				"@ariakit/react-core": "0.4.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ariakit"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
-			}
-		},
-		"packages/dataviews/node_modules/@ariakit/react-core": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.1.tgz",
-			"integrity": "sha512-cwDczl9XWBloXNg0CuHmJtBfEe7qF265JE0Pwlcp8wMSY9PsJeb0mKBlTygUPKn/FsKpKGaYSI7DlDntbcZciw==",
-			"dependencies": {
-				"@ariakit/core": "0.4.1",
-				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
-			}
-		},
 		"packages/date": {
 			"name": "@wordpress/date",
 			"version": "5.3.0",
@@ -69200,30 +69165,6 @@
 				"@wordpress/private-apis": "file:../private-apis",
 				"clsx": "^2.1.1",
 				"remove-accents": "^0.5.0"
-			},
-			"dependencies": {
-				"@ariakit/core": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.1.tgz",
-					"integrity": "sha512-Rdhw0/K0x+50gFvzuMW9wp+WJxpkrgiMgegRTOZSU92bv1K+6XfQWnlieIkLt2FC7pZGrDpGlS4C7ztEVF+JRg=="
-				},
-				"@ariakit/react": {
-					"version": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.1.tgz",
-					"integrity": "sha512-hKfCYjc3MFW20kn2dcvejB5zbYt/uU33Teq82c414/utf5sEoeRF+bxjNku8x1baJby9/SDP6zj2IgWPuedFNA==",
-					"requires": {
-						"@ariakit/react-core": "0.4.1"
-					}
-				},
-				"@ariakit/react-core": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.1.tgz",
-					"integrity": "sha512-cwDczl9XWBloXNg0CuHmJtBfEe7qF265JE0Pwlcp8wMSY9PsJeb0mKBlTygUPKn/FsKpKGaYSI7DlDntbcZciw==",
-					"requires": {
-						"@ariakit/core": "0.4.1",
-						"@floating-ui/dom": "^1.0.0",
-						"use-sync-external-store": "^1.2.0"
-					}
-				}
 			}
 		},
 		"@wordpress/date": {


### PR DESCRIPTION
I noticed that there is a duplicate version of Ariakit packages installed in `packages/dataviews/node_modules` so in this PR I'm deduping them. There is a good enough version (0.3.2) in the root `node_modules`, shared with `packages/components`.