### PR TITLE
Core Data: Mark 'canUser' related actions resolvers as resolved

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -450,6 +450,15 @@ export const canUser =
 					.join( '/' );
 
 				dispatch.receiveUserPermission( key, permissions[ action ] );
+
+				// Mark related action resolutions as finished.
+				if ( action !== requestedAction ) {
+					dispatch.finishResolution( 'canUser', [
+						action,
+						resource,
+						id,
+					] );
+				}
 			}
 		} );
 	};

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -308,6 +308,7 @@ describe( 'canUser', () => {
 		};
 		dispatch = Object.assign( jest.fn(), {
 			receiveUserPermission: jest.fn(),
+			finishResolution: jest.fn(),
 		} );
 		dispatch.mockReturnValue( ENTITIES );
 		triggerFetch.mockReset();


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/pull/63430#discussion_r1673944129.

PR updates the `canUser` resolver to mark related actions as resolved when their store records are populated.

## Testing Instructions
1. Open a post editor.
2. Check capabilities for an entity - `wp.data.select( 'core' ).canUser( 'update', { kind: 'root', name: 'media', id: 1342 } );`.
3. Confirm that similar actions are also marked as resolved - `wp.data.select( 'core' ).hasFinishedResolution( 'canUser', [ 'read', { kind: 'root', name: 'media', id: 1342 } ] );`

### Testing Instructions for Keyboard
Same.
