### PR TITLE
Fix invalid css for nested fullwidth layouts with zero padding applied

### DIFF
--- a/backport-changelog/6.6/7036.md
+++ b/backport-changelog/6.6/7036.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7036
+
+* https://github.com/WordPress/gutenberg/pull/63436

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -307,6 +307,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 */
 			if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
 				$padding_right   = $block_spacing_values['declarations']['padding-right'];
+				// Add unit if 0.
+				if ( 0 == $padding_right ) {
+					$padding_right = '0px';
+				}
 				$layout_styles[] = array(
 					'selector'     => "$selector > .alignfull",
 					'declarations' => array( 'margin-right' => "calc($padding_right * -1)" ),
@@ -314,6 +318,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 			if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
 				$padding_left    = $block_spacing_values['declarations']['padding-left'];
+				// Add unit if 0.
+				if ( 0 == $padding_left ) {
+					$padding_left = '0px';
+				}
 				$layout_styles[] = array(
 					'selector'     => "$selector > .alignfull",
 					'declarations' => array( 'margin-left' => "calc($padding_left * -1)" ),

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -308,7 +308,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
 				$padding_right   = $block_spacing_values['declarations']['padding-right'];
 				// Add unit if 0.
-				if ( 0 == $padding_right ) {
+				if ( '0' === $padding_right ) {
 					$padding_right = '0px';
 				}
 				$layout_styles[] = array(
@@ -319,7 +319,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
 				$padding_left    = $block_spacing_values['declarations']['padding-left'];
 				// Add unit if 0.
-				if ( 0 == $padding_left ) {
+				if ( '0' === $padding_left ) {
 					$padding_left = '0px';
 				}
 				$layout_styles[] = array(

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -306,7 +306,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 * They're added separately because padding might only be set on one side.
 			 */
 			if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
-				$padding_right   = $block_spacing_values['declarations']['padding-right'];
+				$padding_right = $block_spacing_values['declarations']['padding-right'];
 				// Add unit if 0.
 				if ( '0' === $padding_right ) {
 					$padding_right = '0px';
@@ -317,7 +317,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				);
 			}
 			if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
-				$padding_left    = $block_spacing_values['declarations']['padding-left'];
+				$padding_left = $block_spacing_values['declarations']['padding-left'];
 				// Add unit if 0.
 				if ( '0' === $padding_left ) {
 					$padding_left = '0px';

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -234,15 +234,23 @@ export default {
 			const paddingValues = getCSSRules( style );
 			paddingValues.forEach( ( rule ) => {
 				if ( rule.key === 'paddingRight' ) {
+					// Add unit if 0, to avoid calc(0 * -1) which is invalid.
+					const paddingRightValue =
+						rule.value === '0' ? '0px' : rule.value;
+
 					output += `
 					${ appendSelectors( selector, '> .alignfull' ) } {
-						margin-right: calc(${ rule.value } * -1);
+						margin-right: calc(${ paddingRightValue } * -1);
 					}
 					`;
 				} else if ( rule.key === 'paddingLeft' ) {
+					// Add unit if 0, to avoid calc(0 * -1) which is invalid.
+					const paddingLeftValue =
+						rule.value === '0' ? '0px' : rule.value;
+
 					output += `
 					${ appendSelectors( selector, '> .alignfull' ) } {
-						margin-left: calc(${ rule.value } * -1);
+						margin-left: calc(${ paddingLeftValue } * -1);
 					}
 					`;
 				}


### PR DESCRIPTION
## What?
Closes #63432 by ensuring a `px` unit is provided, to do the proper calculation when padding left or right is set to the string value of `0` via the padding controls. 

## Why?
Nested fullwidth blocks have outer padding properly negated, but when you use a custom padding value, that value is used to negate the margins, rather than the outer padding. This works great for every case where a unit is supplied with the custom value (as is always the case, other than when the value is `0`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Open the code editor within the top editor options panel. 
3. Copy and paste [this gist](https://gist.github.com/richtabor/8c9422e5ac760641b5a0a4874b8fd2c9), which configures the conditions properly (nested align full blocks, with padding zeroed out on the parent). 
4. See no horizontal scroll in the editor and the front end. 

## Visuals

### Before

With unintentional horizontal scroll: 

https://github.com/WordPress/gutenberg/assets/1813435/9d8854ed-2ec5-499f-a15b-f921227c5403


### After

With no horizontal scroll:

https://github.com/WordPress/gutenberg/assets/1813435/34cdd758-f882-49d4-aa9e-2ca22888c8c9

