### PR TITLE
DropdownMenuV2: invert animation direction

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   `CustomSelectControl`: switch to ariakit-based implementation ([#63258](https://github.com/WordPress/gutenberg/pull/63258)).
 -   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
 -   `CustomSelectControlV2`: do not flip popover if legacy adapter. ([#63357](https://github.com/WordPress/gutenberg/pull/63357)).
+-   `CustomSelectControlV2`: invert animation direction. ([#63443](https://github.com/WordPress/gutenberg/pull/63443)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,7 +11,7 @@
 -   `CustomSelectControl`: switch to ariakit-based implementation ([#63258](https://github.com/WordPress/gutenberg/pull/63258)).
 -   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
 -   `CustomSelectControlV2`: do not flip popover if legacy adapter. ([#63357](https://github.com/WordPress/gutenberg/pull/63357)).
--   `CustomSelectControlV2`: invert animation direction. ([#63443](https://github.com/WordPress/gutenberg/pull/63443)).
+-   `DropdownMenuV2`: invert animation direction. ([#63443](https://github.com/WordPress/gutenberg/pull/63443)).
 
 ### Enhancements
 

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -107,13 +107,13 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 	/* Default animation.*/
 	animation-name: ${ slideDownAndFade };
 
-	&[data-side='right'] {
+	&[data-side='left'] {
 		animation-name: ${ slideLeftAndFade };
 	}
-	&[data-side='bottom'] {
+	&[data-side='up'] {
 		animation-name: ${ slideUpAndFade };
 	}
-	&[data-side='left'] {
+	&[data-side='right'] {
 		animation-name: ${ slideRightAndFade };
 	}
 	@media ( prefers-reduced-motion ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Apply feedback received on `CustomSelectControl`'s popover animation in https://github.com/WordPress/gutenberg/pull/63343 to `DropdownMenuV2` and invert the direction of the popover enter animation based on the popover placement.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For consistency across the different components.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By swapping left/right and up/down enter animation directions in code,

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the Storybook examples for `DropdownMenuV2`, and play with the dropdown popover (both the main one, and the sub-menu ones). Make sure that the popover animates "away from the trigger" — if the popover opens below the trigger, it should slide down; if it opens to the right of the trigger, it should animate towards the right.

_Note: the applied popover "placement" exposed by Ariakit doesn't take into account when the popover gets "flipped" for lack of viewport estate in the expected direction — and therefore we can not easily reflect that information in the animation._

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/5c5bb2ee-fbc1-437c-89bb-581997a462ed" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/42d203ee-99ea-4b09-9034-64fb759f0037" /> |

