### PR TITLE
Inserter category height buttons

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -243,7 +243,10 @@ $block-inserter-tabs-height: 44px;
 		display: block;
 		position: relative;
 		height: auto;
-		min-height: $grid-unit-50;
+
+		@include break-medium {
+			min-height: $grid-unit-50;
+		}
 
 		&[aria-selected="true"] {
 			color: var(--wp-admin-theme-color);

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -243,6 +243,7 @@ $block-inserter-tabs-height: 44px;
 		display: block;
 		position: relative;
 		height: auto;
+		min-height: $grid-unit-50;
 
 		&[aria-selected="true"] {
 			color: var(--wp-admin-theme-color);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/63440
## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes design regression.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Polish.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Override min-height of tabs for non-mobile devices

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open inserter
- Click patterns tab
- Button heights should be 40px

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
**Before** 
<img width="654" alt="Patterns tab with larger height" src="https://github.com/WordPress/gutenberg/assets/967608/27838458-93a4-467b-9f13-5637a1ece328">

**After**
<img width="652" alt="Patterns tab with 40px height" src="https://github.com/WordPress/gutenberg/assets/967608/501575be-d539-4ec0-af37-b3a85422a302">
