### PR TITLE
Tabs: Vertical Tabs should be 40px min height

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -243,6 +243,7 @@ $block-inserter-tabs-height: 44px;
 		display: block;
 		position: relative;
 		height: auto;
+		min-height: 40px;
 
 		&[aria-selected="true"] {
 			color: var(--wp-admin-theme-color);

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -243,7 +243,6 @@ $block-inserter-tabs-height: 44px;
 		display: block;
 		position: relative;
 		height: auto;
-		min-height: 40px;
 
 		&[aria-selected="true"] {
 			color: var(--wp-admin-theme-color);

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `CustomSelectControlV2`: animate select popover appearance. ([#63343](https://github.com/WordPress/gutenberg/pull/63343))
 -   `CustomSelectControlV2`: do not flip popover if legacy adapter. ([#63357](https://github.com/WordPress/gutenberg/pull/63357)).
 -   `DropdownMenuV2`: invert animation direction. ([#63443](https://github.com/WordPress/gutenberg/pull/63443)).
+-   `Tabs`: Vertical Tabs should be 40px min height. ([#63446](https://github.com/WordPress/gutenberg/pull/63446)).
 
 ### Enhancements
 

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -120,6 +120,12 @@ export const Tab = styled( Ariakit.Tab )`
 			opacity: 1;
 		}
 	}
+
+	[aria-orientation='vertical'] & {
+		min-height: ${ space(
+			10
+		) }; // Avoid fixed height to allow for long strings that go in multiple lines.
+	}
 `;
 
 export const TabPanel = styled( Ariakit.TabPanel )`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Vertical tabs should be 40px min-height.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We don't need as much spacing for vertical tabs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Apply `min-height: 40px` to tabs which have a `[aria-orientation='vertical']` attribute.

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
|<img width="351" alt="Screenshot 2024-07-11 at 16 31 26" src="https://github.com/WordPress/gutenberg/assets/275961/0cfa77a8-4069-49aa-9c28-321c1d330fba">|<img width="354" alt="Screenshot 2024-07-11 at 16 30 07" src="https://github.com/WordPress/gutenberg/assets/275961/26d92b06-b346-41e0-9234-98133e3fb34f">|