### PR TITLE
DataViews: Combine featured image and title in the posts table

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -84,8 +84,8 @@ function useView( postType ) {
 		if ( isCustom === 'false' && layout ) {
 			return {
 				...defaultView,
+				...defaultLayouts[ layout ],
 				type: layout,
-				layout: defaultLayouts[ layout ]?.layout,
 			};
 		}
 		return defaultView;
@@ -124,7 +124,7 @@ function useView( postType ) {
 
 		return {
 			...storedView,
-			layout: defaultLayouts[ storedView?.type ]?.layout,
+			...defaultLayouts[ layout ],
 		};
 	}, [ editedViewRecord?.content ] );
 

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -30,27 +30,38 @@ export const defaultLayouts = {
 	[ LAYOUT_TABLE ]: {
 		layout: {
 			primaryField: 'title',
+			combinedFields: [
+				{
+					id: 'post',
+					header: __( 'Title' ),
+					children: [ 'featured-image', 'title' ],
+					direction: 'horizontal',
+				},
+			],
 			styles: {
 				'featured-image': {
 					width: '1%',
 				},
-				title: {
+				post: {
 					maxWidth: 300,
 				},
 			},
 		},
+		fields: [ 'post', 'author', 'status' ],
 	},
 	[ LAYOUT_GRID ]: {
 		layout: {
 			mediaField: 'featured-image',
 			primaryField: 'title',
 		},
+		fields: [ 'title', 'author', 'status' ],
 	},
 	[ LAYOUT_LIST ]: {
 		layout: {
 			primaryField: 'title',
 			mediaField: 'featured-image',
 		},
+		fields: [ 'title', 'author', 'status' ],
 	},
 };
 
@@ -64,8 +75,8 @@ const DEFAULT_POST_BASE = {
 		field: 'date',
 		direction: 'desc',
 	},
-	fields: [ 'title', 'author', 'status' ],
 	layout: defaultLayouts[ LAYOUT_LIST ].layout,
+	fields: defaultLayouts[ LAYOUT_LIST ].fields,
 };
 
 export function useDefaultViews( { postType } ) {


### PR DESCRIPTION
Fixes #58012 

## What?

This PR combines the "title" with the "featured image" fields in the "pages" dataviews.

<img width="1070" alt="Screenshot 2024-07-11 at 7 02 54 PM" src="https://github.com/WordPress/gutenberg/assets/272444/f2d192bd-e164-420e-99e5-ba0b6a329e75">

## Testing Instructions

1- Open the pages dataviews page
2- Check that the featured image is combined with the "title" field in the table layout