### PR TITLE
ToggleGroupControl: support `disabled` options

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `ComboboxControl`: Fix ComboboxControl reset button when using the keyboard. ([#63410](https://github.com/WordPress/gutenberg/pull/63410))
 -   `Button`: Never apply `aria-disabled` to anchor ([#63376](https://github.com/WordPress/gutenberg/pull/63376)).
+-   `ToggleGroupControl`: support disabled options ([#63450](https://github.com/WordPress/gutenberg/pull/63450)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 -   `ComboboxControl`: Fix ComboboxControl reset button when using the keyboard. ([#63410](https://github.com/WordPress/gutenberg/pull/63410))
 -   `Button`: Never apply `aria-disabled` to anchor ([#63376](https://github.com/WordPress/gutenberg/pull/63376)).
--   `ToggleGroupControl`: support disabled options ([#63450](https://github.com/WordPress/gutenberg/pull/63450)).
 
 ### Internal
 
@@ -22,6 +21,7 @@
 
 ### Enhancements
 
+-   `ToggleGroupControl`: support disabled options ([#63450](https://github.com/WordPress/gutenberg/pull/63450)).
 -   `CustomSelectControl`: Stabilize `__experimentalShowSelectedHint` and `options[]. __experimentalHint` props ([#63248](https://github.com/WordPress/gutenberg/pull/63248)).
 
 ## 28.3.0 (2024-07-10)

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -132,6 +132,11 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   border: 0;
 }
 
+.emotion-12[disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .emotion-12:active {
   background: #fff;
 }
@@ -213,6 +218,11 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   border: 0;
 }
 
+.emotion-18[disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .emotion-18:active {
   background: #fff;
 }
@@ -238,7 +248,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
         class="components-toggle-group-control emotion-8 emotion-9"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
-        id="toggle-group-control-as-radio-group-10"
+        id="toggle-group-control-as-radio-group-11"
         role="radiogroup"
       >
         <div
@@ -252,7 +262,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             data-value="uppercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-as-radio-group-10-24"
+            id="toggle-group-control-as-radio-group-11-30"
             role="radio"
             type="button"
             value="uppercase"
@@ -291,7 +301,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             data-value="lowercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-as-radio-group-10-25"
+            id="toggle-group-control-as-radio-group-11-31"
             role="radio"
             type="button"
             value="lowercase"
@@ -452,6 +462,11 @@ exports[`ToggleGroupControl controlled should render correctly with text options
   border: 0;
 }
 
+.emotion-12[disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .emotion-12:active {
   background: #fff;
 }
@@ -486,7 +501,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
         class="components-toggle-group-control emotion-8 emotion-9"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
-        id="toggle-group-control-as-radio-group-9"
+        id="toggle-group-control-as-radio-group-10"
         role="radiogroup"
       >
         <div
@@ -499,7 +514,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
             data-value="rigas"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-as-radio-group-9-22"
+            id="toggle-group-control-as-radio-group-10-28"
             role="radio"
             type="button"
             value="rigas"
@@ -521,7 +536,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
             data-value="jack"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-as-radio-group-9-23"
+            id="toggle-group-control-as-radio-group-10-29"
             role="radio"
             type="button"
             value="jack"
@@ -677,6 +692,11 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   border: 0;
 }
 
+.emotion-12[disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .emotion-12:active {
   background: #fff;
 }
@@ -756,6 +776,11 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 
 .emotion-18::-moz-focus-inner {
   border: 0;
+}
+
+.emotion-18[disabled] {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .emotion-18:active {
@@ -989,6 +1014,11 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
 
 .emotion-12::-moz-focus-inner {
   border: 0;
+}
+
+.emotion-12[disabled] {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .emotion-12:active {

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -132,9 +132,23 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   border: 0;
 }
 
-.emotion-12[disabled] {
-  opacity: 0.4;
+.emotion-12[disabled],
+.emotion-12[aria-disabled='true'] {
   cursor: default;
+}
+
+.emotion-12[disabled] .emotion-14,
+.emotion-12[aria-disabled='true'] .emotion-14 {
+  opacity: 0.4;
+}
+
+.emotion-12[disabled][role='radio']:focus-visible::after,
+.emotion-12[aria-disabled='true'][role='radio']:focus-visible::after {
+  position: absolute;
+  content: '';
+  inset: var( --wp-admin-border-width-focus ) 4px;
+  border-radius: 2px;
+  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }
 
 .emotion-12:active {
@@ -218,9 +232,23 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   border: 0;
 }
 
-.emotion-18[disabled] {
-  opacity: 0.4;
+.emotion-18[disabled],
+.emotion-18[aria-disabled='true'] {
   cursor: default;
+}
+
+.emotion-18[disabled] .emotion-14,
+.emotion-18[aria-disabled='true'] .emotion-14 {
+  opacity: 0.4;
+}
+
+.emotion-18[disabled][role='radio']:focus-visible::after,
+.emotion-18[aria-disabled='true'][role='radio']:focus-visible::after {
+  position: absolute;
+  content: '';
+  inset: var( --wp-admin-border-width-focus ) 4px;
+  border-radius: 2px;
+  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }
 
 .emotion-18:active {
@@ -462,9 +490,23 @@ exports[`ToggleGroupControl controlled should render correctly with text options
   border: 0;
 }
 
-.emotion-12[disabled] {
-  opacity: 0.4;
+.emotion-12[disabled],
+.emotion-12[aria-disabled='true'] {
   cursor: default;
+}
+
+.emotion-12[disabled] .emotion-14,
+.emotion-12[aria-disabled='true'] .emotion-14 {
+  opacity: 0.4;
+}
+
+.emotion-12[disabled][role='radio']:focus-visible::after,
+.emotion-12[aria-disabled='true'][role='radio']:focus-visible::after {
+  position: absolute;
+  content: '';
+  inset: var( --wp-admin-border-width-focus ) 4px;
+  border-radius: 2px;
+  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }
 
 .emotion-12:active {
@@ -692,9 +734,23 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   border: 0;
 }
 
-.emotion-12[disabled] {
-  opacity: 0.4;
+.emotion-12[disabled],
+.emotion-12[aria-disabled='true'] {
   cursor: default;
+}
+
+.emotion-12[disabled] .emotion-14,
+.emotion-12[aria-disabled='true'] .emotion-14 {
+  opacity: 0.4;
+}
+
+.emotion-12[disabled][role='radio']:focus-visible::after,
+.emotion-12[aria-disabled='true'][role='radio']:focus-visible::after {
+  position: absolute;
+  content: '';
+  inset: var( --wp-admin-border-width-focus ) 4px;
+  border-radius: 2px;
+  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }
 
 .emotion-12:active {
@@ -778,9 +834,23 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   border: 0;
 }
 
-.emotion-18[disabled] {
-  opacity: 0.4;
+.emotion-18[disabled],
+.emotion-18[aria-disabled='true'] {
   cursor: default;
+}
+
+.emotion-18[disabled] .emotion-14,
+.emotion-18[aria-disabled='true'] .emotion-14 {
+  opacity: 0.4;
+}
+
+.emotion-18[disabled][role='radio']:focus-visible::after,
+.emotion-18[aria-disabled='true'][role='radio']:focus-visible::after {
+  position: absolute;
+  content: '';
+  inset: var( --wp-admin-border-width-focus ) 4px;
+  border-radius: 2px;
+  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }
 
 .emotion-18:active {
@@ -1016,9 +1086,23 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
   border: 0;
 }
 
-.emotion-12[disabled] {
-  opacity: 0.4;
+.emotion-12[disabled],
+.emotion-12[aria-disabled='true'] {
   cursor: default;
+}
+
+.emotion-12[disabled] .emotion-14,
+.emotion-12[aria-disabled='true'] .emotion-14 {
+  opacity: 0.4;
+}
+
+.emotion-12[disabled][role='radio']:focus-visible::after,
+.emotion-12[aria-disabled='true'][role='radio']:focus-visible::after {
+  position: absolute;
+  content: '';
+  inset: var( --wp-admin-border-width-focus ) 4px;
+  border-radius: 2px;
+  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }
 
 .emotion-12:active {

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -132,23 +132,9 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   border: 0;
 }
 
-.emotion-12[disabled],
-.emotion-12[aria-disabled='true'] {
-  cursor: default;
-}
-
-.emotion-12[disabled] .emotion-14,
-.emotion-12[aria-disabled='true'] .emotion-14 {
+.emotion-12[disabled] {
   opacity: 0.4;
-}
-
-.emotion-12[disabled][role='radio']:focus-visible::after,
-.emotion-12[aria-disabled='true'][role='radio']:focus-visible::after {
-  position: absolute;
-  content: '';
-  inset: var( --wp-admin-border-width-focus ) 4px;
-  border-radius: 2px;
-  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+  cursor: default;
 }
 
 .emotion-12:active {
@@ -232,23 +218,9 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   border: 0;
 }
 
-.emotion-18[disabled],
-.emotion-18[aria-disabled='true'] {
-  cursor: default;
-}
-
-.emotion-18[disabled] .emotion-14,
-.emotion-18[aria-disabled='true'] .emotion-14 {
+.emotion-18[disabled] {
   opacity: 0.4;
-}
-
-.emotion-18[disabled][role='radio']:focus-visible::after,
-.emotion-18[aria-disabled='true'][role='radio']:focus-visible::after {
-  position: absolute;
-  content: '';
-  inset: var( --wp-admin-border-width-focus ) 4px;
-  border-radius: 2px;
-  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+  cursor: default;
 }
 
 .emotion-18:active {
@@ -490,23 +462,9 @@ exports[`ToggleGroupControl controlled should render correctly with text options
   border: 0;
 }
 
-.emotion-12[disabled],
-.emotion-12[aria-disabled='true'] {
-  cursor: default;
-}
-
-.emotion-12[disabled] .emotion-14,
-.emotion-12[aria-disabled='true'] .emotion-14 {
+.emotion-12[disabled] {
   opacity: 0.4;
-}
-
-.emotion-12[disabled][role='radio']:focus-visible::after,
-.emotion-12[aria-disabled='true'][role='radio']:focus-visible::after {
-  position: absolute;
-  content: '';
-  inset: var( --wp-admin-border-width-focus ) 4px;
-  border-radius: 2px;
-  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+  cursor: default;
 }
 
 .emotion-12:active {
@@ -734,23 +692,9 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   border: 0;
 }
 
-.emotion-12[disabled],
-.emotion-12[aria-disabled='true'] {
-  cursor: default;
-}
-
-.emotion-12[disabled] .emotion-14,
-.emotion-12[aria-disabled='true'] .emotion-14 {
+.emotion-12[disabled] {
   opacity: 0.4;
-}
-
-.emotion-12[disabled][role='radio']:focus-visible::after,
-.emotion-12[aria-disabled='true'][role='radio']:focus-visible::after {
-  position: absolute;
-  content: '';
-  inset: var( --wp-admin-border-width-focus ) 4px;
-  border-radius: 2px;
-  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+  cursor: default;
 }
 
 .emotion-12:active {
@@ -834,23 +778,9 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   border: 0;
 }
 
-.emotion-18[disabled],
-.emotion-18[aria-disabled='true'] {
-  cursor: default;
-}
-
-.emotion-18[disabled] .emotion-14,
-.emotion-18[aria-disabled='true'] .emotion-14 {
+.emotion-18[disabled] {
   opacity: 0.4;
-}
-
-.emotion-18[disabled][role='radio']:focus-visible::after,
-.emotion-18[aria-disabled='true'][role='radio']:focus-visible::after {
-  position: absolute;
-  content: '';
-  inset: var( --wp-admin-border-width-focus ) 4px;
-  border-radius: 2px;
-  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+  cursor: default;
 }
 
 .emotion-18:active {
@@ -1086,23 +1016,9 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
   border: 0;
 }
 
-.emotion-12[disabled],
-.emotion-12[aria-disabled='true'] {
-  cursor: default;
-}
-
-.emotion-12[disabled] .emotion-14,
-.emotion-12[aria-disabled='true'] .emotion-14 {
+.emotion-12[disabled] {
   opacity: 0.4;
-}
-
-.emotion-12[disabled][role='radio']:focus-visible::after,
-.emotion-12[aria-disabled='true'][role='radio']:focus-visible::after {
-  position: absolute;
-  content: '';
-  inset: var( --wp-admin-border-width-focus ) 4px;
-  border-radius: 2px;
-  outline: var( --wp-admin-border-width-focus ) solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+  cursor: default;
 }
 
 .emotion-12:active {

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -80,6 +80,13 @@ const optionsWithTooltip = (
 		/>
 	</>
 );
+const optionsWithDisabledOption = (
+	<>
+		<ToggleGroupControlOption value="pizza" label="Pizza" />
+		<ToggleGroupControlOption value="rice" label="Rice" disabled />
+		<ToggleGroupControlOption value="pasta" label="Pasta" />
+	</>
+);
 
 describe.each( [
 	[ 'uncontrolled', ToggleGroupControl ],
@@ -351,6 +358,53 @@ describe.each( [
 
 				expect( expectedFocusTarget ).toHaveFocus();
 			} );
+
+			it( 'should ignore disabled radio options', async () => {
+				const mockOnChange = jest.fn();
+
+				render(
+					<Component
+						value="pizza"
+						onChange={ mockOnChange }
+						label="Test Toggle Group Control"
+					>
+						{ optionsWithDisabledOption }
+					</Component>
+				);
+
+				await sleep();
+				await press.Tab();
+
+				expect(
+					screen.getByRole( 'radio', { name: 'Pizza' } )
+				).toBeChecked();
+				expect(
+					screen.getByRole( 'radio', { name: 'Rice' } )
+				).toBeDisabled();
+
+				// Arrow navigation skips the disabled option
+				await press.ArrowRight();
+				expect(
+					screen.getByRole( 'radio', { name: 'Pasta' } )
+				).toBeChecked();
+				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pasta' );
+
+				// Arrow navigation skips the disabled option
+				await press.ArrowLeft();
+				expect(
+					screen.getByRole( 'radio', { name: 'Pizza' } )
+				).toBeChecked();
+				expect( mockOnChange ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pizza' );
+
+				// Clicks don't cause the option to be selected
+				await click( screen.getByRole( 'radio', { name: 'Rice' } ) );
+				expect(
+					screen.getByRole( 'radio', { name: 'Pizza' } )
+				).toBeChecked();
+				expect( mockOnChange ).toHaveBeenCalledTimes( 2 );
+			} );
 		} );
 
 		describe( 'isDeselectable = true', () => {
@@ -420,6 +474,66 @@ describe.each( [
 						pressed: false,
 					} )
 				).toHaveFocus();
+			} );
+
+			it( 'should ignore disabled options', async () => {
+				const mockOnChange = jest.fn();
+
+				render(
+					<Component
+						value="pizza"
+						isDeselectable
+						onChange={ mockOnChange }
+						label="Test Toggle Group Control"
+					>
+						{ optionsWithDisabledOption }
+					</Component>
+				);
+
+				await sleep();
+				await press.Tab();
+
+				expect(
+					screen.getByRole( 'button', {
+						name: 'Pizza',
+						pressed: true,
+					} )
+				).toBeVisible();
+				expect(
+					screen.getByRole( 'button', {
+						name: 'Rice',
+						pressed: false,
+					} )
+				).toBeDisabled();
+
+				// Tab key navigation skips the disabled option
+				await press.Tab();
+				await press.Space();
+				expect(
+					screen.getByRole( 'button', {
+						name: 'Pasta',
+						pressed: true,
+					} )
+				).toHaveFocus();
+				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pasta' );
+
+				// Tab key navigation skips the disabled option
+				await press.ShiftTab();
+				expect(
+					screen.getByRole( 'button', {
+						name: 'Pizza',
+						pressed: false,
+					} )
+				).toHaveFocus();
+
+				// Clicks don't cause the option to be selected.
+				await click(
+					screen.getByRole( 'button', {
+						name: 'Rice',
+					} )
+				);
+				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 			} );
 		} );
 	} );

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -359,7 +359,7 @@ describe.each( [
 				expect( expectedFocusTarget ).toHaveFocus();
 			} );
 
-			it( 'should keep disabled radio options focusable but not selectable', async () => {
+			it( 'should ignore disabled radio options', async () => {
 				const mockOnChange = jest.fn();
 
 				render(
@@ -375,37 +375,35 @@ describe.each( [
 				await sleep();
 				await press.Tab();
 
-				const pizzaOption = screen.getByRole( 'radio', {
-					name: 'Pizza',
-				} );
-				expect( pizzaOption ).toHaveFocus();
-				expect( pizzaOption ).toBeChecked();
+				expect(
+					screen.getByRole( 'radio', { name: 'Pizza' } )
+				).toBeChecked();
+				expect(
+					screen.getByRole( 'radio', { name: 'Rice' } )
+				).toBeDisabled();
 
-				// Arrow navigation focuses the disabled option
+				// Arrow navigation skips the disabled option
 				await press.ArrowRight();
-				const riceOption = screen.getByRole( 'radio', {
-					name: 'Rice',
-				} );
-				expect( riceOption ).toHaveFocus();
-				expect( riceOption ).toHaveAttribute( 'aria-disabled', 'true' );
-				expect( riceOption ).not.toBeChecked();
-				expect( mockOnChange ).not.toHaveBeenCalled();
-
-				// Arrow navigation focuses the next enabled option
-				await press.ArrowRight();
-				const pastaOption = screen.getByRole( 'radio', {
-					name: 'Pasta',
-				} );
-				expect( pastaOption ).toHaveFocus();
-				expect( pastaOption ).toBeChecked();
+				expect(
+					screen.getByRole( 'radio', { name: 'Pasta' } )
+				).toBeChecked();
 				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pasta' );
 
-				// Clicks don't cause the option to be selected nor to be focused.
-				await click( riceOption );
-				expect( pastaOption ).toHaveFocus();
-				expect( pastaOption ).toBeChecked();
-				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+				// Arrow navigation skips the disabled option
+				await press.ArrowLeft();
+				expect(
+					screen.getByRole( 'radio', { name: 'Pizza' } )
+				).toBeChecked();
+				expect( mockOnChange ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pizza' );
+
+				// Clicks don't cause the option to be selected
+				await click( screen.getByRole( 'radio', { name: 'Rice' } ) );
+				expect(
+					screen.getByRole( 'radio', { name: 'Pizza' } )
+				).toBeChecked();
+				expect( mockOnChange ).toHaveBeenCalledTimes( 2 );
 			} );
 		} );
 
@@ -478,7 +476,7 @@ describe.each( [
 				).toHaveFocus();
 			} );
 
-			it( 'should keep disabled button options focusable but not selectable', async () => {
+			it( 'should ignore disabled options', async () => {
 				const mockOnChange = jest.fn();
 
 				render(
@@ -500,20 +498,15 @@ describe.each( [
 						name: 'Pizza',
 						pressed: true,
 					} )
-				).toHaveFocus();
-
-				// Tab key navigation focuses the disabled option
-				await press.Tab();
-				await press.Space();
+				).toBeVisible();
 				expect(
 					screen.getByRole( 'button', {
 						name: 'Rice',
 						pressed: false,
 					} )
-				).toHaveFocus();
-				expect( mockOnChange ).not.toHaveBeenCalled();
+				).toBeDisabled();
 
-				// Tab key navigation focuses the next enabled option
+				// Tab key navigation skips the disabled option
 				await press.Tab();
 				await press.Space();
 				expect(
@@ -525,18 +518,21 @@ describe.each( [
 				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pasta' );
 
-				// Clicks don't cause the option to be selected nor to be focused.
+				// Tab key navigation skips the disabled option
+				await press.ShiftTab();
+				expect(
+					screen.getByRole( 'button', {
+						name: 'Pizza',
+						pressed: false,
+					} )
+				).toHaveFocus();
+
+				// Clicks don't cause the option to be selected.
 				await click(
 					screen.getByRole( 'button', {
 						name: 'Rice',
 					} )
 				);
-				expect(
-					screen.getByRole( 'button', {
-						name: 'Pasta',
-						pressed: true,
-					} )
-				).toHaveFocus();
 				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 			} );
 		} );

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -359,7 +359,7 @@ describe.each( [
 				expect( expectedFocusTarget ).toHaveFocus();
 			} );
 
-			it( 'should ignore disabled radio options', async () => {
+			it( 'should keep disabled radio options focusable but not selectable', async () => {
 				const mockOnChange = jest.fn();
 
 				render(
@@ -375,35 +375,37 @@ describe.each( [
 				await sleep();
 				await press.Tab();
 
-				expect(
-					screen.getByRole( 'radio', { name: 'Pizza' } )
-				).toBeChecked();
-				expect(
-					screen.getByRole( 'radio', { name: 'Rice' } )
-				).toBeDisabled();
+				const pizzaOption = screen.getByRole( 'radio', {
+					name: 'Pizza',
+				} );
+				expect( pizzaOption ).toHaveFocus();
+				expect( pizzaOption ).toBeChecked();
 
-				// Arrow navigation skips the disabled option
+				// Arrow navigation focuses the disabled option
 				await press.ArrowRight();
-				expect(
-					screen.getByRole( 'radio', { name: 'Pasta' } )
-				).toBeChecked();
+				const riceOption = screen.getByRole( 'radio', {
+					name: 'Rice',
+				} );
+				expect( riceOption ).toHaveFocus();
+				expect( riceOption ).toHaveAttribute( 'aria-disabled', 'true' );
+				expect( riceOption ).not.toBeChecked();
+				expect( mockOnChange ).not.toHaveBeenCalled();
+
+				// Arrow navigation focuses the next enabled option
+				await press.ArrowRight();
+				const pastaOption = screen.getByRole( 'radio', {
+					name: 'Pasta',
+				} );
+				expect( pastaOption ).toHaveFocus();
+				expect( pastaOption ).toBeChecked();
 				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pasta' );
 
-				// Arrow navigation skips the disabled option
-				await press.ArrowLeft();
-				expect(
-					screen.getByRole( 'radio', { name: 'Pizza' } )
-				).toBeChecked();
-				expect( mockOnChange ).toHaveBeenCalledTimes( 2 );
-				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pizza' );
-
-				// Clicks don't cause the option to be selected
-				await click( screen.getByRole( 'radio', { name: 'Rice' } ) );
-				expect(
-					screen.getByRole( 'radio', { name: 'Pizza' } )
-				).toBeChecked();
-				expect( mockOnChange ).toHaveBeenCalledTimes( 2 );
+				// Clicks don't cause the option to be selected nor to be focused.
+				await click( riceOption );
+				expect( pastaOption ).toHaveFocus();
+				expect( pastaOption ).toBeChecked();
+				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 			} );
 		} );
 
@@ -476,7 +478,7 @@ describe.each( [
 				).toHaveFocus();
 			} );
 
-			it( 'should ignore disabled options', async () => {
+			it( 'should keep disabled button options focusable but not selectable', async () => {
 				const mockOnChange = jest.fn();
 
 				render(
@@ -498,15 +500,20 @@ describe.each( [
 						name: 'Pizza',
 						pressed: true,
 					} )
-				).toBeVisible();
+				).toHaveFocus();
+
+				// Tab key navigation focuses the disabled option
+				await press.Tab();
+				await press.Space();
 				expect(
 					screen.getByRole( 'button', {
 						name: 'Rice',
 						pressed: false,
 					} )
-				).toBeDisabled();
+				).toHaveFocus();
+				expect( mockOnChange ).not.toHaveBeenCalled();
 
-				// Tab key navigation skips the disabled option
+				// Tab key navigation focuses the next enabled option
 				await press.Tab();
 				await press.Space();
 				expect(
@@ -518,21 +525,18 @@ describe.each( [
 				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 				expect( mockOnChange ).toHaveBeenLastCalledWith( 'pasta' );
 
-				// Tab key navigation skips the disabled option
-				await press.ShiftTab();
-				expect(
-					screen.getByRole( 'button', {
-						name: 'Pizza',
-						pressed: false,
-					} )
-				).toHaveFocus();
-
-				// Clicks don't cause the option to be selected.
+				// Clicks don't cause the option to be selected nor to be focused.
 				await click(
 					screen.getByRole( 'button', {
 						name: 'Rice',
 					} )
 				);
+				expect(
+					screen.getByRole( 'button', {
+						name: 'Pasta',
+						pressed: true,
+					} )
+				).toHaveFocus();
 				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 			} );
 		} );

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -52,7 +52,9 @@ function ToggleGroupControlOptionBase(
 			false
 		>,
 		// the element's id is generated internally
-		'id'
+		| 'id'
+		// due to how the component works, only the `disabled` prop should be used
+		| 'aria-disabled'
 	>,
 	forwardedRef: ForwardedRef< any >
 ) {
@@ -82,6 +84,7 @@ function ToggleGroupControlOptionBase(
 		children,
 		showTooltip = false,
 		onFocus: onFocusProp,
+		disabled,
 		...otherButtonProps
 	} = buttonProps;
 
@@ -130,6 +133,7 @@ function ToggleGroupControlOptionBase(
 				{ isDeselectable ? (
 					<button
 						{ ...commonProps }
+						disabled={ disabled }
 						onFocus={ onFocusProp }
 						aria-pressed={ isPressed }
 						type="button"
@@ -139,6 +143,7 @@ function ToggleGroupControlOptionBase(
 					</button>
 				) : (
 					<Ariakit.Radio
+						disabled={ disabled }
 						render={
 							<button
 								type="button"

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -33,16 +33,6 @@ const REDUCED_MOTION_TRANSITION_CONFIG = {
 
 const LAYOUT_ID = 'toggle-group-backdrop-shared-layout-id';
 
-const handleDisabledMouseEvent = (
-	event: React.MouseEvent,
-	disabled?: boolean
-) => {
-	if ( disabled ) {
-		event.stopPropagation();
-		event.preventDefault();
-	}
-};
-
 const WithToolTip = ( { showTooltip, text, children }: WithToolTipProps ) => {
 	if ( showTooltip && text ) {
 		return (
@@ -119,35 +109,19 @@ function ToggleGroupControlOptionBase(
 	);
 	const backdropClasses = useMemo( () => cx( styles.backdropView ), [ cx ] );
 
+	const buttonOnClick = () => {
+		if ( isDeselectable && isPressed ) {
+			toggleGroupControlContext.setValue( undefined );
+		} else {
+			toggleGroupControlContext.setValue( value );
+		}
+	};
+
 	const commonProps = {
 		...otherButtonProps,
 		className: itemClasses,
 		'data-value': value,
 		ref: forwardedRef,
-	};
-
-	const buttonOnMouseDown: React.MouseEventHandler< HTMLButtonElement > = (
-		event
-	) => {
-		handleDisabledMouseEvent( event, disabled );
-
-		commonProps.onMouseDown?.( event );
-	};
-
-	const buttonOnClick: React.MouseEventHandler< HTMLButtonElement > = (
-		event
-	) => {
-		handleDisabledMouseEvent( event, disabled );
-
-		if ( ! disabled ) {
-			if ( isDeselectable && isPressed ) {
-				toggleGroupControlContext.setValue( undefined );
-			} else {
-				toggleGroupControlContext.setValue( value );
-			}
-		}
-
-		commonProps.onClick?.( event );
 	};
 
 	return (
@@ -159,18 +133,16 @@ function ToggleGroupControlOptionBase(
 				{ isDeselectable ? (
 					<button
 						{ ...commonProps }
-						aria-disabled={ disabled }
+						disabled={ disabled }
 						onFocus={ onFocusProp }
 						aria-pressed={ isPressed }
 						type="button"
 						onClick={ buttonOnClick }
-						onMouseDown={ buttonOnMouseDown }
 					>
 						<ButtonContentView>{ children }</ButtonContentView>
 					</button>
 				) : (
 					<Ariakit.Radio
-						accessibleWhenDisabled
 						disabled={ disabled }
 						render={
 							<button
@@ -181,11 +153,7 @@ function ToggleGroupControlOptionBase(
 									if ( event.defaultPrevented ) {
 										return;
 									}
-									if ( ! disabled ) {
-										toggleGroupControlContext.setValue(
-											value
-										);
-									}
+									toggleGroupControlContext.setValue( value );
 								} }
 							/>
 						}

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -33,6 +33,16 @@ const REDUCED_MOTION_TRANSITION_CONFIG = {
 
 const LAYOUT_ID = 'toggle-group-backdrop-shared-layout-id';
 
+const handleDisabledMouseEvent = (
+	event: React.MouseEvent,
+	disabled?: boolean
+) => {
+	if ( disabled ) {
+		event.stopPropagation();
+		event.preventDefault();
+	}
+};
+
 const WithToolTip = ( { showTooltip, text, children }: WithToolTipProps ) => {
 	if ( showTooltip && text ) {
 		return (
@@ -109,19 +119,35 @@ function ToggleGroupControlOptionBase(
 	);
 	const backdropClasses = useMemo( () => cx( styles.backdropView ), [ cx ] );
 
-	const buttonOnClick = () => {
-		if ( isDeselectable && isPressed ) {
-			toggleGroupControlContext.setValue( undefined );
-		} else {
-			toggleGroupControlContext.setValue( value );
-		}
-	};
-
 	const commonProps = {
 		...otherButtonProps,
 		className: itemClasses,
 		'data-value': value,
 		ref: forwardedRef,
+	};
+
+	const buttonOnMouseDown: React.MouseEventHandler< HTMLButtonElement > = (
+		event
+	) => {
+		handleDisabledMouseEvent( event, disabled );
+
+		commonProps.onMouseDown?.( event );
+	};
+
+	const buttonOnClick: React.MouseEventHandler< HTMLButtonElement > = (
+		event
+	) => {
+		handleDisabledMouseEvent( event, disabled );
+
+		if ( ! disabled ) {
+			if ( isDeselectable && isPressed ) {
+				toggleGroupControlContext.setValue( undefined );
+			} else {
+				toggleGroupControlContext.setValue( value );
+			}
+		}
+
+		commonProps.onClick?.( event );
 	};
 
 	return (
@@ -133,11 +159,12 @@ function ToggleGroupControlOptionBase(
 				{ isDeselectable ? (
 					<button
 						{ ...commonProps }
-						disabled={ disabled }
+						aria-disabled={ disabled }
 						onFocus={ onFocusProp }
 						aria-pressed={ isPressed }
 						type="button"
 						onClick={ buttonOnClick }
+						onMouseDown={ buttonOnMouseDown }
 					>
 						<ButtonContentView>{ children }</ButtonContentView>
 					</button>

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -143,6 +143,7 @@ function ToggleGroupControlOptionBase(
 					</button>
 				) : (
 					<Ariakit.Radio
+						accessibleWhenDisabled
 						disabled={ disabled }
 						render={
 							<button
@@ -153,7 +154,11 @@ function ToggleGroupControlOptionBase(
 									if ( event.defaultPrevented ) {
 										return;
 									}
-									toggleGroupControlContext.setValue( value );
+									if ( ! disabled ) {
+										toggleGroupControlContext.setValue(
+											value
+										);
+									}
 								} }
 							/>
 						}

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -64,6 +64,11 @@ export const buttonView = ( {
 		border: 0;
 	}
 
+	&[disabled] {
+		opacity: 0.4;
+		cursor: default;
+	}
+
 	&:active {
 		background: ${ CONFIG.toggleGroupControlBackgroundColor };
 	}

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -64,9 +64,28 @@ export const buttonView = ( {
 		border: 0;
 	}
 
-	&[disabled] {
-		opacity: 0.4;
+	&[disabled],
+	&[aria-disabled='true'] {
 		cursor: default;
+		${ ButtonContentView } {
+			opacity: 0.4;
+		}
+
+		/**
+		 * Show an additional focus ring for disabled radio items, since the
+		 * indicator won't follow keyboard focus. This is not an issue for non-radio
+		 * items, since the backdrop is already decoupled from keyboard focus.
+		 */
+		&[role='radio']:focus-visible::after {
+			position: absolute;
+			content: '';
+
+			/* y-axis inset matches the border width for good sub-pixel alignment */
+			inset: var( --wp-admin-border-width-focus ) 4px;
+			border-radius: 2px;
+			outline: var( --wp-admin-border-width-focus ) solid
+				${ COLORS.theme.accent };
+		}
 	}
 
 	&:active {

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -64,28 +64,9 @@ export const buttonView = ( {
 		border: 0;
 	}
 
-	&[disabled],
-	&[aria-disabled='true'] {
+	&[disabled] {
+		opacity: 0.4;
 		cursor: default;
-		${ ButtonContentView } {
-			opacity: 0.4;
-		}
-
-		/**
-		 * Show an additional focus ring for disabled radio items, since the
-		 * indicator won't follow keyboard focus. This is not an issue for non-radio
-		 * items, since the backdrop is already decoupled from keyboard focus.
-		 */
-		&[role='radio']:focus-visible::after {
-			position: absolute;
-			content: '';
-
-			/* y-axis inset matches the border width for good sub-pixel alignment */
-			inset: var( --wp-admin-border-width-focus ) 4px;
-			border-radius: 2px;
-			outline: var( --wp-admin-border-width-focus ) solid
-				${ COLORS.theme.accent };
-		}
 	}
 
 	&:active {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #57862
Closes #57862
New take on #34945

- Adds support for `disabled` option for the `ToggleGroupControl` component
- Adds styles for disabled options

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This was a missing feature in the component, a gap that should be filled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By forwarding the `disabled` prop to the correct internal components in the `ToggleGroupControlOptionBase` component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Review new unit tests and make sure they pass reliably;
- Edit the Storybook examples, by passing the `disabled` prop to some options, and interact with the component. Make sure that disabled option are correctly skipped and impossible to select

<details>

<summary>Here's a quick patch to test the storybook examples</summary>

```diff
diff --git a/packages/components/src/toggle-group-control/stories/index.story.tsx b/packages/components/src/toggle-group-control/stories/index.story.tsx
index 92f1e60762..3b9b9a400f 100644
--- a/packages/components/src/toggle-group-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.story.tsx
@@ -81,7 +81,7 @@ Default.args = {
 	children: [
 		{ value: 'left', label: 'Left' },
 		{ value: 'center', label: 'Center' },
-		{ value: 'right', label: 'Right' },
+		{ value: 'right', label: 'Right', disabled: true },
 		{ value: 'justify', label: 'Justify' },
 	].map( mapPropsToOptionComponent ),
 	isBlock: true,
@@ -125,7 +125,12 @@ WithIcons.args = {
 	...Default.args,
 	children: [
 		{ value: 'uppercase', label: 'Uppercase', icon: formatUppercase },
-		{ value: 'lowercase', label: 'Lowercase', icon: formatLowercase },
+		{
+			value: 'lowercase',
+			label: 'Lowercase',
+			icon: formatLowercase,
+			disabled: true,
+		},
 	].map( mapPropsToOptionIconComponent ),
 	isBlock: false,
 };

```
</details>

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/1083581/4b831aef-2915-4f87-b893-205def11d8ae" /> | <video src="https://github.com/WordPress/gutenberg/assets/1083581/6568467d-eb0d-4ddc-8116-a5b44c507ddc" /> |

## ✍️ Dev note

`ToggleGroupControlOption` components can now be marked as disabled via the newly added `disabled` prop. While disabled, an option cannot be selected by the end user.