### PR TITLE
DataViews: Fix field rendering

### DIFF
--- a/packages/dataviews/src/layouts/grid/index.tsx
+++ b/packages/dataviews/src/layouts/grid/index.tsx
@@ -53,6 +53,12 @@ function GridItem< Item >( {
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
+	const renderedMediaField = mediaField?.render ? (
+		<mediaField.render item={ item } />
+	) : null;
+	const renderedPrimaryField = primaryField?.render ? (
+		<primaryField.render item={ item } />
+	) : null;
 	return (
 		<VStack
 			spacing={ 0 }
@@ -76,7 +82,7 @@ function GridItem< Item >( {
 			} }
 		>
 			<div className="dataviews-view-grid__media">
-				{ mediaField?.render( { item } ) }
+				{ renderedMediaField }
 			</div>
 			<HStack
 				justify="space-between"
@@ -91,7 +97,7 @@ function GridItem< Item >( {
 					disabled={ ! hasBulkAction }
 				/>
 				<HStack className="dataviews-view-grid__primary-field">
-					{ primaryField?.render( { item } ) }
+					{ renderedPrimaryField }
 				</HStack>
 				<ItemActions item={ item } actions={ actions } isCompact />
 			</HStack>
@@ -104,18 +110,12 @@ function GridItem< Item >( {
 					justify="flex-start"
 				>
 					{ badgeFields.map( ( field ) => {
-						const renderedValue = field.render( {
-							item,
-						} );
-						if ( ! renderedValue ) {
-							return null;
-						}
 						return (
 							<FlexItem
 								key={ field.id }
 								className="dataviews-view-grid__field-value"
 							>
-								{ renderedValue }
+								<field.render item={ item } />
 							</FlexItem>
 						);
 					} ) }
@@ -124,12 +124,6 @@ function GridItem< Item >( {
 			{ !! visibleFields?.length && (
 				<VStack className="dataviews-view-grid__fields" spacing={ 1 }>
 					{ visibleFields.map( ( field ) => {
-						const renderedValue = field.render( {
-							item,
-						} );
-						if ( ! renderedValue ) {
-							return null;
-						}
 						return (
 							<Flex
 								className={ clsx(
@@ -157,7 +151,7 @@ function GridItem< Item >( {
 										className="dataviews-view-grid__field-value"
 										style={ { maxHeight: 'none' } }
 									>
-										{ renderedValue }
+										<field.render item={ item } />
 									</FlexItem>
 								</>
 							</Flex>

--- a/packages/dataviews/src/layouts/list/index.tsx
+++ b/packages/dataviews/src/layouts/list/index.tsx
@@ -112,6 +112,16 @@ function ListItem< Item >( {
 			? primaryAction.label
 			: primaryAction.label( [ item ] ) );
 
+	const renderedMediaField = mediaField?.render ? (
+		<mediaField.render item={ item } />
+	) : (
+		<div className="dataviews-view-list__media-placeholder"></div>
+	);
+
+	const renderedPrimaryField = primaryField?.render ? (
+		<primaryField.render item={ item } />
+	) : null;
+
 	return (
 		<CompositeRow
 			ref={ itemRef }
@@ -147,9 +157,7 @@ function ListItem< Item >( {
 							alignment="flex-start"
 						>
 							<div className="dataviews-view-list__media-wrapper">
-								{ mediaField?.render( { item } ) || (
-									<div className="dataviews-view-list__media-placeholder"></div>
-								) }
+								{ renderedMediaField }
 							</div>
 							<VStack
 								spacing={ 1 }
@@ -159,7 +167,7 @@ function ListItem< Item >( {
 									className="dataviews-view-list__primary-field"
 									id={ labelId }
 								>
-									{ primaryField?.render( { item } ) }
+									{ renderedPrimaryField }
 								</span>
 								<div
 									className="dataviews-view-list__fields"
@@ -177,7 +185,7 @@ function ListItem< Item >( {
 												{ field.header }
 											</VisuallyHidden>
 											<span className="dataviews-view-list__field-value">
-												{ field.render( { item } ) }
+												<field.render item={ item } />
 											</span>
 										</div>
 									) ) }

--- a/packages/dataviews/src/layouts/table/index.tsx
+++ b/packages/dataviews/src/layouts/table/index.tsx
@@ -360,23 +360,15 @@ function TableColumnField< Item >( {
 	item,
 	field,
 }: TableColumnFieldProps< Item > ) {
-	const value = field.render( {
-		item,
-	} );
 	return (
-		!! value && (
-			<div
-				className={ clsx(
-					'dataviews-view-table__cell-content-wrapper',
-					{
-						'dataviews-view-table__primary-field':
-							primaryField?.id === field.id,
-					}
-				) }
-			>
-				{ value }
-			</div>
-		)
+		<div
+			className={ clsx( 'dataviews-view-table__cell-content-wrapper', {
+				'dataviews-view-table__primary-field':
+					primaryField?.id === field.id,
+			} ) }
+		>
+			<field.render { ...{ item } } />
+		</div>
 	);
 }
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -244,6 +244,12 @@
 	}
 }
 
+.dataviews-view-table__cell-content-wrapper:empty,
+.dataviews-view-grid__field-value:empty,
+.dataviews-view-grid__field:empty {
+	display: none;
+}
+
 .dataviews-view-list__primary-field,
 .dataviews-view-grid__primary-field,
 .dataviews-view-table__primary-field {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactElement, ComponentType } from 'react';
 
 /**
  * Internal dependencies
@@ -73,7 +73,7 @@ export type Field< Item > = {
 	/**
 	 * Callback used to render the field. Defaults to `field.getValue`.
 	 */
-	render?: ( args: { item: Item } ) => ReactNode;
+	render?: ComponentType< { item: Item } >;
 
 	/**
 	 * Whether the field is sortable.
@@ -118,7 +118,7 @@ export type Field< Item > = {
 export type NormalizedField< Item > = Field< Item > & {
 	header: string;
 	getValue: ( args: { item: Item } ) => any;
-	render: ( args: { item: Item } ) => ReactNode;
+	render: ComponentType< { item: Item } >;
 };
 
 /**


### PR DESCRIPTION
Related #55083 

## What?

So it turns out that we were making a noob error when rendering the different fields of the dataviews, while the fields have `render` property that is supposed to be a component, we were not rendering it as a component, instead we were just calling it as a regular function. The problem with that is that if a render property was using `useSelect` or any other hook, it would result in errors as we enable/disable the fields. 

The other issue is that it might have had a bad impact on performance potentially as all React and useSelect optimizations were probably ignored.


## Testing Instructions

1- Open the "pages" data views
2- Toggle the "author" field on and off
3- it results in an error in trunk but this PR solves the issue.