### PR TITLE
Fix: Error when calling the PostActions `view-post` callback

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -947,7 +947,7 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 							existingCallback( items, {
 								...argsObject,
 								onActionPerformed: ( _items ) => {
-									if ( argsObject.onActionPerformed ) {
+									if ( argsObject?.onActionPerformed ) {
 										argsObject.onActionPerformed( _items );
 									}
 									onActionPerformed(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Closes https://github.com/WordPress/gutenberg/issues/63457

Fixes the error thrown when clicking PostActions View post in the editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/63120 we added support for `onActionPerformed` at action level, but I've observed the object is undefined in all the cases.

I could check. `onActionPerformed` is only used at hook level instead. If we need to remove the logic that unpacks `argsObject`, I'm happy to update this PR or open a new one.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a condition in case the callback options `argsObject` is undefined.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to edit a post. For example `/wp-admin/post.php?post=1&action=edit`.
2. Open the console in Chrome Dev Tools
3. Click in the three dots to open the Actions dropdown menu.
4. Click in View
5. Observe there are not any issues in the console
6. Observe the browser did open a new window with the post frontend

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/6f279685-fc39-48b9-b1de-09f1070e0491


**After**

https://github.com/user-attachments/assets/fd3df4f6-ad3c-4767-b683-5b96f058d532


