### PR TITLE
FlatTermSelector: Be more defensive about termIds

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -86,7 +86,7 @@ export function FlatTermSelector( { slug } ) {
 
 			const query = {
 				...DEFAULT_QUERY,
-				include: _termIds.join( ',' ),
+				include: _termIds?.join( ',' ),
 				per_page: -1,
 			};
 
@@ -103,7 +103,7 @@ export function FlatTermSelector( { slug } ) {
 					: false,
 				taxonomy: _taxonomy,
 				termIds: _termIds,
-				terms: _termIds.length
+				terms: _termIds?.length
 					? getEntityRecords( 'taxonomy', slug, query )
 					: EMPTY_ARRAY,
 				hasResolvedTerms: hasFinishedResolution( 'getEntityRecords', [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Be more defensive against bad data in `<FlatTermSelector>` that could cause a crash.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's possible (likely through a bug elsewhere) for `<FlatTermSelector>` to completely crash the editor if it can't get `termIds` from the post being edited. This change prevents that crash.

The error can happen when `<FlatTermSelector>` tries to access `_termIds.join` and `_termIds.length` even when `_termIds` is undefined. This is undefined if the [current editor state doesn't have any changes for the relevant attribute](https://github.com/WordPress/gutenberg/blob/4da057ecd6958d40b8f2a83db1152320e5f161e6/packages/editor/src/store/selectors.js#L329) and the [original post doesn't have the relevant attribute](https://github.com/WordPress/gutenberg/blob/4da057ecd6958d40b8f2a83db1152320e5f161e6/packages/editor/src/store/selectors.js#L276). This shouldn't be possible normally.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use the optional chaining operator.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

It's difficult to construct an artificial test case, but on the happy path then nothing should change at all, using the post tags in the sidebar when editing a post should continue to work exactly as it does now.
