### PR TITLE
Separate Command Palette (command + K) and Visible Template title buttons

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
+import { Button, VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
 	EditorKeyboardShortcutsRegister,
@@ -95,7 +95,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 				'trash',
 		};
 	}, [] );
-	useEditorTitle();
+	const editorTitle = useEditorTitle();
 	const _isPreviewingTheme = isPreviewingTheme();
 	const hasDefaultEditorCanvasView = ! useHasEditorCanvasContainer();
 	const iframeProps = useEditorIframeProps();
@@ -182,6 +182,11 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 
 	return (
 		<>
+			<VisuallyHidden as="h1">
+				{ editorTitle
+					? decodeEntities( editorTitle )
+					: __( 'No Title' ) }
+			</VisuallyHidden>
 			<GlobalStylesRenderer />
 			<EditorKeyboardShortcutsRegister />
 			{ isEditMode && <BlockKeyboardShortcuts /> }

--- a/packages/edit-site/src/components/editor/use-editor-title.js
+++ b/packages/edit-site/src/components/editor/use-editor-title.js
@@ -30,6 +30,8 @@ function useEditorTitle() {
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URLQueryController> from double-announcing.
 	useTitle( hasLoadedPost && title );
+
+	return title;
 }
 
 export default useEditorTitle;

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __, isRTL, sprintf } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
@@ -29,17 +29,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { TEMPLATE_POST_TYPES, GLOBAL_POST_TYPES } from '../../store/constants';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-
-const TYPE_LABELS = {
-	// translators: 1: Pattern title.
-	wp_pattern: __( 'Editing pattern: %s' ),
-	// translators: 1: Navigation menu title.
-	wp_navigation: __( 'Editing navigation menu: %s' ),
-	// translators: 1: Template title.
-	wp_template: __( 'Editing template: %s' ),
-	// translators: 1: Template part title.
-	wp_template_part: __( 'Editing template part: %s' ),
-};
 
 const MotionButton = motion( Button );
 
@@ -160,53 +149,49 @@ export default function DocumentBar( props ) {
 			{ isNotFound ? (
 				<Text>{ __( 'Document not found' ) }</Text>
 			) : (
-				<Button
+				<div
 					className="editor-document-bar__command"
-					onClick={ () => openCommandCenter() }
-					size="compact"
+					// Force entry animation when the back button is added or removed.
+					key={ hasBackButton }
+					initial={
+						mounted.current
+							? {
+									opacity: 0,
+									transform: hasBackButton
+										? 'translateX(15%)'
+										: 'translateX(-15%)',
+							  }
+							: false // Don't show entry animation when DocumentBar mounts.
+					}
+					animate={ {
+						opacity: 1,
+						transform: 'translateX(0%)',
+					} }
+					transition={ isReducedMotion ? { duration: 0 } : undefined }
 				>
-					<motion.div
+					<Button
 						className="editor-document-bar__title"
-						// Force entry animation when the back button is added or removed.
-						key={ hasBackButton }
-						initial={
-							mounted.current
-								? {
-										opacity: 0,
-										transform: hasBackButton
-											? 'translateX(15%)'
-											: 'translateX(-15%)',
-								  }
-								: false // Don't show entry animation when DocumentBar mounts.
-						}
-						animate={ {
-							opacity: 1,
-							transform: 'translateX(0%)',
-						} }
-						transition={
-							isReducedMotion ? { duration: 0 } : undefined
-						}
+						tabIndex="-1"
+						onClick={ () => openCommandCenter() }
+						size="compact"
 					>
 						<BlockIcon icon={ icon } />
-						<Text
-							size="body"
-							as="h1"
-							aria-label={
-								! props.title && TYPE_LABELS[ postType ]
-									? // eslint-disable-next-line @wordpress/valid-sprintf
-									  sprintf( TYPE_LABELS[ postType ], title )
-									: undefined
-							}
-						>
+						<Text size="body" as="span">
 							{ title
 								? decodeEntities( title )
 								: __( 'No Title' ) }
 						</Text>
-					</motion.div>
-					<span className="editor-document-bar__shortcut">
+					</Button>
+					<Button
+						onClick={ () => openCommandCenter() }
+						className="editor-document-bar__shortcut"
+						label={ __( 'Command palette' ) }
+						showTooltip
+						size="compact"
+					>
 						{ displayShortcut.primary( 'k' ) }
-					</span>
-				</Button>
+					</Button>
+				</div>
 			) }
 		</div>
 	);

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -14,16 +14,14 @@
 
 	&:hover {
 		background-color: $gray-200;
+		transition: all 0.1s ease-out;
+		@include reduce-motion("transition");
 	}
 
 	.components-button {
 		border-radius: $grid-unit-05;
 		transition: all 0.1s ease-out;
 		@include reduce-motion("transition");
-
-		&:hover {
-			background: $gray-200;
-		}
 	}
 
 	@include break-large() {
@@ -32,23 +30,27 @@
 }
 
 .editor-document-bar__command {
+	display: flex;
 	flex-grow: 1;
 	color: var(--wp-block-synced-color);
-	overflow: hidden;
+	position: relative;
 }
 
 .editor-document-bar__title {
-	flex-grow: 1;
 	overflow: hidden;
 	color: $gray-900;
-	gap: $grid-unit-05;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+	height: auto;
+	position: absolute;
+	padding-left: 0;
+	padding-right: 0;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	max-width: 70%;
 
-	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
-	@include break-medium() {
-		padding-left: $grid-unit-30;
+	&:focus:not(:disabled) {
+		outline: none;
+		box-shadow: none;
 	}
 
 	.editor-document-bar.is-global & {
@@ -60,11 +62,10 @@
 		flex-shrink: 0;
 	}
 
-	h1 {
+	span {
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: 70%;
 		color: currentColor;
 	}
 }
@@ -72,10 +73,15 @@
 .editor-document-bar__shortcut {
 	color: $gray-800;
 	min-width: $grid-unit-30;
-	display: none;
+	height: auto;
+	flex-grow: 2;
+	text-align: right;
+	position: relative; // This is always the button clicked, not the title.
+	z-index: 2;
+	display: initial;
 
-	@include break-medium() {
-		display: initial;
+	&:hover {
+		color: $gray-800;
 	}
 }
 
@@ -84,7 +90,7 @@
 	flex-shrink: 0;
 	color: $gray-700;
 	gap: 0;
-	z-index: 1;
+	z-index: 3;
 	position: absolute;
 
 	&:hover {


### PR DESCRIPTION
This is an odd one to keep the same design and account for improved accessibility. It's admittedly a hodgepodge. The shortcut button (Command + K) is a full-width button with the text aligned right. It has an aria-label tooltip of Command Palette so it can be accessed via a voice command of Command Palette or via the visible template name. The template name button is tabindex=-1 so it never receives focus and is also _behind_ the transparent Command + K button, so that a mouse click will always access the Command + K button and get the full width focus style. The H1 for the template name has been changed to a span. I'll add a visually hidden H1 in a follow-up commit.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
