### PR TITLE
Fix responsive behaviour so both column start and column span are taken into account

### DIFF
--- a/backport-changelog/6.7/6910.md
+++ b/backport-changelog/6.7/6910.md
@@ -4,3 +4,4 @@ https://github.com/WordPress/wordpress-develop/pull/6910
 * https://github.com/WordPress/gutenberg/pull/60652
 * https://github.com/WordPress/gutenberg/pull/62777
 * https://github.com/WordPress/gutenberg/pull/63108
+* https://github.com/WordPress/gutenberg/pull/63464

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -646,10 +646,18 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		if ( ( $column_span || $column_start ) && ( $minimum_column_width || ! $column_count ) ) {
 			$column_span_number  = floatval( $column_span );
 			$column_start_number = floatval( $column_start );
-			$highest_number      = max( $column_span_number, $column_start_number );
 			$parent_column_width = $minimum_column_width ? $minimum_column_width : '12rem';
 			$parent_column_value = floatval( $parent_column_width );
 			$parent_column_unit  = explode( $parent_column_value, $parent_column_width );
+
+			$num_cols_to_break_at = 2;
+			if ( $column_span_number && $column_start_number ) {
+				$num_cols_to_break_at = $column_start_number + $column_span_number - 1;
+			} elseif ( $column_span_number ) {
+				$num_cols_to_break_at = $column_span_number;
+			} else {
+				$num_cols_to_break_at = $column_start_number;
+			}
 
 			/*
 			 * If there is no unit, the width has somehow been mangled so we reset both unit and value
@@ -672,7 +680,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			 * viable to use in the computation of the container query value.
 			 */
 			$default_gap_value             = 'px' === $parent_column_unit ? 24 : 1.5;
-			$container_query_value         = $highest_number * $parent_column_value + ( $highest_number - 1 ) * $default_gap_value;
+			$container_query_value         = $num_cols_to_break_at * $parent_column_value + ( $num_cols_to_break_at - 1 ) * $default_gap_value;
 			$minimum_container_query_value = $parent_column_value * 2 + $default_gap_value - 1;
 			$container_query_value         = max( $container_query_value, $minimum_container_query_value ) . $parent_column_unit;
 			// If a span is set we want to preserve it as long as possible, otherwise we just reset the value.

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -119,11 +119,20 @@ function useBlockPropsChildLayoutStyles( { style } ) {
 				parentColumnUnit = 'rem';
 			}
 
-			const highestNumber = Math.max( columnSpan, columnStart );
+			let numColsToBreakAt = 2;
+
+			if ( columnSpan && columnStart ) {
+				numColsToBreakAt = columnSpan + columnStart - 1;
+			} else if ( columnSpan ) {
+				numColsToBreakAt = columnSpan;
+			} else {
+				numColsToBreakAt = columnStart;
+			}
+
 			const defaultGapValue = parentColumnUnit === 'px' ? 24 : 1.5;
 			const containerQueryValue =
-				highestNumber * parentColumnValue +
-				( highestNumber - 1 ) * defaultGapValue;
+				numColsToBreakAt * parentColumnValue +
+				( numColsToBreakAt - 1 ) * defaultGapValue;
 			// For blocks that only span one column, we want to remove any rowStart values as
 			// the container reduces in size, so that blocks are still arranged in markup order.
 			const minimumContainerQueryValue =


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Responsive behaviour in experimental manual grids is flaky, both because the breakpoint computation gets messed up when no `columnSpan` exists, and because we're currently only looking at the highest of `columnSpan` and `columnStart`, when ideally we should take both into account when they both exist.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the grid interactivity experiment.
2. Paste the following markup and resize the window to check its responsivity:

```
<!-- wp:group {"align":"full","layout":{"type":"grid","columnCount":5,"rowCount":5,"isManualPlacement":true,"minimumColumnWidth":"12rem"}} -->
<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"layout":{"columnSpan":1,"rowSpan":1,"columnStart":1,"rowStart":1}},"backgroundColor":"contrast-2"} -->
<p class="has-contrast-2-background-color has-background">this is inside a </p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnSpan":1,"rowSpan":1,"columnStart":2,"rowStart":1}},"backgroundColor":"contrast-2"} -->
<p class="has-contrast-2-background-color has-background">~GRIDDDgri</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":4,"rowStart":1},"color":{"background":"#411c1c"}}} -->
<p class="has-background" style="background-color:#411c1c">sdsdfgs</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":2,"rowStart":2,"columnSpan":3,"rowSpan":1},"color":{"background":"#4c9052"}}} -->
<p class="has-background" style="background-color:#4c9052">zdfgdfagfd</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":1,"rowStart":3},"color":{"background":"#3a6b3a"}}} -->
<p class="has-background" style="background-color:#3a6b3a">dfgd</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":3,"rowStart":3},"color":{"background":"#8b4f4f"}}} -->
<p class="has-background" style="background-color:#8b4f4f">zdfgdfagfd</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":1,"rowStart":4}}} -->
<p>adfadfgafdg</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":1,"rowStart":4},"color":{"background":"#592b2b"}}} -->
<p class="has-background" style="background-color:#592b2b">sdgf</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnSpan":1,"rowSpan":1,"columnStart":3,"rowStart":4}},"backgroundColor":"contrast-3"} -->
<p class="has-contrast-3-background-color has-background">a bloc</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":4,"rowStart":4}}} -->
<p>sgd</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":4,"rowStart":3,"columnSpan":1,"rowSpan":2}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">sdg</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":1,"rowStart":5},"color":{"background":"#835b1a"}}} -->
<p class="has-background" style="background-color:#835b1a">sgfdsfdgsgsdg</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":2,"rowStart":5,"columnSpan":2,"rowSpan":1},"color":{"background":"#828282"}}} -->
<p class="has-background" style="background-color:#828282">sgdf</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
