### PR TITLE
Pattern Inserter: Fix pagination layout when "Show button text labels" enabled

### DIFF
--- a/packages/block-editor/src/components/block-patterns-paging/style.scss
+++ b/packages/block-editor/src/components/block-patterns-paging/style.scss
@@ -24,11 +24,6 @@
 
 .show-icon-labels {
 	.block-editor-patterns__grid-pagination {
-		flex-direction: column;
-		.block-editor-patterns__grid-pagination-previous,
-		.block-editor-patterns__grid-pagination-next {
-			flex-direction: column;
-		}
 		.components-button {
 			width: auto;
 			// Hide the button icons when labels are set to display...
@@ -41,23 +36,5 @@
 				content: attr(aria-label);
 			}
 		}
-	}
-
-	@media screen and (min-width: $break-large) {
-		.block-editor-patterns__grid-pagination {
-			flex-direction: row;
-			.block-editor-patterns__grid-pagination-previous,
-			.block-editor-patterns__grid-pagination-next {
-				flex-direction: row;
-			}
-		}
-	}
-}
-
-.block-editor-block-patterns-list .block-editor-patterns__grid-pagination {
-	flex-direction: column;
-	.block-editor-patterns__grid-pagination-previous,
-	.block-editor-patterns__grid-pagination-next {
-		flex-direction: column;
 	}
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -698,3 +698,23 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 }
+
+.show-icon-labels {
+	@media (max-width: #{ ($break-large - 1) }) {
+		.block-editor-block-patterns-explorer .block-editor-patterns__grid-pagination {
+			flex-direction: column;
+			.block-editor-patterns__grid-pagination-previous,
+			.block-editor-patterns__grid-pagination-next {
+				flex-direction: column;
+			}
+		}
+	}
+
+	.block-editor-inserter__category-panel .block-editor-patterns__grid-pagination {
+		flex-direction: column;
+		.block-editor-patterns__grid-pagination-previous,
+		.block-editor-patterns__grid-pagination-next {
+			flex-direction: column;
+		}
+	}
+}


### PR DESCRIPTION
Fixes issue introduced by #61776

## What?

This PR fixes the layout of pattern inserter pagination. If "Show button text labels" is disabled, the pagination should always be aligned horizontally.

![image](https://github.com/user-attachments/assets/5f5e1e5e-26c8-44ef-a012-5cd3a08598cf)

## Why?

[The styles here](https://github.com/WordPress/gutenberg/pull/61776/files#diff-d2bc0405a277997c32b9ecf01edb12551304959eb744c0bff96c3d483a10bc90R57-R63) are applied regardless of whether "Show button text labels" is enabled, so the pagination is always aligned vertically, which is unintentional.

## How?

Fixed to change the layout appropriately only if "Show button text labels" is enabled.

Also, these layout styles depend on where and what component the pagination is rendered, so I don't think it's appropriate to define them on the pagination component itself.

Therefore, I moved the layout styles into a stylesheet that covers both the Pattern Inserter and the Pattern Explorer.

## Testing Instructions

Test the following scenarios:

### Pattern Inserter

#### "Show button text labels" is disabled

It should always be horizontally aligned

![inserter-disabled](https://github.com/user-attachments/assets/fb293aa5-0fc9-4dd0-9f1c-23a9a445c192)

#### "Show button text labels" is enabled

It should always be vertically aligned

![inserter-enabled](https://github.com/user-attachments/assets/43c9e7df-79f8-4f4f-8059-024d835d05f7)

### Pattern Explorer

#### "Show button text labels" is disabled

It should always be horizontally aligned

![pattern-explorer-disabled](https://github.com/user-attachments/assets/59c50b21-9a6e-4582-ae1b-db79255bfc12)

#### "Show button text labels" is enabled

If the browser width is 960px or more, it should be aligned horizontally, otherwise it should be aligned vertically.

![pattern-explorer-enabled-wide](https://github.com/user-attachments/assets/bcd42293-f2e4-4b2e-af02-da8fda83a63f)

![pattern-explorer-enabled-narrow](https://github.com/user-attachments/assets/994a0c43-df40-40bf-bd7c-26b54ba61723)


