### PR TITLE
Core Data: Use meta-store actions for resolution status

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -281,16 +281,10 @@ export const getEntityRecords =
 						.filter( ( record ) => record?.[ key ] )
 						.map( ( record ) => [ kind, name, record[ key ] ] );
 
-					dispatch( {
-						type: 'START_RESOLUTIONS',
-						selectorName: 'getEntityRecord',
-						args: resolutionsArgs,
-					} );
-					dispatch( {
-						type: 'FINISH_RESOLUTIONS',
-						selectorName: 'getEntityRecord',
-						args: resolutionsArgs,
-					} );
+					dispatch.finishResolutions(
+						'getEntityRecord',
+						resolutionsArgs
+					);
 				}
 
 				dispatch.__unstableReleaseStoreLock( lock );
@@ -856,16 +850,8 @@ export const getRevisions =
 						record[ key ],
 					] );
 
-				dispatch( {
-					type: 'START_RESOLUTIONS',
-					selectorName: 'getRevision',
-					args: resolutionsArgs,
-				} );
-				dispatch( {
-					type: 'FINISH_RESOLUTIONS',
-					selectorName: 'getRevision',
-					args: resolutionsArgs,
-				} );
+				dispatch.startResolutions( 'getRevision', resolutionsArgs );
+				dispatch.finishResolutions( 'getRevision', resolutionsArgs );
 			}
 		}
 	};

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -211,10 +211,12 @@ describe( 'getEntityRecords', () => {
 	} );
 
 	it( 'marks specific entity records as resolved', async () => {
+		const finishResolutions = jest.fn();
 		const dispatch = Object.assign( jest.fn(), {
 			receiveEntityRecords: jest.fn(),
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
+			finishResolutions,
 		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( ENTITIES );
@@ -230,16 +232,9 @@ describe( 'getEntityRecords', () => {
 		} );
 
 		// The record should have been received.
-		expect( dispatch ).toHaveBeenCalledWith( {
-			type: 'START_RESOLUTIONS',
-			selectorName: 'getEntityRecord',
-			args: [ [ ENTITIES[ 1 ].kind, ENTITIES[ 1 ].name, 2 ] ],
-		} );
-		expect( dispatch ).toHaveBeenCalledWith( {
-			type: 'FINISH_RESOLUTIONS',
-			selectorName: 'getEntityRecord',
-			args: [ [ ENTITIES[ 1 ].kind, ENTITIES[ 1 ].name, 2 ] ],
-		} );
+		expect( finishResolutions ).toHaveBeenCalledWith( 'getEntityRecord', [
+			[ ENTITIES[ 1 ].kind, ENTITIES[ 1 ].name, 2 ],
+		] );
 	} );
 } );
 


### PR DESCRIPTION
## What?
PR replaces hardcoded dispatches with meta-store actions for resolution status.

## Testing Instructions
CI checks should be green.

### Testing Instructions for Keyboard
Same.
