### PR TITLE
Try: Overlay caption w. text-shadow.

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -43,19 +43,43 @@ figure.wp-block-gallery.has-nested-images {
 			width: auto;
 		}
 
-		figcaption {
-			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
-			bottom: 0;
-			color: $white;
-			font-size: $default-font-size;
-			left: 0;
-			margin-bottom: 0;
-			max-height: 60%;
-			overflow: auto;
-			padding: 0 8px 8px;
+		// Position caption and scrim at the bottom.
+		figcaption,
+		figcaption::after {
 			position: absolute;
+			bottom: 0;
+			right: 0;
+			left: 0;
+			max-height: 80%;
+		}
+
+		// Put the scrim on its own layer.
+		figcaption::after {
+			content: "";
+			z-index: -1;
+			height: 100%;
+			max-height: none;
+
+			// Dark gradient scrim. This can just be a solid color, as the mask will make it a
+			//background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.6) 0, rgba($color: $black, $alpha: 0.3) 50%, transparent);
+			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, rgba($color: $black, $alpha: 0.2) 100%, transparent);
+			//filter: blur(10px);
+
+			// Blur the background under the gradient scrim.
+			backdrop-filter: blur(4px);
+
+			// Crop the caption so the blur is only on the edge.
+			mask-image: linear-gradient(0deg, rgba($color: $black, $alpha: 1) 20%, rgba($color: $black, $alpha: 0) 100%);
+		}
+
+		figcaption {
+			color: $white;
+			text-shadow: 0 0 1.5px rgba($color: $black, $alpha: 0.8);
+			font-size: $default-font-size;
+			margin: 0;
+			overflow: auto;
+			padding: 1em;
 			text-align: center;
-			width: 100%;
 			box-sizing: border-box;
 			@include custom-scrollbars-on-hover(transparent, rgba($white, 0.8));
 

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -79,7 +79,6 @@ figure.wp-block-gallery.has-nested-images {
 			@include custom-scrollbars-on-hover(transparent, rgba($white, 0.8));
 
 			// Dark gradient scrim.
-			//background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, rgba($color: $black, $alpha: 0) 100%, transparent);
 			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, transparent 100%);
 
 			img {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -56,12 +56,11 @@ figure.wp-block-gallery.has-nested-images {
 		// Create a background blur layer.
 		&:has(figcaption)::before {
 			content: "";
-			z-index: 0;
 			height: 100%;
 			max-height: 40%;
 
 			// Blur the background under the gradient scrim.
-			backdrop-filter: blur(4px);
+			backdrop-filter: blur(3px);
 
 			// Crop the caption so the blur is only on the edge.
 			mask-image: linear-gradient(0deg, rgba($color: $black, $alpha: 1) 20%, rgba($color: $black, $alpha: 0) 100%);
@@ -69,9 +68,8 @@ figure.wp-block-gallery.has-nested-images {
 
 		// Place the caption at the bottom.
 		figcaption {
-			z-index: 1;
 			color: $white;
-			text-shadow: 0 0 1.5px rgba($color: $black, $alpha: 1);
+			text-shadow: 0 0 1.5px $black;
 			font-size: $default-font-size;
 			margin: 0;
 			overflow: auto;
@@ -81,7 +79,8 @@ figure.wp-block-gallery.has-nested-images {
 			@include custom-scrollbars-on-hover(transparent, rgba($white, 0.8));
 
 			// Dark gradient scrim.
-			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, rgba($color: $black, $alpha: 0) 100%, transparent);
+			//background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, rgba($color: $black, $alpha: 0) 100%, transparent);
+			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, transparent 100%);
 
 			img {
 				display: inline;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -44,7 +44,7 @@ figure.wp-block-gallery.has-nested-images {
 		}
 
 		// Position caption and scrim at the bottom.
-		&:has(figcaption)::after,
+		&:has(figcaption)::before,
 		figcaption {
 			position: absolute;
 			bottom: 0;
@@ -54,7 +54,7 @@ figure.wp-block-gallery.has-nested-images {
 		}
 
 		// Create a background blur layer.
-		&:has(figcaption)::after {
+		&:has(figcaption)::before {
 			content: "";
 			z-index: 0;
 			height: 100%;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -109,6 +109,10 @@ figure.wp-block-gallery.has-nested-images {
 				margin: 0;
 				padding: 10px 10px 9px;
 				position: relative;
+				text-shadow: none;
+			}
+			&::before {
+				content: none;
 			}
 		}
 	}

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -63,7 +63,7 @@ figure.wp-block-gallery.has-nested-images {
 			backdrop-filter: blur(3px);
 
 			// Crop the caption so the blur is only on the edge.
-			mask-image: linear-gradient(0deg, rgba($color: $black, $alpha: 1) 20%, rgba($color: $black, $alpha: 0) 100%);
+			mask-image: linear-gradient(0deg, $black 20%, transparent 100%);
 		}
 
 		// Place the caption at the bottom.

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -44,26 +44,21 @@ figure.wp-block-gallery.has-nested-images {
 		}
 
 		// Position caption and scrim at the bottom.
-		figcaption,
-		figcaption::after {
+		&:has(figcaption)::after,
+		figcaption {
 			position: absolute;
 			bottom: 0;
 			right: 0;
 			left: 0;
-			max-height: 80%;
+			max-height: 100%;
 		}
 
-		// Put the scrim on its own layer.
-		figcaption::after {
+		// Create a background blur layer.
+		&:has(figcaption)::after {
 			content: "";
-			z-index: -1;
+			z-index: 0;
 			height: 100%;
-			max-height: none;
-
-			// Dark gradient scrim. This can just be a solid color, as the mask will make it a
-			//background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.6) 0, rgba($color: $black, $alpha: 0.3) 50%, transparent);
-			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, rgba($color: $black, $alpha: 0.2) 100%, transparent);
-			//filter: blur(10px);
+			max-height: 40%;
 
 			// Blur the background under the gradient scrim.
 			backdrop-filter: blur(4px);
@@ -72,7 +67,9 @@ figure.wp-block-gallery.has-nested-images {
 			mask-image: linear-gradient(0deg, rgba($color: $black, $alpha: 1) 20%, rgba($color: $black, $alpha: 0) 100%);
 		}
 
+		// Place the caption at the bottom.
 		figcaption {
+			z-index: 1;
 			color: $white;
 			text-shadow: 0 0 1.5px rgba($color: $black, $alpha: 1);
 			font-size: $default-font-size;
@@ -82,6 +79,9 @@ figure.wp-block-gallery.has-nested-images {
 			text-align: center;
 			box-sizing: border-box;
 			@include custom-scrollbars-on-hover(transparent, rgba($white, 0.8));
+
+			// Dark gradient scrim.
+			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, rgba($color: $black, $alpha: 0) 100%, transparent);
 
 			img {
 				display: inline;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -74,7 +74,7 @@ figure.wp-block-gallery.has-nested-images {
 
 		figcaption {
 			color: $white;
-			text-shadow: 0 0 1.5px rgba($color: $black, $alpha: 0.8);
+			text-shadow: 0 0 1.5px rgba($color: $black, $alpha: 1);
 			font-size: $default-font-size;
 			margin: 0;
 			overflow: auto;


### PR DESCRIPTION
## What?

Try to make progress on #8030 and #56587 by improving the caption style.

The current dark scrim is a very dark gradient to aid legibility for the white text on light backgrounds, however the sharpness of the gradient itself makes the legibility sub-optimal:

![overlay-caption-before](https://github.com/user-attachments/assets/258e59c6-5836-438b-bd2f-601eaaa127de)

This PR does a few things to keep the spirit of the same style, but improves it by:

* Adding a small text-shadow to the text itself.
* Applying a backdrop-blur to allow the text silhouette to avoid conflicts with complex imagery below.
* Changes the padding to be em based, and slightly more relaxed.
* Changes the color stops of the gradients to afford better contrast not just when it's one line of text, but multiple lines as well.

![overlay-caption-after](https://github.com/user-attachments/assets/82963571-a8af-43cc-b685-490e4976e1bf)

## Testing Instructions

Insert galleries with overlay captions.
