### PR TITLE
Term description and Author biography blocks: fix placeholder content when context is present

### DIFF
--- a/packages/block-library/src/post-author-biography/edit.js
+++ b/packages/block-library/src/post-author-biography/edit.js
@@ -10,31 +10,22 @@ import {
 	AlignmentControl,
 	BlockControls,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as coreStore } from '@wordpress/core-data';
 
 function PostAuthorBiographyEdit( {
-	context: { postType, postId },
 	attributes: { textAlign },
 	setAttributes,
 } ) {
-	const { authorDetails } = useSelect(
-		( select ) => {
-			const { getEditedEntityRecord, getUser } = select( coreStore );
-			const _authorId = getEditedEntityRecord(
-				'postType',
-				postType,
-				postId
-			)?.author;
-
-			return {
-				authorDetails: _authorId ? getUser( _authorId ) : null,
-			};
-		},
-		[ postType, postId ]
-	);
+	const { authorDetails } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const { __experimentalArchiveDescription } = getSettings();
+		return {
+			authorDetails: __experimentalArchiveDescription,
+		};
+	} );
 
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -42,8 +33,7 @@ function PostAuthorBiographyEdit( {
 		} ),
 	} );
 
-	const displayAuthorBiography =
-		authorDetails?.description || __( 'Author Biography' );
+	const displayAuthorBiography = authorDetails || __( 'Author Biography' );
 
 	return (
 		<>

--- a/packages/block-library/src/post-author-biography/edit.js
+++ b/packages/block-library/src/post-author-biography/edit.js
@@ -14,18 +14,37 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 function PostAuthorBiographyEdit( {
+	context: { postType, postId },
 	attributes: { textAlign },
 	setAttributes,
 } ) {
-	const { authorDetails } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const { __experimentalArchiveDescription } = getSettings();
-		return {
-			authorDetails: __experimentalArchiveDescription,
-		};
-	} );
+	const { authorBiography } = useSelect(
+		( select ) => {
+			let authorDetails;
+			let biography;
+			if ( postType && postId ) {
+				const { getEditedEntityRecord, getUser } = select( coreStore );
+				const _authorId = getEditedEntityRecord(
+					'postType',
+					postType,
+					postId
+				)?.author;
+				authorDetails = _authorId ? getUser( _authorId ) : null;
+				biography = authorDetails?.description;
+			} else {
+				const { getSettings } = select( blockEditorStore );
+				const { __experimentalArchiveDescription } = getSettings();
+				biography = __experimentalArchiveDescription;
+			}
+			return {
+				authorBiography: biography,
+			};
+		},
+		[ postType, postId ]
+	);
 
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -33,7 +52,7 @@ function PostAuthorBiographyEdit( {
 		} ),
 	} );
 
-	const displayAuthorBiography = authorDetails || __( 'Author Biography' );
+	const displayAuthorBiography = authorBiography || __( 'Author Biography' );
 
 	return (
 		<>

--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -11,6 +11,9 @@
 			"type": "string"
 		}
 	},
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,

--- a/packages/block-library/src/term-description/edit.js
+++ b/packages/block-library/src/term-description/edit.js
@@ -11,13 +11,22 @@ import {
 	useBlockProps,
 	BlockControls,
 	AlignmentControl,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 export default function TermDescriptionEdit( {
 	attributes,
 	setAttributes,
 	mergedStyle,
 } ) {
+	const { ArchiveDescription } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const { __experimentalArchiveDescription } = getSettings();
+		return {
+			ArchiveDescription: __experimentalArchiveDescription,
+		};
+	} );
 	const { textAlign } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -25,6 +34,9 @@ export default function TermDescriptionEdit( {
 		} ),
 		style: mergedStyle,
 	} );
+
+	const termDescription = ArchiveDescription || __( 'Term Description' );
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -37,7 +49,7 @@ export default function TermDescriptionEdit( {
 			</BlockControls>
 			<div { ...blockProps }>
 				<div className="wp-block-term-description__placeholder">
-					<span>{ __( 'Term Description' ) }</span>
+					<span>{ termDescription }</span>
 				</div>
 			</div>
 		</>

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -60,9 +60,11 @@ function useArchiveLabel( templateSlug ) {
 				select( coreStore );
 			let archiveTypeLabel;
 			let archiveNameLabel;
+			let archiveDescription;
 			if ( taxonomy ) {
 				archiveTypeLabel =
 					getTaxonomy( taxonomy )?.labels?.singular_name;
+				archiveDescription = getTaxonomy( taxonomy )?.description;
 			}
 			if ( term ) {
 				const records = getEntityRecords( 'taxonomy', taxonomy, {
@@ -71,6 +73,7 @@ function useArchiveLabel( templateSlug ) {
 				} );
 				if ( records && records[ 0 ] ) {
 					archiveNameLabel = records[ 0 ].name;
+					archiveDescription = records[ 0 ].description;
 				}
 			}
 			if ( isAuthor ) {
@@ -79,12 +82,14 @@ function useArchiveLabel( templateSlug ) {
 					const authorRecords = getAuthors( { slug: authorSlug } );
 					if ( authorRecords && authorRecords[ 0 ] ) {
 						archiveNameLabel = authorRecords[ 0 ].name;
+						archiveDescription = authorRecords[ 0 ].description;
 					}
 				}
 			}
 			return {
 				archiveTypeLabel,
 				archiveNameLabel,
+				archiveDescription,
 			};
 		},
 		[ authorSlug, isAuthor, taxonomy, term ]
@@ -165,6 +170,7 @@ export function useSpecificEditorSettings() {
 			// I wonder if they should be set in the post editor too
 			__experimentalArchiveTitleTypeLabel: archiveLabels.archiveTypeLabel,
 			__experimentalArchiveTitleNameLabel: archiveLabels.archiveNameLabel,
+			__experimentalArchiveDescription: archiveLabels.archiveDescription,
 			__unstableIsPreviewMode: canvasMode === 'view',
 		};
 	}, [
@@ -175,6 +181,7 @@ export function useSpecificEditorSettings() {
 		onNavigateToPreviousEntityRecord,
 		archiveLabels.archiveTypeLabel,
 		archiveLabels.archiveNameLabel,
+		archiveLabels.archiveDescription,
 	] );
 
 	return defaultEditorSettings;

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -85,6 +85,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableIsBlockBasedTheme',
 	'__experimentalArchiveTitleTypeLabel',
 	'__experimentalArchiveTitleNameLabel',
+	'__experimentalArchiveDescription',
 ];
 
 const {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When adding a block preview example to the Term description block I noticed that even when given context, the block does not render the value of the description, just a placeholder. This adds the correct content when context is given and fixes the same problem on the Author biography block

Part of https://github.com/WordPress/gutenberg/issues/30029

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because whenever we have real content that is preferable to generic placeholder text

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I'm extending how we already do the name and label for Archive terms in blocks like the query title.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a new template for a category or tag that has a description
2. Insert the Term description block. The preview should show the description. The inserted block should too
3. Create a new template for a specific author that has a bio
4. Insert the Author biography block, it should show the bio

If we do the same steps for categories/tags/authors that don't have bio/description, the placeholder should show instead.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Author with bio:

<img width="1151" alt="Screenshot 2024-07-12 at 11 02 17" src="https://github.com/user-attachments/assets/8d2566eb-e299-4d9a-9994-b3ffa38cc090">

Preview:
<img width="842" alt="Screenshot 2024-07-12 at 11 02 26" src="https://github.com/user-attachments/assets/c76e042b-5813-44e5-8213-d67bf7b1727c">

Tag with description:
<img width="1172" alt="Screenshot 2024-07-12 at 11 02 45" src="https://github.com/user-attachments/assets/ef290bee-2ddc-4a9b-93c7-a2c943a91dc5">

Preview:
<img width="797" alt="Screenshot 2024-07-12 at 11 02 51" src="https://github.com/user-attachments/assets/59d6f211-57e8-4423-b590-847732375e6b">

Category with description:
<img width="1064" alt="Screenshot 2024-07-12 at 11 03 17" src="https://github.com/user-attachments/assets/8dfc7229-9e4c-44d3-95a0-5400cfe84515">

Category without description:
<img width="1194" alt="Screenshot 2024-07-12 at 11 03 50" src="https://github.com/user-attachments/assets/13b25b27-2a74-4e66-8c02-c03b1f2683b2">
