### PR TITLE
Query Loop: Fix 'block' scoped variations to get the `query` defaults

### DIFF
--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -122,6 +122,7 @@ function QueryVariationPicker( {
 						setAttributes( {
 							...variation.attributes,
 							query: {
+								...attributes.query,
 								...variation.attributes.query,
 								postType:
 									attributes.query.postType ||

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -25,7 +25,6 @@ export default function QueryPlaceholder( {
 	clientId,
 	name,
 	openPatternSelectionModal,
-	setAttributes,
 } ) {
 	const [ isStartingBlank, setIsStartingBlank ] = useState( false );
 	const blockProps = useBlockProps();
@@ -64,7 +63,6 @@ export default function QueryPlaceholder( {
 			<QueryVariationPicker
 				clientId={ clientId }
 				attributes={ attributes }
-				setAttributes={ setAttributes }
 				icon={ icon }
 				label={ label }
 			/>
@@ -101,13 +99,7 @@ export default function QueryPlaceholder( {
 	);
 }
 
-function QueryVariationPicker( {
-	clientId,
-	attributes,
-	setAttributes,
-	icon,
-	label,
-} ) {
+function QueryVariationPicker( { clientId, attributes, icon, label } ) {
 	const scopeVariations = useScopedBlockVariations( attributes );
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const blockProps = useBlockProps();
@@ -118,19 +110,6 @@ function QueryVariationPicker( {
 				label={ label }
 				variations={ scopeVariations }
 				onSelect={ ( variation ) => {
-					if ( variation.attributes ) {
-						setAttributes( {
-							...variation.attributes,
-							query: {
-								...attributes.query,
-								...variation.attributes.query,
-								postType:
-									attributes.query.postType ||
-									variation.attributes.query.postType,
-							},
-							namespace: attributes.namespace,
-						} );
-					}
 					if ( variation.innerBlocks ) {
 						replaceInnerBlocks(
 							clientId,

--- a/test/e2e/specs/editor/various/is-typing.spec.js
+++ b/test/e2e/specs/editor/various/is-typing.spec.js
@@ -53,6 +53,9 @@ test.describe( 'isTyping', () => {
 			.getByRole( 'button', { name: 'Title & Date' } )
 			.click();
 
+		await editor.openDocumentSettingsSidebar();
+		await page.getByLabel( 'Inherit query from template' ).click();
+
 		// Moving the mouse shows the toolbar.
 		await editor.showBlockToolbar();
 		// Open the dropdown.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/63353

The intention of the linked PR was to allow the `block` scoped Query Loop variations to get the default query values and especially the `inherit: true` value. That PR did would normally work, but with the nuances of `object` handling attributes in GB and specifically also in Query Loop which has [other nuances](https://github.com/WordPress/gutenberg/pull/43285), we need to make the changes in this PR too.





## Testing Instructions
1- Insert Query Loop block
2- Click "Start blank"
3- Pick one of the proposed variations
4- Notice that the inserted query has the "inherit" toggle enabled.

