### PR TITLE
Query Title block: Rely on the editor store to apply the right archive title placeholder.

### DIFF
--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -13,11 +13,14 @@ import {
 	useBlockProps,
 	Warning,
 	HeadingLevelDropdown,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { ToggleControl, PanelBody } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useArchiveLabel } from './use-archive-label';
 
 const SUPPORTED_TYPES = [ 'archive', 'search' ];
 
@@ -25,17 +28,7 @@ export default function QueryTitleEdit( {
 	attributes: { type, level, textAlign, showPrefix, showSearchTerm },
 	setAttributes,
 } ) {
-	const { archiveTypeTitle, archiveNameLabel } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const {
-			__experimentalArchiveTitleNameLabel,
-			__experimentalArchiveTitleTypeLabel,
-		} = getSettings();
-		return {
-			archiveTypeTitle: __experimentalArchiveTitleTypeLabel,
-			archiveNameLabel: __experimentalArchiveTitleNameLabel,
-		};
-	} );
+	const { archiveTypeLabel, archiveNameLabel } = useArchiveLabel();
 
 	const TagName = `h${ level }`;
 	const blockProps = useBlockProps( {
@@ -55,20 +48,20 @@ export default function QueryTitleEdit( {
 	let titleElement;
 	if ( type === 'archive' ) {
 		let title;
-		if ( archiveTypeTitle ) {
+		if ( archiveTypeLabel ) {
 			if ( showPrefix ) {
 				if ( archiveNameLabel ) {
 					title = sprintf(
 						/* translators: 1: Archive type title e.g: "Category", 2: Label of the archive e.g: "Shoes" */
 						__( '%1$s: %2$s' ),
-						archiveTypeTitle,
+						archiveTypeLabel,
 						archiveNameLabel
 					);
 				} else {
 					title = sprintf(
 						/* translators: %s: Archive type title e.g: "Category", "Tag"... */
 						__( '%s: Name' ),
-						archiveTypeTitle
+						archiveTypeLabel
 					);
 				}
 			} else if ( archiveNameLabel ) {
@@ -77,7 +70,7 @@ export default function QueryTitleEdit( {
 				title = sprintf(
 					/* translators: %s: Archive type title e.g: "Category", "Tag"... */
 					__( '%s name' ),
-					archiveTypeTitle
+					archiveTypeLabel
 				);
 			}
 		} else {

--- a/packages/block-library/src/query-title/use-archive-label.js
+++ b/packages/block-library/src/query-title/use-archive-label.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+export function useArchiveLabel() {
+	const templateSlug = useSelect( ( select ) => {
+		// @wordpress/block-library should not depend on @wordpress/editor.
+		// Blocks can be loaded into a *non-post* block editor, so to avoid
+		// declaring @wordpress/editor as a dependency, we must access its
+		// store by string.
+		// The solution here is to split WP specific blocks from generic blocks.
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
+		const { getCurrentPostId, getCurrentPostType, getCurrentTemplateId } =
+			select( 'core/editor' );
+		const currentPostType = getCurrentPostType();
+		const templateId =
+			getCurrentTemplateId() ||
+			( currentPostType === 'wp_template' ? getCurrentPostId() : null );
+
+		return templateId
+			? select( coreStore ).getEditedEntityRecord(
+					'postType',
+					'wp_template',
+					templateId
+			  )?.slug
+			: null;
+	}, [] );
+	const taxonomyMatches = templateSlug?.match(
+		/^(category|tag|taxonomy-([^-]+))$|^(((category|tag)|taxonomy-([^-]+))-(.+))$/
+	);
+	let taxonomy;
+	let term;
+	let isAuthor = false;
+	let authorSlug;
+	if ( taxonomyMatches ) {
+		// If is for a all taxonomies of a type
+		if ( taxonomyMatches[ 1 ] ) {
+			taxonomy = taxonomyMatches[ 2 ]
+				? taxonomyMatches[ 2 ]
+				: taxonomyMatches[ 1 ];
+		}
+		// If is for a all taxonomies of a type
+		else if ( taxonomyMatches[ 3 ] ) {
+			taxonomy = taxonomyMatches[ 6 ]
+				? taxonomyMatches[ 6 ]
+				: taxonomyMatches[ 4 ];
+			term = taxonomyMatches[ 7 ];
+		}
+		taxonomy = taxonomy === 'tag' ? 'post_tag' : taxonomy;
+
+		//getTaxonomy( 'category' );
+		//wp.data.select('core').getEntityRecords( 'taxonomy', 'category', {slug: 'newcat'} );
+	} else {
+		const authorMatches = templateSlug?.match( /^(author)$|^author-(.+)$/ );
+		if ( authorMatches ) {
+			isAuthor = true;
+			if ( authorMatches[ 2 ] ) {
+				authorSlug = authorMatches[ 2 ];
+			}
+		}
+	}
+	return useSelect(
+		( select ) => {
+			const { getEntityRecords, getTaxonomy, getAuthors } =
+				select( coreStore );
+			let archiveTypeLabel;
+			let archiveNameLabel;
+			if ( taxonomy ) {
+				archiveTypeLabel =
+					getTaxonomy( taxonomy )?.labels?.singular_name;
+			}
+			if ( term ) {
+				const records = getEntityRecords( 'taxonomy', taxonomy, {
+					slug: term,
+					per_page: 1,
+				} );
+				if ( records && records[ 0 ] ) {
+					archiveNameLabel = records[ 0 ].name;
+				}
+			}
+			if ( isAuthor ) {
+				archiveTypeLabel = 'Author';
+				if ( authorSlug ) {
+					const authorRecords = getAuthors( { slug: authorSlug } );
+					if ( authorRecords && authorRecords[ 0 ] ) {
+						archiveNameLabel = authorRecords[ 0 ].name;
+					}
+				}
+			}
+			return {
+				archiveTypeLabel,
+				archiveNameLabel,
+			};
+		},
+		[ authorSlug, isAuthor, taxonomy, term ]
+	);
+}

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -3,7 +3,6 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { usePrevious } from '@wordpress/compose';
@@ -18,78 +17,6 @@ import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
 const { useBlockEditorSettings } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
-
-function useArchiveLabel( templateSlug ) {
-	const taxonomyMatches = templateSlug?.match(
-		/^(category|tag|taxonomy-([^-]+))$|^(((category|tag)|taxonomy-([^-]+))-(.+))$/
-	);
-	let taxonomy;
-	let term;
-	let isAuthor = false;
-	let authorSlug;
-	if ( taxonomyMatches ) {
-		// If is for a all taxonomies of a type
-		if ( taxonomyMatches[ 1 ] ) {
-			taxonomy = taxonomyMatches[ 2 ]
-				? taxonomyMatches[ 2 ]
-				: taxonomyMatches[ 1 ];
-		}
-		// If is for a all taxonomies of a type
-		else if ( taxonomyMatches[ 3 ] ) {
-			taxonomy = taxonomyMatches[ 6 ]
-				? taxonomyMatches[ 6 ]
-				: taxonomyMatches[ 4 ];
-			term = taxonomyMatches[ 7 ];
-		}
-		taxonomy = taxonomy === 'tag' ? 'post_tag' : taxonomy;
-
-		//getTaxonomy( 'category' );
-		//wp.data.select('core').getEntityRecords( 'taxonomy', 'category', {slug: 'newcat'} );
-	} else {
-		const authorMatches = templateSlug?.match( /^(author)$|^author-(.+)$/ );
-		if ( authorMatches ) {
-			isAuthor = true;
-			if ( authorMatches[ 2 ] ) {
-				authorSlug = authorMatches[ 2 ];
-			}
-		}
-	}
-	return useSelect(
-		( select ) => {
-			const { getEntityRecords, getTaxonomy, getAuthors } =
-				select( coreStore );
-			let archiveTypeLabel;
-			let archiveNameLabel;
-			if ( taxonomy ) {
-				archiveTypeLabel =
-					getTaxonomy( taxonomy )?.labels?.singular_name;
-			}
-			if ( term ) {
-				const records = getEntityRecords( 'taxonomy', taxonomy, {
-					slug: term,
-					per_page: 1,
-				} );
-				if ( records && records[ 0 ] ) {
-					archiveNameLabel = records[ 0 ].name;
-				}
-			}
-			if ( isAuthor ) {
-				archiveTypeLabel = 'Author';
-				if ( authorSlug ) {
-					const authorRecords = getAuthors( { slug: authorSlug } );
-					if ( authorRecords && authorRecords[ 0 ] ) {
-						archiveNameLabel = authorRecords[ 0 ].name;
-					}
-				}
-			}
-			return {
-				archiveTypeLabel,
-				archiveNameLabel,
-			};
-		},
-		[ authorSlug, isAuthor, taxonomy, term ]
-	);
-}
 
 function useNavigateToPreviousEntityRecord() {
 	const location = useLocation();
@@ -114,39 +41,21 @@ function useNavigateToPreviousEntityRecord() {
 
 export function useSpecificEditorSettings() {
 	const onNavigateToEntityRecord = useNavigateToEntityRecord();
-	const {
-		templateSlug,
-		canvasMode,
-		settings,
-		shouldUseTemplateAsDefaultRenderingMode,
-	} = useSelect( ( select ) => {
-		const {
-			getEditedPostType,
-			getEditedPostId,
-			getEditedPostContext,
-			getCanvasMode,
-			getSettings,
-		} = unlock( select( editSiteStore ) );
-		const { getEditedEntityRecord } = select( coreStore );
-		const usedPostType = getEditedPostType();
-		const usedPostId = getEditedPostId();
-		const _record = getEditedEntityRecord(
-			'postType',
-			usedPostType,
-			usedPostId
-		);
-		const _context = getEditedPostContext();
-		return {
-			templateSlug: _record.slug,
-			canvasMode: getCanvasMode(),
-			settings: getSettings(),
-			// TODO: The `postType` check should be removed when the default rendering mode per post type is merged.
-			// @see https://github.com/WordPress/gutenberg/pull/62304/
-			shouldUseTemplateAsDefaultRenderingMode:
-				_context?.postId && _context?.postType !== 'post',
-		};
-	}, [] );
-	const archiveLabels = useArchiveLabel( templateSlug );
+	const { canvasMode, settings, shouldUseTemplateAsDefaultRenderingMode } =
+		useSelect( ( select ) => {
+			const { getEditedPostContext, getCanvasMode, getSettings } = unlock(
+				select( editSiteStore )
+			);
+			const _context = getEditedPostContext();
+			return {
+				canvasMode: getCanvasMode(),
+				settings: getSettings(),
+				// TODO: The `postType` check should be removed when the default rendering mode per post type is merged.
+				// @see https://github.com/WordPress/gutenberg/pull/62304/
+				shouldUseTemplateAsDefaultRenderingMode:
+					_context?.postId && _context?.postType !== 'post',
+			};
+		}, [] );
 	const defaultRenderingMode = shouldUseTemplateAsDefaultRenderingMode
 		? 'template-locked'
 		: 'post-only';
@@ -162,9 +71,6 @@ export function useSpecificEditorSettings() {
 			defaultRenderingMode,
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
-			// I wonder if they should be set in the post editor too
-			__experimentalArchiveTitleTypeLabel: archiveLabels.archiveTypeLabel,
-			__experimentalArchiveTitleNameLabel: archiveLabels.archiveNameLabel,
 			__unstableIsPreviewMode: canvasMode === 'view',
 		};
 	}, [
@@ -173,8 +79,6 @@ export function useSpecificEditorSettings() {
 		defaultRenderingMode,
 		onNavigateToEntityRecord,
 		onNavigateToPreviousEntityRecord,
-		archiveLabels.archiveTypeLabel,
-		archiveLabels.archiveNameLabel,
 	] );
 
 	return defaultEditorSettings;

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -83,8 +83,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableIsPreviewMode',
 	'__unstableResolvedAssets',
 	'__unstableIsBlockBasedTheme',
-	'__experimentalArchiveTitleTypeLabel',
-	'__experimentalArchiveTitleNameLabel',
 ];
 
 const {


### PR DESCRIPTION
This is the first step to solve this but #59082 

## What?

This PR refactors the way the Query Title block retrieves the current template in order to change the placeholder contextually. Instead of relying on a random block editor setting, it relies on the actual template used in the "core/editor" store directly.

The reason we can do this is because some blocks of block-library are WP specific and can actually make use of the editor package. It's the case for the Query Title block.


## Testing Instructions

1- Create tag archive block template
2- Make the sure the title shows the right placeholder: "Tag: name".
