### PR TITLE
Storybook: Remove popover-related height buffers

### DIFF
--- a/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
@@ -65,18 +65,6 @@ const meta: Meta< typeof DropdownMenu > = {
 			source: { excludeDecorators: true },
 		},
 	},
-	decorators: [
-		// Layout wrapper
-		( Story ) => (
-			<div
-				style={ {
-					minHeight: '300px',
-				} }
-			>
-				<Story />
-			</div>
-		),
-	],
 };
 export default meta;
 

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -44,13 +44,6 @@ const meta: Meta< typeof DropdownMenu > = {
 export default meta;
 
 export const Default: StoryObj< typeof DropdownMenu > = {
-	decorators: [
-		( Story ) => (
-			<div style={ { height: 150 } }>
-				<Story />
-			</div>
-		),
-	],
 	args: {
 		label: 'Select a direction.',
 		icon: menu,

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -42,13 +42,6 @@ const meta: Meta< typeof Dropdown > = {
 export default meta;
 
 export const Default: StoryObj< typeof Dropdown > = {
-	decorators: [
-		( Story ) => (
-			<div style={ { height: 150 } }>
-				<Story />
-			</div>
-		),
-	],
 	args: {
 		renderToggle: ( { isOpen, onToggle } ) => (
 			<Button


### PR DESCRIPTION
## What?

Removes now-unnecessary height buffers for `Popover`-based stories in Storybook.

## Why?

Due to #53889, `Popover`s are now rendering at the end of the document rather than within the each story div, which used to cut them off visually.

## Testing Instructions

See stories for affected components in the main Docs view. The popovers should appear above the story div, and not be cut off.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/48236ae9-8e10-4bfa-ba42-5c5ffb54a41a" alt="Story with height buffer" width="400">|<img src="https://github.com/user-attachments/assets/ffbac25c-3c91-4f99-a21c-b3073398badd" alt="Story without height buffer" width="400">|

