### PR TITLE
Revert "Pages: Trash view should default to table layout."

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -29,7 +29,7 @@ export default function DataViewItem( {
 	suffix,
 } ) {
 	const {
-		params: { postType, layout, activeView: previousView },
+		params: { postType, layout },
 	} = useLocation();
 
 	const iconToUse =
@@ -41,7 +41,7 @@ export default function DataViewItem( {
 	}
 	const linkInfo = useLink( {
 		postType,
-		layout: type !== 'list' || previousView === 'trash' ? type : layout,
+		layout,
 		activeView,
 		isCustom: isCustom ? 'true' : undefined,
 	} );

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -166,7 +166,6 @@ export function useDefaultViews( { postType } ) {
 					icon: trash,
 					view: {
 						...DEFAULT_POST_BASE,
-						type: LAYOUT_TABLE,
 						filters: [
 							{
 								field: 'status',


### PR DESCRIPTION
Reverts: https://github.com/WordPress/gutenberg/pull/63138/
Although the CI passed on the PR it caused the CI to fail on the trunk. Debugging it seems the CI error on the performance test is legitimate. I'm going to revert the PR and address the issue separately.