### PR TITLE
Writing flow: select next block on Enter key

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -701,6 +701,11 @@ function BlockListBlockProvider( props ) {
 				originalBlockClientId: isInvalid
 					? blocksWithSameName[ 0 ]
 					: false,
+				supportsSplitting: hasBlockSupport(
+					blockName,
+					'splitting',
+					false
+				),
 			};
 		},
 		[ clientId, rootClientId ]
@@ -743,6 +748,7 @@ function BlockListBlockProvider( props ) {
 		className,
 		defaultClassName,
 		originalBlockClientId,
+		supportsSplitting,
 	} = selectedProps;
 
 	// Users of the editor.BlockListBlock filter used to be able to
@@ -791,6 +797,7 @@ function BlockListBlockProvider( props ) {
 		originalBlockClientId,
 		themeSupportsLayout,
 		canMove,
+		supportsSplitting,
 	};
 
 	// Here we separate between the props passed to BlockListBlock and any other

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -771,6 +771,11 @@ function BlockListBlockProvider( props ) {
 				blockVisibility,
 				deviceType,
 				viewportSettings,
+				supportsSplitting: hasBlockSupport(
+					blockName,
+					'splitting',
+					false
+				),
 			};
 		},
 		[ clientId, rootClientId, ghostBlock, ghostBlockWithoutAttributes ]
@@ -854,6 +859,7 @@ function BlockListBlockProvider( props ) {
 		blockVisibility,
 		deviceType,
 		viewportSettings,
+		supportsSplitting,
 	} = selectedProps;
 
 	const privateContext = {
@@ -896,6 +902,7 @@ function BlockListBlockProvider( props ) {
 		blockVisibility,
 		deviceType,
 		viewportSettings,
+		supportsSplitting,
 	};
 
 	if (

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -43,6 +43,10 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 			return;
 		}
 
+		if ( initialPosition === undefined || initialPosition === null ) {
+			return;
+		}
+
 		if ( ! ref.current ) {
 			return;
 		}
@@ -54,7 +58,7 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 			return;
 		}
 
-		if ( initialPosition === undefined || initialPosition === null ) {
+		if ( initialPosition === true ) {
 			ref.current.focus();
 			return;
 		}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -43,10 +43,6 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 			return;
 		}
 
-		if ( initialPosition === undefined || initialPosition === null ) {
-			return;
-		}
-
 		if ( ! ref.current ) {
 			return;
 		}
@@ -55,6 +51,11 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 
 		// Do not focus the block if it already contains the active element.
 		if ( isInsideRootBlock( ref.current, ownerDocument.activeElement ) ) {
+			return;
+		}
+
+		if ( initialPosition === undefined || initialPosition === null ) {
+			ref.current.focus();
 			return;
 		}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -50,6 +50,11 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 			return;
 		}
 
+		if ( initialPosition === true ) {
+			ref.current.focus();
+			return;
+		}
+
 		// Find all tabbables within node.
 		const textInputs = focus.tabbable
 			.find( ref.current )

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -5,7 +5,7 @@ import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 import { createRoot } from '@wordpress/element';
-import { store as blocksStore, getDefaultBlockName } from '@wordpress/blocks';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -24,23 +24,14 @@ import BlockDraggableChip from '../../../components/block-draggable/draggable-ch
  */
 export function useEventHandlers( { clientId, isSelected } ) {
 	const { getBlockType } = useSelect( blocksStore );
-	const {
-		getBlockRootClientId,
-		isZoomOut,
-		hasMultiSelection,
-		getBlockName,
-		canInsertBlockType,
-		getNextBlockClientId,
-		getBlockOrder,
-		getBlockEditingMode,
-	} = unlock( useSelect( blockEditorStore ) );
+	const { getBlockRootClientId, isZoomOut, hasMultiSelection, getBlockName } =
+		unlock( useSelect( blockEditorStore ) );
 	const {
 		insertAfterBlock,
 		removeBlock,
 		resetZoomLevel,
 		startDraggingBlocks,
 		stopDraggingBlocks,
-		selectBlock,
 	} = unlock( useDispatch( blockEditorStore ) );
 
 	return useRefEffect(
@@ -77,49 +68,13 @@ export function useEventHandlers( { clientId, isSelected } ) {
 					return;
 				}
 
-				event.preventDefault();
-
-				if ( keyCode === ENTER && isZoomOut() ) {
-					resetZoomLevel();
-				} else if ( keyCode === ENTER ) {
-					const rootClientId = getBlockRootClientId( clientId );
-					if (
-						canInsertBlockType(
-							getDefaultBlockName(),
-							rootClientId
-						)
-					) {
-						insertAfterBlock( clientId );
-					} else {
-						function getNextClientId( id ) {
-							let nextClientId = null;
-
-							while (
-								typeof id === 'string' &&
-								! ( nextClientId = getNextBlockClientId( id ) )
-							) {
-								id = getBlockRootClientId( id );
-							}
-
-							return nextClientId;
-						}
-
-						let nextClientId =
-							getBlockOrder( clientId )[ 0 ] ??
-							getNextClientId( clientId );
-
-						while (
-							nextClientId &&
-							getBlockEditingMode( nextClientId ) === 'disabled'
-						) {
-							nextClientId = getNextClientId( nextClientId );
-						}
-
-						if ( nextClientId ) {
-							selectBlock( nextClientId, null );
-						}
+				if ( keyCode === ENTER ) {
+					if ( isZoomOut() ) {
+						event.preventDefault();
+						resetZoomLevel();
 					}
 				} else {
+					event.preventDefault();
 					removeBlock( clientId );
 				}
 			}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -116,7 +116,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 						}
 
 						if ( nextClientId ) {
-							selectBlock( nextClientId );
+							selectBlock( nextClientId, null );
 						}
 					}
 				} else {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { isTextField } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
@@ -52,10 +53,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			function onKeyDown( event ) {
 				const { keyCode, target } = event;
 
-				if ( event.defaultPrevented ) {
-					return;
-				}
-
 				if (
 					keyCode !== ENTER &&
 					keyCode !== BACKSPACE &&
@@ -64,7 +61,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 					return;
 				}
 
-				if ( target !== node ) {
+				if ( target !== node || isTextField( target ) ) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -28,7 +28,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 		getBlock,
 	} = unlock( useSelect( blockEditorStore ) );
 	const {
-		insertAfterBlock,
 		removeBlock,
 		resetZoomLevel,
 		startDraggingBlocks,
@@ -66,13 +65,13 @@ export function useEventHandlers( { clientId, isSelected } ) {
 					return;
 				}
 
-				event.preventDefault();
-
-				if ( keyCode === ENTER && isZoomOut() ) {
-					resetZoomLevel();
-				} else if ( keyCode === ENTER ) {
-					insertAfterBlock( clientId );
+				if ( keyCode === ENTER ) {
+					if ( isZoomOut() ) {
+						event.preventDefault();
+						resetZoomLevel();
+					}
 				} else {
+					event.preventDefault();
 					removeBlock( clientId );
 				}
 			}
@@ -327,7 +326,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			getBlock,
 			isReusableBlock,
 			isTemplatePart,
-			insertAfterBlock,
 			removeBlock,
 			isZoomOut,
 			resetZoomLevel,

--- a/packages/block-editor/src/components/rich-text/event-listeners/enter.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/enter.js
@@ -19,10 +19,21 @@ export default ( props ) => ( element ) => {
 			value,
 			onSplitAtDoubleLineEnd,
 			registry,
+			onSplitAtEnd,
 		} = props.current;
 		const { text, start, end } = value;
 
-		if (
+		if ( event.shiftKey ) {
+			if ( ! disableLineBreaks ) {
+				event.preventDefault();
+				onChange( insert( value, '\n' ) );
+			}
+		} else if ( onSplitAtEnd && start === end && end === text.length ) {
+			event.preventDefault();
+			onSplitAtEnd();
+		} else if ( onReplace && onSplit ) {
+			event.__deprecatedOnSplit = true;
+		} else if (
 			! supportsSplitting &&
 			! disableLineBreaks &&
 			! event.defaultPrevented
@@ -47,10 +58,6 @@ export default ( props ) => ( element ) => {
 				onChange( insert( value, '\n' ) );
 			}
 		}
-
-		if ( onReplace && onSplit ) {
-			event.__deprecatedOnSplit = true;
-		}
 	}
 
 	function onDefaultKeyDown( event ) {
@@ -68,20 +75,9 @@ export default ( props ) => ( element ) => {
 			return;
 		}
 
-		const { value, onChange, disableLineBreaks, onSplitAtEnd } =
-			props.current;
-
+		// On ENTER, we ALWAYS want to prevent the default browser behaviour
+		// at this last interception point.
 		event.preventDefault();
-
-		const { text, start, end } = value;
-
-		if ( event.shiftKey ) {
-			if ( ! disableLineBreaks ) {
-				onChange( insert( value, '\n' ) );
-			}
-		} else if ( onSplitAtEnd && start === end && end === text.length ) {
-			onSplitAtEnd();
-		}
 	}
 
 	const { defaultView } = element.ownerDocument;

--- a/packages/block-editor/src/components/rich-text/event-listeners/enter.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/enter.js
@@ -29,6 +29,7 @@ export default ( props ) => ( element ) => {
 				onChange( insert( value, '\n' ) );
 			}
 		} else if ( onSplitAtEnd && start === end && end === text.length ) {
+			// This is no longer used anywhere. Deprecate?
 			event.preventDefault();
 			onSplitAtEnd();
 		} else if ( onReplace && onSplit ) {

--- a/packages/block-editor/src/components/rich-text/event-listeners/enter.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/enter.js
@@ -22,7 +22,11 @@ export default ( props ) => ( element ) => {
 		} = props.current;
 		const { text, start, end } = value;
 
-		if ( ! supportsSplitting && ! disableLineBreaks ) {
+		if (
+			! supportsSplitting &&
+			! disableLineBreaks &&
+			! event.defaultPrevented
+		) {
 			event.preventDefault();
 			if (
 				// For some blocks it's desirable to split at the end of the

--- a/packages/block-editor/src/components/rich-text/event-listeners/enter.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/enter.js
@@ -11,19 +11,62 @@ const { subscribeOwnedListener, ownsSelection } = unlock( richTextPrivateApis );
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
 
 export default ( props ) => ( element ) => {
-	function onKeyDownDeprecated( event ) {
+	function onKeyDown( event ) {
 		if ( event.keyCode !== ENTER ) {
 			return;
 		}
 
-		const { onReplace, onSplit } = props.current;
+		const {
+			onReplace,
+			onSplit,
+			supportsSplitting,
+			disableLineBreaks,
+			onChange,
+			value,
+			onSplitAtDoubleLineEnd,
+			registry,
+			onSplitAtEnd,
+		} = props.current;
+		const { text, start, end } = value;
 
-		if ( onReplace && onSplit ) {
+		if ( event.shiftKey ) {
+			if ( ! disableLineBreaks ) {
+				event.preventDefault();
+				onChange( insert( value, '\n' ) );
+			}
+		} else if ( onSplitAtEnd && start === end && end === text.length ) {
+			event.preventDefault();
+			onSplitAtEnd();
+		} else if ( onReplace && onSplit ) {
 			event.__deprecatedOnSplit = true;
+		} else if (
+			! supportsSplitting &&
+			! disableLineBreaks &&
+			! event.defaultPrevented
+		) {
+			event.preventDefault();
+			if (
+				// For some blocks it's desirable to split at the end of the
+				// block when there are two line breaks at the end of the
+				// block, so triple Enter exits the block.
+				onSplitAtDoubleLineEnd &&
+				start === end &&
+				end === text.length &&
+				text.slice( -2 ) === '\n\n'
+			) {
+				registry.batch( () => {
+					const _value = { ...value };
+					_value.start = _value.end - 2;
+					onChange( remove( _value ) );
+					onSplitAtDoubleLineEnd();
+				} );
+			} else {
+				onChange( insert( value, '\n' ) );
+			}
 		}
 	}
 
-	function onKeyDown( event ) {
+	function onDefaultKeyDown( event ) {
 		if ( event.defaultPrevented ) {
 			return;
 		}
@@ -39,64 +82,30 @@ export default ( props ) => ( element ) => {
 			return;
 		}
 
-		const {
-			value,
-			onChange,
-			disableLineBreaks,
-			onSplitAtEnd,
-			onSplitAtDoubleLineEnd,
-			registry,
-		} = props.current;
-
+		// On ENTER, we ALWAYS want to prevent the default browser behaviour
+		// at this last interception point.
 		event.preventDefault();
-
-		const { text, start, end } = value;
-
-		if ( event.shiftKey ) {
-			if ( ! disableLineBreaks ) {
-				onChange( insert( value, '\n' ) );
-			}
-		} else if ( onSplitAtEnd && start === end && end === text.length ) {
-			onSplitAtEnd();
-		} else if (
-			// For some blocks it's desirable to split at the end of the
-			// block when there are two line breaks at the end of the
-			// block, so triple Enter exits the block.
-			onSplitAtDoubleLineEnd &&
-			start === end &&
-			end === text.length &&
-			text.slice( -2 ) === '\n\n'
-		) {
-			registry.batch( () => {
-				const _value = { ...value };
-				_value.start = _value.end - 2;
-				onChange( remove( _value ) );
-				onSplitAtDoubleLineEnd();
-			} );
-		} else if ( ! disableLineBreaks ) {
-			onChange( insert( value, '\n' ) );
-		}
 	}
 
 	const { defaultView } = element.ownerDocument;
 
 	// Attach the listener to the window so parent elements have the chance to
 	// prevent the default behavior.
-	const unsubscribeKeyDown = subscribeDelegatedListener(
+	const unsubscribeDefaultKeyDown = subscribeDelegatedListener(
 		defaultView,
 		'keydown',
-		onKeyDown
+		onDefaultKeyDown
 	);
 	// Capture phase so this runs before ancestor (writing flow) bubble
 	// handlers, matching the timing of the previous raw element listener.
-	const unsubscribeKeyDownDeprecated = subscribeOwnedListener(
+	const unsubscribeKeyDown = subscribeOwnedListener(
 		element,
 		'keydown',
-		onKeyDownDeprecated,
+		onKeyDown,
 		true
 	);
 	return () => {
+		unsubscribeDefaultKeyDown();
 		unsubscribeKeyDown();
-		unsubscribeKeyDownDeprecated();
 	};
 };

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -78,7 +78,7 @@ function removeNativeProps( props ) {
 	return restProps;
 }
 
-export function RichTextWrapper(
+function _RichTextWrapper(
 	{
 		children,
 		tagName = 'div',
@@ -501,11 +501,11 @@ export function RichTextWrapper(
 	);
 }
 
+export const RichTextWrapper = forwardRef( _RichTextWrapper );
+
 // This is the private API for the RichText component.
 // It allows access to all props, not just the public ones.
-export const PrivateRichText = withDeprecations(
-	forwardRef( RichTextWrapper )
-);
+export const PrivateRichText = withDeprecations( RichTextWrapper );
 
 PrivateRichText.Content = Content;
 PrivateRichText.isEmpty = ( value ) => {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -41,6 +41,7 @@ import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import { canBindBlock } from '../../utils/block-bindings';
 import BlockContext from '../block-context';
+import { PrivateBlockContext } from '../block-list/private-block-context';
 
 export const keyboardShortcutContext = createContext();
 export const inputEventContext = createContext();
@@ -118,6 +119,7 @@ export function RichTextWrapper(
 		} );
 	}
 
+	const { supportsSplitting } = useContext( PrivateBlockContext );
 	const instanceId = useInstanceId( RichTextWrapper );
 	const anchorRef = useRef();
 	const context = useBlockEditContext();
@@ -471,6 +473,7 @@ export function RichTextWrapper(
 						onSplitAtDoubleLineEnd,
 						keyboardShortcuts,
 						inputEvents,
+						supportsSplitting,
 					} ),
 					anchorRef,
 				] ) }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -33,6 +33,7 @@ import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import BlockContext from '../block-context';
 import { unlock } from '../../lock-unlock';
+import { PrivateBlockContext } from '../block-list/private-block-context';
 
 // `RichTextShortcut` and `RichTextInputEvent` now live in
 // `@wordpress/rich-text` so they share the shortcut and input-event contexts
@@ -48,7 +49,7 @@ const {
 
 const instanceIdKey = Symbol( 'instanceId' );
 
-export function RichTextWrapper(
+function RichTextWrapper(
 	{
 		children,
 		tagName = 'div',
@@ -87,6 +88,7 @@ export function RichTextWrapper(
 		} );
 	}
 
+	const { supportsSplitting } = useContext( PrivateBlockContext );
 	const instanceId = useInstanceId( RichTextWrapper );
 	const anchorRef = useRef();
 	const [ anchorElement, setAnchorElement ] = useState( null );
@@ -511,6 +513,7 @@ export function RichTextWrapper(
 						onSplitAtDoubleLineEnd,
 						keyboardShortcuts,
 						inputEvents,
+						supportsSplitting,
 					} ),
 					anchorRef,
 					setAnchorElement,
@@ -529,11 +532,13 @@ export function RichTextWrapper(
 	);
 }
 
+const ForwardedRichTextWrapper = forwardRef( RichTextWrapper );
+
+export { ForwardedRichTextWrapper as RichTextWrapper };
+
 // This is the private API for the RichText component.
 // It allows access to all props, not just the public ones.
-export const PrivateRichText = withDeprecations(
-	forwardRef( RichTextWrapper )
-);
+export const PrivateRichText = withDeprecations( ForwardedRichTextWrapper );
 
 PrivateRichText.Content = Content;
 PrivateRichText.isEmpty = ( value ) => {

--- a/packages/block-editor/src/components/rich-text/multiline.js
+++ b/packages/block-editor/src/components/rich-text/multiline.js
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useInsertionEffect, useRef } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { ENTER } from '@wordpress/keycodes';
 import { create, split, toHTMLString } from '@wordpress/rich-text';
+import { useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -14,6 +15,115 @@ import { RichTextWrapper } from './';
 import { store as blockEditorStore } from '../../store';
 import { useBlockEditContext } from '../block-edit';
 import { getMultilineTag } from './utils';
+
+function useEnterRef( props ) {
+	const { getSelectionStart, getSelectionEnd } =
+		useSelect( blockEditorStore );
+	const { selectionChange } = useDispatch( blockEditorStore );
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			if ( event.keyCode !== ENTER ) {
+				return;
+			}
+
+			event.preventDefault();
+
+			const { value, values, onChange, index, identifier, clientId } =
+				props.current;
+			const { offset: start } = getSelectionStart();
+			const { offset: end } = getSelectionEnd();
+
+			// Cannot split if there is no selection.
+			if ( typeof start !== 'number' || typeof end !== 'number' ) {
+				return;
+			}
+
+			const richTextValue = create( { html: value } );
+			richTextValue.start = start;
+			richTextValue.end = end;
+
+			const array = split( richTextValue ).map( ( v ) =>
+				toHTMLString( { value: v } )
+			);
+
+			const newValues = values.slice();
+			newValues.splice( index, 1, ...array );
+			onChange( newValues );
+			selectionChange( clientId, `${ identifier }-${ index + 1 }`, 0, 0 );
+		}
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}
+
+function Line( lineProps ) {
+	const {
+		value,
+		values,
+		onChange,
+		index,
+		identifier,
+		multilineTagName,
+		...props
+	} = lineProps;
+	const { clientId } = useBlockEditContext();
+	const { selectionChange } = useDispatch( blockEditorStore );
+	const latestRef = useRef();
+	useInsertionEffect( () => {
+		latestRef.current = { ...lineProps, clientId };
+	} );
+	const ref = useEnterRef( latestRef );
+	return (
+		<RichTextWrapper
+			key={ index }
+			identifier={ `${ identifier }-${ index }` }
+			tagName={ multilineTagName }
+			value={ value }
+			onChange={ ( newValue ) => {
+				const newValues = values.slice();
+				newValues[ index ] = newValue;
+				onChange( newValues );
+			} }
+			isSelected={ undefined }
+			ref={ ref }
+			onMerge={ ( forward ) => {
+				const newValues = values.slice();
+				let offset = 0;
+				if ( forward ) {
+					if ( ! newValues[ index + 1 ] ) {
+						return;
+					}
+					newValues.splice(
+						index,
+						2,
+						newValues[ index ] + newValues[ index + 1 ]
+					);
+					offset = newValues[ index ].length - 1;
+				} else {
+					if ( ! newValues[ index - 1 ] ) {
+						return;
+					}
+					newValues.splice(
+						index - 1,
+						2,
+						newValues[ index - 1 ] + newValues[ index ]
+					);
+					offset = newValues[ index - 1 ].length - 1;
+				}
+				onChange( newValues );
+				selectionChange(
+					clientId,
+					`${ identifier }-${ index - ( forward ? 0 : 1 ) }`,
+					offset,
+					offset
+				);
+			} }
+			{ ...props }
+		/>
+	);
+}
 
 function RichTextMultiline(
 	{
@@ -33,11 +143,6 @@ function RichTextMultiline(
 		alternative: 'nested blocks (InnerBlocks)',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/',
 	} );
-
-	const { clientId } = useBlockEditContext();
-	const { getSelectionStart, getSelectionEnd } =
-		useSelect( blockEditorStore );
-	const { selectionChange } = useDispatch( blockEditorStore );
 
 	const multilineTagName = getMultilineTag( multiline );
 	value = value || `<${ multilineTagName }></${ multilineTagName }>`;
@@ -61,87 +166,14 @@ function RichTextMultiline(
 		<TagName ref={ forwardedRef }>
 			{ values.map( ( _value, index ) => {
 				return (
-					<RichTextWrapper
+					<Line
 						key={ index }
-						identifier={ `${ identifier }-${ index }` }
-						tagName={ multilineTagName }
+						values={ values }
 						value={ _value }
-						onChange={ ( newValue ) => {
-							const newValues = values.slice();
-							newValues[ index ] = newValue;
-							_onChange( newValues );
-						} }
-						isSelected={ undefined }
-						onKeyDown={ ( event ) => {
-							if ( event.keyCode !== ENTER ) {
-								return;
-							}
-
-							event.preventDefault();
-
-							const { offset: start } = getSelectionStart();
-							const { offset: end } = getSelectionEnd();
-
-							// Cannot split if there is no selection.
-							if (
-								typeof start !== 'number' ||
-								typeof end !== 'number'
-							) {
-								return;
-							}
-
-							const richTextValue = create( { html: _value } );
-							richTextValue.start = start;
-							richTextValue.end = end;
-
-							const array = split( richTextValue ).map( ( v ) =>
-								toHTMLString( { value: v } )
-							);
-
-							const newValues = values.slice();
-							newValues.splice( index, 1, ...array );
-							_onChange( newValues );
-							selectionChange(
-								clientId,
-								`${ identifier }-${ index + 1 }`,
-								0,
-								0
-							);
-						} }
-						onMerge={ ( forward ) => {
-							const newValues = values.slice();
-							let offset = 0;
-							if ( forward ) {
-								if ( ! newValues[ index + 1 ] ) {
-									return;
-								}
-								newValues.splice(
-									index,
-									2,
-									newValues[ index ] + newValues[ index + 1 ]
-								);
-								offset = newValues[ index ].length - 1;
-							} else {
-								if ( ! newValues[ index - 1 ] ) {
-									return;
-								}
-								newValues.splice(
-									index - 1,
-									2,
-									newValues[ index - 1 ] + newValues[ index ]
-								);
-								offset = newValues[ index - 1 ].length - 1;
-							}
-							_onChange( newValues );
-							selectionChange(
-								clientId,
-								`${ identifier }-${
-									index - ( forward ? 0 : 1 )
-								}`,
-								offset,
-								offset
-							);
-						} }
+						onChange={ _onChange }
+						index={ index }
+						identifier={ identifier }
+						multilineTagName={ multilineTagName }
 						{ ...props }
 					/>
 				);

--- a/packages/block-editor/src/components/rich-text/multiline.js
+++ b/packages/block-editor/src/components/rich-text/multiline.js
@@ -1,12 +1,130 @@
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useInsertionEffect, useRef } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { ENTER } from '@wordpress/keycodes';
-import { create, split, toHTMLString } from '@wordpress/rich-text';
+import {
+	create,
+	split,
+	toHTMLString,
+	privateApis as richTextPrivateApis,
+} from '@wordpress/rich-text';
+import { useRefEffect } from '@wordpress/compose';
 import { RichTextWrapper } from './';
 import { store as blockEditorStore } from '../../store';
 import { useBlockEditContext } from '../block-edit';
 import { getMultilineTag } from './utils';
+import { unlock } from '../../lock-unlock';
+
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
+
+function useEnterRef( props ) {
+	const { getSelectionStart, getSelectionEnd } =
+		useSelect( blockEditorStore );
+	const { selectionChange } = useDispatch( blockEditorStore );
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			if ( event.keyCode !== ENTER ) {
+				return;
+			}
+
+			event.preventDefault();
+
+			const { value, values, onChange, index, identifier, clientId } =
+				props.current;
+			const { offset: start } = getSelectionStart();
+			const { offset: end } = getSelectionEnd();
+
+			// Cannot split if there is no selection.
+			if ( typeof start !== 'number' || typeof end !== 'number' ) {
+				return;
+			}
+
+			const richTextValue = create( { html: value } );
+			richTextValue.start = start;
+			richTextValue.end = end;
+
+			const array = split( richTextValue ).map( ( v ) =>
+				toHTMLString( { value: v } )
+			);
+
+			const newValues = values.slice();
+			newValues.splice( index, 1, ...array );
+			onChange( newValues );
+			selectionChange( clientId, `${ identifier }-${ index + 1 }`, 0, 0 );
+		}
+		// Capture phase so this runs before the generic rich text enter
+		// listener, which skips events that already had their default
+		// prevented.
+		return subscribeOwnedListener( element, 'keydown', onKeyDown, true );
+	}, [] );
+}
+
+function Line( lineProps ) {
+	const {
+		value,
+		values,
+		onChange,
+		index,
+		identifier,
+		multilineTagName,
+		...props
+	} = lineProps;
+	const { clientId } = useBlockEditContext();
+	const { selectionChange } = useDispatch( blockEditorStore );
+	const latestRef = useRef();
+	useInsertionEffect( () => {
+		latestRef.current = { ...lineProps, clientId };
+	} );
+	const ref = useEnterRef( latestRef );
+	return (
+		<RichTextWrapper
+			key={ index }
+			identifier={ `${ identifier }-${ index }` }
+			tagName={ multilineTagName }
+			value={ value }
+			onChange={ ( newValue ) => {
+				const newValues = values.slice();
+				newValues[ index ] = newValue;
+				onChange( newValues );
+			} }
+			isSelected={ undefined }
+			ref={ ref }
+			onMerge={ ( forward ) => {
+				const newValues = values.slice();
+				let offset = 0;
+				if ( forward ) {
+					if ( ! newValues[ index + 1 ] ) {
+						return;
+					}
+					newValues.splice(
+						index,
+						2,
+						newValues[ index ] + newValues[ index + 1 ]
+					);
+					offset = newValues[ index ].length - 1;
+				} else {
+					if ( ! newValues[ index - 1 ] ) {
+						return;
+					}
+					newValues.splice(
+						index - 1,
+						2,
+						newValues[ index - 1 ] + newValues[ index ]
+					);
+					offset = newValues[ index - 1 ].length - 1;
+				}
+				onChange( newValues );
+				selectionChange(
+					clientId,
+					`${ identifier }-${ index - ( forward ? 0 : 1 ) }`,
+					offset,
+					offset
+				);
+			} }
+			{ ...props }
+		/>
+	);
+}
 
 function RichTextMultiline(
 	{
@@ -26,11 +144,6 @@ function RichTextMultiline(
 		alternative: 'nested blocks (InnerBlocks)',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/',
 	} );
-
-	const { clientId } = useBlockEditContext();
-	const { getSelectionStart, getSelectionEnd } =
-		useSelect( blockEditorStore );
-	const { selectionChange } = useDispatch( blockEditorStore );
 
 	const multilineTagName = getMultilineTag( multiline );
 	value = value || `<${ multilineTagName }></${ multilineTagName }>`;
@@ -54,87 +167,14 @@ function RichTextMultiline(
 		<TagName ref={ forwardedRef }>
 			{ values.map( ( _value, index ) => {
 				return (
-					<RichTextWrapper
+					<Line
 						key={ index }
-						identifier={ `${ identifier }-${ index }` }
-						tagName={ multilineTagName }
+						values={ values }
 						value={ _value }
-						onChange={ ( newValue ) => {
-							const newValues = values.slice();
-							newValues[ index ] = newValue;
-							_onChange( newValues );
-						} }
-						isSelected={ undefined }
-						onKeyDown={ ( event ) => {
-							if ( event.keyCode !== ENTER ) {
-								return;
-							}
-
-							event.preventDefault();
-
-							const { offset: start } = getSelectionStart();
-							const { offset: end } = getSelectionEnd();
-
-							// Cannot split if there is no selection.
-							if (
-								typeof start !== 'number' ||
-								typeof end !== 'number'
-							) {
-								return;
-							}
-
-							const richTextValue = create( { html: _value } );
-							richTextValue.start = start;
-							richTextValue.end = end;
-
-							const array = split( richTextValue ).map( ( v ) =>
-								toHTMLString( { value: v } )
-							);
-
-							const newValues = values.slice();
-							newValues.splice( index, 1, ...array );
-							_onChange( newValues );
-							selectionChange(
-								clientId,
-								`${ identifier }-${ index + 1 }`,
-								0,
-								0
-							);
-						} }
-						onMerge={ ( forward ) => {
-							const newValues = values.slice();
-							let offset = 0;
-							if ( forward ) {
-								if ( ! newValues[ index + 1 ] ) {
-									return;
-								}
-								newValues.splice(
-									index,
-									2,
-									newValues[ index ] + newValues[ index + 1 ]
-								);
-								offset = newValues[ index ].length - 1;
-							} else {
-								if ( ! newValues[ index - 1 ] ) {
-									return;
-								}
-								newValues.splice(
-									index - 1,
-									2,
-									newValues[ index - 1 ] + newValues[ index ]
-								);
-								offset = newValues[ index - 1 ].length - 1;
-							}
-							_onChange( newValues );
-							selectionChange(
-								clientId,
-								`${ identifier }-${
-									index - ( forward ? 0 : 1 )
-								}`,
-								offset,
-								offset
-							);
-						} }
+						onChange={ _onChange }
+						index={ index }
+						identifier={ identifier }
+						multilineTagName={ multilineTagName }
 						{ ...props }
 					/>
 				);

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -110,10 +110,10 @@ export default function useInput() {
 
 					// Ensure template is not locked.
 					if (
+						! __unstableIsFullySelected() &&
 						canInsertBlockType( blockName, rootClientId ) &&
-						! hasBlockSupport( blockName, 'splitting', false ) &&
-						! event.__deprecatedOnSplit &&
-						! __unstableIsFullySelected()
+						( hasBlockSupport( blockName, 'splitting', false ) ||
+							event.__deprecatedOnSplit )
 					) {
 						event.preventDefault();
 						__unstableSplitSelection();

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -159,7 +159,7 @@ export default function useInput() {
 
 							if ( nextClientId ) {
 								event.preventDefault();
-								selectBlock( nextClientId, null );
+								selectBlock( nextClientId, true );
 							}
 						}
 					}

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/blocks';
 import { store as blockEditorStore } from '../../store';
 import { setContentEditableWrapper } from './utils';
-import { getSelectionEditableElement } from '../../utils/dom';
+import { getBlockClientId, getSelectionEditableElement } from '../../utils/dom';
 
 /**
  * Handles input for selections across blocks.
@@ -134,8 +134,11 @@ export default function useInput() {
 						event.preventDefault();
 						__unstableSplitSelection();
 					} else if (
-						event.target.ownerDocument.activeElement?.getAttribute(
-							'data-block'
+						// The editable element may be nested within the
+						// block wrapper (e.g. Site Title), so resolve the
+						// block from the active element.
+						getBlockClientId(
+							event.target.ownerDocument.activeElement
 						) === clientId
 					) {
 						// The default block depends on context: containers

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -31,6 +31,7 @@ export default function useInput() {
 		getNextBlockClientId,
 		getBlockOrder,
 		getBlockEditingMode,
+		getBlockListSettings,
 	} = useSelect( blockEditorStore );
 	const {
 		replaceBlocks,
@@ -136,9 +137,18 @@ export default function useInput() {
 							'data-block'
 						) === clientId
 					) {
+						// The default block depends on context: containers
+						// such as the gallery define their own default
+						// block, which is what insertAfterBlock inserts.
+						const { defaultBlock: directInsertBlock } =
+							( rootClientId &&
+								getBlockListSettings( rootClientId ) ) ||
+							{};
+
 						if (
 							canInsertBlockType(
-								getDefaultBlockName(),
+								directInsertBlock?.name ??
+									getDefaultBlockName(),
 								rootClientId
 							)
 						) {

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -28,6 +28,9 @@ export default function useInput() {
 		getSelectionStart,
 		getSelectionEnd,
 		getBlockAttributes,
+		getNextBlockClientId,
+		getBlockOrder,
+		getBlockEditingMode,
 	} = useSelect( blockEditorStore );
 	const {
 		replaceBlocks,
@@ -36,6 +39,8 @@ export default function useInput() {
 		__unstableDeleteSelection,
 		__unstableExpandSelection,
 		__unstableMarkAutomaticChange,
+		insertAfterBlock,
+		selectBlock,
 	} = useDispatch( blockEditorStore );
 
 	return useRefEffect( ( node ) => {
@@ -70,7 +75,7 @@ export default function useInput() {
 
 			if ( ! hasMultiSelection() ) {
 				if ( event.keyCode === ENTER ) {
-					if ( event.shiftKey || __unstableIsFullySelected() ) {
+					if ( event.shiftKey ) {
 						return;
 					}
 
@@ -111,26 +116,66 @@ export default function useInput() {
 						}
 					}
 
-					if (
-						! hasBlockSupport( blockName, 'splitting', false ) &&
-						! event.__deprecatedOnSplit
-					) {
-						return;
-					}
+					const rootClientId = getBlockRootClientId( clientId );
 
 					// Ensure template is not locked.
 					if (
-						canInsertBlockType(
+						! __unstableIsFullySelected() &&
+						( canInsertBlockType(
 							getDefaultBlockName(),
-							getBlockRootClientId( clientId )
+							rootClientId
 						) ||
-						canInsertBlockType(
-							blockName,
-							getBlockRootClientId( clientId )
-						)
+							canInsertBlockType( blockName, rootClientId ) ) &&
+						( hasBlockSupport( blockName, 'splitting', false ) ||
+							event.__deprecatedOnSplit )
 					) {
-						__unstableSplitSelection();
 						event.preventDefault();
+						__unstableSplitSelection();
+					} else if (
+						event.target.ownerDocument.activeElement?.getAttribute(
+							'data-block'
+						) === clientId
+					) {
+						if (
+							canInsertBlockType(
+								getDefaultBlockName(),
+								rootClientId
+							)
+						) {
+							event.preventDefault();
+							insertAfterBlock( clientId );
+						} else {
+							function getNextClientId( id ) {
+								let nextClientId = null;
+
+								while (
+									typeof id === 'string' &&
+									! ( nextClientId =
+										getNextBlockClientId( id ) )
+								) {
+									id = getBlockRootClientId( id );
+								}
+
+								return nextClientId;
+							}
+
+							let nextClientId =
+								getBlockOrder( clientId )[ 0 ] ??
+								getNextClientId( clientId );
+
+							while (
+								nextClientId &&
+								getBlockEditingMode( nextClientId ) ===
+									'disabled'
+							) {
+								nextClientId = getNextClientId( nextClientId );
+							}
+
+							if ( nextClientId ) {
+								event.preventDefault();
+								selectBlock( nextClientId, true );
+							}
+						}
 					}
 				}
 				return;

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -210,6 +210,10 @@ export default function useInput() {
 
 							if ( nextClientId ) {
 								event.preventDefault();
+								// An initial position of `true` is an
+								// internal sentinel: it focuses the block
+								// wrapper instead of a text field within
+								// it. See useFocusFirstElement.
 								selectBlock( nextClientId, true );
 							}
 						}

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -41,6 +41,7 @@ export default function useInput() {
 		__unstableExpandSelection,
 		__unstableMarkAutomaticChange,
 		insertAfterBlock,
+		insertBlock,
 		selectBlock,
 	} = useDispatch( blockEditorStore );
 
@@ -155,19 +156,26 @@ export default function useInput() {
 							event.preventDefault();
 							insertAfterBlock( clientId );
 						} else {
-							// An empty container renders a ghost of its
-							// default block instead of a stored child.
-							// Focus materialises it through the ghost's
-							// own focus listener.
+							// Descend into an empty container by inserting
+							// its default block, the same block an appender
+							// or ghost would insert.
 							if ( ! getBlockOrder( clientId ).length ) {
-								const ghostElement =
-									event.target.ownerDocument.activeElement.querySelector(
-										'[data-block]'
-									);
+								const { defaultBlock } =
+									getBlockListSettings( clientId ) ?? {};
+								const name =
+									defaultBlock?.name ??
+									getDefaultBlockName();
 
-								if ( ghostElement ) {
+								if ( canInsertBlockType( name, clientId ) ) {
 									event.preventDefault();
-									ghostElement.focus();
+									insertBlock(
+										createBlock(
+											name,
+											defaultBlock?.attributes
+										),
+										0,
+										clientId
+									);
 									return;
 								}
 							}

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -145,6 +145,23 @@ export default function useInput() {
 							event.preventDefault();
 							insertAfterBlock( clientId );
 						} else {
+							// An empty container renders a ghost of its
+							// default block instead of a stored child.
+							// Focus materialises it through the ghost's
+							// own focus listener.
+							if ( ! getBlockOrder( clientId ).length ) {
+								const ghostElement =
+									event.target.ownerDocument.activeElement.querySelector(
+										'[data-block]'
+									);
+
+								if ( ghostElement ) {
+									event.preventDefault();
+									ghostElement.focus();
+									return;
+								}
+							}
+
 							function getNextClientId( id ) {
 								let nextClientId = null;
 

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -119,6 +119,7 @@ export default function useInput() {
 					}
 
 					const rootClientId = getBlockRootClientId( clientId );
+					const { activeElement } = event.target.ownerDocument;
 
 					// Ensure template is not locked.
 					if (
@@ -134,12 +135,15 @@ export default function useInput() {
 						event.preventDefault();
 						__unstableSplitSelection();
 					} else if (
-						// The editable element may be nested within the
-						// block wrapper (e.g. Site Title), so resolve the
-						// block from the active element.
-						getBlockClientId(
-							event.target.ownerDocument.activeElement
-						) === clientId
+						// Handle Enter only on the block wrapper itself or
+						// an editable element within the block, which may be
+						// nested within the wrapper (e.g. Site Title). Other
+						// focusable elements (an embed's URL field, an
+						// appender button) keep their native Enter behavior.
+						( activeElement.getAttribute( 'data-block' ) ===
+							clientId ||
+							activeElement.isContentEditable ) &&
+						getBlockClientId( activeElement ) === clientId
 					) {
 						// The default block depends on context: containers
 						// such as the gallery define their own default

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -163,8 +163,7 @@ export default function useInput() {
 								const { defaultBlock } =
 									getBlockListSettings( clientId ) ?? {};
 								const name =
-									defaultBlock?.name ??
-									getDefaultBlockName();
+									defaultBlock?.name ?? getDefaultBlockName();
 
 								if ( canInsertBlockType( name, clientId ) ) {
 									event.preventDefault();

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/block-editor';
 import { ToggleControl, TextControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
@@ -25,7 +24,6 @@ export default function PostTitleEdit( {
 	attributes: { level, levelOptions, textAlign, isLink, rel, linkTarget },
 	setAttributes,
 	context: { postType, postId, queryId },
-	insertBlocksAfter,
 } ) {
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
@@ -57,9 +55,6 @@ export default function PostTitleEdit( {
 		postId
 	);
 	const [ link ] = useEntityProp( 'postType', postType, 'link', postId );
-	const onSplitAtEnd = () => {
-		insertBlocksAfter( createBlock( getDefaultBlockName() ) );
-	};
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -77,7 +72,7 @@ export default function PostTitleEdit( {
 				value={ rawTitle }
 				onChange={ setTitle }
 				__experimentalVersion={ 2 }
-				__unstableOnSplitAtEnd={ onSplitAtEnd }
+				disableLineBreaks
 				{ ...blockProps }
 			/>
 		) : (
@@ -100,7 +95,7 @@ export default function PostTitleEdit( {
 					value={ rawTitle }
 					onChange={ setTitle }
 					__experimentalVersion={ 2 }
-					__unstableOnSplitAtEnd={ onSplitAtEnd }
+					disableLineBreaks
 				/>
 			</TagName>
 		) : (

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -14,7 +14,6 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -24,7 +23,6 @@ export default function PostTitleEdit( {
 	attributes: { level, levelOptions, isLink, rel, linkTarget, placeholder },
 	setAttributes,
 	context: { postType, postId, queryId },
-	insertBlocksAfter,
 } ) {
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
@@ -56,11 +54,6 @@ export default function PostTitleEdit( {
 		postId
 	);
 	const [ link ] = useEntityProp( 'postType', postType, 'link', postId );
-	const onSplitAtEnd = insertBlocksAfter
-		? () => {
-				insertBlocksAfter( createBlock( getDefaultBlockName() ) );
-		  }
-		: undefined;
 	const blockProps = useBlockProps();
 	const blockEditingMode = useBlockEditingMode();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -77,7 +70,7 @@ export default function PostTitleEdit( {
 				value={ rawTitle }
 				onChange={ setTitle }
 				__experimentalVersion={ 2 }
-				__unstableOnSplitAtEnd={ onSplitAtEnd }
+				disableLineBreaks
 				{ ...blockProps }
 			/>
 		) : (
@@ -104,7 +97,7 @@ export default function PostTitleEdit( {
 					value={ rawTitle }
 					onChange={ setTitle }
 					__experimentalVersion={ 2 }
-					__unstableOnSplitAtEnd={ onSplitAtEnd }
+					disableLineBreaks
 				/>
 			</TagName>
 		) : (

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -22,14 +22,9 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
 
-export default function SiteTitleEdit( {
-	attributes,
-	setAttributes,
-	insertBlocksAfter,
-} ) {
+export default function SiteTitleEdit( { attributes, setAttributes } ) {
 	const { level, levelOptions, textAlign, isLink, linkTarget } = attributes;
 	const { canUserEdit, title } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
@@ -72,9 +67,6 @@ export default function SiteTitleEdit( {
 				onChange={ setTitle }
 				allowedFormats={ [] }
 				disableLineBreaks
-				__unstableOnSplitAtEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
-				}
 			/>
 		</TagName>
 	) : (

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -14,7 +14,6 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
@@ -22,7 +21,7 @@ import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 export default function SiteTitleEdit( props ) {
 	useDeprecatedTextAlign( props );
 
-	const { attributes, setAttributes, insertBlocksAfter } = props;
+	const { attributes, setAttributes } = props;
 
 	const { level, levelOptions, isLink, linkTarget } = attributes;
 	const { canUserEdit, title } = useSelect( ( select ) => {
@@ -66,14 +65,6 @@ export default function SiteTitleEdit( props ) {
 				onChange={ setTitle }
 				allowedFormats={ [] }
 				disableLineBreaks
-				__unstableOnSplitAtEnd={
-					insertBlocksAfter
-						? () =>
-								insertBlocksAfter(
-									createBlock( getDefaultBlockName() )
-								)
-						: undefined
-				}
 			/>
 		</TagName>
 	) : (

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -91,7 +91,7 @@ test.describe( 'Post-type locking', () => {
 				.click();
 
 			await page.keyboard.type( 'First line' );
-			await page.keyboard.press( 'Enter' );
+			await pageUtils.pressKeys( 'shift+Enter' );
 			await page.keyboard.type( 'Second line' );
 			await pageUtils.pressKeys( 'shift+Enter' );
 			await page.keyboard.type( 'Third line' );

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -89,7 +89,7 @@ test.describe( 'Post-type locking', () => {
 				.click();
 
 			await page.keyboard.type( 'First line' );
-			await page.keyboard.press( 'Enter' );
+			await pageUtils.pressKeys( 'shift+Enter' );
 			await page.keyboard.type( 'Second line' );
 			await pageUtils.pressKeys( 'shift+Enter' );
 			await page.keyboard.type( 'Third line' );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1391,6 +1391,54 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		);
 		await expect( focusedElement.locator( 'a[href="#"]' ) ).toBeVisible();
 	} );
+
+	test( 'inserts the container default block on Enter on a selected block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			innerBlocks: [
+				{
+					name: 'core/image',
+					attributes: {
+						url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+					},
+				},
+				{
+					name: 'core/image',
+					attributes: {
+						url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+					},
+				},
+			],
+		} );
+
+		const firstImage = editor.canvas
+			.getByRole( 'document', { name: 'Block: Image' } )
+			.first();
+		await editor.selectBlocks( firstImage );
+		await expect( firstImage ).toBeFocused();
+
+		// A gallery defines the image as its default block, so Enter
+		// inserts a new empty image after the selected one.
+		await page.keyboard.press( 'Enter' );
+
+		await expect
+			.poll( () =>
+				editor.getBlocks().then( ( [ gallery ] ) =>
+					gallery.innerBlocks.map( ( { name, attributes } ) => ( {
+						name,
+						hasUrl: !! attributes.url,
+					} ) )
+				)
+			)
+			.toEqual( [
+				{ name: 'core/image', hasUrl: true },
+				{ name: 'core/image', hasUrl: false },
+				{ name: 'core/image', hasUrl: true },
+			] );
+	} );
 } );
 
 class WritingFlowUtils {

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -70,4 +70,42 @@ test.describe( 'Site editor writing flow', () => {
 		);
 		await expect( inspectorBlockTab ).toBeFocused();
 	} );
+
+	test( 'enter selects the next block', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const { id } = await requestUtils.createPage( {
+			status: 'draft',
+			title: 'test',
+		} );
+
+		await admin.visitSiteEditor( {
+			postId: id,
+			postType: 'page',
+			canvas: 'edit',
+		} );
+
+		// select the first block
+		const firstBlock = editor.canvas.locator(
+			'role=document[name="Block: Title"i]'
+		);
+		await editor.selectBlocks( firstBlock );
+
+		await expect( firstBlock ).toBeFocused();
+
+		await page.keyboard.press( 'Enter' );
+		const secondBlock = editor.canvas.locator(
+			'role=document[name="Block: Content"i]'
+		);
+		await expect( secondBlock ).toBeFocused();
+
+		await page.keyboard.press( 'Enter' );
+		const thirdBlock = editor.canvas.getByRole( 'document', {
+			name: 'Empty block',
+		} );
+		await expect( thirdBlock ).toBeFocused();
+	} );
 } );

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -67,4 +67,42 @@ test.describe( 'Site editor writing flow', () => {
 		);
 		await expect( inspectorBlockTab ).toBeFocused();
 	} );
+
+	test( 'enter selects the next block', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const { id } = await requestUtils.createPage( {
+			status: 'draft',
+			title: 'test',
+		} );
+
+		await admin.visitSiteEditor( {
+			postId: id,
+			postType: 'page',
+			canvas: 'edit',
+		} );
+
+		// select the first block
+		const firstBlock = editor.canvas.locator(
+			'role=document[name="Block: Title"i]'
+		);
+		await editor.selectBlocks( firstBlock );
+
+		await expect( firstBlock ).toBeFocused();
+
+		await page.keyboard.press( 'Enter' );
+		const secondBlock = editor.canvas.locator(
+			'role=document[name="Block: Content"i]'
+		);
+		await expect( secondBlock ).toBeFocused();
+
+		await page.keyboard.press( 'Enter' );
+		const thirdBlock = editor.canvas.getByRole( 'document', {
+			name: 'Empty block',
+		} );
+		await expect( thirdBlock ).toBeFocused();
+	} );
 } );

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -77,12 +77,24 @@ test.describe( 'Site editor writing flow', () => {
 		const { id } = await requestUtils.createPage( {
 			status: 'draft',
 			title: 'test',
+			content: '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->',
 		} );
 
 		await admin.visitSiteEditor( {
 			postId: id,
 			postType: 'page',
 			canvas: 'edit',
+		} );
+
+		// Render the page within its template so the template blocks
+		// surround the post blocks.
+		await expect(
+			editor.canvas.getByRole( 'textbox', { name: 'Add title' } )
+		).toBeVisible();
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/editor' )
+				.setRenderingMode( 'template-locked' );
 		} );
 
 		// select the first block

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -77,7 +77,6 @@ test.describe( 'Site editor writing flow', () => {
 		const { id } = await requestUtils.createPage( {
 			status: 'draft',
 			title: 'test',
-			content: '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->',
 		} );
 
 		await admin.visitSiteEditor( {
@@ -116,5 +115,11 @@ test.describe( 'Site editor writing flow', () => {
 			name: 'Empty block',
 		} );
 		await expect( thirdBlock ).toBeFocused();
+
+		// Typing proves the ghost materialised into a real stored block.
+		await page.keyboard.type( 'a' );
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		).toHaveText( 'a' );
 	} );
 } );

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -122,4 +122,42 @@ test.describe( 'Site editor writing flow', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
 		).toHaveText( 'a' );
 	} );
+
+	test( 'enter in a nested editable inserts a block after', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//header',
+			postType: 'wp_template_part',
+			canvas: 'edit',
+		} );
+
+		// The Site Title's editable element is nested within the block
+		// wrapper, unlike e.g. a paragraph, where they are the same
+		// element.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Site title text' } )
+			.click();
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a' );
+
+		await expect
+			.poll( () =>
+				editor.getBlocks().then( ( blocks ) =>
+					blocks.map( ( { name, attributes } ) => ( {
+						name,
+						...( name === 'core/paragraph' && {
+							content: attributes.content,
+						} ),
+					} ) )
+				)
+			)
+			.toEqual( [
+				{ name: 'core/site-title' },
+				{ name: 'core/paragraph', content: 'a' },
+				{ name: 'core/site-tagline' },
+			] );
+	} );
 } );

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -144,19 +144,10 @@ test.describe( 'Site editor writing flow', () => {
 		await page.keyboard.type( 'a' );
 
 		await expect
-			.poll( () =>
-				editor.getBlocks().then( ( blocks ) =>
-					blocks.map( ( { name, attributes } ) => ( {
-						name,
-						...( name === 'core/paragraph' && {
-							content: attributes.content,
-						} ),
-					} ) )
-				)
-			)
-			.toEqual( [
+			.poll( () => editor.getBlocks() )
+			.toMatchObject( [
 				{ name: 'core/site-title' },
-				{ name: 'core/paragraph', content: 'a' },
+				{ name: 'core/paragraph', attributes: { content: 'a' } },
 				{ name: 'core/site-tagline' },
 			] );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #54984.

Whenever a default block cannot be inserted on Enter, select the next block.

The next block means:
* The first child block, if any.
* If no child block, the next sibling block.
* If no next sibling block, look up the tree for a next sibling block of any parent.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Enter does not do anything useful when a template is locked and no default block can be inserter after the block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This ended up being a slightly larger refactor.

* We need to intercept Enter keydown in writing flow, right AFTER the the behaviour that checks if a block can be split.
* The problem is that the rich text fallback to split on Enter when "preserve line breaks" is on was running on even AFTER that. It must run before the Enter behaviour to select the next block, so we can disable that behaviour if necessary. (We don't want Enter in a verse block for example to select the next block.)
* Additionally, because of moving the rich text line break behaviour away from a window listener, I had to also move the listener for the deprecated multi line rich text from a React listener to a native DOM listener.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

In the Site Editor, select the post title. Enter should select the next block, and so on. Generally anytime a block is selected and no default block can be inserted, Enter should select the next block.

## Screenshots or screencast <!-- if applicable -->
