### PR TITLE
Update: Data views grid layout: Make aspect ratio consumer configurable.

### DIFF
--- a/packages/dataviews/src/aspect-ratio-control.tsx
+++ b/packages/dataviews/src/aspect-ratio-control.tsx
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { fullscreen } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import type { ViewGrid } from './types';
+
+export default function AspectRatioControl( {
+	view,
+	onChangeView,
+}: {
+	view: ViewGrid;
+	onChangeView: ( view: ViewGrid ) => void;
+} ) {
+	const hasOneAspectRatio = view.layout?.hasOneOneAspectRatio !== false;
+	return (
+		<>
+			<Button
+				size="compact"
+				isPressed={ hasOneAspectRatio }
+				icon={ fullscreen }
+				label={
+					hasOneAspectRatio
+						? __( 'Change aspect ratio to auto' )
+						: __( 'Change aspect ratio to 1:1' )
+				}
+				onClick={ () => {
+					if ( hasOneAspectRatio ) {
+						onChangeView( {
+							...view,
+							layout: {
+								...view.layout,
+								hasOneOneAspectRatio: false,
+							},
+						} );
+					} else if ( view.layout ) {
+						const { hasOneOneAspectRatio, ...layout } = view.layout;
+						onChangeView( {
+							...view,
+							layout,
+						} );
+					}
+				} }
+			/>
+		</>
+	);
+}

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -32,6 +32,7 @@ import type {
 	SupportedLayouts,
 } from './types';
 import type { SetSelection, SelectionOrUpdater } from './private-types';
+import AspectRatioControl from './aspect-ratio-control';
 
 type ItemWithId = { id: string };
 
@@ -134,6 +135,12 @@ export default function DataViews< Item >( {
 						setOpenedFilter={ setOpenedFilter }
 					/>
 				</HStack>
+				{ view.type === LAYOUT_GRID && (
+					<AspectRatioControl
+						view={ view }
+						onChangeView={ onChangeView }
+					/>
+				) }
 				{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
 					hasPossibleBulkAction && (
 						<BulkActions

--- a/packages/dataviews/src/layouts/grid/index.tsx
+++ b/packages/dataviews/src/layouts/grid/index.tsx
@@ -36,6 +36,7 @@ interface GridItemProps< Item > {
 	visibleFields: NormalizedField< Item >[];
 	badgeFields: NormalizedField< Item >[];
 	columnFields?: string[];
+	hasOneOneAspectRatio?: boolean;
 }
 
 function GridItem< Item >( {
@@ -49,6 +50,7 @@ function GridItem< Item >( {
 	visibleFields,
 	badgeFields,
 	columnFields,
+	hasOneOneAspectRatio,
 }: GridItemProps< Item > ) {
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
@@ -59,6 +61,8 @@ function GridItem< Item >( {
 	const renderedPrimaryField = primaryField?.render ? (
 		<primaryField.render item={ item } />
 	) : null;
+	const mediaStyle =
+		hasOneOneAspectRatio === false ? { aspectRatio: 'auto' } : undefined;
 	return (
 		<VStack
 			spacing={ 0 }
@@ -81,7 +85,7 @@ function GridItem< Item >( {
 				}
 			} }
 		>
-			<div className="dataviews-view-grid__media">
+			<div className="dataviews-view-grid__media" style={ mediaStyle }>
 				{ renderedMediaField }
 			</div>
 			<HStack
@@ -226,6 +230,9 @@ export default function ViewGrid< Item >( {
 								visibleFields={ visibleFields }
 								badgeFields={ badgeFields }
 								columnFields={ view.layout?.columnFields }
+								hasOneOneAspectRatio={
+									view.layout?.hasOneOneAspectRatio
+								}
 							/>
 						);
 					} ) }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -332,6 +332,11 @@ export interface ViewGrid extends ViewBase {
 		 * The fields to use as badge fields.
 		 */
 		badgeFields?: string[];
+
+		/**
+		 * True if the grid has a 1:1 aspect ratio the default, and false if it doesn't.
+		 */
+		hasOneOneAspectRatio?: boolean;
 	};
 }
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/60891

Adds the possibility for the user to configure the aspect ratio on grid items between auto and 1/1 (the default).

cc: @jameskoster 

## Screenshots
<img width="1706" alt="Screenshot 2024-07-12 at 15 21 10" src="https://github.com/user-attachments/assets/dd97847b-bccf-4b32-8f88-41cef4b1bcd1">
<img width="1690" alt="Screenshot 2024-07-12 at 15 20 49" src="https://github.com/user-attachments/assets/4b958eac-ab95-448b-890e-39260dd079d3">



## Testing Instructions
Verified I was able to change the aspect ratio successfully.
