### PR TITLE
Templates DataViews: Set the right context for the preview field

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -18,7 +18,10 @@ import {
 } from '@wordpress/block-editor';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import {
+	privateApis as editorPrivateApis,
+	EditorProvider,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -42,9 +45,7 @@ import { useEditPostAction } from '../dataviews-actions';
 
 const { usePostActions } = unlock( editorPrivateApis );
 
-const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
-	blockEditorPrivateApis
-);
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
@@ -176,7 +177,7 @@ function Preview( { item, viewType } ) {
 	// the block editor settings are needed in context where we don't have the block editor.
 	// Explore how we can solve this in a better way.
 	return (
-		<ExperimentalBlockEditorProvider settings={ settings }>
+		<EditorProvider post={ item } settings={ settings }>
 			<div
 				className={ `page-templates-preview-field is-viewtype-${ viewType }` }
 				style={ { backgroundColor } }
@@ -202,7 +203,7 @@ function Preview( { item, viewType } ) {
 					</button>
 				) }
 			</div>
-		</ExperimentalBlockEditorProvider>
+		</EditorProvider>
 	);
 }
 


### PR DESCRIPTION
Fixes #59082 

## What?

Some core blocks are WP specific and require the "EditorProvider" (the core/editor store) context to work properly and render the right information.

One of these blocks is the QueryTitle block and this is fixed in this PR.

## Testing Instructions

1- Create a "Tag Archive" template and use the Archive Title block in it. 
2- In the data views, the block should show the right placeholder.