### PR TITLE
Update MediaUpload button for site logo from "Add media" to "Choose logo"

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -631,7 +631,7 @@ export default function LogoEdit( {
 											{ isLoading ? (
 												<Spinner />
 											) : (
-												__( 'Add media' )
+												__( 'Add Site Logo' )
 											) }
 										</Button>
 										<DropZone onFilesDrop={ onFilesDrop } />

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -631,7 +631,7 @@ export default function LogoEdit( {
 											{ isLoading ? (
 												<Spinner />
 											) : (
-												__( 'Add Site Logo' )
+												__( 'Choose Site Logo' )
 											) }
 										</Button>
 										<DropZone onFilesDrop={ onFilesDrop } />

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -590,8 +590,6 @@ export default function LogoEdit( {
 
 	const blockProps = useBlockProps( { className: classes } );
 
-	const label = __( 'Add a site logo' );
-
 	const mediaInspectorPanel = ( canUserEdit || logoUrl ) && (
 		<InspectorControls>
 			<PanelBody title={ __( 'Media' ) }>
@@ -631,7 +629,7 @@ export default function LogoEdit( {
 											{ isLoading ? (
 												<Spinner />
 											) : (
-												__( 'Choose Site Logo' )
+												__( 'Choose logo' )
 											) }
 										</Button>
 										<DropZone onFilesDrop={ onFilesDrop } />
@@ -671,9 +669,9 @@ export default function LogoEdit( {
 							<Button
 								icon={ upload }
 								variant="primary"
-								label={ label }
+								label={ __( 'Choose logo' ) }
 								showTooltip
-								tooltipPosition="top center"
+								tooltipPosition="bottom center"
 								onClick={ () => {
 									open();
 								} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes the button much clearer what you are intended to upload. Part of https://github.com/WordPress/gutenberg/issues/63327. 

I went with "Choose Site Logo" to map to the Site Icon setting in the General Settings admin view. 

Other alternatives: 
- I did consider "Add Site Logo", but it is a bit redundant as the Site Logo block itself was already added to the page. 
- "Add logo" could work, but since we're specific about "Site Logo" as the block name I was thinking it would feel more contextual to use "Site Logo" in the control. 
- "Select Site Logo" is another alternative; relative to "Select Site Icon" from the Customizer setting. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert the Site Logo block. 
3. Reset the logo if there is an existing one uploaded already. 
4. See changes in the Inspector. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-07-12 at 14 27 20](https://github.com/user-attachments/assets/fdb95f57-3a42-450e-9a1d-77da04b6fe06)|![CleanShot 2024-07-22 at 16 00 41](https://github.com/user-attachments/assets/4b881749-b0ea-4911-a814-a93a01ba414c)|



