### PR TITLE
Block Switcher Preview: Adjust the position and enable pattern list preview in mobile viewport

### DIFF
--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, useViewportMatch } from '@wordpress/compose';
 import { chevronRight } from '@wordpress/icons';
 
 import {
@@ -34,6 +34,7 @@ function PatternTransformationsMenu( {
 } ) {
 	const [ showTransforms, setShowTransforms ] = useState( false );
 	const patterns = useTransformedPatterns( statePatterns, blocks );
+
 	if ( ! patterns.length ) {
 		return null;
 	}
@@ -60,21 +61,22 @@ function PatternTransformationsMenu( {
 }
 
 function PreviewPatternsPopover( { patterns, onSelect } ) {
+	const isMobile = useViewportMatch( 'medium', '<' );
+
 	return (
-		<div className="block-editor-block-switcher__popover__preview__parent">
-			<div className="block-editor-block-switcher__popover__preview__container">
-				<Popover
-					className="block-editor-block-switcher__preview__popover"
-					position="bottom right"
-				>
-					<div className="block-editor-block-switcher__preview is-pattern-list-preview">
-						<BlockPatternsList
-							patterns={ patterns }
-							onSelect={ onSelect }
-						/>
-					</div>
-				</Popover>
-			</div>
+		<div className="block-editor-block-switcher__popover-preview-container">
+			<Popover
+				className="block-editor-block-switcher__popover-preview"
+				placement={ isMobile ? 'bottom' : 'right-start' }
+				offset={ 16 }
+			>
+				<div className="block-editor-block-switcher__preview is-pattern-list-preview">
+					<BlockPatternsList
+						patterns={ patterns }
+						onSelect={ onSelect }
+					/>
+				</div>
+			</Popover>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-switcher/preview-block-popover.js
+++ b/packages/block-editor/src/components/block-switcher/preview-block-popover.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -10,22 +11,27 @@ import { Popover } from '@wordpress/components';
 import BlockPreview from '../block-preview';
 
 export default function PreviewBlockPopover( { blocks } ) {
+	const isMobile = useViewportMatch( 'medium', '<' );
+
+	if ( isMobile ) {
+		return null;
+	}
+
 	return (
-		<div className="block-editor-block-switcher__popover__preview__parent">
-			<div className="block-editor-block-switcher__popover__preview__container">
-				<Popover
-					className="block-editor-block-switcher__preview__popover"
-					placement="bottom-start"
-					focusOnMount={ false }
-				>
-					<div className="block-editor-block-switcher__preview">
-						<div className="block-editor-block-switcher__preview-title">
-							{ __( 'Preview' ) }
-						</div>
-						<BlockPreview viewportWidth={ 500 } blocks={ blocks } />
+		<div className="block-editor-block-switcher__popover-preview-container">
+			<Popover
+				className="block-editor-block-switcher__popover-preview"
+				placement="right-start"
+				focusOnMount={ false }
+				offset={ 16 }
+			>
+				<div className="block-editor-block-switcher__preview">
+					<div className="block-editor-block-switcher__preview-title">
+						{ __( 'Preview' ) }
 					</div>
-				</Popover>
-			</div>
+					<BlockPreview viewportWidth={ 500 } blocks={ blocks } />
+				</div>
+			</Popover>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -84,26 +84,17 @@
 	min-width: 300px;
 }
 
-.block-editor-block-switcher__popover__preview__parent {
-	.block-editor-block-switcher__popover__preview__container {
-		position: absolute;
-		top: -$grid-unit-15;
-		left: calc(100% + #{$grid-unit-20});
-	}
+.block-editor-block-switcher__popover-preview-container {
+	left: 0;
+	position: absolute;
+	top: -$border-width;
+	width: 100%;
+	bottom: 0;
+	pointer-events: none;
 }
 
-.block-editor-block-switcher__preview__popover {
-	display: none;
+.block-editor-block-switcher__popover-preview {
 	overflow: hidden;
-
-	// Position correctly. Needs specificity.
-	&.components-popover {
-		margin-top: $grid-unit-15 - $border-width;
-	}
-
-	@include break-medium() {
-		display: block;
-	}
 
 	.components-popover__content {
 		width: 300px;


### PR DESCRIPTION
Fixes #51309

## What?

This PR solves two problems:

- Preview is not positioned correctly on narrow browser width
- Pattern preview is not displayed in the mobile viewport, so conversion to pattern is not possible

## Why?

### Preview is not positioned correctly on narrow browser width

The `Popover` component has `flip` prop to flip the popover when there isn't enough space by default. But the anchor element is a "point" and is fixed to the top right of the switcher popover:

![anchor-point-1](https://github.com/user-attachments/assets/701a7dd3-9810-479d-833b-4c0de59eb8cb)

As a result, the preview popover will flip based on this anchor and overlap the switcher popover if there is not enough space to the right.
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

### Pattern preview is not displayed in the mobile viewport, so conversion to pattern is not possible

On mobile viewports, [the preview popover is hidden via CSS](https://github.com/WordPress/gutenberg/blob/0aecc891389b6188da50bd865086a8934bdc7ce1/packages/block-editor/src/components/block-switcher/style.scss#L96), so clicking "Patterns" from the switcher popover does nothing.

![mobile-pattern-transform](https://github.com/user-attachments/assets/33b88a5c-6d98-4052-be42-d11ea9043d4a)

If we're transforming blocks, we don't necessarily need the preview popover, but for patterns, we need the preview popover because we need to select any pattern from the pattern list.

## How?

### Preview is not positioned correctly on narrow browser width

Position the preview popover's anchor so that it's equal in size and position to the switcher popover:

![anchor-point-2](https://github.com/user-attachments/assets/892b4963-5311-40fc-b8dd-214c716b38b7)

This will position the preview popover to the left of the switcher popover if there's not enough space to the right.


### Pattern preview is not displayed in the mobile viewport, so conversion to pattern is not possible

On mobile viewports, there isn't enough space to display the preview popover on either the left or right side. As a workaround, place the preview popover below the switcher popover:

![image](https://github.com/user-attachments/assets/506d7cfc-f596-4a04-ab76-45798071405f)

## Testing Instructions

- Insert a block to test the transformation.
  - The Query Loop block would be appropriate for testing default transformations and pattern transformations.
  - The Group block would be appropriate for testing variation transformations.
- The preview popover should be positioned on the right when the browser is wide.
- Open the List View and make your browser width about 1000px. The preview popover will appear on the left.
- Narrow your browser width to 782px or less.
  - For default and variation transforms, the preview popover will not appear.
  - For pattern transforms, the preview popover will be located below the switcher popover.
- (Bonus): It should work as expected when "Top Toolbar" is enabled.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/77ce0305-e3cb-4c41-802d-1b66563f5192

