### PR TITLE
Remove double shadow on Inserter category panel when zoomed out

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -703,6 +703,10 @@ $block-inserter-tabs-height: 44px;
 			height: 100%;
 		}
 	}
+
+	.block-editor-inserter__category-panel {
+		box-shadow: none;
+	}
 }
 
 .show-icon-labels {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -704,6 +704,8 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 
+	// Remove doubled-up shadow that occurs when categories panel is opened, only in zoom out.
+	// Shadow cannot be removed from the source, as it is required when not zoomed out.
 	.block-editor-inserter__category-panel {
 		box-shadow: none;
 	}


### PR DESCRIPTION
## What?
Fixes: #63511 

## Why?
When the experimental `Zoom Out` is enabled, we get to see double shadow on the category panel.

## Testing Instructions
#### Turn **ON** `Zoom Out`
1. Open Site Editor
2. Edit any template and click on Inserter > Pattern > Click on any pattern
3. See that there isn't any double shadow.

#### Turn **OFF** `Zoom Out`
1. Open Site Editor
2. Edit any template and click on Inserter > Pattern > Click on any pattern
3. See that there isn't any regression (the fix does not remove the shadow when zoom out is not active).

## Screenshots or screencast <!-- if applicable -->

When Zoom Out is enabled:
<img width="723" alt="image" src="https://github.com/user-attachments/assets/138a27e3-963c-42ed-bd8f-d316834d52a6">

When Zoom Out is disabled:
<img width="724" alt="image" src="https://github.com/user-attachments/assets/eec1e998-b250-4853-afe9-6ce7a32fcb60">
