### PR TITLE
Issue template: use checkboxes instead of dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -52,16 +52,16 @@ body:
     - type: checkboxes
       id: existing
       attributes:
-          required: true
           label: Please confirm that you have searched existing issues in the repo.
           description: You can do this by searching https://github.com/WordPress/gutenberg/issues and making sure the bug is not related to another plugin.
           options:
               - label: 'Yes'
+                required: true
 
     - type: checkboxes
       id: plugins
       attributes:
-          required: true
           label: Please confirm that you have tested with all plugins deactivated except Gutenberg.
           options:
               - label: 'Yes'
+                required: true

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -56,8 +56,7 @@ body:
           description: You can do this by searching https://github.com/WordPress/gutenberg/issues and making sure the bug is not related to another plugin.
           options:
               - label: 'Yes'
-      validations:
-          required: true
+              - required: true
 
     - type: checkboxes
       id: plugins
@@ -65,5 +64,4 @@ body:
           label: Please confirm that you have tested with all plugins deactivated except Gutenberg.
           options:
               - label: 'Yes'
-      validations:
-          required: true
+              - required: true

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -49,23 +49,21 @@ body:
       validations:
           required: false
 
-    - type: dropdown
+    - type: checkboxes
       id: existing
       attributes:
           label: Please confirm that you have searched existing issues in the repo.
           description: You can do this by searching https://github.com/WordPress/gutenberg/issues and making sure the bug is not related to another plugin.
-          multiple: true
           options:
               - 'Yes'
               - 'No'
       validations:
           required: true
 
-    - type: dropdown
+    - type: checkboxes
       id: plugins
       attributes:
           label: Please confirm that you have tested with all plugins deactivated except Gutenberg.
-          multiple: true
           options:
               - 'Yes'
               - 'No'

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -55,8 +55,7 @@ body:
           label: Please confirm that you have searched existing issues in the repo.
           description: You can do this by searching https://github.com/WordPress/gutenberg/issues and making sure the bug is not related to another plugin.
           options:
-              - 'Yes'
-              - 'No'
+              - label: 'Yes'
       validations:
           required: true
 
@@ -65,7 +64,6 @@ body:
       attributes:
           label: Please confirm that you have tested with all plugins deactivated except Gutenberg.
           options:
-              - 'Yes'
-              - 'No'
+              - label: 'Yes'
       validations:
           required: true

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -52,16 +52,16 @@ body:
     - type: checkboxes
       id: existing
       attributes:
+          required: true
           label: Please confirm that you have searched existing issues in the repo.
           description: You can do this by searching https://github.com/WordPress/gutenberg/issues and making sure the bug is not related to another plugin.
           options:
               - label: 'Yes'
-              - required: true
 
     - type: checkboxes
       id: plugins
       attributes:
+          required: true
           label: Please confirm that you have tested with all plugins deactivated except Gutenberg.
           options:
               - label: 'Yes'
-              - required: true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Also removes "multiple", it doesn't make sense at all to select both. I've also just left a checkbox for Yes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's super annoying to have to open a dropdown twice to be able to file a bug report.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
