### PR TITLE
Reduce duplication of font library group headings

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -52,7 +52,7 @@ function FontFamilies() {
 			<VStack spacing={ 4 }>
 				{ themeFonts.length > 0 && (
 					<VStack>
-						<Subtitle level={ 3 }>{ __( 'Theme Fonts' ) }</Subtitle>
+						<Subtitle level={ 3 }>{ __( 'Theme' ) }</Subtitle>
 						<ItemGroup isBordered isSeparated>
 							{ themeFonts.map( ( font ) => (
 								<FontFamilyItem
@@ -65,9 +65,7 @@ function FontFamilies() {
 				) }
 				{ customFonts.length > 0 && (
 					<VStack>
-						<Subtitle level={ 3 }>
-							{ __( 'Custom fonts' ) }
-						</Subtitle>
+						<Subtitle level={ 3 }>{ __( 'Custom' ) }</Subtitle>
 						<ItemGroup isBordered isSeparated>
 							{ customFonts.map( ( font ) => (
 								<FontFamilyItem

--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -55,7 +55,7 @@ function FontFamilies() {
 						<Subtitle level={ 3 }>
 							{
 								/* translators: Heading for a list of fonts provided by the theme. */
-								_x( 'Theme' )
+								_x( 'Theme', 'font source' )
 							}
 						</Subtitle>
 						<ItemGroup isBordered isSeparated>
@@ -73,7 +73,7 @@ function FontFamilies() {
 						<Subtitle level={ 3 }>
 							{
 								/* translators: Heading for a list of fonts installed by the user. */
-								_x( 'Custom' )
+								_x( 'Custom', 'font source' )
 							}
 						</Subtitle>
 						<ItemGroup isBordered isSeparated>

--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	__experimentalText as Text,
 	__experimentalItemGroup as ItemGroup,
@@ -52,7 +52,12 @@ function FontFamilies() {
 			<VStack spacing={ 4 }>
 				{ themeFonts.length > 0 && (
 					<VStack>
-						<Subtitle level={ 3 }>{ __( 'Theme' ) }</Subtitle>
+						<Subtitle level={ 3 }>
+							{
+								/* translators: Heading for a list of fonts provided by the theme. */
+								_x( 'Theme' )
+							}
+						</Subtitle>
 						<ItemGroup isBordered isSeparated>
 							{ themeFonts.map( ( font ) => (
 								<FontFamilyItem
@@ -65,7 +70,12 @@ function FontFamilies() {
 				) }
 				{ customFonts.length > 0 && (
 					<VStack>
-						<Subtitle level={ 3 }>{ __( 'Custom' ) }</Subtitle>
+						<Subtitle level={ 3 }>
+							{
+								/* translators: Heading for a list of fonts installed by the user. */
+								_x( 'Custom' )
+							}
+						</Subtitle>
 						<ItemGroup isBordered isSeparated>
 							{ customFonts.map( ( font ) => (
 								<FontFamilyItem

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -20,7 +20,7 @@ import {
 import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useContext, useEffect, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -172,7 +172,10 @@ function InstalledFonts() {
 								{ baseThemeFonts.length > 0 && (
 									<VStack>
 										<h2 className="font-library-modal__fonts-title">
-											{ __( 'Theme' ) }
+											{
+												/* translators: Heading for a list of fonts provided by the theme. */
+												_x( 'Theme' )
+											}
 										</h2>
 										{ /*
 										 * Disable reason: The `list` ARIA role is redundant but
@@ -209,7 +212,10 @@ function InstalledFonts() {
 								{ baseCustomFonts.length > 0 && (
 									<VStack>
 										<h2 className="font-library-modal__fonts-title">
-											{ __( 'Custom' ) }
+											{
+												/* translators: Heading for a list of fonts installed by the user. */
+												_x( 'Custom' )
+											}
 										</h2>
 										{ /*
 										 * Disable reason: The `list` ARIA role is redundant but

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -172,7 +172,7 @@ function InstalledFonts() {
 								{ baseThemeFonts.length > 0 && (
 									<VStack>
 										<h2 className="font-library-modal__fonts-title">
-											{ __( 'Theme Fonts' ) }
+											{ __( 'Theme' ) }
 										</h2>
 										{ /*
 										 * Disable reason: The `list` ARIA role is redundant but
@@ -209,7 +209,7 @@ function InstalledFonts() {
 								{ baseCustomFonts.length > 0 && (
 									<VStack>
 										<h2 className="font-library-modal__fonts-title">
-											{ __( 'Custom fonts' ) }
+											{ __( 'Custom' ) }
 										</h2>
 										{ /*
 										 * Disable reason: The `list` ARIA role is redundant but

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -174,7 +174,7 @@ function InstalledFonts() {
 										<h2 className="font-library-modal__fonts-title">
 											{
 												/* translators: Heading for a list of fonts provided by the theme. */
-												_x( 'Theme' )
+												_x( 'Theme', 'font source' )
 											}
 										</h2>
 										{ /*
@@ -214,7 +214,7 @@ function InstalledFonts() {
 										<h2 className="font-library-modal__fonts-title">
 											{
 												/* translators: Heading for a list of fonts installed by the user. */
-												_x( 'Custom' )
+												_x( 'Custom', 'font source' )
 											}
 										</h2>
 										{ /*


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/63502

## Screenshots
<img width="269" alt="image" src="https://github.com/user-attachments/assets/ac9d703a-fdb7-41c5-90c6-1a99d3f7c6d5">

<img width="1253" alt="image" src="https://github.com/user-attachments/assets/600d11b1-74d8-4f08-8205-9e2fed5f1669">
