### PR TITLE
Heading: Enable heading level curation

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -360,7 +360,7 @@ Introduce new sections and organize content to help visitors (and search engines
 -	**Name:** core/heading
 -	**Category:** text
 -	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, className, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight)
--	**Attributes:** content, level, placeholder, textAlign
+-	**Attributes:** content, level, levelOptions, placeholder, textAlign
 
 ## Home Link
 

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -21,6 +21,9 @@
 			"type": "number",
 			"default": 2
 		},
+		"levelOptions": {
+			"type": "array"
+		},
 		"placeholder": {
 			"type": "string"
 		}

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -32,7 +32,8 @@ function HeadingEdit( {
 	style,
 	clientId,
 } ) {
-	const { textAlign, content, level, placeholder, anchor } = attributes;
+	const { textAlign, content, level, levelOptions, placeholder, anchor } =
+		attributes;
 	const tagName = 'h' + level;
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -95,6 +96,7 @@ function HeadingEdit( {
 				<BlockControls group="block">
 					<HeadingLevelDropdown
 						value={ level }
+						options={ levelOptions }
 						onChange={ ( newLevel ) =>
 							setAttributes( { level: newLevel } )
 						}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/63527, https://github.com/WordPress/gutenberg/issues/20213

## What?
This PR is a minimalistic attempt to solve the longstanding issue that you cannot modify the available heading levels provided by the Heading block. This block is powered by the [HeadingLevelDropdown](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/block-heading-level-dropdown) component. This component accepts an `options` parameter that allows you to choose which levels are available in the dropdown. Unfortunately, there is no way to modify this `options` parameter from a Heading block.

This PR adds a `levelOptions` parameter to the Heading block to resolve this. 

## Why?
Being able to restrict the available heading levels is crucial in many situations, whether it be general Editor curation, accessibility, block governance, SEO, etc. 

## How?
This PR adds a `levelOptions` parameter to the Heading block that allows developers to define which heading levels should be displayed in the Heading dropdown UI. The approach is very simple and does not require a depreciation. Any previously set heading levels are respected in the markup. This attribute just allows you to control the UI. I could see how we may want to extend this future in the future, but the goal with this PR is to keep things simple and solve an immediate need of the community. Implementing this attribute does not block/preclude additional enhancements in the future. 

I chose the name `levelOptions` because we are already using the `level` attribute in the block, and the parameter in the `HeadingLevelDropdown` component is `options`. 

If we like this approach, follow-up PRs should be created to add similar functionality to all blocks that use the `HeadingLevelDropdown`.

With this new attribute, you can restrict the UI in many different ways, making this approach very flexible and powerful. For example, you could restrict options directly in block markup for a pattern or template. Try copying and pasting the following in the Editor. 

```
<!-- wp:heading {"level":3,"className":"wp-block-heading","levelOptions":[3,4,5]} -->
<h3 class="wp-block-heading">Markup example</h3>
<!-- /wp:heading -->
```

Or you could modify the attribute programmatically via filters. The following will disable `h1` globally. You could also add conditionals for post type, user permissions, etc. There are filters for both PHP and JavaScript so the applications are endless.

```
function example_modify_heading_levels_globally( $args, $block_type ) {
	
	if ( 'core/heading' !== $block_type ) {
		return $args;
	}

	// Remove H1.
	$args['attributes']['levelOptions']['default'] = [ 2, 3, 4, 5, 6 ];
	
	return $args;
}
add_filter( 'register_block_type_args', 'example_modify_heading_levels_globally', 10, 2 );

``` 

## Testing Instructions
1. Use any block theme with this PR enabled. You can also test in [Playground](https://playground.wordpress.net/gutenberg.html).
2. Try copying the block code above into the Code Editor, then switch to the Editor View to see the restricted Heading levels UI
3. Try copying the filter code into the `functions.php` file of your theme and see that `h1` is disabled. 


## Screenshots or screencast

| Default | Block markup example | Filter example |
|-|-|-|
|<img width="543" alt="image" src="https://github.com/user-attachments/assets/cbc2459c-fe6e-43ea-be13-7b72731c75ff">|<img width="548" alt="image" src="https://github.com/user-attachments/assets/f503a370-8160-437c-917d-1c188d9b323f">|<img width="523" alt="image" src="https://github.com/user-attachments/assets/266da30d-0100-4a19-a1cf-af0456dda83e">|

cc @ryanwelcher @troychaplin @amberhinds since we chatted about this at WordCamp Canada. 🇨🇦
cc @carolinan @fabiankaegy @richtabor @jasmussen for additional code/design feedback 🙏