### PR TITLE
List: Prevent style bleed into non-List block lists

### DIFF
--- a/packages/block-library/src/list/style.scss
+++ b/packages/block-library/src/list/style.scss
@@ -3,6 +3,6 @@ ul {
 	box-sizing: border-box;
 }
 
-:root :where(ul.has-background, ol.has-background) {
+:root :where(.wp-block-list.has-background) {
 	padding: $block-bg-padding--v $block-bg-padding--h;
 }


### PR DESCRIPTION

## What?

Prevents List block styles targeting generic `ul` and `ol` elements from bleeding into other blocks and lists.

## Why?

This style bleed leads to unexpected padding.

## How?

After #56469, the List block now has a class injected into its markup. We can use this to more accurately apply the list block's styles. The approach taken in #56469 also mean preexisting blocks get the new `.wp-block-list` class so is safe in that regard for BC.

The only core block that applies a `.has-background` class to a `ul` or `ol` element is the Page List block. This only happens when it is a child of a Navigation block which provides background colors via Block Context. The Navigation block also defines higher specificity styles resetting the padding so the Page List isn't impacted by the bleed. The end result is this change won't affect the Page List block.

There were quite a few hits for `.has-background` styles in the WP Directory. Most of these were for the navigation block and all of them had a higher specificity than the style being changed in this PR, so those themes should also be unaffected.

## Testing Instructions

1. Apply the changes from this PR and https://github.com/WordPress/gutenberg/pull/63407
2. Add List, Page List (within a nav block), and Categories List blocks to a post or page
3. Apply a background color to each (via nav block for the page list)
4. Confirm that only the List block gets default padding applied

Whether the categories list should also receive default padding when it has a background is outside the scope of this PR and can be considered a part of https://github.com/WordPress/gutenberg/pull/63407.

## Screenshots or screencast <!-- if applicable -->

There should be no visual change for the List and Page List blocks. 