### PR TITLE
Heading: Add border support

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -30,6 +30,18 @@
 		"anchor": true,
 		"className": true,
 		"splitting": true,
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"color": {
 			"gradients": true,
 			"link": true,


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/43241

## What?

Adopts border support for heading blocks.

## Why?

- Offers greater design flexibility
- Improves consistency in design tooling with other blocks
- Block already has padding and background color support. This adds another missing piece.

## How?

- Adopt all border supports.

## Testing Instructions

1. In the site editor, add a Heading block to a page
2. Style all Heading blocks via Global Styles and confirm the editor and frontend display correctly
3. Override the global styles on a block instance and confirm they display appropriately in the editor and frontend


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/96abe7d8-f4de-4b38-b980-055ff85b05dd

