### PR TITLE
List: Add border support

### DIFF
--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -39,6 +39,18 @@
 	"supports": {
 		"anchor": true,
 		"html": false,
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -87,6 +87,9 @@
 			"clientNavigation": true
 		}
 	},
+	"selectors": {
+		"border": ".wp-block-list:not(.wp-block-list .wp-block-list)"
+	},
 	"editorStyle": "wp-block-list-editor",
 	"style": "wp-block-list"
 }

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -43,13 +43,7 @@
 			"color": true,
 			"radius": true,
 			"style": true,
-			"width": true,
-			"__experimentalDefaultControls": {
-				"color": true,
-				"radius": true,
-				"style": true,
-				"width": true
-			}
+			"width": true
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/43241

## What?

Adopts border support for the List block

## Why?

- Offers greater design flexibility
- Improves consistency in design tooling with other blocks

## How?

- Adopts all the available border block supports
- Makes the border controls optional to match the dimension controls
- Defines a custom selector so global styles only target top-level List blocks

## Testing Instructions

- In the site editor, add a List block with some items including a nested list or two, to a page
- Style List blocks via Global Styles and confirm the editor and frontend display correctly
- Override the global styles on the block instance and confirm they display appropriately in the editor and frontend
- Confirm block instance styles apply correctly to nested List blocks


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/cf973e61-e475-45c6-8b0d-52a0bf5acb06

