### PR TITLE
List Item: Add border support

### DIFF
--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -69,6 +69,7 @@
 		}
 	},
 	"selectors": {
-		"root": ".wp-block-list > li"
+		"root": ".wp-block-list > li",
+		"border": ".wp-block-list:not(.wp-block-list .wp-block-list) > li"
 	}
 }

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -23,6 +23,18 @@
 		"anchor": true,
 		"className": false,
 		"splitting": true,
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"color": {
 			"gradients": true,
 			"link": true,

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -27,13 +27,7 @@
 			"color": true,
 			"radius": true,
 			"style": true,
-			"width": true,
-			"__experimentalDefaultControls": {
-				"color": true,
-				"radius": true,
-				"style": true,
-				"width": true
-			}
+			"width": true
 		},
 		"color": {
 			"gradients": true,


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/43241

## What?

Adopts border support for individual list items.

## Why?

- Offers greater design flexibility
- Improves consistency in design tooling with other blocks

## How?

- Adopts all the available border block supports
- Leaves the border controls as optional to match the dimension controls
- Defines a custom selector for borders so that the global styles only target top-level List Items

## Testing Instructions

- In the site editor, add a List block with a few items, including a nested list or two, to a page
- Style List Item blocks via Global Styles and confirm the editor and frontend display correctly
- Override the global styles on a single List Item block instance and confirm they display appropriately in the editor and frontend
- Test applying border styles to a block instance that is nested within another list


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/4d7a8b1d-1f0c-419c-8b49-a503e892bd0e

