### PR TITLE
Media Text: Add border support

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -103,6 +103,18 @@
 		"anchor": true,
 		"align": [ "wide", "full" ],
 		"html": false,
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"color": {
 			"gradients": true,
 			"heading": true,


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/43241

## What?

Adopts border support for Media and Text block.

## Why?
- Offers greater design flexibility
- Improves consistency in design tooling with other blocks

## How?

- Adopts all the available border block supports

## Testing Instructions

- In the site editor, add a Media Text block to a page
- Style via Global Styles and confirm the editor and frontend display correctly
- Override the global styles on the block instance and confirm they display appropriately in the editor and frontend


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/5cc14b84-a866-4a2a-ae4d-196c563966a9

