### PR TITLE
Paragraph: Add border support

### DIFF
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -37,13 +37,7 @@
 			"color": true,
 			"radius": true,
 			"style": true,
-			"width": true,
-			"__experimentalDefaultControls": {
-				"color": true,
-				"radius": true,
-				"style": true,
-				"width": true
-			}
+			"width": true
 		},
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -33,6 +33,18 @@
 		"splitting": true,
 		"anchor": true,
 		"className": false,
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"color": {
 			"gradients": true,
 			"link": true,


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/43241

## What?

Adopts border support for Paragraph block.

## Why?
- Offers greater design flexibility
- Improves consistency in design tooling with other blocks

## How?

- Adopts all the available border block supports

## Testing Instructions

- In the site editor, add a paragraph block to a page
- Style via Global Styles and confirm the editor and frontend display correctly
- Override the global styles on the block instance and confirm they display appropriately in the editor and frontend


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/33363f23-e91d-4702-a014-d7e22ba9497d



