### PR TITLE
Quote: Add border support

### DIFF
--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -36,6 +36,18 @@
 				"backgroundImage": true
 			}
 		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"dimensions": {
 			"minHeight": true,
 			"__experimentalDefaultControls": {


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/43241

## What?

Adopts border support for the Quote block.

## Why?
- Offers greater design flexibility
- Improves consistency in design tooling with other blocks

## How?

- Adopts all the available border block supports

## Testing Instructions

- In the site editor, add a Quote block to a page
- Style via Global Styles and confirm the editor and frontend display correctly
- Override the global styles on the block instance and confirm they display appropriately in the editor and frontend


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/5a8e2e64-341d-42c2-8442-2d57af206ab1




