### PR TITLE
Quote: Add spacing supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -783,7 +783,7 @@ Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Ju
 
 -	**Name:** core/quote
 -	**Category:** text
--	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** citation, textAlign, value
 
 ## Read More

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -70,7 +70,9 @@
 			"allowEditing": false
 		},
 		"spacing": {
-			"blockGap": true
+			"blockGap": true,
+			"padding": true,
+			"margin": true
 		},
 		"interactivity": {
 			"clientNavigation": true


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/43241

## What?

Adopts padding and margin support for the Quote block.

## Why?

- Offers greater design flexibility
- Improves consistency in design tooling with other blocks

## How?

- Adopts padding and margin block supports

## Testing Instructions

- In the site editor, add a Quote block to a page
- Style via Global Styles and confirm the editor and frontend display correctly
- Override the global styles on the block instance and confirm they display appropriately in the editor and frontend

Note: Global margins will be overridden by layout whereas block instance margins will not be. There is also an unrelated bug with the spacing visualizers that is being addressed separately.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/10a31bd9-d134-4d7d-be44-3d02a24926ec







