### PR TITLE
Search: Add margin support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -810,7 +810,7 @@ Help visitors find your content. ([Source](https://github.com/WordPress/gutenber
 
 -	**Name:** core/search
 -	**Category:** widgets
--	**Supports:** align (center, left, right), color (background, gradients, text), interactivity, typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (center, left, right), color (background, gradients, text), interactivity, spacing (margin), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** buttonPosition, buttonText, buttonUseIcon, isSearchFieldHidden, label, placeholder, query, showLabel, width, widthUnit
 
 ## Separator

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -85,6 +85,9 @@
 				"width": true
 			}
 		},
+		"spacing": {
+			"margin": true
+		},
 		"html": false
 	},
 	"editorStyle": "wp-block-search-editor",


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/43241

## What?

- Adopts margin support for the Search block

## Why?

- Offers greater design flexibility
- Improves consistency in design tooling with other blocks

## How?

- Adopts margin block support

## Testing Instructions

- In the site editor, add a Search block to a page
- Style via Global Styles and confirm the editor and frontend display correctly
- Override the global styles on the block instance and confirm they display appropriately in the editor and frontend

**Note: Global margins will be overridden by layout whereas block instance margins will not be. There is also an unrelated bug with the spacing visualizers that is being addressed separately.**

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/957a6ea0-6d49-48cd-b41f-28fa8764da49













