### PR TITLE
Bug: eslint `recommended-with-formatting` allows for unnecessary spaces

### DIFF
--- a/packages/eslint-plugin/configs/es5.js
+++ b/packages/eslint-plugin/configs/es5.js
@@ -72,7 +72,13 @@ module.exports = {
 				asyncArrow: 'always',
 			},
 		],
-		'space-in-parens': [ 'error', 'always' ],
+		'space-in-parens': [
+			'error',
+			'always',
+			{
+				exceptions: [ 'empty' ],
+			},
+		],
 		'space-infix-ops': 'error',
 		'space-unary-ops': [
 			'error',


### PR DESCRIPTION


## What?
Configures the `es5.js` ruleset to disallow space in empty function call/signature

## Why?
Closes #63548

## How?
See eslint's docs for this rule:
https://eslint.org/docs/latest/rules/space-in-parens#empty-exception
