### PR TITLE
Background Image: Make panel appear in a consistent location

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -133,6 +133,10 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 							className="color-block-support-panel__inner-wrapper"
 						/>
 						<InspectorControls.Slot
+							group="background"
+							label={ __( 'Background image' ) }
+						/>
+						<InspectorControls.Slot
 							group="typography"
 							label={ __( 'Typography' ) }
 						/>
@@ -286,6 +290,10 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 						className="color-block-support-panel__inner-wrapper"
 					/>
 					<InspectorControls.Slot
+						group="background"
+						label={ __( 'Background image' ) }
+					/>
+					<InspectorControls.Slot
 						group="typography"
 						label={ __( 'Typography' ) }
 					/>
@@ -298,10 +306,6 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 						label={ borderPanelLabel }
 					/>
 					<InspectorControls.Slot group="styles" />
-					<InspectorControls.Slot
-						group="background"
-						label={ __( 'Background image' ) }
-					/>
 					<PositionControls />
 					<div>
 						<AdvancedControls />


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63188

Issue was also flagged in https://github.com/WordPress/gutenberg/pull/61382#pullrequestreview-2168327052

## What?

This PR makes sure that the background image panel appears in the same location between blocks regardless of whether the block utilises the styles tab or has all panels within the block inspector itself.

The background image panel was also added to those displayed for multi-block selections when there are multiple blocks of the same type selected with support for background images.

## Why?

- Consistency in positioning will help discovery and overall UX
- Allows multiple blocks to be selected and have their background images changed at once for power users

## How?

- Move the background image panel to the same location as it was set in the Styles tab
- Add the background image panel to the multi selection block inspector

## Testing Instructions

1. Add multiple verse and group blocks to a post or page
2. Select a verse block and open the block inspector. Note the position of the background image panel
3. Select a group block and open the block inspector. The background image panel should be in the same location.
4. Select multiple verse blocks and confirm the background image panel appears in the inspector
5. Confirm that you can bulk assign background images when multiple verse blocks selected
6. Select a mix of verse and group blocks. The background image panel should not be in the inspector


## Screenshots or screencast <!-- if applicable -->

### Verse Block

<details>
<summary>Before and After</summary>
| Before | After |
|---|---|
| <img width="280" alt="Screenshot 2024-07-15 at 5 04 57 PM" src="https://github.com/user-attachments/assets/6dcf4511-a261-47e4-b41e-b376d91dc651"> | <img width="278" alt="Screenshot 2024-07-15 at 5 21 53 PM" src="https://github.com/user-attachments/assets/f0d1b06a-347b-4c19-b00e-c6eff3a82ac7"> |

</details>


### Group Block ( No change )
<details>
<summary>Before and After</summary>

| Before | After |
|---|---|
| <img width="267" alt="Screenshot 2024-07-15 at 5 05 11 PM" src="https://github.com/user-attachments/assets/dce74dff-de25-4c63-93dc-17288d0b2917"> | <img width="266" alt="Screenshot 2024-07-15 at 5 08 32 PM" src="https://github.com/user-attachments/assets/84071904-f62c-4ba0-a782-175104121e81"> |
</details>


### Multiple Selections
<details>
<summary>Before and After</summary>

| Before | After |
|---|---|
| <img width="279" alt="Screenshot 2024-07-15 at 5 11 08 PM" src="https://github.com/user-attachments/assets/475e6562-ebaf-49f2-9095-846fbf7d8b29"> | <img width="281" alt="Screenshot 2024-07-15 at 5 23 08 PM" src="https://github.com/user-attachments/assets/af7cf1ed-dec9-46fd-a43e-ff0bef5e4524"> |
</details>

