### PR TITLE
FontSizePicker: tidy up internal logic

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `ToggleGroupControl`: support disabled options ([#63450](https://github.com/WordPress/gutenberg/pull/63450)).
 -   `CustomSelectControl`: Stabilize `__experimentalShowSelectedHint` and `options[]. __experimentalHint` props ([#63248](https://github.com/WordPress/gutenberg/pull/63248)).
 -   `SelectControl`: Add `"minimal"` variant ([#63265](https://github.com/WordPress/gutenberg/pull/63265)).
+-   `FontSizePicker`: tidy up internal logic ([#63553](https://github.com/WordPress/gutenberg/pull/63553)).
 
 ### Internal
 

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -45,19 +45,6 @@ const DEFAULT_UNITS = [ 'px', 'em', 'rem', 'vw', 'vh' ];
 const shouldUseSelectOverToggle = ( howManyfontSizes: number ) =>
 	howManyfontSizes > 5;
 
-const getPickerType = (
-	showCustomValuePicker: boolean,
-	fontSizes: FontSize[]
-): FontSizePickerType => {
-	if ( showCustomValuePicker ) {
-		return 'custom';
-	}
-
-	return shouldUseSelectOverToggle( fontSizes.length )
-		? 'select'
-		: 'togglegroup';
-};
-
 const getHeaderHint = (
 	currentPickerType: FontSizePickerType,
 	selectedFontSize: FontSize | undefined,
@@ -117,14 +104,17 @@ const UnforwardedFontSizePicker = (
 
 	if ( fontSizes.length === 0 && disableCustomFontSizes ) {
 		return null;
+	let currentPickerType;
+	if ( ! disableCustomFontSizes && userRequestedCustom ) {
+		// While showing the custom value picker, switch back to predef only if
+		// `disableCustomFontSizes` is set to `true`.
+		currentPickerType = 'custom' as const;
+	} else {
+		currentPickerType = shouldUseSelectOverToggle( fontSizes.length )
+			? ( 'select' as const )
+			: ( 'togglegroup' as const );
 	}
 
-	const currentPickerType = getPickerType(
-		// If showing the custom value picker, switch back to predef only
-		// if `disableCustomFontSizes` is set to `true`.
-		! disableCustomFontSizes && userRequestedCustom,
-		fontSizes
-	);
 
 	const headerHint = getHeaderHint(
 		currentPickerType,

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -8,7 +8,7 @@ import type { ForwardedRef } from 'react';
  */
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
-import { useState, useEffect, forwardRef } from '@wordpress/element';
+import { useState, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -107,27 +107,9 @@ const UnforwardedFontSizePicker = (
 	);
 	const isCustomValue = !! value && ! selectedFontSize;
 
-	const [ currentPickerType, setCurrentPickerType ] = useState(
-		getPickerType( ! disableCustomFontSizes && isCustomValue, fontSizes )
-	);
-
-	useEffect( () => {
-		setCurrentPickerType(
-			getPickerType(
-				// If showing the custom value picker, switch back to predef only
-				// if `disableCustomFontSizes` is set to `true`.
-				currentPickerType === 'custom'
-					? ! disableCustomFontSizes
-					: ! disableCustomFontSizes && isCustomValue,
-				fontSizes
-			)
-		);
-	}, [
-		currentPickerType,
-		disableCustomFontSizes,
-		isCustomValue,
-		fontSizes,
-	] );
+	// Initially request a custom picker if the value is not from the predef list.
+	const [ userRequestedCustom, setUserRequestedCustom ] =
+		useState( isCustomValue );
 
 	const units = useCustomUnits( {
 		availableUnits: unitsProp,
@@ -136,6 +118,13 @@ const UnforwardedFontSizePicker = (
 	if ( fontSizes.length === 0 && disableCustomFontSizes ) {
 		return null;
 	}
+
+	const currentPickerType = getPickerType(
+		// If showing the custom value picker, switch back to predef only
+		// if `disableCustomFontSizes` is set to `true`.
+		! disableCustomFontSizes && userRequestedCustom,
+		fontSizes
+	);
 
 	const headerHint = getHeaderHint(
 		currentPickerType,
@@ -180,14 +169,9 @@ const UnforwardedFontSizePicker = (
 									: __( 'Set custom size' )
 							}
 							icon={ settings }
-							onClick={ () => {
-								setCurrentPickerType(
-									getPickerType(
-										currentPickerType !== 'custom',
-										fontSizes
-									)
-								);
-							} }
+							onClick={ () =>
+								setUserRequestedCustom( ! userRequestedCustom )
+							}
 							isPressed={ currentPickerType === 'custom' }
 							size="small"
 						/>
@@ -215,9 +199,7 @@ const UnforwardedFontSizePicker = (
 								);
 							}
 						} }
-						onSelectCustom={ () =>
-							setCurrentPickerType( 'custom' )
-						}
+						onSelectCustom={ () => setUserRequestedCustom( true ) }
 					/>
 				) }
 				{ currentPickerType === 'togglegroup' && (
@@ -251,6 +233,8 @@ const UnforwardedFontSizePicker = (
 								hideLabelFromVision
 								value={ value }
 								onChange={ ( newValue ) => {
+									setUserRequestedCustom( true );
+
 									if ( newValue === undefined ) {
 										onChange?.( undefined );
 									} else {
@@ -281,6 +265,8 @@ const UnforwardedFontSizePicker = (
 										initialPosition={ fallbackFontSize }
 										withInputField={ false }
 										onChange={ ( newValue ) => {
+											setUserRequestedCustom( true );
+
 											if ( newValue === undefined ) {
 												onChange?.( undefined );
 											} else if ( hasUnits ) {

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -57,6 +57,10 @@ const UnforwardedFontSizePicker = (
 		withReset = true,
 	} = props;
 
+	const units = useCustomUnits( {
+		availableUnits: unitsProp,
+	} );
+
 	const selectedFontSize = fontSizes.find(
 		( fontSize ) => fontSize.size === value
 	);
@@ -65,10 +69,6 @@ const UnforwardedFontSizePicker = (
 	// Initially request a custom picker if the value is not from the predef list.
 	const [ userRequestedCustom, setUserRequestedCustom ] =
 		useState( isCustomValue );
-
-	const units = useCustomUnits( {
-		availableUnits: unitsProp,
-	} );
 
 	let currentPickerType;
 	if ( ! disableCustomFontSizes && userRequestedCustom ) {

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -141,9 +141,7 @@ describe( 'FontSizePicker', () => {
 				render(
 					<FontSizePicker fontSizes={ fontSizes } value={ value } />
 				);
-				expect(
-					screen.getByLabelText( expectedLabel )
-				).toBeInTheDocument();
+				expect( screen.getByLabelText( expectedLabel ) ).toBeVisible();
 			}
 		);
 
@@ -266,9 +264,7 @@ describe( 'FontSizePicker', () => {
 				render(
 					<FontSizePicker fontSizes={ fontSizes } value={ value } />
 				);
-				expect(
-					screen.getByLabelText( expectedLabel )
-				).toBeInTheDocument();
+				expect( screen.getByLabelText( expectedLabel ) ).toBeVisible();
 			}
 		);
 
@@ -383,9 +379,7 @@ describe( 'FontSizePicker', () => {
 				render(
 					<FontSizePicker fontSizes={ fontSizes } value={ value } />
 				);
-				expect(
-					screen.getByLabelText( expectedLabel )
-				).toBeInTheDocument();
+				expect( screen.getByLabelText( expectedLabel ) ).toBeVisible();
 			}
 		);
 
@@ -457,9 +451,7 @@ describe( 'FontSizePicker', () => {
 				render(
 					<FontSizePicker fontSizes={ fontSizes } value={ value } />
 				);
-				expect(
-					screen.getByLabelText( expectedLabel )
-				).toBeInTheDocument();
+				expect( screen.getByLabelText( expectedLabel ) ).toBeVisible();
 			}
 		);
 
@@ -516,7 +508,7 @@ describe( 'FontSizePicker', () => {
 				render(
 					<FontSizePicker fontSizes={ fontSizes } value={ value } />
 				);
-				expect( screen.getByRole( 'radiogroup' ) ).toBeInTheDocument();
+				expect( screen.getByRole( 'radiogroup' ) ).toBeVisible();
 				expect(
 					screen.queryByRole( 'radio', { checked: true } )
 				).not.toBeInTheDocument();
@@ -537,7 +529,7 @@ describe( 'FontSizePicker', () => {
 			await user.click(
 				screen.getByRole( 'option', { name: 'Custom' } )
 			);
-			expect( screen.getByLabelText( 'Custom' ) ).toBeInTheDocument();
+			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
 			expect( onChange ).not.toHaveBeenCalled();
 		} );
 	}
@@ -545,14 +537,14 @@ describe( 'FontSizePicker', () => {
 	function commonTests( fontSizes: FontSize[] ) {
 		it( 'shows custom input when value is unknown', () => {
 			render( <FontSizePicker fontSizes={ fontSizes } value="3px" /> );
-			expect( screen.getByLabelText( 'Custom' ) ).toBeInTheDocument();
+			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
 		} );
 
 		it( 'hides custom input when disableCustomFontSizes is set to `true` with a custom font size', () => {
 			const { rerender } = render(
 				<FontSizePicker fontSizes={ fontSizes } value="3px" />
 			);
-			expect( screen.getByLabelText( 'Custom' ) ).toBeInTheDocument();
+			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
 
 			rerender(
 				<FontSizePicker
@@ -570,7 +562,7 @@ describe( 'FontSizePicker', () => {
 			const { rerender } = render(
 				<FontSizePicker fontSizes={ fontSizes } value="3px" />
 			);
-			expect( screen.getByLabelText( 'Custom' ) ).toBeInTheDocument();
+			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
 
 			rerender(
 				<FontSizePicker
@@ -578,7 +570,7 @@ describe( 'FontSizePicker', () => {
 					value={ fontSizes[ 0 ].size }
 				/>
 			);
-			expect( screen.getByLabelText( 'Custom' ) ).toBeInTheDocument();
+			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
 		} );
 
 		it( 'allows custom values by default', async () => {

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -1,5 +1,3 @@
-export type FontSizePickerType = 'select' | 'togglegroup' | 'custom';
-
 export type FontSizePickerProps = {
 	/**
 	 * If `true`, it will not be possible to choose a custom fontSize. The user

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -39,8 +39,9 @@ export type FontSizePickerProps = {
 	 */
 	value?: number | string;
 	/**
-	 * If `true`, the UI will contain a slider, instead of a numeric text input
-	 * field. If `false`, no slider will be present.
+	 * If `true`, a slider will be displayed alongside the input field when a
+	 * custom font size is active. Has no effect when `disableCustomFontSizes`
+	 * is `true`.
 	 *
 	 * @default false
 	 */
@@ -48,7 +49,7 @@ export type FontSizePickerProps = {
 	/**
 	 * If `true`, a reset button will be displayed alongside the input field
 	 * when a custom font size is active. Has no effect when
-	 * `disableCustomFontSizes` or `withSlider` is `true`.
+	 * `disableCustomFontSizes` is `true`.
 	 *
 	 * @default true
 	 */

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -1,3 +1,5 @@
+export type FontSizePickerType = 'select' | 'togglegroup' | 'custom';
+
 export type FontSizePickerProps = {
 	/**
 	 * If `true`, it will not be possible to choose a custom fontSize. The user


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extract some of the changes from #63040 to tidy up `FontSizePicker`'s internal logic

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The component's internal logic for which UI to show is based on several boolean flags spread across the file, which makes it difficult to read/understand and bug-prone.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This reactor extracts the logic to a few utility functions and condenses the UI state into one internal state variable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Make sure that the unit tests (including the ones added in this PR) also pass both on `trunk` and on this PR
- Test `FontSizePicker` in Storybook, especially around the props that influence what UI is presented to the user:
  - `fontSizes` (>= 5 font sizes => `CustomSelectControl`,  < 5 font sizes => `ToggleGroupControl`)
  - `disableCustomFontSizes` should disable the custom UI and hide the toggle
  - experiment with changing those props while different UIs are presented
- Smoke test in the editor

> [!NOTE]
> The new PR introduces a slight behavioral change to the component, which is IMO an improvement. Here's how to reproduce:
> 1. Load the default `FontSizePicker` Storybook example
> 2. Show the custom value UI by clicking on the toggle in the top-right corner
> 3. Change the `disableCustomFontSizes` prop to `true`
> 4. On `trunk`, no UI is presented to the user. On this PR, either `ToggleGroupControl` or `CustomSelectControl` UIs are shows based on how many font sizes the user can pick from.