### PR TITLE
Footnotes: Register format within the init function

### DIFF
--- a/packages/block-library/src/footnotes/index.js
+++ b/packages/block-library/src/footnotes/index.js
@@ -21,8 +21,7 @@ export const settings = {
 	edit,
 };
 
-registerFormatType( formatName, format );
-
 export const init = () => {
+	registerFormatType( formatName, format );
 	initBlock( { name, metadata, settings } );
 };

--- a/packages/core-data/src/test/entity-provider.js
+++ b/packages/core-data/src/test/entity-provider.js
@@ -14,7 +14,8 @@ import {
 } from '@wordpress/blocks';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
-import '@wordpress/block-library';
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { unregisterFormatType } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -137,12 +138,15 @@ describe( 'useEntityBlockEditor', () => {
 			title: 'block title',
 			edit,
 		} );
+
+		registerCoreBlocks();
 	} );
 
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
 		} );
+		unregisterFormatType( 'core/footnote' );
 	} );
 
 	it( 'does not mutate block attributes that include an array of strings or null values', async () => {

--- a/test/integration/helpers/integration-test-editor.js
+++ b/test/integration/helpers/integration-test-editor.js
@@ -20,6 +20,11 @@ import {
 	unregisterBlockType,
 	getBlockTypes,
 } from '@wordpress/blocks';
+import {
+	store as richTextStore,
+	unregisterFormatType,
+} from '@wordpress/rich-text';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -58,14 +63,18 @@ export async function selectBlock( name ) {
 
 export function Editor( { testBlocks, settings = {} } ) {
 	const [ currentBlocks, updateBlocks ] = useState( testBlocks );
+	const { getFormatTypes } = useSelect( richTextStore );
 
 	useEffect( () => {
 		return () => {
 			getBlockTypes().forEach( ( { name } ) =>
 				unregisterBlockType( name )
 			);
+			getFormatTypes().forEach( ( { name } ) =>
+				unregisterFormatType( name )
+			);
 		};
-	}, [] );
+	}, [ getFormatTypes ] );
 
 	return (
 		<BlockEditorProvider


### PR DESCRIPTION
Address https://github.com/WordPress/gutenberg/pull/51201#discussion_r1671641381 
Related #53874 

## What?

Some third-party editor uses the `@wordpress/block-library` package but only pick generic blocks from it. Things are WP specific like footnotes are not needed. 

The problem in trunk right now is that the "footnotes" format is registered as soon as you import the package regardless of whether you register the footnotes block or not which results in a 404 api request for all these editors.

This PR fixes that by moving the registration of the footnote format to the "init" function.

## Testing Instructions

1- Check that footnotes still work in the post editor.
2- Check that when you type in the "storybook" example for block editors, you won't see any failed API request. 