### PR TITLE
Style variations: Don't display the default if its the only variation

### DIFF
--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -110,6 +110,10 @@ export default function StyleVariationsContainer( { gap = 2 } ) {
 		];
 	}, [ fullStyleVariations, userStyles?.blocks, userStyles?.css ] );
 
+	if ( ! fullStyleVariations || fullStyleVariations?.length < 1 ) {
+		return null;
+	}
+
 	return (
 		<Grid
 			columns={ 2 }


### PR DESCRIPTION
## What?
Don't display the default variation if there are no other variations.  Alternative to #63083

## Why?
It's not necessary to display the default when there are no other options to choose from.

## How?
Return null if `fullStyleVariations` is not set or has no items.

## Testing Instructions
1. Remove all style variations from your theme
2. Open the Styles panel
3. Check that you don't see any style variations, including the default
4. Also try this when you have some color and typography variations.

## Screenshots or screencast <!-- if applicable -->
<img width="324" alt="Screenshot 2024-07-15 at 11 47 51" src="https://github.com/user-attachments/assets/c7553321-03c2-4bea-8acb-0f55e34723d6">
