### PR TITLE
Layout: Don't remount the block when rendering grid tools

### DIFF
--- a/packages/block-editor/src/hooks/grid-visualizer.js
+++ b/packages/block-editor/src/hooks/grid-visualizer.js
@@ -39,7 +39,7 @@ function GridTools( { clientId, layout } ) {
 const addGridVisualizerToBlockEdit = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		if ( props.attributes.layout?.type !== 'grid' ) {
-			return <BlockEdit { ...props } />;
+			return <BlockEdit key="edit" { ...props } />;
 		}
 
 		return (
@@ -48,7 +48,7 @@ const addGridVisualizerToBlockEdit = createHigherOrderComponent(
 					clientId={ props.clientId }
 					layout={ props.attributes.layout }
 				/>
-				<BlockEdit { ...props } />
+				<BlockEdit key="edit" { ...props } />
 			</>
 		);
 	},


### PR DESCRIPTION
## What?

PR updates the `addGridVisualizerToBlockEdit` filter and prevents the `BlockEdit` component from remounting when the `GridTools` are rendered.

## Why?
I noticed the issue while debugging the focus loss problem.

The focus moves back to the block element when transforming a Group block to the Grid variation using the sidebar. This affects both the keyboard and mouse but is more noticeable with the former.

I traced the issue to the `useFocusFirstElement` hook. It was called again when the block edit component was remounted; it was just a symptom of the actual bug.

## How?
I added a static `key` to the `BlockEdit`, hinting to React that it's working with the same component even when its position changes in the tree.

## Testing Instructions

1. Open a post or page.
2. Add a group block.
3. Transform it to the Grid using sidebar transformation controls.
4. Confirm that the focus remains on the control elements and isn't moved to the block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/6fe43aa0-39ba-4db2-99e3-1f02f69e7a18

**After**


https://github.com/user-attachments/assets/bf72d1a3-1335-4d98-8005-fbb7070c92fc

