### PR TITLE
Disallow scrolling the block preview.

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -112,9 +112,9 @@
 .edit-site-global-styles__block-preview-panel {
 	position: relative;
 	width: 100%;
-	overflow: auto;
 	border: $gray-200 $border-width solid;
 	border-radius: $radius-block-ui;
+	overflow: hidden;
 }
 
 .edit-site-global-styles__shadow-preview-panel {


### PR DESCRIPTION
## What?

The block preview is scrollable (related, #45719):

![before](https://github.com/user-attachments/assets/e7750d19-e534-43cf-8c25-87372f1f9d1c)

This PR makes it not scrollable:

![after](https://github.com/user-attachments/assets/25124433-0d54-4ba8-a87b-fa670a858abc)


## Why?

The content is inert, not meant to be interacted with.

## Testing Instructions

Go to site editor > global styles. Go to blocks, select a block such as paragraph. The preview here should not be scrollable.