### PR TITLE
Background tool: Fix double border.

### DIFF
--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -192,14 +192,21 @@
 	.components-toggle-control {
 		margin-bottom: 0;
 	}
+
 	.components-focal-point-picker-wrapper {
 		background-color: $gray-100;
 		width: 100%;
 		border-radius: $radius-block-ui;
 		border: $border-width solid $gray-300;
 	}
+
 	.components-focal-point-picker__media--image {
 		max-height: 180px;
+	}
+
+	// Override focal picker to avoid a double border.
+	.components-focal-point-picker::after {
+		content: none;
 	}
 }
 


### PR DESCRIPTION
## What?

There's a double border in the global styles background tools:

![before](https://github.com/user-attachments/assets/7845d751-0554-4821-a37d-8d82ee673519)

This PR removes that double border:

![after](https://github.com/user-attachments/assets/b980d55c-6cd4-4a65-9189-1fe752107251)

## How?

Using a local CSS override. 

## Testing Instructions

Open global styles > blocks > quote, then scroll down and add a square background image. Open the flyout and observe only a single border in the focal point picker area. 