### PR TITLE
Hide custom font size preset UI if customFontSize is disabled by the theme

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
@@ -171,6 +171,10 @@ function FontSizes() {
 		'typography.defaultFontSizes'
 	);
 
+	const [ customFontSizeEnabled ] = useGlobalSetting(
+		'typography.customFontSize'
+	);
+
 	const handleAddFontSize = () => {
 		const index = getNewIndexFromPresets( customFontSizes, 'custom-' );
 		const newFontSize = {
@@ -242,17 +246,19 @@ function FontSizes() {
 								/>
 							) }
 
-						<FontSizeGroup
-							label={ __( 'Custom' ) }
-							origin="custom"
-							sizes={ customFontSizes }
-							handleAddFontSize={ handleAddFontSize }
-							handleResetFontSizes={
-								customFontSizes.length > 0
-									? () => setCustomFontSizes( [] )
-									: null
-							}
-						/>
+						{ customFontSizeEnabled && (
+							<FontSizeGroup
+								label={ __( 'Custom' ) }
+								origin="custom"
+								sizes={ customFontSizes }
+								handleAddFontSize={ handleAddFontSize }
+								handleResetFontSizes={
+									customFontSizes.length > 0
+										? () => setCustomFontSizes( [] )
+										: null
+								}
+							/>
+						) }
 					</VStack>
 				</Spacer>
 			</View>


### PR DESCRIPTION
## What?
Hide custom font size preset UI if customFontSize is disabled by the theme.

## Why?
Fixes: https://github.com/WordPress/gutenberg/issues/63560

## How?
Check if `settings.typography.defaultFontSizes` is disabled and avoids rendering the UI.

## Testing Instructions
1. Activate, for example, TT4 theme.
2. Set in your theme.json file settings.typography.defaultFontSizes: false.
3. Check that UI to add custom font sizes is not rendered.


## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
| ![Screenshot from 2024-07-15 16-32-35](https://github.com/user-attachments/assets/a12345fd-8b14-4608-a11f-4e4802596a02) | ![Screenshot from 2024-07-15 16-32-20](https://github.com/user-attachments/assets/bdbf2f0c-2166-4c7d-bfdc-70360d1133de) |
