### PR TITLE
Global Styles: Disable "Reset styles" button when there are no changes

### DIFF
--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -85,7 +85,11 @@ const VALID_SETTINGS = [
 ];
 
 export const useGlobalStylesReset = () => {
-	const { user: config, setUserConfig } = useContext( GlobalStylesContext );
+	const { user, setUserConfig } = useContext( GlobalStylesContext );
+	const config = {
+		settings: user.settings,
+		styles: user.styles,
+	};
 	const canReset = !! config && ! fastDeepEqual( config, EMPTY_CONFIG );
 	return [
 		canReset,


### PR DESCRIPTION
## What?

This PR disables "Reset styles" button when there are no changes in the global styles.

## Why?

#61271 adds the `_links` field to the global style context. This causes the `fastDeepEqual()` function to always return `false`, so the global styles is always considered "changed."

## How?

Exclude the _links field.

## Testing Instructions

- Click the Reset styles button.
- When you open the menu again, the button will be disabled.
- Make changes to the global styles and save them.
- The button will be enabled again.


