### PR TITLE
ImageURLInputUI: Make onSetLightbox and resetLightbox optional

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -272,7 +272,7 @@ const ImageURLInputUI = ( {
 						icon={ linkOff }
 						label={ __( 'Disable expand on click' ) }
 						onClick={ () => {
-							onSetLightbox( false );
+							onSetLightbox?.( false );
 						} }
 						size="compact"
 					/>
@@ -302,7 +302,7 @@ const ImageURLInputUI = ( {
 						label={ __( 'Remove link' ) }
 						onClick={ () => {
 							onLinkRemove();
-							resetLightbox();
+							resetLightbox?.();
 						} }
 						size="compact"
 					/>
@@ -366,7 +366,7 @@ const ImageURLInputUI = ( {
 													LINK_DESTINATION_NONE,
 												href: '',
 											} );
-											onSetLightbox( true );
+											onSetLightbox?.( true );
 											stopEditLink();
 										} }
 									>


### PR DESCRIPTION
Related to #57608, #59890

## What?
This PR makes `onSetLightbox` and `resetLightbox` optional.
<!-- In a few words, what is the PR actually doing? -->

## Why?

This component is public and the `onSetLightbox` and `resetLightbox` props are not required, but these two functions may be called, so the following error will be logged in the browser:

```
image-url-input-ui.js:305 Uncaught TypeError: resetLightbox is not a function
```

## How?

Add the optional chaining to the two functions.

## Testing Instructions

Currently, the only core block that will cause this error is the Media & Text block, because [it doesn't have a `resetLightbox` prop](https://github.com/WordPress/gutenberg/blob/c54c0020a7a8ebf22738aa96cb398ea4cf17a30a/packages/block-library/src/media-text/edit.js#L464-L474) that fires whenever you remove a link.

- Insert a Media & Text block.
- Add and remove the link.
- There should be no errors in the browser console.