### PR TITLE
DataViews: Do not render bulk actions Dropdown if no actions are available

### DIFF
--- a/packages/dataviews/src/bulk-actions.tsx
+++ b/packages/dataviews/src/bulk-actions.tsx
@@ -160,7 +160,9 @@ function ActionsMenuGroup< Item >( {
 			);
 		} );
 	}, [ actions, selectedItems ] );
-
+	if ( ! elligibleActions.length ) {
+		return null;
+	}
 	return (
 		<>
 			<DropdownMenuGroup>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small follow up of: https://github.com/WordPress/gutenberg/pull/63473


## Testing instructions
If have no item selected and click the `bulk actions` button in Data Views lists, we should render an empty Dropdown and the separator.
