### PR TITLE
Inserter: Fade pattern previews in

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -108,6 +108,7 @@ function ScaledBlockPreview( {
 							? minHeight / scale
 							: minHeight,
 				} }
+				withLoadingEffects
 			>
 				<EditorStyles styles={ editorStyles } />
 				{ contentResizeListener }

--- a/packages/block-editor/src/components/block-preview/content.scss
+++ b/packages/block-editor/src/components/block-preview/content.scss
@@ -1,3 +1,9 @@
+.block-editor-block-preview__content-iframe {
+	opacity: 0;
+	transition: opacity 1s ease-in-out;
+	transition-delay: 0.5s;
+}
+
 // Hide inserter from previews.
 .block-editor-block-preview__content-iframe .block-list-appender {
 	display: none;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -23,7 +23,7 @@
 
 .block-editor-iframe__html {
 	transform-origin: top center;
-	transition: transform 0.3s;
+	transition: transform 0.3s, opacity 0.5s ease-in-out 0.1s;
 	@include reduce-motion("transition");
 }
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -110,6 +110,7 @@ function Iframe( {
 	readonly,
 	forwardedRef: ref,
 	title = __( 'Editor canvas' ),
+	withLoadingEffects,
 	...props
 } ) {
 	const { resolvedAssets, isPreviewMode } = useSelect( ( select ) => {
@@ -191,6 +192,10 @@ function Iframe( {
 				preventFileDropDefault,
 				false
 			);
+
+			if ( withLoadingEffects ) {
+				documentElement.style.setProperty( 'opacity', 1 );
+			}
 		}
 
 		node.addEventListener( 'load', onLoad );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Crude experimentation to fade in pattern previews.

**Please don't merge, this isn't production-ready.** 

## Why?
Pattern previews loading is often slow and clunky.

See https://github.com/WordPress/gutenberg/issues/44750

## How?
Adding an extra prop and some a simple CSS opacity transition.

## Testing Instructions
Open the pattern inserter and switch through some tabs.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/8c487cb8-3527-49d4-85e6-5fec0aa04124

