### PR TITLE
FontSizePicker: Fix docs for default `units`

### DIFF
--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -92,7 +92,7 @@ Size of the control.
 Available units for custom font size selection.
 
 -   Required: No
--   Default: `[ 'px', 'em', 'rem' ]`
+-   Default: `[ 'px', 'em', 'rem', 'vw', 'vh' ]`
 
 ### `value`: `number | string`
 

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -29,7 +29,7 @@ export type FontSizePickerProps = {
 	/**
 	 * Available units for custom font size selection.
 	 *
-	 * @default `[ 'px', 'em', 'rem' ]`
+	 * @default [ 'px', 'em', 'rem', 'vw', 'vh' ]
 	 */
 	units?: string[];
 	/**


### PR DESCRIPTION
Fixup for #60607

## What?

[Updates the docs](https://github.com/WordPress/gutenberg/pull/60607#pullrequestreview-2049243029) for `FontSizePicker` to reflect the changes introduced in #60607.

## Testing Instructions

Readme, JSDocs, and Storybook should show the correct default.