### PR TITLE
Add Clear button for Overlay color option in Cover Block

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -260,6 +260,7 @@ export default function CoverInspectorControls( {
 									gradient: undefined,
 									customGradient: undefined,
 								} ),
+								clearable: true,
 							},
 						] }
 						panelId={ clientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes [#63571](https://github.com/WordPress/gutenberg/issues/63571)

## What?
This PR adds a clear button for the overlay color in the Cover block inspector controls, similar to the existing clear buttons for text and heading colors.

## Why?
The Cover block currently lacks a clear button for the overlay color, which is inconsistent with other color settings like text and heading colors.

## How?
Added `clearable: true` in ColorGradientSettingsDropdown component

## Testing Instructions
1. Open a post or page in the WordPress editor.
2. Insert a Cover block.
3. Apply an overlay color to the Cover block.
4. Verify the new "Clear Overlay Color" button appears in the color settings of the Cover block inspector controls.
5. Click the "Clear Overlay Color" button and ensure the overlay color is removed, reverting to its default state.

## Screenshots or screencast <!-- if applicable -->
<img width="787" alt="Screenshot 2024-07-15 at 10 43 27 PM" src="https://github.com/user-attachments/assets/82fc526e-4ec3-4b9b-ab03-d2942291f912">
