### PR TITLE
Update JSON Schemas to Draft 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,7 +160,6 @@
 				"@wordpress/scripts": "file:packages/scripts",
 				"@wordpress/stylelint-config": "file:packages/stylelint-config",
 				"ajv": "8.7.1",
-				"ajv-draft-04": "1.0.0",
 				"appium": "2.0.0",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.1.3",
@@ -17541,20 +17540,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ajv-draft-04": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-			"dev": true,
-			"peerDependencies": {
-				"ajv": "^8.5.0"
-			},
-			"peerDependenciesMeta": {
-				"ajv": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/ajv-errors": {
@@ -69388,12 +69373,6 @@
 					"dev": true
 				}
 			}
-		},
-		"ajv-draft-04": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-			"dev": true
 		},
 		"ajv-errors": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
 		"@wordpress/scripts": "file:packages/scripts",
 		"@wordpress/stylelint-config": "file:packages/stylelint-config",
 		"ajv": "8.7.1",
-		"ajv-draft-04": "1.0.0",
 		"appium": "2.0.0",
 		"babel-jest": "29.7.0",
 		"babel-loader": "9.1.3",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress blocks",
-	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"definitions": {
 		"//": {
 			"reference": "https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/",

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress Font Collections",
-	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"type": "object",
 	"definitions": {
 		"fontFace": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress block theme global settings and styles",
-	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"definitions": {
 		"//": {
 			"explainer": "https://developer.wordpress.org/themes/advanced-topics/theme-json/",
@@ -469,8 +469,7 @@
 								"increment": {
 									"description": "The amount to increment each step by.",
 									"type": "number",
-									"exclusiveMinimum": true,
-									"minimum": 0,
+									"exclusiveMinimum": 0,
 									"default": 1.5
 								},
 								"steps": {
@@ -483,8 +482,7 @@
 								"mediumStep": {
 									"description": "The value to medium setting in the scale.",
 									"type": "number",
-									"exclusiveMinimum": true,
-									"minimum": 0,
+									"exclusiveMinimum": 0,
 									"default": 1.5
 								},
 								"unit": {
@@ -821,18 +819,18 @@
 				},
 				{
 					"properties": {
-						"appearanceTools": {},
-						"background": {},
-						"border": {},
-						"color": {},
-						"dimensions": {},
-						"layout": {},
-						"lightbox": {},
-						"position": {},
-						"shadow": {},
-						"spacing": {},
-						"typography": {},
-						"custom": {}
+						"appearanceTools": true,
+						"background": true,
+						"border": true,
+						"color": true,
+						"dimensions": true,
+						"layout": true,
+						"lightbox": true,
+						"position": true,
+						"shadow": true,
+						"spacing": true,
+						"typography": true,
+						"custom": true
 					},
 					"additionalProperties": false
 				}
@@ -1889,16 +1887,16 @@
 				},
 				{
 					"properties": {
-						"background": {},
-						"border": {},
-						"color": {},
-						"dimensions": {},
-						"spacing": {},
-						"typography": {},
-						"filter": {},
-						"shadow": {},
-						"outline": {},
-						"css": {}
+						"background": true,
+						"border": true,
+						"color": true,
+						"dimensions": true,
+						"spacing": true,
+						"typography": true,
+						"filter": true,
+						"shadow": true,
+						"outline": true,
+						"css": true
 					},
 					"additionalProperties": false
 				}
@@ -1916,16 +1914,16 @@
 						},
 						{
 							"properties": {
-								"border": {},
-								"background": {},
-								"color": {},
-								"dimensions": {},
-								"filter": {},
-								"shadow": {},
-								"outline": {},
-								"spacing": {},
-								"typography": {},
-								"css": {},
+								"border": true,
+								"background": true,
+								"color": true,
+								"dimensions": true,
+								"filter": true,
+								"shadow": true,
+								"outline": true,
+								"spacing": true,
+								"typography": true,
+								"css": true,
 								":hover": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
@@ -1957,16 +1955,16 @@
 						},
 						{
 							"properties": {
-								"background": {},
-								"border": {},
-								"color": {},
-								"dimensions": {},
-								"spacing": {},
-								"typography": {},
-								"filter": {},
-								"shadow": {},
-								"outline": {},
-								"css": {},
+								"background": true,
+								"border": true,
+								"color": true,
+								"dimensions": true,
+								"spacing": true,
+								"typography": true,
+								"filter": true,
+								"shadow": true,
+								"outline": true,
+								"css": true,
 								":hover": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
@@ -2334,16 +2332,16 @@
 				},
 				{
 					"properties": {
-						"background": {},
-						"border": {},
-						"color": {},
-						"dimensions": {},
-						"spacing": {},
-						"typography": {},
-						"filter": {},
-						"shadow": {},
-						"outline": {},
-						"css": {},
+						"background": true,
+						"border": true,
+						"color": true,
+						"dimensions": true,
+						"spacing": true,
+						"typography": true,
+						"filter": true,
+						"shadow": true,
+						"outline": true,
+						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
@@ -2371,16 +2369,16 @@
 				},
 				{
 					"properties": {
-						"background": {},
-						"border": {},
-						"color": {},
-						"dimensions": {},
-						"spacing": {},
-						"typography": {},
-						"filter": {},
-						"shadow": {},
-						"outline": {},
-						"css": {},
+						"background": true,
+						"border": true,
+						"color": true,
+						"dimensions": true,
+						"spacing": true,
+						"typography": true,
+						"filter": true,
+						"shadow": true,
+						"outline": true,
+						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
@@ -2408,16 +2406,16 @@
 				},
 				{
 					"properties": {
-						"background": {},
-						"border": {},
-						"color": {},
-						"dimensions": {},
-						"spacing": {},
-						"typography": {},
-						"filter": {},
-						"shadow": {},
-						"outline": {},
-						"css": {},
+						"background": true,
+						"border": true,
+						"color": true,
+						"dimensions": true,
+						"spacing": true,
+						"typography": true,
+						"filter": true,
+						"shadow": true,
+						"outline": true,
+						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
@@ -2742,16 +2740,16 @@
 				},
 				{
 					"properties": {
-						"background": {},
-						"border": {},
-						"color": {},
-						"dimensions": {},
-						"spacing": {},
-						"typography": {},
-						"filter": {},
-						"shadow": {},
-						"outline": {},
-						"css": {},
+						"background": true,
+						"border": true,
+						"color": true,
+						"dimensions": true,
+						"spacing": true,
+						"typography": true,
+						"filter": true,
+						"shadow": true,
+						"outline": true,
+						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						}
@@ -2770,7 +2768,7 @@
 		"version": {
 			"description": "Version of theme.json to use.",
 			"type": "integer",
-			"enum": [ 3 ]
+			"const": 3
 		},
 		"title": {
 			"type": "string",
@@ -2800,21 +2798,21 @@
 				},
 				{
 					"properties": {
-						"appearanceTools": {},
+						"appearanceTools": true,
 						"useRootPaddingAwareAlignments": {
 							"$ref": "#/definitions/settingsPropertiesUseRootPaddingAwareAlignments/properties/useRootPaddingAwareAlignments"
 						},
-						"background": {},
-						"color": {},
-						"layout": {},
-						"lightbox": {},
-						"spacing": {},
-						"typography": {},
-						"border": {},
-						"shadow": {},
-						"position": {},
-						"dimensions": {},
-						"custom": {},
+						"background": true,
+						"color": true,
+						"layout": true,
+						"lightbox": true,
+						"spacing": true,
+						"typography": true,
+						"border": true,
+						"shadow": true,
+						"position": true,
+						"dimensions": true,
+						"custom": true,
 						"blocks": {
 							"$ref": "#/definitions/settingsBlocksPropertiesComplete"
 						}
@@ -2832,16 +2830,16 @@
 				},
 				{
 					"properties": {
-						"background": {},
-						"border": {},
-						"color": {},
-						"dimensions": {},
-						"spacing": {},
-						"typography": {},
-						"filter": {},
-						"shadow": {},
-						"outline": {},
-						"css": {},
+						"background": true,
+						"border": true,
+						"color": true,
+						"dimensions": true,
+						"spacing": true,
+						"typography": true,
+						"filter": true,
+						"shadow": true,
+						"outline": true,
+						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -811,6 +811,22 @@
 				{ "$ref": "#/definitions/settingsPropertiesCustom" }
 			]
 		},
+		"settingsPropertyNames": {
+			"enum": [
+				"appearanceTools",
+				"background",
+				"border",
+				"color",
+				"dimensions",
+				"layout",
+				"lightbox",
+				"position",
+				"shadow",
+				"spacing",
+				"typography",
+				"custom"
+			]
+		},
 		"settingsPropertiesComplete": {
 			"type": "object",
 			"allOf": [
@@ -818,21 +834,9 @@
 					"$ref": "#/definitions/settingsProperties"
 				},
 				{
-					"properties": {
-						"appearanceTools": true,
-						"background": true,
-						"border": true,
-						"color": true,
-						"dimensions": true,
-						"layout": true,
-						"lightbox": true,
-						"position": true,
-						"shadow": true,
-						"spacing": true,
-						"typography": true,
-						"custom": true
-					},
-					"additionalProperties": false
+					"propertyNames": {
+						"$ref": "#/definitions/settingsPropertyNames"
+					}
 				}
 			]
 		},
@@ -1879,6 +1883,20 @@
 				}
 			}
 		},
+		"stylesPropertyNames": {
+			"enum": [
+				"background",
+				"border",
+				"color",
+				"dimensions",
+				"spacing",
+				"typography",
+				"filter",
+				"shadow",
+				"outline",
+				"css"
+			]
+		},
 		"stylesPropertiesComplete": {
 			"type": "object",
 			"allOf": [
@@ -1886,19 +1904,9 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
-					"properties": {
-						"background": true,
-						"border": true,
-						"color": true,
-						"dimensions": true,
-						"spacing": true,
-						"typography": true,
-						"filter": true,
-						"shadow": true,
-						"outline": true,
-						"css": true
-					},
-					"additionalProperties": false
+					"propertyNames": {
+						"$ref": "#/definitions/stylesPropertyNames"
+					}
 				}
 			]
 		},
@@ -1914,16 +1922,6 @@
 						},
 						{
 							"properties": {
-								"border": true,
-								"background": true,
-								"color": true,
-								"dimensions": true,
-								"filter": true,
-								"shadow": true,
-								"outline": true,
-								"spacing": true,
-								"typography": true,
-								"css": true,
 								":hover": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
@@ -1942,8 +1940,26 @@
 								":any-link": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								}
-							},
-							"additionalProperties": false
+							}
+						},
+						{
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"enum": [
+											":hover",
+											":focus",
+											":active",
+											":visited",
+											":link",
+											":any-link"
+										]
+									}
+								]
+							}
 						}
 					]
 				},
@@ -1955,16 +1971,6 @@
 						},
 						{
 							"properties": {
-								"background": true,
-								"border": true,
-								"color": true,
-								"dimensions": true,
-								"spacing": true,
-								"typography": true,
-								"filter": true,
-								"shadow": true,
-								"outline": true,
-								"css": true,
 								":hover": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
@@ -1983,8 +1989,26 @@
 								":any-link": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								}
-							},
-							"additionalProperties": false
+							}
+						},
+						{
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"enum": [
+											":hover",
+											":focus",
+											":active",
+											":visited",
+											":link",
+											":any-link"
+										]
+									}
+								]
+							}
 						}
 					]
 				},
@@ -2332,24 +2356,25 @@
 				},
 				{
 					"properties": {
-						"background": true,
-						"border": true,
-						"color": true,
-						"dimensions": true,
-						"spacing": true,
-						"typography": true,
-						"filter": true,
-						"shadow": true,
-						"outline": true,
-						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
 						"variations": {
 							"$ref": "#/definitions/stylesVariationsPropertiesComplete"
 						}
-					},
-					"additionalProperties": false
+					}
+				},
+				{
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "variations" ]
+							}
+						]
+					}
 				}
 			]
 		},
@@ -2369,24 +2394,25 @@
 				},
 				{
 					"properties": {
-						"background": true,
-						"border": true,
-						"color": true,
-						"dimensions": true,
-						"spacing": true,
-						"typography": true,
-						"filter": true,
-						"shadow": true,
-						"outline": true,
-						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
 						"blocks": {
 							"$ref": "#/definitions/stylesVariationBlocksPropertiesComplete"
 						}
-					},
-					"additionalProperties": false
+					}
+				},
+				{
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "blocks" ]
+							}
+						]
+					}
 				}
 			]
 		},
@@ -2406,24 +2432,25 @@
 				},
 				{
 					"properties": {
-						"background": true,
-						"border": true,
-						"color": true,
-						"dimensions": true,
-						"spacing": true,
-						"typography": true,
-						"filter": true,
-						"shadow": true,
-						"outline": true,
-						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
 						"blocks": {
 							"$ref": "#/definitions/stylesVariationBlocksPropertiesComplete"
 						}
-					},
-					"additionalProperties": false
+					}
+				},
+				{
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "blocks" ]
+							}
+						]
+					}
 				}
 			]
 		},
@@ -2740,21 +2767,22 @@
 				},
 				{
 					"properties": {
-						"background": true,
-						"border": true,
-						"color": true,
-						"dimensions": true,
-						"spacing": true,
-						"typography": true,
-						"filter": true,
-						"shadow": true,
-						"outline": true,
-						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						}
-					},
-					"additionalProperties": false
+					}
+				},
+				{
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements" ]
+							}
+						]
+					}
 				}
 			]
 		}
@@ -2798,26 +2826,28 @@
 				},
 				{
 					"properties": {
-						"appearanceTools": true,
 						"useRootPaddingAwareAlignments": {
 							"$ref": "#/definitions/settingsPropertiesUseRootPaddingAwareAlignments/properties/useRootPaddingAwareAlignments"
 						},
-						"background": true,
-						"color": true,
-						"layout": true,
-						"lightbox": true,
-						"spacing": true,
-						"typography": true,
-						"border": true,
-						"shadow": true,
-						"position": true,
-						"dimensions": true,
-						"custom": true,
 						"blocks": {
 							"$ref": "#/definitions/settingsBlocksPropertiesComplete"
 						}
-					},
-					"additionalProperties": false
+					}
+				},
+				{
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/settingsPropertyNames"
+							},
+							{
+								"enum": [
+									"useRootPaddingAwareAlignments",
+									"blocks"
+								]
+							}
+						]
+					}
 				}
 			]
 		},
@@ -2830,16 +2860,6 @@
 				},
 				{
 					"properties": {
-						"background": true,
-						"border": true,
-						"color": true,
-						"dimensions": true,
-						"spacing": true,
-						"typography": true,
-						"filter": true,
-						"shadow": true,
-						"outline": true,
-						"css": true,
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
@@ -2849,8 +2869,19 @@
 						"variations": {
 							"$ref": "#/definitions/stylesVariationsProperties"
 						}
-					},
-					"additionalProperties": false
+					}
+				},
+				{
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "blocks", "variations" ]
+							}
+						]
+					}
 				}
 			]
 		},

--- a/schemas/json/wp-env.json
+++ b/schemas/json/wp-env.json
@@ -63,6 +63,17 @@
 					"type": "object"
 				}
 			}
+		},
+		"wpEnvPropertyNames": {
+			"enum": [
+				"core",
+				"phpVersion",
+				"plugins",
+				"themes",
+				"port",
+				"config",
+				"mappings"
+			]
 		}
 	},
 	"type": "object",
@@ -85,16 +96,9 @@
 							"allOf": [
 								{ "$ref": "#/definitions/wpEnvProperties" },
 								{
-									"properties": {
-										"core": true,
-										"phpVersion": true,
-										"plugins": true,
-										"themes": true,
-										"port": true,
-										"config": true,
-										"mappings": true
-									},
-									"additionalProperties": false
+									"propertyNames": {
+										"$ref": "#/definitions/wpEnvPropertyNames"
+									}
 								}
 							]
 						}
@@ -103,18 +107,16 @@
 			}
 		},
 		{
-			"properties": {
-				"$schema": true,
-				"core": true,
-				"phpVersion": true,
-				"plugins": true,
-				"themes": true,
-				"port": true,
-				"config": true,
-				"mappings": true,
-				"env": true
-			},
-			"additionalProperties": false
+			"propertyNames": {
+				"anyOf": [
+					{
+						"$ref": "#/definitions/wpEnvPropertyNames"
+					},
+					{
+						"enum": [ "$schema", "env" ]
+					}
+				]
+			}
 		}
 	]
 }

--- a/schemas/json/wp-env.json
+++ b/schemas/json/wp-env.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress wp-env configuration files",
-	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"definitions": {
 		"//": {
 			"reference": "https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/"
@@ -86,13 +86,13 @@
 								{ "$ref": "#/definitions/wpEnvProperties" },
 								{
 									"properties": {
-										"core": {},
-										"phpVersion": {},
-										"plugins": {},
-										"themes": {},
-										"port": {},
-										"config": {},
-										"mappings": {}
+										"core": true,
+										"phpVersion": true,
+										"plugins": true,
+										"themes": true,
+										"port": true,
+										"config": true,
+										"mappings": true
 									},
 									"additionalProperties": false
 								}
@@ -104,15 +104,15 @@
 		},
 		{
 			"properties": {
-				"$schema": {},
-				"core": {},
-				"phpVersion": {},
-				"plugins": {},
-				"themes": {},
-				"port": {},
-				"config": {},
-				"mappings": {},
-				"env": {}
+				"$schema": true,
+				"core": true,
+				"phpVersion": true,
+				"plugins": true,
+				"themes": true,
+				"port": true,
+				"config": true,
+				"mappings": true,
+				"env": true
 			},
 			"additionalProperties": false
 		}

--- a/test/integration/blocks-schema.test.js
+++ b/test/integration/blocks-schema.test.js
@@ -16,7 +16,7 @@ describe( 'block.json schema', () => {
 	);
 	const ajv = new Ajv();
 
-	test( 'strictly adheres to the draft-04 meta schema', () => {
+	test( 'strictly adheres to the draft-07 meta schema', () => {
 		// Use ajv.compile instead of ajv.validateSchema to validate the schema
 		// because validateSchema only checks syntax, whereas, compile checks
 		// if the schema is semantically correct with strict mode.

--- a/test/integration/blocks-schema.test.js
+++ b/test/integration/blocks-schema.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Ajv from 'ajv-draft-04';
+import Ajv from 'ajv';
 import glob from 'fast-glob';
 
 /**

--- a/test/integration/fixtures/schemas/settings.json
+++ b/test/integration/fixtures/schemas/settings.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"settings": {
+		"invalidAdditionalProperty": true
+	}
+}

--- a/test/integration/fixtures/schemas/settingsPropertiesComplete.json
+++ b/test/integration/fixtures/schemas/settingsPropertiesComplete.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"settings": {
+		"blocks": {
+			"core/button": {
+				"invalidAdditionalProperty": true
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/styles.json
+++ b/test/integration/fixtures/schemas/styles.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"invalidAdditionalProperty": true
+	}
+}

--- a/test/integration/fixtures/schemas/stylesElementsPropertiesComplete_button.json
+++ b/test/integration/fixtures/schemas/stylesElementsPropertiesComplete_button.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"elements": {
+			"button": {
+				"invalidAdditionalProperty": true
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesElementsPropertiesComplete_link.json
+++ b/test/integration/fixtures/schemas/stylesElementsPropertiesComplete_link.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"elements": {
+			"link": {
+				"invalidAdditionalProperty": true
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesPropertiesAndElementsComplete.json
+++ b/test/integration/fixtures/schemas/stylesPropertiesAndElementsComplete.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/button": {
+				"invalidAdditionalProperty": true
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesPropertiesComplete.json
+++ b/test/integration/fixtures/schemas/stylesPropertiesComplete.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"elements": {
+			"button": {
+				":hover": {
+					"invalidAdditionalProperty": true
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesVariationBlockPropertiesComplete.json
+++ b/test/integration/fixtures/schemas/stylesVariationBlockPropertiesComplete.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"variations": {
+			"custom-variation": {
+				"blocks": {
+					"core/button": {
+						"invalidAdditionalProperty": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesVariationProperties.json
+++ b/test/integration/fixtures/schemas/stylesVariationProperties.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"variations": {
+			"custom-variation": {
+				"invalidAdditionalProperty": true
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesVariationPropertiesComplete.json
+++ b/test/integration/fixtures/schemas/stylesVariationPropertiesComplete.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/button": {
+				"variations": {
+					"custom-variation": {
+						"invalidAdditionalProperty": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -14,6 +14,10 @@ describe( 'theme.json schema', () => {
 		[ 'packages/*/src/**/theme.json', '{lib,phpunit,test}/**/theme.json' ],
 		{ onlyFiles: true }
 	);
+	const invalidFiles = glob.sync(
+		[ 'test/integration/fixtures/schemas/*.json' ],
+		{ onlyFiles: true }
+	);
 	const ajv = new Ajv( {
 		// Used for matching unknown blocks without repeating core blocks names
 		// with patternProperties in settings.blocks and settings.styles
@@ -44,5 +48,14 @@ describe( 'theme.json schema', () => {
 		const result = ajv.validate( themeSchema, metadata ) || ajv.errors;
 
 		expect( result ).toBe( true );
+	} );
+
+	test.each( invalidFiles )( 'invalidates schema for `%s`', ( filepath ) => {
+		// We want to validate the theme.json file using the local schema.
+		const { $schema, ...metadata } = require( filepath );
+
+		const result = ajv.validate( themeSchema, metadata );
+
+		expect( result ).toBe( false );
 	} );
 } );

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -20,7 +20,7 @@ describe( 'theme.json schema', () => {
 		allowMatchingProperties: true,
 	} );
 
-	it( 'strictly adheres to the draft-04 meta schema', () => {
+	it( 'strictly adheres to the draft-07 meta schema', () => {
 		// Use ajv.compile instead of ajv.validateSchema to validate the schema
 		// because validateSchema only checks syntax, whereas, compile checks
 		// if the schema is semantically correct with strict mode.

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Ajv from 'ajv-draft-04';
+import Ajv from 'ajv';
 import glob from 'fast-glob';
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates all JSON Schemas to use the [Draft 7 metaschema](https://json-schema.org/specification-links#draft-7).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #62462

> We've been following the [SchemaStore best practices](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md?rgh-link-date=2024-06-11T05%3A13%3A33Z#best-practices) for the development of our JSON schemas. They recommend a schema version based on what is widely supported in editors and IDEs. Previously this was draft-04, so all of our schemas currently use that version. However the new recommendation is draft-07 which comes with some quality of life improvements that can improve the readability and maintainability of our JSON schemas.

Additionally, updating to using `propertyNames` uncovered some places where the `additionalProperties` hack wasn't updated properly. Those were fixed in #63582, and this change should ensure that it doesn't happen again in these places.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Used `ajv-cli` for initial automated migration to handle `exclusiveMinimum` and `const` usage.
2. Manually updated places to use `propertyNames` where appropriate.
3. Updated tests to use the new schema version.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Ensure that validation is still working for all schemas.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
