### PR TITLE
Background image block support: Fix dropzone size

### DIFF
--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -103,8 +103,13 @@
 .block-editor-global-styles-background-panel__image-tools-panel-item {
 	border: 1px solid $gray-300;
 	border-radius: 2px;
+
 	// Full width. ToolsPanel lays out children in a grid.
 	grid-column: 1 / -1;
+
+	// Ensure the dropzone is positioned to the size of the item.
+	position: relative;
+
 	// Since there is no option to skip rendering the drag'n'drop icon in drop
 	// zone, we hide it for now.
 	.components-drop-zone__content-icon {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix the size of the dropzone for the background image block support by making the tools panel item `position: relative`.

Kudos @jasmussen for reporting.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without this, the whole sidebar becomes the dropzone for background images.

Note: not covered in this PR, but that I noticed while testing:

* While the image is uploading, we don't change the state of the button. Perhaps in a follow up we could add a loading state or visually disable the button while the image is being uploaded?
* It doesn't look like you can drag onto the button if an image is already set.

I think these issues are outside the scope of this particular tiny fix, and could be looked into separately as polishing tasks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add `position: relative` to the background image panel's tools panel item.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Group block to a post or template
2. In the Styles sidebar, go to drag an image from the desktop on to the "Add background image" button
3. Prior to this PR, notice that the whole sidebar goes blue for the dropzone
4. With this PR applied, only the "Add background image" button should be highlighted
5. Go to the site editor > global styles > blocks > verse
6. Repeat the above — with this PR applied, only the "Add background image" button should be highlighted

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/57532e3e-37a8-4ff0-925f-9157af613a58

### After

https://github.com/user-attachments/assets/ebd8770a-b0ca-47c1-a096-48acf92aa7ff


