### PR TITLE
Use static 'key' when filtering BlockEdit components

### DIFF
--- a/packages/customize-widgets/src/filters/move-to-sidebar.js
+++ b/packages/customize-widgets/src/filters/move-to-sidebar.js
@@ -83,7 +83,7 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 
 		return (
 			<>
-				<BlockEdit { ...props } />
+				<BlockEdit key="edit" { ...props } />
 				{ hasMultipleSidebars && canInsertBlockInSidebar && (
 					<BlockControls>
 						<MoveToWidgetArea

--- a/packages/customize-widgets/src/filters/wide-widget-display.js
+++ b/packages/customize-widgets/src/filters/wide-widget-display.js
@@ -14,7 +14,7 @@ const withWideWidgetDisplay = createHigherOrderComponent(
 				( widget ) => widget.id_base === idBase
 			)?.is_wide ?? false;
 
-		return <BlockEdit { ...props } isWide={ isWide } />;
+		return <BlockEdit key="edit" { ...props } isWide={ isWide } />;
 	},
 	'withWideWidgetDisplay'
 );

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -375,7 +375,7 @@ function PushChangesToGlobalStyles( props ) {
 const withPushChangesToGlobalStyles = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => (
 		<>
-			<BlockEdit { ...props } />
+			<BlockEdit key="edit" { ...props } />
 			{ props.isSelected && <PushChangesToGlobalStyles { ...props } /> }
 		</>
 	)

--- a/packages/edit-widgets/src/filters/move-to-widget-area.js
+++ b/packages/edit-widgets/src/filters/move-to-widget-area.js
@@ -48,7 +48,7 @@ const withMoveToWidgetAreaToolbarItem = createHigherOrderComponent(
 
 		return (
 			<>
-				<BlockEdit { ...props } />
+				<BlockEdit key="edit" { ...props } />
 				{ isMoveToWidgetAreaVisible && (
 					<BlockControls>
 						<MoveToWidgetArea

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -41,7 +41,7 @@ const withPatternOverrideControls = createHigherOrderComponent(
 
 		return (
 			<>
-				<BlockEdit { ...props } />
+				<BlockEdit key="edit" { ...props } />
 				{ props.isSelected && isSupportedBlock && (
 					<ControlsWithStoreSubscription { ...props } />
 				) }


### PR DESCRIPTION
## What?
PR updates the `BlockEdit` component instances returned by the `editor.BlockEdit` filter and adds a static "edit" key.

## Why?
While these filters don't experience this bug, the `key` prevents accidental remounts like #63557.

> Specifying a `key` tells React to use the `key` itself as part of the position, instead of their order within the parent.

## Testing Instructions
CI checks should be green

### Testing Instructions for Keyboard
Same.
