### PR TITLE
JSON Schema Reorganization and Fixes

### DIFF
--- a/bin/api-docs/gen-theme-reference.mjs
+++ b/bin/api-docs/gen-theme-reference.mjs
@@ -220,7 +220,7 @@ const formatType = ( prop ) => {
 // Settings
 const settings = Object.entries( themejson.definitions )
 	.filter( ( [ settingsKey ] ) =>
-		/^settingsProperties(?!Complete)\w+$/.test( settingsKey )
+		/^settings\w+Properties$/.test( settingsKey )
 	)
 	.reduce(
 		( settingsObj, [ , { properties } ] ) =>

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -39,15 +39,6 @@ Setting that enables the following UI tools:
 
 ---
 
-### useRootPaddingAwareAlignments
-
-Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.
-
-Please note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.
-
-
----
-
 ### border
 
 Settings related to borders.

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -273,8 +273,8 @@ Typography styles.
 | fontWeight | string, object |  |
 | letterSpacing | string, object |  |
 | lineHeight | string, object |  |
-| textAlign | string |  |
-| textColumns | string |  |
+| textAlign | string, object |  |
+| textColumns | string, object |  |
 | textDecoration | string, object |  |
 | writingMode | string, object |  |
 | textTransform | string, object |  |

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -130,7 +130,6 @@ Settings related to position.
 
 | Property  | Type   | Default | Props  |
 | ---    | ---    | ---    |---   |
-| fixed | boolean | false |  |
 | sticky | boolean | false |  |
 
 ---

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -41,8 +41,6 @@ Setting that enables the following UI tools:
 
 ### useRootPaddingAwareAlignments
 
-_**Note:** Since WordPress 6.1._
-
 Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.
 
 Please note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -130,6 +130,7 @@ Settings related to position.
 
 | Property  | Type   | Default | Props  |
 | ---    | ---    | ---    |---   |
+| fixed | boolean | false |  |
 | sticky | boolean | false |  |
 
 ---

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -39,6 +39,17 @@ Setting that enables the following UI tools:
 
 ---
 
+### background
+
+Settings related to background.
+
+| Property  | Type   | Default | Props  |
+| ---    | ---    | ---    |---   |
+| backgroundImage | boolean | false |  |
+| backgroundSize | boolean | false |  |
+
+---
+
 ### border
 
 Settings related to borders.
@@ -49,17 +60,6 @@ Settings related to borders.
 | radius | boolean | false |  |
 | style | boolean | false |  |
 | width | boolean | false |  |
-
----
-
-### shadow
-
-Settings related to shadows.
-
-| Property  | Type   | Default | Props  |
-| ---    | ---    | ---    |---   |
-| defaultPresets | boolean | true |  |
-| presets | array |  | name, shadow, slug |
 
 ---
 
@@ -84,17 +84,6 @@ Settings related to colors.
 | heading | boolean | true |  |
 | button | boolean | true |  |
 | caption | boolean | true |  |
-
----
-
-### background
-
-Settings related to background.
-
-| Property  | Type   | Default | Props  |
-| ---    | ---    | ---    |---   |
-| backgroundImage | boolean | false |  |
-| backgroundSize | boolean | false |  |
 
 ---
 
@@ -142,6 +131,17 @@ Settings related to position.
 | Property  | Type   | Default | Props  |
 | ---    | ---    | ---    |---   |
 | sticky | boolean | false |  |
+
+---
+
+### shadow
+
+Settings related to shadows.
+
+| Property  | Type   | Default | Props  |
+| ---    | ---    | ---    |---   |
+| defaultPresets | boolean | true |  |
+| presets | array |  | name, shadow, slug |
 
 ---
 

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -238,6 +238,13 @@ Color styles.
 
 ---
 
+### css
+
+Sets custom CSS to apply styling not covered by other theme.json properties.
+
+
+---
+
 ### dimensions
 
 Dimensions styles
@@ -246,6 +253,36 @@ Dimensions styles
 | ---       | ---    |---   |
 | aspectRatio | string, object |  |
 | minHeight | string, object |  |
+
+---
+
+### filter
+
+CSS and SVG filter styles.
+
+| Property  | Type   |  Props  |
+| ---       | ---    |---   |
+| duotone | string, object |  |
+
+---
+
+### outline
+
+Outline styles.
+
+| Property  | Type   |  Props  |
+| ---       | ---    |---   |
+| color | string, object |  |
+| offset | string, object |  |
+| style | string, object |  |
+| width | string, object |  |
+
+---
+
+### shadow
+
+Box shadow styles.
+
 
 ---
 
@@ -278,43 +315,6 @@ Typography styles.
 | textDecoration | string, object |  |
 | writingMode | string, object |  |
 | textTransform | string, object |  |
-
----
-
-### filter
-
-CSS and SVG filter styles.
-
-| Property  | Type   |  Props  |
-| ---       | ---    |---   |
-| duotone | string, object |  |
-
----
-
-### shadow
-
-Box shadow styles.
-
-
----
-
-### outline
-
-Outline styles.
-
-| Property  | Type   |  Props  |
-| ---       | ---    |---   |
-| color | string, object |  |
-| offset | string, object |  |
-| style | string, object |  |
-| width | string, object |  |
-
----
-
-### css
-
-Sets custom CSS to apply styling not covered by other theme.json properties.
-
 
 ---
 ## customTemplates

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -248,7 +248,7 @@ Sets custom CSS to apply styling not covered by other theme.json properties.
 
 ### dimensions
 
-Dimensions styles
+Dimensions styles.
 
 | Property  | Type   |  Props  |
 | ---       | ---    |---   |

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -16,15 +16,15 @@
 			"type": "string"
 		},
 		"apiVersion": {
-			"type": "integer",
 			"description": "The version of the Block API used by the block. The most recent version is 3 and it was introduced in WordPress 6.3.\n\n See the API versions documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/ for more details.",
-			"default": 1,
-			"enum": [ 1, 2, 3 ]
+			"type": "integer",
+			"enum": [ 1, 2, 3 ],
+			"default": 1
 		},
 		"name": {
+			"description": "The name for a block is a unique string that identifies a block. Names have to be structured as `namespace/block-name`, where namespace is the name of your plugin or theme.",
 			"type": "string",
-			"pattern": "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$",
-			"description": "The name for a block is a unique string that identifies a block. Names have to be structured as `namespace/block-name`, where namespace is the name of your plugin or theme."
+			"pattern": "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$"
 		},
 		"__experimental": {
 			"description": "The name of the experiment this block is a part of, or boolean true if there is no specific experiment name.",
@@ -38,8 +38,8 @@
 			]
 		},
 		"title": {
-			"type": "string",
-			"description": "This is the display title for your block, which can be translated with our translation functions. The block inserter will show this name."
+			"description": "This is the display title for your block, which can be translated with our translation functions. The block inserter will show this name.",
+			"type": "string"
 		},
 		"category": {
 			"description": "Blocks are grouped into categories to help users browse and discover them.\n Core provided categories are: text, media, design, widgets, theme, embed\n\nPlugins and Themes can also register custom block categories.\n\nhttps://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#managing-block-categories",
@@ -48,6 +48,7 @@
 					"type": "string"
 				},
 				{
+					"type": "string",
 					"enum": [
 						"text",
 						"media",
@@ -60,52 +61,52 @@
 			]
 		},
 		"parent": {
-			"type": "array",
 			"description": "Setting parent lets a block require that it is only available when nested within the specified blocks. For example, you might want to allow an ‘Add to Cart’ block to only be available within a ‘Product’ block.",
+			"type": "array",
 			"items": {
 				"type": "string"
 			}
 		},
 		"ancestor": {
-			"type": "array",
 			"description": "The `ancestor` property makes a block available inside the specified block types at any position of the ancestor block subtree. That allows, for example, to place a ‘Comment Content’ block inside a ‘Column’ block, as long as ‘Column’ is somewhere within a ‘Comment Template’ block.",
+			"type": "array",
 			"items": {
 				"type": "string"
 			}
 		},
 		"allowedBlocks": {
-			"type": "array",
 			"description": "The `allowedBlocks` property specifies that only the listed block types can be the children of this block. For example, a ‘List’ block allows only ‘List Item’ blocks as direct children.",
+			"type": "array",
 			"items": {
 				"type": "string"
 			}
 		},
 		"icon": {
-			"type": "string",
-			"description": "An icon property should be specified to make it easier to identify a block. These can be any of WordPress’ Dashicons (slug serving also as a fallback in non-js contexts)."
+			"description": "An icon property should be specified to make it easier to identify a block. These can be any of WordPress’ Dashicons (slug serving also as a fallback in non-js contexts).",
+			"type": "string"
 		},
 		"description": {
-			"type": "string",
-			"description": "This is a short description for your block, which can be translated with our translation functions. This will be shown in the block inspector."
+			"description": "This is a short description for your block, which can be translated with our translation functions. This will be shown in the block inspector.",
+			"type": "string"
 		},
 		"keywords": {
-			"type": "array",
 			"description": "Sometimes a block could have aliases that help users discover it while searching. For example, an image block could also want to be discovered by photo. You can do so by providing an array of unlimited terms (which are translated).",
+			"type": "array",
 			"items": {
 				"type": "string"
 			}
 		},
 		"version": {
-			"type": "string",
-			"description": "The current version number of the block, such as 1.0 or 1.0.3. It’s similar to how plugins are versioned. This field might be used with block assets to control cache invalidation, and when the block author omits it, then the installed version of WordPress is used instead."
+			"description": "The current version number of the block, such as 1.0 or 1.0.3. It’s similar to how plugins are versioned. This field might be used with block assets to control cache invalidation, and when the block author omits it, then the installed version of WordPress is used instead.",
+			"type": "string"
 		},
 		"textdomain": {
-			"type": "string",
-			"description": "The gettext text domain of the plugin/block. More information can be found in the Text Domain section of the How to Internationalize your Plugin page.\n\nhttps://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/"
+			"description": "The gettext text domain of the plugin/block. More information can be found in the Text Domain section of the How to Internationalize your Plugin page.\n\nhttps://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/",
+			"type": "string"
 		},
 		"attributes": {
-			"type": "object",
 			"description": "Attributes provide the structured data needs of a block. They can exist in different forms when they are serialized, but they are declared together under a common interface.\n\nSee the attributes documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/ for more details.",
+			"type": "object",
 			"patternProperties": {
 				"[a-zA-Z]": {
 					"type": "object",
@@ -145,25 +146,19 @@
 							]
 						},
 						"enum": {
-							"type": "array",
 							"description": "An attribute can be defined as one of a fixed set of values. This is specified by an enum, which contains an array of allowed values:",
+							"type": "array",
 							"items": {
 								"oneOf": [
-									{
-										"type": "boolean"
-									},
-									{
-										"type": "number"
-									},
-									{
-										"type": "string"
-									}
+									{ "type": "boolean" },
+									{ "type": "number" },
+									{ "type": "string" }
 								]
 							}
 						},
 						"source": {
-							"type": "string",
 							"description": "Attribute sources are used to define how the attribute values are extracted from saved post content. They provide a mechanism to map from the saved markup to a JavaScript representation of a block.",
+							"type": "string",
 							"enum": [
 								"attribute",
 								"text",
@@ -175,40 +170,36 @@
 							]
 						},
 						"selector": {
-							"type": "string",
-							"description": "The selector can be an HTML tag, or anything queryable with querySelector, such as a class or id attribute. Examples are given below.\n\nFor example, a selector of img will match an img element, and img.class will match an img element that has a class of class."
+							"description": "The selector can be an HTML tag, or anything queryable with querySelector, such as a class or id attribute. Examples are given below.\n\nFor example, a selector of img will match an img element, and img.class will match an img element that has a class of class.",
+							"type": "string"
 						},
 						"attribute": {
-							"type": "string",
-							"description": "Use an attribute source to extract the value from an attribute in the markup. The attribute is specified by the attribute field, which must be supplied.\n\nExample: Extract the src attribute from an image found in the block’s markup."
+							"description": "Use an attribute source to extract the value from an attribute in the markup. The attribute is specified by the attribute field, which must be supplied.\n\nExample: Extract the src attribute from an image found in the block’s markup.",
+							"type": "string"
 						},
 						"query": {
-							"type": "object",
-							"description": "Use query to extract an array of values from markup. Entries of the array are determined by the selector argument, where each matched element within the block will have an entry structured corresponding to the second argument, an object of attribute sources."
+							"description": "Use query to extract an array of values from markup. Entries of the array are determined by the selector argument, where each matched element within the block will have an entry structured corresponding to the second argument, an object of attribute sources.",
+							"type": "object"
 						},
 						"meta": {
-							"type": "string",
-							"description": "Although attributes may be obtained from a post’s meta, meta attribute sources are considered deprecated; EntityProvider and related hook APIs should be used instead, as shown in the Create Meta Block how-to here:\n\nhttps://developer.wordpress.org/block-editor/how-to-guides/metabox/#step-2-add-meta-block"
+							"description": "Although attributes may be obtained from a post’s meta, meta attribute sources are considered deprecated; EntityProvider and related hook APIs should be used instead, as shown in the Create Meta Block how-to here:\n\nhttps://developer.wordpress.org/block-editor/how-to-guides/metabox/#step-2-add-meta-block",
+							"type": "string"
 						},
 						"default": {
 							"description": "A block attribute can contain a default value, which will be used if the type and source do not match anything within the block content.\n\nThe value is provided by the default field, and the value should match the expected format of the attribute."
 						}
 					},
 					"anyOf": [
-						{
-							"required": [ "type" ]
-						},
-						{
-							"required": [ "enum" ]
-						}
+						{ "required": [ "type" ] },
+						{ "required": [ "enum" ] }
 					]
 				}
 			},
 			"additionalProperties": false
 		},
 		"providesContext": {
-			"type": "object",
 			"description": "Context provided for available access by descendants of blocks of this type, in the form of an object which maps a context name to one of the block’s own attribute.\n\nSee the block context documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/ for more details.",
+			"type": "object",
 			"patternProperties": {
 				"[a-zA-Z]": {
 					"type": "string"
@@ -216,8 +207,8 @@
 			}
 		},
 		"usesContext": {
-			"type": "array",
 			"description": "Array of the names of context values to inherit from an ancestor provider.\n\nSee the block context documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/ for more details.",
+			"type": "array",
 			"items": {
 				"type": "string"
 			}
@@ -227,12 +218,11 @@
 			"type": "object",
 			"properties": {
 				"anchor": {
-					"type": "boolean",
 					"description": "Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.",
+					"type": "boolean",
 					"default": false
 				},
 				"align": {
-					"default": false,
 					"description": "This property adds block controls which allow to change block’s alignment.",
 					"oneOf": [
 						{
@@ -251,21 +241,22 @@
 								]
 							}
 						}
-					]
+					],
+					"default": false
 				},
 				"alignWide": {
-					"type": "boolean",
 					"description": "This property allows to enable wide alignment for your theme. To disable this behavior for a single block, set this flag to false.",
+					"type": "boolean",
 					"default": true
 				},
 				"ariaLabel": {
-					"type": "boolean",
 					"description": "ARIA-labels let you define an accessible label for elements. This property allows enabling the definition of an aria-label for the block, without exposing a UI field.",
+					"type": "boolean",
 					"default": false
 				},
 				"className": {
-					"type": "boolean",
 					"description": "By default, the class .wp-block-your-block-name is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If, for whatever reason, a class is not desired on the markup, this functionality can be disabled.",
+					"type": "boolean",
 					"default": true
 				},
 				"color": {
@@ -273,45 +264,45 @@
 					"type": "object",
 					"properties": {
 						"background": {
-							"type": "boolean",
 							"description": "This property adds UI controls which allow the user to apply a solid background color to a block.\n\nWhen color support is declared, this property is enabled by default (along with text), so simply setting color will enable background color.\n\nTo disable background support while keeping other color supports enabled, set to false.\n\nWhen the block declares support for color.background, its attributes definition is extended to include two new attributes: backgroundColor and style",
+							"type": "boolean",
 							"default": true
 						},
 						"gradients": {
-							"type": "boolean",
 							"description": "This property adds UI controls which allow the user to apply a gradient background to a block.\n\nGradient presets are sourced from editor-gradient-presets theme support.\n\nWhen the block declares support for color.gradient, its attributes definition is extended to include two new attributes: gradient and style",
+							"type": "boolean",
 							"default": false
 						},
 						"link": {
-							"type": "boolean",
 							"description": "This property adds block controls which allow the user to set link color in a block, link color is disabled by default.\n\nLink color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.link, its attributes definition is extended to include the style attribute",
+							"type": "boolean",
 							"default": false
 						},
 						"text": {
-							"type": "boolean",
 							"description": "This property adds block controls which allow the user to set text color in a block.\n\nWhen color support is declared, this property is enabled by default (along with background), so simply setting color will enable text color.\n\nText color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.text, its attributes definition is extended to include two new attributes: textColor and style",
+							"type": "boolean",
 							"default": true
 						},
 						"heading": {
-							"type": "boolean",
 							"description": "This property adds block controls which allow the user to set heading colors in a block. Heading color is disabled by default.\n\nHeading color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.heading, its attributes definition is extended to include the style attribute",
+							"type": "boolean",
 							"default": false
 						},
 						"button": {
-							"type": "boolean",
 							"description": "This property adds block controls which allow the user to set button colors in a block. Button color is disabled by default.\n\nButton color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.button, its attributes definition is extended to include the style attribute",
+							"type": "boolean",
 							"default": false
 						},
 						"enableContrastChecker": {
-							"type": "boolean",
 							"description": "Determines whether the contrast checker widget displays in the block editor UI.\n\nThe contrast checker appears only if the block declares support for color. It tests the readability of color combinations and warns if there is a potential issue. The property is enabled by default.\n\nSet to `false` to explicitly disable.",
+							"type": "boolean",
 							"default": true
 						}
 					}
 				},
 				"customClassName": {
-					"type": "boolean",
 					"description": "This property adds a field to define a custom className for the block’s wrapper.",
+					"type": "boolean",
 					"default": true
 				},
 				"dimensions": {
@@ -319,13 +310,13 @@
 					"type": "object",
 					"properties": {
 						"aspectRatio": {
-							"type": "boolean",
 							"description": "Allow blocks to define an aspect ratio value.",
+							"type": "boolean",
 							"default": false
 						},
 						"minHeight": {
-							"type": "boolean",
 							"description": "Allow blocks to define a minimum height value.",
+							"type": "boolean",
 							"default": false
 						}
 					}
@@ -335,8 +326,8 @@
 					"type": "object",
 					"properties": {
 						"duotone": {
-							"type": "boolean",
 							"description": "Allow blocks to define a duotone filter.",
+							"type": "boolean",
 							"default": false
 						}
 					}
@@ -346,34 +337,33 @@
 					"type": "object",
 					"properties": {
 						"backgroundImage": {
-							"type": "boolean",
 							"description": "Allow blocks to define a background image.",
+							"type": "boolean",
 							"default": false
 						},
 						"backgroundSize": {
-							"type": "boolean",
 							"description": "Allow blocks to define values related to the size of a background image, including size, position, and repeat controls",
+							"type": "boolean",
 							"default": false
 						}
 					}
 				},
 				"html": {
-					"type": "boolean",
 					"description": "By default, a block’s markup can be edited individually. To disable this behavior, set html to false.",
+					"type": "boolean",
 					"default": true
 				},
 				"inserter": {
-					"type": "boolean",
 					"description": "By default, all blocks will appear in the inserter, block transforms menu, Style Book, etc. To hide a block from all parts of the user interface so that it can only be inserted programmatically, set inserter to false.",
+					"type": "boolean",
 					"default": true
 				},
 				"renaming": {
-					"type": "boolean",
 					"description": "By default, a block can be renamed by a user from the block 'Options' dropdown or the 'Advanced' panel. To disable this behavior, set renaming to false.",
+					"type": "boolean",
 					"default": true
 				},
 				"layout": {
-					"default": false,
 					"description": "This value only applies to blocks that are containers for inner blocks. If set to `true` the layout type will be `flow`. For other layout types it's necessary to set the `type` explicitly inside the `default` object.",
 					"oneOf": [
 						{ "type": "boolean" },
@@ -385,8 +375,8 @@
 									"type": "object",
 									"properties": {
 										"type": {
-											"type": "string",
 											"description": "The layout type.",
+											"type": "string",
 											"enum": [
 												"constrained",
 												"grid",
@@ -394,16 +384,16 @@
 											]
 										},
 										"contentSize": {
-											"type": "string",
-											"description": "The content size used on all children."
+											"description": "The content size used on all children.",
+											"type": "string"
 										},
 										"wideSize": {
-											"type": "string",
-											"description": "The wide size used on alignwide children."
+											"description": "The wide size used on alignwide children.",
+											"type": "string"
 										},
 										"justifyContent": {
-											"type": "string",
 											"description": "Content justification value.",
+											"type": "string",
 											"enum": [
 												"right",
 												"center",
@@ -413,18 +403,18 @@
 											]
 										},
 										"orientation": {
-											"type": "string",
 											"description": "The orientation of the layout.",
+											"type": "string",
 											"enum": [ "horizontal", "vertical" ]
 										},
 										"flexWrap": {
-											"type": "string",
 											"description": "The flex wrap value.",
+											"type": "string",
 											"enum": [ "wrap", "nowrap" ]
 										},
 										"verticalAlignment": {
-											"type": "string",
 											"description": "The vertical alignment value.",
+											"type": "string",
 											"enum": [
 												"top",
 												"center",
@@ -434,72 +424,73 @@
 											]
 										},
 										"minimumColumnWidth": {
-											"type": "string",
-											"description": "The minimum column width value."
+											"description": "The minimum column width value.",
+											"type": "string"
 										},
 										"columnCount": {
-											"type": "number",
-											"description": "The column count value."
+											"description": "The column count value.",
+											"type": "number"
 										}
 									}
 								},
 								"allowSwitching": {
-									"type": "boolean",
 									"description": "Exposes a switcher control that allows toggling between all existing layout types.",
+									"type": "boolean",
 									"default": false
 								},
 								"allowEditing": {
-									"type": "boolean",
 									"description": "Determines display of layout controls in the block sidebar. If set to false, layout controls will be hidden.",
+									"type": "boolean",
 									"default": true
 								},
 								"allowInheriting": {
-									"type": "boolean",
 									"description": "For the `flow` layout type only, determines display of the `Inner blocks use content width` toggle.",
+									"type": "boolean",
 									"default": true
 								},
 								"allowSizingOnChildren": {
-									"type": "boolean",
 									"description": "For the `flex` layout type only, determines display of sizing controls (Fit/Fill/Fixed) on all child blocks of the flex block.",
+									"type": "boolean",
 									"default": false
 								},
 								"allowVerticalAlignment": {
-									"type": "boolean",
 									"description": "For the `flex` layout type only, determines display of vertical alignment controls in the block toolbar.",
+									"type": "boolean",
 									"default": true
 								},
 								"allowJustification": {
-									"type": "boolean",
 									"description": "For the `flex` layout type, determines display of justification controls in the block toolbar and block sidebar. For the `constrained` layout type, determines display of justification control in the block sidebar.",
+									"type": "boolean",
 									"default": true
 								},
 								"allowOrientation": {
-									"type": "boolean",
 									"description": "For the `flex` layout type only, determines display of the orientation control in the block toolbar.",
+									"type": "boolean",
 									"default": true
 								},
 								"allowCustomContentAndWideSize": {
-									"type": "boolean",
 									"description": "For the `constrained` layout type only, determines display of the custom content and wide size controls in the block sidebar.",
+									"type": "boolean",
 									"default": true
 								}
 							}
 						}
-					]
+					],
+					"default": false
 				},
 				"multiple": {
-					"type": "boolean",
 					"description": "A non-multiple block can be inserted into each post, one time only. For example, the built-in ‘More’ block cannot be inserted again if it already exists in the post being edited. A non-multiple block’s icon is automatically dimmed (unclickable) to prevent multiple instances.",
+					"type": "boolean",
 					"default": true
 				},
 				"reusable": {
-					"type": "boolean",
 					"description": "A block may want to disable the ability of being converted into a reusable block. By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.",
+					"type": "boolean",
 					"default": true
 				},
 				"lock": {
-					"type": "boolean",
 					"description": "A block may want to disable the ability to toggle the lock state. It can be locked/unlocked by a user from the block 'Options' dropdown by default. To disable this behavior, set lock to false.",
+					"type": "boolean",
 					"default": true
 				},
 				"position": {
@@ -507,8 +498,8 @@
 					"type": "object",
 					"properties": {
 						"sticky": {
-							"type": "boolean",
 							"description": "Allow blocks to stick to their immediate parent when scrolling the page.",
+							"type": "boolean",
 							"default": false
 						}
 					}
@@ -572,30 +563,30 @@
 					}
 				},
 				"shadow": {
-					"default": false,
 					"description": "Allow blocks to define a box shadow.",
 					"oneOf": [
 						{
-							"type": "boolean",
-							"description": "Defines whether a box shadow is enabled or not."
+							"description": "Defines whether a box shadow is enabled or not.",
+							"type": "boolean"
 						},
 						{
 							"type": "object"
 						}
-					]
+					],
+					"default": false
 				},
 				"typography": {
 					"description": "This value signals that a block supports some of the CSS style properties related to typography. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific typography property, its attributes definition is extended to include the style attribute.",
 					"type": "object",
 					"properties": {
 						"fontSize": {
-							"type": "boolean",
 							"description": "This value signals that a block supports the font-size CSS style property. When it does, the block editor will show an UI control for the user to set its value.\n\nThe values shown in this control are the ones declared by the theme via the editor-font-sizes theme support, or the default ones if none is provided.\n\nWhen the block declares support for fontSize, its attributes definition is extended to include two new attributes: fontSize and style",
+							"type": "boolean",
 							"default": false
 						},
 						"lineHeight": {
-							"type": "boolean",
 							"description": "This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value if the theme declares support.\n\nWhen the block declares support for lineHeight, its attributes definition is extended to include a new attribute style of object type with no default assigned. It stores the custom value set by the user. The block can apply a default style by specifying its own style attribute with a default",
+							"type": "boolean",
 							"default": false
 						},
 						"textAlign": {
@@ -620,21 +611,21 @@
 					"description": "Indicates if the block is using Interactivity API features.",
 					"oneOf": [
 						{
-							"type": "boolean",
 							"description": "Indicates whether the block is using the Interactivity API directives.",
+							"type": "boolean",
 							"default": false
 						},
 						{
 							"type": "object",
 							"properties": {
 								"clientNavigation": {
-									"type": "boolean",
 									"description": "Indicates whether a block is compatible with the Interactivity API client-side navigation.\n\nSet it to true only if the block is not interactive or if it is interactive using the Interactivity API. Set it to false if the block is interactive but uses vanilla JS, jQuery or another JS framework/library other than the Interactivity API.",
+									"type": "boolean",
 									"default": false
 								},
 								"interactive": {
-									"type": "boolean",
 									"description": "Indicates whether the block is using the Interactivity API directives.",
+									"type": "boolean",
 									"default": false
 								}
 							}
@@ -642,8 +633,8 @@
 					]
 				},
 				"splitting": {
-					"type": "boolean",
 					"description": "This property indicates whether the block can split when the Enter key is pressed or when blocks are pasted.",
+					"type": "boolean",
 					"default": false
 				}
 			},
@@ -654,8 +645,8 @@
 			"type": "object",
 			"properties": {
 				"root": {
-					"type": "string",
-					"description": "The primary CSS class to apply to the block. This replaces the `.wp-block-name` class if set."
+					"description": "The primary CSS class to apply to the block. This replaces the `.wp-block-name` class if set.",
+					"type": "string"
 				},
 				"border": {
 					"description": "Custom CSS selector used to generate rules for the block's theme.json border styles.",
@@ -749,8 +740,8 @@
 			}
 		},
 		"styles": {
-			"type": "array",
 			"description": "Block styles can be used to provide alternative styles to block. It works by adding a class name to the block’s wrapper. Using CSS, a theme developer can target the class name for the block style if it is selected.\n\nPlugins and Themes can also register custom block style for existing blocks.\n\nhttps://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles",
+			"type": "array",
 			"items": {
 				"type": "object",
 				"properties": {
@@ -774,17 +765,17 @@
 			"type": "object",
 			"properties": {
 				"viewportWidth": {
-					"type": "number",
 					"description": "The viewportWidth controls the width of the iFrame container in which the block preview will get rendered",
+					"type": "number",
 					"default": 1200
 				},
 				"attributes": {
-					"type": "object",
-					"description": "Set the attributes for the block example"
+					"description": "Set the attributes for the block example",
+					"type": "object"
 				},
 				"innerBlocks": {
-					"type": "array",
-					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this:\n\n[ { \"name\": \"core/heading\", \"attributes\": { \"content\": \"This is an Example\" } } ]\n\nWhere each block itself is an object that contains the block name, the block attributes, and the blocks inner blocks."
+					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this:\n\n[ { \"name\": \"core/heading\", \"attributes\": { \"content\": \"This is an Example\" } } ]\n\nWhere each block itself is an object that contains the block name, the block attributes, and the blocks inner blocks.",
+					"type": "array"
 				}
 			}
 		},
@@ -793,6 +784,7 @@
 			"type": "object",
 			"patternProperties": {
 				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+					"type": "string",
 					"enum": [ "before", "after", "firstChild", "lastChild" ]
 				}
 			},
@@ -900,26 +892,26 @@
 			"description": "Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality.",
 			"oneOf": [
 				{
-					"type": "string",
-					"description": "The path to a PHP file that returns an array of block variations."
+					"description": "The path to a PHP file that returns an array of block variations.",
+					"type": "string"
 				},
 				{
-					"type": "array",
 					"description": "An array of block variations.",
+					"type": "array",
 					"items": {
 						"type": "object",
 						"properties": {
 							"name": {
-								"type": "string",
-								"description": "The unique and machine-readable name."
+								"description": "The unique and machine-readable name.",
+								"type": "string"
 							},
 							"title": {
-								"type": "string",
-								"description": "A human-readable variation title."
+								"description": "A human-readable variation title.",
+								"type": "string"
 							},
 							"description": {
-								"type": "string",
-								"description": "A detailed variation description."
+								"description": "A detailed variation description.",
+								"type": "string"
 							},
 							"category": {
 								"description": "A category classification, used in search interfaces to arrange block types by category.",
@@ -928,6 +920,7 @@
 										"type": "string"
 									},
 									{
+										"type": "string",
 										"enum": [
 											"text",
 											"media",
@@ -944,46 +937,47 @@
 								"type": "string"
 							},
 							"isDefault": {
+								"description": "Indicates whether the current variation is the default one.",
 								"type": "boolean",
-								"default": false,
-								"description": "Indicates whether the current variation is the default one."
+								"default": false
 							},
 							"attributes": {
-								"type": "object",
-								"description": "Values that override block attributes."
+								"description": "Values that override block attributes.",
+								"type": "object"
 							},
 							"innerBlocks": {
+								"description": "Initial configuration of nested blocks.",
 								"type": "array",
 								"items": {
 									"type": "array"
-								},
-								"description": "Initial configuration of nested blocks."
+								}
 							},
 							"example": {
-								"type": "object",
-								"description": "Example provides structured data for the block preview. You can set to undefined to disable the preview shown for the block type."
+								"description": "Example provides structured data for the block preview. You can set to undefined to disable the preview shown for the block type.",
+								"type": "object"
 							},
 							"scope": {
-								"type": "array",
 								"description": "The list of scopes where the variation is applicable.",
+								"type": "array",
 								"items": {
+									"type": "string",
 									"enum": [ "inserter", "block", "transform" ]
 								},
 								"default": [ "inserter", "block" ]
 							},
 							"keywords": {
-								"type": "array",
 								"description": "An array of terms (which can be translated) that help users discover the variation while searching.",
+								"type": "array",
 								"items": {
 									"type": "string"
 								}
 							},
 							"isActive": {
+								"description": "The list of attributes that should be compared. Each attributes will be matched and the variation will be active if all of them are matching.",
 								"type": "array",
 								"items": {
 									"type": "string"
-								},
-								"description": "The list of attributes that should be compared. Each attributes will be matched and the variation will be active if all of them are matching."
+								}
 							}
 						},
 						"required": [ "name", "title" ],
@@ -993,8 +987,8 @@
 			]
 		},
 		"render": {
-			"type": "string",
-			"description": "Template file loaded on the server when rendering a block."
+			"description": "Template file loaded on the server when rendering a block.",
+			"type": "string"
 		}
 	},
 	"required": [ "name", "title" ],

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -223,8 +223,8 @@
 			}
 		},
 		"supports": {
-			"type": "object",
 			"description": "It contains as set of options to control features used in the editor. See the supports documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/ for more details.",
+			"type": "object",
 			"properties": {
 				"anchor": {
 					"type": "boolean",
@@ -269,8 +269,8 @@
 					"default": true
 				},
 				"color": {
-					"type": "object",
 					"description": "This value signals that a block supports some of the properties related to color. When it does, the block editor will show UI controls for the user to set their values.\n\nNote that the background and text keys have a default value of true, so if the color property is present they’ll also be considered enabled",
+					"type": "object",
 					"properties": {
 						"background": {
 							"type": "boolean",
@@ -315,8 +315,8 @@
 					"default": true
 				},
 				"dimensions": {
-					"type": "object",
 					"description": "This value signals that a block supports some of the CSS style properties related to dimensions. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific dimensions property, its attributes definition is extended to include the style attribute.",
+					"type": "object",
 					"properties": {
 						"aspectRatio": {
 							"type": "boolean",
@@ -331,8 +331,8 @@
 					}
 				},
 				"filter": {
-					"type": "object",
 					"description": "This value signals that a block supports some of the properties related to filters. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific filter property, its attributes definition is extended to include the style attribute.",
+					"type": "object",
 					"properties": {
 						"duotone": {
 							"type": "boolean",
@@ -342,8 +342,8 @@
 					}
 				},
 				"background": {
-					"type": "object",
 					"description": "This value signals that a block supports some of the CSS style properties related to background. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific background property, its attributes definition is extended to include the style attribute.",
+					"type": "object",
 					"properties": {
 						"backgroundImage": {
 							"type": "boolean",
@@ -381,8 +381,8 @@
 							"type": "object",
 							"properties": {
 								"default": {
-									"type": "object",
 									"description": "Allows setting the `type` property to define what layout type is default for the block, and also default values for any properties inherent to that layout type, e.g., for a `flex` layout, a default value can be set for `flexWrap`.",
+									"type": "object",
 									"properties": {
 										"type": {
 											"type": "string",
@@ -503,8 +503,8 @@
 					"default": true
 				},
 				"position": {
-					"type": "object",
 					"description": "This value signals that a block supports some of the CSS style properties related to position. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific position property, its attributes definition is extended to include the style attribute.",
+					"type": "object",
 					"properties": {
 						"sticky": {
 							"type": "boolean",
@@ -514,8 +514,8 @@
 					}
 				},
 				"spacing": {
-					"type": "object",
 					"description": "This value signals that a block supports some of the CSS style properties related to spacing. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific spacing property, its attributes definition is extended to include the style attribute.",
+					"type": "object",
 					"properties": {
 						"margin": {
 							"oneOf": [
@@ -585,8 +585,8 @@
 					]
 				},
 				"typography": {
-					"type": "object",
 					"description": "This value signals that a block supports some of the CSS style properties related to typography. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific typography property, its attributes definition is extended to include the style attribute.",
+					"type": "object",
 					"properties": {
 						"fontSize": {
 							"type": "boolean",
@@ -650,8 +650,8 @@
 			"additionalProperties": true
 		},
 		"selectors": {
-			"type": "object",
 			"description": "Provides custom CSS selectors and mappings for the block. Selectors may be set for the block itself or per-feature e.g. typography. Custom selectors per feature or sub-feature, allow different block styles to be applied to different elements within the block.",
+			"type": "object",
 			"properties": {
 				"root": {
 					"type": "string",
@@ -770,8 +770,8 @@
 			}
 		},
 		"example": {
-			"type": "object",
 			"description": "It provides structured example data for the block. This data is used to construct a preview for the block to be shown in the Inspector Help Panel when the user mouses over the block.\n\nSee the example documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#example-optional for more details.",
+			"type": "object",
 			"properties": {
 				"viewportWidth": {
 					"type": "number",
@@ -908,8 +908,6 @@
 					"description": "An array of block variations.",
 					"items": {
 						"type": "object",
-						"required": [ "name", "title" ],
-						"additionalProperties": false,
 						"properties": {
 							"name": {
 								"type": "string",
@@ -987,7 +985,9 @@
 								},
 								"description": "The list of attributes that should be compared. Each attributes will be matched and the variation will be active if all of them are matching."
 							}
-						}
+						},
+						"required": [ "name", "title" ],
+						"additionalProperties": false
 					}
 				}
 			]

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -114,8 +114,8 @@
 								"type": "string"
 							},
 							"preview": {
-								"type": "string",
-								"description": "URL to a preview image of the font family."
+								"description": "URL to a preview image of the font family.",
+								"type": "string"
 							},
 							"fontFace": {
 								"description": "Array of font-face definitions.",
@@ -129,8 +129,8 @@
 						"additionalProperties": false
 					},
 					"categories": {
-						"type": "array",
 						"description": "Array of category slugs.",
+						"type": "array",
 						"items": {
 							"type": "string"
 						}

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -1,7 +1,6 @@
 {
 	"title": "JSON schema for WordPress Font Collections",
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"type": "object",
 	"definitions": {
 		"fontFace": {
 			"description": "Font face settings, with added preview property.",
@@ -95,6 +94,7 @@
 			"additionalProperties": false
 		}
 	},
+	"type": "object",
 	"properties": {
 		"$schema": {
 			"description": "JSON schema URI for font-collection.json.",

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -22,28 +22,19 @@
 				},
 				"fontWeight": {
 					"description": "List of available font weights, separated by a space.",
-					"default": "400",
-					"oneOf": [
-						{
-							"type": "string"
-						},
-						{
-							"type": "integer"
-						}
-					]
+					"oneOf": [ { "type": "string" }, { "type": "integer" } ],
+					"default": "400"
 				},
 				"fontDisplay": {
 					"description": "CSS font-display value.",
 					"type": "string",
-					"default": "fallback",
-					"enum": [ "auto", "block", "fallback", "swap", "optional" ]
+					"enum": [ "auto", "block", "fallback", "swap", "optional" ],
+					"default": "fallback"
 				},
 				"src": {
 					"description": "Paths or URLs to the font files.",
 					"oneOf": [
-						{
-							"type": "string"
-						},
+						{ "type": "string" },
 						{
 							"type": "array",
 							"items": {
@@ -101,8 +92,8 @@
 			"type": "string"
 		},
 		"font_families": {
-			"type": "array",
 			"description": "Array of font families ready to be installed.",
+			"type": "array",
 			"items": {
 				"type": "object",
 				"properties": {
@@ -130,11 +121,7 @@
 								"description": "Array of font-face definitions.",
 								"type": "array",
 								"items": {
-									"allOf": [
-										{
-											"$ref": "#/definitions/fontFace"
-										}
-									]
+									"$ref": "#/definitions/fontFace"
 								}
 							}
 						},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2580,20 +2580,20 @@
 			"const": 3
 		},
 		"title": {
-			"type": "string",
-			"description": "Title of the global styles variation. If not defined, the file name will be used."
+			"description": "Title of the global styles variation. If not defined, the file name will be used.",
+			"type": "string"
 		},
 		"slug": {
-			"type": "string",
-			"description": "Slug of the global styles variation. If not defined, the kebab-case title will be used."
+			"description": "Slug of the global styles variation. If not defined, the kebab-case title will be used.",
+			"type": "string"
 		},
 		"description": {
-			"type": "string",
-			"description": "Description of the global styles variation."
+			"description": "Description of the global styles variation.",
+			"type": "string"
 		},
 		"blockTypes": {
-			"type": "array",
 			"description": "List of block types that can use the block style variation this theme.json file represents.",
+			"type": "array",
 			"items": {
 				"type": "string"
 			}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -417,8 +417,8 @@
 							"items": {
 								"type": "string"
 							},
-							"default": [ "px", "em", "rem", "vh", "vw", "%" ],
-							"minItems": 1
+							"minItems": 1,
+							"default": [ "px", "em", "rem", "vh", "vw", "%" ]
 						},
 						"customSpacingSize": {
 							"description": "Allow users to set custom space sizes.",
@@ -699,7 +699,6 @@
 												},
 												"fontWeight": {
 													"description": "List of available font weights, separated by a space.",
-													"default": "400",
 													"oneOf": [
 														{
 															"type": "string"
@@ -707,19 +706,20 @@
 														{
 															"type": "integer"
 														}
-													]
+													],
+													"default": "400"
 												},
 												"fontDisplay": {
 													"description": "CSS font-display value.",
 													"type": "string",
-													"default": "fallback",
 													"enum": [
 														"auto",
 														"block",
 														"fallback",
 														"swap",
 														"optional"
-													]
+													],
+													"default": "fallback"
 												},
 												"src": {
 													"description": "Paths or URLs to the font files.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1434,7 +1434,7 @@
 					"type": "string"
 				},
 				"dimensions": {
-					"description": "Dimensions styles",
+					"description": "Dimensions styles.",
 					"type": "object",
 					"properties": {
 						"aspectRatio": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1172,10 +1172,8 @@
 						"backgroundImage": {
 							"description": "Sets the `background-image` CSS property.",
 							"oneOf": [
-								{
-									"description": "A valid CSS value for the background-image CSS property.",
-									"type": "string"
-								},
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" },
 								{
 									"type": "object",
 									"properties": {
@@ -1185,54 +1183,35 @@
 										}
 									},
 									"additionalProperties": false
-								},
-								{
-									"$ref": "#/definitions/refComplete"
 								}
 							]
 						},
 						"backgroundPosition": {
 							"description": "Sets the `background-position` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"backgroundRepeat": {
 							"description": "Sets the `background-repeat` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"backgroundSize": {
 							"description": "Sets the `background-size` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"backgroundAttachment": {
 							"description": "Sets the `background-attachment` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						}
 					},
@@ -1245,32 +1224,22 @@
 						"color": {
 							"description": "Sets the `border-color` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"radius": {
 							"description": "Sets the `border-radius` CSS property.",
 							"anyOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								},
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" },
 								{
 									"type": "object",
 									"properties": {
 										"topLeft": {
 											"description": "Sets the `border-top-left-radius` CSS property.",
 											"oneOf": [
-												{
-													"type": "string"
-												},
+												{ "type": "string" },
 												{
 													"$ref": "#/definitions/refComplete"
 												}
@@ -1279,9 +1248,7 @@
 										"topRight": {
 											"description": "Sets the `border-top-right-radius` CSS property.",
 											"oneOf": [
-												{
-													"type": "string"
-												},
+												{ "type": "string" },
 												{
 													"$ref": "#/definitions/refComplete"
 												}
@@ -1290,9 +1257,7 @@
 										"bottomLeft": {
 											"description": "Sets the `border-bottom-left-radius` CSS property.",
 											"oneOf": [
-												{
-													"type": "string"
-												},
+												{ "type": "string" },
 												{
 													"$ref": "#/definitions/refComplete"
 												}
@@ -1301,9 +1266,7 @@
 										"bottomRight": {
 											"description": "Sets the `border-bottom-right-radius` CSS property.",
 											"oneOf": [
-												{
-													"type": "string"
-												},
+												{ "type": "string" },
 												{
 													"$ref": "#/definitions/refComplete"
 												}
@@ -1316,23 +1279,15 @@
 						"style": {
 							"description": "Sets the `border-style` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"width": {
 							"description": "Sets the `border-width` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"top": {
@@ -1341,34 +1296,22 @@
 								"color": {
 									"description": "Sets the `border-top-color` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"style": {
 									"description": "Sets the `border-top-style` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"width": {
 									"description": "Sets the `border-top-width` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								}
 							},
@@ -1380,34 +1323,22 @@
 								"color": {
 									"description": "Sets the `border-right-color` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"style": {
 									"description": "Sets the `border-right-style` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"width": {
 									"description": "Sets the `border-right-width` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								}
 							},
@@ -1419,34 +1350,22 @@
 								"color": {
 									"description": "Sets the `border-bottom-color` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"style": {
 									"description": "Sets the `border-bottom-style` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"width": {
 									"description": "Sets the `border-bottom-width` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								}
 							},
@@ -1458,34 +1377,22 @@
 								"color": {
 									"description": "Sets the `border-left-color` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"style": {
 									"description": "Sets the `border-left-style` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"width": {
 									"description": "Sets the `border-left-width` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								}
 							},
@@ -1501,34 +1408,22 @@
 						"background": {
 							"description": "Sets the `background-color` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"gradient": {
 							"description": "Sets the `background` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"text": {
 							"description": "Sets the `color` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						}
 					},
@@ -1545,23 +1440,15 @@
 						"aspectRatio": {
 							"description": "Sets the `aspect-ratio` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"minHeight": {
 							"description": "Sets the `min-height` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						}
 					}
@@ -1573,12 +1460,8 @@
 						"duotone": {
 							"description": "Sets the duotone filter.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						}
 					},
@@ -1591,45 +1474,29 @@
 						"color": {
 							"description": "Sets the `outline-color` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"offset": {
 							"description": "Sets the `outline-offset` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"style": {
 							"description": "Sets the `outline-style` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"width": {
 							"description": "Sets the `outline-width` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						}
 					},
@@ -1638,12 +1505,8 @@
 				"shadow": {
 					"description": "Box shadow styles.",
 					"oneOf": [
-						{
-							"type": "string"
-						},
-						{
-							"$ref": "#/definitions/refComplete"
-						}
+						{ "type": "string" },
+						{ "$ref": "#/definitions/refComplete" }
 					]
 				},
 				"spacing": {
@@ -1653,12 +1516,8 @@
 						"blockGap": {
 							"description": "Sets the `--wp--style--block-gap` CSS custom property when settings.spacing.blockGap is true.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"margin": {
@@ -1668,45 +1527,29 @@
 								"top": {
 									"description": "Sets the `margin-top` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"right": {
 									"description": "Sets the `margin-right` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"bottom": {
 									"description": "Sets the `margin-bottom` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"left": {
 									"description": "Sets the `margin-left` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								}
 							},
@@ -1719,45 +1562,29 @@
 								"top": {
 									"description": "Sets the `padding-top` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"right": {
 									"description": "Sets the `padding-right` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"bottom": {
 									"description": "Sets the `padding-bottom` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								},
 								"left": {
 									"description": "Sets the `padding-left` CSS property.",
 									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"$ref": "#/definitions/refComplete"
-										}
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
 									]
 								}
 							},
@@ -1773,122 +1600,78 @@
 						"fontFamily": {
 							"description": "Sets the `font-family` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"fontSize": {
 							"description": "Sets the `font-size` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"fontStyle": {
 							"description": "Sets the `font-style` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"fontWeight": {
 							"description": "Sets the `font-weight` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"letterSpacing": {
 							"description": "Sets the `letter-spacing` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"lineHeight": {
 							"description": "Sets the `line-height` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"textAlign": {
 							"description": "Sets the `text-align` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"textColumns": {
 							"description": "Sets the `column-count` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"textDecoration": {
 							"description": "Sets the `text-decoration` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"writingMode": {
 							"description": "Sets the `writing-mode` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"textTransform": {
 							"description": "Sets the `text-transform` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						}
 					},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -331,11 +331,6 @@
 					"description": "Settings related to position.",
 					"type": "object",
 					"properties": {
-						"fixed": {
-							"description": "Allow users to set fixed position.",
-							"type": "boolean",
-							"default": false
-						},
 						"sticky": {
 							"description": "Allow users to set sticky position.",
 							"type": "boolean",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -27,6 +27,28 @@
 				}
 			}
 		},
+		"settingsPropertiesBackground": {
+			"type": "object",
+			"properties": {
+				"background": {
+					"description": "Settings related to background.",
+					"type": "object",
+					"properties": {
+						"backgroundImage": {
+							"description": "Allow users to set a background image.",
+							"type": "boolean",
+							"default": false
+						},
+						"backgroundSize": {
+							"description": "Allow users to set values related to the size of a background image, including size, position, and repeat controls.",
+							"type": "boolean",
+							"default": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
 		"settingsPropertiesBorder": {
 			"type": "object",
 			"properties": {
@@ -53,46 +75,6 @@
 							"description": "Allow users to set custom border widths.",
 							"type": "boolean",
 							"default": false
-						}
-					},
-					"additionalProperties": false
-				}
-			}
-		},
-		"settingsPropertiesShadow": {
-			"type": "object",
-			"properties": {
-				"shadow": {
-					"description": "Settings related to shadows.",
-					"type": "object",
-					"properties": {
-						"defaultPresets": {
-							"description": "Allow users to choose shadows from the default shadow presets.",
-							"type": "boolean",
-							"default": true
-						},
-						"presets": {
-							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",
-							"type": "array",
-							"items": {
-								"type": "object",
-								"properties": {
-									"name": {
-										"description": "Name of the shadow preset, translatable.",
-										"type": "string"
-									},
-									"slug": {
-										"description": "Kebab-case unique identifier for the shadow preset.",
-										"type": "string"
-									},
-									"shadow": {
-										"description": "CSS box-shadow value",
-										"type": "string"
-									}
-								},
-								"required": [ "name", "slug", "shadow" ],
-								"additionalProperties": false
-							}
 						}
 					},
 					"additionalProperties": false
@@ -244,28 +226,6 @@
 				}
 			}
 		},
-		"settingsPropertiesBackground": {
-			"type": "object",
-			"properties": {
-				"background": {
-					"description": "Settings related to background.",
-					"type": "object",
-					"properties": {
-						"backgroundImage": {
-							"description": "Allow users to set a background image.",
-							"type": "boolean",
-							"default": false
-						},
-						"backgroundSize": {
-							"description": "Allow users to set values related to the size of a background image, including size, position, and repeat controls.",
-							"type": "boolean",
-							"default": false
-						}
-					},
-					"additionalProperties": false
-				}
-			}
-		},
 		"settingsPropertiesDimensions": {
 			"type": "object",
 			"properties": {
@@ -375,6 +335,46 @@
 							"description": "Allow users to set sticky position.",
 							"type": "boolean",
 							"default": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsPropertiesShadow": {
+			"type": "object",
+			"properties": {
+				"shadow": {
+					"description": "Settings related to shadows.",
+					"type": "object",
+					"properties": {
+						"defaultPresets": {
+							"description": "Allow users to choose shadows from the default shadow presets.",
+							"type": "boolean",
+							"default": true
+						},
+						"presets": {
+							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the shadow preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the shadow preset.",
+										"type": "string"
+									},
+									"shadow": {
+										"description": "CSS box-shadow value",
+										"type": "string"
+									}
+								},
+								"required": [ "name", "slug", "shadow" ],
+								"additionalProperties": false
+							}
 						}
 					},
 					"additionalProperties": false
@@ -796,10 +796,10 @@
 				{ "$ref": "#/definitions/settingsPropertiesBorder" },
 				{ "$ref": "#/definitions/settingsPropertiesColor" },
 				{ "$ref": "#/definitions/settingsPropertiesDimensions" },
-				{ "$ref": "#/definitions/settingsPropertiesShadow" },
 				{ "$ref": "#/definitions/settingsPropertiesLayout" },
 				{ "$ref": "#/definitions/settingsPropertiesLightbox" },
 				{ "$ref": "#/definitions/settingsPropertiesPosition" },
+				{ "$ref": "#/definitions/settingsPropertiesShadow" },
 				{ "$ref": "#/definitions/settingsPropertiesSpacing" },
 				{ "$ref": "#/definitions/settingsPropertiesTypography" },
 				{ "$ref": "#/definitions/settingsPropertiesCustom" }

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1529,6 +1529,10 @@
 					},
 					"additionalProperties": false
 				},
+				"css": {
+					"description": "Sets custom CSS to apply styling not covered by other theme.json properties.",
+					"type": "string"
+				},
 				"dimensions": {
 					"description": "Dimensions styles",
 					"type": "object",
@@ -1556,6 +1560,86 @@
 							]
 						}
 					}
+				},
+				"filter": {
+					"description": "CSS and SVG filter styles.",
+					"type": "object",
+					"properties": {
+						"duotone": {
+							"description": "Sets the duotone filter.",
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"outline": {
+					"description": "Outline styles.",
+					"type": "object",
+					"properties": {
+						"color": {
+							"description": "Sets the `outline-color` CSS property.",
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
+						},
+						"offset": {
+							"description": "Sets the `outline-offset` CSS property.",
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
+						},
+						"style": {
+							"description": "Sets the `outline-style` CSS property.",
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
+						},
+						"width": {
+							"description": "Sets the `outline-width` CSS property.",
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"shadow": {
+					"description": "Box shadow styles.",
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"$ref": "#/definitions/refComplete"
+						}
+					]
 				},
 				"spacing": {
 					"description": "Spacing styles.",
@@ -1804,90 +1888,6 @@
 						}
 					},
 					"additionalProperties": false
-				},
-				"filter": {
-					"description": "CSS and SVG filter styles.",
-					"type": "object",
-					"properties": {
-						"duotone": {
-							"description": "Sets the duotone filter.",
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						}
-					},
-					"additionalProperties": false
-				},
-				"shadow": {
-					"description": "Box shadow styles.",
-					"oneOf": [
-						{
-							"type": "string"
-						},
-						{
-							"$ref": "#/definitions/refComplete"
-						}
-					]
-				},
-				"outline": {
-					"description": "Outline styles.",
-					"type": "object",
-					"properties": {
-						"color": {
-							"description": "Sets the `outline-color` CSS property.",
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						},
-						"offset": {
-							"description": "Sets the `outline-offset` CSS property.",
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						},
-						"style": {
-							"description": "Sets the `outline-style` CSS property.",
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						},
-						"width": {
-							"description": "Sets the `outline-width` CSS property.",
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
-							]
-						}
-					},
-					"additionalProperties": false
-				},
-				"css": {
-					"description": "Sets custom CSS to apply styling not covered by other theme.json properties.",
-					"type": "string"
 				}
 			}
 		},
@@ -1896,13 +1896,13 @@
 				"background",
 				"border",
 				"color",
+				"css",
 				"dimensions",
-				"spacing",
-				"typography",
 				"filter",
-				"shadow",
 				"outline",
-				"css"
+				"shadow",
+				"spacing",
+				"typography"
 			]
 		},
 		"stylesPropertiesComplete": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -680,7 +680,96 @@
 										"description": "Array of font-face declarations.",
 										"type": "array",
 										"items": {
-											"$ref": "#/definitions/fontFace"
+											"type": "object",
+											"properties": {
+												"fontFamily": {
+													"description": "CSS font-family value.",
+													"type": "string",
+													"default": ""
+												},
+												"fontStyle": {
+													"description": "CSS font-style value.",
+													"type": "string",
+													"default": "normal"
+												},
+												"fontWeight": {
+													"description": "List of available font weights, separated by a space.",
+													"default": "400",
+													"oneOf": [
+														{
+															"type": "string"
+														},
+														{
+															"type": "integer"
+														}
+													]
+												},
+												"fontDisplay": {
+													"description": "CSS font-display value.",
+													"type": "string",
+													"default": "fallback",
+													"enum": [
+														"auto",
+														"block",
+														"fallback",
+														"swap",
+														"optional"
+													]
+												},
+												"src": {
+													"description": "Paths or URLs to the font files.",
+													"oneOf": [
+														{
+															"type": "string"
+														},
+														{
+															"type": "array",
+															"items": {
+																"type": "string"
+															}
+														}
+													],
+													"default": []
+												},
+												"fontStretch": {
+													"description": "CSS font-stretch value.",
+													"type": "string"
+												},
+												"ascentOverride": {
+													"description": "CSS ascent-override value.",
+													"type": "string"
+												},
+												"descentOverride": {
+													"description": "CSS descent-override value.",
+													"type": "string"
+												},
+												"fontVariant": {
+													"description": "CSS font-variant value.",
+													"type": "string"
+												},
+												"fontFeatureSettings": {
+													"description": "CSS font-feature-settings value.",
+													"type": "string"
+												},
+												"fontVariationSettings": {
+													"description": "CSS font-variation-settings value.",
+													"type": "string"
+												},
+												"lineGapOverride": {
+													"description": "CSS line-gap-override value.",
+													"type": "string"
+												},
+												"sizeAdjust": {
+													"description": "CSS size-adjust value.",
+													"type": "string"
+												},
+												"unicodeRange": {
+													"description": "CSS unicode-range value.",
+													"type": "string"
+												}
+											},
+											"required": [ "fontFamily", "src" ],
+											"additionalProperties": false
 										}
 									}
 								},
@@ -691,92 +780,6 @@
 					"additionalProperties": false
 				}
 			}
-		},
-		"fontFace": {
-			"type": "object",
-			"properties": {
-				"fontFamily": {
-					"description": "CSS font-family value.",
-					"type": "string",
-					"default": ""
-				},
-				"fontStyle": {
-					"description": "CSS font-style value.",
-					"type": "string",
-					"default": "normal"
-				},
-				"fontWeight": {
-					"description": "List of available font weights, separated by a space.",
-					"default": "400",
-					"oneOf": [
-						{
-							"type": "string"
-						},
-						{
-							"type": "integer"
-						}
-					]
-				},
-				"fontDisplay": {
-					"description": "CSS font-display value.",
-					"type": "string",
-					"default": "fallback",
-					"enum": [ "auto", "block", "fallback", "swap", "optional" ]
-				},
-				"src": {
-					"description": "Paths or URLs to the font files.",
-					"oneOf": [
-						{
-							"type": "string"
-						},
-						{
-							"type": "array",
-							"items": {
-								"type": "string"
-							}
-						}
-					],
-					"default": []
-				},
-				"fontStretch": {
-					"description": "CSS font-stretch value.",
-					"type": "string"
-				},
-				"ascentOverride": {
-					"description": "CSS ascent-override value.",
-					"type": "string"
-				},
-				"descentOverride": {
-					"description": "CSS descent-override value.",
-					"type": "string"
-				},
-				"fontVariant": {
-					"description": "CSS font-variant value.",
-					"type": "string"
-				},
-				"fontFeatureSettings": {
-					"description": "CSS font-feature-settings value.",
-					"type": "string"
-				},
-				"fontVariationSettings": {
-					"description": "CSS font-variation-settings value.",
-					"type": "string"
-				},
-				"lineGapOverride": {
-					"description": "CSS line-gap-override value.",
-					"type": "string"
-				},
-				"sizeAdjust": {
-					"description": "CSS size-adjust value.",
-					"type": "string"
-				},
-				"unicodeRange": {
-					"description": "CSS unicode-range value.",
-					"type": "string"
-				}
-			},
-			"required": [ "fontFamily", "src" ],
-			"additionalProperties": false
 		},
 		"settingsPropertiesCustom": {
 			"type": "object",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -27,15 +27,6 @@
 				}
 			}
 		},
-		"settingsPropertiesUseRootPaddingAwareAlignments": {
-			"properties": {
-				"useRootPaddingAwareAlignments": {
-					"description": "Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
-					"type": "boolean",
-					"default": false
-				}
-			}
-		},
 		"settingsPropertiesBorder": {
 			"type": "object",
 			"properties": {
@@ -2827,7 +2818,9 @@
 				{
 					"properties": {
 						"useRootPaddingAwareAlignments": {
-							"$ref": "#/definitions/settingsPropertiesUseRootPaddingAwareAlignments/properties/useRootPaddingAwareAlignments"
+							"description": "Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
+							"type": "boolean",
+							"default": false
 						},
 						"blocks": {
 							"$ref": "#/definitions/settingsBlocksPropertiesComplete"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -30,7 +30,7 @@
 		"settingsPropertiesUseRootPaddingAwareAlignments": {
 			"properties": {
 				"useRootPaddingAwareAlignments": {
-					"description": "_**Note:** Since WordPress 6.1._\n\nEnables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
+					"description": "Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
 					"type": "boolean",
 					"default": false
 				}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -827,6 +827,7 @@
 					"$ref": "#/definitions/settingsProperties"
 				},
 				{
+					"type": "object",
 					"propertyNames": {
 						"$ref": "#/definitions/settingsPropertyNames"
 					}
@@ -1891,12 +1892,12 @@
 			]
 		},
 		"stylesPropertiesComplete": {
-			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"type": "object",
 					"propertyNames": {
 						"$ref": "#/definitions/stylesPropertyNames"
 					}
@@ -1938,7 +1939,6 @@
 		},
 		"stylesElementsPropertiesComplete": {
 			"description": "Styles defined on a per-element basis using the element's selector.",
-			"type": "object",
 			"properties": {
 				"button": {
 					"allOf": [
@@ -1949,6 +1949,7 @@
 							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
 						},
 						{
+							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
@@ -1971,6 +1972,7 @@
 							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
 						},
 						{
+							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
@@ -2326,6 +2328,7 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"type": "object",
 					"properties": {
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
@@ -2336,6 +2339,7 @@
 					}
 				},
 				{
+					"type": "object",
 					"propertyNames": {
 						"anyOf": [
 							{
@@ -2363,6 +2367,7 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"type": "object",
 					"properties": {
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
@@ -2373,6 +2378,7 @@
 					}
 				},
 				{
+					"type": "object",
 					"propertyNames": {
 						"anyOf": [
 							{
@@ -2400,6 +2406,7 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"type": "object",
 					"properties": {
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
@@ -2410,6 +2417,7 @@
 					}
 				},
 				{
+					"type": "object",
 					"propertyNames": {
 						"anyOf": [
 							{
@@ -2734,6 +2742,7 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"type": "object",
 					"properties": {
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
@@ -2741,6 +2750,7 @@
 					}
 				},
 				{
+					"type": "object",
 					"propertyNames": {
 						"anyOf": [
 							{
@@ -2792,6 +2802,7 @@
 					"$ref": "#/definitions/settingsProperties"
 				},
 				{
+					"type": "object",
 					"properties": {
 						"useRootPaddingAwareAlignments": {
 							"description": "Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
@@ -2804,6 +2815,7 @@
 					}
 				},
 				{
+					"type": "object",
 					"propertyNames": {
 						"anyOf": [
 							{
@@ -2827,6 +2839,7 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"type": "object",
 					"properties": {
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
@@ -2840,6 +2853,7 @@
 					}
 				},
 				{
+					"type": "object",
 					"propertyNames": {
 						"anyOf": [
 							{

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1903,6 +1903,39 @@
 				}
 			]
 		},
+		"stylesElementsPseudoSelectorsProperties": {
+			"type": "object",
+			"properties": {
+				":active": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":any-link": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":hover": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":link": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":visited": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
+		},
+		"stylesElementsPseudoSelectorsPropertyNames": {
+			"enum": [
+				":active",
+				":any-link",
+				":focus",
+				":hover",
+				":link",
+				":visited"
+			]
+		},
 		"stylesElementsPropertiesComplete": {
 			"description": "Styles defined on a per-element basis using the element's selector.",
 			"type": "object",
@@ -1913,27 +1946,7 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"type": "object",
-							"properties": {
-								":hover": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":focus": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":active": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":visited": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":link": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":any-link": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								}
-							}
+							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
 						},
 						{
 							"propertyNames": {
@@ -1942,14 +1955,7 @@
 										"$ref": "#/definitions/stylesPropertyNames"
 									},
 									{
-										"enum": [
-											":hover",
-											":focus",
-											":active",
-											":visited",
-											":link",
-											":any-link"
-										]
+										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
 									}
 								]
 							}
@@ -1962,27 +1968,7 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"type": "object",
-							"properties": {
-								":hover": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":focus": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":active": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":visited": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":link": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								},
-								":any-link": {
-									"$ref": "#/definitions/stylesPropertiesComplete"
-								}
-							}
+							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
 						},
 						{
 							"propertyNames": {
@@ -1991,14 +1977,7 @@
 										"$ref": "#/definitions/stylesPropertyNames"
 									},
 									{
-										"enum": [
-											":hover",
-											":focus",
-											":active",
-											":visited",
-											":link",
-											":any-link"
-										]
+										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
 									}
 								]
 							}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -331,6 +331,11 @@
 					"description": "Settings related to position.",
 					"type": "object",
 					"properties": {
+						"fixed": {
+							"description": "Allow users to set fixed position.",
+							"type": "boolean",
+							"default": false
+						},
 						"sticky": {
 							"description": "Allow users to set sticky position.",
 							"type": "boolean",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1749,11 +1749,25 @@
 						},
 						"textAlign": {
 							"description": "Sets the `text-align` CSS property.",
-							"type": "string"
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
 						},
 						"textColumns": {
 							"description": "Sets the `column-count` CSS property.",
-							"type": "string"
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
 						},
 						"textDecoration": {
 							"description": "Sets the `text-decoration` CSS property.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -661,8 +661,8 @@
 							"description": "Font family presets for the font family selector.\nGenerates a single custom property (`--wp--preset--font-family--{slug}`) per preset value.",
 							"type": "array",
 							"items": {
-								"type": "object",
 								"description": "Font family preset",
+								"type": "object",
 								"properties": {
 									"name": {
 										"description": "Name of the font family preset, translatable.",
@@ -822,7 +822,6 @@
 			]
 		},
 		"settingsPropertiesComplete": {
-			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/settingsProperties"
@@ -1909,12 +1908,12 @@
 			"type": "object",
 			"properties": {
 				"button": {
-					"type": "object",
 					"allOf": [
 						{
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
+							"type": "object",
 							"properties": {
 								":hover": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
@@ -1958,12 +1957,12 @@
 					]
 				},
 				"link": {
-					"type": "object",
 					"allOf": [
 						{
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
+							"type": "object",
 							"properties": {
 								":hover": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
@@ -2343,7 +2342,6 @@
 			"additionalProperties": false
 		},
 		"stylesPropertiesAndElementsComplete": {
-			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/stylesProperties"
@@ -2381,7 +2379,6 @@
 			}
 		},
 		"stylesVariationProperties": {
-			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/stylesProperties"
@@ -2419,7 +2416,6 @@
 			}
 		},
 		"stylesVariationPropertiesComplete": {
-			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/stylesProperties"
@@ -2754,7 +2750,6 @@
 			"additionalProperties": false
 		},
 		"stylesVariationBlockPropertiesComplete": {
-			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/stylesProperties"
@@ -2813,7 +2808,6 @@
 		},
 		"settings": {
 			"description": "Settings for the block editor and individual blocks. These include things like:\n- Which customization options should be available to the user. \n- The default colors, font sizes... available to the user. \n- CSS custom properties and class names used in styles.\n- And the default layout of the editor (widths and available alignments).",
-			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/settingsProperties"
@@ -2849,7 +2843,6 @@
 		},
 		"styles": {
 			"description": "Organized way to set CSS properties. Styles in the top-level will be added in the `body` selector.",
-			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/stylesProperties"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -17,7 +17,7 @@
 			},
 			"additionalProperties": false
 		},
-		"settingsPropertiesAppearanceTools": {
+		"settingsAppearanceToolsProperties": {
 			"type": "object",
 			"properties": {
 				"appearanceTools": {
@@ -27,7 +27,7 @@
 				}
 			}
 		},
-		"settingsPropertiesBackground": {
+		"settingsBackgroundProperties": {
 			"type": "object",
 			"properties": {
 				"background": {
@@ -49,7 +49,7 @@
 				}
 			}
 		},
-		"settingsPropertiesBorder": {
+		"settingsBorderProperties": {
 			"type": "object",
 			"properties": {
 				"border": {
@@ -81,7 +81,7 @@
 				}
 			}
 		},
-		"settingsPropertiesColor": {
+		"settingsColorProperties": {
 			"type": "object",
 			"properties": {
 				"color": {
@@ -226,7 +226,7 @@
 				}
 			}
 		},
-		"settingsPropertiesDimensions": {
+		"settingsDimensionsProperties": {
 			"type": "object",
 			"properties": {
 				"dimensions": {
@@ -274,7 +274,7 @@
 				}
 			}
 		},
-		"settingsPropertiesLayout": {
+		"settingsLayoutProperties": {
 			"type": "object",
 			"properties": {
 				"layout": {
@@ -304,7 +304,7 @@
 				}
 			}
 		},
-		"settingsPropertiesLightbox": {
+		"settingsLightboxProperties": {
 			"type": "object",
 			"properties": {
 				"lightbox": {
@@ -324,7 +324,7 @@
 				}
 			}
 		},
-		"settingsPropertiesPosition": {
+		"settingsPositionProperties": {
 			"type": "object",
 			"properties": {
 				"position": {
@@ -346,7 +346,7 @@
 				}
 			}
 		},
-		"settingsPropertiesShadow": {
+		"settingsShadowProperties": {
 			"type": "object",
 			"properties": {
 				"shadow": {
@@ -386,7 +386,7 @@
 				}
 			}
 		},
-		"settingsPropertiesSpacing": {
+		"settingsSpacingProperties": {
 			"type": "object",
 			"properties": {
 				"spacing": {
@@ -524,7 +524,7 @@
 				}
 			}
 		},
-		"settingsPropertiesTypography": {
+		"settingsTypographyProperties": {
 			"type": "object",
 			"properties": {
 				"typography": {
@@ -786,7 +786,7 @@
 				}
 			}
 		},
-		"settingsPropertiesCustom": {
+		"settingsCustomProperties": {
 			"type": "object",
 			"properties": {
 				"custom": {
@@ -796,18 +796,18 @@
 		},
 		"settingsProperties": {
 			"allOf": [
-				{ "$ref": "#/definitions/settingsPropertiesAppearanceTools" },
-				{ "$ref": "#/definitions/settingsPropertiesBackground" },
-				{ "$ref": "#/definitions/settingsPropertiesBorder" },
-				{ "$ref": "#/definitions/settingsPropertiesColor" },
-				{ "$ref": "#/definitions/settingsPropertiesDimensions" },
-				{ "$ref": "#/definitions/settingsPropertiesLayout" },
-				{ "$ref": "#/definitions/settingsPropertiesLightbox" },
-				{ "$ref": "#/definitions/settingsPropertiesPosition" },
-				{ "$ref": "#/definitions/settingsPropertiesShadow" },
-				{ "$ref": "#/definitions/settingsPropertiesSpacing" },
-				{ "$ref": "#/definitions/settingsPropertiesTypography" },
-				{ "$ref": "#/definitions/settingsPropertiesCustom" }
+				{ "$ref": "#/definitions/settingsAppearanceToolsProperties" },
+				{ "$ref": "#/definitions/settingsBackgroundProperties" },
+				{ "$ref": "#/definitions/settingsBorderProperties" },
+				{ "$ref": "#/definitions/settingsColorProperties" },
+				{ "$ref": "#/definitions/settingsDimensionsProperties" },
+				{ "$ref": "#/definitions/settingsLayoutProperties" },
+				{ "$ref": "#/definitions/settingsLightboxProperties" },
+				{ "$ref": "#/definitions/settingsPositionProperties" },
+				{ "$ref": "#/definitions/settingsShadowProperties" },
+				{ "$ref": "#/definitions/settingsSpacingProperties" },
+				{ "$ref": "#/definitions/settingsTypographyProperties" },
+				{ "$ref": "#/definitions/settingsCustomProperties" }
 			]
 		},
 		"settingsPropertyNames": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1958,6 +1958,7 @@
 		},
 		"stylesElementsPropertiesComplete": {
 			"description": "Styles defined on a per-element basis using the element's selector.",
+			"type": "object",
 			"properties": {
 				"button": {
 					"allOf": [

--- a/schemas/json/wp-env.json
+++ b/schemas/json/wp-env.json
@@ -10,7 +10,6 @@
 			"properties": {
 				"core": {
 					"description": "The WordPress installation to use. If null is specified, wp-env will use the latest production release of WordPress.",
-					"default": null,
 					"oneOf": [
 						{
 							"type": "string"
@@ -18,11 +17,11 @@
 						{
 							"type": "null"
 						}
-					]
+					],
+					"default": null
 				},
 				"phpVersion": {
 					"description": "The PHP version to use. If null is specified, wp-env will use the default version used with production release of WordPress.",
-					"default": null,
 					"oneOf": [
 						{
 							"type": "string"
@@ -30,38 +29,39 @@
 						{
 							"type": "null"
 						}
-					]
+					],
+					"default": null
 				},
 				"plugins": {
 					"description": "A list of plugins to install and activate in the environment.",
-					"default": [],
 					"type": "array",
 					"items": {
 						"type": "string"
-					}
+					},
+					"default": []
 				},
 				"themes": {
 					"description": "A list of themes to install in the environment.",
-					"default": [],
 					"type": "array",
 					"items": {
 						"type": "string"
-					}
+					},
+					"default": []
 				},
 				"port": {
 					"description": "The primary port number to use for the installation. You'll access the instance through the port: 'http://localhost:8888'.",
-					"default": 8888,
-					"type": "integer"
+					"type": "integer",
+					"default": 8888
 				},
 				"config": {
 					"description": "Mapping of wp-config.php constants to their desired values.",
-					"default": {},
-					"type": "object"
+					"type": "object",
+					"default": {}
 				},
 				"mappings": {
 					"description": "Mapping of WordPress directories to local directories to be mounted in the WordPress instance.",
-					"default": {},
-					"type": "object"
+					"type": "object",
+					"default": {}
 				}
 			}
 		},
@@ -89,7 +89,6 @@
 				"env": {
 					"description": "The key env is available to override any of the above options on an individual-environment basis.",
 					"type": "object",
-					"default": {},
 					"patternProperties": {
 						"[a-zA-Z]": {
 							"type": "object",
@@ -102,7 +101,8 @@
 								}
 							]
 						}
-					}
+					},
+					"default": {}
 				}
 			}
 		},

--- a/schemas/json/wp-env.json
+++ b/schemas/json/wp-env.json
@@ -6,6 +6,7 @@
 			"reference": "https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/"
 		},
 		"wpEnvProperties": {
+			"type": "object",
 			"properties": {
 				"core": {
 					"description": "The WordPress installation to use. If null is specified, wp-env will use the latest production release of WordPress.",
@@ -76,7 +77,6 @@
 			]
 		}
 	},
-	"type": "object",
 	"allOf": [
 		{
 			"$ref": "#/definitions/wpEnvProperties"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Post-update code organization for JSON schema.

JSON structure changes:
- Inline `useRootPaddingAwareAlignments` property.
- Inline `fontFace` items.
- Sort `settingsProperties` alphabetically.
- Ensure every subschema with `properties` has `"type": "object"`.
- Ensure every subschema with `propertyNames` has `"type": "object"`.
- Alphabetize `stylesProperties`.

Fixes:
- Remove references to WordPress versions.
- Add missing ref support for `textAlign` and `textColumns`.
- Reuse `#/definitions/stylesElementsPseudoSelectorsProperties`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Follow-up to #62462 to fix some things found while working on it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See the commits for details.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check that [the new docs](https://github.com/WordPress/gutenberg/blob/update/json-schema-cleanup/docs/reference-guides/theme-json-reference/theme-json-living.md) and [new schema](https://github.com/WordPress/gutenberg/blob/update/json-schema-cleanup/schemas/json/theme.json) look correct.

Do all of the properties seem like they're in an intuitive order that makes sense?

Is the JSON file readable? Would you more easily be able to figure out where to add a new property if you need to?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
