### PR TITLE
DataViews: Update pagination icons

### DIFF
--- a/packages/dataviews/src/pagination.tsx
+++ b/packages/dataviews/src/pagination.tsx
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement, memo } from '@wordpress/element';
 import { sprintf, __, _x } from '@wordpress/i18n';
-import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { next, previous } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -92,7 +92,7 @@ const Pagination = memo( function Pagination( {
 						disabled={ currentPage === 1 }
 						accessibleWhenDisabled
 						label={ __( 'Previous page' ) }
-						icon={ chevronLeft }
+						icon={ previous }
 						showTooltip
 						size="compact"
 						tooltipPosition="top"
@@ -104,7 +104,7 @@ const Pagination = memo( function Pagination( {
 						disabled={ currentPage >= totalPages }
 						accessibleWhenDisabled
 						label={ __( 'Next page' ) }
-						icon={ chevronRight }
+						icon={ next }
 						showTooltip
 						size="compact"
 						tooltipPosition="top"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/63128

This PR just updates the pagination icons to `next/previous` which is quite similar to me with the suggested `raquo` icons.


### Before 
<img width="314" alt="Screenshot 2024-07-16 at 10 13 09 AM" src="https://github.com/user-attachments/assets/8d9f03d8-524b-4337-9b46-478bf8c9a501">

### After
<img width="314" alt="Screenshot 2024-07-16 at 10 12 38 AM" src="https://github.com/user-attachments/assets/291cf39a-369e-4593-977b-32284a1804d7">

