### PR TITLE
Global styles block previews: fix scaling

### DIFF
--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -35,6 +35,12 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 	const viewportWidth = blockExample?.viewportWidth ?? 500;
 	// Same as height of InserterPreviewPanel.
 	const previewHeight = 144;
+	const sidebarWidth = 235;
+	const scale = sidebarWidth / viewportWidth;
+	const minHeight =
+		scale !== 0 && scale < 1 && previewHeight
+			? previewHeight / scale
+			: previewHeight;
 
 	if ( ! blockExample ) {
 		return null;
@@ -57,7 +63,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 								css: `
 								body{
 									padding: 24px;
-									min-height:100%;
+									min-height:${ Math.round( minHeight ) }px;
 									display:flex;
 									align-items:center;
 								}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the problem found in https://github.com/WordPress/gutenberg/pull/63558#issuecomment-2230251421

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it was a bug that hid the content of the preview when changing the font sizes

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the same way that we use in the inserter to calculate the height of it instead of relying on using 100% because it needs to be recalculated after the changes

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go on Global Styles / Blocks / Paragraph
2. Check the preview, it should be vertically centered
3. change the font sizes for it, from small to big and back to small, the text shouldn't disappear from the preview. It's ok if some of it is cut out by the overflow

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![Screen Capture on 2024-07-16 at 10-35-49](https://github.com/user-attachments/assets/d1c40365-324c-46ee-8c83-7f50c0f74b51)

