### PR TITLE
DataViews: Bootstrap Quick Edit

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -31,6 +31,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-zoomed-out-patterns-tab', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomedOutPatternsTab = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-quick-edit-dataviews', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalQuickEditDataViews = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -151,6 +151,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-quick-edit-dataviews',
+		__( 'Quick Edit in DataViews', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Allow access to a quick edit panel in the pages data views.', 'gutenberg' ),
+			'id'    => 'gutenberg-quick-edit-dataviews',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
@@ -39,6 +44,7 @@ type DataViewsProps< Item > = {
 	defaultLayouts: SupportedLayouts;
 	selection?: string[];
 	onChangeSelection?: ( items: string[] ) => void;
+	header?: ReactNode;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
@@ -59,6 +65,7 @@ export default function DataViews< Item >( {
 	defaultLayouts,
 	selection: selectionProperty,
 	onChangeSelection,
+	header,
 }: DataViewsProps< Item > ) {
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const [ density, setDensity ] = useState< number >( 0 );
@@ -123,6 +130,7 @@ export default function DataViews< Item >( {
 					) }
 					<DataViewsBulkActions />
 					<DataViewsViewConfig defaultLayouts={ defaultLayouts } />
+					{ header }
 				</HStack>
 				<DataViewsLayout />
 				<DataviewsPagination />

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -129,8 +129,16 @@ export default function DataViews< Item >( {
 						/>
 					) }
 					<DataViewsBulkActions />
-					<DataViewsViewConfig defaultLayouts={ defaultLayouts } />
-					{ header }
+					<HStack
+						spacing={ 1 }
+						expanded={ false }
+						style={ { flexShrink: 0 } }
+					>
+						<DataViewsViewConfig
+							defaultLayouts={ defaultLayouts }
+						/>
+						{ header }
+					</HStack>
 				</HStack>
 				<DataViewsLayout />
 				<DataviewsPagination />

--- a/packages/dataviews/src/layouts/table/index.tsx
+++ b/packages/dataviews/src/layouts/table/index.tsx
@@ -238,7 +238,7 @@ function TableRow< Item >( {
 					onChangeSelection(
 						selection.includes( id )
 							? selection.filter( ( itemId ) => id !== itemId )
-							: [ ...selection, id ]
+							: [ id ]
 					);
 				}
 			} }

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -41,33 +41,3 @@ export const useEditPostAction = () => {
 		[ history ]
 	);
 };
-
-export const useQuickEditPostAction = () => {
-	const history = useHistory();
-	return useMemo(
-		() => ( {
-			id: 'quick-edit-post',
-			label: __( 'Quick Edit' ),
-			icon: edit,
-			isEligible( post ) {
-				if ( post.status === 'trash' ) {
-					return false;
-				}
-
-				// Temporary limitation to only support pages for now.
-				return post.type === 'page';
-			},
-			callback( items ) {
-				const post = items[ 0 ];
-				const { params } = history.getLocationWithParams();
-				history.push( {
-					...params,
-					postId: post.id,
-					postType: post.type,
-					quickEdit: true,
-				} );
-			},
-		} ),
-		[ history ]
-	);
-};

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -41,3 +41,33 @@ export const useEditPostAction = () => {
 		[ history ]
 	);
 };
+
+export const useQuickEditPostAction = () => {
+	const history = useHistory();
+	return useMemo(
+		() => ( {
+			id: 'quick-edit-post',
+			label: __( 'Quick Edit' ),
+			icon: edit,
+			isEligible( post ) {
+				if ( post.status === 'trash' ) {
+					return false;
+				}
+
+				// Temporary limitation to only support pages for now.
+				return post.type === 'page';
+			},
+			callback( items ) {
+				const post = items[ 0 ];
+				const { params } = history.getLocationWithParams();
+				history.push( {
+					...params,
+					postId: post.id,
+					postType: post.type,
+					quickEdit: true,
+				} );
+			},
+		} ),
+		[ history ]
+	);
+};

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -201,6 +201,17 @@ export default function Layout( { route } ) {
 							</div>
 						) }
 
+					{ ! isMobileViewport && areas.edit && (
+						<div
+							className="edit-site-layout__area"
+							style={ {
+								maxWidth: widths?.edit,
+							} }
+						>
+							{ areas.edit }
+						</div>
+					) }
+
 					{ ! isMobileViewport && areas.preview && (
 						<div className="edit-site-layout__canvas-container">
 							{ canvasResizer }

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -26,6 +26,7 @@ import {
 	TEMPLATE_PART_POST_TYPE,
 	TEMPLATE_POST_TYPE,
 } from '../../utils/constants';
+import { PostEdit } from '../post-edit';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
@@ -74,7 +75,8 @@ function useRedirectOldPaths() {
 
 export default function useLayoutAreas() {
 	const { params } = useLocation();
-	const { postType, postId, path, layout, isCustom, canvas } = params;
+	const { postType, postId, path, layout, isCustom, canvas, quickEdit } =
+		params;
 	const hasEditCanvasMode = canvas === 'edit';
 	useRedirectOldPaths();
 
@@ -92,15 +94,20 @@ export default function useLayoutAreas() {
 					/>
 				),
 				content: <PostList postType={ postType } />,
-				preview: ( isListLayout || hasEditCanvasMode ) && <Editor />,
+				preview: ! quickEdit &&
+					( isListLayout || hasEditCanvasMode ) && <Editor />,
 				mobile: hasEditCanvasMode ? (
 					<Editor />
 				) : (
 					<PostList postType={ postType } />
 				),
+				edit: quickEdit && (
+					<PostEdit postType={ postType } postId={ postId } />
+				),
 			},
 			widths: {
-				content: isListLayout ? 380 : undefined,
+				content: ! quickEdit && isListLayout ? 380 : undefined,
+				edit: quickEdit ? 380 : undefined,
 			},
 		};
 	}

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -83,6 +83,7 @@ export default function useLayoutAreas() {
 	// Page list
 	if ( postType === 'page' ) {
 		const isListLayout = layout === 'list' || ! layout;
+		const showQuickEdit = quickEdit && ! isListLayout;
 		return {
 			key: 'pages',
 			areas: {
@@ -94,20 +95,20 @@ export default function useLayoutAreas() {
 					/>
 				),
 				content: <PostList postType={ postType } />,
-				preview: ! quickEdit &&
+				preview: ! showQuickEdit &&
 					( isListLayout || hasEditCanvasMode ) && <Editor />,
 				mobile: hasEditCanvasMode ? (
 					<Editor />
 				) : (
 					<PostList postType={ postType } />
 				),
-				edit: quickEdit && (
+				edit: showQuickEdit && (
 					<PostEdit postType={ postType } postId={ postId } />
 				),
 			},
 			widths: {
-				content: ! quickEdit && isListLayout ? 380 : undefined,
-				edit: quickEdit ? 380 : undefined,
+				content: isListLayout ? 380 : undefined,
+				edit: showQuickEdit ? 380 : undefined,
 			},
 		};
 	}

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -14,7 +19,7 @@ import { useState, useMemo } from '@wordpress/element';
 import Page from '../page';
 import usePostFields from '../post-fields';
 
-export function PostEdit( { postType, postId } ) {
+function PostEditForm( { postType, postId } ) {
 	const { item } = useSelect(
 		( select ) => {
 			return {
@@ -45,21 +50,37 @@ export function PostEdit( { postType, postId } ) {
 		setEdits( {} );
 	};
 
+	if ( ! item ) {
+		return null;
+	}
+
 	return (
-		<Page className="edit-site-post-edit" label={ __( 'Post Edit' ) }>
-			{ item && (
-				<form onSubmit={ onSubmit }>
-					<DataForm
-						data={ itemWithEdits }
-						fields={ fields }
-						form={ form }
-						onChange={ setEdits }
-					/>
-					<Button variant="primary" type="submit">
-						{ __( 'Update' ) }
-					</Button>
-				</form>
+		<form onSubmit={ onSubmit }>
+			<DataForm
+				data={ itemWithEdits }
+				fields={ fields }
+				form={ form }
+				onChange={ setEdits }
+			/>
+			<Button variant="primary" type="submit">
+				{ __( 'Update' ) }
+			</Button>
+		</form>
+	);
+}
+
+export function PostEdit( { postType, postId } ) {
+	return (
+		<Page
+			className={ clsx( 'edit-site-post-edit', {
+				'is-empty': ! postId,
+			} ) }
+			label={ __( 'Post Edit' ) }
+		>
+			{ postId && (
+				<PostEditForm postType={ postType } postId={ postId } />
 			) }
+			{ ! postId && <p>{ __( 'Select a page to edit' ) }</p> }
 		</Page>
 	);
 }

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { DataForm } from '@wordpress/dataviews';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { Button } from '@wordpress/components';
+import { useState, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Page from '../page';
+import usePostFields from '../post-fields';
+
+export function PostEdit( { postType, postId } ) {
+	const { item } = useSelect(
+		( select ) => {
+			return {
+				item: select( coreDataStore ).getEntityRecord(
+					'postType',
+					postType,
+					postId
+				),
+			};
+		},
+		[ postType, postId ]
+	);
+	const { saveEntityRecord } = useDispatch( coreDataStore );
+	const { fields } = usePostFields();
+	const form = {
+		visibleFields: [ 'title' ],
+	};
+	const [ edits, setEdits ] = useState( {} );
+	const itemWithEdits = useMemo( () => {
+		return {
+			...item,
+			...edits,
+		};
+	}, [ item, edits ] );
+	const onSubmit = ( event ) => {
+		event.preventDefault();
+		saveEntityRecord( 'postType', postType, itemWithEdits );
+		setEdits( {} );
+	};
+
+	return (
+		<Page className="edit-site-post-edit" label={ __( 'Post Edit' ) }>
+			{ item && (
+				<form onSubmit={ onSubmit }>
+					<DataForm
+						data={ itemWithEdits }
+						fields={ fields }
+						form={ form }
+						onChange={ setEdits }
+					/>
+					<Button variant="primary" type="submit">
+						{ __( 'Update' ) }
+					</Button>
+				</form>
+			) }
+		</Page>
+	);
+}

--- a/packages/edit-site/src/components/post-edit/style.scss
+++ b/packages/edit-site/src/components/post-edit/style.scss
@@ -1,0 +1,3 @@
+.edit-site-post-edit {
+	padding: $grid-unit-30;
+}

--- a/packages/edit-site/src/components/post-edit/style.scss
+++ b/packages/edit-site/src/components/post-edit/style.scss
@@ -1,3 +1,9 @@
 .edit-site-post-edit {
 	padding: $grid-unit-30;
+
+	&.is-empty .edit-site-page-content {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 }

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -1,0 +1,345 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import {
+	createInterpolateElement,
+	useMemo,
+	useState,
+} from '@wordpress/element';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import {
+	trash,
+	drafts,
+	published,
+	scheduled,
+	pending,
+	notAllowed,
+	commentAuthorAvatar as authorIcon,
+} from '@wordpress/icons';
+import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	LAYOUT_GRID,
+	LAYOUT_TABLE,
+	LAYOUT_LIST,
+	OPERATOR_IS_ANY,
+} from '../../utils/constants';
+import { default as Link, useLink } from '../routes/link';
+import Media from '../media';
+
+// See https://github.com/WordPress/gutenberg/issues/55886
+// We do not support custom statutes at the moment.
+const STATUSES = [
+	{ value: 'draft', label: __( 'Draft' ), icon: drafts },
+	{ value: 'future', label: __( 'Scheduled' ), icon: scheduled },
+	{ value: 'pending', label: __( 'Pending Review' ), icon: pending },
+	{ value: 'private', label: __( 'Private' ), icon: notAllowed },
+	{ value: 'publish', label: __( 'Published' ), icon: published },
+	{ value: 'trash', label: __( 'Trash' ), icon: trash },
+];
+
+const getFormattedDate = ( dateToDisplay ) =>
+	dateI18n(
+		getSettings().formats.datetimeAbbreviated,
+		getDate( dateToDisplay )
+	);
+
+function FeaturedImage( { item, viewType } ) {
+	const isDisabled = item.status === 'trash';
+	const { onClick } = useLink( {
+		postId: item.id,
+		postType: item.type,
+		canvas: 'edit',
+	} );
+	const hasMedia = !! item.featured_media;
+	const size =
+		viewType === LAYOUT_GRID
+			? [ 'large', 'full', 'medium', 'thumbnail' ]
+			: [ 'thumbnail', 'medium', 'large', 'full' ];
+	const media = hasMedia ? (
+		<Media
+			className="edit-site-post-list__featured-image"
+			id={ item.featured_media }
+			size={ size }
+		/>
+	) : null;
+	const renderButton = viewType !== LAYOUT_LIST && ! isDisabled;
+	return (
+		<div
+			className={ `edit-site-post-list__featured-image-wrapper is-layout-${ viewType }` }
+		>
+			{ renderButton ? (
+				<button
+					className="edit-site-post-list__featured-image-button"
+					type="button"
+					onClick={ onClick }
+					aria-label={ item.title?.rendered || __( '(no title)' ) }
+				>
+					{ media }
+				</button>
+			) : (
+				media
+			) }
+		</div>
+	);
+}
+
+function PostStatusField( { item } ) {
+	const status = STATUSES.find( ( { value } ) => value === item.status );
+	const label = status?.label || item.status;
+	const icon = status?.icon;
+	return (
+		<HStack alignment="left" spacing={ 0 }>
+			{ icon && (
+				<div className="edit-site-post-list__status-icon">
+					<Icon icon={ icon } />
+				</div>
+			) }
+			<span>{ label }</span>
+		</HStack>
+	);
+}
+
+function PostAuthorField( { item } ) {
+	const { text, imageUrl } = useSelect(
+		( select ) => {
+			const { getUser } = select( coreStore );
+			const user = getUser( item.author );
+			return {
+				imageUrl: user?.avatar_urls?.[ 48 ],
+				text: user?.name,
+			};
+		},
+		[ item ]
+	);
+	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
+	return (
+		<HStack alignment="left" spacing={ 0 }>
+			{ !! imageUrl && (
+				<div
+					className={ clsx( 'page-templates-author-field__avatar', {
+						'is-loaded': isImageLoaded,
+					} ) }
+				>
+					<img
+						onLoad={ () => setIsImageLoaded( true ) }
+						alt={ __( 'Author avatar' ) }
+						src={ imageUrl }
+					/>
+				</div>
+			) }
+			{ ! imageUrl && (
+				<div className="page-templates-author-field__icon">
+					<Icon icon={ authorIcon } />
+				</div>
+			) }
+			<span className="page-templates-author-field__name">{ text }</span>
+		</HStack>
+	);
+}
+
+function usePostFields( viewType ) {
+	const { records: authors, isResolving: isLoadingAuthors } =
+		useEntityRecords( 'root', 'user', { per_page: -1 } );
+
+	const { frontPageId, postsPageId } = useSelect( ( select ) => {
+		const { getEntityRecord } = select( coreStore );
+		const siteSettings = getEntityRecord( 'root', 'site' );
+		return {
+			frontPageId: siteSettings?.page_on_front,
+			postsPageId: siteSettings?.page_for_posts,
+		};
+	}, [] );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'featured-image',
+				header: __( 'Featured Image' ),
+				getValue: ( { item } ) => item.featured_media,
+				render: ( { item } ) => (
+					<FeaturedImage item={ item } viewType={ viewType } />
+				),
+				enableSorting: false,
+			},
+			{
+				header: __( 'Title' ),
+				id: 'title',
+				type: 'text',
+				getValue: ( { item } ) =>
+					typeof item.title === 'string'
+						? item.title
+						: item.title?.raw,
+				render: ( { item } ) => {
+					const addLink =
+						[ LAYOUT_TABLE, LAYOUT_GRID ].includes( viewType ) &&
+						item.status !== 'trash';
+					const title = addLink ? (
+						<Link
+							params={ {
+								postId: item.id,
+								postType: item.type,
+								canvas: 'edit',
+							} }
+						>
+							{ decodeEntities( item.title?.rendered ) ||
+								__( '(no title)' ) }
+						</Link>
+					) : (
+						<span>
+							{ decodeEntities( item.title?.rendered ) ||
+								__( '(no title)' ) }
+						</span>
+					);
+
+					let suffix = '';
+					if ( item.id === frontPageId ) {
+						suffix = (
+							<span className="edit-site-post-list__title-badge">
+								{ __( 'Homepage' ) }
+							</span>
+						);
+					} else if ( item.id === postsPageId ) {
+						suffix = (
+							<span className="edit-site-post-list__title-badge">
+								{ __( 'Posts Page' ) }
+							</span>
+						);
+					}
+
+					return (
+						<HStack
+							className="edit-site-post-list__title"
+							alignment="center"
+							justify="flex-start"
+						>
+							{ title }
+							{ suffix }
+						</HStack>
+					);
+				},
+				enableHiding: false,
+			},
+			{
+				header: __( 'Author' ),
+				id: 'author',
+				getValue: ( { item } ) => item._embedded?.author[ 0 ]?.name,
+				elements:
+					authors?.map( ( { id, name } ) => ( {
+						value: id,
+						label: name,
+					} ) ) || [],
+				render: PostAuthorField,
+			},
+			{
+				header: __( 'Status' ),
+				id: 'status',
+				getValue: ( { item } ) =>
+					STATUSES.find( ( { value } ) => value === item.status )
+						?.label ?? item.status,
+				elements: STATUSES,
+				render: PostStatusField,
+				enableSorting: false,
+				filterBy: {
+					operators: [ OPERATOR_IS_ANY ],
+				},
+			},
+			{
+				header: __( 'Date' ),
+				id: 'date',
+				render: ( { item } ) => {
+					const isDraftOrPrivate = [ 'draft', 'private' ].includes(
+						item.status
+					);
+					if ( isDraftOrPrivate ) {
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: page creation date */
+								__( '<span>Modified: <time>%s</time></span>' ),
+								getFormattedDate( item.date )
+							),
+							{
+								span: <span />,
+								time: <time />,
+							}
+						);
+					}
+
+					const isScheduled = item.status === 'future';
+					if ( isScheduled ) {
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: page creation date */
+								__( '<span>Scheduled: <time>%s</time></span>' ),
+								getFormattedDate( item.date )
+							),
+							{
+								span: <span />,
+								time: <time />,
+							}
+						);
+					}
+
+					// Pending & Published posts show the modified date if it's newer.
+					const dateToDisplay =
+						getDate( item.modified ) > getDate( item.date )
+							? item.modified
+							: item.date;
+
+					const isPending = item.status === 'pending';
+					if ( isPending ) {
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: the newest of created or modified date for the page */
+								__( '<span>Modified: <time>%s</time></span>' ),
+								getFormattedDate( dateToDisplay )
+							),
+							{
+								span: <span />,
+								time: <time />,
+							}
+						);
+					}
+
+					const isPublished = item.status === 'publish';
+					if ( isPublished ) {
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: the newest of created or modified date for the page */
+								__( '<span>Published: <time>%s</time></span>' ),
+								getFormattedDate( dateToDisplay )
+							),
+							{
+								span: <span />,
+								time: <time />,
+							}
+						);
+					}
+
+					// Unknow status.
+					return <time>{ getFormattedDate( item.date ) }</time>;
+				},
+			},
+		],
+		[ authors, viewType, frontPageId, postsPageId ]
+	);
+
+	return {
+		isLoading: isLoadingAuthors,
+		fields,
+	};
+}
+
+export default usePostFields;

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -19,11 +19,7 @@ import {
 	useDefaultViews,
 	defaultLayouts,
 } from '../sidebar-dataviews/default-views';
-import {
-	LAYOUT_LIST,
-	OPERATOR_IS_ANY,
-	OPERATOR_IS_NONE,
-} from '../../utils/constants';
+import { OPERATOR_IS_ANY, OPERATOR_IS_NONE } from '../../utils/constants';
 
 import AddNewPostModal from '../add-new-post';
 import { unlock } from '../../lock-unlock';
@@ -147,17 +143,14 @@ export default function PostList( { postType } ) {
 		( items ) => {
 			setSelection( items );
 			const { params } = history.getLocationWithParams();
-			if (
-				( params.isCustom ?? 'false' ) === 'false' &&
-				view?.type === LAYOUT_LIST
-			) {
+			if ( ( params.isCustom ?? 'false' ) === 'false' ) {
 				history.push( {
 					...params,
 					postId: items.length === 1 ? items[ 0 ] : undefined,
 				} );
 			}
 		},
-		[ history, view?.type ]
+		[ history ]
 	);
 
 	const queryArgs = useMemo( () => {
@@ -304,6 +297,7 @@ export default function PostList( { postType } ) {
 				header={
 					postType === 'page' && (
 						<Button
+							isPressed={ quickEdit }
 							icon={ drawerLeft }
 							label={
 								quickEdit

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -297,10 +297,11 @@ export default function PostList( { postType } ) {
 				header={
 					postType === 'page' && (
 						<Button
+							size="compact"
 							isPressed={ quickEdit }
 							icon={ drawerLeft }
 							label={
-								quickEdit
+								! quickEdit
 									? __( 'Show quick edit sidebar' )
 									: __( 'Close quick edit sidebar' )
 							}

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -19,7 +19,11 @@ import {
 	useDefaultViews,
 	defaultLayouts,
 } from '../sidebar-dataviews/default-views';
-import { OPERATOR_IS_ANY, OPERATOR_IS_NONE } from '../../utils/constants';
+import {
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	LAYOUT_LIST,
+} from '../../utils/constants';
 
 import AddNewPostModal from '../add-new-post';
 import { unlock } from '../../lock-unlock';
@@ -295,6 +299,7 @@ export default function PostList( { postType } ) {
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
 				header={
+					view.type !== LAYOUT_LIST &&
 					postType === 'page' && (
 						<Button
 							size="compact"

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -8,6 +8,8 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { drawerLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -25,10 +27,7 @@ import {
 
 import AddNewPostModal from '../add-new-post';
 import { unlock } from '../../lock-unlock';
-import {
-	useEditPostAction,
-	useQuickEditPostAction,
-} from '../dataviews-actions';
+import { useEditPostAction } from '../dataviews-actions';
 import { usePrevious } from '@wordpress/compose';
 import usePostFields from '../post-fields';
 
@@ -141,9 +140,8 @@ function getItemId( item ) {
 export default function PostList( { postType } ) {
 	const [ view, setView ] = useView( postType );
 	const history = useHistory();
-	const {
-		params: { postId },
-	} = useLocation();
+	const location = useLocation();
+	const { postId, quickEdit = false } = location.params;
 	const [ selection, setSelection ] = useState( [ postId ] );
 	const onChangeSelection = useCallback(
 		( items ) => {
@@ -247,10 +245,9 @@ export default function PostList( { postType } ) {
 		context: 'list',
 	} );
 	const editAction = useEditPostAction();
-	const quickEditAction = useQuickEditPostAction();
 	const actions = useMemo(
-		() => [ quickEditAction, editAction, ...postTypeActions ],
-		[ quickEditAction, postTypeActions, editAction ]
+		() => [ editAction, ...postTypeActions ],
+		[ postTypeActions, editAction ]
 	);
 
 	const [ showAddPostModal, setShowAddPostModal ] = useState( false );
@@ -304,6 +301,24 @@ export default function PostList( { postType } ) {
 				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
+				header={
+					postType === 'page' && (
+						<Button
+							icon={ drawerLeft }
+							label={
+								quickEdit
+									? __( 'Show quick edit sidebar' )
+									: __( 'Close quick edit sidebar' )
+							}
+							onClick={ () => {
+								history.push( {
+									...location.params,
+									quickEdit: quickEdit ? undefined : true,
+								} );
+							} }
+						/>
+					)
+				}
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -299,6 +299,7 @@ export default function PostList( { postType } ) {
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
 				header={
+					window.__experimentalQuickEditDataViews &&
 					view.type !== LAYOUT_LIST &&
 					postType === 'page' && (
 						<Button

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -259,7 +259,7 @@ export default function PostList( { postType } ) {
 		} );
 		closeModal();
 	};
-	const { isLoading, fields } = usePostFields( view.type );
+	const { isLoading: isLoadingFields, fields } = usePostFields( view.type );
 
 	return (
 		<Page
@@ -291,7 +291,7 @@ export default function PostList( { postType } ) {
 				fields={ fields }
 				actions={ actions }
 				data={ records || EMPTY_ARRAY }
-				isLoading={ isLoadingMainEntities || isLoading }
+				isLoading={ isLoadingMainEntities || isLoadingFields }
 				view={ view }
 				onChangeView={ setView }
 				selection={ selection }

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -9,7 +9,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import { drawerLeft } from '@wordpress/icons';
+import { drawerRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -305,7 +305,7 @@ export default function PostList( { postType } ) {
 						<Button
 							size="compact"
 							isPressed={ quickEdit }
-							icon={ drawerLeft }
+							icon={ drawerRight }
 							label={
 								! quickEdit
 									? __( 'Show quick edit sidebar' )

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -28,6 +28,7 @@
 @import "./components/site-icon/style.scss";
 @import "./components/style-book/style.scss";
 @import "./components/editor-canvas-container/style.scss";
+@import "./components/post-edit/style.scss";
 @import "./components/post-list/style.scss";
 @import "./components/resizable-frame/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";


### PR DESCRIPTION
Related to #55101 and #59745 

## What?

This PR bootstraps a panel for quick edit pages in the pages dataviews of the site editor. There's a lot of iterations and questions that needs answering but my goal for this initial PR is to set the "architecture" in place:

 - How do we render the panel.
 - How do we select an item.
 - How do we save changes.
 - How do we organize the code base.

The following items will be left for other PRs: (I don't mind feedback on them but I know that they need work and would prefer to leave them separate)

 - The design of the panel itself. It's using the raw "DataForm" for now, I think we probably need two kind of "views" when rendering forms: regular forms and panels (like the inspector panels)
 - Bulk editing: it has its own challenges, I think we should quickly follow-up with a PR for this in order to see how the code base and the flows can be adapted to edit multiple entities rather than one.

## Testing Instructions

1- Open the "pages" section of the site editor.
2- Click "quick edit" in the actions menu of a given page.
3- Notice that you can edit the title.