### PR TITLE
React: Restore umd builds

### DIFF
--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -102,6 +102,13 @@ const exportDefaultPackages = [
 	'warning',
 ];
 
+const copiedVendors = {
+	'react.js': 'react/umd/react.development.js',
+	'react.min.js': 'react/umd/react.production.min.js',
+	'react-dom.js': 'react-dom/umd/react-dom.development.js',
+	'react-dom.min.js': 'react-dom/umd/react-dom.production.min.js',
+};
+
 module.exports = {
 	...baseConfig,
 	name: 'packages',
@@ -148,7 +155,13 @@ module.exports = {
 					transform: stylesTransform,
 					noErrorOnMissing: true,
 				} ) )
-				.concat( bundledPackagesPhpConfig ),
+				.concat( bundledPackagesPhpConfig )
+				.concat(
+					Object.entries( copiedVendors ).map( ( [ to, from ] ) => ( {
+						from: `node_modules/${ from }`,
+						to: `build/vendors/${ to }`,
+					} ) )
+				),
 		} ),
 		new MomentTimezoneDataPlugin( {
 			startYear: 2000,

--- a/tools/webpack/vendors.js
+++ b/tools/webpack/vendors.js
@@ -4,8 +4,6 @@
 const { join } = require( 'path' );
 
 const importedVendors = {
-	react: { import: 'react', global: 'React' },
-	'react-dom': { import: 'react-dom', global: 'ReactDOM' },
 	'react-jsx-runtime': {
 		import: 'react/jsx-runtime',
 		global: 'ReactJSXRuntime',
@@ -35,12 +33,9 @@ module.exports = [
 					},
 				},
 
-				externals:
-					name === 'react'
-						? {}
-						: {
-								react: 'React',
-						  },
+				externals: {
+					react: 'React',
+				},
 			};
 		} );
 	} ),


### PR DESCRIPTION
In 6.6 we tried moving away from the deprecated React UMD builds, the issue we faced is that there's a warning that is triggered on the console because we're not using a separate impact for `createRoot`. (SCRIPT_DEBUG true and `npm run build`)

`Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".`

This warning has been removed in React 19 along with the removal of the UMD builds, so we should be able to revert this PR when we upgrade to React 19.

Related Core PR here https://github.com/WordPress/wordpress-develop/pull/7021 

