### PR TITLE
Increase column-gap between fields in List layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -579,7 +579,7 @@
 	.dataviews-view-list__fields {
 		color: $gray-700;
 		display: flex;
-		gap: $grid-unit-10;
+		gap: $grid-unit-15;
 		row-gap: $grid-unit-05;
 		flex-wrap: wrap;
 		font-size: 12px;


### PR DESCRIPTION
Now that fields can include icons the spacing is a bit too small. If you squint it's not clear which label the icon is associated with here:

<img width="400" alt="Screenshot 2024-07-16 at 10 50 01" src="https://github.com/user-attachments/assets/cba22881-31ed-4d5f-a3d6-503a7433f3a9">

This PR bumps the spacing up from 8px to 12px:

<img width="398" alt="Screenshot 2024-07-16 at 10 50 17" src="https://github.com/user-attachments/assets/c5f56785-9331-41ba-b96e-033f1f324793">

### Testing instructions

- Navigate to a data view like Pages
- Switch to List layout
- Toggle on multiple fields
- Notice the increased horizontal spacing between each field