### PR TITLE
core-data: Fix `canUser` allowed methods handling

### DIFF
--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -24,11 +24,9 @@ describe( 'useResourcePermissions', () => {
 		registry.register( coreDataStore );
 
 		triggerFetch.mockImplementation( () => ( {
-			headers: {
-				get: () => ( {
-					allow: 'POST',
-				} ),
-			},
+			headers: new Headers( {
+				allow: 'POST',
+			} ),
 		} ) );
 	} );
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -419,8 +419,7 @@ export const canUser =
 		// Optional chaining operator is used here because the API requests don't
 		// return the expected result in the native version. Instead, API requests
 		// only return the result, without including response properties like the headers.
-		const allowHeader = response.headers?.get( 'allow' );
-		const allowedMethods = allowHeader?.allow || allowHeader || '';
+		const allowedMethods = response.headers?.get( 'allow' ) || '';
 
 		const permissions = {};
 		const methods = {


### PR DESCRIPTION
## What?
This PR cleans up a wrong access for retrieving the allowed methods inside `canUser`. 

## Why?
See https://github.com/WordPress/gutenberg/pull/63430#discussion_r1679400833

Because it's not necessary and was wrong. It was introduced in #43117 and the related test that needed to be improved was added in #38785.

## How?
Fixing the test fixture and removing the unnecessary object access. 

## Testing Instructions
* Verify all tests pass.
* Smoke test the site editor and verify all requests continue to work. 

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None