### PR TITLE
Template Part: Add check if create action should be allowed

### DIFF
--- a/packages/block-library/src/template-part/edit/placeholder.js
+++ b/packages/block-library/src/template-part/edit/placeholder.js
@@ -4,6 +4,8 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, Button, Spinner } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -28,6 +30,21 @@ export default function TemplatePartPlaceholder( {
 		templatePartId
 	);
 	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
+
+	const { isBlockBasedTheme, canCreateTemplatePart } = useSelect(
+		( select ) => {
+			const { getCurrentTheme, canUser } = select( coreStore );
+			return {
+				isBlockBasedTheme: getCurrentTheme()?.is_block_theme,
+				canCreateTemplatePart: canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_template_part',
+				} ),
+			};
+		},
+		[]
+	);
+
 	const [ showTitleModal, setShowTitleModal ] = useState( false );
 	const areaObject = useTemplatePartArea( area );
 	const createFromBlocks = useCreateTemplatePartFromBlocks(
@@ -39,11 +56,19 @@ export default function TemplatePartPlaceholder( {
 		<Placeholder
 			icon={ areaObject.icon }
 			label={ areaObject.label }
-			instructions={ sprintf(
-				// Translators: %s as template part area title ("Header", "Footer", etc.).
-				__( 'Choose an existing %s or create a new one.' ),
-				areaObject.label.toLowerCase()
-			) }
+			instructions={
+				isBlockBasedTheme
+					? sprintf(
+							// Translators: %s as template part area title ("Header", "Footer", etc.).
+							__( 'Choose an existing %s or create a new one.' ),
+							areaObject.label.toLowerCase()
+					  )
+					: sprintf(
+							// Translators: %s as template part area title ("Header", "Footer", etc.).
+							__( 'Choose an existing %s.' ),
+							areaObject.label.toLowerCase()
+					  )
+			}
 		>
 			{ isResolving && <Spinner /> }
 
@@ -54,7 +79,7 @@ export default function TemplatePartPlaceholder( {
 					</Button>
 				) }
 
-			{ ! isResolving && (
+			{ ! isResolving && isBlockBasedTheme && canCreateTemplatePart && (
 				<Button
 					variant="secondary"
 					onClick={ () => {


### PR DESCRIPTION
Fixes #58344

## What?

This PR allows the creation of new template parts in a template part block only if the following conditions are met:

- If the current theme is a block theme
- If the current user has capabilities to create template parts

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/05b5d8b3-196a-4239-8d6c-e461f96d716c) | ![image](https://github.com/user-attachments/assets/1e718e5f-f192-4947-86cd-69146b19b73f)| 

## Why?

Creating template parts is not the intended behavior if the theme is not a block theme or if the user does not have the permissions.


## How?

I added a check similar to [the Add New Pattern button dropdown](https://github.com/WordPress/gutenberg/blob/c55aea6d6c0459b324e216ab7f248670e7a783b4/packages/edit-site/src/components/add-new-pattern/index.js#L105).

Another approach would be to not allow the insertion of template part blocks if the current theme is not a block theme, but I did allow the insertion of template part blocks because there might be edge cases where users want to nest template parts.

## Testing Instructions

- Access `http://localhost:8889/wp-admin` and activate the `Emptyhybrid` theme.
- Go to Appearance > Patterns > All template parts > header
- Insert a template part block
-  Make sure there is no "Start blank" button.

## 🤔 About User Capabilities

Regarding user capabilities, I've come across an issue where we might not be able to disable the capability to create template parts.

I removed the `create_posts` capability via the code below to test this PR:

```php
add_filter(
	'register_post_type_args',
	function ( $args ) {
		$args['capabilities']['create_posts'] = 'nonexistent_capability';
		return $args;
	}
);
```

But strangely, `canUser` always returns `true` _only_ for template parts:

```javascript
wp.data.select('core').canUser('create',{kind: 'postType',name: 'page'})
// >> false
wp.data.select('core').canUser('create',{kind: 'postType',name: 'post'})
// >> false
wp.data.select('core').canUser('create',{kind: 'postType',name: 'wp_block'})
// >> false
wp.data.select('core').canUser('create',{kind: 'postType',name: 'wp_template_part'})
// >> true
```

This issue may need to be investigated separately.