### PR TITLE
Fix missing ref support for textAlign and textColumns in theme.json schema

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -270,8 +270,8 @@ Typography styles.
 | fontWeight | string, object |  |
 | letterSpacing | string, object |  |
 | lineHeight | string, object |  |
-| textAlign | string |  |
-| textColumns | string |  |
+| textAlign | string, object |  |
+| textColumns | string, object |  |
 | textDecoration | string, object |  |
 | writingMode | string, object |  |
 | textTransform | string, object |  |

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1678,11 +1678,25 @@
 						},
 						"textAlign": {
 							"description": "Sets the `text-align` CSS property.",
-							"type": "string"
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
 						},
 						"textColumns": {
 							"description": "Sets the `column-count` CSS property.",
-							"type": "string"
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
+							]
 						},
 						"textDecoration": {
 							"description": "Sets the `text-decoration` CSS property.",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes missing ref support for textAlign and textColumns in theme.json schema.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

With trunk being migrated to JSON Schema Draft 7, it'll be easier to open this PR directly with the `wp/6.6` branch instead of being backported from #63591.

Docs are sourced from trunk, not this branch, but I updated them here anyway to show the change in the docs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See that `styles.typography.textAlign` and `styles.typography.textColumns` correctly allow `{ "ref": "other-location" }` as a value.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
