### PR TITLE
Block Bindings: Don't provide default `canUserEditValue` in reducer

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -188,7 +188,7 @@ export function RichTextWrapper(
 						binding.source
 					);
 					if (
-						! blockBindingsSource?.canUserEditValue( {
+						! blockBindingsSource?.canUserEditValue?.( {
 							select,
 							context: blockContext,
 							args: binding.args,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -247,7 +247,7 @@ function ButtonEdit( props ) {
 			return {
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
-					! blockBindingsSource?.canUserEditValue( {
+					! blockBindingsSource?.canUserEditValue?.( {
 						select,
 						context,
 						args: metadata?.bindings?.url?.args,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -308,7 +308,7 @@ export function ImageEdit( {
 			return {
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
-					! blockBindingsSource?.canUserEditValue( {
+					! blockBindingsSource?.canUserEditValue?.( {
 						select,
 						context,
 						args: metadata?.bindings?.url?.args,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -479,7 +479,7 @@ export default function Image( {
 			return {
 				lockUrlControls:
 					!! urlBinding &&
-					! urlBindingSource?.canUserEditValue( {
+					! urlBindingSource?.canUserEditValue?.( {
 						select,
 						context,
 						args: urlBinding?.args,
@@ -494,7 +494,7 @@ export default function Image( {
 					hasParentPattern,
 				lockAltControls:
 					!! altBinding &&
-					! altBindingSource?.canUserEditValue( {
+					! altBindingSource?.canUserEditValue?.( {
 						select,
 						context,
 						args: altBinding?.args,
@@ -508,7 +508,7 @@ export default function Image( {
 					: __( 'Connected to dynamic data' ),
 				lockTitleControls:
 					!! titleBinding &&
-					! titleBindingSource?.canUserEditValue( {
+					! titleBindingSource?.canUserEditValue?.( {
 						select,
 						context,
 						args: titleBinding?.args,

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1607,7 +1607,7 @@ describe( 'blocks', () => {
 			expect( source.setValue ).toBeUndefined();
 			expect( source.setValues ).toBeUndefined();
 			expect( source.getPlaceholder ).toBeUndefined();
-			expect( source.canUserEditValue() ).toBe( false );
+			expect( source.canUserEditValue ).toBeUndefined();
 			unregisterBlockBindingsSource( 'core/valid-source' );
 		} );
 

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -382,8 +382,7 @@ export function blockBindingsSources( state = {}, action ) {
 					setValue: action.setValue,
 					setValues: action.setValues,
 					getPlaceholder: action.getPlaceholder,
-					canUserEditValue:
-						action.canUserEditValue || ( () => false ),
+					canUserEditValue: action.canUserEditValue,
 				},
 			};
 		case 'REMOVE_BLOCK_BINDINGS_SOURCE':


### PR DESCRIPTION
## What?
This was suggested [here](https://github.com/WordPress/gutenberg/pull/63117#discussion_r1679170259) by @gziolo .

Right now, we define a default function that returns `false` in the reducer to ensure that sources are not editable unless explicitly specified. However, I believe we can avoid that and just not calling the function when it is undefined.

## Why?
To keep consistency with the rest of the properties that don't have a default value.

## How?
I changed where we are calling `canUserEditValue` to be called conditionally. If it is not defined, it will return undefined, which will lock the editing anyways.

## Testing Instructions
* Sources with `canUserEdit` are editable. These should be tested by post-meta and pattern-overrides.
* Sources without `canUserEdit` should be locked. This should be covered in [this test](https://github.com/WordPress/gutenberg/blob/ff9d6df37ff1b43fb3788da05c5449cf705eb77b/test/e2e/specs/editor/various/block-bindings.spec.js#L115).
