### PR TITLE
Social Links: Add border block support 

### DIFF
--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -81,6 +81,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"styles": [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Social Links` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Social Links` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that `Social Links` border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add `Social Links` block and Apply the border styles
- Verify that block borders take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend

## Screenshots or screencast <!-- if applicable -->
In backend:
<img width="1227" alt="Screenshot at Jul 16 22-13-28" src="https://github.com/user-attachments/assets/76b759fd-0117-4092-89da-3421c8e83795">

In frontend:
<img width="669" alt="Screenshot at Jul 16 22-13-39" src="https://github.com/user-attachments/assets/89396f3f-14ce-4cf0-b490-b26a47d74e4f">
