### PR TITLE
Term Description: Add border block support

### DIFF
--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -40,6 +40,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	}
 }

--- a/packages/block-library/src/term-description/style.scss
+++ b/packages/block-library/src/term-description/style.scss
@@ -1,5 +1,7 @@
 // Lowest specificity on wrapper margins to avoid overriding layout styles.
 :where(.wp-block-term-description) {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
 	margin-top: var(--wp--style--block-gap);
 	margin-bottom: var(--wp--style--block-gap);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Term Description` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Term Description` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that `Term Description` block's border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add `Term Description` block and Apply the border styles
- Verify that block borders take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend
 
## Screenshots or screencast <!-- if applicable -->
 
In backend:
<img width="1240" alt="Screenshot at Jul 16 22-18-11" src="https://github.com/user-attachments/assets/0e9723d9-688f-4396-8a7f-1bf5addaac89"> 
In frontend: 
<img width="740" alt="Screenshot at Jul 16 22-17-58" src="https://github.com/user-attachments/assets/5b3d915b-827e-4c37-9a95-0166eebf0b45">