### PR TITLE
Always open block settings sidebar on block selection

### DIFF
--- a/packages/editor/src/components/provider/use-auto-switch-editor-sidebars.js
+++ b/packages/editor/src/components/provider/use-auto-switch-editor-sidebars.js
@@ -12,10 +12,9 @@ import { store as interfaceStore } from '@wordpress/interface';
  * sidebar state.
  */
 function useAutoSwitchEditorSidebars() {
-	const { hasBlockSelection } = useSelect( ( select ) => {
+	const { clientId } = useSelect( ( select ) => {
 		return {
-			hasBlockSelection:
-				!! select( blockEditorStore ).getBlockSelectionStart(),
+			clientId: select( blockEditorStore ).getSelectedBlockClientId(),
 		};
 	}, [] );
 
@@ -24,25 +23,29 @@ function useAutoSwitchEditorSidebars() {
 	const { get: getPreference } = useSelect( preferencesStore );
 
 	useEffect( () => {
+		const isDistractionFree = getPreference( 'core', 'distractionFree' );
+		if ( isDistractionFree ) {
+			return;
+		}
+
 		const activeGeneralSidebar = getActiveComplementaryArea( 'core' );
 		const isEditorSidebarOpened = [
 			'edit-post/document',
 			'edit-post/block',
 		].includes( activeGeneralSidebar );
-		const isDistractionFree = getPreference( 'core', 'distractionFree' );
-		if ( ! isEditorSidebarOpened || isDistractionFree ) {
-			return;
-		}
-		if ( hasBlockSelection ) {
+
+		// Experiment: If the block is selected, show the block sidebar.
+		// https://github.com/WordPress/gutenberg/issues/54633
+		if ( clientId ) {
 			enableComplementaryArea( 'core', 'edit-post/block' );
-		} else {
+		} else if ( isEditorSidebarOpened ) {
 			enableComplementaryArea( 'core', 'edit-post/document' );
 		}
 	}, [
-		hasBlockSelection,
 		getActiveComplementaryArea,
 		enableComplementaryArea,
 		getPreference,
+		clientId,
 	] );
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Experiment to always open block settings when a block is selected. Exploration as part of https://github.com/WordPress/gutenberg/issues/54633.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
