### PR TITLE
Merge 63406 (Navigation block: Allow themes to override block library text-decoration rule) into wp/6.6 branch

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -76,15 +76,10 @@ $navigation-icon-size: 24px;
 		}
 	}
 
-	&:where(:not([class*="has-text-decoration"])) {
-		a {
-			text-decoration: none;
-
-			&:focus,
-			&:active {
-				text-decoration: none;
-			}
-		}
+	& :where(a),
+	& :where(a:focus),
+	& :where(a:active) {
+		text-decoration: none;
 	}
 
 	// Submenu indicator.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR proposes merging "Navigation block: Allow themes to override block library text-decoration rule (#63406)" into the `wp/6.6` branch.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A separate PR is used here so that we have a clean build of the `wp/6.6` branch with this change applied on top of it, and can download a zip file of the generated artefact.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Checked out the `wp/6.6` branch, and cherry picked the merge commit from #63406 into this branch.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow the testing instructions in #63406
