### PR TITLE
Zoom Out: fix crash due to absence of selected block

### DIFF
--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -29,10 +29,11 @@ export function useShowBlockTools() {
 		const clientId =
 			getSelectedBlockClientId() || getFirstMultiSelectedBlockClientId();
 
-		const block = getBlock( clientId ) || { name: '', attributes: {} };
+		const block = getBlock( clientId );
 		const editorMode = __unstableGetEditorMode();
-		const hasSelectedBlock = clientId && block?.name;
-		const isEmptyDefaultBlock = isUnmodifiedDefaultBlock( block );
+		const hasSelectedBlock = !! clientId && !! block;
+		const isEmptyDefaultBlock =
+			hasSelectedBlock && isUnmodifiedDefaultBlock( block );
 		const _showEmptyBlockSideInserter =
 			clientId &&
 			! isTyping() &&
@@ -43,8 +44,9 @@ export function useShowBlockTools() {
 			! hasMultiSelection() &&
 			editorMode === 'navigation';
 
+		const isZoomOut = editorMode === 'zoom-out';
 		const _showBlockToolbarPopover =
-			editorMode !== 'zoom-out' &&
+			! isZoomOut &&
 			! getSettings().hasFixedToolbar &&
 			! _showEmptyBlockSideInserter &&
 			hasSelectedBlock &&
@@ -57,7 +59,8 @@ export function useShowBlockTools() {
 				! _showEmptyBlockSideInserter && maybeShowBreadcrumb,
 			showBlockToolbarPopover: _showBlockToolbarPopover,
 			showZoomOutToolbar:
-				editorMode === 'zoom-out' &&
+				hasSelectedBlock &&
+				isZoomOut &&
 				! _showEmptyBlockSideInserter &&
 				! maybeShowBreadcrumb &&
 				! _showBlockToolbarPopover,


### PR DESCRIPTION
## What?
A fix for crashes in the editor while zoomed out when either a block is removed or a block is deselected.

## Why?
Without this it’s fairly easy to crash the editor in Zoom Out. To fix #63456.

## How?
Revises the show block tools hook to avoid returning `true` for `showZoomOutToolbar` when no block is selected.

## Testing Instructions
### Undo while zoomed out
1. With the Zoom Out experiment enabled
2. Go to the Site editor and select a page to edit
3. Open the inserter, select a pattern category and insert a pattern
4. Undo
5. Note there is no crash

### Deselect a block while zoomed out
1. With the Zoom Out experiment enabled
2. Open a post that has content
3. Open the inserter, select a pattern category
4. Select a block
5. Click somewhere that will deselect the block without selecting another
6. Note there is no crash

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
