### PR TITLE
Image block: Show placeholder when uploading HEIC files

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -174,7 +174,7 @@
 		left: 0;
 		pointer-events: none;
 		background: currentColor;
-		opacity: 0.2;
+		opacity: 0.1;
 	}
 }
 

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -174,7 +174,7 @@
 		left: 0;
 		pointer-events: none;
 		background: currentColor;
-		opacity: 0.1;
+		opacity: 0.2;
 	}
 }
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -3,7 +3,7 @@
 .wp-block-image.wp-block-image {
 
 	// Show Placeholder style on-select.
-	&.is-selected .components-placeholder {
+	&.is-selected .block-editor-media-placeholder {
 		// Block UI appearance.
 		color: $gray-900;
 		background-color: $white;
@@ -61,12 +61,6 @@ figure.wp-block-image:not(.wp-block) {
 		display: inline;
 	}
 
-	// Shown while image is being uploded but cannot be previewed.
-	.block-editor-image__skeleton {
-		aspect-ratio: 4 / 3;
-		background: $gray-100;
-	}
-
 	// Shown while image is being uploaded.
 	.components-spinner {
 		position: absolute;
@@ -74,6 +68,11 @@ figure.wp-block-image:not(.wp-block) {
 		left: 50%;
 		transform: translate(-50%, -50%);
 	}
+}
+
+// Shown while image is being uploded but cannot be previewed.
+.wp-block-image__placeholder {
+	aspect-ratio: 4 / 3;
 }
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -61,6 +61,12 @@ figure.wp-block-image:not(.wp-block) {
 		display: inline;
 	}
 
+	// Shown while image is being uploded but cannot be previewed.
+	.block-editor-image__skeleton {
+		aspect-ratio: 4 / 3;
+		background: $gray-100;
+	}
+
 	// Shown while image is being uploaded.
 	.components-spinner {
 		position: absolute;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -176,6 +176,7 @@ export default function Image( {
 	] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const [ externalBlob, setExternalBlob ] = useState();
+	const [ hasImageErrored, setHasImageErrored ] = useState( false );
 	const hasNonContentControls = blockEditingMode === 'default';
 	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 	const isResizable =
@@ -245,13 +246,22 @@ export default function Image( {
 	}
 
 	function onImageError() {
+		setHasImageErrored( true );
+
 		// Check if there's an embed block that handles this URL, e.g., instagram URL.
 		// See: https://github.com/WordPress/gutenberg/pull/11472
 		const embedBlock = createUpgradedEmbedBlock( { attributes: { url } } );
-
 		if ( undefined !== embedBlock ) {
 			onReplace( embedBlock );
 		}
+	}
+
+	function onImageLoad( event ) {
+		setHasImageErrored( false );
+		setLoadedNaturalSize( {
+			loadedNaturalWidth: event.target?.naturalWidth,
+			loadedNaturalHeight: event.target?.naturalHeight,
+		} );
 	}
 
 	function onSetHref( props ) {
@@ -815,37 +825,43 @@ export default function Image( {
 	const shadowProps = getShadowClassesAndStyles( attributes );
 	const isRounded = attributes.className?.includes( 'is-style-rounded' );
 
-	let img = (
-		// Disable reason: Image itself is not meant to be interactive, but
-		// should direct focus to block.
-		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
-		<>
-			<img
-				src={ temporaryURL || url }
-				alt={ defaultedAlt }
-				onError={ () => onImageError() }
-				onLoad={ ( event ) => {
-					setLoadedNaturalSize( {
-						loadedNaturalWidth: event.target?.naturalWidth,
-						loadedNaturalHeight: event.target?.naturalHeight,
-					} );
-				} }
-				ref={ imageRef }
-				className={ borderProps.className }
-				style={ {
-					width:
-						( width && height ) || aspectRatio ? '100%' : undefined,
-					height:
-						( width && height ) || aspectRatio ? '100%' : undefined,
-					objectFit: scale,
-					...borderProps.style,
-					...shadowProps.style,
-				} }
-			/>
-			{ temporaryURL && <Spinner /> }
-		</>
-		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
-	);
+	let img =
+		temporaryURL && hasImageErrored ? (
+			// Show a placeholder during upload when the blob URL can't be loaded. This can
+			// happen when the user uploads a HEIC image in a browser that doesn't support them.
+			<div className="block-editor-image__skeleton">
+				<Spinner />
+			</div>
+		) : (
+			// Disable reason: Image itself is not meant to be interactive, but
+			// should direct focus to block.
+			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
+			<>
+				<img
+					src={ temporaryURL || url }
+					alt={ defaultedAlt }
+					onError={ onImageError }
+					onLoad={ onImageLoad }
+					ref={ imageRef }
+					className={ borderProps.className }
+					style={ {
+						width:
+							( width && height ) || aspectRatio
+								? '100%'
+								: undefined,
+						height:
+							( width && height ) || aspectRatio
+								? '100%'
+								: undefined,
+						objectFit: scale,
+						...borderProps.style,
+						...shadowProps.style,
+					} }
+				/>
+				{ temporaryURL && <Spinner /> }
+			</>
+			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
+		);
 
 	if ( canEditImage && isEditingImage ) {
 		img = (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -14,6 +14,7 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUseCustomUnits as useCustomUnits,
+	Placeholder,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -829,9 +830,12 @@ export default function Image( {
 		temporaryURL && hasImageErrored ? (
 			// Show a placeholder during upload when the blob URL can't be loaded. This can
 			// happen when the user uploads a HEIC image in a browser that doesn't support them.
-			<div className="block-editor-image__skeleton">
+			<Placeholder
+				className="wp-block-image__placeholder"
+				withIllustration
+			>
 				<Spinner />
-			</div>
+			</Placeholder>
 		) : (
 			// Disable reason: Image itself is not meant to be interactive, but
 			// should direct focus to block.


### PR DESCRIPTION
## What, why, how

In https://core.trac.wordpress.org/ticket/53645 we're adding support for HEIC images to Core. These will be automatically converted to a JPEG on the server after they're uploaded.

This PR improves the UX of uploading a HEIC image in a browser that doesn't support viewing HEIC images e.g. Chrome, Firefox.

Currently the temporary blob image that displays during upload can't be displayed and so the browser will display the default alt text during upload:

https://github.com/user-attachments/assets/b5154500-4818-4dfc-b45a-31bad838682a

This PR detects when the image fails to load and during upload shows a placeholder `div` instead:

https://github.com/user-attachments/assets/dda78ffe-3650-4d95-88b7-f00834d0a6d8

In browsers that support HEIC aka Safari, you'll see a preview of the image while it uploads.

### Testing instructions

It's a bit tricky, sorry. You'll have to set Gutenberg to use this branch and WordPress to use `adamsilverstein:add/heic-support` ([wordpress-develop#7034](https://github.com/WordPress/wordpress-develop/pull/7034)).

One way to do that is to:
1. Clone `wordpress-develop` locally and `cd` to it
2. Check out `adamsilverstein:add/heic-support`
3. `npm install; npx grunt`
4. `cd` back to your local Gutenberg repo
5. Create a `.wp-env.override.json` with `{ "core": "/path/to/your/local/wordpress-develop/build" }
6. `npx wp-env start` 

Unfortunately we can't use Playground because it doesn't support ImageMagick.

Once your testing environment is set up:

1. Open the post or site editor
2. Upload a HEIC image. There are sample images available here: https://github.com/dsoprea/heic-exif-samples
3. Test both a browser that supports HEIC (Safari) and one that doesn't (Firefox, Chrome)