### PR TITLE
DataViews: Remove redundant setSelection prop

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
-- `onSelectionChange` has been renamed to `onChangeSelection`.
+- `onSelectionChange` prop has been renamed to `onChangeSelection`.
+- `setSelection` prop has been removed. Please use `onChangeSelection` instead.
 
 ## 3.0.0 (2024-07-10)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- `onSelectionChange` prop has been renamed to `onChangeSelection`.
+- `onSelectionChange` prop has been renamed to `onChangeSelection` and its argument has been updated to be a list of ids.
 - `setSelection` prop has been removed. Please use `onChangeSelection` instead.
 
 ## 3.0.0 (2024-07-10)

--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -31,7 +31,7 @@ import type {
 	ViewBaseProps,
 	SupportedLayouts,
 } from './types';
-import type { SetSelection, SelectionOrUpdater } from './private-types';
+import type { SelectionOrUpdater } from './private-types';
 
 type ItemWithId = { id: string };
 
@@ -50,15 +50,12 @@ type DataViewsProps< Item > = {
 	};
 	defaultLayouts: SupportedLayouts;
 	selection?: string[];
-	setSelection?: SetSelection;
-	onChangeSelection?: ( items: Item[] ) => void;
+	onChangeSelection?: ( items: string[] ) => void;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
 
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
-
-const defaultOnChangeSelection = () => {};
 
 export default function DataViews< Item >( {
 	view,
@@ -73,25 +70,23 @@ export default function DataViews< Item >( {
 	paginationInfo,
 	defaultLayouts,
 	selection: selectionProperty,
-	setSelection: setSelectionProperty,
-	onChangeSelection = defaultOnChangeSelection,
+	onChangeSelection,
 }: DataViewsProps< Item > ) {
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const isUncontrolled =
-		selectionProperty === undefined || setSelectionProperty === undefined;
+		selectionProperty === undefined || onChangeSelection === undefined;
 	const selection = isUncontrolled ? selectionState : selectionProperty;
-	const setSelection = isUncontrolled
-		? setSelectionState
-		: setSelectionProperty;
 	const [ openedFilter, setOpenedFilter ] = useState< string | null >( null );
 
 	function setSelectionWithChange( value: SelectionOrUpdater ) {
 		const newValue =
 			typeof value === 'function' ? value( selection ) : value;
-		onChangeSelection(
-			data.filter( ( item ) => newValue.includes( getItemId( item ) ) )
-		);
-		return setSelection( value );
+		if ( ! isUncontrolled ) {
+			setSelectionState( newValue );
+		}
+		if ( onChangeSelection ) {
+			onChangeSelection( newValue );
+		}
 	}
 
 	const ViewComponent = VIEW_LAYOUTS.find( ( v ) => v.type === view.type )

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -262,7 +262,7 @@ export default function PageTemplates() {
 			if ( view?.type === LAYOUT_LIST ) {
 				history.push( {
 					...params,
-					postId: items.length === 1 ? items[ 0 ].id : undefined,
+					postId: items.length === 1 ? items[ 0 ] : undefined,
 				} );
 			}
 		},

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -258,6 +258,7 @@ export default function PageTemplates() {
 	const history = useHistory();
 	const onChangeSelection = useCallback(
 		( items ) => {
+			setSelection( items );
 			if ( view?.type === LAYOUT_LIST ) {
 				history.push( {
 					...params,
@@ -374,7 +375,6 @@ export default function PageTemplates() {
 				onChangeView={ onChangeView }
 				onChangeSelection={ onChangeSelection }
 				selection={ selection }
-				setSelection={ setSelection }
 				defaultLayouts={ defaultLayouts }
 			/>
 		</Page>

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -292,7 +292,7 @@ export default function PostList( { postType } ) {
 			) {
 				history.push( {
 					...params,
-					postId: items.length === 1 ? items[ 0 ].id : undefined,
+					postId: items.length === 1 ? items[ 0 ] : undefined,
 				} );
 			}
 		},

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -284,6 +284,7 @@ export default function PostList( { postType } ) {
 	const [ selection, setSelection ] = useState( [ postId ] );
 	const onChangeSelection = useCallback(
 		( items ) => {
+			setSelection( items );
 			const { params } = history.getLocationWithParams();
 			if (
 				( params.isCustom ?? 'false' ) === 'false' &&
@@ -611,7 +612,6 @@ export default function PostList( { postType } ) {
 				view={ view }
 				onChangeView={ setView }
 				selection={ selection }
-				setSelection={ setSelection }
 				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/63087 

## What?

Just removes a redundant `setSelection` prop from the DataViews component. We can do the same thing in the `onChangeSelection` callback.

## Testing Instructions

Check that you can select items properly in the different dataviews. 