### PR TITLE
Update: Pages: Trash view should default to table layout try 2.

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -18,7 +18,7 @@ const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 /**
  * Hook to switch to table layout when switching to the trash view.
- * When going out of the trash view, it switches back to the previous layout if 
+ * When going out of the trash view, it switches back to the previous layout if
  * there was an automatic switch to table layout.
  */
 function useSwitchToTableOnTrash() {

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -3,20 +3,55 @@
  */
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useRef, useEffect } from '@wordpress/element';
+import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { useDefaultViews } from './default-views';
 import { unlock } from '../../lock-unlock';
-const { useLocation } = unlock( routerPrivateApis );
 import DataViewItem from './dataview-item';
 import CustomDataViewsList from './custom-dataviews-list';
+
+const { useLocation, useHistory } = unlock( routerPrivateApis );
+
+/**
+ * Hook to switch to table layout when switching to the trash view.
+ * When going out of the trash view, it switches back to the previous layout if 
+ * there was an automatic switch to table layout.
+ */
+function useSwitchToTableOnTrash() {
+	const {
+		params: { activeView, layout, ...restParams },
+	} = useLocation();
+	const history = useHistory();
+	const viewToSwitchOutOfTrash = useRef( undefined );
+	const previousActiveView = usePrevious( activeView );
+	useEffect( () => {
+		if ( activeView === 'trash' && previousActiveView !== 'trash' ) {
+			viewToSwitchOutOfTrash.current = layout || 'list';
+			history.push( { ...restParams, layout: 'table', activeView } );
+		} else if (
+			previousActiveView === 'trash' &&
+			activeView !== 'trash' &&
+			viewToSwitchOutOfTrash.current
+		) {
+			history.push( {
+				...restParams,
+				layout: viewToSwitchOutOfTrash.current,
+				activeView,
+			} );
+			viewToSwitchOutOfTrash.current = undefined;
+		}
+	}, [ previousActiveView, activeView, layout, history, restParams ] );
+}
 
 export default function DataViewsSidebarContent() {
 	const {
 		params: { postType, activeView = 'all', isCustom = 'false' },
 	} = useLocation();
+	useSwitchToTableOnTrash();
 	const DEFAULT_VIEWS = useDefaultViews( { postType } );
 	if ( ! postType ) {
 		return null;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/63128.
This is the second attempt for https://github.com/WordPress/gutenberg/pull/63138, which was previously reverted at https://github.com/WordPress/gutenberg/pull/63481 due to causing a test failure on the trunk. The test failure did not occur on the branch itself.

The test failure was legitimate; the issue was that when switching from the "All pages" with table layout to the trash view, the table layout was maintained. However, when switching back to "All pages," the layout switched to list view instead of maintaining the table view.

This PR resolves that issue. Now, we have logic in place to ensure that when an automatic switch to table layout occurs because the draft view becomes active, the system will switch back to the previously active view instead of defaulting to the list view.

cc: @WordPress/gutenberg-design, I would appreciate, if someone could retest and ensure everything is working as expected. Thank you in advance 😊




## Testing Instructions
Open `/wp-admin/site-editor.php?postType=page`.
Switch to the trash view, and confirm that the table layout becomes active.
Change to the all pages view and ensure that the list layout becomes active again.
Next, open `wp-admin/site-editor.php?postType=page&layout=table`.
Switch to the trash view and verify that the table layout remains active.
Switch to the all pages view and confirm that the table layout continues to remain active.