### PR TITLE
Separator, Code: don't require Enter for shortcut

### DIFF
--- a/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
@@ -99,6 +99,7 @@ export default ( props ) => ( element ) => {
 			__unstableAllowPrefixTransformations,
 			formatTypes,
 			registry,
+			onReplace,
 		} = props.current;
 
 		// Only run input rules when inserting text.
@@ -111,6 +112,22 @@ export default ( props ) => ( element ) => {
 		}
 
 		const value = getValue();
+
+		const transforms = getBlockTransforms( 'from' ).filter(
+			( transform ) => transform.type === 'input'
+		);
+		const transformation = findTransform( transforms, ( item ) => {
+			return item.regExp.test( value.text );
+		} );
+
+		if ( transformation ) {
+			onReplace( transformation.transform() );
+			registry
+				.dispatch( blockEditorStore )
+				.__unstableMarkAutomaticChange();
+			return;
+		}
+
 		const transformed = formatTypes.reduce(
 			( accumulator, { __unstableInputRule } ) => {
 				if ( __unstableInputRule ) {

--- a/packages/block-library/src/code/transforms.js
+++ b/packages/block-library/src/code/transforms.js
@@ -12,7 +12,7 @@ import { getTransformedAttributes } from '../utils/get-transformed-attributes';
 const transforms = {
 	from: [
 		{
-			type: 'enter',
+			type: 'input',
 			regExp: /^```$/,
 			transform: () => createBlock( 'core/code' ),
 		},

--- a/packages/block-library/src/separator/transforms.js
+++ b/packages/block-library/src/separator/transforms.js
@@ -1,14 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
 const transforms = {
 	from: [
 		{
 			type: 'input',
 			regExp: /^-{3,}$/,
-			transform: () => createBlock( 'core/separator' ),
+			transform: () => [
+				createBlock( 'core/separator' ),
+				createBlock( getDefaultBlockName() ),
+			],
 		},
 		{
 			type: 'raw',

--- a/packages/block-library/src/separator/transforms.js
+++ b/packages/block-library/src/separator/transforms.js
@@ -6,7 +6,7 @@ import { createBlock } from '@wordpress/blocks';
 const transforms = {
 	from: [
 		{
-			type: 'enter',
+			type: 'input',
 			regExp: /^-{3,}$/,
 			transform: () => createBlock( 'core/separator' ),
 		},

--- a/test/e2e/specs/editor/blocks/__snapshots__/Code-can-be-created-by-three-backticks-and-enter-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Code-can-be-created-by-three-backticks-and-enter-1-chromium.txt
@@ -1,3 +1,0 @@
-<!-- wp:code -->
-<pre class="wp-block-code"><code>&lt;?php</code></pre>
-<!-- /wp:code -->

--- a/test/e2e/specs/editor/blocks/code.spec.js
+++ b/test/e2e/specs/editor/blocks/code.spec.js
@@ -8,18 +8,20 @@ test.describe( 'Code', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'can be created by three backticks and enter', async ( {
-		editor,
-		page,
-	} ) => {
+	test( 'can be created by three backticks', async ( { editor, page } ) => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
-		await page.keyboard.type( '```' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '<?php' );
+		await page.keyboard.type( '```<?php' );
 
-		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/code',
+				attributes: {
+					content: '&lt;?php',
+				},
+			},
+		] );
 	} );
 
 	test( 'should delete block when backspace in an empty code', async ( {

--- a/test/e2e/specs/editor/blocks/separator.spec.js
+++ b/test/e2e/specs/editor/blocks/separator.spec.js
@@ -12,11 +12,18 @@ test.describe( 'Separator', () => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
-		await page.keyboard.type( '---' );
+		// Should be able to keep typing after the separator transform.
+		await page.keyboard.type( '---a' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/separator',
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'a',
+				},
 			},
 		] );
 	} );

--- a/test/e2e/specs/editor/blocks/separator.spec.js
+++ b/test/e2e/specs/editor/blocks/separator.spec.js
@@ -8,16 +8,16 @@ test.describe( 'Separator', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'can be created by three dashes and enter', async ( {
-		editor,
-		page,
-	} ) => {
+	test( 'can be created by three dashes', async ( { editor, page } ) => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '---' );
-		await page.keyboard.press( 'Enter' );
 
-		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/separator',
+			},
+		] );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Introduces a new transform/shortcut type `input`, which transform text into a block as soon as the sequence is complete (instead of waiting for `Enter`).

Question: in case of the separator, would it make more sense to also add an empty paragraph after it?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because currently the `enter` shortcut is not discoverable enough, and there's not really any harm in transforming sooner. It's still possible to undo the transform.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Type `---` or ` ``` ` in a paragraph block, which should transform it to a Separator or Code block respectively.

## Screenshots or screencast <!-- if applicable -->
