### PR TITLE
Site Editor: Fix error when duplicating a template part

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -934,11 +934,16 @@ export const duplicateTemplatePartAction = {
 		const blocks = useMemo( () => {
 			return (
 				item.blocks ??
-				parse( item.content.raw, {
-					__unstableSkipMigrationLogs: true,
-				} )
+				parse(
+					typeof item.content === 'string'
+						? item.content
+						: item.content.raw,
+					{
+						__unstableSkipMigrationLogs: true,
+					}
+				)
 			);
-		}, [ item?.content?.raw, item.blocks ] );
+		}, [ item.content, item.blocks ] );
 		const { createSuccessNotice } = useDispatch( noticesStore );
 		function onTemplatePartSuccess() {
 			createSuccessNotice(


### PR DESCRIPTION
## What?
Fixes #63655.

PR prevents Site Editor from crashing when trying to duplicate a template part.

## Why?
The `item.content` is a string when editing a template, and it's an object with the `raw` property when viewing a list of template part items. The code should account for both

## Testing Instructions

1. Open the Site Editor.
2. Open any template part.
3. Try duplicating it from Document Settings actions.
4. The duplication modal should be displayed correctly without crashing the editor.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-17 at 17 21 25](https://github.com/user-attachments/assets/1fefb523-97ff-4ac3-9df4-a01c18b543f0)
