### PR TITLE
Allow editing of description only for custom templates

### DIFF
--- a/packages/editor/src/components/post-excerpt/panel.js
+++ b/packages/editor/src/components/post-excerpt/panel.js
@@ -148,7 +148,8 @@ function PrivateExcerpt() {
 						isPattern ||
 						( template &&
 							template.source === TEMPLATE_ORIGINS.custom &&
-							! template.has_theme_file ) ),
+							! template.has_theme_file &&
+							template.is_custom ) ),
 			};
 		}, [] );
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/63659

>Currently it's possible to edit descriptions for non-$custom templates when created by users. For instance see the Blog Home template here:

> <img width="280" alt="Screenshot 2024-07-17 at 13 30 56" src="https://github.com/user-attachments/assets/7be18501-6fd0-48a7-bad3-12945650b710">

### Testing Instructions 
1. Template description  is only editable for custom templates.
2. Everything else should work as before.
