### PR TITLE
Zoom Out: Only show the inserters when a block is selected or hovered

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -562,6 +562,18 @@ _Returns_
 
 -   `number`: Number of blocks in the post, or number of blocks with name equal to blockName.
 
+### getHoveredBlock
+
+Returns the currently hovered block.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `Object`: Client Id of the hovered block.
+
 ### getInserterItems
 
 Determines the items that appear in the inserter. Includes both static items (e.g. a regular block type) and dynamic items (e.g. a reusable block).
@@ -1256,6 +1268,18 @@ _Parameters_
 ### hideInsertionPoint
 
 Action that hides the insertion point.
+
+### hoverBlock
+
+Returns an action object used in signalling that the block with the specified client ID has been hovered.
+
+_Parameters_
+
+-   _clientId_ `string`: Block client ID.
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### insertAfterBlock
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -562,7 +562,7 @@ _Returns_
 
 -   `number`: Number of blocks in the post, or number of blocks with name equal to blockName.
 
-### getHoveredBlock
+### getHoveredBlockClientId
 
 Returns the currently hovered block.
 

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -115,7 +115,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		useFocusHandler( clientId ),
 		useEventHandlers( { clientId, isSelected } ),
 		useNavModeExit( clientId ),
-		useIsHovered(),
+		useIsHovered( { clientId } ),
 		useIntersectionObserver(),
 		useMovingAnimation( { triggerAnimationOnChange: index, clientId } ),
 		useDisabled( { isDisabled: ! hasOverlay } ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -2,23 +2,35 @@
  * WordPress dependencies
  */
 import { useRefEffect } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
 
-function listener( event ) {
-	if ( event.defaultPrevented ) {
-		return;
-	}
-
-	const action = event.type === 'mouseover' ? 'add' : 'remove';
-
-	event.preventDefault();
-	event.currentTarget.classList[ action ]( 'is-hovered' );
-}
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
 
 /*
  * Adds `is-hovered` class when the block is hovered and in navigation or
  * outline mode.
  */
-export function useIsHovered() {
+export function useIsHovered( { clientId } ) {
+	const { hoverBlock } = useDispatch( blockEditorStore );
+
+	function listener( event ) {
+		if ( event.defaultPrevented ) {
+			return;
+		}
+
+		const action = event.type === 'mouseover' ? 'add' : 'remove';
+
+		event.preventDefault();
+		event.currentTarget.classList[ action ]( 'is-hovered' );
+
+		if ( action === 'add' ) {
+			hoverBlock( clientId );
+		}
+	}
+
 	return useRefEffect( ( node ) => {
 		node.addEventListener( 'mouseout', listener );
 		node.addEventListener( 'mouseover', listener );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -28,6 +28,8 @@ export function useIsHovered( { clientId } ) {
 
 		if ( action === 'add' ) {
 			hoverBlock( clientId );
+		} else {
+			hoverBlock( null );
 		}
 	}
 
@@ -41,6 +43,7 @@ export function useIsHovered( { clientId } ) {
 
 			// Remove class in case it lingers.
 			node.classList.remove( 'is-hovered' );
+			hoverBlock( null );
 		};
 	}, [] );
 }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -285,3 +285,11 @@
 		border: none;
 	}
 }
+
+.block-editor-block-tools__zoom-out-mode-inserter-button {
+	visibility: hidden;
+
+	&.is-visible {
+		visibility: visible;
+	}
+}

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
@@ -54,7 +54,8 @@ function ZoomOutModeInserterButton( {
 			selectedBlockClientId === nextClientId );
 
 	const isHovered =
-		hoveredBlockClientId === previousClientId || hoveredBlockClientId === nextClientId;
+		hoveredBlockClientId === previousClientId ||
+		hoveredBlockClientId === nextClientId;
 
 	const [
 		zoomOutModeInserterButtonHovered,

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
@@ -44,7 +44,7 @@ function ZoomOutModeInserterButton( {
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
 			selectedBlockClientId: getSelectedBlockClientId(),
-			hoveredBlock: getHoveredBlock(),
+			hoveredBlockClientId: getHoveredBlockClientId(),
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { plus } from '@wordpress/icons';
+import { _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+function ZoomOutModeInserterButton( {
+	previousClientId,
+	nextClientId,
+	index,
+} ) {
+	const {
+		sectionRootClientId,
+		setInserterIsOpened,
+		hasSelection,
+		selectedBlockClientId,
+		hoveredBlock,
+	} = useSelect( ( select ) => {
+		const {
+			getSettings,
+			getSelectionStart,
+			getSelectedBlockClientId,
+			getHoveredBlock,
+		} = select( blockEditorStore );
+		const { sectionRootClientId: root } = unlock( getSettings() );
+
+		return {
+			hasSelection: !! getSelectionStart().clientId,
+			sectionRootClientId: root,
+			setInserterIsOpened:
+				getSettings().__experimentalSetIsInserterOpened,
+			selectedBlockClientId: getSelectedBlockClientId(),
+			hoveredBlock: getHoveredBlock(),
+		};
+	}, [] );
+
+	const isSelected =
+		hasSelection &&
+		( selectedBlockClientId === previousClientId ||
+			selectedBlockClientId === nextClientId );
+
+	const isHovered =
+		hoveredBlock === previousClientId || hoveredBlock === nextClientId;
+
+	const [
+		zoomOutModeInserterButtonHovered,
+		setZoomOutModeInserterButtonHovered,
+	] = useState( false );
+
+	return (
+		<Button
+			variant="primary"
+			icon={ plus }
+			size="compact"
+			className={ clsx(
+				'block-editor-button-pattern-inserter__button',
+				'block-editor-block-tools__zoom-out-mode-inserter-button',
+				{
+					'is-visible':
+						isHovered ||
+						isSelected ||
+						zoomOutModeInserterButtonHovered,
+				}
+			) }
+			onClick={ () => {
+				setInserterIsOpened( {
+					rootClientId: sectionRootClientId,
+					insertionIndex: index,
+					tab: 'patterns',
+					category: 'all',
+				} );
+			} }
+			onMouseOver={ () => {
+				setZoomOutModeInserterButtonHovered( true );
+			} }
+			onMouseOut={ () => {
+				setZoomOutModeInserterButtonHovered( false );
+			} }
+			label={ _x(
+				'Add pattern',
+				'Generic label for pattern inserter button'
+			) }
+		/>
+	);
+}
+
+export default ZoomOutModeInserterButton;

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
@@ -6,57 +6,12 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
-
-function ZoomOutModeInserterButton( {
-	previousClientId,
-	nextClientId,
-	index,
-} ) {
-	const {
-		sectionRootClientId,
-		setInserterIsOpened,
-		hasSelection,
-		selectedBlockClientId,
-		hoveredBlockClientId,
-	} = useSelect( ( select ) => {
-		const {
-			getSettings,
-			getSelectionStart,
-			getSelectedBlockClientId,
-			getHoveredBlockClientId,
-		} = select( blockEditorStore );
-		const { sectionRootClientId: root } = unlock( getSettings() );
-
-		return {
-			hasSelection: !! getSelectionStart().clientId,
-			sectionRootClientId: root,
-			setInserterIsOpened:
-				getSettings().__experimentalSetIsInserterOpened,
-			selectedBlockClientId: getSelectedBlockClientId(),
-			hoveredBlockClientId: getHoveredBlockClientId(),
-		};
-	}, [] );
-
-	const isSelected =
-		hasSelection &&
-		( selectedBlockClientId === previousClientId ||
-			selectedBlockClientId === nextClientId );
-
-	const isHovered =
-		hoveredBlockClientId === previousClientId ||
-		hoveredBlockClientId === nextClientId;
-
+function ZoomOutModeInserterButton( { isVisible, onClick } ) {
 	const [
 		zoomOutModeInserterButtonHovered,
 		setZoomOutModeInserterButtonHovered,
@@ -71,20 +26,10 @@ function ZoomOutModeInserterButton( {
 				'block-editor-button-pattern-inserter__button',
 				'block-editor-block-tools__zoom-out-mode-inserter-button',
 				{
-					'is-visible':
-						isHovered ||
-						isSelected ||
-						zoomOutModeInserterButtonHovered,
+					'is-visible': isVisible || zoomOutModeInserterButtonHovered,
 				}
 			) }
-			onClick={ () => {
-				setInserterIsOpened( {
-					rootClientId: sectionRootClientId,
-					insertionIndex: index,
-					tab: 'patterns',
-					category: 'all',
-				} );
-			} }
+			onClick={ onClick }
 			onMouseOver={ () => {
 				setZoomOutModeInserterButtonHovered( true );
 			} }

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
@@ -28,7 +28,7 @@ function ZoomOutModeInserterButton( {
 		setInserterIsOpened,
 		hasSelection,
 		selectedBlockClientId,
-		hoveredBlock,
+		hoveredBlockClientId,
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
@@ -34,7 +34,7 @@ function ZoomOutModeInserterButton( {
 			getSettings,
 			getSelectionStart,
 			getSelectedBlockClientId,
-			getHoveredBlock,
+			getHoveredBlockClientId,
 		} = select( blockEditorStore );
 		const { sectionRootClientId: root } = unlock( getSettings() );
 

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserter-button.js
@@ -54,7 +54,7 @@ function ZoomOutModeInserterButton( {
 			selectedBlockClientId === nextClientId );
 
 	const isHovered =
-		hoveredBlock === previousClientId || hoveredBlock === nextClientId;
+		hoveredBlockClientId === previousClientId || hoveredBlockClientId === nextClientId;
 
 	const [
 		zoomOutModeInserterButtonHovered,

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -102,7 +102,7 @@ function ZoomOutModeInserters() {
 				previousClientId={ clientId }
 				nextClientId={ blockOrder[ index ] }
 			>
-				{ insertionPoint.insertionIndex === index && (
+				{ shouldRenderInsertionPoint && (
 					<div
 						style={ {
 							borderRadius: '0',

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -22,9 +22,16 @@ function ZoomOutModeInserters() {
 		insertionPoint,
 		setInserterIsOpened,
 		hasSelection,
+		selectedBlockClientId,
+		hoveredBlock,
 	} = useSelect( ( select ) => {
-		const { getSettings, getBlockOrder, getSelectionStart } =
-			select( blockEditorStore );
+		const {
+			getSettings,
+			getBlockOrder,
+			getSelectionStart,
+			getSelectedBlockClientId,
+			getHoveredBlock,
+		} = select( blockEditorStore );
 		const { sectionRootClientId: root } = unlock( getSettings() );
 		// To do: move ZoomOutModeInserters to core/editor.
 		// Or we perhaps we should move the insertion point state to the
@@ -40,6 +47,8 @@ function ZoomOutModeInserters() {
 			sectionRootClientId: root,
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
+			selectedBlockClientId: getSelectedBlockClientId(),
+			hoveredBlock: getHoveredBlock(),
 		};
 	}, [] );
 
@@ -69,6 +78,16 @@ function ZoomOutModeInserters() {
 	}
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
+		const isSelected =
+			selectedBlockClientId === clientId ||
+			selectedBlockClientId === blockOrder[ index ];
+		const isHovered =
+			hoveredBlock === clientId || hoveredBlock === blockOrder[ index ];
+
+		const shouldRenderInserter =
+			( isHovered || isSelected ) &&
+			insertionPoint.insertionIndex !== index;
+
 		return (
 			<BlockPopoverInbetween
 				key={ index }
@@ -87,7 +106,7 @@ function ZoomOutModeInserters() {
 						className="block-editor-block-list__insertion-point-indicator"
 					/>
 				) }
-				{ insertionPoint.insertionIndex !== index && (
+				{ shouldRenderInserter && (
 					<Button
 						variant="primary"
 						icon={ plus }

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -73,20 +73,28 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
-	if ( ! isReady || ! hasSelection ) {
+	if ( ! isReady ) {
 		return null;
 	}
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
 		const isSelected =
-			selectedBlockClientId === clientId ||
-			selectedBlockClientId === blockOrder[ index ];
+			hasSelection &&
+			( selectedBlockClientId === clientId ||
+				selectedBlockClientId === blockOrder[ index ] );
 		const isHovered =
 			hoveredBlock === clientId || hoveredBlock === blockOrder[ index ];
 
 		const shouldRenderInserter =
 			( isHovered || isSelected ) &&
 			insertionPoint.insertionIndex !== index;
+
+		const shouldRenderInsertionPoint =
+			insertionPoint.insertionIndex === index;
+
+		if ( ! shouldRenderInserter && ! shouldRenderInsertionPoint ) {
+			return null;
+		}
 
 		return (
 			<BlockPopoverInbetween

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -3,54 +3,45 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
-import { plus } from '@wordpress/icons';
-import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import BlockPopoverInbetween from '../block-popover/inbetween';
+import ZoomOutModeInserterButton from './zoom-out-mode-inserter-button';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
-	const {
-		blockOrder,
-		sectionRootClientId,
-		insertionPoint,
-		setInserterIsOpened,
-		hasSelection,
-		selectedBlockClientId,
-		hoveredBlock,
-	} = useSelect( ( select ) => {
-		const {
-			getSettings,
-			getBlockOrder,
-			getSelectionStart,
-			getSelectedBlockClientId,
-			getHoveredBlock,
-		} = select( blockEditorStore );
-		const { sectionRootClientId: root } = unlock( getSettings() );
-		// To do: move ZoomOutModeInserters to core/editor.
-		// Or we perhaps we should move the insertion point state to the
-		// block-editor store. I'm not sure what it was ever moved to the editor
-		// store, because all the inserter components all live in the
-		// block-editor package.
-		// eslint-disable-next-line @wordpress/data-no-store-string-literals
-		const editor = select( 'core/editor' );
-		return {
-			hasSelection: !! getSelectionStart().clientId,
-			blockOrder: getBlockOrder( root ),
-			insertionPoint: unlock( editor ).getInsertionPoint(),
-			sectionRootClientId: root,
-			setInserterIsOpened:
-				getSettings().__experimentalSetIsInserterOpened,
-			selectedBlockClientId: getSelectedBlockClientId(),
-			hoveredBlock: getHoveredBlock(),
-		};
-	}, [] );
+	const { blockOrder, insertionPoint, setInserterIsOpened } = useSelect(
+		( select ) => {
+			const {
+				getSettings,
+				getBlockOrder,
+				getSelectionStart,
+				getSelectedBlockClientId,
+			} = select( blockEditorStore );
+			const { sectionRootClientId: root } = unlock( getSettings() );
+			// To do: move ZoomOutModeInserters to core/editor.
+			// Or we perhaps we should move the insertion point state to the
+			// block-editor store. I'm not sure what it was ever moved to the editor
+			// store, because all the inserter components all live in the
+			// block-editor package.
+			// eslint-disable-next-line @wordpress/data-no-store-string-literals
+			const editor = select( 'core/editor' );
+			return {
+				hasSelection: !! getSelectionStart().clientId,
+				blockOrder: getBlockOrder( root ),
+				insertionPoint: unlock( editor ).getInsertionPoint(),
+				sectionRootClientId: root,
+				setInserterIsOpened:
+					getSettings().__experimentalSetIsInserterOpened,
+				selectedBlockClientId: getSelectedBlockClientId(),
+			};
+		},
+		[]
+	);
 
 	const isMounted = useRef( false );
 
@@ -78,16 +69,7 @@ function ZoomOutModeInserters() {
 	}
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
-		const isSelected =
-			hasSelection &&
-			( selectedBlockClientId === clientId ||
-				selectedBlockClientId === blockOrder[ index ] );
-		const isHovered =
-			hoveredBlock === clientId || hoveredBlock === blockOrder[ index ];
-
-		const shouldRenderInserter =
-			( isHovered || isSelected ) &&
-			insertionPoint.insertionIndex !== index;
+		const shouldRenderInserter = insertionPoint.insertionIndex !== index;
 
 		const shouldRenderInsertionPoint =
 			insertionPoint.insertionIndex === index;
@@ -115,23 +97,10 @@ function ZoomOutModeInserters() {
 					/>
 				) }
 				{ shouldRenderInserter && (
-					<Button
-						variant="primary"
-						icon={ plus }
-						size="compact"
-						className="block-editor-button-pattern-inserter__button"
-						onClick={ () => {
-							setInserterIsOpened( {
-								rootClientId: sectionRootClientId,
-								insertionIndex: index,
-								tab: 'patterns',
-								category: 'all',
-							} );
-						} }
-						label={ _x(
-							'Add pattern',
-							'Generic label for pattern inserter button'
-						) }
+					<ZoomOutModeInserterButton
+						previousClientId={ clientId }
+						nextClientId={ blockOrder[ index ] }
+						index={ index }
 					/>
 				) }
 			</BlockPopoverInbetween>

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -214,6 +214,21 @@ export function selectBlock( clientId, initialPosition = 0 ) {
 }
 
 /**
+ * Returns an action object used in signalling that the block with the
+ * specified client ID has been hovered.
+ *
+ * @param {string} clientId Block client ID.
+ *
+ * @return {Object} Action object.
+ */
+export function hoverBlock( clientId ) {
+	return {
+		type: 'HOVER_BLOCK',
+		clientId,
+	};
+}
+
+/**
  * Yields action objects used in signalling that the block preceding the given
  * clientId (or optionally, its first parent from bottom to top)
  * should be selected.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2117,7 +2117,7 @@ const combinedReducers = combineReducers( {
 	blockRemovalRules,
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
-	hoveredBlock,
+	hoveredBlockClientId,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2068,6 +2068,23 @@ export function lastFocus( state = false, action ) {
 	return state;
 }
 
+/**
+ * Reducer setting currently hovered block.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function hoveredBlock( state = false, action ) {
+	switch ( action.type ) {
+		case 'HOVER_BLOCK':
+			return action.clientId;
+	}
+
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2100,6 +2117,7 @@ const combinedReducers = combineReducers( {
 	blockRemovalRules,
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
+	hoveredBlock,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2076,7 +2076,7 @@ export function lastFocus( state = false, action ) {
  *
  * @return {boolean} Updated state.
  */
-export function hoveredBlock( state = false, action ) {
+export function hoveredBlockClientId( state = false, action ) {
 	switch ( action.type ) {
 		case 'HOVER_BLOCK':
 			return action.clientId;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2816,7 +2816,7 @@ export function isBlockVisible( state, clientId ) {
  * @return {Object} Client Id of the hovered block.
  */
 export function getHoveredBlockClientId( state ) {
-	return state.hoveredBlock;
+	return state.hoveredBlockClientId;
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2815,7 +2815,7 @@ export function isBlockVisible( state, clientId ) {
  * @param {Object} state Global application state.
  * @return {Object} Client Id of the hovered block.
  */
-export function getHoveredBlock( state ) {
+export function getHoveredBlockClientId( state ) {
 	return state.hoveredBlock;
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2810,6 +2810,16 @@ export function isBlockVisible( state, clientId ) {
 }
 
 /**
+ * Returns the currently hovered block.
+ *
+ * @param {Object} state Global application state.
+ * @return {Object} Client Id of the hovered block.
+ */
+export function getHoveredBlock( state ) {
+	return state.hoveredBlock;
+}
+
+/**
  * Returns the list of all hidden blocks.
  *
  * @param {Object} state Global application state.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
At the moment in Zoom Out mode the inserters always show. This updates the zoom out inserters so that they only show if either, the block is selected, or the block is hovered.

## Why?
It's not helpful to show too many inserters, its better to only show the ones we need.

## How?
1. Add a new action that tracks the client Id of the last hovered block
2. Call the action when hovering blocks
3. Update the logic that displays the zoom out inserters to only show them when a block is selected or hovered.

## Testing Instructions
1. Open the Site Editor
2. Open the inserter
3. Open the patterns tab, to trigger zoom out
4. Check that inserters only appear either side of blocks that are selected or hovered.

## Screenshots or screencast <!-- if applicable -->
<img width="969" alt="Screenshot 2024-07-17 at 15 21 26" src="https://github.com/user-attachments/assets/d6705554-42e4-4dbb-9a34-7ba86ea0c495">

