### PR TITLE
Improve PostURL terminology and accessibility

### DIFF
--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -17,7 +17,7 @@ import {
 import { store as noticesStore } from '@wordpress/notices';
 import { copySmall } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
-import { useCopyToClipboard } from '@wordpress/compose';
+import { useCopyToClipboard, useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -70,87 +70,96 @@ export default function PostURL( { onClose } ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const [ forceEmptyField, setForceEmptyField ] = useState( false );
 	const copyButtonRef = useCopyToClipboard( permalink, () => {
-		createNotice( 'info', __( 'Copied URL to clipboard.' ), {
+		createNotice( 'info', __( 'Copied Permalink to clipboard.' ), {
 			isDismissible: true,
 			type: 'snackbar',
 		} );
 	} );
+	const postUrlSlugDescriptionId =
+		'editor-post-url__slug-descriotion-' + useInstanceId( PostURL );
+
 	return (
 		<div className="editor-post-url">
 			<InspectorPopoverHeader
-				title={ __( 'Link' ) }
+				title={ __( 'Slug' ) }
 				onClose={ onClose }
 			/>
 			<VStack spacing={ 3 }>
 				{ isEditable && (
-					<div>
-						{ createInterpolateElement(
-							__(
-								'Customize the last part of the URL. <a>Learn more.</a>'
-							),
-							{
-								a: (
-									<ExternalLink
-										href={ __(
-											'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
-										) }
-									/>
-								),
-							}
-						) }
-					</div>
+					<p className="editor-post-url__intro">
+						<span id={ postUrlSlugDescriptionId }>
+							{ __(
+								'Customize the last part of the Permalink.'
+							) }
+						</span>
+						<ExternalLink
+							href={ __(
+								'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
+							) }
+						>
+							{ __( 'Learn more.' ) }
+						</ExternalLink>
+					</p>
 				) }
 				<div>
 					{ isEditable && (
-						<InputControl
-							__next40pxDefaultSize
-							prefix={
-								<InputControlPrefixWrapper>
-									/
-								</InputControlPrefixWrapper>
-							}
-							suffix={
-								<InputControlSuffixWrapper variant="control">
-									<Button
-										icon={ copySmall }
-										ref={ copyButtonRef }
-										size="small"
-										label="Copy"
-									/>
-								</InputControlSuffixWrapper>
-							}
-							label={ __( 'Link' ) }
-							hideLabelFromVision
-							value={ forceEmptyField ? '' : postSlug }
-							autoComplete="off"
-							spellCheck="false"
-							type="text"
-							className="editor-post-url__input"
-							onChange={ ( newValue ) => {
-								editPost( { slug: newValue } );
-								// When we delete the field the permalink gets
-								// reverted to the original value.
-								// The forceEmptyField logic allows the user to have
-								// the field temporarily empty while typing.
-								if ( ! newValue ) {
-									if ( ! forceEmptyField ) {
-										setForceEmptyField( true );
+						<>
+							<InputControl
+								__next40pxDefaultSize
+								prefix={
+									<InputControlPrefixWrapper>
+										/
+									</InputControlPrefixWrapper>
+								}
+								suffix={
+									<InputControlSuffixWrapper variant="control">
+										<Button
+											icon={ copySmall }
+											ref={ copyButtonRef }
+											size="small"
+											label="Copy"
+										/>
+									</InputControlSuffixWrapper>
+								}
+								label={ __( 'Slug' ) }
+								hideLabelFromVision
+								value={ forceEmptyField ? '' : postSlug }
+								autoComplete="off"
+								spellCheck="false"
+								type="text"
+								className="editor-post-url__input"
+								onChange={ ( newValue ) => {
+									editPost( { slug: newValue } );
+									// When we delete the field the permalink gets
+									// reverted to the original value.
+									// The forceEmptyField logic allows the user to have
+									// the field temporarily empty while typing.
+									if ( ! newValue ) {
+										if ( ! forceEmptyField ) {
+											setForceEmptyField( true );
+										}
+										return;
 									}
-									return;
-								}
-								if ( forceEmptyField ) {
-									setForceEmptyField( false );
-								}
-							} }
-							onBlur={ ( event ) => {
-								editPost( {
-									slug: cleanForSlug( event.target.value ),
-								} );
-								if ( forceEmptyField ) {
-									setForceEmptyField( false );
-								}
-							} }
-							help={
+									if ( forceEmptyField ) {
+										setForceEmptyField( false );
+									}
+								} }
+								onBlur={ ( event ) => {
+									editPost( {
+										slug: cleanForSlug(
+											event.target.value
+										),
+									} );
+									if ( forceEmptyField ) {
+										setForceEmptyField( false );
+									}
+								} }
+								aria-describedby={ postUrlSlugDescriptionId }
+							/>
+							<p className="editor-post-url__permalink">
+								<span className="editor-post-url__permalink-visual-label">
+									{ __( 'Permalink:' ) }
+								</span>
 								<ExternalLink
 									className="editor-post-url__link"
 									href={ postLink }
@@ -166,8 +175,8 @@ export default function PostURL( { onClose } ) {
 										{ permalinkSuffix }
 									</span>
 								</ExternalLink>
-							}
-						/>
+							</p>
+						</>
 					) }
 					{ ! isEditable && (
 						<ExternalLink

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -89,7 +89,7 @@ export default function PostURL( { onClose } ) {
 					<p className="editor-post-url__intro">
 						{ createInterpolateElement(
 							__(
-								'<span>Customize the last part of the URL.</span> <a>Learn more.</a>'
+								'<span>Customize the last part of the Permalink.</span> <a>Learn more.</a>'
 							),
 							{
 								span: <span id={ postUrlSlugDescriptionId } />,

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -87,18 +87,21 @@ export default function PostURL( { onClose } ) {
 			<VStack spacing={ 3 }>
 				{ isEditable && (
 					<p className="editor-post-url__intro">
-						<span id={ postUrlSlugDescriptionId }>
-							{ __(
-								'Customize the last part of the Permalink.'
-							) }
-						</span>
-						<ExternalLink
-							href={ __(
-								'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
-							) }
-						>
-							{ __( 'Learn more.' ) }
-						</ExternalLink>
+						{ createInterpolateElement(
+							__(
+								'<span>Customize the last part of the URL.</span> <a>Learn more.</a>'
+							),
+							{
+								span: <span id={ postUrlSlugDescriptionId } />,
+								a: (
+									<ExternalLink
+										href={ __(
+											'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
+										) }
+									/>
+								),
+							}
+						) }
 					</p>
 				) }
 				<div>

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -3,12 +3,7 @@
  */
 import { useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import {
-	Dropdown,
-	Button,
-	ExternalLink,
-	__experimentalTruncate as Truncate,
-} from '@wordpress/components';
+import { Dropdown, Button, ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { safeDecodeURIComponent } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
@@ -102,7 +97,7 @@ function PostURLToggle( { isOpen, onClick } ) {
 			aria-label={ sprintf( __( 'Change link: %s' ), decodedSlug ) }
 			onClick={ onClick }
 		>
-			<Truncate numberOfLines={ 1 }>{ decodedSlug }</Truncate>
+			<>{ decodedSlug }</>
 		</Button>
 	);
 }

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -9,13 +9,18 @@
 }
 
 /* rtl:begin:ignore */
-.editor-post-url__link {
+.editor-post-url__link,
+.editor-post-url__front-page-link {
 	direction: ltr;
 	word-break: break-word;
-	margin-top: $grid-unit-05;
-	color: $gray-700;
 }
 /* rtl:end:ignore */
+
+.editor-post-url__front-page-link {
+	// Match padding on tertiary buttons for alignment.
+	padding: $grid-unit-15 * 0.5 0 $grid-unit-15 * 0.5 $grid-unit-15;
+}
+
 
 .editor-post-url__link-slug {
 	font-weight: 600;
@@ -29,4 +34,17 @@
 
 .editor-post-url__panel-toggle {
 	word-break: break-word;
+}
+
+.editor-post-url__intro {
+	margin-bottom: 0;
+}
+
+.editor-post-url__permalink {
+	margin-top: $grid-unit-10;
+	margin-bottom: 0;
+
+	&-visual-label {
+		display: block;
+	}
 }

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -37,7 +37,7 @@
 }
 
 .editor-post-url__intro {
-	margin-bottom: 0;
+	margin: 0;
 }
 
 .editor-post-url__permalink {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/61196

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR proposes to restore the terminology WordPress always used when editing a post 'link':
- Slug: the last part of the URL
- Permalink: the permanent link to the post

The current UI allows users to edit _the last part of the link_ and calls it 'link'. That's not what usees are editing. Actually, they are editing the _slug_.

On top of that, fixes some accessibility and usability issues:
- An URL isn't a meaningful description to be associated to the input field with aria-describedby. The explanatory text before the input should be used as a description instead,
- When the UI shows the link of the Front Page, there is no need to have a toggle button that opens a popover only to show again the non-editable link that is already shown in the Inspector panel. See the 'before' screenshot. In this case, the popover should not be used in the first place. The panel already shows the link.
- Sometimes, when possible, please let's use paragraph elements to wrap text. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For better usability and accessibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Changes the term 'Link' back to 'Slug' to indicate the last part of a post URL.
- Adds back the terme 'Permalink' to indicate the full permanent link of a post.
- Keeps the term 'Link' only when the UI shows the Front Page full link.
- Associates the explaantory text as the accessible description of the input field.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post.
- Observe in the Inspector post panel the row to edit the slug is now called 'Slug;.
- Click the toggle button to edit the Slug.
- Observe the popover title is now 'Slug'.
- Observe the text 'Customize the last part of the URL.' is now 'Customize the last part of the Permalink.'
- Inspect the source and observe this text is associated as a description of the input field via an `aria-describedby` attribute.
- Observe the permalink preview after the input field is now prepended with text to commnicate what it is: 'ermalink:' and it is styled like a link (blue instead of grey).
- Go to the admin Settings > Reading settings, and set WordPress to use a static page for the home page.
- Edit that page.
- Observe in the Inspector post panel the row that shows the Front page link is called 'Link'.
- Observe the UI shows the clickable link instead of a button that opens a popover.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/user-attachments/assets/1b16aa9f-7a80-48da-9c5b-3976f2ca33a4)


After:

![after](https://github.com/user-attachments/assets/c8588b45-90b2-4264-b37d-fa7c8486a0cc)


