### PR TITLE
ColorPicker: Use `minimal` variant for SelectControl

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   `CustomSelectControlV2`: do not flip popover if legacy adapter. ([#63357](https://github.com/WordPress/gutenberg/pull/63357)).
 -   `DropdownMenuV2`: invert animation direction. ([#63443](https://github.com/WordPress/gutenberg/pull/63443)).
 -   `Tabs`: Vertical Tabs should be 40px min height. ([#63446](https://github.com/WordPress/gutenberg/pull/63446)).
+-   `ColorPicker`: Use `minimal` variant for `SelectControl` ([#63676](https://github.com/WordPress/gutenberg/pull/63676)).
 
 ## 28.3.0 (2024-07-10)
 

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -16,11 +16,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	useContextSystem,
-	contextConnect,
-	ContextSystemProvider,
-} from '../context';
+import { useContextSystem, contextConnect } from '../context';
 import {
 	ColorfulWrapper,
 	SelectControl,
@@ -42,9 +38,6 @@ const options = [
 	{ label: 'HSL', value: 'hsl' as const },
 	{ label: 'Hex', value: 'hex' as const },
 ];
-
-// `isBorderless` is still experimental and not a public prop for InputControl yet.
-const BORDERLESS_SELECT_CONTROL_CONTEXT = { InputBase: { isBorderless: true } };
 
 const UnconnectedColorPicker = (
 	props: ColorPickerProps,
@@ -92,20 +85,17 @@ const UnconnectedColorPicker = (
 			/>
 			<AuxiliaryColorArtefactWrapper>
 				<AuxiliaryColorArtefactHStackHeader justify="space-between">
-					<ContextSystemProvider
-						value={ BORDERLESS_SELECT_CONTROL_CONTEXT }
-					>
-						<SelectControl
-							__nextHasNoMarginBottom
-							options={ options }
-							value={ colorType }
-							onChange={ ( nextColorType ) =>
-								setColorType( nextColorType as ColorType )
-							}
-							label={ __( 'Color format' ) }
-							hideLabelFromVision
-						/>
-					</ContextSystemProvider>
+					<SelectControl
+						__nextHasNoMarginBottom
+						options={ options }
+						value={ colorType }
+						onChange={ ( nextColorType ) =>
+							setColorType( nextColorType as ColorType )
+						}
+						label={ __( 'Color format' ) }
+						hideLabelFromVision
+						variant="minimal"
+					/>
 					<ColorCopyButton
 						color={ safeColordColor }
 						colorType={ copyFormat || colorType }


### PR DESCRIPTION
Follow-up to #63265

## What?

Replace the "unofficial" borderless `SelectControl` in `ColorPicker` with the official `minimal` variant.

## Why?

We used to achieve this by passing a context value under the table, but now we have an official variant to achieve the same thing.

Also, I accidentally introduced a regression to this implementation in `ColorPicker` (the `isBorderless` context property needed to be moved under a [`__overrides` property](https://github.com/WordPress/gutenberg/blob/88dffa048232c538ffdcaff6cd6a5ece2454706f/packages/components/src/context/use-context-system.js#L45) so it takes precedence), so this also fixes that.

## Testing Instructions

See Storybook story for ColorPicker.

## Screenshots or screencast <!-- if applicable -->

| Before (regressed) | After (correct) |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/96bb06a7-67c7-4a17-bcef-26b5300064df" alt="Select has border" width="250">|<img src="https://github.com/user-attachments/assets/210d0f40-3180-428b-a096-37d59a6ba7a9" alt="Select is borderless" width="250">|
