### PR TITLE
Fix: Distraction free breaks the Document Tools ARIA toolbar keyboard interaction

### DIFF
--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/block-editor';
 import { Button, ToolbarItem } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as preferencesStore } from '@wordpress/preferences';
 
@@ -103,6 +103,14 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		'Generic label for block inserter button'
 	);
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
+
+	useEffect( () => {
+		if ( inserterSidebarToggleRef.current ) {
+			inserterSidebarToggleRef.current.tabIndex = isDistractionFree
+				? -1
+				: 0;
+		}
+	}, [ isDistractionFree ] );
 
 	return (
 		// Some plugins expect and use the `edit-post-header-toolbar` CSS class to


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes issue number: https://github.com/WordPress/gutenberg/issues/63614

## Why?
By default, keyboard interaction works as expected. However, when enabling 'Distraction free' and then disabling, all the buttons within the toolbar get a tabindex="-1" attribute. As such, none of them is focusable and there is no way to tab into the toolbar.

## How?
I resolved the issue by using the `useEffect` hook in React. It triggers only when the `distractionFree` variable changes. When this happens, I use the button's ref to set `tabIndex` to 0.
<img width="599" alt="image" src="https://github.com/user-attachments/assets/4b58a7f9-2a6e-4807-84f0-902c2f9e2639">


## Testing Instructions
Go to the Post editor or Site editor.
Use the Tab key to move focus to the WP logo.
Press Tab to move focus to the Inserter plus icon button.
Press the Left or Right arrow keys or press the Home and End keys and observe navigation through the toolbar buttons works as expected.
Enable Distraction free from the Options menu.
Disable Distraction free.
Move focus to the WP logo.
Press Tab.
Observe that pressing Tab entirely skips the toolbar an focus jumps to the Document bar in the middle of the editor top bar.
Expected: focus to move to the Document tools toolbar.
Inspect the source and observe all the buttons within the Document tools toolbar have a tabindex="-1" attribute.
Expected: one of the buttons (the last that received focus) to not have a tabindex attribute.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/72516257-9e39-4fb7-90a0-7fb0874b4b31

