### PR TITLE
Navigable regions: skip empty regions

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/index.tsx
+++ b/packages/components/src/higher-order/navigate-regions/index.tsx
@@ -49,7 +49,7 @@ export function useNavigateRegions( shortcuts: Shortcuts = defaultShortcuts ) {
 	function focusRegion( offset: number ) {
 		const regions = Array.from(
 			ref.current?.querySelectorAll< HTMLElement >(
-				'[role="region"][tabindex="-1"]'
+				'[role="region"][tabindex="-1"]:not(:empty)'
 			) ?? []
 		);
 		if ( ! regions.length ) {


### PR DESCRIPTION
## What?
A fix to skip empty regions when using the keyboard shortcuts.

## Why?
Empty regions are currently navigated/focused by the shortcuts and yet don’t have any content. It also creates a feeling like the shortcut didn’t work or you failed to press the key because an empty region isn’t visibly focused yet is still a “stop” in the circuit of regions.

## How?
Simply excludes empty regions by only matching `:not(:empty)` regions.

## Testing Instructions
This is applicable in any editor but it’s worth noting that the Post editor has one empty region when the "Editor settings" sidebar is not open. The Site editor has two when in edit mode and the "Editor Settings" sidebar is not open.

1. Open the Post or Site editor
2. Close the "Editor settings" sidebar if open
3. Use the keyboard shortcuts to navigate regions
4. Note the focus cycles through all regions except empty ones

### Testing Instructions for Keyboard
I think the above instructions suffice?

## Screenshots or screencast <!-- if applicable -->

### Before (Site editor)

https://github.com/user-attachments/assets/378a5750-fd9a-4a35-aea3-eb26d3336eca

### After (Site editor)

https://github.com/user-attachments/assets/14b5a6a1-39f3-4243-8fe1-5d17cc213139

