### PR TITLE
Try: Post content: Add clearfix

### DIFF
--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -54,5 +54,6 @@
 			}
 		}
 	},
+	"style": "wp-block-post-content",
 	"editorStyle": "wp-block-post-content-editor"
 }

--- a/packages/block-library/src/post-content/style.scss
+++ b/packages/block-library/src/post-content/style.scss
@@ -1,0 +1,5 @@
+.wp-block-post-content::after {
+	content: "";
+	display: table;
+	clear: both;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -29,6 +29,7 @@
 @import "./paragraph/style.scss";
 @import "./post-author/style.scss";
 @import "./post-comments-form/style.scss";
+@import "./post-content/style.scss";
 @import "./post-date/style.scss";
 @import "./post-excerpt/style.scss";
 @import "./post-featured-image/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds a clearfix to the post content block, so that left and right aligned blocks in the content do not overflow the content area. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If the last item in the post content is left or right aligned, it can be incorrectly positioned left or right of the next element, even if it is outside the designated content area. For example to the left of the site footer instead of above it. You can see examples of this in the issue:
https://github.com/WordPress/gutenberg/issues/63336

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR adds a new CSS file to the post content block and adds a clearfix.

## Testing Instructions
Activate Twenty Twenty-Four or Twenty Twenty-Three.
Create a new **page**. (It has to be the page template, not a post)
Add an image and select the left alignment.
Save and view the front of the page.
Notice that the image remains in the "content area".

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="1508" alt="A left aligned image block before the PR, positioned left of the footer" src="https://github.com/user-attachments/assets/5911bf34-8aa0-458a-a4dc-dce6b243c822">

After:
![66 local_clear-test_](https://github.com/user-attachments/assets/2233fc61-2283-488a-94f3-aaf9c27bcbce)

