### PR TITLE
Pass the comments query `paged` arg to functions  `get_next_comments_link` and `get_previous_comments_link`

### DIFF
--- a/packages/block-library/src/comments-pagination-next/index.php
+++ b/packages/block-library/src/comments-pagination-next/index.php
@@ -37,7 +37,7 @@ function render_block_core_comments_pagination_next( $attributes, $content, $blo
 		$label .= $pagination_arrow;
 	}
 
-	$next_comments_link = get_next_comments_link( $label, $max_page );
+	$next_comments_link = get_next_comments_link( $label, $max_page, $comment_vars['paged'] );
 
 	remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 

--- a/packages/block-library/src/comments-pagination-previous/index.php
+++ b/packages/block-library/src/comments-pagination-previous/index.php
@@ -29,7 +29,8 @@ function render_block_core_comments_pagination_previous( $attributes, $content, 
 	};
 	add_filter( 'previous_comments_link_attributes', $filter_link_attributes );
 
-	$previous_comments_link = get_previous_comments_link( $label );
+	$comment_vars           = build_comment_query_vars_from_block( $block );
+	$previous_comments_link = get_previous_comments_link( $label, $comment_vars['paged'] );
 
 	remove_filter( 'previous_comments_link_attributes', $filter_link_attributes );
 


### PR DESCRIPTION
## What?
According to [this report](https://core.trac.wordpress.org/ticket/60806), the solution introduced in [this pull request](https://github.com/WordPress/gutenberg/pull/39227) to solved the mentioned bug, where `cpage` was updated based on the query, is causing problems with plugins relying on it being `0` or undefined.

This pull request explores another alternative to solve the initial bug without modifying `cpage.`

It needs to be tested with [this other core pull request](https://github.com/WordPress/wordpress-develop/pull/7275), which modifies the relevant functions to accept the new parameter.

## How?
Pass the `paged` argument from the query to [get_next_comments_link](https://github.com/WordPress/wordpress-develop/blob/dea027eac82ca7244eff421642562b2d75918e19/src/wp-includes/link-template.php#L3103C10-L3103C32) and [get_previous_comments_link](https://github.com/WordPress/wordpress-develop/blob/dea027eac82ca7244eff421642562b2d75918e19/src/wp-includes/link-template.php#L3171) so they only read the `cpage` when it is not defined. A check like the following must be added in the core functions:

```php
	if ( empty( $page ) ) {
		$page = get_query_var( 'cpage' );
	}
```

## Testing Instructions
It needs to be tested with [this other core pull request](https://github.com/WordPress/wordpress-develop/pull/7275), which modifies the relevant functions to accept the new parameter.
1. Add comments to a post.
2. Go to Settings -> Discussion and set "Break comments into pages with 2 top-level comments per page and the 
**last** page displayed by default.
3. Go to the post and check that the pagination links are correct.
