### PR TITLE
Zoom Out: Fix error when block is null

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -33,8 +33,8 @@ export default function ZoomOutToolbar( { clientId, rootClientId } ) {
 				canMoveBlock,
 			} = select( blockEditorStore );
 			const { getBlockType } = select( blocksStore );
-			const { name } = getBlock( clientId );
-			const blockType = getBlockType( name );
+			const block = getBlock( clientId );
+			const blockType = getBlockType( block?.name );
 			const isBlockTemplatePart =
 				blockType?.name === 'core/template-part';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? 
Fixes https://github.com/WordPress/gutenberg/issues/63456, an error when deselecting a block in zoom out mode.

## Why?
Stops an error being thrown.

## How?
Don't assume the `getBlock` always returns an object.

## Testing Instructions
0. Turn on the zoom out experiment
1. Open the Site Editor
2. Open the block inserter
3. Switch to the patterns tab so that the canvas zooms out
4. Select a block in the canvas
5. Select the grey area around the canvas so that the blocks are deselected
6. Check that there is no error in the console

## Screenshots or screencast <!-- if applicable -->
The error in trunk:
<img width="719" alt="Screenshot 2024-07-18 at 15 18 26" src="https://github.com/user-attachments/assets/c6c3a6a6-3859-4d02-a15b-3b3da131e097">
