### PR TITLE
Fix: DataViews: Layout resets for patterns each time a new pattern category is selected.

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -351,12 +351,9 @@ export default function DataviewsPatterns() {
 	// Reset the page number when the category changes.
 	useEffect( () => {
 		if ( previousCategoryId !== categoryId ) {
-			setView( {
-				...view,
-				page: 1,
-			} );
+			setView( ( prevView ) => ( { ...prevView, page: 1 } ) );
 		}
-	}, [ categoryId, previousCategoryId, view ] );
+	}, [ categoryId, previousCategoryId ] );
 	const { data, paginationInfo } = useMemo( () => {
 		// Search is managed server-side as well as filters for patterns.
 		// However, the author filter in template parts is done client-side.

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -351,9 +351,12 @@ export default function DataviewsPatterns() {
 	// Reset the page number when the category changes.
 	useEffect( () => {
 		if ( previousCategoryId !== categoryId ) {
-			setView( DEFAULT_VIEW );
+			setView( {
+				...view,
+				page: 1,
+			} );
 		}
-	}, [ categoryId, previousCategoryId ] );
+	}, [ categoryId, previousCategoryId, view ] );
 	const { data, paginationInfo } = useMemo( () => {
 		// Search is managed server-side as well as filters for patterns.
 		// However, the author filter in template parts is done client-side.


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63393

We were forcing the grid layout each time a pattern category was changed, and all the other defaults. This PR fixes the issue by keeping the previous view, and just resetting the page to 1 as the comment there indicated.


## Testing Instructions
Go to the patterns page.
Switch to the table layout, change the pattern category, and verify that the table layout is active.
