### PR TITLE
Patterns: Render draggable only when enabled

### DIFF
--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -43,6 +43,14 @@ const InserterDraggableBlocks = ( {
 		useDispatch( blockEditorStore )
 	);
 
+	if ( ! isEnabled ) {
+		return children( {
+			draggable: false,
+			onDragStart: undefined,
+			onDragEnd: undefined,
+		} );
+	}
+
 	return (
 		<Draggable
 			__experimentalTransferDataType="wp-blocks"
@@ -72,9 +80,9 @@ const InserterDraggableBlocks = ( {
 		>
 			{ ( { onDraggableStart, onDraggableEnd } ) => {
 				return children( {
-					draggable: isEnabled,
-					onDragStart: isEnabled ? onDraggableStart : undefined,
-					onDragEnd: isEnabled ? onDraggableEnd : undefined,
+					draggable: true,
+					onDragStart: onDraggableStart,
+					onDragEnd: onDraggableEnd,
 				} );
 			} }
 		</Draggable>


### PR DESCRIPTION
## What?
Render the `Draggable` components inside the inserter patterns only when draggable is actually enabled. 

## Why?
Currently, we'll render a `<Draggable />` with its draggable chip unnecessarily when draggable is disabled. This feels unnecessary since, in some instances, the patterns will intentionally never be draggable.

## How?
We're skipping the render of `Draggable` and the draggable chip. This results in a smaller component tree and fewer items in the DOM tree when patterns are not draggable.

## Testing Instructions
* Open the inserter.
* Verify blocks are still draggable and droppable.
* Click "Patterns"
* Verify patterns are still draggable and droppable.
* Click the "Explore all patterns" button
* Verify you can still insert those patterns and they render the same way as before. 
* You can also observe a smaller DOM / component tree.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|---|---|
|![Screenshot 2024-07-18 at 18 49 13](https://github.com/user-attachments/assets/ff486bc5-0de1-40c2-b3ec-487193cbbf48)|![Screenshot 2024-07-18 at 18 45 20](https://github.com/user-attachments/assets/b9fd4a35-3a47-4ceb-ba02-96577f0b5165)
