### PR TITLE
Add unit test for get_user_data_from_wp_global_styles.

### DIFF
--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -766,6 +766,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_get_user_data_from_wp_global_styles_returns_created_post() {
 		// Switch to a theme that does have support.
 		switch_theme( 'block-theme' );
+		wp_set_current_user( self::$administrator_id );
 		$theme = wp_get_theme();
 
 		$created  = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme, true );

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -761,6 +761,20 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles
+	 */
+	public function test_get_user_data_from_wp_global_styles_returns_created_post() {
+		// Switch to a theme that does have support.
+		switch_theme( 'block-theme' );
+		$theme = wp_get_theme();
+
+		$created  = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme, true );
+		$returned = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
+
+		$this->assertSame( $created, $returned, 'User data does not return created post' );
+	}
+
+	/**
 	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_theme_data
 	 */
 	public function test_get_theme_data_theme_supports_overrides_theme_json() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds a unit test to demonstrate that `WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles` returns an empty array when no `$create_post` param is passed after being previously called with the `$create_post` param set to `true`.

See: https://github.com/WordPress/gutenberg/issues/63722

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While attempting to write a unit test to confirm that caching added to `wp_add_global_styles_for_blocks()` would get cleared if user data changed ([related issue](https://github.com/WordPress/gutenberg/issues/63467)), I noticed that after calling `WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles()` and passing a value to the second parameter to create a post, the next time that method is called, the created post is not returned.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR demonstrates a possible bug. If valid, the PR would need to be updated to fix the issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Review the Unit test failure on the PR or run the test locally:

`npm run test:unit:php:base -- --filter test_get_user_data_from_wp_global_styles_returns_created_post`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a