### PR TITLE
Fix canvas issues by removing VisualEditor’s height

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,8 +1,3 @@
-.edit-post-visual-editor:not(.is-iframed) {
-	flex: 1 0 auto;
-	height: auto;
-}
-
 .edit-post-layout__metaboxes {
 	flex-shrink: 0;
 	clear: both;

--- a/packages/editor/src/components/editor-interface/style.scss
+++ b/packages/editor/src/components/editor-interface/style.scss
@@ -1,3 +1,7 @@
 .editor-editor-interface .entities-saved-states__panel-header {
 	height: $header-height + $border-width;
 }
+
+.editor-visual-editor {
+	flex: 1 0 auto;
+}

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -1,6 +1,5 @@
 .editor-visual-editor {
 	position: relative;
-	height: 100%;
 	display: block;
 	background-color: $gray-300;
 	// Make this a stacking context to contain the z-index of children elements.


### PR DESCRIPTION
## What?
A bug fix that’s also a general code quality improvement.

## Why?
To fix #63708 — In the Post editor metaboxes overlay the canvas while using device previews. Also this should make working with`VisualEditor` easier because its styling is a little less opinionated.

## How?
- Remove’s a `height` rule in `VisualEditor`’s styles.
- Adds a `flex` rule instead and specified by the parent component’s styles.
- Removes what is now an outdated override in the Post editor’s styles.

## Testing Instructions
Test every canvas everywhere for everything! Here are a couple scenarios that must be covered. I may add more.

### Fix for metaboxes overlaying the canvas in the Post editor
1. Install and activate the Yoast SEO plugin. This plugin injects a meta box with lots of content into the post editor.
2. Visit the post editor.
3. Switch to tablet/mobile view.
4. Make sure the Yoast metabox is expanded (should be by default)
5. Verify it stays below the device preview and does not obscure it.

### Verify no regression of the background clipping from #62952 
> * Enable the TT1 theme, which has a more visible background color.
> * To make the post editor not an iframe, do one of the following:
>   
>   * Activate the Jetpack plugin. This plugin contains version 1 blocks.
>   * Change the apiVerson of one of the core blocks to 2 via the following hook:
>     ```
>     function example_filter_metadata_registration( $settings, $metadata ) {
>     	if ( 'core/paragraph' === $metadata['name'] ) {
>     		$settings['api_version'] = 2;
>     	}
>     	return $settings;
>     };
>     add_filter( 'block_type_metadata_settings', 'example_filter_metadata_registration', 10, 2 );
>     ```
> * Access the post editor and enter more content.
> * Scroll to the very bottom of the content.

Verify the theme background color is not clipped.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
