### PR TITLE
Downgrade node 22(.5) unit tests to 22.4

### DIFF
--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -14,13 +14,17 @@ concurrency:
 
 jobs:
     checks:
-        name: Checks w/Node.js ${{ matrix.node }} on ${{ matrix.os }}
+        name: Checks w/Node.js ${{ matrix.node.name }} on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22.4']
+                node:
+                    - name: 20
+                      version: 20
+                    - name: 22
+                      version: 22.4
                 os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
 
         steps:
@@ -31,7 +35,7 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
               with:
-                  node-version: ${{ matrix.node }}
+                  node-version: ${{ matrix.node.version }}
 
             - name: Create block
               shell: bash

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -20,7 +20,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22']
+                node: ['20', '22.4']
                 os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
 
         steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22.4.x']
+                node: ['20', '22.4']
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
@@ -66,7 +66,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22']
+                node: ['20', '22.4']
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,13 +21,17 @@ concurrency:
 
 jobs:
     unit-js:
-        name: JavaScript (Node.js ${{ matrix.node }}) ${{ matrix.shard }}
+        name: JavaScript (Node.js ${{ matrix.node.name }}) ${{ matrix.shard }}
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22.4']
+                node:
+                    - name: 20
+                      version: 20
+                    - name: 22
+                      version: 22.4
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
@@ -39,7 +43,7 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
               with:
-                  node-version: ${{ matrix.node }}
+                  node-version: ${{ matrix.node.version }}
 
             - name: Determine the number of CPU cores
               uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
@@ -60,13 +64,17 @@ jobs:
                     --cacheDirectory="$HOME/.jest-cache"
 
     unit-js-date:
-        name: JavaScript Date Tests (Node.js ${{ matrix.node }})
+        name: JavaScript Date Tests (Node.js ${{ matrix.node.name }})
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22.4']
+                node:
+                    - name: 20
+                      version: 20
+                    - name: 22
+                      version: 22.4
 
         steps:
             - name: Checkout repository
@@ -77,7 +85,7 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
               with:
-                  node-version: ${{ matrix.node }}
+                  node-version: ${{ matrix.node.version }}
 
             - name: Determine the number of CPU cores
               uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22']
+                node: ['20', '22.4.x']
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:


### PR DESCRIPTION
Currently all node 22 unit tests are failing in trunk. It seems to be an issue for npm running on node 22.5.

Comments on https://github.com/npm/cli/issues/7657 imply this is an npm bug, and running on node 22.4 can be a temporary measure to keep CI working.