### PR TITLE
Move useSelectNearestEditableBlock out of src/hooks

### DIFF
--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -34,7 +34,7 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import EditTemplateBlocksNotification from './edit-template-blocks-notification';
 import ResizableEditor from '../resizable-editor';
-import useSelectNearestEditableBlock from '../../hooks/use-select-nearest-editable-block';
+import useSelectNearestEditableBlock from './use-select-nearest-editable-block';
 import {
 	NAVIGATION_POST_TYPE,
 	PATTERN_POST_TYPE,

--- a/packages/editor/src/components/visual-editor/use-select-nearest-editable-block.js
+++ b/packages/editor/src/components/visual-editor/use-select-nearest-editable-block.js
@@ -8,7 +8,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { unlock } from '../lock-unlock';
+import { unlock } from '../../lock-unlock';
 
 const DISTANCE_THRESHOLD = 500;
 


### PR DESCRIPTION
It's a little thing but I noticed `use-select-nearest-editable-block.js` is in `packages/editor/src/hooks` which is a folder full of WordPress hooks (`addFilter`), not React hooks. It's an internal function only used in `visual-editor` so I've moved it there.