### PR TITLE
DataViews: Fix pattens list selection

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -13,7 +13,13 @@ import {
 	Flex,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { useState, useMemo, useId, useEffect } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	useId,
+	useEffect,
+	useCallback,
+} from '@wordpress/element';
 import {
 	BlockPreview,
 	privateApis as blockEditorPrivateApis,
@@ -252,6 +258,10 @@ export default function DataviewsPatterns() {
 	const {
 		params: { postType, categoryId: categoryIdFromURL },
 	} = useLocation();
+	const [ selection, setSelection ] = useState( [] );
+	const onChangeSelection = useCallback( ( items ) => {
+		setSelection( items );
+	}, [] );
 	const type = postType || PATTERN_TYPES.user;
 	const categoryId = categoryIdFromURL || PATTERN_DEFAULT_CATEGORY;
 	const [ view, setView ] = useState( DEFAULT_VIEW );
@@ -409,6 +419,8 @@ export default function DataviewsPatterns() {
 					isLoading={ isResolving }
 					view={ view }
 					onChangeView={ setView }
+					selection={ selection }
+					onChangeSelection={ onChangeSelection }
 					defaultLayouts={ defaultLayouts }
 				/>
 			</Page>

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -13,13 +13,7 @@ import {
 	Flex,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import {
-	useState,
-	useMemo,
-	useId,
-	useEffect,
-	useCallback,
-} from '@wordpress/element';
+import { useState, useMemo, useId, useEffect } from '@wordpress/element';
 import {
 	BlockPreview,
 	privateApis as blockEditorPrivateApis,
@@ -259,9 +253,6 @@ export default function DataviewsPatterns() {
 		params: { postType, categoryId: categoryIdFromURL },
 	} = useLocation();
 	const [ selection, setSelection ] = useState( [] );
-	const onChangeSelection = useCallback( ( items ) => {
-		setSelection( items );
-	}, [] );
 	const type = postType || PATTERN_TYPES.user;
 	const categoryId = categoryIdFromURL || PATTERN_DEFAULT_CATEGORY;
 	const [ view, setView ] = useState( DEFAULT_VIEW );
@@ -420,7 +411,7 @@ export default function DataviewsPatterns() {
 					view={ view }
 					onChangeView={ setView }
 					selection={ selection }
-					onChangeSelection={ onChangeSelection }
+					onChangeSelection={ setSelection }
 					defaultLayouts={ defaultLayouts }
 				/>
 			</Page>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/63725

This handles the selection issue for GB. aria-labels seems fine in trunk..

From the issue:

>The inability to bulk select seems to be an issue in the gutenberg plugin.






## Testing Instructions
1. In patterns list in site editor make sure the selection works as expected
