### PR TITLE
Widget Editor: Remove unused values returned from 'mapSelect'

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -55,8 +55,6 @@ export default function WidgetAreasBlockEditorProvider( {
 			? getEntityRecord( 'root', 'site' )
 			: undefined;
 		return {
-			widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
-			widgets: select( editWidgetsStore ).getWidgets(),
 			reusableBlocks: ALLOW_REUSABLE_BLOCKS
 				? getEntityRecords( 'postType', 'wp_block' )
 				: EMPTY_ARRAY,


### PR DESCRIPTION
## What?
The `WidgetAreasBlockEditorProvider` was selecting `widgets` and `widgetAreas` values but never actually using them. PR removes these selections.

The selections seem to be leftovers from the PRs #24290 and #26164.

## Why?
Components should only select what they're using.

## Testing Instructions
The editor has e2e test coverage that should catch any regressions.

1. Enable a non-block theme like TT1.
2. Open the Widgets Editor.
3. Confirm it works as before.

### Testing Instructions for Keyboard
Same.
