### PR TITLE
Make Query Loop settings more intuitive with a ToggleGroup and simplified help text

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -146,6 +146,7 @@ export default function QueryInspectorControls( props ) {
 				<PanelBody title={ __( 'Settings' ) }>
 					{ showInheritControl && (
 						<ToggleGroupControl
+							__next40pxDefaultSize
 							label={ __( 'Query type' ) }
 							isBlock
 							onChange={ ( value ) => {

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -155,7 +155,7 @@ export default function QueryInspectorControls( props ) {
 							onChange={ ( value ) => {
 								setQuery( { inherit: !! value } );
 							} }
-							help={ !! inherit ? inheritControlHelp : '' }
+							help={ inherit && inheritControlHelp }
 							value={ !! inherit }
 						>
 							<ToggleGroupControlOption

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -100,13 +100,6 @@ export default function QueryInspectorControls( props ) {
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
-	const inheritControlLabel = __( 'Query Type' );
-	const inheritControlDefaultHelp = __(
-		'Display a list of posts or custom post types based on the current template.'
-	);
-	const inheritControlCustomHelp = __(
-		'Display a list of posts or custom post types based on specific criteria.'
-	);
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
 	const postTypeControlLabel = __( 'Post type' );
@@ -153,15 +146,19 @@ export default function QueryInspectorControls( props ) {
 				<PanelBody title={ __( 'Settings' ) }>
 					{ showInheritControl && (
 						<ToggleGroupControl
-							label={ inheritControlLabel }
+							label={ __( 'Query type' ) }
 							isBlock
 							onChange={ ( value ) => {
 								setQuery( { inherit: !! value } );
 							} }
 							help={
 								inherit
-									? inheritControlDefaultHelp
-									: inheritControlCustomHelp
+									? __(
+											'Display a list of posts or custom post types based on the current template.'
+									  )
+									: __(
+											'Display a list of posts or custom post types based on specific criteria.'
+									  )
 							}
 							value={ !! inherit }
 						>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -6,7 +6,6 @@ import {
 	TextControl,
 	SelectControl,
 	RangeControl,
-	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	Notice,
@@ -101,6 +100,10 @@ export default function QueryInspectorControls( props ) {
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
+	const inheritControlLabel = __( 'Contents' );
+	const inheritControlHelp = __(
+		"Block will display items matching the page's context, e.g. category archive or search result"
+	);
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
 	const postTypeControlLabel = __( 'Content type' );
@@ -146,17 +149,24 @@ export default function QueryInspectorControls( props ) {
 			{ showSettingsPanel && (
 				<PanelBody title={ __( 'Settings' ) }>
 					{ showInheritControl && (
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Inherit query from template' ) }
-							help={ __(
-								'Enable to use the global query context that is set with the current template, such as an archive or search. Disable to customize the settings independently.'
-							) }
-							checked={ !! inherit }
-							onChange={ ( value ) =>
-								setQuery( { inherit: !! value } )
-							}
-						/>
+						<ToggleGroupControl
+							label={ inheritControlLabel }
+							isBlock
+							onChange={ ( value ) => {
+								setQuery( { inherit: !! value } );
+							} }
+							help={ !! inherit ? inheritControlHelp : '' }
+							value={ !! inherit }
+						>
+							<ToggleGroupControlOption
+								value
+								label={ __( 'Default' ) }
+							/>
+							<ToggleGroupControlOption
+								value={ false }
+								label={ __( 'Custom' ) }
+							/>
+						</ToggleGroupControl>
 					) }
 					{ showPostTypeControl &&
 						( postTypesSelectOptions.length > 2 ? (

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -100,15 +100,18 @@ export default function QueryInspectorControls( props ) {
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
-	const inheritControlLabel = __( 'Contents' );
-	const inheritControlHelp = __(
-		"Block will display items matching the page's context, e.g. category archive or search result"
+	const inheritControlLabel = __( 'Query Type' );
+	const inheritControlDefaultHelp = __(
+		'Display a list of posts or custom post types based on the current template.'
+	);
+	const inheritControlCustomHelp = __(
+		'Display a list of posts or custom post types based on specific criteria.'
 	);
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
-	const postTypeControlLabel = __( 'Content type' );
+	const postTypeControlLabel = __( 'Post type' );
 	const postTypeControlHelp = __(
-		'WordPress contains different types of content you can filter by. Posts and pages are the default types, but plugins could add more.'
+		'Select the type of content to display: posts, pages, or custom post types.'
 	);
 	const showColumnsControl = false;
 	const showOrderControl =
@@ -155,7 +158,11 @@ export default function QueryInspectorControls( props ) {
 							onChange={ ( value ) => {
 								setQuery( { inherit: !! value } );
 							} }
-							help={ inherit && inheritControlHelp }
+							help={
+								inherit
+									? inheritControlDefaultHelp
+									: inheritControlCustomHelp
+							}
 							value={ !! inherit }
 						>
 							<ToggleGroupControlOption

--- a/test/e2e/specs/editor/various/is-typing.spec.js
+++ b/test/e2e/specs/editor/various/is-typing.spec.js
@@ -54,7 +54,7 @@ test.describe( 'isTyping', () => {
 			.click();
 
 		await editor.openDocumentSettingsSidebar();
-		await page.getByLabel( 'Inherit query from template' ).click();
+		await page.getByLabel( 'Custom' ).click();
 
 		// Moving the mouse shows the toolbar.
 		await editor.showBlockToolbar();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/63598. 
Swap "Inherit query from template" toggle with Contents: Default | Custom toggle group.

What | Before | After
-- | -- | --
`inherit: true` | <img width="288" alt="image" src="https://github.com/user-attachments/assets/aad77c3b-877f-43b9-9121-70970cd49b38"> | ![CleanShot 2024-07-26 at 09 23 00](https://github.com/user-attachments/assets/630016b8-079f-471d-8f42-711c9b131f37)
`inherit: false` | <img width="289" alt="image" src="https://github.com/user-attachments/assets/6d102f84-27f2-4fad-a1fe-2de93e56ce02"> | ![CleanShot 2024-07-26 at 09 24 25](https://github.com/user-attachments/assets/3931e280-196c-4831-a299-647d08f36318)





## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This control has confused users (and engineers) for a long time now. This is an attempt to make it clearer as per https://github.com/WordPress/gutenberg/issues/63598.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replace `ToggleControl` with `ToggleGroupControl` component.

## Testing Instructions

1. Go to Editor and All Archives template
2. Focus on Query Loop block
3. **Expected:** There's "Contents" control as per screenshots above
4. Switch to "Custom"
5. **Expected:** All the customization controls appear
6. Switch back to "Default"
7. **Expected:** All the customization controls disappear and help text appears

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
