### PR TITLE
FocalPointPicker: optionally hide controls

### DIFF
--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -100,6 +100,7 @@ export function FocalPointPicker( {
 		x: 0.5,
 		y: 0.5,
 	},
+	hideControls = false,
 	...restProps
 }: WordPressComponentProps< FocalPointPickerProps, 'div', false > ) {
 	const [ point, setPoint ] = useState( valueProp );
@@ -283,15 +284,17 @@ export function FocalPointPicker( {
 					/>
 				</MediaContainer>
 			</MediaWrapper>
-			<Controls
-				__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
-				__next40pxDefaultSize={ __next40pxDefaultSize }
-				hasHelpText={ !! help }
-				point={ { x, y } }
-				onChange={ ( value ) => {
-					onChange?.( getFinalValue( value ) );
-				} }
-			/>
+			{ ! hideControls && (
+				<Controls
+					__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
+					__next40pxDefaultSize={ __next40pxDefaultSize }
+					hasHelpText={ !! help }
+					point={ { x, y } }
+					onChange={ ( value ) => {
+						onChange?.( getFinalValue( value ) );
+					} }
+				/>
+			) }
 		</BaseControl>
 	);
 }

--- a/packages/components/src/focal-point-picker/stories/index.story.tsx
+++ b/packages/components/src/focal-point-picker/stories/index.story.tsx
@@ -91,3 +91,9 @@ Snapping.args = {
 		return { x, y };
 	},
 };
+
+export const WithInputControlsHidden = Template.bind( {} );
+WithInputControlsHidden.args = {
+	...Default.args,
+	hideControls: true,
+};

--- a/packages/components/src/focal-point-picker/types.ts
+++ b/packages/components/src/focal-point-picker/types.ts
@@ -64,6 +64,12 @@ export type FocalPointPickerProps = Pick<
 	 * The focal point. Should be an object containing `x` and `y` params.
 	 */
 	value: FocalPoint;
+	/**
+	 * If `true`, the input controls will be hidden.
+	 *
+	 * @default false
+	 */
+	hideControls?: boolean;
 };
 
 export type FocalPointPickerControlsProps = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
