### PR TITLE
Zoom Out: Fix vertical toolbar position

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-popover.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-popover.js
@@ -28,6 +28,7 @@ export default function ZoomOutPopover( { clientId, __unstableContentRef } ) {
 		...popoverProps,
 		placement: 'left-start',
 		flip: false,
+		shift: true,
 	};
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Ensures that the vertical toolbar is always sticky.

## Why?
The vertical toolbar should always be sticky!

## How?
Pass `shift: true` to the BlockPopover component.

## Testing Instructions
1. Open the Site Editor
2. Open the inserter
3. Open the patterns tab
4. Select a category
5. Zoom out mode should be engaged
6. Select a pattern
7. Check that the vertical toolbar always sticks to the top of the screen when you scroll

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ba08d308-7b4b-4695-940a-274ae86c1a30

