### PR TITLE
Site Editor: Improve author filter scaling for multiple authors

### DIFF
--- a/packages/dataviews/src/dataviews.tsx
+++ b/packages/dataviews/src/dataviews.tsx
@@ -110,7 +110,7 @@ export default function DataViews< Item >( {
 				className="dataviews-filters__view-actions"
 			>
 				<HStack
-					justify="start"
+					justify="space-between"
 					className="dataviews-filters__container"
 					wrap
 				>
@@ -121,12 +121,11 @@ export default function DataViews< Item >( {
 							onChangeView={ onChangeView }
 						/>
 					) }
-					<Filters
+					<ViewActions
 						fields={ _fields }
 						view={ view }
 						onChangeView={ onChangeView }
-						openedFilter={ openedFilter }
-						setOpenedFilter={ setOpenedFilter }
+						defaultLayouts={ defaultLayouts }
 					/>
 				</HStack>
 				{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type ) &&
@@ -139,13 +138,21 @@ export default function DataViews< Item >( {
 							getItemId={ getItemId }
 						/>
 					) }
-				<ViewActions
+			</HStack>
+			<HStack
+				style={ { paddingTop: 0 } }
+				justify="start"
+				className="dataviews-filters__view-actions"
+			>
+				<Filters
 					fields={ _fields }
 					view={ view }
 					onChangeView={ onChangeView }
-					defaultLayouts={ defaultLayouts }
+					openedFilter={ openedFilter }
+					setOpenedFilter={ setOpenedFilter }
 				/>
 			</HStack>
+
 			<ViewComponent
 				actions={ actions }
 				data={ data }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -793,8 +793,6 @@
 		background: $gray-100;
 		color: $gray-800;
 		position: relative;
-		display: flex;
-		align-items: center;
 
 		&.has-reset {
 			padding-inline-end: $button-size-small + $grid-unit-05;


### PR DESCRIPTION
Fixes [#63718](https://github.com/WordPress/gutenberg/issues/63718)

## What?
This PR improves the scaling of author filters for pages in the Site Editor when multiple authors are present. It adjusts the placement of Filters and ViewActions components and updates related SCSS.

## Why?
This PR addresses issue #63718, where the author filter design in the Site Editor doesn't scale well with 2+ authors. The current design becomes squished and difficult to read as more authors are added, with words sometimes appearing on a second line.

## How?
The implementation involves:
- Adjusting the placement of the Filters and ViewActions components to allow for better scaling.
- Updating the SCSS to improve the layout and readability of the author filter interface.
- Ensuring the design remains consistent and functional across various numbers of authors.

## Testing Instructions
- Open the Site Editor.
- Navigate to the Pages section.
- Attempt to filter pages by author.
- Add multiple authors (2 or more) to the filter.
- Observe that the filter interface scales properly, maintaining readability and proper layout.
- Test with increasing numbers of authors to ensure the design remains functional and visually appealing.

## Screenshots or screencast

https://github.com/user-attachments/assets/56abac18-6071-4f3a-856b-18538ec915ac


