### PR TITLE
`RadioControl`: add support for option help text

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   `ColorPalette`: Remove extra bottom margin when `CircularOptionPicker` is unneeded ([#63961](https://github.com/WordPress/gutenberg/pull/63961)).
 -   `CustomSelectControl`: Restore `describedBy` functionality ([#63957](https://github.com/WordPress/gutenberg/pull/63957)).
 
+### Enhancements
+
+-   `RadioControl`: add support for option help text ([#63751](https://github.com/WordPress/gutenberg/pull/63751)).
+
 ### Internal
 
 -   `DropdownMenuV2`: break menu item help text on multiple lines for better truncation. ([#63916](https://github.com/WordPress/gutenberg/pull/63916)).

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -88,7 +88,13 @@ export function RadioControl(
 							onChange={ onChangeValue }
 							checked={ option.value === selected }
 							aria-describedby={
-								!! help ? `${ id }__help` : undefined
+								// TODO: will improve if we like this solution
+								// eslint-disable-next-line no-nested-ternary
+								!! option.helpText
+									? `${ id }-${ index }-help`
+									: !! help
+									? `${ id }__help`
+									: undefined
 							}
 							{ ...additionalProps }
 						/>
@@ -96,18 +102,16 @@ export function RadioControl(
 							className="components-radio-control__label"
 							htmlFor={ `${ id }-${ index }` }
 						>
-							<span className="components-radio-control__label-text">
-								{ option.label }
-							</span>
-							{ !! option.helpText ? (
-								<span
-									aria-hidden="true"
-									className="components-radio-control__help-text"
-								>
-									{ option.helpText }
-								</span>
-							) : null }
+							{ option.label }
 						</label>
+						{ !! option.helpText ? (
+							<span
+								id={ `${ id }-${ index }-help` }
+								className="components-radio-control__help-text"
+							>
+								{ option.helpText }
+							</span>
+						) : null }
 					</div>
 				) ) }
 			</VStack>

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -16,6 +16,7 @@ import BaseControl from '../base-control';
 import type { WordPressComponentProps } from '../context';
 import type { RadioControlProps } from './types';
 import { VStack } from '../v-stack';
+import { Text } from '../text';
 
 /**
  * Render a user interface to select the user type using radio inputs.
@@ -105,12 +106,14 @@ export function RadioControl(
 							{ option.label }
 						</label>
 						{ !! option.helpText ? (
-							<span
+							<Text
+								variant="muted"
+								size={ 12 }
 								id={ `${ id }-${ index }-help` }
 								className="components-radio-control__help-text"
 							>
 								{ option.helpText }
-							</span>
+							</Text>
 						) : null }
 					</div>
 				) ) }

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -16,7 +16,7 @@ import BaseControl from '../base-control';
 import type { WordPressComponentProps } from '../context';
 import type { RadioControlProps } from './types';
 import { VStack } from '../v-stack';
-import { Text } from '../text';
+import { StyledHelp } from '../base-control/styles/base-control-styles';
 
 // This is the id that BaseControl assigns to the help text element.
 function generateHelpTextId( id: string ) {
@@ -114,14 +114,13 @@ export function RadioControl(
 							{ option.label }
 						</label>
 						{ !! option.description ? (
-							<Text
-								variant="muted"
-								size={ 12 }
+							<StyledHelp
+								__nextHasNoMarginBottom
 								id={ generateOptionDescriptionId( id, index ) }
 								className="components-radio-control__option-description"
 							>
 								{ option.description }
-							</Text>
+							</StyledHelp>
 						) : null }
 					</div>
 				) ) }

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -83,7 +83,14 @@ export function RadioControl(
 			help={ help }
 			className={ clsx( className, 'components-radio-control' ) }
 		>
-			<VStack spacing={ 2 }>
+			<VStack
+				spacing={ 3 }
+				className={ clsx(
+					'components-radio-control__group-wrapper',
+					!! help &&
+						'components-radio-control__group-wrapper--with-help'
+				) }
+			>
 				{ options.map( ( option, index ) => (
 					<div
 						key={ `${ id }-${ index }` }

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -18,6 +18,15 @@ import type { RadioControlProps } from './types';
 import { VStack } from '../v-stack';
 import { Text } from '../text';
 
+// This is the id that BaseControl assigns to the help text element.
+function generateHelpTextId( id: string ) {
+	return `${ id }__help`;
+}
+
+function generateOptionDescriptionId( id: string, index: number ) {
+	return `${ id }-${ index }-option-description`;
+}
+
 /**
  * Render a user interface to select the user type using radio inputs.
  *
@@ -88,15 +97,14 @@ export function RadioControl(
 							value={ option.value }
 							onChange={ onChangeValue }
 							checked={ option.value === selected }
-							aria-describedby={
-								// TODO: will improve if we like this solution
-								// eslint-disable-next-line no-nested-ternary
+							aria-describedby={ [
 								!! option.description
-									? `${ id }-${ index }-option-description`
-									: !! help
-									? `${ id }__help`
-									: undefined
-							}
+									? generateOptionDescriptionId( id, index )
+									: undefined,
+								!! help ? generateHelpTextId( id ) : undefined,
+							]
+								.filter( Boolean )
+								.join( ' ' ) }
 							{ ...additionalProps }
 						/>
 						<label
@@ -109,7 +117,7 @@ export function RadioControl(
 							<Text
 								variant="muted"
 								size={ 12 }
-								id={ `${ id }-${ index }-option-description` }
+								id={ generateOptionDescriptionId( id, index ) }
 								className="components-radio-control__option-description"
 							>
 								{ option.description }

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -91,8 +91,8 @@ export function RadioControl(
 							aria-describedby={
 								// TODO: will improve if we like this solution
 								// eslint-disable-next-line no-nested-ternary
-								!! option.helpText
-									? `${ id }-${ index }-help`
+								!! option.description
+									? `${ id }-${ index }-option-description`
 									: !! help
 									? `${ id }__help`
 									: undefined
@@ -105,14 +105,14 @@ export function RadioControl(
 						>
 							{ option.label }
 						</label>
-						{ !! option.helpText ? (
+						{ !! option.description ? (
 							<Text
 								variant="muted"
 								size={ 12 }
-								id={ `${ id }-${ index }-help` }
-								className="components-radio-control__help-text"
+								id={ `${ id }-${ index }-option-description` }
+								className="components-radio-control__option-description"
 							>
-								{ option.helpText }
+								{ option.description }
 							</Text>
 						) : null }
 					</div>

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -95,11 +95,9 @@ export function RadioControl(
 		>
 			<VStack
 				spacing={ 3 }
-				className={ clsx(
-					'components-radio-control__group-wrapper',
-					!! help &&
-						'components-radio-control__group-wrapper--with-help'
-				) }
+				className={ clsx( 'components-radio-control__group-wrapper', {
+					'has-help': !! help,
+				} ) }
 			>
 				{ options.map( ( option, index ) => (
 					<div

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -96,7 +96,17 @@ export function RadioControl(
 							className="components-radio-control__label"
 							htmlFor={ `${ id }-${ index }` }
 						>
-							{ option.label }
+							<span className="components-radio-control__label-text">
+								{ option.label }
+							</span>
+							{ !! option.helpText ? (
+								<span
+									aria-hidden="true"
+									className="components-radio-control__help-text"
+								>
+									{ option.helpText }
+								</span>
+							) : null }
 						</label>
 					</div>
 				) ) }

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -16,15 +16,15 @@ import BaseControl from '../base-control';
 import type { WordPressComponentProps } from '../context';
 import type { RadioControlProps } from './types';
 import { VStack } from '../v-stack';
+import { useBaseControlProps } from '../base-control/hooks';
 import { StyledHelp } from '../base-control/styles/base-control-styles';
 
-// This is the id that BaseControl assigns to the help text element.
-function generateHelpTextId( id: string ) {
-	return `${ id }__help`;
+function generateOptionDescriptionId( radioGroupId: string, index: number ) {
+	return `${ radioGroupId }-${ index }-option-description`;
 }
 
-function generateOptionDescriptionId( id: string, index: number ) {
-	return `${ id }-${ index }-option-description`;
+function generateOptionId( radioGroupId: string, index: number ) {
+	return `${ radioGroupId }-${ index }`;
 }
 
 /**
@@ -63,12 +63,22 @@ export function RadioControl(
 		onChange,
 		hideLabelFromVision,
 		options = [],
+		id: preferredId,
 		...additionalProps
 	} = props;
-	const instanceId = useInstanceId( RadioControl );
-	const id = `inspector-radio-control-${ instanceId }`;
+	const id = useInstanceId(
+		RadioControl,
+		'inspector-radio-control',
+		preferredId
+	);
+
 	const onChangeValue = ( event: ChangeEvent< HTMLInputElement > ) =>
 		onChange( event.target.value );
+
+	// Use `useBaseControlProps` to get the id of the help text.
+	const {
+		controlProps: { 'aria-describedby': helpTextId },
+	} = useBaseControlProps( { id, help } );
 
 	if ( ! options?.length ) {
 		return null;
@@ -93,30 +103,32 @@ export function RadioControl(
 			>
 				{ options.map( ( option, index ) => (
 					<div
-						key={ `${ id }-${ index }` }
+						key={ generateOptionId( id, index ) }
 						className="components-radio-control__option"
 					>
 						<input
-							id={ `${ id }-${ index }` }
+							id={ generateOptionId( id, index ) }
 							className="components-radio-control__input"
 							type="radio"
 							name={ id }
 							value={ option.value }
 							onChange={ onChangeValue }
 							checked={ option.value === selected }
-							aria-describedby={ [
-								!! option.description
-									? generateOptionDescriptionId( id, index )
-									: undefined,
-								!! help ? generateHelpTextId( id ) : undefined,
-							]
-								.filter( Boolean )
-								.join( ' ' ) }
+							aria-describedby={
+								clsx( [
+									!! option.description &&
+										generateOptionDescriptionId(
+											id,
+											index
+										),
+									helpTextId,
+								] ) || undefined
+							}
 							{ ...additionalProps }
 						/>
 						<label
 							className="components-radio-control__label"
-							htmlFor={ `${ id }-${ index }` }
+							htmlFor={ generateOptionId( id, index ) }
 						>
 							{ option.label }
 						</label>

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -75,12 +75,20 @@ export const WithOptionHelpText: StoryFn< typeof RadioControl > = Template.bind(
 WithOptionHelpText.args = {
 	...Default.args,
 	options: [
-		{ label: 'Public', value: 'public', helpText: 'Visible to everyone' },
-		{ label: 'Private', value: 'private', helpText: 'Only visible to you' },
+		{
+			label: 'Public',
+			value: 'public',
+			description: 'Visible to everyone',
+		},
+		{
+			label: 'Private',
+			value: 'private',
+			description: 'Only visible to you',
+		},
 		{
 			label: 'Password Protected',
 			value: 'password',
-			helpText: 'Protected by a password',
+			description: 'Protected by a password',
 		},
 	],
 };

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -69,10 +69,9 @@ Default.args = {
 	],
 };
 
-export const WithOptionHelpText: StoryFn< typeof RadioControl > = Template.bind(
-	{}
-);
-WithOptionHelpText.args = {
+export const WithOptionDescriptions: StoryFn< typeof RadioControl > =
+	Template.bind( {} );
+WithOptionDescriptions.args = {
 	...Default.args,
 	options: [
 		{

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -74,8 +74,13 @@ export const WithOptionHelpText: StoryFn< typeof RadioControl > = Template.bind(
 );
 WithOptionHelpText.args = {
 	...Default.args,
-	options: Default.args.options?.map( ( option ) => ( {
-		...option,
-		helpText: 'This is some help text',
-	} ) ),
+	options: [
+		{ label: 'Public', value: 'public', helpText: 'Visible to everyone' },
+		{ label: 'Private', value: 'private', helpText: 'Only visible to you' },
+		{
+			label: 'Password Protected',
+			value: 'password',
+			helpText: 'Protected by a password',
+		},
+	],
 };

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -68,3 +68,14 @@ Default.args = {
 		{ label: 'Password Protected', value: 'password' },
 	],
 };
+
+export const WithOptionHelpText: StoryFn< typeof RadioControl > = Template.bind(
+	{}
+);
+WithOptionHelpText.args = {
+	...Default.args,
+	options: Default.args.options?.map( ( option ) => ( {
+		...option,
+		helpText: 'This is some help text',
+	} ) ),
+};

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -2,7 +2,7 @@
 	display: grid;
 	grid-template-columns: auto 1fr;
 	grid-template-rows: auto minmax(0, max-content);
-	column-gap: $grid-unit-10;
+	column-gap: $grid-unit-15;
 	align-items: center;
 }
 

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -46,7 +46,7 @@
 	}
 }
 
-.components-radio-control__help-text {
+.components-radio-control__option-description {
 	grid-column: 2;
 	grid-row: 2;
 }

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -49,4 +49,8 @@
 .components-radio-control__option-description {
 	grid-column: 2;
 	grid-row: 2;
+
+	// Override the top margin of the StyledHelp component from BaseControl.
+	// TODO: we should tweak the StyledHelp component to not have a top margin.
+	margin-top: 0;
 }

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -1,5 +1,9 @@
 .components-radio-control__option {
-	display: flex;
+	display: grid;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: auto minmax(0, max-content);
+	column-gap: $grid-unit-10;
+	row-gap: 0;
 	align-items: center;
 }
 
@@ -28,10 +32,33 @@
 }
 
 .components-radio-control__label {
+	grid-column: 2;
+	grid-row: 1 / -1;
+
+	display: grid;
+	grid-template-rows: subgrid;
+	align-items: center;
+
 	cursor: pointer;
 	line-height: $radio-input-size-sm;
 
 	@include break-small() {
 		line-height: $radio-input-size;
 	}
+}
+
+.components-radio-control__label-text {
+	grid-column: 1;
+	grid-row: 1;
+}
+
+.components-radio-control__help-text {
+	grid-column: 1;
+	grid-row: 2;
+
+	font-size: $helptext-font-size;
+	font-style: normal;
+	font-weight: normal;
+	line-height: $default-line-height;
+	color: $components-color-gray-700;
 }

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -3,7 +3,7 @@
 	grid-template-columns: auto 1fr;
 	grid-template-rows: auto minmax(0, max-content);
 	column-gap: $grid-unit-10;
-	row-gap: 0;
+	row-gap: $grid-unit-05;
 	align-items: center;
 }
 
@@ -14,7 +14,7 @@
 	@include radio-control;
 
 	display: inline-flex;
-	margin: 0 $grid-unit-10 0 0;
+	margin: 0;
 	padding: 0;
 	appearance: none;
 	cursor: pointer;

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -8,6 +8,9 @@
 }
 
 .components-radio-control__input[type="radio"] {
+	grid-column: 1;
+	grid-row: 1;
+
 	@include radio-control;
 
 	display: inline-flex;
@@ -33,11 +36,7 @@
 
 .components-radio-control__label {
 	grid-column: 2;
-	grid-row: 1 / -1;
-
-	display: grid;
-	grid-template-rows: subgrid;
-	align-items: center;
+	grid-row: 1;
 
 	cursor: pointer;
 	line-height: $radio-input-size-sm;
@@ -47,13 +46,8 @@
 	}
 }
 
-.components-radio-control__label-text {
-	grid-column: 1;
-	grid-row: 1;
-}
-
 .components-radio-control__help-text {
-	grid-column: 1;
+	grid-column: 2;
 	grid-row: 2;
 
 	font-size: $helptext-font-size;

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -1,4 +1,4 @@
-.components-radio-control__group-wrapper--with-help {
+.components-radio-control__group-wrapper.has-help {
 	margin-block-end: $grid-unit-15;
 }
 

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -1,8 +1,12 @@
+.components-radio-control__group-wrapper--with-help {
+	margin-block-end: $grid-unit-15;
+}
+
 .components-radio-control__option {
 	display: grid;
 	grid-template-columns: auto 1fr;
 	grid-template-rows: auto minmax(0, max-content);
-	column-gap: $grid-unit-15;
+	column-gap: $grid-unit-10;
 	align-items: center;
 }
 
@@ -49,7 +53,7 @@
 	grid-column: 2;
 	grid-row: 2;
 
-	padding-block-start: $grid-unit-10;
+	padding-block-start: $grid-unit-05;
 
 	// Override the top margin of the StyledHelp component from BaseControl.
 	// TODO: we should tweak the StyledHelp component to not have a top margin.

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -49,10 +49,4 @@
 .components-radio-control__help-text {
 	grid-column: 2;
 	grid-row: 2;
-
-	font-size: $helptext-font-size;
-	font-style: normal;
-	font-weight: normal;
-	line-height: $default-line-height;
-	color: $components-color-gray-700;
 }

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -3,7 +3,6 @@
 	grid-template-columns: auto 1fr;
 	grid-template-rows: auto minmax(0, max-content);
 	column-gap: $grid-unit-10;
-	row-gap: $grid-unit-05;
 	align-items: center;
 }
 
@@ -49,6 +48,8 @@
 .components-radio-control__option-description {
 	grid-column: 2;
 	grid-row: 2;
+
+	padding-block-start: $grid-unit-10;
 
 	// Override the top margin of the StyledHelp component from BaseControl.
 	// TODO: we should tweak the StyledHelp component to not have a top margin.

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -49,6 +49,7 @@ const defaultPropsWithDescriptions = {
 };
 
 describe.each( [
+	// TODO: `RadioControl` doesn't currently support uncontrolled mode.
 	// [ 'uncontrolled', RadioControl ],
 	[ 'controlled', ControlledRadioControl ],
 ] )( 'RadioControl %s', ( ...modeAndComponent ) => {

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -1,0 +1,273 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import RadioControl from '../';
+
+const ControlledRadioControl = ( {
+	...props
+}: React.ComponentProps< typeof RadioControl > ) => {
+	const [ option, setOption ] = useState( props.selected );
+
+	return (
+		<RadioControl
+			{ ...props }
+			onChange={ ( newValue ) => {
+				setOption( newValue );
+				props.onChange?.( newValue );
+			} }
+			selected={ option }
+		/>
+	);
+};
+
+const defaultProps = {
+	options: [
+		{ label: 'Mouse', value: 'mouse' },
+		{ label: 'Cat', value: 'cat' },
+		{ label: 'Dog', value: 'dog' },
+	],
+	label: 'Animal',
+};
+
+const defaultPropsWithDescriptions = {
+	...defaultProps,
+	options: defaultProps.options.map( ( option, index ) => ( {
+		...option,
+		description: `This is the option number ${ index + 1 }.`,
+	} ) ),
+};
+
+describe.each( [
+	// [ 'uncontrolled', RadioControl ],
+	[ 'controlled', ControlledRadioControl ],
+] )( 'RadioControl %s', ( ...modeAndComponent ) => {
+	const [ , Component ] = modeAndComponent;
+
+	describe( 'semantics and labelling', () => {
+		it( 'should render radio inputs with accessible labels', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component { ...defaultProps } onChange={ onChangeSpy } />
+			);
+
+			for ( const option of defaultProps.options ) {
+				const optionEl = screen.getByRole( 'radio', {
+					name: option.label,
+				} );
+				expect( optionEl ).toBeVisible();
+				expect( optionEl ).not.toBeChecked();
+			}
+		} );
+
+		it( 'should not select have a selected value when the `selected` prop does not match any available options', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component { ...defaultProps } onChange={ onChangeSpy } />
+			);
+
+			expect(
+				screen.queryByRole( 'radio', {
+					checked: true,
+				} )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should render mutually exclusive radio inputs', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component
+					{ ...defaultProps }
+					onChange={ onChangeSpy }
+					selected={ defaultProps.options[ 1 ].value }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'radio', {
+					checked: true,
+				} )
+			).toHaveAccessibleName( defaultProps.options[ 1 ].label );
+		} );
+
+		it( 'should use the group help text to describe individual options', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component
+					{ ...defaultProps }
+					onChange={ onChangeSpy }
+					selected={ defaultProps.options[ 1 ].value }
+					help="Select your favorite animal."
+				/>
+			);
+
+			for ( const option of defaultProps.options ) {
+				expect(
+					screen.getByRole( 'radio', { name: option.label } )
+				).toHaveAccessibleDescription( 'Select your favorite animal.' );
+			}
+		} );
+
+		it( 'should use the option description text to describe individual options', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component
+					{ ...defaultPropsWithDescriptions }
+					onChange={ onChangeSpy }
+					selected={ defaultProps.options[ 1 ].value }
+				/>
+			);
+
+			let index = 1;
+			for ( const option of defaultProps.options ) {
+				expect(
+					screen.getByRole( 'radio', { name: option.label } )
+				).toHaveAccessibleDescription(
+					`This is the option number ${ index }.`
+				);
+				index += 1;
+			}
+		} );
+
+		it( 'should use both the option description text and the group help text to describe individual options', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component
+					{ ...defaultPropsWithDescriptions }
+					onChange={ onChangeSpy }
+					selected={ defaultProps.options[ 1 ].value }
+					help="Select your favorite animal"
+				/>
+			);
+
+			let index = 1;
+			for ( const option of defaultProps.options ) {
+				expect(
+					screen.getByRole( 'radio', { name: option.label } )
+				).toHaveAccessibleDescription(
+					`This is the option number ${ index }. Select your favorite animal`
+				);
+				index += 1;
+			}
+		} );
+	} );
+
+	describe( 'interaction', () => {
+		it( 'should select a new value when clicking on the radio input', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+			render(
+				<Component { ...defaultProps } onChange={ onChangeSpy } />
+			);
+
+			// Click on the third radio, make sure it's selected.
+			await user.click(
+				screen.getByRole( 'radio', {
+					name: defaultProps.options[ 2 ].label,
+				} )
+			);
+			expect(
+				screen.getByRole( 'radio', {
+					checked: true,
+				} )
+			).toHaveAccessibleName( defaultProps.options[ 2 ].label );
+
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onChangeSpy ).toHaveBeenLastCalledWith(
+				defaultProps.options[ 2 ].value
+			);
+		} );
+
+		it( 'should select a new value when clicking on the radio label', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+			render(
+				<Component { ...defaultProps } onChange={ onChangeSpy } />
+			);
+
+			// Click on the second radio's label, make sure it selects the associated radio.
+			await user.click(
+				screen.getByText( defaultProps.options[ 1 ].label )
+			);
+			expect(
+				screen.getByRole( 'radio', {
+					checked: true,
+				} )
+			).toHaveAccessibleName( defaultProps.options[ 1 ].label );
+
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onChangeSpy ).toHaveBeenLastCalledWith(
+				defaultProps.options[ 1 ].value
+			);
+		} );
+
+		it( 'should select a new value when using the arrow keys', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+			render(
+				<Component { ...defaultProps } onChange={ onChangeSpy } />
+			);
+
+			await user.tab();
+
+			expect(
+				screen.getByRole( 'radio', {
+					name: defaultProps.options[ 0 ].label,
+				} )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowDown}' );
+
+			expect(
+				screen.getByRole( 'radio', {
+					checked: true,
+					name: defaultProps.options[ 1 ].label,
+				} )
+			).toHaveFocus();
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 2 );
+			expect( onChangeSpy ).toHaveBeenLastCalledWith(
+				defaultProps.options[ 1 ].value
+			);
+
+			await user.keyboard( '{ArrowDown}' );
+			await user.keyboard( '{ArrowDown}' );
+
+			// The selection wrap around.
+			expect(
+				screen.getByRole( 'radio', {
+					checked: true,
+					name: defaultProps.options[ 0 ].label,
+				} )
+			).toHaveFocus();
+			// TODO: why called twice for every interaction?
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 6 );
+			expect( onChangeSpy ).toHaveBeenLastCalledWith(
+				defaultProps.options[ 0 ].value
+			);
+
+			await user.keyboard( '{ArrowUp}' );
+
+			expect(
+				screen.getByRole( 'radio', {
+					checked: true,
+					name: defaultProps.options[ 2 ].label,
+				} )
+			).toHaveFocus();
+
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 8 );
+			expect( onChangeSpy ).toHaveBeenLastCalledWith(
+				defaultProps.options[ 2 ].value
+			);
+		} );
+	} );
+} );

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -24,6 +24,10 @@ export type RadioControlProps = Pick<
 		 * The internal value compared against select and passed to onChange
 		 */
 		value: string;
+		/**
+		 * Optional help text to be shown in addition the label.
+		 */
+		helpText?: string;
 	}[];
 	/**
 	 * The value property of the currently selected option.

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -27,7 +27,7 @@ export type RadioControlProps = Pick<
 		/**
 		 * Optional help text to be shown in addition the label.
 		 */
-		helpText?: string;
+		description?: string;
 	}[];
 	/**
 	 * The value property of the currently selected option.

--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -17,12 +17,12 @@ const COMMENT_OPTIONS = [
 	{
 		label: _x( 'Open', 'Adjective: e.g. "Comments are open"' ),
 		value: 'open',
-		helpText: __( 'Visitors can add new comments and replies.' ),
+		description: __( 'Visitors can add new comments and replies.' ),
 	},
 	{
 		label: __( 'Closed' ),
 		value: 'closed',
-		helpText: [
+		description: [
 			__( 'Visitors cannot add new comments or replies.' ),
 			__( 'Existing comments remain visible.' ),
 		].join( ' ' ),

--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -4,7 +4,6 @@
 import { __, _x } from '@wordpress/i18n';
 import {
 	RadioControl,
-	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -16,29 +15,17 @@ import { store as editorStore } from '../../store';
 
 const COMMENT_OPTIONS = [
 	{
-		label: (
-			<>
-				{ _x( 'Open', 'Adjective: e.g. "Comments are open"' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Visitors can add new comments and replies.' ) }
-				</Text>
-			</>
-		),
+		label: _x( 'Open', 'Adjective: e.g. "Comments are open"' ),
 		value: 'open',
+		helpText: __( 'Visitors can add new comments and replies.' ),
 	},
 	{
-		label: (
-			<>
-				{ __( 'Closed' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Visitors cannot add new comments or replies.' ) }
-				</Text>
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Existing comments remain visible.' ) }
-				</Text>
-			</>
-		),
+		label: __( 'Closed' ),
 		value: 'closed',
+		helpText: [
+			__( 'Visitors cannot add new comments or replies.' ),
+			__( 'Existing comments remain visible.' ),
+		].join( ' ' ),
 	},
 ];
 

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -49,59 +49,29 @@ const postStatusesInfo = {
 
 export const STATUS_OPTIONS = [
 	{
-		label: (
-			<>
-				{ __( 'Draft' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Not ready to publish.' ) }
-				</Text>
-			</>
-		),
+		label: __( 'Draft' ),
 		value: 'draft',
+		helpText: __( 'Not ready to publish.' ),
 	},
 	{
-		label: (
-			<>
-				{ __( 'Pending' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Waiting for review before publishing.' ) }
-				</Text>
-			</>
-		),
+		label: __( 'Pending' ),
 		value: 'pending',
+		helpText: __( 'Waiting for review before publishing.' ),
 	},
 	{
-		label: (
-			<>
-				{ __( 'Private' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Only visible to site admins and editors.' ) }
-				</Text>
-			</>
-		),
+		label: __( 'Private' ),
 		value: 'private',
+		helpText: __( 'Only visible to site admins and editors.' ),
 	},
 	{
-		label: (
-			<>
-				{ __( 'Scheduled' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Publish automatically on a chosen date.' ) }
-				</Text>
-			</>
-		),
+		label: __( 'Scheduled' ),
 		value: 'future',
+		helpText: __( 'Publish automatically on a chosen date.' ),
 	},
 	{
-		label: (
-			<>
-				{ __( 'Published' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Visible to everyone.' ) }
-				</Text>
-			</>
-		),
+		label: __( 'Published' ),
 		value: 'publish',
+		helpText: __( 'Visible to everyone.' ),
 	},
 ];
 

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -51,27 +51,27 @@ export const STATUS_OPTIONS = [
 	{
 		label: __( 'Draft' ),
 		value: 'draft',
-		helpText: __( 'Not ready to publish.' ),
+		description: __( 'Not ready to publish.' ),
 	},
 	{
 		label: __( 'Pending' ),
 		value: 'pending',
-		helpText: __( 'Waiting for review before publishing.' ),
+		description: __( 'Waiting for review before publishing.' ),
 	},
 	{
 		label: __( 'Private' ),
 		value: 'private',
-		helpText: __( 'Only visible to site admins and editors.' ),
+		description: __( 'Only visible to site admins and editors.' ),
 	},
 	{
 		label: __( 'Scheduled' ),
 		value: 'future',
-		helpText: __( 'Publish automatically on a chosen date.' ),
+		description: __( 'Publish automatically on a chosen date.' ),
 	},
 	{
 		label: __( 'Published' ),
 		value: 'publish',
-		helpText: __( 'Visible to everyone.' ),
+		description: __( 'Visible to everyone.' ),
 	},
 ];
 

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -5,7 +5,6 @@ import {
 	Button,
 	CheckboxControl,
 	Dropdown,
-	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	TextControl,
 	RadioControl,

--- a/packages/editor/src/components/site-discussion/index.js
+++ b/packages/editor/src/components/site-discussion/index.js
@@ -25,12 +25,12 @@ const COMMENT_OPTIONS = [
 	{
 		label: _x( 'Open', 'Adjective: e.g. "Comments are open"' ),
 		value: 'open',
-		helpText: __( 'Visitors can add new comments and replies.' ),
+		description: __( 'Visitors can add new comments and replies.' ),
 	},
 	{
 		label: __( 'Closed' ),
 		value: '',
-		helpText: [
+		description: [
 			__( 'Visitors cannot add new comments or replies.' ),
 			__( 'Existing comments remain visible.' ),
 		].join( ' ' ),

--- a/packages/editor/src/components/site-discussion/index.js
+++ b/packages/editor/src/components/site-discussion/index.js
@@ -23,29 +23,17 @@ import { store as editorStore } from '../../store';
 
 const COMMENT_OPTIONS = [
 	{
-		label: (
-			<>
-				{ _x( 'Open', 'Adjective: e.g. "Comments are open"' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Visitors can add new comments and replies.' ) }
-				</Text>
-			</>
-		),
+		label: _x( 'Open', 'Adjective: e.g. "Comments are open"' ),
 		value: 'open',
+		helpText: __( 'Visitors can add new comments and replies.' ),
 	},
 	{
-		label: (
-			<>
-				{ __( 'Closed' ) }
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Visitors cannot add new comments or replies.' ) }
-				</Text>
-				<Text variant="muted" size={ 12 }>
-					{ __( 'Existing comments remain visible.' ) }
-				</Text>
-			</>
-		),
+		label: __( 'Closed' ),
 		value: '',
+		helpText: [
+			__( 'Visitors cannot add new comments or replies.' ),
+			__( 'Existing comments remain visible.' ),
+		].join( ' ' ),
 	},
 ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #63735

Add support for help text to individual radio options in the `RadioControl` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> It'd be fantastic to add native support for a help text to the individual radio button options. We already use it in a few different places in the site editor and it will become even more important when we start building out forms and settings screens in the new admin.
>
> &mdash; <cite>@jarekmorawski  in https://github.com/WordPress/gutenberg/issues/63735</cite>

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Add an extra `options[].description` property
- Render the description (help) text after the label, and use it as the input's description (via the `aria-describedby` attribute)
- Refactor the layout to a grid layout

## Follow-ups

- [ ] refactor the component to use `fieldset` to properly label the radio group (https://github.com/WordPress/gutenberg/pull/63751#discussion_r1688420283);
- [ ] low priority, but tweak `BaseControl` so that its `StyledHelp` sub-component doesn't come with a top margin.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Visit the newly added "With Option Descriptions" Storybook example, make sure that the description (help) text shows as expected for each options that specifies one
- In the editor, check the places where we showed custom help text, and where now we are able to use the new `options[].description` property. Make sure that the radio inputs continue working as expected


## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-07-24 at 21 36 39](https://github.com/user-attachments/assets/eef49be6-66fc-4e97-b57a-be6be48246f1)

