### PR TITLE
Update 'Front page' badge

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -428,7 +428,7 @@ export default function PostList( { postType } ) {
 					if ( item.id === frontPageId ) {
 						suffix = (
 							<span className="edit-site-post-list__title-badge">
-								{ __( 'Front Page' ) }
+								{ __( 'Homepage' ) }
 							</span>
 						);
 					} else if ( item.id === postsPageId ) {

--- a/packages/edit-site/src/components/post-list/style.scss
+++ b/packages/edit-site/src/components/post-list/style.scss
@@ -72,6 +72,7 @@
 	font-size: 12px;
 	font-weight: 400;
 	flex-shrink: 0;
+	line-height: $grid-unit-05 * 5;
 }
 
 .edit-site-post-list__status-icon {

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -104,7 +104,7 @@ export default function PostCardPanel( { actions } ) {
 					{ title ? decodeEntities( title ) : __( 'No Title' ) }
 					{ isFrontPage && (
 						<span className="editor-post-card-panel__title-badge">
-							{ __( 'Front Page' ) }
+							{ __( 'Homepage' ) }
 						</span>
 					) }
 					{ isPostsPage && (


### PR DESCRIPTION
Discussed in https://github.com/WordPress/gutenberg/issues/56244

This PR does two things:

1. Updated the 'Front page' badge to read 'Homepage' which is more familiar, and echoes the reading settings
2. Ensures the badges have a consistent appearance across data view layouts and the page inspector

| Before | After |
| --- | --- |
| <img width="301" alt="Screenshot 2024-07-19 at 14 49 28" src="https://github.com/user-attachments/assets/4c588311-d21f-4e7d-80a5-c4103a9532e1"> | <img width="306" alt="Screenshot 2024-07-19 at 14 49 51" src="https://github.com/user-attachments/assets/cc5749c3-3ea3-42c6-a963-fcd8f00d4353"> |



### Testing instructions

1. Ensure your site has a static homepage
2. Go to the Pages data view in the Site Editor and locate the homepage
4. Observe it includes a badge with label: "Homepage"
5. Switch between different data view layouts and observe that this badge has the same appearance across (20px tall, 4px horizontal padding)
6. Enter the Editor and ensure the "Homepage" badge in the Inspector also matches the appearance in data views