### PR TITLE
Tabs: keep full opacity of focus ring on disabled tabs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,7 +27,7 @@
 -   `DropdownMenuV2`: invert animation direction. ([#63443](https://github.com/WordPress/gutenberg/pull/63443)).
 -   `Tabs`: Vertical Tabs should be 40px min height. ([#63446](https://github.com/WordPress/gutenberg/pull/63446)).
 -   `ColorPicker`: Use `minimal` variant for `SelectControl` ([#63676](https://github.com/WordPress/gutenberg/pull/63676)).
--   `Tabs`: keep full opacity of focus ring on disabled tabs ([#63754](https://github.com/WordPress/gutenberg/pull/63754)).
+-   `Tabs`: keep full opacity of focus ring and remove hover styles on disabled tabs ([#63754](https://github.com/WordPress/gutenberg/pull/63754)).
 
 ### Documentation
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,6 +27,7 @@
 -   `DropdownMenuV2`: invert animation direction. ([#63443](https://github.com/WordPress/gutenberg/pull/63443)).
 -   `Tabs`: Vertical Tabs should be 40px min height. ([#63446](https://github.com/WordPress/gutenberg/pull/63446)).
 -   `ColorPicker`: Use `minimal` variant for `SelectControl` ([#63676](https://github.com/WordPress/gutenberg/pull/63676)).
+-   `Tabs`: keep full opacity of focus ring on disabled tabs ([#63754](https://github.com/WordPress/gutenberg/pull/63754)).
 
 ### Documentation
 

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -76,10 +76,11 @@ export const Tab = styled( Ariakit.Tab )`
 		font-weight: 500;
 		text-align: inherit;
 		hyphens: auto;
+		color: ${ COLORS.theme.foreground };
 
 		&[aria-disabled='true'] {
 			cursor: default;
-			opacity: 0.3;
+			color: ${ COLORS.theme.gray[ 700 ] };
 		}
 
 		&:hover {

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -80,7 +80,7 @@ export const Tab = styled( Ariakit.Tab )`
 
 		&[aria-disabled='true'] {
 			cursor: default;
-			color: ${ COLORS.theme.gray[ 700 ] };
+			color: ${ COLORS.ui.textDisabled };
 		}
 
 		&:hover {

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -83,7 +83,7 @@ export const Tab = styled( Ariakit.Tab )`
 			color: ${ COLORS.ui.textDisabled };
 		}
 
-		&:hover {
+		&:not( [aria-disabled='true'] ):hover {
 			color: ${ COLORS.theme.accent };
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #52997

Inspired by #62480, this PR makes sure that the focus ring on disabled `Tabs.Tab` components is fully opaque, and that the text color of disabled tabs doesn't change on hover. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The focus ring on disabled tabs should have full contrast, and disabled tabs should not show "interactive" hints on hover since they're not interactive.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- By not setting a low `opacity` on disabled tabs, and instead changing the text color to achieve a similar result.
- By enabling hover styles only for non-disabled tabs

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Visit the "disabled" `Tabs` Storybook example
- Using the arrow keys, move focus on the disabled tab
- Make sure that the focus ring is fully opaqu

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (trunk) |
|---|---|
| ![Screenshot 2024-07-19 at 17 04 05](https://github.com/user-attachments/assets/56b8d912-8c14-469b-bf62-102646cfbb14) | ![Screenshot 2024-07-22 at 09 49 10](https://github.com/user-attachments/assets/918c8164-91bc-490a-be1d-4c34d43969c6) |
