### PR TITLE
Update: Expand search on list view.

### DIFF
--- a/packages/dataviews/src/components/dataviews-search/index.tsx
+++ b/packages/dataviews/src/components/dataviews-search/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -10,6 +15,7 @@ import { useDebouncedInput } from '@wordpress/compose';
  * Internal dependencies
  */
 import DataViewsContext from '../dataviews-context';
+import { LAYOUT_LIST } from '../../constants';
 
 interface SearchProps {
 	label?: string;
@@ -37,8 +43,12 @@ const DataViewsSearch = memo( function Search( { label }: SearchProps ) {
 		} );
 	}, [ debouncedSearch ] );
 	const searchLabel = label || __( 'Search' );
+
 	return (
 		<SearchControl
+			className={ classnames( 'dataviews-search', {
+				'is-expanded': view.type === LAYOUT_LIST,
+			} ) }
 			__nextHasNoMarginBottom
 			onChange={ setSearch }
 			value={ search }

--- a/packages/dataviews/src/components/dataviews-search/style.scss
+++ b/packages/dataviews/src/components/dataviews-search/style.scss
@@ -1,0 +1,3 @@
+.dataviews-search.is-expanded .components-base-control__field {
+	max-width: unset;
+}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -2,6 +2,7 @@
 @import "./components/dataviews-bulk-actions/style.scss";
 @import "./components/dataviews-bulk-actions-toolbar/style.scss";
 @import "./components/dataviews-filters/style.scss";
+@import "./components/dataviews-search/style.scss";
 @import "./components/dataviews-pagination/style.scss";
 @import "./components/dataviews-item-actions/style.scss";
 @import "./components/dataviews-selection-checkbox/style.scss";


### PR DESCRIPTION
Applies a suggestion by @jameskoster at https://github.com/WordPress/gutenberg/pull/63203#issuecomment-2236934477 removes the max-width on the search for the list view layout.

Before:
<img width="499" alt="Screenshot 2024-07-19 at 18 33 30" src="https://github.com/user-attachments/assets/18ebb7ff-d157-41de-89da-e6febd4e322f">

After:
<img width="482" alt="Screenshot 2024-07-19 at 18 34 03" src="https://github.com/user-attachments/assets/60024573-41ef-4523-9037-376a90b41ce0">

