### PR TITLE
Update HeightControl component to label inputs

### DIFF
--- a/packages/block-editor/src/components/height-control/index.js
+++ b/packages/block-editor/src/components/height-control/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useInstanceId } from '@wordpress/compose';
 import { useMemo } from '@wordpress/element';
 import {
 	BaseControl,
@@ -68,6 +69,10 @@ export default function HeightControl( {
 	value,
 } ) {
 	const customRangeValue = parseFloat( value );
+	const id = useInstanceId( HeightControl, 'inspector-height-control' );
+	const labelId = `${ id }__label`;
+	const inputId = `${ id }__input`;
+	const rangeId = `${ id }__range`;
 
 	const [ availableUnits ] = useSettings( 'spacing.units' );
 	const units = useCustomUnits( {
@@ -144,13 +149,14 @@ export default function HeightControl( {
 	};
 
 	return (
-		<fieldset className="block-editor-height-control">
-			<BaseControl.VisualLabel as="legend">
+		<div className="block-editor-height-control" id={ id }>
+			<BaseControl.VisualLabel as="label" for={ inputId } id={ labelId }>
 				{ label }
 			</BaseControl.VisualLabel>
 			<Flex>
 				<FlexItem isBlock>
 					<UnitControl
+						id={ inputId }
 						value={ value }
 						units={ units }
 						onChange={ onChange }
@@ -164,6 +170,9 @@ export default function HeightControl( {
 				<FlexItem isBlock>
 					<Spacer marginX={ 2 } marginBottom={ 0 }>
 						<RangeControl
+							aria-controls={ inputId }
+							aria-labelledby={ labelId }
+							id={ rangeId }
 							value={ customRangeValue }
 							min={ 0 }
 							max={
@@ -183,6 +192,6 @@ export default function HeightControl( {
 					</Spacer>
 				</FlexItem>
 			</Flex>
-		</fieldset>
+		</div>
 	);
 }

--- a/packages/block-editor/src/components/height-control/index.js
+++ b/packages/block-editor/src/components/height-control/index.js
@@ -69,7 +69,7 @@ export default function HeightControl( {
 	value,
 } ) {
 	const customRangeValue = parseFloat( value );
-	const id = useInstanceId( HeightControl, 'inspector-height-control' );
+	const id = useInstanceId( HeightControl, 'block-editor-height-control' );
 	const labelId = `${ id }__label`;
 	const inputId = `${ id }__input`;
 	const rangeId = `${ id }__range`;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   `CustomSelectControl`: Stabilize `__experimentalShowSelectedHint` and `options[]. __experimentalHint` props ([#63248](https://github.com/WordPress/gutenberg/pull/63248)).
 -   `SelectControl`: Add `"minimal"` variant ([#63265](https://github.com/WordPress/gutenberg/pull/63265)).
 -   `FontSizePicker`: tidy up internal logic ([#63553](https://github.com/WordPress/gutenberg/pull/63553)).
+-   `RangeControl`: Allow external `id` prop ([#63761](https://github.com/WordPress/gutenberg/pull/63761)).
 
 ### Internal
 

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -41,6 +41,15 @@ import { space } from '../utils/space';
 
 const noop = () => {};
 
+function useUniqueId( idProp?: string ) {
+	const id = useInstanceId(
+		UnforwardedRangeControl,
+		'inspector-range-control'
+	);
+
+	return idProp || id;
+}
+
 function UnforwardedRangeControl(
 	props: WordPressComponentProps< RangeControlProps, 'input', false >,
 	forwardedRef: ForwardedRef< HTMLInputElement >
@@ -56,6 +65,7 @@ function UnforwardedRangeControl(
 		disabled = false,
 		help,
 		hideLabelFromVision = false,
+		id: idProp,
 		initialPosition,
 		isShiftStepEnabled = true,
 		label,
@@ -123,10 +133,7 @@ function UnforwardedRangeControl(
 		!! marks && 'is-marked'
 	);
 
-	const id = useInstanceId(
-		UnforwardedRangeControl,
-		'inspector-range-control'
-	);
+	const id = useUniqueId( idProp );
 	const describedBy = !! help ? `${ id }__help` : undefined;
 	const enableTooltip = hasTooltip !== false && Number.isFinite( value );
 


### PR DESCRIPTION
This is a copy of #48498 from @andrewhayward , moved to a branch on this repo (instead than a fork).

## What?

Adds accessible names to both inputs in the `HeightControl` component, replacing the `fieldset` wrapper and using `aria-controls` instead.

## Why?

Currently, `HeightControl` uses a `<fieldset>` to label the input fields, but this doesn't provide an accessible name for either. [Both fields should have an appropriate name](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions).

## How?

* Updates the `RangeControl` component to accept an optional ID.
* Replaces the `<fieldset>`/`<legend>` combination with a `<label>`, pointing at the text input, to ensure it has an accessible name.
* The range input references the `<label>` with an `aria-labelledby` to get its own accessible name.
* The range input gains an `aria-controls` attribute, pointing at the text input (while acknowledging that `aria-controls` has little support at the time of writing).

## Testing Instructions

* Launch storybook: `npm run storybook:dev`
* Go to the `HeightControl` component
* Check that both fields have accessible names (using the inspector)

### Testing Instructions for Keyboard

Nothing has functionally changed, so both inputs should remain as expected
