### PR TITLE
Small Typo in Experiment Page

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -184,7 +184,7 @@ function gutenberg_display_experiment_field( $args ) {
  */
 function gutenberg_display_experiment_section() {
 	?>
-	<p><?php echo __( "The block editor includes experimental features that are useable while they're in development. Select the ones you'd like to enable. These features are likely to change, so avoid using them in production.", 'gutenberg' ); ?></p>
+	<p><?php echo __( "The block editor includes experimental features that are usable while they're in development. Select the ones you'd like to enable. These features are likely to change, so avoid using them in production.", 'gutenberg' ); ?></p>
 
 	<?php
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63772