### PR TITLE
Site Tagline: Add border block support 

### DIFF
--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -70,5 +70,6 @@
 			}
 		}
 	},
-	"editorStyle": "wp-block-site-tagline-editor"
+	"editorStyle": "wp-block-site-tagline-editor",
+	"style": "wp-block-site-tagline"
 }

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -61,13 +61,7 @@
 			"radius": true,
 			"color": true,
 			"width": true,
-			"style": true,
-			"__experimentalDefaultControls": {
-				"radius": true,
-				"color": true,
-				"width": true,
-				"style": true
-			}
+			"style": true
 		}
 	},
 	"editorStyle": "wp-block-site-tagline-editor",

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -56,6 +56,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-site-tagline-editor"

--- a/packages/block-library/src/site-tagline/style.scss
+++ b/packages/block-library/src/site-tagline/style.scss
@@ -1,0 +1,4 @@
+:root :where(.wp-block-site-tagline) {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/site-tagline/style.scss
+++ b/packages/block-library/src/site-tagline/style.scss
@@ -1,4 +1,4 @@
-:root :where(.wp-block-site-tagline) {
+.wp-block-site-tagline {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -47,6 +47,7 @@
 @import "./search/style.scss";
 @import "./separator/style.scss";
 @import "./site-logo/style.scss";
+@import "./site-tagline/style.scss";
 @import "./site-title/style.scss";
 @import "./social-links/style.scss";
 @import "./spacer/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Site Tagline` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Site Tagline` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that `Site Tagline` block's border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add `Site Tagline`  block and Apply the border styles
- Verify that block styles take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend

Watch attached video for more information.

## Screenshots or screencast <!-- if applicable -->
 
  
[site-tagline-block-border-support-video.webm](https://github.com/user-attachments/assets/69b7da09-a15a-4543-a063-fe082abce59a)
