### PR TITLE
Search: Prevent override of global button radii in editor

### DIFF
--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -7,7 +7,7 @@
 }
 
 .wp-block-search {
-	.wp-block-search__button {
+	:where(.wp-block-search__button) {
 		height: auto;
 		border-radius: initial;
 		display: flex;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63769

## What?

Reduces specificity of style targeting Search block's submit button in the editor so that theme.json border radius isn't overridden and the editor matches the frontend.

## Why?

Bring the editor back in line with the frontend after the introduction of global button element styling.

## How?

Wrap inner selector in `:where()` to bring it down to `0-1-0` specificity used by global styles.

## Testing Instructions

1. Checkout trunk and activate TT4 (it has global button border radii style in theme.json)
2. Add a Search button to a post
3. Save the post and compare the search block's button in the editor to the frontend
4. Checkout this PR and reload editor and frontend
5. The button should have the same radii in both places now
6. Make sure that there is no other visual variance, checking different search block layouts e.g. inner button, button only etc.


## Screenshots or screencast <!-- if applicable -->

### Before

| Editor | Frontend |
|---|---|
| <img width="649" alt="Screenshot 2024-07-22 at 10 13 22 AM" src="https://github.com/user-attachments/assets/b1b14802-0285-44b8-b317-f04e913de693"> | <img width="651" alt="Screenshot 2024-07-22 at 10 13 16 AM" src="https://github.com/user-attachments/assets/269c81e5-2fe5-4d15-a714-d04e07f85cf9"> |


### After

| Editor | Frontend |
|---|---|
| <img width="647" alt="Screenshot 2024-07-22 at 10 15 52 AM" src="https://github.com/user-attachments/assets/83e78f15-1431-409a-b10e-d89ccc7b0da9"> | <img width="641" alt="Screenshot 2024-07-22 at 10 15 58 AM" src="https://github.com/user-attachments/assets/2116e7d4-28b4-4cc4-89f8-76279c7d9226"> |

### Editor Styles

| Before | After |
|---|---|
| <img width="434" alt="Screenshot 2024-07-22 at 10 15 22 AM" src="https://github.com/user-attachments/assets/c8ad6dd6-500c-476f-97be-6b5fb902c68a"> | <img width="432" alt="Screenshot 2024-07-22 at 10 15 27 AM" src="https://github.com/user-attachments/assets/ddfd9752-f3b2-4519-a416-1dc30cfeda15"> |
