### PR TITLE
Comments: Allow button element shadows from theme.json

### DIFF
--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -38,7 +38,7 @@
 	}
 
 	// Styles copied from button block styles.
-	input[type="submit"] {
+	:where(input[type="submit"]) {
 		box-shadow: none;
 		cursor: pointer;
 		display: inline-block;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63767

## What?

Reduces specificity of comments form button default styles to allow theme.json global button element shadows to take effect.

## Why?

Allows comments form button to match global button styles.

## How?

Wrap the inner `input[type="submit"]` selector in `:where()`

## Testing Instructions

1. Add the following shadow definition to your theme.json under `styles.elements.button.shadow`:
`"shadow": "10px 10px 5px 0px rgba(0,0,0,0.66)"`
2. Add a post comments form block to a post
3. Ensure the comment form button has the shadow defined
4. Save the post and confirm the shadow also appears on the frontend.

## Screenshots or screencast <!-- if applicable -->

### Before 
| Editor | Frontend |
|---|---|
| <img width="645" alt="Screenshot 2024-07-22 at 10 36 49 AM" src="https://github.com/user-attachments/assets/684bcdea-a176-4cfa-8ed5-784f24abe715"> | <img width="642" alt="Screenshot 2024-07-22 at 10 36 59 AM" src="https://github.com/user-attachments/assets/66f922df-a82d-4127-91ec-15dcd5bc12fb"> |

### After 
| Editor | Frontend |
|---|---|
| <img width="658" alt="Screenshot 2024-07-22 at 10 37 36 AM" src="https://github.com/user-attachments/assets/5b8b9683-0267-48ea-b7f1-e41f2348c283"> | <img width="656" alt="Screenshot 2024-07-22 at 10 37 26 AM" src="https://github.com/user-attachments/assets/39c15355-6d58-43d5-9bd4-a6533f7b3861"> |