### PR TITLE
Discussions panel: Distinguish between verb and adjective form of open for internationalization

### DIFF
--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	RadioControl,
 	__experimentalText as Text,
@@ -18,7 +18,7 @@ const COMMENT_OPTIONS = [
 	{
 		label: (
 			<>
-				{ __( 'Open' ) }
+				{ _x( 'Open', 'Adjective: e.g. "Comments are open"' ) }
 				<Text variant="muted" size={ 12 }>
 					{ __( 'Visitors can add new comments and replies.' ) }
 				</Text>

--- a/packages/editor/src/components/post-discussion/panel.js
+++ b/packages/editor/src/components/post-discussion/panel.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	Dropdown,
 	Button,
@@ -62,9 +62,11 @@ function PostDiscussionToggle( { isOpen, onClick } ) {
 	let label;
 	if ( commentStatus === 'open' ) {
 		if ( pingStatus === 'open' ) {
-			label = __( 'Open' );
+			label = _x( 'Open', 'Adjective: e.g. "Comments are open"' );
 		} else {
-			label = trackbacksSupported ? __( 'Comments only' ) : __( 'Open' );
+			label = trackbacksSupported
+				? __( 'Comments only' )
+				: _x( 'Open', 'Adjective: e.g. "Comments are open"' );
 		}
 	} else if ( pingStatus === 'open' ) {
 		label = commentsSupported ? __( 'Pings only' ) : __( 'Pings enabled' );

--- a/packages/editor/src/components/site-discussion/index.js
+++ b/packages/editor/src/components/site-discussion/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
@@ -25,7 +25,7 @@ const COMMENT_OPTIONS = [
 	{
 		label: (
 			<>
-				{ __( 'Open' ) }
+				{ _x( 'Open', 'Adjective: e.g. "Comments are open"' ) }
 				<Text variant="muted" size={ 12 }>
 					{ __( 'Visitors can add new comments and replies.' ) }
 				</Text>


### PR DESCRIPTION
## What?
Fixes an issue spotted in replying to #63780

The word open can be used as an verb "Open a page" or adjective "The page is open", and some of the i18n in the codebase doesn't distinguish.

## Why?
I imagine the words could be translated differently depending on this context (I'm not multilingual, but I think in French it could be "Ouvrir" or "Ouvert").

## How?
Uses the `_x` function to add a context string for the translation

## Testing Instructions
Create a post and in the document sidebar, check that the 'Discussion' options still show the English text 'Open'.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-07-22 at 10 52 18 AM](https://github.com/user-attachments/assets/a32348e1-4a6e-441d-b317-86b9a2ccd110)
