### PR TITLE
Block Bindings: Allow bindings bootstrap after registration

### DIFF
--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1706,7 +1706,7 @@ describe( 'blocks', () => {
 
 		it( 'should correctly merge properties when bootstrap happens after registration', () => {
 			// Register source in the client.
-			const clientProperties = {
+			const clientOnlyProperties = {
 				getValues: () => 'values',
 				setValues: () => 'new values',
 				getPlaceholder: () => 'placeholder',
@@ -1715,7 +1715,8 @@ describe( 'blocks', () => {
 			registerBlockBindingsSource( {
 				name: 'core/custom-source',
 				label: 'Client Label',
-				...clientProperties,
+				usesContext: [ 'postId', 'postType' ],
+				...clientOnlyProperties,
 			} );
 
 			// Bootstrap source from the server.
@@ -1724,14 +1725,17 @@ describe( 'blocks', () => {
 			).addBootstrappedBlockBindingsSource( {
 				name: 'core/custom-source',
 				label: 'Server Label',
-				usesContext: [ 'postId' ],
+				usesContext: [ 'postId', 'serverContext' ],
 			} );
 
 			// Check that the bootstrap values prevail and the client properties are still there.
 			expect( getBlockBindingsSource( 'core/custom-source' ) ).toEqual( {
+				// Should use the server label.
 				label: 'Server Label',
-				usesContext: [ 'postId' ],
-				...clientProperties,
+				// Should merge usesContext from server and client.
+				usesContext: [ 'postId', 'postType', 'serverContext' ],
+				// Should keep client properties.
+				...clientOnlyProperties,
 			} );
 
 			unregisterBlockBindingsSource( 'core/custom-source' );

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1704,7 +1704,7 @@ describe( 'blocks', () => {
 			);
 		} );
 
-		it( 'should not be overriden if bootstrap happens after registration', () => {
+		it( 'should correctly merge properties when bootstrap happens after registration', () => {
 			// Register source in the client.
 			const clientProperties = {
 				getValues: () => 'values',

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1703,6 +1703,39 @@ describe( 'blocks', () => {
 				'Block bindings source "core/test-source" is already registered.'
 			);
 		} );
+
+		it( 'should not be overriden if bootstrap happens after registration', () => {
+			// Register source in the client.
+			const clientProperties = {
+				getValues: () => 'values',
+				setValues: () => 'new values',
+				getPlaceholder: () => 'placeholder',
+				canUserEditValue: () => true,
+			};
+			registerBlockBindingsSource( {
+				name: 'core/custom-source',
+				label: 'Client Label',
+				...clientProperties,
+			} );
+
+			// Bootstrap source from the server.
+			unlock(
+				dispatch( blocksStore )
+			).addBootstrappedBlockBindingsSource( {
+				name: 'core/custom-source',
+				label: 'Server Label',
+				usesContext: [ 'postId' ],
+			} );
+
+			// Check that the bootstrap values prevail and the client properties are still there.
+			expect( getBlockBindingsSource( 'core/custom-source' ) ).toEqual( {
+				label: 'Server Label',
+				usesContext: [ 'postId' ],
+				...clientProperties,
+			} );
+
+			unregisterBlockBindingsSource( 'core/custom-source' );
+		} );
 	} );
 
 	describe( 'unregisterBlockBindingsSource', () => {

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -372,19 +372,19 @@ export function collections( state = {}, action ) {
 }
 
 export function blockBindingsSources( state = {}, action ) {
+	// Merge usesContext with existing values, potentially defined in the server registration.
+	let mergedUsesContext = [
+		...( state[ action.name ]?.usesContext || [] ),
+		...( action.usesContext || [] ),
+	];
+	// Remove duplicates.
+	mergedUsesContext =
+		mergedUsesContext.length > 0
+			? [ ...new Set( mergedUsesContext ) ]
+			: undefined;
+
 	switch ( action.type ) {
 		case 'ADD_BLOCK_BINDINGS_SOURCE':
-			// Merge usesContext with existing values, potentially defined in the server registration.
-			let mergedUsesContext = [
-				...( state[ action.name ]?.usesContext || [] ),
-				...( action.usesContext || [] ),
-			];
-			// Remove duplicates.
-			mergedUsesContext =
-				mergedUsesContext.length > 0
-					? [ ...new Set( mergedUsesContext ) ]
-					: undefined;
-
 			return {
 				...state,
 				[ action.name ]: {
@@ -407,7 +407,7 @@ export function blockBindingsSources( state = {}, action ) {
 					 */
 					...state[ action.name ],
 					label: action.label,
-					usesContext: action.usesContext,
+					usesContext: mergedUsesContext,
 				},
 			};
 		case 'REMOVE_BLOCK_BINDINGS_SOURCE':

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -401,6 +401,11 @@ export function blockBindingsSources( state = {}, action ) {
 			return {
 				...state,
 				[ action.name ]: {
+					/*
+					 * Keep the exisitng properties in case the source has been registered
+					 * in the client before bootstrapping.
+					 */
+					...state[ action.name ],
 					label: action.label,
 					usesContext: action.usesContext,
 				},

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -373,15 +373,13 @@ export function collections( state = {}, action ) {
 
 export function blockBindingsSources( state = {}, action ) {
 	// Merge usesContext with existing values, potentially defined in the server registration.
-	let mergedUsesContext = [
-		...( state[ action.name ]?.usesContext || [] ),
-		...( action.usesContext || [] ),
-	];
-	// Remove duplicates.
-	mergedUsesContext =
-		mergedUsesContext.length > 0
-			? [ ...new Set( mergedUsesContext ) ]
-			: undefined;
+	const existingUsesContext = state[ action.name ]?.usesContext || [];
+	const newUsesContext = action.usesContext || [];
+	const mergedArrays = Array.from(
+		new Set( existingUsesContext.concat( newUsesContext ) )
+	);
+	const mergedUsesContext =
+		mergedArrays.length > 0 ? mergedArrays : undefined;
 
 	switch ( action.type ) {
 		case 'ADD_BLOCK_BINDINGS_SOURCE':


### PR DESCRIPTION
## What?
As reported [here](https://github.com/WordPress/gutenberg/pull/63470#discussion_r1686181167) by @gziolo , when plugins start using the editor APIs, there could be a use case where sources are registered in the client before they are bootstrapped from the server. This pull request ensures the properties are not overriden.

## Why?
It could break the developer experience once these APIs are public.

## How?
Preserving the existing properties in the reducer.

## Testing Instructions
I added a unit test to cover this use case. The other registration tests should pass as well.