### PR TITLE
Navigation: Don't output the main class on the inner wrapper

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -181,6 +181,8 @@ class WP_Navigation_Block_Renderer {
 			)
 		);
 
+		$container_attributes = preg_replace('/(\s|\")(wp-block-navigation)(\s|\")/', '$1', $container_attributes);
+
 		$inner_blocks_html = '';
 		$is_list_open      = false;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes the main block class from the `ul` inside in the `nav`.

Fixes https://github.com/WordPress/gutenberg/issues/62690

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The main block class should only be used once per block. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Regex!

## Testing Instructions
1. Add a navigation block to a post or page
2. View the source
3. Check that the wp-block-navigation class is only used on the outer `nav` element, and not on the `ul` (or anywhere else).
