### PR TITLE
Reduce gap between steps in SpacingSizesControl, add animation, remove first/last marks

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -193,10 +193,12 @@ export default function SpacingInputControl( {
 		name: size.name,
 	} ) );
 
-	const marks = spacingSizes.map( ( _newValue, index ) => ( {
-		value: index,
-		label: undefined,
-	} ) );
+	const marks = spacingSizes
+		.slice( 1, spacingSizes.length - 1 )
+		.map( ( _newValue, index ) => ( {
+			value: index + 1,
+			label: undefined,
+		} ) );
 
 	const sideLabel =
 		ALL_SIDES.includes( side ) && showSideInLabel ? LABELS[ side ] : '';

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -42,11 +42,6 @@
 
 	.components-range-control__marks {
 		margin-top: 17px;
-
-		:last-child,
-		:first-child {
-			display: none;
-		}
 	}
 
 	.components-range-control__thumb-wrapper {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -32,6 +32,7 @@
 	}
 
 	.components-range-control__mark {
+		transform: translateX(-50%);
 		height: $grid-unit-05;
 		width: math.div($grid-unit-05, 2);
 		background-color: $white;

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -4,9 +4,16 @@
 		margin-bottom: 0;
 	}
 
-	.components-range-control__track {
-		transition: width ease 0.1s;
-		@include reduce-motion("transition");
+	.is-marked {
+		.components-range-control__track {
+			transition: width ease 0.1s;
+			@include reduce-motion("transition");
+		}
+
+		.components-range-control__thumb-wrapper {
+			transition: left ease 0.1s;
+			@include reduce-motion("transition");
+		}
 	}
 
 	.spacing-sizes-control__range-control,
@@ -25,24 +32,28 @@
 	}
 
 	.components-range-control__mark {
-		height: $grid-unit-05;
-		width: 3px;
-		background-color: #fff;
+		height: 8px;
+		width: 2px;
+		background-color: $gray-300;
 		z-index: 1;
+		top: -6px;
+		border-radius: 2px;
+
+		&.is-filled {
+			z-index: -1;
+		}
 	}
 
 	.components-range-control__marks {
 		margin-top: 17px;
 
-		:first-child {
-			display: none;
+		:last-child {
+			transform: translateX(-2px);
 		}
 	}
 
 	.components-range-control__thumb-wrapper {
 		z-index: 3;
-		transition: left ease 0.1s;
-		@include reduce-motion("transition");
 	}
 }
 

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -33,11 +33,10 @@
 
 	.components-range-control__mark {
 		height: 4px;
-		width: 4px;
-		background-color: rgba($black, 0.2);
+		width: 1.5px;
+		background-color: rgba($black, 0.15);
 		z-index: 1;
 		top: -4px;
-		border-radius: 2px;
 
 		&.is-filled {
 			background-color: rgba($white, 0.5);
@@ -47,8 +46,9 @@
 	.components-range-control__marks {
 		margin-top: 17px;
 
-		:last-child {
-			transform: translateX(-4px);
+		:last-child,
+		:first-child {
+			display: none;
 		}
 	}
 

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -4,6 +4,11 @@
 		margin-bottom: 0;
 	}
 
+	.components-range-control__track {
+		transition: width ease 0.1s;
+		@include reduce-motion("transition");
+	}
+
 	.spacing-sizes-control__range-control,
 	.spacing-sizes-control__custom-value-range {
 		height: 40px;
@@ -36,6 +41,8 @@
 
 	.components-range-control__thumb-wrapper {
 		z-index: 3;
+		transition: left ease 0.1s;
+		@include reduce-motion("transition");
 	}
 }
 

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -32,15 +32,15 @@
 	}
 
 	.components-range-control__mark {
-		height: 8px;
-		width: 2px;
-		background-color: $gray-300;
+		height: 4px;
+		width: 4px;
+		background-color: rgba($black, 0.2);
 		z-index: 1;
-		top: -6px;
+		top: -4px;
 		border-radius: 2px;
 
 		&.is-filled {
-			z-index: -1;
+			background-color: rgba($white, 0.5);
 		}
 	}
 
@@ -48,7 +48,7 @@
 		margin-top: 17px;
 
 		:last-child {
-			transform: translateX(-2px);
+			transform: translateX(-4px);
 		}
 	}
 

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -32,11 +32,11 @@
 	}
 
 	.components-range-control__mark {
-		height: 4px;
-		width: 1.5px;
+		height: $grid-unit-05;
+		width: math.div($grid-unit-05, 2);
 		background-color: $white;
 		z-index: 1;
-		top: -4px;
+		top: -#{$grid-unit-05};
 	}
 
 	.components-range-control__marks {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -34,13 +34,9 @@
 	.components-range-control__mark {
 		height: 4px;
 		width: 1.5px;
-		background-color: rgba($black, 0.15);
+		background-color: $white;
 		z-index: 1;
 		top: -4px;
-
-		&.is-filled {
-			background-color: rgba($white, 0.5);
-		}
 	}
 
 	.components-range-control__marks {


### PR DESCRIPTION
## What?
Refine the appearance of `SpacingSizesControl`.

## Why?
The white space between options makes the control feel heavy and noisy, drawing more attention than is warranted. This PR reduces it slightly.

Animation on the value / handle add polish and underline the nature of the range.

## Before

https://github.com/user-attachments/assets/6c44b736-1b1e-45f9-9851-057c3121d364



## After



https://github.com/user-attachments/assets/cb7f5cc7-655d-4907-ab7b-1661dd2c721d


